### PR TITLE
fix(software-inventory): load list for "All Orgs" (aggregate across accessible orgs)

### DIFF
--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -93,6 +93,7 @@ vi.mock('../db', () => ({
     insert: vi.fn(() => chainMock([])),
     update: vi.fn(() => chainMock(undefined)),
     delete: vi.fn(() => chainMock(undefined)),
+    execute: vi.fn(async () => []),
     transaction: vi.fn(async (fn: any) => fn({
       select: vi.fn(() => chainMock([])),
       insert: vi.fn(() => chainMock([])),
@@ -316,7 +317,11 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
       await expectNotOrgIdRequired400(res);
     });
 
-    it('GET /software-inventory 400s when orgId is missing', async () => {
+    // Exception to the #620 "missing orgId => 400" rule: the software-inventory
+    // READ endpoints now aggregate across all accessible orgs ("All Orgs") when
+    // no orgId is supplied, rather than 400ing. (The catalog/discovery/huntress
+    // routes below still require an explicit orgId.)
+    it('GET /software-inventory aggregates across all orgs when orgId is missing', async () => {
       const { softwareInventoryRoutes } = await import('./softwareInventory');
       const app = new Hono().route('/software-inventory', softwareInventoryRoutes);
 
@@ -325,7 +330,7 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
         headers: { Authorization: 'Bearer t' },
       });
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
     });
 
     it('GET /software-inventory 403s when ?orgId= is foreign', async () => {

--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -7,7 +7,9 @@
  * handlers). Each affected route file is exercised: the resolver should accept
  * the user-supplied orgId, validate it against `accessibleOrgIds`, and forward
  * it through. Foreign orgIds must 403; missing orgId must still 400 with the
- * existing "orgId is required..." message.
+ * existing "orgId is required..." message — EXCEPT the software-inventory READ
+ * endpoints, which now aggregate across all accessible orgs ("All Orgs") on a
+ * missing orgId instead of 400ing (see the software-inventory describe block).
  *
  * #723: GET /orgs/sites must scope by the explicit `organizationId`, not the
  * ambient `orgId` the web client auto-injects (see the #723 describe block).
@@ -319,7 +321,7 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
 
     // Exception to the #620 "missing orgId => 400" rule: the software-inventory
     // READ endpoints now aggregate across all accessible orgs ("All Orgs") when
-    // no orgId is supplied, rather than 400ing. (The catalog/discovery/huntress
+    // no orgId is supplied, rather than 400ing. (The catalog and discovery
     // routes below still require an explicit orgId.)
     it('GET /software-inventory aggregates across all orgs when orgId is missing', async () => {
       const { softwareInventoryRoutes } = await import('./softwareInventory');

--- a/apps/api/src/routes/softwareInventory.test.ts
+++ b/apps/api/src/routes/softwareInventory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { eq, inArray } from 'drizzle-orm';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -127,6 +128,32 @@ function setAuth(allowedSiteIds?: string[]) {
   });
 }
 
+const ORG_A = '11111111-1111-1111-1111-1111111111aa';
+const ORG_B = '22222222-2222-2222-2222-2222222222bb';
+const ORG_FOREIGN = '99999999-9999-9999-9999-999999999999';
+
+// Partner/system scope users have orgId=null and reach multiple orgs. "All Orgs"
+// (no orgId query param) must aggregate across auth.accessibleOrgIds via the
+// shared auth.orgCondition() helper — never 400 "Organization context required".
+function setMultiOrgAuth(scope: 'partner' | 'system', orgIds: string[] | null) {
+  vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      scope,
+      partnerId: scope === 'partner' ? 'partner-1' : null,
+      orgId: null,
+      accessibleOrgIds: orgIds,
+      orgCondition: (col: any) => {
+        if (orgIds === null) return undefined; // system scope — no filter
+        if (orgIds.length === 1) return eq(col, orgIds[0]);
+        return inArray(col, orgIds);
+      },
+      canAccessOrg: (id: string) => orgIds === null || orgIds.includes(id),
+    });
+    return next();
+  });
+}
+
 function mockPolicyStatusMap(rows: any[] = []) {
   vi.mocked(db.select).mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
@@ -239,6 +266,83 @@ describe('softwareInventoryRoutes site-scope reads', () => {
     });
   });
 
+  describe('GET /software-inventory — All Orgs (multi-org) reads', () => {
+    const FIREFOX_ROW = {
+      name: 'Firefox',
+      vendor: 'Mozilla',
+      device_count: '3',
+      first_seen: null,
+      last_seen: null,
+      version_data: null,
+    };
+
+    it('aggregates across all accessible orgs when no orgId is provided (partner scope)', async () => {
+      setMultiOrgAuth('partner', [ORG_A, ORG_B]);
+      vi.mocked(db.execute)
+        .mockResolvedValueOnce([{ total: '1' }] as any)
+        .mockResolvedValueOnce([FIREFOX_ROW] as any);
+      mockPolicyStatusMap();
+
+      const res = await app.request('/software-inventory', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const countSql = dumpSql(vi.mocked(db.execute).mock.calls[0]?.[0]);
+      const listSql = dumpSql(vi.mocked(db.execute).mock.calls[1]?.[0]);
+      for (const sqlText of [countSql, listSql]) {
+        expect(sqlText).toContain(ORG_A);
+        expect(sqlText).toContain(ORG_B);
+      }
+    });
+
+    it('does not 400 for a system-scope caller viewing all orgs (no org filter)', async () => {
+      setMultiOrgAuth('system', null);
+      vi.mocked(db.execute)
+        .mockResolvedValueOnce([{ total: '1' }] as any)
+        .mockResolvedValueOnce([FIREFOX_ROW] as any);
+      mockPolicyStatusMap();
+
+      const res = await app.request('/software-inventory', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('scopes to a single org when an accessible orgId is provided (partner scope)', async () => {
+      setMultiOrgAuth('partner', [ORG_A, ORG_B]);
+      vi.mocked(db.execute)
+        .mockResolvedValueOnce([{ total: '1' }] as any)
+        .mockResolvedValueOnce([FIREFOX_ROW] as any);
+      mockPolicyStatusMap();
+
+      const res = await app.request(`/software-inventory?orgId=${ORG_A}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const listSql = dumpSql(vi.mocked(db.execute).mock.calls[1]?.[0]);
+      expect(listSql).toContain(ORG_A);
+      expect(listSql).not.toContain(ORG_B);
+    });
+
+    it('rejects an orgId outside the accessible set with 403', async () => {
+      setMultiOrgAuth('partner', [ORG_A, ORG_B]);
+
+      const res = await app.request(`/software-inventory?orgId=${ORG_FOREIGN}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.execute)).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GET /software-inventory/:name/devices', () => {
     it('narrows drilldown count and list to allowed sites for a restricted caller', async () => {
       setAuth([SITE_ALLOWED]);
@@ -259,6 +363,26 @@ describe('softwareInventoryRoutes site-scope reads', () => {
         expect(rendered).toContain('devices.siteId');
         expect(rendered).toContain(SITE_ALLOWED);
         expect(rendered).not.toContain(SITE_DENIED);
+      }
+    });
+
+    it('drills down across all accessible orgs when no orgId is provided (partner scope)', async () => {
+      setMultiOrgAuth('partner', [ORG_A, ORG_B]);
+      const whereArgs: unknown[] = [];
+      mockDrilldownCount([{ count: 2 }], whereArgs);
+      mockDrilldownRows([{ deviceId: DEVICE_ALLOWED, hostname: 'allowed-device' }], whereArgs);
+
+      const res = await app.request('/software-inventory/Firefox/devices', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(whereArgs).toHaveLength(2);
+      for (const where of whereArgs) {
+        const rendered = dumpSql(where);
+        expect(rendered).toContain(ORG_A);
+        expect(rendered).toContain(ORG_B);
       }
     });
 

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -136,6 +136,11 @@ async function getPolicyStatusMap(orgFilter: SQL | undefined): Promise<Map<strin
     .from(softwarePolicies)
     .where(and(...conditions));
 
+  // Keyed by name|vendor with no org dimension. In an "All Orgs" aggregate this
+  // collapses policies from every accessible org onto one row; if two orgs hold
+  // conflicting policies for the same software the badge is last-write-wins. This
+  // is a display approximation on an org-collapsed row, never a cross-tenant read
+  // (RLS still scopes the policies query to accessible orgs).
   const statusMap = new Map<string, PolicyStatus>();
 
   for (const policy of policies) {

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, eq, inArray, sql, desc, asc, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
 import { db } from '../db';
 import {
   configPolicyAssignments,
@@ -102,9 +103,30 @@ function resolveOrgId(auth: AuthContext, requestedOrgId?: string): ResolveOrgIdR
   return { error: 'Organization context required', status: 400 };
 }
 
+// Read endpoints support "All Orgs": when no orgId is requested, scope to every
+// org the caller can reach via auth.orgCondition() (returns undefined for system
+// scope — no filter, RLS governs). A requested orgId must be accessible. Unlike
+// resolveOrgId (used by the policy writes, which need a single target org), this
+// never demands a single org, so partner/system callers can aggregate.
+type OrgReadScope =
+  | { applyTo: (column: PgColumn) => SQL | undefined }
+  | { error: string; status: 403 };
+
+function resolveOrgReadScope(auth: AuthContext, requestedOrgId?: string): OrgReadScope {
+  if (requestedOrgId) {
+    if (!auth.canAccessOrg(requestedOrgId)) {
+      return { error: 'Access to this organization denied', status: 403 };
+    }
+    return { applyTo: (column) => eq(column, requestedOrgId) };
+  }
+  return { applyTo: (column) => auth.orgCondition(column) };
+}
+
 type PolicyStatus = 'allowed' | 'blocked' | 'audit' | 'no_policy';
 
-async function getPolicyStatusMap(orgId: string): Promise<Map<string, PolicyStatus>> {
+async function getPolicyStatusMap(orgFilter: SQL | undefined): Promise<Map<string, PolicyStatus>> {
+  const conditions: SQL[] = [eq(softwarePolicies.isActive, true)];
+  if (orgFilter) conditions.push(orgFilter);
   const policies = await db
     .select({
       mode: softwarePolicies.mode,
@@ -112,7 +134,7 @@ async function getPolicyStatusMap(orgId: string): Promise<Map<string, PolicyStat
       isActive: softwarePolicies.isActive,
     })
     .from(softwarePolicies)
-    .where(and(eq(softwarePolicies.orgId, orgId), eq(softwarePolicies.isActive, true)));
+    .where(and(...conditions));
 
   const statusMap = new Map<string, PolicyStatus>();
 
@@ -208,13 +230,14 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
   const perms = c.get('permissions') as UserPermissions | undefined;
   const { search, vendor, limit, offset, sortBy, sortOrder } = c.req.valid('query');
 
-  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
-  if ('error' in orgResult) {
-    return c.json({ error: orgResult.error }, orgResult.status);
+  const orgScope = resolveOrgReadScope(auth, c.req.query('orgId'));
+  if ('error' in orgScope) {
+    return c.json({ error: orgScope.error }, orgScope.status);
   }
-  const { orgId } = orgResult;
 
-  const conditions: SQL[] = [eq(devices.orgId, orgId)];
+  const conditions: SQL[] = [];
+  const deviceOrgFilter = orgScope.applyTo(devices.orgId);
+  if (deviceOrgFilter) conditions.push(deviceOrgFilter);
   if (perms?.allowedSiteIds) {
     if (perms.allowedSiteIds.length === 0) {
       return c.json({ data: [], pagination: { total: 0, limit, offset } });
@@ -231,7 +254,9 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
     conditions.push(sql`LOWER(COALESCE(${softwareInventory.vendor}, '')) LIKE LOWER(${'%' + escaped + '%'})`);
   }
 
-  const whereClause = and(...conditions);
+  // System-scope "All Orgs" with no search/site filter leaves conditions empty;
+  // fall back to TRUE so the raw-SQL WHERE clause stays valid (RLS still scopes).
+  const whereClause = conditions.length > 0 ? and(...conditions) : sql`TRUE`;
 
   // Count total unique software entries
   const countResult = await db.execute(sql`
@@ -272,7 +297,7 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
   `);
 
   // Build policy status map
-  const policyStatusMap = await getPolicyStatusMap(orgId);
+  const policyStatusMap = await getPolicyStatusMap(orgScope.applyTo(softwarePolicies.orgId));
 
   // Process results
   const data = (rows as unknown as Array<{
@@ -660,16 +685,16 @@ softwareInventoryRoutes.get('/:name/devices', requireSoftwareInventoryRead, zVal
   const softwareName = decodeURIComponent(c.req.param('name'));
   const { vendor, limit, offset } = c.req.valid('query');
 
-  const orgResult = resolveOrgId(auth, c.req.query('orgId'));
-  if ('error' in orgResult) {
-    return c.json({ error: orgResult.error }, orgResult.status);
+  const orgScope = resolveOrgReadScope(auth, c.req.query('orgId'));
+  if ('error' in orgScope) {
+    return c.json({ error: orgScope.error }, orgScope.status);
   }
-  const { orgId } = orgResult;
 
   const conditions: SQL[] = [
-    eq(devices.orgId, orgId),
     sql`LOWER(${softwareInventory.name}) = LOWER(${softwareName})`,
   ];
+  const deviceOrgFilter = orgScope.applyTo(devices.orgId);
+  if (deviceOrgFilter) conditions.push(deviceOrgFilter);
   if (perms?.allowedSiteIds) {
     if (perms.allowedSiteIds.length === 0) {
       return c.json({

--- a/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
+++ b/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { inArray } from 'drizzle-orm';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -409,7 +410,9 @@ describe('software inventory routes', () => {
           scope: 'partner',
           orgId: null,
           accessibleOrgIds: ['org-a', 'org-b'],
-          orgCondition: () => undefined,
+          // Real partner orgCondition narrows to the accessible orgs (not undefined,
+          // which would exercise the system-scope path instead).
+          orgCondition: (col: any) => inArray(col, ['org-a', 'org-b']),
           canAccessOrg: () => true,
         });
         return next();
@@ -424,6 +427,7 @@ describe('software inventory routes', () => {
       });
 
       expect(res.status).toBe(200);
+      expect((await res.json()).pagination.total).toBe(0);
     });
   });
 

--- a/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
+++ b/apps/api/src/routes/softwareInventory_deny_clear_devices.test.ts
@@ -397,7 +397,11 @@ describe('software inventory routes', () => {
       expect(body.data).toHaveLength(0);
     });
 
-    it('returns 400 when no org context', async () => {
+    // "All Orgs": a partner/multi-org caller with no orgId now drills down across
+    // every accessible org (via auth.orgCondition) instead of 400ing — matching
+    // the aggregate list. The old #620 "Organization context required" contract
+    // no longer applies to this read endpoint.
+    it('aggregates across accessible orgs when no orgId is provided (All Orgs)', async () => {
       const { authMiddleware } = await import('../middleware/auth');
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
         c.set('auth', {
@@ -405,17 +409,21 @@ describe('software inventory routes', () => {
           scope: 'partner',
           orgId: null,
           accessibleOrgIds: ['org-a', 'org-b'],
+          orgCondition: () => undefined,
           canAccessOrg: () => true,
         });
         return next();
       });
+
+      mockSelectFromInnerJoinWhere([{ count: 0 }]);
+      mockSelectFromInnerJoinWhereOrderByLimitOffset([]);
 
       const res = await app.request('/software-inventory/TestApp/devices', {
         method: 'GET',
         headers: { Authorization: 'Bearer token' },
       });
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
     });
   });
 

--- a/apps/api/src/routes/softwareInventory_list_approve.test.ts
+++ b/apps/api/src/routes/softwareInventory_list_approve.test.ts
@@ -206,7 +206,11 @@ describe('software inventory routes', () => {
       expect(body.pagination.total).toBe(2);
     });
 
-    it('returns 400 when no org context', async () => {
+    // "All Orgs": a partner/multi-org caller with no orgId now aggregates across
+    // every accessible org (via auth.orgCondition) instead of 400ing. This
+    // supersedes the old #620 "Organization context required" contract for the
+    // inventory READ endpoints; the policy writes still require a single org.
+    it('aggregates across accessible orgs when no orgId is provided (All Orgs)', async () => {
       const { authMiddleware } = await import('../middleware/auth');
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
         c.set('auth', {
@@ -214,19 +218,23 @@ describe('software inventory routes', () => {
           scope: 'partner',
           orgId: null,
           accessibleOrgIds: ['org-a', 'org-b'],
+          orgCondition: () => undefined,
           canAccessOrg: () => true,
         });
         return next();
       });
+
+      mockSelectFromWhere([]); // getPolicyStatusMap
+      vi.mocked(db.execute)
+        .mockResolvedValueOnce([{ total: '0' }] as any)
+        .mockResolvedValueOnce([] as any);
 
       const res = await app.request('/software-inventory', {
         method: 'GET',
         headers: { Authorization: 'Bearer token' },
       });
 
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(body.error).toContain('Organization context required');
+      expect(res.status).toBe(200);
     });
 
     it('filters by search term', async () => {

--- a/apps/api/src/routes/softwareInventory_list_approve.test.ts
+++ b/apps/api/src/routes/softwareInventory_list_approve.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { inArray } from 'drizzle-orm';
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -218,7 +219,9 @@ describe('software inventory routes', () => {
           scope: 'partner',
           orgId: null,
           accessibleOrgIds: ['org-a', 'org-b'],
-          orgCondition: () => undefined,
+          // Real partner orgCondition narrows to the accessible orgs (not undefined,
+          // which would exercise the system-scope path instead).
+          orgCondition: (col: any) => inArray(col, ['org-a', 'org-b']),
           canAccessOrg: () => true,
         });
         return next();
@@ -235,6 +238,7 @@ describe('software inventory routes', () => {
       });
 
       expect(res.status).toBe(200);
+      expect((await res.json()).pagination.total).toBe(0);
     });
 
     it('filters by search term', async () => {


### PR DESCRIPTION
## Problem

Selecting **All Orgs** on the Software Inventory page failed with *"Failed to load software inventory."* The web client omits `orgId` when no org is selected, and the route deliberately rejected that with `400 "Organization context required"` — a design decision from #620, which required partner/multi-org users to pick a specific org for these routes. So "All Orgs" was never supported here, unlike the Devices page.

## Fix

Added `resolveOrgReadScope` for the two **read** endpoints — the aggregate list (`GET /`) and the device drilldown (`GET /:name/devices`):

- **No `orgId`** → scope across every accessible org via `auth.orgCondition()` (the same `inArray(accessibleOrgIds)` / RLS pattern the Devices list uses). System scope adds no filter and relies on RLS.
- **`orgId` provided** → validated with `auth.canAccessOrg()`; foreign org → `403`.
- `getPolicyStatusMap()` takes the same org filter so policy badges aggregate too.
- `WHERE TRUE` fallback covers the system-scope/no-filter case in the raw SQL.

The policy **write** endpoints (`/approve`, `/deny`, `/clear`) still use the single-org `resolveOrgId` — writing a policy needs a specific target org, so the #620 contract still holds there. No frontend change required.

## Behavior change vs #620

This intentionally supersedes #620's *"missing orgId ⇒ 400"* rule **for the software-inventory read endpoints only** (catalog / discovery / Huntress routes are unchanged). Decision confirmed with the product owner: aggregate across all orgs, matching the Devices page.

## Tests

- New cases in `softwareInventory.test.ts`: partner multi-org aggregation (asserts both org IDs in the SQL), system-scope all-orgs, explicit-org scoping, foreign-org `403`, and the drilldown all-orgs case.
- Updated the three pre-existing tests that asserted the old #620 `400` contract for the read endpoints (`softwareInventory_list_approve`, `softwareInventory_deny_clear_devices`, and the `partner_multi_org_orgid` #620 suite), each annotated with the read-endpoint exception.
- **73 tests pass** across the 7 software-inventory test files; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)