### PR TITLE
fix(alerts): repair config-policy offline rules + remove dead network metric (#1857)

### DIFF
--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -253,28 +253,38 @@ async function processMarkOffline(data: MarkOfflineJobData): Promise<{
  * non-offline rules are no-ops for an offline device since their metric/status
  * conditions won't trip.
  *
- * @returns true if at least one config-policy alert was created
+ * Errors are reported via the returned `fatalError` rather than thrown inline,
+ * so the caller can still run the legacy standalone-rule path before surfacing
+ * the failure. The `42P01` "tables not migrated yet" case is treated as a
+ * benign warn-once-and-skip (matching alertWorker); any other error is a fatal
+ * error the caller MUST re-throw so the BullMQ job fails and retries — silently
+ * swallowing it would re-open the exact "offline alerts never fire" symptom of
+ * issue #1857 with no retry and no failed-job signal.
+ *
+ * @returns `created` (true if ≥1 config-policy alert was created) and, on an
+ *   unexpected error, `fatalError` for the caller to re-throw.
  */
 async function triggerConfigPolicyOfflineAlerts(
   device: typeof devices.$inferSelect
-): Promise<boolean> {
+): Promise<{ created: boolean; fatalError?: unknown }> {
   try {
     const createdIds = await evaluateDeviceAlertsFromPolicy(device.id);
     if (createdIds.length > 0) {
       console.log(`[OfflineDetector] Created ${createdIds.length} config-policy alert(s) for device ${device.id}`);
     }
-    return createdIds.length > 0;
+    return { created: createdIds.length > 0 };
   } catch (error) {
     if (isRelationNotFoundError(error)) {
       if (!_configPolicyTableWarningLogged) {
         _configPolicyTableWarningLogged = true;
         console.warn('[OfflineDetector] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping config policy offline alert evaluation.');
       }
-      return false;
+      return { created: false };
     }
-    // Don't let a config-policy evaluation failure abort the legacy path.
+    // Unexpected error — log here for context, but return it so the caller can
+    // run the legacy path first and then re-throw (job fails + retries).
     console.error(`[OfflineDetector] Error evaluating config policy offline alerts for device ${device.id}:`, error);
-    return false;
+    return { created: false, fatalError: error };
   }
 }
 
@@ -293,7 +303,8 @@ async function triggerConfigPolicyOfflineAlerts(
 export async function triggerOfflineAlerts(
   device: typeof devices.$inferSelect
 ): Promise<boolean> {
-  let alertCreated = await triggerConfigPolicyOfflineAlerts(device);
+  const configPolicyResult = await triggerConfigPolicyOfflineAlerts(device);
+  let alertCreated = configPolicyResult.created;
 
   // Find legacy standalone alert rules that have offline conditions
   // We need to find rules where the template conditions include type: 'offline'
@@ -316,6 +327,9 @@ export async function triggerOfflineAlerts(
     );
 
   if (rules.length === 0) {
+    // No legacy rules — surface any config-policy failure before returning so
+    // the BullMQ job fails and retries (consistent with alertWorker).
+    if (configPolicyResult.fatalError) throw configPolicyResult.fatalError;
     return alertCreated;
   }
 
@@ -376,6 +390,10 @@ export async function triggerOfflineAlerts(
       console.log(`[OfflineDetector] Created offline alert ${alertId} for device ${device.id}`);
     }
   }
+
+  // Legacy path ran successfully; now surface any config-policy failure so the
+  // BullMQ job fails and retries (consistent with alertWorker).
+  if (configPolicyResult.fatalError) throw configPolicyResult.fatalError;
 
   return alertCreated;
 }

--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -11,7 +11,7 @@ import { devices, alertRules, alertTemplates, alerts } from '../db/schema';
 import { eq, and, lt, gt, asc, inArray, or } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { publishEvent } from '../services/eventBus';
-import { createAlert } from '../services/alertService';
+import { createAlert, evaluateDeviceAlertsFromPolicy } from '../services/alertService';
 import { interpolateTemplate } from '../services/alertConditions';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
@@ -31,6 +31,15 @@ let offlineQueue: Queue | null = null;
 
 // Default offline threshold in minutes
 const DEFAULT_OFFLINE_THRESHOLD_MINUTES = 5;
+
+let _configPolicyTableWarningLogged = false;
+
+/** Check if a Drizzle/Postgres error is "relation does not exist" (42P01). */
+function isRelationNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const cause = (error as { cause?: { code?: string } }).cause;
+  return cause?.code === '42P01';
+}
 
 /**
  * Get or create the offline detection queue
@@ -235,12 +244,58 @@ async function processMarkOffline(data: MarkOfflineJobData): Promise<{
 }
 
 /**
- * Find and trigger offline-type alert rules for a device
+ * Evaluate configuration-policy alert rules for a freshly-offline device.
+ *
+ * Delegates to evaluateDeviceAlertsFromPolicy(), which resolves the device's
+ * config-policy alert rules from the hierarchy, honours maintenance windows and
+ * cooldowns, evaluates each rule's conditions (including offline conditions via
+ * the registry's `offline` handler + `status` alias), and writes alerts. Any
+ * non-offline rules are no-ops for an offline device since their metric/status
+ * conditions won't trip.
+ *
+ * @returns true if at least one config-policy alert was created
  */
-async function triggerOfflineAlerts(
+async function triggerConfigPolicyOfflineAlerts(
   device: typeof devices.$inferSelect
 ): Promise<boolean> {
-  // Find alert rules that have offline conditions
+  try {
+    const createdIds = await evaluateDeviceAlertsFromPolicy(device.id);
+    if (createdIds.length > 0) {
+      console.log(`[OfflineDetector] Created ${createdIds.length} config-policy alert(s) for device ${device.id}`);
+    }
+    return createdIds.length > 0;
+  } catch (error) {
+    if (isRelationNotFoundError(error)) {
+      if (!_configPolicyTableWarningLogged) {
+        _configPolicyTableWarningLogged = true;
+        console.warn('[OfflineDetector] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping config policy offline alert evaluation.');
+      }
+      return false;
+    }
+    // Don't let a config-policy evaluation failure abort the legacy path.
+    console.error(`[OfflineDetector] Error evaluating config policy offline alerts for device ${device.id}:`, error);
+    return false;
+  }
+}
+
+/**
+ * Find and trigger offline-type alert rules for a device.
+ *
+ * Evaluates BOTH rule sources:
+ *  - legacy standalone `alertRules` (template-based) below, and
+ *  - configuration-policy alert rules via evaluateDeviceAlertsFromPolicy().
+ *
+ * Config-policy offline rules must be evaluated here because the periodic
+ * alertWorker sweep only queues devices that are still `online` with a recent
+ * heartbeat (alertWorker.ts), so a device offline long enough to trip an
+ * offline threshold is never evaluated by that path (issue #1857).
+ */
+export async function triggerOfflineAlerts(
+  device: typeof devices.$inferSelect
+): Promise<boolean> {
+  let alertCreated = await triggerConfigPolicyOfflineAlerts(device);
+
+  // Find legacy standalone alert rules that have offline conditions
   // We need to find rules where the template conditions include type: 'offline'
 
   // Get all active rules for this device's org
@@ -261,7 +316,7 @@ async function triggerOfflineAlerts(
     );
 
   if (rules.length === 0) {
-    return false;
+    return alertCreated;
   }
 
   // Get templates for all rules
@@ -272,8 +327,6 @@ async function triggerOfflineAlerts(
     .where(inArray(alertTemplates.id, templateIds));
 
   const templateMap = new Map(templates.map(t => [t.id, t]));
-
-  let alertCreated = false;
 
   for (const rule of rules) {
     const template = templateMap.get(rule.templateId);

--- a/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
+++ b/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { evaluateFromPolicyMock, selectMock } = vi.hoisted(() => ({
+  evaluateFromPolicyMock: vi.fn(),
+  // db.select().from().where() resolves to the legacy alertRules rows.
+  selectMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    getJob = vi.fn();
+    add = vi.fn();
+    close = vi.fn();
+  },
+  Worker: class {
+    close = vi.fn();
+    on = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (..._args: unknown[]) => selectMock(),
+      }),
+    }),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {},
+  alertRules: { orgId: {}, isActive: {}, targetType: {}, targetId: {} },
+  alertTemplates: {},
+  alerts: {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));
+
+vi.mock('../services/alertService', () => ({
+  createAlert: vi.fn(),
+  evaluateDeviceAlertsFromPolicy: evaluateFromPolicyMock,
+}));
+
+vi.mock('../services/alertConditions', () => ({ interpolateTemplate: vi.fn() }));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(), and: vi.fn(), lt: vi.fn(), gt: vi.fn(), asc: vi.fn(),
+  inArray: vi.fn(), or: vi.fn(),
+}));
+
+import { triggerOfflineAlerts } from './offlineDetector';
+
+const device = {
+  id: 'device-1',
+  orgId: 'org-1',
+  siteId: 'site-1',
+  hostname: 'host-1',
+  displayName: 'Host 1',
+  status: 'offline',
+  lastSeenAt: new Date('2026-06-24T11:30:00.000Z'),
+  osType: 'windows',
+  osVersion: '11',
+} as never;
+
+describe('triggerOfflineAlerts — config policy wiring (issue #1857)', () => {
+  beforeEach(() => {
+    evaluateFromPolicyMock.mockReset();
+    selectMock.mockReset();
+    // No legacy standalone alert rules for this org by default.
+    selectMock.mockResolvedValue([]);
+  });
+
+  it('evaluates config-policy offline rules for an offline device', async () => {
+    evaluateFromPolicyMock.mockResolvedValue([]);
+
+    await triggerOfflineAlerts(device);
+
+    expect(evaluateFromPolicyMock).toHaveBeenCalledWith('device-1');
+  });
+
+  it('returns true when a config-policy alert is created (even with no legacy rules)', async () => {
+    evaluateFromPolicyMock.mockResolvedValue(['alert-1']);
+
+    const created = await triggerOfflineAlerts(device);
+
+    expect(created).toBe(true);
+  });
+
+  it('returns false when neither config-policy nor legacy rules fire', async () => {
+    evaluateFromPolicyMock.mockResolvedValue([]);
+
+    const created = await triggerOfflineAlerts(device);
+
+    expect(created).toBe(false);
+  });
+
+  it('does not abort the legacy path if config-policy evaluation throws', async () => {
+    evaluateFromPolicyMock.mockRejectedValue(new Error('boom'));
+
+    // Should swallow the config-policy error and fall through to legacy (no rules → false).
+    const created = await triggerOfflineAlerts(device);
+
+    expect(created).toBe(false);
+    expect(selectMock).toHaveBeenCalled(); // legacy query still ran
+  });
+
+  it('skips config-policy evaluation gracefully when tables are missing (42P01)', async () => {
+    const relErr = Object.assign(new Error('relation does not exist'), {
+      cause: { code: '42P01' },
+    });
+    evaluateFromPolicyMock.mockRejectedValue(relErr);
+
+    const created = await triggerOfflineAlerts(device);
+
+    expect(created).toBe(false);
+  });
+});

