### PR TITLE
fix(helper): honor per-session --config flag in tray config (#1856)

### DIFF
--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -210,8 +210,51 @@ fn helper_config_path() -> PathBuf {
     agent_config_path().with_file_name("helper_config.yaml")
 }
 
+/// Extract the value of a `--config <path>` / `--config=<path>` flag from an
+/// argv-style iterator.
+///
+/// The Go agent spawns the helper per user session with
+/// `--config <…/sessions/<key>/helper_config.yaml>` so that per-session policy
+/// values (tray item visibility, portal URL, device info) reach the helper
+/// (`agent/internal/helper/manager.go:447`, `session_state.go:43-49`). The
+/// helper must honor that flag; otherwise it falls back to the fixed path next
+/// to `agent.yaml`, which holds no policy values, and the tray silently shows
+/// the three `HelperConfig::default()` items regardless of policy (issue #1856).
+fn config_path_from_args<I, S>(args: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        let arg = arg.as_ref();
+        if arg == "--config" {
+            // `--config <path>` form — value is the next argument.
+            if let Some(value) = iter.next() {
+                let value = value.as_ref();
+                if !value.is_empty() {
+                    return Some(PathBuf::from(value));
+                }
+            }
+        } else if let Some(value) = arg.strip_prefix("--config=") {
+            // `--config=<path>` form.
+            if !value.is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
+    }
+    None
+}
+
+/// Resolve which helper config file to read: the per-session path supplied via
+/// `--config`, or the legacy fixed path next to `agent.yaml` when no flag is
+/// passed (preserves single-session behavior for older agents).
+fn resolve_helper_config_path() -> PathBuf {
+    config_path_from_args(std::env::args().skip(1)).unwrap_or_else(helper_config_path)
+}
+
 fn load_helper_config() -> HelperConfig {
-    let path = helper_config_path();
+    let path = resolve_helper_config_path();
     match std::fs::read_to_string(&path) {
         Ok(contents) => serde_yaml::from_str(&contents).unwrap_or_default(),
         Err(_) => HelperConfig::default(),
@@ -1075,6 +1118,55 @@ mod tests {
         assert!(value.get("token").is_none());
         assert_eq!(value["api_url"], "https://api.example.test");
         assert_eq!(value["agent_id"], "agent-1");
+    }
+
+    #[test]
+    fn config_path_from_args_parses_space_separated_flag() {
+        let args = vec![
+            "breeze-helper",
+            "--config",
+            "/var/lib/breeze/sessions/s-1/helper_config.yaml",
+        ];
+        assert_eq!(
+            config_path_from_args(args.into_iter().skip(1)),
+            Some(PathBuf::from(
+                "/var/lib/breeze/sessions/s-1/helper_config.yaml"
+            ))
+        );
+    }
+
+    #[test]
+    fn config_path_from_args_parses_equals_form() {
+        let args = vec!["--config=/etc/breeze/sessions/s-2/helper_config.yaml"];
+        assert_eq!(
+            config_path_from_args(args.into_iter()),
+            Some(PathBuf::from(
+                "/etc/breeze/sessions/s-2/helper_config.yaml"
+            ))
+        );
+    }
+
+    #[test]
+    fn config_path_from_args_returns_none_when_flag_absent() {
+        let args = vec!["breeze-helper", "--other", "value"];
+        assert_eq!(config_path_from_args(args.into_iter().skip(1)), None);
+    }
+
+    #[test]
+    fn config_path_from_args_ignores_empty_value() {
+        // `--config` with no following value, and `--config=` with an empty
+        // value, must both fall through to the fixed-path fallback (None here).
+        assert_eq!(config_path_from_args(vec!["--config"].into_iter()), None);
+        assert_eq!(config_path_from_args(vec!["--config="].into_iter()), None);
+    }
+
+    #[test]
+    fn config_path_from_args_takes_first_occurrence() {
+        let args = vec!["--config", "/first.yaml", "--config", "/second.yaml"];
+        assert_eq!(
+            config_path_from_args(args.into_iter()),
+            Some(PathBuf::from("/first.yaml"))
+        );
     }
 
     #[test]

--- a/apps/helper/src-tauri/src/lib.rs
+++ b/apps/helper/src-tauri/src/lib.rs
@@ -256,8 +256,32 @@ fn resolve_helper_config_path() -> PathBuf {
 fn load_helper_config() -> HelperConfig {
     let path = resolve_helper_config_path();
     match std::fs::read_to_string(&path) {
-        Ok(contents) => serde_yaml::from_str(&contents).unwrap_or_default(),
-        Err(_) => HelperConfig::default(),
+        Ok(contents) => match serde_yaml::from_str(&contents) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                // A corrupt/partial config silently reverts the tray to the
+                // three default items — the exact #1856 symptom. Log the path
+                // and error so a field verification can tell "fix didn't take"
+                // apart from "config file is malformed".
+                log_helper_error(&format!(
+                    "[helper] failed to parse helper config at {}: {}; using defaults",
+                    path.display(),
+                    e
+                ));
+                HelperConfig::default()
+            }
+        },
+        Err(e) => {
+            // A missing/unreadable per-session config also reverts to defaults.
+            // Logged so it is distinguishable from a successful policy that
+            // simply enables all three items.
+            log_helper_error(&format!(
+                "[helper] could not read helper config at {}: {}; using defaults",
+                path.display(),
+                e
+            ));
+            HelperConfig::default()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The Breeze Helper (Tauri tray app) **ignored the `--config <path>` argv** that the Go agent passes per user session, so Configuration Policy settings for Breeze Assist had no effect — the tray always showed the three default items (Request Support / Open Breeze Portal / Device Info).

**Root cause:** `load_helper_config()` always resolved a fixed path next to `agent.yaml` via `helper_config_path()` and never parsed `std::env::args()`. The agent writes the policy's helper config to `<…/sessions/<key>/helper_config.yaml>` and launches with `--config <that path>` (`agent/internal/helper/manager.go:447`, `session_state.go:43-49`), but that file was never read → fall back to `HelperConfig::default()` (all flags `true`) → the three default items. Both spawn-time and the 60s reload loop read the wrong path.

**Why #1382 didn't fix it:** #1382 fixed only the Go side (restart the helper to "re-read `--config`"), but the helper never read `--config` to begin with.

## Fix

- New `config_path_from_args()` parses `--config <path>` and `--config=<path>` from argv.
- New `resolve_helper_config_path()` returns the `--config` value, falling back to the fixed `helper_config_path()` only when no flag is supplied (preserves legacy single-session behavior for older agents).
- `load_helper_config()` now uses `resolve_helper_config_path()`, so **all four call sites** (spawn `lib.rs:928`, `open_portal` handler, and the 60s reload loop) honor the per-session file with no per-call changes.
- Adds 5 unit tests for the argv parser (space form, `=` form, absent flag, empty value, first-occurrence).

## Testing

- `cargo test --lib`: 38 passed (5 new). `cargo build`: clean (only pre-existing `tauri-plugin-shell` deprecation warnings, untouched by this change).

## Caveat — manual follow-up

Real **in-tray verification on Windows/macOS** could not be performed here (the GUI cannot run in this environment). A manual check that a policy hiding/showing tray items takes effect on a live device is recommended before considering this fully verified.

Refs #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)