### PR TITLE
fix(automations): config-policy runs RLS-visible in portal (correct tenant key) (#1855)

### DIFF
--- a/apps/api/migrations/2026-06-24-config-policy-run-tenant-key-backfill.sql
+++ b/apps/api/migrations/2026-06-24-config-policy-run-tenant-key-backfill.sql
@@ -1,0 +1,44 @@
+-- Backfill mis-keyed config-policy automation runs (issue #1855).
+--
+-- `createConfigPolicyAutomationRun` historically stored
+-- `config_policy_feature_links.id` (the feature-link id) into
+-- `automation_runs.config_policy_id`, but every consumer treats that column as a
+-- `configuration_policies.id`:
+--   * the RLS EXISTS-join (2026-05-30-fk-child-tables-rls.sql) joins
+--     configuration_policies on cp.id = automation_runs.config_policy_id, and
+--   * the read route joins configurationPolicies on run.config_policy_id.
+-- A feature-link id matches no configuration_policies row, so those runs were
+-- RLS-invisible to org-scoped readers and 404'd in the portal even though the
+-- INSERT succeeded under the worker's system db context.
+--
+-- The code fix resolves the owning configuration_policies.id before insert.
+-- This migration remaps the existing bad rows: config-policy runs
+-- (automation_id IS NULL) whose config_policy_id is in fact a feature-link id
+-- are rewritten to that link's configuration_policies.id.
+--
+-- Idempotent: re-running is a no-op because the WHERE clause only matches rows
+-- whose config_policy_id still equals a config_policy_feature_links.id (and the
+-- guard excludes ids that are already a valid configuration_policies.id, so a
+-- feature-link id that happens to collide with a policy id is left untouched).
+-- No inner BEGIN/COMMIT — autoMigrate wraps the file in a transaction.
+
+DO $$
+DECLARE
+  remapped bigint;
+BEGIN
+  UPDATE automation_runs ar
+  SET config_policy_id = fl.config_policy_id
+  FROM config_policy_feature_links fl
+  WHERE ar.automation_id IS NULL
+    AND ar.config_policy_id = fl.id
+    -- Only touch rows that are NOT already a valid policy id, so a run already
+    -- pointing at a real configuration_policies.id is never disturbed.
+    AND NOT EXISTS (
+      SELECT 1 FROM configuration_policies cp WHERE cp.id = ar.config_policy_id
+    );
+
+  GET DIAGNOSTICS remapped = ROW_COUNT;
+  IF remapped > 0 THEN
+    RAISE WARNING 'config-policy-run-tenant-key-backfill: remapped % automation_runs rows from feature-link id to configuration_policies.id (#1855)', remapped;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/configPolicyAutomationRunRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyAutomationRunRls.integration.test.ts
@@ -184,6 +184,31 @@ describe('config policy automation run RLS visibility (#1855)', () => {
     expect(systemView).toHaveLength(0);
   });
 
+  it('fails loudly (no row written) when the feature link cannot be resolved (#1855)', async () => {
+    // An automation row whose featureLinkId points at no config_policy_feature_links
+    // row (orphaned/deleted link). createConfigPolicyAutomationRun must throw a
+    // domain error before inserting — never write a null/invisible run.
+    const orphan = { ...automationRow, featureLinkId: crypto.randomUUID() };
+
+    await expect(
+      withSystemDbAccessContext(() =>
+        createConfigPolicyAutomationRun({
+          automation: orphan,
+          targetDeviceIds: ['dev-1'],
+          triggeredBy: 'scheduler',
+        }),
+      ),
+    ).rejects.toThrow('Could not resolve configurationPolicies.id');
+
+    // No automation_runs row was created for this orphan automation.
+    const tdb = getTestDb();
+    const rows = await tdb
+      .select({ id: automationRuns.id })
+      .from(automationRuns)
+      .where(eq(automationRuns.configItemName, orphan.name));
+    expect(rows).toHaveLength(0);
+  });
+
   it('a foreign org cannot SELECT another org\'s config policy run', async () => {
     const run = await withSystemDbAccessContext(() =>
       createConfigPolicyAutomationRun({

--- a/apps/api/src/__tests__/integration/configPolicyAutomationRunRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configPolicyAutomationRunRls.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Regression (#1855): Config Policy automation runs were RLS-invisible in the
+ * portal because `createConfigPolicyAutomationRun` stored a
+ * `config_policy_feature_links.id` into `automation_runs.config_policy_id`,
+ * while every consumer treats that column as a `configuration_policies.id`.
+ *
+ * `automation_runs` has no `org_id`; tenancy is an EXISTS-join against
+ * `configuration_policies` (2026-05-30-fk-child-tables-rls.sql):
+ *   EXISTS (SELECT 1 FROM configuration_policies cp
+ *           WHERE cp.id = automation_runs.config_policy_id
+ *             AND breeze_has_org_access(cp.org_id))
+ * A feature-link id matches no `configuration_policies` row, so an org-scoped
+ * reader saw zero rows even though the worker's system-scope INSERT succeeded.
+ *
+ * These run against a real DB as `breeze_app` (forced RLS) under an org-scoped
+ * context, exactly as the portal read path does. They are RED before the fix
+ * (the run created with the feature-link id is invisible) and GREEN after (the
+ * run is created with the resolved policy id and is visible).
+ *
+ * Per CLAUDE.md, RLS forge tests MUST run on a non-BYPASSRLS connection — case
+ * (0) asserts `rolbypassrls = false` under the app context before trusting the
+ * visibility assertions (see memory: worktree_env_test_rls_vacuous).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import './setup';
+import { getTestDb } from './setup';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { partners, organizations } from '../../db/schema';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAutomations,
+} from '../../db/schema/configurationPolicies';
+import { automationRuns } from '../../db/schema/automations';
+import { createConfigPolicyAutomationRun } from '../../services/automationRuntime';
+
+let orgId: string;
+let foreignOrgId: string;
+let policyId: string;
+let featureLinkId: string;
+let automationRow: typeof configPolicyAutomations.$inferSelect;
+let orgContext: DbAccessContext;
+
+beforeEach(async () => {
+  // Seed on the superuser test connection (bypasses RLS).
+  const tdb = getTestDb();
+  const sfx = `${Date.now()}-${Math.floor(performance.now())}`;
+
+  // automation_runs has no FK to configuration_policies / organizations, so the
+  // organizations TRUNCATE CASCADE in setup.ts does NOT clear it. Wipe it here.
+  await tdb.delete(automationRuns);
+
+  const [p] = await tdb
+    .insert(partners)
+    .values({ name: 'CP Run RLS', slug: `cp-run-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+    .returning({ id: partners.id });
+  const [o] = await tdb
+    .insert(organizations)
+    .values({ partnerId: p!.id, name: 'CP Run Org', slug: `cp-run-org-${sfx}` })
+    .returning({ id: organizations.id });
+  orgId = o!.id;
+  const [fo] = await tdb
+    .insert(organizations)
+    .values({ partnerId: p!.id, name: 'CP Run Foreign Org', slug: `cp-run-forg-${sfx}` })
+    .returning({ id: organizations.id });
+  foreignOrgId = fo!.id;
+
+  const [policy] = await tdb
+    .insert(configurationPolicies)
+    .values({ orgId, name: 'CP Run Policy' })
+    .returning({ id: configurationPolicies.id });
+  policyId = policy!.id;
+
+  const [link] = await tdb
+    .insert(configPolicyFeatureLinks)
+    .values({ configPolicyId: policyId, featureType: 'automation' })
+    .returning({ id: configPolicyFeatureLinks.id });
+  featureLinkId = link!.id;
+
+  const [auto] = await tdb
+    .insert(configPolicyAutomations)
+    .values({
+      featureLinkId,
+      name: 'CP Run Automation',
+      triggerType: 'schedule',
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      actions: [{ type: 'execute_command', command: 'echo hello' }],
+    })
+    .returning();
+  automationRow = auto!;
+
+  // Org-scoped context exactly as the request middleware would build it for a
+  // user in `orgId`.
+  orgContext = {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: null,
+    userId: null,
+    currentPartnerId: p!.id,
+  };
+});
+
+describe('config policy automation run RLS visibility (#1855)', () => {
+  it('(0) app context runs as breeze_app with RLS enforced (guards vacuous pass)', async () => {
+    const rows = await withDbAccessContext(orgContext, () =>
+      db.execute(sql`SELECT current_user AS who, rolbypassrls
+                     FROM pg_roles WHERE rolname = current_user`),
+    );
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row?.who).toBe('breeze_app');
+    expect(row?.rolbypassrls).toBe(false);
+  });
+
+  it('an org-scoped reader can SELECT a run created by the worker (the fix)', async () => {
+    // The worker inserts under system db context (automationWorker.ts).
+    const run = await withSystemDbAccessContext(() =>
+      createConfigPolicyAutomationRun({
+        automation: automationRow,
+        targetDeviceIds: ['dev-1', 'dev-2'],
+        triggeredBy: 'scheduler',
+      }),
+    );
+
+    // The stored config_policy_id must be the owning configuration_policies.id,
+    // NOT the feature-link id — otherwise the RLS EXISTS-join resolves nothing.
+    expect(run.configPolicyId).toBe(policyId);
+    expect(run.configPolicyId).not.toBe(featureLinkId);
+
+    // An org-scoped reader (breeze_app, forced RLS) must see the run.
+    const visible = await withDbAccessContext(orgContext, () =>
+      db
+        .select({ id: automationRuns.id, configPolicyId: automationRuns.configPolicyId })
+        .from(automationRuns)
+        .where(eq(automationRuns.id, run.id))
+        .limit(1),
+    );
+    expect(visible).toHaveLength(1);
+    expect(visible[0]!.configPolicyId).toBe(policyId);
+  });
+
+  it('a run mis-keyed with the feature-link id is RLS-invisible (the bug it replaces)', async () => {
+    // Seed a legacy mis-keyed row on the superuser test connection (bypasses
+    // RLS). Such rows could exist from before the automation_runs RLS migration
+    // (2026-05-30) landed its WITH CHECK — the bug wrote the feature-link id,
+    // which the EXISTS-join can no longer resolve. (Note: the breeze_app
+    // INSERT WITH CHECK now rejects a feature-link id even under system scope,
+    // because the EXISTS finds no matching configuration_policies row — which is
+    // itself a useful guard, but is not how the legacy rows were created.)
+    const tdb = getTestDb();
+    const [bad] = await tdb
+      .insert(automationRuns)
+      .values({
+        automationId: null,
+        configPolicyId: featureLinkId, // the bug
+        configItemName: 'Mis-keyed run',
+        triggeredBy: 'scheduler',
+        status: 'running',
+      })
+      .returning({ id: automationRuns.id });
+
+    // The superuser connection (bypasses RLS) proves the row exists.
+    const superuserView = await tdb
+      .select({ id: automationRuns.id })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, bad!.id));
+    expect(superuserView).toHaveLength(1);
+
+    // Org scope sees nothing — the feature-link id matches no configuration_policies row.
+    const orgView = await withDbAccessContext(orgContext, () =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, bad!.id)),
+    );
+    expect(orgView).toHaveLength(0);
+
+    // Even system scope (breeze_app with the system GUC) cannot SELECT it: the
+    // EXISTS-join still needs a matching configuration_policies row, which a
+    // feature-link id never has. This is exactly why such runs are unreadable
+    // in the portal.
+    const systemView = await withSystemDbAccessContext(() =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, bad!.id)),
+    );
+    expect(systemView).toHaveLength(0);
+  });
+
+  it('a foreign org cannot SELECT another org\'s config policy run', async () => {
+    const run = await withSystemDbAccessContext(() =>
+      createConfigPolicyAutomationRun({
+        automation: automationRow,
+        targetDeviceIds: ['dev-1'],
+        triggeredBy: 'scheduler',
+      }),
+    );
+
+    const foreignContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: foreignOrgId,
+      accessibleOrgIds: [foreignOrgId],
+      accessiblePartnerIds: null,
+      userId: null,
+      currentPartnerId: null,
+    };
+    const foreignView = await withDbAccessContext(foreignContext, () =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, run.id)),
+    );
+    expect(foreignView).toHaveLength(0);
+  });
+
+  it('the backfill remaps a feature-keyed run to the policy id, making it visible', async () => {
+    // Seed a legacy mis-keyed row on the superuser connection (bypasses RLS),
+    // then run the backfill UPDATE.
+    const tdb = getTestDb();
+    const [legacy] = await tdb
+      .insert(automationRuns)
+      .values({
+        automationId: null,
+        configPolicyId: featureLinkId, // legacy bug value
+        configItemName: 'Legacy run',
+        triggeredBy: 'scheduler',
+        status: 'completed',
+      })
+      .returning({ id: automationRuns.id });
+
+    // Invisible before backfill.
+    const before = await withDbAccessContext(orgContext, () =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, legacy!.id)),
+    );
+    expect(before).toHaveLength(0);
+
+    // The backfill statement from 2026-06-24-config-policy-run-tenant-key-backfill.sql.
+    await tdb.execute(sql`
+      UPDATE automation_runs ar
+      SET config_policy_id = fl.config_policy_id
+      FROM config_policy_feature_links fl
+      WHERE ar.automation_id IS NULL
+        AND ar.config_policy_id = fl.id
+        AND NOT EXISTS (
+          SELECT 1 FROM configuration_policies cp WHERE cp.id = ar.config_policy_id
+        )
+    `);
+
+    // Visible after backfill, now keyed to the policy id.
+    const after = await withDbAccessContext(orgContext, () =>
+      db
+        .select({ id: automationRuns.id, configPolicyId: automationRuns.configPolicyId })
+        .from(automationRuns)
+        .where(eq(automationRuns.id, legacy!.id)),
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0]!.configPolicyId).toBe(policyId);
+
+    // Idempotent: re-running the backfill is a no-op (already a valid policy id).
+    await tdb.execute(sql`
+      UPDATE automation_runs ar
+      SET config_policy_id = fl.config_policy_id
+      FROM config_policy_feature_links fl
+      WHERE ar.automation_id IS NULL
+        AND ar.config_policy_id = fl.id
+        AND NOT EXISTS (
+          SELECT 1 FROM configuration_policies cp WHERE cp.id = ar.config_policy_id
+        )
+    `);
+    const afterRerun = await withDbAccessContext(orgContext, () =>
+      db
+        .select({ configPolicyId: automationRuns.configPolicyId })
+        .from(automationRuns)
+        .where(and(eq(automationRuns.id, legacy!.id), isNull(automationRuns.automationId))),
+    );
+    expect(afterRerun[0]!.configPolicyId).toBe(policyId);
+  });
+});

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -225,6 +225,24 @@ describe('createConfigPolicyAutomationRun', () => {
     );
   });
 
+  it('throws a domain error when the feature link cannot be resolved (#1855)', async () => {
+    // resolveConfigPolicyId returns null (orphaned/missing feature link). The
+    // function must fail loudly rather than write a null config_policy_id (which
+    // the RLS WITH CHECK would reject with an opaque error).
+    mockResolveConfigPolicyId(null);
+    const valuesMock = mockInsertCapturingValues([{ id: 'run-1' }]);
+
+    await expect(
+      createConfigPolicyAutomationRun({
+        automation: makeConfigPolicyAutomation({ featureLinkId: 'fl-orphan' }),
+        targetDeviceIds: ['dev-1'],
+        triggeredBy: 'scheduler',
+      })
+    ).rejects.toThrow('Could not resolve configurationPolicies.id');
+    // The insert must never be attempted when resolution fails.
+    expect(valuesMock).not.toHaveBeenCalled();
+  });
+
   it('throws when DB insert returns empty', async () => {
     mockResolveConfigPolicyId('cp-1');
     mockInsertReturning([]);

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -103,16 +103,35 @@ function mockSelectChain(result: unknown[]) {
   } as any);
 }
 
+// createConfigPolicyAutomationRun resolves the owning configurationPolicies.id
+// from the feature-link id via:
+//   db.select({ configPolicyId }).from(configPolicyFeatureLinks).where(...).limit(1)
+// Mock that lookup so the inserted configPolicyId is the resolved policy id, not
+// the feature-link id (issue #1855).
+function mockResolveConfigPolicyId(configPolicyId: string | null) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(
+          configPolicyId === null ? [] : [{ configPolicyId }],
+        ),
+      }),
+    }),
+  } as any);
+}
+
 describe('createConfigPolicyAutomationRun', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('creates a run record with automationId=null and verifies DB values', async () => {
+  it('creates a run record with automationId=null and the resolved configPolicyId', async () => {
+    // featureLinkId 'fl-1' resolves to configurationPolicies.id 'cp-1'.
+    mockResolveConfigPolicyId('cp-1');
     const run = {
       id: 'run-1',
       automationId: null,
-      configPolicyId: 'fl-1',
+      configPolicyId: 'cp-1',
       configItemName: 'Test Automation',
       status: 'running',
       triggeredBy: 'scheduler',
@@ -130,12 +149,12 @@ describe('createConfigPolicyAutomationRun', () => {
     });
 
     expect(result.automationId).toBeNull();
-    expect(result.configPolicyId).toBe('fl-1');
+    expect(result.configPolicyId).toBe('cp-1');
     expect(result.configItemName).toBe('Test Automation');
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         automationId: null,
-        configPolicyId: 'fl-1',
+        configPolicyId: 'cp-1',
         configItemName: 'Test Automation',
         triggeredBy: 'scheduler',
         devicesTargeted: 2,
@@ -143,12 +162,17 @@ describe('createConfigPolicyAutomationRun', () => {
     );
   });
 
-  it('sets configPolicyId to automation.featureLinkId', async () => {
+  it('writes the resolved configurationPolicies.id, NOT the feature-link id (#1855)', async () => {
+    // The feature link 'fl-custom' belongs to configurationPolicies.id
+    // 'cp-custom'. automation_runs.config_policy_id MUST hold the policy id so
+    // the RLS EXISTS-join and the read route can resolve the owning org; writing
+    // the feature-link id made the run RLS-invisible in the portal.
     const automation = makeConfigPolicyAutomation({ featureLinkId: 'fl-custom' });
+    mockResolveConfigPolicyId('cp-custom');
     const run = {
       id: 'run-1',
       automationId: null,
-      configPolicyId: 'fl-custom',
+      configPolicyId: 'cp-custom',
       configItemName: 'Test Automation',
       status: 'running',
     };
@@ -160,18 +184,24 @@ describe('createConfigPolicyAutomationRun', () => {
       triggeredBy: 'manual',
     });
 
-    expect(result.configPolicyId).toBe('fl-custom');
+    expect(result.configPolicyId).toBe('cp-custom');
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         automationId: null,
-        configPolicyId: 'fl-custom',
+        configPolicyId: 'cp-custom',
         triggeredBy: 'manual',
       })
+    );
+    // Guard against regressing to the bug: the feature-link id must never be
+    // written as the config_policy_id.
+    expect(valuesMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ configPolicyId: 'fl-custom' })
     );
   });
 
   it('sets configItemName to automation.name', async () => {
     const automation = makeConfigPolicyAutomation({ name: 'Custom Name' });
+    mockResolveConfigPolicyId('cp-1');
     const run = {
       id: 'run-1',
       automationId: null,
@@ -196,6 +226,7 @@ describe('createConfigPolicyAutomationRun', () => {
   });
 
   it('throws when DB insert returns empty', async () => {
+    mockResolveConfigPolicyId('cp-1');
     mockInsertReturning([]);
 
     await expect(
@@ -214,6 +245,7 @@ describe('createConfigPolicyAutomationRun', () => {
       devicesTargeted: 3,
       status: 'running',
     };
+    mockResolveConfigPolicyId('cp-1');
     mockInsertReturning([run]);
 
     const result = await createConfigPolicyAutomationRun({
@@ -232,6 +264,7 @@ describe('createConfigPolicyAutomationRun', () => {
       status: 'running',
       logs: [{ timestamp: '2026-02-17T00:00:00Z', level: 'info', message: 'Config policy automation run created' }],
     };
+    mockResolveConfigPolicyId('cp-1');
     mockInsertReturning([run]);
 
     const result = await createConfigPolicyAutomationRun({
@@ -280,6 +313,16 @@ describe('executeConfigPolicyAutomationRun', () => {
               where: vi.fn().mockReturnValue({
                 limit: vi.fn().mockResolvedValue([{ orgId: 'org-1' }]),
               }),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
             }),
           }),
         } as any;
@@ -338,6 +381,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         // Load devices
         return {
           from: vi.fn().mockReturnValue({
@@ -404,6 +457,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([
@@ -466,6 +529,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([
@@ -532,6 +605,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([
@@ -597,6 +680,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([
@@ -662,6 +755,16 @@ describe('executeConfigPolicyAutomationRun', () => {
           }),
         } as any;
       }
+      if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
       return {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([]),
@@ -710,6 +813,16 @@ describe('executeConfigPolicyAutomationRun', () => {
         } as any;
       }
       if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: "cp-1" }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1584,8 +1584,37 @@ async function resolveConfigPolicyOrgId(featureLinkId: string): Promise<string |
 }
 
 /**
+ * Resolves the owning `configurationPolicies.id` for a configPolicyAutomation by
+ * traversing configPolicyFeatureLinks -> configurationPolicies.
+ *
+ * `automationRuns.config_policy_id` is read by every consumer (the RLS
+ * EXISTS-join in `2026-05-30-fk-child-tables-rls.sql` and the read route in
+ * `routes/automations.ts`) as a `configurationPolicies.id`, NOT a feature-link
+ * id. Writing the feature-link id here would make the run RLS-invisible to any
+ * org-scoped reader (it matches no `configurationPolicies` row), so the run is
+ * silently un-readable in the portal even though the INSERT succeeds under the
+ * worker's system db context (issue #1855).
+ */
+async function resolveConfigPolicyId(featureLinkId: string): Promise<string | null> {
+  // Import here to avoid circular dependency at module level
+  const { configPolicyFeatureLinks } = await import('../db/schema');
+
+  const [row] = await db
+    .select({ configPolicyId: configPolicyFeatureLinks.configPolicyId })
+    .from(configPolicyFeatureLinks)
+    .where(eq(configPolicyFeatureLinks.id, featureLinkId))
+    .limit(1);
+
+  return row?.configPolicyId ?? null;
+}
+
+/**
  * Creates an automationRuns record for a config policy automation execution.
  * Uses `automationId: null` and fills `configPolicyId` + `configItemName`.
+ *
+ * `configPolicyId` is resolved to the owning `configurationPolicies.id` (NOT
+ * the feature-link id on `automation.featureLinkId`) so the run is readable by
+ * org-scoped consumers — see `resolveConfigPolicyId` / issue #1855.
  */
 export async function createConfigPolicyAutomationRun(options: {
   automation: ConfigPolicyAutomationRow;
@@ -1593,11 +1622,13 @@ export async function createConfigPolicyAutomationRun(options: {
   triggeredBy: string;
   details?: Record<string, unknown>;
 }): Promise<AutomationRunRow> {
+  const configPolicyId = await resolveConfigPolicyId(options.automation.featureLinkId);
+
   const [run] = await db
     .insert(automationRuns)
     .values({
       automationId: null,
-      configPolicyId: options.automation.featureLinkId,
+      configPolicyId,
       configItemName: options.automation.name,
       triggeredBy: options.triggeredBy,
       status: 'running',

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1623,6 +1623,17 @@ export async function createConfigPolicyAutomationRun(options: {
   details?: Record<string, unknown>;
 }): Promise<AutomationRunRow> {
   const configPolicyId = await resolveConfigPolicyId(options.automation.featureLinkId);
+  if (!configPolicyId) {
+    // The feature link is missing/orphaned, so we can't key the run to a real
+    // configuration_policies.id. Fail loudly with a domain message rather than
+    // writing a null config_policy_id, which the automation_runs RLS WITH CHECK
+    // would reject with an opaque "violates row-level security policy" error
+    // (and, if it didn't, would re-create the RLS-invisible run this fix
+    // removes). Symmetric to the orgId guard in executeConfigPolicyAutomationRun.
+    throw new Error(
+      `Could not resolve configurationPolicies.id for config policy automation ${options.automation.id} (featureLinkId=${options.automation.featureLinkId})`,
+    );
+  }
 
   const [run] = await db
     .insert(automationRuns)


### PR DESCRIPTION
## Summary

Config Policy automations (Run Script with Schedule / Device Online triggers) executed on the agent but **zero run records appeared in the portal**, plus an RLS error in the `api` logs (reported by @win-wxx in #1854 item 5).

**Root cause:** `createConfigPolicyAutomationRun` (`apps/api/src/services/automationRuntime.ts`) wrote `automation.featureLinkId` (a `config_policy_feature_links.id`) into `automation_runs.config_policy_id`, but every consumer treats that column as a `configuration_policies.id`:

- The RLS policy on `automation_runs` has no `org_id`; tenancy is an EXISTS-join (`2026-05-30-fk-child-tables-rls.sql`):
  `EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND breeze_has_org_access(cp.org_id))`. A feature-link id matches no `configuration_policies` row → the run is invisible to any org-scoped reader.
- The read route (`apps/api/src/routes/automations.ts:503-512`) joins `configurationPolicies` on `run.configPolicyId` → 404.

The bug was codified by a **mocked** unit test (`automationRuntime.configPolicy.test.ts`), which is why CI stayed green while prod was broken — the repo's known "only a forge/integration test catches it" pattern.

## Fix

- **`automationRuntime.ts`** — new `resolveConfigPolicyId(featureLinkId)` helper resolves the owning `configuration_policies.id`; `createConfigPolicyAutomationRun` now writes that, not the feature-link id.
- **Backfill migration** `2026-06-24-config-policy-run-tenant-key-backfill.sql` — remaps legacy mis-keyed rows (`automation_id IS NULL` and `config_policy_id` matching a `config_policy_feature_links.id`) to the link's `configuration_policies.id`. Idempotent (skips rows already a valid policy id), no inner `BEGIN/COMMIT`, reports the remapped count via `GET DIAGNOSTICS` per the migration-cleanup convention.
- **Unit test** — the assertion that codified the bug (`configPolicyId: 'fl-custom'`) is replaced with one asserting the resolved policy id, plus a guard that the feature-link id is never written.
- **New integration test** `configPolicyAutomationRunRls.integration.test.ts` — runs on the `breeze_app` (forced-RLS, non-BYPASSRLS) connection and proves: an org-scoped reader can SELECT a worker-created run; a feature-keyed row is RLS-invisible to **both** org and system scope; a foreign org cannot read it; and the backfill makes a legacy row visible (and is idempotent). Case (0) asserts `rolbypassrls = false` so the forge assertions can't pass vacuously.

## Note on the WITH CHECK

The `automation_runs` INSERT `WITH CHECK` requires the EXISTS-join to resolve. A feature-link id has no matching `configuration_policies` row, so under `breeze_app` (even with the system GUC) the bad INSERT is *rejected*, not silently stored — so post-RLS-migration mis-keyed rows largely couldn't be written via the app at all. The backfill still targets any legacy rows that predate that migration (or were written via a privileged path). The fix makes the worker INSERT both succeed and be portal-readable.

## Testing

- `vitest run automationRuntime.configPolicy.test.ts` — 15 passed
- `vitest run --config vitest.integration.config.ts configPolicyAutomationRunRls.integration.test.ts` — 5 passed (breeze_app, RLS enforced)
- `tsc --noEmit` — clean
- `autoMigrate.test.ts` (migration ordering) — 43 passed
- Migration applies cleanly against the test DB

No schema change (data-only migration); the `db:check-drift` failure on the shared test DB is pre-existing ledger contamination from other branches' migrations, unrelated to this PR.

Refs #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)