--- a/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
+++ b/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
@@ -105,14 +105,14 @@ describe('triggerOfflineAlerts — config policy wiring (issue #1857)', () => {
     expect(created).toBe(false);
   });
 
-  it('does not abort the legacy path if config-policy evaluation throws', async () => {
-    evaluateFromPolicyMock.mockRejectedValue(new Error('boom'));
+  it('runs the legacy path then re-throws an unexpected config-policy error (job fails + retries)', async () => {
+    const boom = new Error('boom');
+    evaluateFromPolicyMock.mockRejectedValue(boom);
 
-    // Should swallow the config-policy error and fall through to legacy (no rules → false).
-    const created = await triggerOfflineAlerts(device);
-
-    expect(created).toBe(false);
-    expect(selectMock).toHaveBeenCalled(); // legacy query still ran
+    // The legacy query must still run, but the unexpected error must surface so
+    // BullMQ marks the job failed and retries it — not silently swallowed (#1857).
+    await expect(triggerOfflineAlerts(device)).rejects.toThrow('boom');
+    expect(selectMock).toHaveBeenCalled(); // legacy query still ran first
   });
 
   it('skips config-policy evaluation gracefully when tables are missing (42P01)', async () => {

--- a/apps/api/src/services/alertConditions/handlers/offline.test.ts
+++ b/apps/api/src/services/alertConditions/handlers/offline.test.ts
@@ -101,6 +101,33 @@ describe('offlineHandler', () => {
     expect(result.description).toBe('Device offline for 5min');
   });
 
+  it('prefers durationMinutes over a legacy duration when both are present', async () => {
+    // 12 min stale. durationMinutes:10 (used) → offline; duration:99 (ignored) would be online.
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:48:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate(
+      { type: 'offline', durationMinutes: 10, duration: 99 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.description).toBe('Device offline for 10min');
+  });
+
+  it('falls back to the 5-minute default for non-positive durations', async () => {
+    // 6 min stale. durationMinutes:0 is invalid → default 5 → offline.
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:54:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'offline', durationMinutes: 0 }, DEVICE_ID);
+
+    expect(result.passed).toBe(true);
+    expect(result.description).toBe('Device offline for 5min');
+  });
+
   it('returns "Device not found" when the device does not exist', async () => {
     getDeviceMock.mockResolvedValue(null);
 

--- a/apps/api/src/services/alertConditions/handlers/offline.test.ts
+++ b/apps/api/src/services/alertConditions/handlers/offline.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getDeviceMock } = vi.hoisted(() => ({
+  getDeviceMock: vi.fn(),
+}));
+
+// getDevice touches the db; mock the whole utils module so we can drive it.
+vi.mock('../utils', () => ({
+  getDevice: getDeviceMock,
+}));
+
+import { offlineHandler } from './offline';
+
+const DEVICE_ID = 'device-1';
+
+function makeDevice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DEVICE_ID,
+    status: 'online',
+    lastSeenAt: new Date('2026-06-24T12:00:00.000Z'),
+    ...overrides,
+  } as never;
+}
+
+describe('offlineHandler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T12:00:00.000Z'));
+    getDeviceMock.mockReset();
+  });
+
+  it('declares the type "offline" and registers a "status" alias for legacy rows', () => {
+    expect(offlineHandler.type).toBe('offline');
+    expect(offlineHandler.aliases).toContain('status');
+  });
+
+  it('passes when device.status is "offline"', async () => {
+    getDeviceMock.mockResolvedValue(makeDevice({ status: 'offline' }));
+
+    const result = await offlineHandler.evaluate({ type: 'offline', durationMinutes: 15 }, DEVICE_ID);
+
+    expect(result.passed).toBe(true);
+    expect(result.description).toBe('Device offline for 15min');
+  });
+
+  it('passes when lastSeenAt is older than the canonical durationMinutes threshold', async () => {
+    // 20 min stale, threshold 15 → offline
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:40:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'offline', durationMinutes: 15 }, DEVICE_ID);
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('does NOT pass when lastSeenAt is within the threshold and status is online', async () => {
+    // 5 min stale, threshold 15 → still online
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:55:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'offline', durationMinutes: 15 }, DEVICE_ID);
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('reads the legacy "duration" field (status-alias rows) as the threshold', async () => {
+    // 10 min stale; legacy condition uses `duration: 5` → should be offline.
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:50:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'status', duration: 5 }, DEVICE_ID);
+
+    expect(result.passed).toBe(true);
+    // Description reflects the resolved duration, not the canonical field name.
+    expect(result.description).toBe('Device offline for 5min');
+  });
+
+  it('does NOT pass a legacy "duration" row when within threshold', async () => {
+    // 3 min stale; legacy condition uses `duration: 15` → still online.
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:57:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'status', duration: 15 }, DEVICE_ID);
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('defaults to a 5-minute threshold when no duration field is present', async () => {
+    getDeviceMock.mockResolvedValue(
+      makeDevice({ status: 'online', lastSeenAt: new Date('2026-06-24T11:54:00.000Z') })
+    );
+
+    const result = await offlineHandler.evaluate({ type: 'offline' }, DEVICE_ID);
+
+    // 6 min stale vs default 5 → offline.
+    expect(result.passed).toBe(true);
+    expect(result.description).toBe('Device offline for 5min');
+  });
+
+  it('returns "Device not found" when the device does not exist', async () => {
+    getDeviceMock.mockResolvedValue(null);
+
+    const result = await offlineHandler.evaluate({ type: 'offline', durationMinutes: 5 }, DEVICE_ID);
+
+    expect(result.passed).toBe(false);
+    expect(result.description).toBe('Device not found');
+  });
+
+  describe('validate', () => {
+    it('accepts a numeric durationMinutes', () => {
+      expect(offlineHandler.validate({ type: 'offline', durationMinutes: 15 }, 'cond')).toEqual([]);
+    });
+
+    it('accepts a numeric legacy duration', () => {
+      expect(offlineHandler.validate({ type: 'status', duration: 5 }, 'cond')).toEqual([]);
+    });
+
+    it('rejects a non-numeric durationMinutes', () => {
+      const errors = offlineHandler.validate({ type: 'offline', durationMinutes: 'soon' }, 'cond');
+      expect(errors).toContain('cond.durationMinutes: Must be a number');
+    });
+
+    it('rejects a non-numeric legacy duration', () => {
+      const errors = offlineHandler.validate({ type: 'status', duration: 'soon' }, 'cond');
+      expect(errors).toContain('cond.duration: Must be a number');
+    });
+  });
+});

