### PR TITLE
docs(ml): device-instability shadow model — execution addendum + Phase A plan

### DIFF
--- a/docs/superpowers/plans/2026-06-23-ml-device-instability-shadow-phase-a.md
+++ b/docs/superpowers/plans/2026-06-23-ml-device-instability-shadow-phase-a.md
@@ -1,0 +1,500 @@
+# Device Instability Shadow Model — Phase A (Foundation & Contracts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the tenant-isolated foundation for the device-instability shadow model — feature flag, the `device_instability_candidates` table (RLS + cascade), and an empty (zeroed) evaluation endpoint behind authz — without the scorer.
+
+**Architecture:** Pure additive foundation in the existing TypeScript/Hono/Drizzle/Postgres stack. A new Shape-1 (direct `org_id`) tenant table mirrors `metric_anomalies`. A new ML feature flag (default off) gates all future writes. An empty admin evaluation endpoint establishes the contract Phase C will fill. No worker, no scoring, no UI in this phase.
+
+**Tech Stack:** Hono, Drizzle ORM, PostgreSQL (hand-written idempotent SQL migrations), Vitest (unit + integration configs), BullMQ (not used until Phase B).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-23-ml-device-instability-shadow-execution-addendum.md` (extends `internal/specs/2026-06-19-ml-device-instability-shadow-plan.md`). Where they conflict, the addendum wins.
+- **Phase B gate:** Do NOT build the scorer in this plan. The scorer depends on reliability v0 fix PR #1851 being merged. This plan is Phase A only and ships independently.
+- **Out of scope here:** the `device_status_changes` flap ledger (deferred per addendum §#2), the scorer/worker (Phase B), evaluation logic (Phase C), UI (Phase D).
+- **Migrations:** hand-written SQL under `apps/api/migrations/`, filename `YYYY-MM-DD-<slug>.sql`, fully idempotent (`IF NOT EXISTS`, `DROP POLICY IF EXISTS` then `CREATE`), no inner `BEGIN;`/`COMMIT;` (autoMigrate wraps each file in a transaction). Never edit a shipped migration.
+- **Tenant isolation:** new tenant table MUST enable + force RLS with `breeze_has_org_access(org_id)` policies for all four DML commands, and `GRANT ... TO breeze_app`. A direct-`org_id` Shape-1 table is auto-discovered by the RLS coverage contract test — no allowlist entry. It MUST be added to `ORG_CASCADE_DELETE_ORDER` in `localeCompare` order.
+- **Flag default:** `ml.device_instability.shadow.enabled` defaults to `false` (off until baked).
+- **Model version constant:** `device-instability-v0-shadow`. Horizon default: `72` hours.
+- **Node:** prefix `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH` for all pnpm/vitest commands.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `apps/api/src/services/mlFeatureFlags.ts` | Register the new flag + its default | Modify |
+| `apps/api/src/services/mlFeatureFlags.test.ts` | Assert the new flag's default | Modify |
+| `apps/api/migrations/2026-06-23-device-instability-candidates.sql` | Create table + RLS + indexes | Create |
+| `apps/api/src/db/schema/analytics.ts` | Drizzle definition for the new table | Modify |
+| `apps/api/src/db/schema/index.ts` | (already `export * from './analytics'` — verify) | Verify |
+| `apps/api/src/services/tenantCascade.ts` | Add table to `ORG_CASCADE_DELETE_ORDER` | Modify |
+| `apps/api/src/services/deviceInstability.ts` | Pure `emptyInstabilityEvaluationSummary()` + types | Create |
+| `apps/api/src/services/deviceInstability.test.ts` | Unit-test the empty summary | Create |
+| `apps/api/src/routes/reliability.ts` | Add `GET /instability/evaluation` handler | Modify |
+| `apps/api/src/routes/reliability.test.ts` | Route test for the new endpoint | Modify |
+
+---
+
+## Task 1: Register the `ml.device_instability.shadow.enabled` feature flag
+
+**Files:**
+- Modify: `apps/api/src/services/mlFeatureFlags.ts` (the `ML_FEATURE_FLAGS` array, lines 6-18; `defaultMlFeatureFlagValue`, lines 100-120)
+- Test: `apps/api/src/services/mlFeatureFlags.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the flag literal `'ml.device_instability.shadow.enabled'` is now a valid `MlFeatureFlagName`; `defaultMlFeatureFlagValue('ml.device_instability.shadow.enabled', …)` returns `false`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/src/services/mlFeatureFlags.test.ts`, inside the existing defaults `describe` block:
+
+```typescript
+it('defaults the device-instability shadow flag to off (off until baked)', () => {
+  expect(defaultMlFeatureFlagValue('ml.device_instability.shadow.enabled', { nodeEnv: 'production' })).toBe(false);
+  expect(defaultMlFeatureFlagValue('ml.device_instability.shadow.enabled', { nodeEnv: 'development' })).toBe(false);
+});
+
+it('lists the device-instability shadow flag as a known ML flag', () => {
+  expect(ML_FEATURE_FLAGS).toContain('ml.device_instability.shadow.enabled');
+});
+```
+
+If `ML_FEATURE_FLAGS` is not already imported in the test file, add it to the existing import from `./mlFeatureFlags`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm exec vitest run src/services/mlFeatureFlags.test.ts`
+Expected: FAIL — the flag string is not assignable to `MlFeatureFlagName` (type error) / `ML_FEATURE_FLAGS` does not contain it.
+
+- [ ] **Step 3: Add the flag to the array**
+
+In `apps/api/src/services/mlFeatureFlags.ts`, add the entry to `ML_FEATURE_FLAGS` (keep the existing entries; append after `'ml.user_risk_v1.enabled'`):
+
+```typescript
+export const ML_FEATURE_FLAGS = [
+  'ml.alert_correlation.enabled',
+  'ml.rca.enabled',
+  'ml.metric_rollups.enabled',
+  'ml.anomalies.enabled',
+  'ml.anomalies.v1_shadow.enabled',
+  'ml.anomalies.create_alerts',
+  'ml.remediation_suggestions.enabled',
+  'ml.ticket_triage.enabled',
+  'ml.device_reliability.enabled',
+  'ml.user_risk_v0.enabled',
+  'ml.user_risk_v1.enabled',
+  'ml.device_instability.shadow.enabled',
+] as const;
+```
+
+No change to `defaultMlFeatureFlagValue` is needed: the final `return false;` already makes it default-off. (The test asserts that explicitly so the default can't silently flip later.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && pnpm exec vitest run src/services/mlFeatureFlags.test.ts`
+Expected: PASS (all cases, including the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/mlFeatureFlags.ts apps/api/src/services/mlFeatureFlags.test.ts
+git commit -m "feat(ml): register ml.device_instability.shadow.enabled flag (default off)"
+```
+
+---
+
+## Task 2: Create the `device_instability_candidates` table (migration + schema + cascade)
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-23-device-instability-candidates.sql`
+- Modify: `apps/api/src/db/schema/analytics.ts` (append the table; reuse existing imports at lines 1-17)
+- Verify: `apps/api/src/db/schema/index.ts` already has `export * from './analytics';`
+- Modify: `apps/api/src/services/tenantCascade.ts` (`ORG_CASCADE_DELETE_ORDER`, lines 63-154)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: Drizzle table `deviceInstabilityCandidates` (exported from `db/schema`), backing SQL table `device_instability_candidates` with RLS + cascade. Columns later tasks/phases rely on: `id, orgId, deviceId, modelVersion, windowStart, windowEnd, predictedHorizonHours, score, riskLevel, topSignals, evidence, outcomeSummary, readinessState, baselineStartedAt, createdAt, updatedAt`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-23-device-instability-candidates.sql`:
+
+```sql
+-- Device instability shadow model output (ML next phase, Phase A foundation).
+-- Direct org_id RLS shape 1. Idempotent throughout.
+-- autoMigrate wraps this file in a transaction (no inner BEGIN/COMMIT).
+
+CREATE TABLE IF NOT EXISTS device_instability_candidates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  model_version VARCHAR(60) NOT NULL DEFAULT 'device-instability-v0-shadow',
+  window_start TIMESTAMP NOT NULL,
+  window_end TIMESTAMP NOT NULL,
+  predicted_horizon_hours INTEGER NOT NULL DEFAULT 72,
+  score INTEGER NOT NULL DEFAULT 0,
+  risk_level VARCHAR(20) NOT NULL DEFAULT 'low',
+  readiness_state VARCHAR(20) NOT NULL DEFAULT 'learning',
+  baseline_started_at TIMESTAMP,
+  top_signals JSONB NOT NULL DEFAULT '[]'::jsonb,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  outcome_summary JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT device_instability_risk_level_check CHECK (
+    risk_level IN ('low', 'medium', 'high', 'critical')
+  ),
+  CONSTRAINT device_instability_readiness_check CHECK (
+    readiness_state IN ('learning', 'ready', 'insufficient_data')
+  ),
+  CONSTRAINT device_instability_window_check CHECK (window_start < window_end),
+  CONSTRAINT device_instability_horizon_check CHECK (predicted_horizon_hours > 0),
+  CONSTRAINT device_instability_score_check CHECK (score >= 0 AND score <= 100),
+  CONSTRAINT device_instability_top_signals_array_check CHECK (jsonb_typeof(top_signals) = 'array'),
+  CONSTRAINT device_instability_evidence_object_check CHECK (jsonb_typeof(evidence) = 'object'),
+  CONSTRAINT device_instability_top_signals_size_check CHECK (octet_length(top_signals::text) <= 8192),
+  CONSTRAINT device_instability_evidence_size_check CHECK (octet_length(evidence::text) <= 8192),
+  CONSTRAINT device_instability_outcome_summary_object_check CHECK (
+    outcome_summary IS NULL OR jsonb_typeof(outcome_summary) = 'object'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS device_instability_candidates_key_uq
+  ON device_instability_candidates (
+    org_id,
+    device_id,
+    model_version,
+    window_end,
+    predicted_horizon_hours
+  );
+
+CREATE INDEX IF NOT EXISTS device_instability_org_risk_created_idx
+  ON device_instability_candidates (org_id, risk_level, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS device_instability_device_created_idx
+  ON device_instability_candidates (device_id, created_at DESC);
+
+ALTER TABLE device_instability_candidates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE device_instability_candidates FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON device_instability_candidates;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON device_instability_candidates;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON device_instability_candidates;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON device_instability_candidates;
+
+CREATE POLICY breeze_org_isolation_select ON device_instability_candidates
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON device_instability_candidates
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON device_instability_candidates
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON device_instability_candidates
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE device_instability_candidates TO breeze_app;
+```
+
+- [ ] **Step 2: Verify the migration applies idempotently on a throwaway Postgres**
+
+Run (applies twice; second run must be a clean no-op):
+
+```bash
+cd apps/api
+docker run --rm -d --name breeze-mig-check -e POSTGRES_PASSWORD=pw -p 55432:5432 postgres:16
+sleep 4
+# minimal prerequisites: the helper fn + referenced tables must exist for a real apply;
+# for a syntax/idempotency check, apply just this file twice against a DB where they exist,
+# or rely on the full `pnpm db:check-drift` path below which runs the whole migration set.
+docker exec -i breeze-mig-check psql -U postgres -c "SELECT 1;" >/dev/null && echo "pg up"
+docker rm -f breeze-mig-check
+```
+
+Expected: container starts and stops cleanly. (Full apply happens via `db:check-drift` in Step 5, which runs the entire ordered migration set including the `breeze_has_org_access` function and `organizations`/`devices` tables.)
+
+- [ ] **Step 3: Add the Drizzle schema definition**
+
+In `apps/api/src/db/schema/analytics.ts`, append after the `metricAnomalies`/`metricAnomalyCandidates` definitions (the imports at lines 1-17 already include `pgTable, uuid, varchar, timestamp, jsonb, integer, index, uniqueIndex` and `organizations`, `devices`):
+
+```typescript
+export const deviceInstabilityCandidates = pgTable('device_instability_candidates', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  deviceId: uuid('device_id').notNull().references(() => devices.id, { onDelete: 'cascade' }),
+  modelVersion: varchar('model_version', { length: 60 }).notNull().default('device-instability-v0-shadow'),
+  windowStart: timestamp('window_start').notNull(),
+  windowEnd: timestamp('window_end').notNull(),
+  predictedHorizonHours: integer('predicted_horizon_hours').notNull().default(72),
+  score: integer('score').notNull().default(0),
+  riskLevel: varchar('risk_level', { length: 20 }).notNull().default('low'),
+  readinessState: varchar('readiness_state', { length: 20 }).notNull().default('learning'),
+  baselineStartedAt: timestamp('baseline_started_at'),
+  topSignals: jsonb('top_signals').notNull().default([]),
+  evidence: jsonb('evidence').notNull().default({}),
+  outcomeSummary: jsonb('outcome_summary'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  keyUniq: uniqueIndex('device_instability_candidates_key_uq').on(
+    table.orgId,
+    table.deviceId,
+    table.modelVersion,
+    table.windowEnd,
+    table.predictedHorizonHours
+  ),
+  orgRiskCreatedIdx: index('device_instability_org_risk_created_idx').on(table.orgId, table.riskLevel, table.createdAt),
+  deviceCreatedIdx: index('device_instability_device_created_idx').on(table.deviceId, table.createdAt)
+}));
+```
+
+- [ ] **Step 4: Add the cascade-order entry**
+
+In `apps/api/src/services/tenantCascade.ts`, add `'device_instability_candidates'` to `ORG_CASCADE_DELETE_ORDER` in `localeCompare` position — it sorts between `'device_hardware'` and `'device_ip_history'`:
+
+```typescript
+  'device_hardware',
+  'device_instability_candidates',
+  'device_ip_history',
+```
+
+(Verify with `node -e "const a=['device_hardware','device_instability_candidates','device_ip_history']; console.log(JSON.stringify([...a].sort((x,y)=>x.localeCompare(y)))===JSON.stringify(a))"` → must print `true`.)
+
+- [ ] **Step 5: Verify schema/migration agree (drift) and types compile**
+
+Run:
+
+```bash
+cd /Users/toddhebebrand/breeze
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:check-drift
+cd apps/api && pnpm exec tsc --noEmit -p tsconfig.json
+```
+
+Expected: `db:check-drift` reports no drift (schema matches the migration); `tsc` exits 0.
+
+- [ ] **Step 6: Verify RLS + cascade contracts (real DB integration tests)**
+
+These run in the Integration Tests CI job; run locally against the test DB. Per repo convention they live in `src/__tests__/integration/*` and need a real `breeze_app` DB:
+
+```bash
+cd apps/api
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5433/breeze"   # test DB
+pnpm exec vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts
+```
+
+Expected: PASS — the new `org_id` table is auto-discovered and its four policies + FORCE RLS are present, so it does NOT appear in `offenders`. Then forge a cross-tenant insert as `breeze_app` and confirm it fails with `new row violates row-level security policy` (per CLAUDE.md verification step). Also run the org-cascade contract test in the same integration suite to confirm the new table is registered (a miss only shows here, not in unit tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-23-device-instability-candidates.sql \
+        apps/api/src/db/schema/analytics.ts \
+        apps/api/src/services/tenantCascade.ts
+git commit -m "feat(ml): device_instability_candidates table (RLS shape-1 + cascade)"
+```
+
+---
+
+## Task 3: Empty instability evaluation endpoint (behind authz)
+
+**Files:**
+- Create: `apps/api/src/services/deviceInstability.ts`
+- Create: `apps/api/src/services/deviceInstability.test.ts`
+- Modify: `apps/api/src/routes/reliability.ts` (imports lines 1-15; add handler; router defined at the `export const reliabilityRoutes = new Hono()` line)
+- Modify: `apps/api/src/routes/reliability.test.ts`
+
+**Interfaces:**
+- Consumes: `requireScope`, `requirePermission`/`requireReliabilityRead`, `authMiddleware` (already imported/used in `reliability.ts`); `zValidator`, `z`.
+- Produces: exported `InstabilityEvaluationRange = '7d' | '30d' | '90d'`, `InstabilityEvaluationSummary` interface, and `emptyInstabilityEvaluationSummary(range: InstabilityEvaluationRange): InstabilityEvaluationSummary`. New route `GET /reliability/instability/evaluation?range=30d`.
+
+- [ ] **Step 1: Write the failing unit test for the pure summary**
+
+Create `apps/api/src/services/deviceInstability.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { emptyInstabilityEvaluationSummary } from './deviceInstability';
+
+describe('emptyInstabilityEvaluationSummary', () => {
+  it('returns a zeroed summary with the model version and requested range', () => {
+    const summary = emptyInstabilityEvaluationSummary('30d');
+    expect(summary.modelVersion).toBe('device-instability-v0-shadow');
+    expect(summary.window).toEqual({ range: '30d' });
+    expect(summary.totalCandidates).toBe(0);
+    expect(summary.byRiskLevel).toEqual({ low: 0, medium: 0, high: 0, critical: 0 });
+    expect(summary.byReadiness).toEqual({ learning: 0, ready: 0, insufficient_data: 0 });
+    expect(summary.outcomes).toEqual({ within72h: 0, highOrCriticalWithin72h: 0, highOrCriticalNoOutcome: 0 });
+    expect(summary.rates).toEqual({ highOrCriticalOutcomeRate: null, mediumPlusOutcomeRate: null });
+  });
+
+  it('echoes other valid ranges', () => {
+    expect(emptyInstabilityEvaluationSummary('7d').window).toEqual({ range: '7d' });
+    expect(emptyInstabilityEvaluationSummary('90d').window).toEqual({ range: '90d' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm exec vitest run src/services/deviceInstability.test.ts`
+Expected: FAIL — module `./deviceInstability` does not exist.
+
+- [ ] **Step 3: Implement the pure summary module**
+
+Create `apps/api/src/services/deviceInstability.ts`:
+
+```typescript
+// Device instability shadow model — evaluation contract (Phase A).
+// The scorer (Phase B) and real evaluation (Phase C) are not built yet; this
+// module pins the response shape so the admin endpoint exists and is testable.
+
+export const DEVICE_INSTABILITY_MODEL_VERSION = 'device-instability-v0-shadow';
+
+export type InstabilityEvaluationRange = '7d' | '30d' | '90d';
+
+export interface InstabilityEvaluationSummary {
+  modelVersion: string;
+  window: { range: InstabilityEvaluationRange };
+  totalCandidates: number;
+  byRiskLevel: { low: number; medium: number; high: number; critical: number };
+  byReadiness: { learning: number; ready: number; insufficient_data: number };
+  outcomes: { within72h: number; highOrCriticalWithin72h: number; highOrCriticalNoOutcome: number };
+  // Rates are null when there is nothing to divide by (no candidates yet).
+  rates: { highOrCriticalOutcomeRate: number | null; mediumPlusOutcomeRate: number | null };
+}
+
+export function emptyInstabilityEvaluationSummary(
+  range: InstabilityEvaluationRange,
+): InstabilityEvaluationSummary {
+  return {
+    modelVersion: DEVICE_INSTABILITY_MODEL_VERSION,
+    window: { range },
+    totalCandidates: 0,
+    byRiskLevel: { low: 0, medium: 0, high: 0, critical: 0 },
+    byReadiness: { learning: 0, ready: 0, insufficient_data: 0 },
+    outcomes: { within72h: 0, highOrCriticalWithin72h: 0, highOrCriticalNoOutcome: 0 },
+    rates: { highOrCriticalOutcomeRate: null, mediumPlusOutcomeRate: null },
+  };
+}
+```
+
+- [ ] **Step 4: Run unit test to verify it passes**
+
+Run: `cd apps/api && pnpm exec vitest run src/services/deviceInstability.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the route handler**
+
+In `apps/api/src/routes/reliability.ts`, add to the imports near the top:
+
+```typescript
+import {
+  emptyInstabilityEvaluationSummary,
+  type InstabilityEvaluationRange,
+} from '../services/deviceInstability';
+```
+
+Then, after the existing `reliabilityRoutes.use('*', authMiddleware);` line and alongside the other handlers, add:
+
+```typescript
+const instabilityEvaluationQuerySchema = z.object({
+  range: z.enum(['7d', '30d', '90d']).default('30d'),
+  orgId: z.string().uuid().optional(),
+});
+
+// Internal/admin preview of the device-instability shadow model's quality.
+// Phase A: returns a zeroed summary (no candidates produced yet) behind the same
+// authz as the reliability surface. Phase C fills in real aggregation.
+reliabilityRoutes.get(
+  '/instability/evaluation',
+  requireScope('organization', 'partner', 'system'),
+  requireReliabilityRead,
+  zValidator('query', instabilityEvaluationQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+
+    if (query.orgId && !auth.canAccessOrg(query.orgId)) {
+      return c.json({ error: 'Access denied to this organization' }, 403);
+    }
+
+    return c.json(emptyInstabilityEvaluationSummary(query.range as InstabilityEvaluationRange));
+  }
+);
+```
+
+(If `z` / `zValidator` / `requireScope` / `requireReliabilityRead` are not already imported in this file, they are — see the existing handlers; reuse them.)
+
+- [ ] **Step 6: Write the route test**
+
+Add to `apps/api/src/routes/reliability.test.ts`, mirroring the auth-mock setup already used by the other cases in that file (same `app`/request harness and mocked `auth` context):
+
+```typescript
+describe('GET /reliability/instability/evaluation', () => {
+  it('returns a zeroed summary for an authorized org-scope request', async () => {
+    const res = await testRequest('/reliability/instability/evaluation?range=30d', { scope: 'organization' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.modelVersion).toBe('device-instability-v0-shadow');
+    expect(body.window).toEqual({ range: '30d' });
+    expect(body.totalCandidates).toBe(0);
+    expect(body.byRiskLevel).toEqual({ low: 0, medium: 0, high: 0, critical: 0 });
+  });
+
+  it('defaults range to 30d when omitted', async () => {
+    const res = await testRequest('/reliability/instability/evaluation', { scope: 'organization' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).window).toEqual({ range: '30d' });
+  });
+
+  it('rejects an invalid range', async () => {
+    const res = await testRequest('/reliability/instability/evaluation?range=bogus', { scope: 'organization' });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+Note: `testRequest(path, { scope })` is a stand-in for whatever request helper `reliability.test.ts` already defines (it sets up `authMiddleware`/`auth` context). Use that file's existing helper and auth-mock pattern verbatim — do not invent a new harness. If the existing tests assert on `res.status`/`res.json()` directly via `app.request(...)`, follow that exact form instead.
+
+- [ ] **Step 7: Run the route test + typecheck**
+
+Run:
+```bash
+cd apps/api
+pnpm exec vitest run src/routes/reliability.test.ts src/services/deviceInstability.test.ts
+pnpm exec tsc --noEmit -p tsconfig.json
+```
+Expected: PASS; `tsc` exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/services/deviceInstability.ts \
+        apps/api/src/services/deviceInstability.test.ts \
+        apps/api/src/routes/reliability.ts \
+        apps/api/src/routes/reliability.test.ts
+git commit -m "feat(ml): empty device-instability evaluation endpoint behind authz"
+```
+
+---
+
+## Phase A Done / Next
+
+After all three tasks: the flag exists (off), the tenant-isolated table exists with passing RLS + cascade + drift checks, and `GET /reliability/instability/evaluation` returns a zeroed, range-validated summary behind authz. No behavior changes for users; nothing writes candidates yet.
+
+**Not in this plan (separate plans, in order):**
+1. **Phase B — Scorer v0** (gated on #1851): signal extractors (event-log bursts, metric anomalies, patch failures, reliability degradation; connectivity via last-seen/missed-check-ins), weighted score + readiness/learning caps, idempotent upserts, the `device-instability-shadow` BullMQ worker (mirror `reliabilityWorker.ts` init/shutdown + `index.ts` registration), all gated by `ml.device_instability.shadow.enabled`.
+2. **Phase C — Evaluation:** fill `emptyInstabilityEvaluationSummary` with real outcome-linked aggregation; backfill for internal orgs.
+3. **Phase D — Preview UI:** device-detail panel + minimal org-wide internal list.
+4. **Deferred — flap ledger:** `device_status_changes` + `offlineDetector` write hook (needed for the connectivity flap feature).
+
+## Self-Review
+
+- **Spec coverage (addendum Phase A items):** feature flag → Task 1 ✓; `device_instability_candidates` schema/migration/RLS/cascade → Task 2 ✓; empty evaluation endpoint behind authz → Task 3 ✓. Plumbing checklist: flag ✓, RLS shape-1 auto-discovery (no allowlist) ✓, cascade order ✓, FK ON DELETE CASCADE ✓. Worker/scorer/ledger correctly deferred (out of Phase A scope) ✓.
+- **Placeholder scan:** no TBD/TODO; all SQL, schema, and TypeScript shown in full. The one soft reference (route-test harness `testRequest`) is explicitly pinned to the existing `reliability.test.ts` pattern with a fallback to `app.request(...)`, because that harness already exists and must not be reinvented.
+- **Type consistency:** `emptyInstabilityEvaluationSummary(range)` signature, `InstabilityEvaluationSummary` fields, and `DEVICE_INSTABILITY_MODEL_VERSION = 'device-instability-v0-shadow'` are identical across the service, its test, and the route. Drizzle column names match the SQL migration columns one-to-one (verified field by field). Cascade string `'device_instability_candidates'` matches the SQL table name and the Drizzle `pgTable` name.

--- a/docs/superpowers/specs/2026-06-23-ml-device-instability-shadow-execution-addendum.md
+++ b/docs/superpowers/specs/2026-06-23-ml-device-instability-shadow-execution-addendum.md
@@ -1,0 +1,166 @@
+# Device Instability Shadow Model — Execution Addendum
+
+**Status:** Execution-ready addendum (resolves open decisions + pins contracts)
+**Date:** 2026-06-23
+**Owner:** Todd
+**Extends (does NOT replace):** `internal/specs/2026-06-19-ml-device-instability-shadow-plan.md`
+**Related:** `internal/specs/2026-06-18-ml-roadmap-execution-plan.md`, reliability v0 fix PR #1851
+
+## Why this document exists
+
+The 2026-06-19 shadow plan is already ~90% a spec — table, signals, scoring v0,
+learning period, worker, evaluation, UI, Phase A–E sequence, test plan, promotion
+criteria. It is **not yet executable** for three reasons, which this addendum
+closes:
+
+1. Its four **Open Decisions** were unresolved.
+2. Its assumed input contracts ("where available") were not validated against the
+   current schema. One assumption is **false** (online/offline flap history does
+   not exist) and changes v0 scope.
+3. It predates the reliability v0 fix (#1851). The "reliability as input" signal
+   should read the corrected availability-based score, not the boot-snapshot one.
+
+Read the 2026-06-19 plan first. This document only records the deltas. Where the
+two conflict, **this addendum wins**.
+
+## Hard dependency on #1851
+
+The model consumes `device_reliability` as a feature (plan §5). Until #1851
+(uptime from observed availability) is merged, that feature is the broken
+boot-snapshot uptime — a routine reboot reads as ~5% uptime. **Do not start the
+scorer (Phase B) until #1851 is merged**, or the shadow model trains/evaluates on
+a signal we already know is wrong. Phases A (contracts) and the migration may
+proceed in parallel.
+
+## Resolved open decisions
+
+### #2 — Canonical online/offline flapping source → **does not exist; resolve by adding a prospective ledger; flapping deferred out of v0**
+
+The plan's connectivity signal (plan §3: "offline/online flaps in last 24h") is
+**not natively queryable**. The `devices` table carries only current
+`status` and `last_seen_at` (`apps/api/src/db/schema/devices.ts:66`); there is no
+`device_status_history`. `offlineDetector` (`apps/api/src/jobs/offlineDetector.ts`)
+derives offline by threshold but does not record the transition.
+
+Resolution:
+
+- **v0 connectivity signal uses only what exists today**, computed from
+  `last_seen_at`: *time since last seen* and *missed expected check-ins* (gaps in
+  reliability/heartbeat reporting vs the device's normal cadence). No flap count
+  in v0.
+- **Add a lightweight `device_status_changes` ledger** (org_id, device_id,
+  from_status, to_status, changed_at), written **prospectively** by
+  `offlineDetector` when it flips a device's status. No backfill. Once it has ≥24h
+  of data, the flap-count feature activates as an additive signal in a later
+  iteration — it is **not** a blocker for v0.
+- This keeps v0 shippable now and makes flapping a clean, additive follow-up.
+
+### #3 — Event-log rare-event / burst baseline granularity → **per-device/source/eventId, with org-wide (source,eventId) fallback**
+
+Validated feasible. `device_event_logs`
+(`apps/api/src/db/schema/eventLogs.ts:26`) has `device_id, org_id, timestamp,
+level, category, source, event_id, message, details`, with a dedup index on
+`(device_id, source, event_id)` (line 45) — that triple is the natural baseline
+grain.
+
+Resolution: compute burst/rare-event baselines **per (device, source, event_id)**;
+for devices with too little history (learning period), fall back to an **org-wide
+(source, event_id)** daily-median baseline. This directly supports the plan's
+`event_log_burst` evidence shape.
+
+### #1 — UI scope (product call) → **device-details preview AND a minimal internal/admin org-wide list**
+
+Recommended (override if you disagree): ship both. During a shadow/internal bake
+with zero labels, the org-wide list is what makes the model *useful to look at* —
+it answers "which devices would this flag fleet-wide?" The device-detail panel
+alone can't surface that. Keep the list minimal (risk level, top signal, last
+seen, candidate time; filters: risk, signal family, site) and clearly marked
+shadow/preview. Both stay behind the flag and never enter the alert inbox.
+
+### #4 — Merge into `device_reliability` vs separate forecast layer (product call) → **separate layer for now; revisit at Phase E**
+
+Recommended (override if you disagree): keep `device_instability_candidates` a
+distinct "instability forecast" layer, exactly as the plan's non-goals state ("do
+not replace the existing `device_reliability` score in this phase"). Merging is a
+one-way door; decide it at Phase E (Bake & Decision) once the precision proxy is
+known. Designing for separation now costs nothing and keeps the phase reversible.
+
+## Validated input contracts
+
+| Signal | Source (file:line) | Status | v0 use |
+|---|---|---|---|
+| Event-log crashes/bursts/rare events | `device_event_logs` (`eventLogs.ts:26`) | YES | per-device/source/eventId baseline + org-wide fallback (#3) |
+| Metric anomalies | `metric_anomalies` (`analytics.ts:65`), `metric_anomaly_candidates` (`analytics.ts:106`) | YES | open/high-confidence counts 24h/7d per device |
+| Patch/update failures | `patch_job_results` (`patches.ts:235`) — `status='failed'`, `error_message`, `completed_at` | YES | failed installs 7d, reboot-required-not-completed |
+| Reliability score + degradation | `device_reliability` (`reliability.ts:59`), `device_reliability_history` (`reliability.ts:42`) | YES (degradation via history query) | latest score + recent slope — **post-#1851** |
+| Connectivity | `devices.status` / `last_seen_at` (`devices.ts:66`) | PARTIAL | time-since-last-seen, missed check-ins; **flaps deferred (#2)** |
+
+## Plumbing checklist (exact registration points)
+
+The new `device_instability_candidates` table is a **Shape #1 direct-`org_id`**
+tenant table.
+
+- **Migration:** `CREATE TABLE IF NOT EXISTS`, RLS enabled + forced, policies
+  `breeze_has_org_access(org_id)`, FK `device_id → devices(id) ON DELETE CASCADE`,
+  unique key per plan (`org_id, device_id, model_version, window_end,
+  predicted_horizon_hours`). Idempotent per CLAUDE.md migration rules.
+- **RLS coverage:** Shape #1 is **auto-discovered** by
+  `rls-coverage.integration.test.ts` — no allowlist entry needed; the contract
+  test enforces the policies exist. (Run it locally against a real DB; verify a
+  cross-tenant insert fails as `breeze_app`.)
+- **Org cascade:** add `'device_instability_candidates'` to
+  `ORG_CASCADE_DELETE_ORDER` in `apps/api/src/services/tenantCascade.ts` in
+  `localeCompare` order (CLAUDE.md cascade-ordering rule). Only the Integration
+  Tests job catches a miss.
+- **Device cascade:** the `ON DELETE CASCADE` FK is the device-cascade mechanism
+  (same pattern as `device_reliability`); confirm device-delete in `core.ts` does
+  not need an explicit list entry for cascade-FK children.
+- **Feature flag:** add `'ml.device_instability.shadow.enabled'` to
+  `ML_FEATURE_FLAGS` and return `false` from `defaultMlFeatureFlagValue()` in
+  `apps/api/src/services/mlFeatureFlags.ts`. Worker checks it before any write.
+- **Worker:** new `apps/api/src/jobs/deviceInstabilityShadowWorker.ts` mirroring
+  `reliabilityWorker.ts` (lazy queue getter, init/shutdown exports); register in
+  the workers array in `apps/api/src/index.ts` next to
+  `initializeReliabilityWorker`. Queue `device-instability-shadow`; stable job IDs
+  and `withSystemDbAccessContext` per the plan's worker contract.
+- **Status-change ledger (for #2):** separate small migration for
+  `device_status_changes` + write hook in `offlineDetector.ts`. Independent of the
+  v0 critical path; can land before or after.
+
+## v0 signal scope (first build)
+
+Available **now**, ship in Phase B v0: event-log bursts/rare events, metric
+anomalies, patch failures, reliability score + degradation. **Deferred:** flap
+count (waits on the `device_status_changes` ledger accumulating data) — v0 still
+uses time-since-last-seen / missed check-ins for connectivity so the signal family
+is represented.
+
+## Retention (close the C4 gap for these tables)
+
+- `device_instability_candidates`: model output → 180–365d (enough to evaluate),
+  per roadmap C4. Add a bounded-batch cleanup worker.
+- `device_status_changes`: 30–90d is plenty for 24h/7d flap features.
+- **Pre-existing gap:** `device_reliability_history` has no retention policy
+  (validation finding). Not introduced here, but worth a separate ticket — the
+  degradation feature reads it and it grows unbounded at 10k+ agents.
+
+## Phase mapping (unchanged from the plan, with deltas)
+
+Follow the plan's Phase A–E. Deltas:
+
+- **Phase A** (contracts): also add the feature flag default and the (optional)
+  `device_status_changes` migration. RLS Shape #1 needs no allowlist entry.
+- **Phase B** (scorer v0): gated on #1851. Implement the v0 signal scope above;
+  flapping extractor stubbed until the ledger has data.
+- **Phase C** (evaluation): unchanged — the existing reliability evaluation harness
+  (`computeReliabilityEvaluationSummary`, `ml_feedback_events`) is the template.
+- **Phase D** (preview UI): build both surfaces per resolved Decision #1.
+- **Phase E** (bake & decide): includes the merge-vs-separate call (Decision #4)
+  and the flap-signal activation review.
+
+## What stays exactly as written in the 2026-06-19 plan
+
+Table columns, score bands, weight groups, learning-period policy
+(`learning`/`ready`/`insufficient_data`, 7/14-day baselines, 72h grace),
+evaluation metrics and response shape, worker contract, test plan, and promotion
+criteria are unchanged. This addendum does not restate them.


### PR DESCRIPTION
Two planning docs for the next ML phase (the "device instability" shadow model), building on the existing `internal/specs/2026-06-19-ml-device-instability-shadow-plan.md`. **Docs only — no code.**

**`docs/superpowers/specs/2026-06-23-ml-device-instability-shadow-execution-addendum.md`** — makes the 2026-06-19 plan executable: resolves its four open decisions, pins every input-signal contract to the current schema (file:line), and records the deltas from validating against code. Key finding: online/offline **flap history is not queryable** today (`devices` carries only current `status` + `last_seen_at`; no transition ledger), so v0 connectivity uses time-since-last-seen / missed check-ins and flap-count is deferred behind a future `device_status_changes` ledger. Also flags the hard dependency on the reliability v0 fix (#1851) before the scorer can train on a trustworthy reliability input.

**`docs/superpowers/plans/2026-06-23-ml-device-instability-shadow-phase-a.md`** — bite-sized TDD plan for the foundation that ships independently of the scorer: the `ml.device_instability.shadow.enabled` flag (default off), the `device_instability_candidates` table (RLS shape-1 + cascade + drift/contract verification), and an empty evaluation endpoint behind authz. Scorer (Phase B, gated on #1851), evaluation (C), UI (D), and the flap ledger are explicitly deferred to follow-on plans.

Context: the current `device_reliability` score is a deterministic heuristic (Phase 1 v0), not ML; there are 0 outcome labels in prod yet. This shadow model is the documented "collect data in shadow" next step before any trained model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)