--- a/apps/api/src/services/alertConditions/handlers/offline.ts
+++ b/apps/api/src/services/alertConditions/handlers/offline.ts
@@ -1,19 +1,34 @@
 import type { ConditionHandler } from '../registry';
-import type { OfflineCondition, ConditionResult } from '../types';
+import type { ConditionResult } from '../types';
 import { getDevice } from '../utils';
+
+/**
+ * Read the offline duration (in minutes) from a condition, tolerating both the
+ * canonical `durationMinutes` field and the legacy `duration` field emitted by
+ * the config-policy alert-rule editor under the `status` alias.
+ */
+function resolveDurationMinutes(condition: unknown): number {
+  const c = (condition ?? {}) as Record<string, unknown>;
+  const value = typeof c.durationMinutes === 'number' ? c.durationMinutes
+    : typeof c.duration === 'number' ? c.duration
+    : undefined;
+  return value && value > 0 ? value : 5;
+}
 
 export const offlineHandler: ConditionHandler = {
   type: 'offline',
+  // `status` is the legacy type emitted by the config-policy alert-rule editor
+  // for "Device Offline" rules. Already-saved rows carry `{type:'status', duration:N}`.
+  aliases: ['status'],
 
   async evaluate(condition: unknown, deviceId: string): Promise<ConditionResult> {
-    const cond = condition as OfflineCondition;
     const device = await getDevice(deviceId);
 
     if (!device) {
       return { passed: false, description: 'Device not found' };
     }
 
-    const durationMinutes = cond.durationMinutes || 5;
+    const durationMinutes = resolveDurationMinutes(condition);
     const offlineThreshold = new Date(Date.now() - durationMinutes * 60 * 1000);
 
     const isOffline = device.status === 'offline' ||
@@ -31,6 +46,11 @@ export const offlineHandler: ConditionHandler = {
 
     if (c.durationMinutes !== undefined && typeof c.durationMinutes !== 'number') {
       errors.push(`${path}.durationMinutes: Must be a number`);
+    }
+
+    // Legacy `status`-alias rows use `duration` instead of `durationMinutes`.
+    if (c.duration !== undefined && typeof c.duration !== 'number') {
+      errors.push(`${path}.duration: Must be a number`);
     }
 
     return errors;

--- a/apps/api/src/services/alertConditions/index.test.ts
+++ b/apps/api/src/services/alertConditions/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// utils.ts (transitively imported by the handlers) pulls in the db module at
+// import time; stub it so importing the registry doesn't open a connection.
+vi.mock('../../db', () => ({ db: {} }));
+
+import './index';
+import { conditionRegistry } from './registry';
+import { offlineHandler } from './handlers/offline';
+
+describe('condition registry wiring (issue #1857)', () => {
+  it('resolves the legacy "status" condition type to the offline handler', () => {
+    expect(conditionRegistry.get('status')).toBe(offlineHandler);
+  });
+
+  it('resolves the canonical "offline" condition type to the offline handler', () => {
+    expect(conditionRegistry.get('offline')).toBe(offlineHandler);
+  });
+
+  it('returns an "Unknown condition type" result for a genuinely unregistered type', async () => {
+    const result = await conditionRegistry.evaluate(
+      { type: 'definitely-not-a-real-type' } as never,
+      'device-1'
+    );
+    expect(result.passed).toBe(false);
+    expect(result.description).toMatch(/Unknown condition type/);
+  });
+});

--- a/apps/api/src/services/alertConditions/utils.test.ts
+++ b/apps/api/src/services/alertConditions/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { METRIC_NAME_MAP, normalizeMetricName, compareValue } from './utils';
+
+describe('METRIC_NAME_MAP', () => {
+  it('maps the UI percentage metrics to their device_metrics columns', () => {
+    expect(METRIC_NAME_MAP.cpu).toBe('cpuPercent');
+    expect(METRIC_NAME_MAP.ram).toBe('ramPercent');
+    expect(METRIC_NAME_MAP.memory).toBe('ramPercent');
+    expect(METRIC_NAME_MAP.disk).toBe('diskPercent');
+  });
+
+  it('does NOT map "network" — there is no network-usage percentage column (issue #1857)', () => {
+    // The dead "Network Usage" option was removed from the editor; ensure the
+    // evaluator likewise treats it as unknown rather than silently mismapping.
+    expect(METRIC_NAME_MAP.network).toBeUndefined();
+    expect(normalizeMetricName('network')).toBeNull();
+  });
+
+  it('round-trips the canonical column names through normalizeMetricName', () => {
+    expect(normalizeMetricName('cpuPercent')).toBe('cpuPercent');
+    expect(normalizeMetricName('diskPercent')).toBe('diskPercent');
+    expect(normalizeMetricName('processCount')).toBe('processCount');
+  });
+});
+
+describe('compareValue', () => {
+  it('evaluates each operator', () => {
+    expect(compareValue(90, 'gt', 80)).toBe(true);
+    expect(compareValue(80, 'gte', 80)).toBe(true);
+    expect(compareValue(70, 'lt', 80)).toBe(true);
+    expect(compareValue(80, 'lte', 80)).toBe(true);
+    expect(compareValue(80, 'eq', 80)).toBe(true);
+    expect(compareValue(81, 'neq', 80)).toBe(true);
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertRuleTab from './AlertRuleTab';
+
+const saveMock = vi.fn();
+const removeMock = vi.fn();
+const clearErrorMock = vi.fn();
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: undefined,
+    clearError: clearErrorMock,
+  }),
+}));
+
+type SavedPayload = { inlineSettings: { items: Array<Record<string, unknown>> } };
+
+function lastSavedItems(): Array<Record<string, unknown>> {
+  const call = saveMock.mock.calls.at(-1) as [string | null, SavedPayload];
+  return call[1].inlineSettings.items;
+}
+
+// Labels in this component are sibling text, not associated via htmlFor, so we
+// locate the control by finding its label text and walking to the field below.
+function controlForLabel(labelText: string): HTMLElement {
+  const label = screen.getAllByText(labelText)[0]!;
+  const control = label.parentElement?.querySelector('select, input');
+  if (!control) throw new Error(`No control found for label "${labelText}"`);
+  return control as HTMLElement;
+}
+
+function addFirstRule(): void {
+  // Both the header and empty-state render an "Add Alert Rule" button; the
+  // empty-state one only exists before any rule is added — click it.
+  const addButtons = screen.getAllByRole('button', { name: /Add Alert Rule/i });
+  fireEvent.click(addButtons[addButtons.length - 1]!);
+}
+
+describe('AlertRuleTab (issue #1857)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1',
+      featureType: 'alert_rule',
+      featurePolicyId: null,
+      inlineSettings: {},
+    });
+  });
+
+  it('does not offer the dead "Network Usage" metric option', () => {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1',
+          featureType: 'alert_rule',
+          featurePolicyId: null,
+          inlineSettings: {
+            items: [
+              {
+                name: 'CPU rule',
+                severity: 'high',
+                conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }],
+                cooldownMinutes: 15,
+                autoResolve: false,
+              },
+            ],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    // Expand the rule so the metric dropdown renders.
+    fireEvent.click(screen.getByText('CPU rule'));
+
+    expect(screen.queryByRole('option', { name: 'Network Usage' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'CPU Usage' })).toBeTruthy();
+  });
+
+  it('migrates a legacy {type:"status", duration} rule to {type:"offline", durationMinutes} on save', async () => {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1',
+          featureType: 'alert_rule',
+          featurePolicyId: null,
+          inlineSettings: {
+            items: [
+              {
+                name: 'Offline rule',
+                severity: 'critical',
+                conditions: [{ type: 'status', duration: 15 }],
+                cooldownMinutes: 15,
+                autoResolve: false,
+              },
+            ],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const condition = lastSavedItems()[0]!.conditions as Array<Record<string, unknown>>;
+    expect(condition[0]).toMatchObject({ type: 'offline', durationMinutes: 15 });
+    expect(condition[0]).not.toHaveProperty('duration');
+  });
+
+  it('renders the offline-duration editor for a migrated legacy status rule', () => {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1',
+          featureType: 'alert_rule',
+          featurePolicyId: null,
+          inlineSettings: {
+            items: [
+              {
+                name: 'Offline rule',
+                severity: 'critical',
+                conditions: [{ type: 'status', duration: 30 }],
+                cooldownMinutes: 15,
+                autoResolve: false,
+              },
+            ],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Offline rule'));
+
+    // The migrated duration shows up in the "Offline Duration (min)" field.
+    const durationInput = controlForLabel('Offline Duration (min)') as HTMLInputElement;
+    expect(durationInput.value).toBe('30');
+  });
+
+  it('saves a newly-added Device Offline condition as {type:"offline", durationMinutes}', async () => {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    // Add a rule, then switch its single condition's type to Device Offline.
+    addFirstRule();
+
+    const typeSelect = controlForLabel('Type') as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: 'offline' } });
+
+    const durationInput = controlForLabel('Offline Duration (min)') as HTMLInputElement;
+    fireEvent.change(durationInput, { target: { value: '20' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const condition = lastSavedItems()[0]!.conditions as Array<Record<string, unknown>>;
+    expect(condition[0]).toMatchObject({ type: 'offline', durationMinutes: 20 });
+  });
+
+  it('offers "Device Offline" (not the legacy "Status") in the condition type dropdown', () => {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={undefined}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    addFirstRule();
+
+    const typeSelect = controlForLabel('Type');
+    expect(within(typeSelect).getByRole('option', { name: 'Device Offline' })).toBeTruthy();
+    expect(within(typeSelect).queryByRole('option', { name: 'Status' })).toBeNull();
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.tsx
@@ -5,7 +5,11 @@ import { FEATURE_META } from './types';
 import { useFeatureLink } from './useFeatureLink';
 import FeatureTabShell from './FeatureTabShell';
 
-type ConditionType = 'metric' | 'status' | 'custom';
+// `offline` is the type understood by the API condition evaluator. The legacy
+// editor emitted `status` with a `duration` field; we normalize those on load
+// (see normalizeConditions) and always emit the `offline`/`durationMinutes`
+// shape on save so rules actually evaluate (issue #1857).
+type ConditionType = 'metric' | 'offline' | 'custom';
 type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
 type Condition = {
@@ -13,7 +17,7 @@ type Condition = {
   metric?: string;
   operator?: string;
   value?: number;
-  duration?: number;
+  durationMinutes?: number;
   field?: string;
   customCondition?: string;
 };
@@ -42,11 +46,15 @@ const severityOptions: { value: AlertSeverity; label: string; color: string }[] 
   { value: 'info', label: 'Info', color: 'bg-gray-500' },
 ];
 
+// Only metrics with a percentage column in device_metrics that the API
+// threshold evaluator (METRIC_NAME_MAP) understands. "Network Usage" was
+// removed: there is no network-usage percentage column to compare against,
+// so the option never fired (issue #1857). Bandwidth alerting has its own
+// dedicated condition type and is not exposed via this simple % dropdown.
 const metricOptions = [
   { value: 'cpu', label: 'CPU Usage' },
   { value: 'ram', label: 'Memory Usage' },
   { value: 'disk', label: 'Disk Usage' },
-  { value: 'network', label: 'Network Usage' },
 ];
 
 const operatorOptions = [
@@ -60,15 +68,28 @@ const operatorOptions = [
 
 const conditionTypeOptions = [
   { value: 'metric', label: 'Metric' },
-  { value: 'status', label: 'Status' },
+  { value: 'offline', label: 'Device Offline' },
   { value: 'custom', label: 'Custom' },
 ];
+
+// Migrate a single condition from the legacy `{type:'status', duration}` shape
+// to the canonical `{type:'offline', durationMinutes}` shape the evaluator reads.
+// Legacy persisted shape, before the `status`→`offline` / `duration`→`durationMinutes` rename.
+type RawCondition = Omit<Condition, 'type'> & { type: ConditionType | 'status'; duration?: number };
+
+function normalizeCondition(condition: Condition): Condition {
+  const { type, durationMinutes, duration, ...rest } = condition as RawCondition;
+  if (type === 'status' || type === 'offline') {
+    return { ...rest, type: 'offline', durationMinutes: durationMinutes ?? duration ?? 5 };
+  }
+  return { ...rest, type } as Condition;
+}
 
 function normalizeConditions(item: AlertItem): AlertItem {
   if (!Array.isArray(item.conditions)) {
     return { ...item, conditions: [...defaultItem.conditions] };
   }
-  return item;
+  return { ...item, conditions: item.conditions.map(normalizeCondition) };
 }
 
 function loadItems(existingLink: FeatureTabProps['existingLink']): AlertItem[] {
@@ -372,14 +393,14 @@ export default function AlertRuleTab({ policyId, existingLink, onLinkChanged, li
                                 </>
                               )}
 
-                              {condition.type === 'status' && (
+                              {condition.type === 'offline' && (
                                 <div className="sm:col-span-3">
                                   <label className="text-xs font-medium text-muted-foreground">Offline Duration (min)</label>
                                   <input
                                     type="number"
                                     min={1}
-                                    value={condition.duration ?? 5}
-                                    onChange={(e) => updateCondition(index, ci, { duration: Number(e.target.value) })}
+                                    value={condition.durationMinutes ?? 5}
+                                    onChange={(e) => updateCondition(index, ci, { durationMinutes: Number(e.target.value) })}
                                     className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-sm"
                                   />
                                 </div>


### PR DESCRIPTION
## Summary

Fixes two related Configuration Policy alert-rule defects reported by @win-wxx in #1854 (item 2).

**Bug A — "Device Offline" config-policy rules never evaluated (triple failure):**
1. **Shape mismatch:** `AlertRuleTab.tsx` saved offline rules as `{type:'status', duration:N}`, but the evaluator only handles `{type:'offline', durationMinutes:N}` → the registry returned "Unknown condition type". Fixed by emitting the canonical shape and migrating legacy `status`/`duration` rows on load (`normalizeCondition`).
2. **Already-saved rows:** registered a `status` **alias** on `offlineHandler` and made it read either `durationMinutes` or the legacy `duration` field, so rows persisted before this PR still evaluate.
3. **Unreachable path:** the periodic `alertWorker` sweep only queues `online` devices with a recent heartbeat (`alertWorker.ts:157-161`), so a device offline long enough to trip a threshold is excluded — the only `evaluateDeviceAlertsFromPolicy` caller never ran for it. Wired `offlineDetector.triggerOfflineAlerts` to also call `evaluateDeviceAlertsFromPolicy(device.id)` (guarded for `42P01` relation-missing, mirroring `alertWorker`), since offline devices flow through the offlineDetector path.

**Bug B — "Network Usage" metric option was dead (removed):**
`AlertRuleTab.tsx` offered `metric:'network'` but `METRIC_NAME_MAP` has no `network` key, so it evaluated to "Unknown metric" and never fired. I **removed** the option rather than mapping it: the threshold/metric path compares a **percentage (0-100)** against a `device_metrics` percentage column, and there is **no network-usage percentage column** — `device_metrics` only has cumulative byte counters (`network_in_bytes`/`network_out_bytes`) and bps gauges (`bandwidth_in_bps`/`bandwidth_out_bps`). Mapping to a byte/bps column would compare a raw byte count against a 0-100 "%" threshold — nonsensical. Real bandwidth alerting already has its own dedicated `bandwidth_high` condition type (Mbps + direction), which is the correct path and not exposed via this simple `%` dropdown.

## Files changed
- `apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.tsx` — emit `{type:'offline', durationMinutes}`, migrate legacy `status`/`duration` rows on load, relabel the option "Device Offline", remove the dead "Network Usage" metric option.
- `apps/api/src/services/alertConditions/handlers/offline.ts` — `status` alias + read `durationMinutes` or legacy `duration`; validate both fields.
- `apps/api/src/jobs/offlineDetector.ts` — evaluate config-policy offline rules via `evaluateDeviceAlertsFromPolicy` (with `42P01` guard) for freshly-offline devices.
- Tests: `offline.test.ts`, `utils.test.ts`, `index.test.ts` (registry wiring), `offlineDetector_configPolicy.test.ts`, `AlertRuleTab.test.tsx`.

## Verification
- `apps/api` affected suites: **34 passed** (`alertConditions/`, `offlineDetector*.test.ts`, `alertService.test.ts`, `alertWorker.test.ts`), `tsc --noEmit` clean.
- `apps/web` `AlertRuleTab.test.tsx`: **5 passed**, `tsc --noEmit` clean.

Refs #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)