### PR TITLE
feat(billing): quote/invoice presentation refresh + typed-name e-signature

### DIFF
--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -100,9 +100,12 @@ quoteRoutes.get('/quotes/:id/images/:imageId', zValidator('param', imageParam), 
   return new Response(new Uint8Array(img.data), { status: 200, headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' } });
 });
 
-// POST /quotes/:id/accept — signer identity = the authenticated portal user.
+// POST /quotes/:id/accept — signer types their full name (electronic signature)
+// in the portal's signature panel; we record it as signerName. Falls back to the
+// authenticated identity if the body omits it (older clients).
 quoteRoutes.post('/quotes/:id/accept', zValidator('param', idParam), zValidator('json', acceptQuoteSchema.partial()), async (c) => {
   const auth = c.get('portalAuth'); const { id } = c.req.valid('param');
+  const signerName = c.req.valid('json').signerName?.trim() || auth.user.name || auth.user.email;
   const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId), ne(quotes.status, 'draft'))).limit(1);
   if (!quote) return c.json({ error: 'Quote not found' }, 404);
   try {
@@ -114,7 +117,7 @@ quoteRoutes.post('/quotes/:id/accept', zValidator('param', idParam), zValidator(
     // Org ownership is already verified by the org-scoped lookup above. The
     // public path (quotesPublic.ts) wraps acceptQuote the same way.
     const res = await runOutsideDbContext(() => withSystemDbAccessContext(() => acceptQuote({
-      quoteId: id, signerName: auth.user.name || auth.user.email, signerEmail: auth.user.email,
+      quoteId: id, signerName, signerEmail: auth.user.email,
       ipAddress: getTrustedClientIpOrUndefined(c) ?? null, userAgent: c.req.header('user-agent') ?? null, actorUserId: null,
     })));
     // Post-commit (outside the DB context): emit invoice.issued + enqueue the PDF

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -15,10 +15,8 @@ import {
 import { QuoteServiceError, type QuoteActor } from '../../services/quoteTypes';
 import { db } from '../../db';
 import { quoteImages } from '../../db/schema/quotes';
-import { partners } from '../../db/schema/orgs';
-import { portalBranding } from '../../db/schema/portal';
 import { safeContentDispositionFilename } from '../../utils/httpHeaders';
-import { buildSellerSnapshot } from '../../services/sellerSnapshot';
+import { resolveQuoteBranding } from '../../services/quoteBranding';
 
 export const quoteCrudRoutes = new Hono();
 const scopes = requireScope('partner', 'system');
@@ -46,8 +44,14 @@ quoteCrudRoutes.post('/', scopes, writePerm, zValidator('json', createQuoteSchem
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {
-  try { return c.json({ data: await getQuote(c.req.valid('param').id, quoteActorFrom(c)) }); }
-  catch (err) { return handleServiceError(c, err); }
+  try {
+    const detail = await getQuote(c.req.valid('param').id, quoteActorFrom(c));
+    // Branding lets the in-app Preview render the customer-facing document
+    // (logo, accent, seller, footer) without a second round-trip — same object
+    // the PDF route builds, so the preview matches what the customer receives.
+    const branding = await resolveQuoteBranding(detail.quote);
+    return c.json({ data: { ...detail, branding } });
+  } catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.patch('/:id', scopes, writePerm, zValidator('param', idParam), zValidator('json', updateQuoteSchema), async (c) => {
   try { return c.json({ data: await updateQuote(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c)) }); }
@@ -94,26 +98,13 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
   try {
     const { quote, blocks, lines } = await getQuote(id, quoteActorFrom(c));
 
-    const [partner] = await db
-      .select()
-      .from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
-    const [brand] = await db
-      .select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText })
-      .from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
-
-    const branding = {
-      partnerName: partner?.name ?? 'Proposal',
-      logoUrl: brand?.logoUrl ?? null,
-      primaryColor: brand?.primaryColor ?? null,
-      footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null,
-      currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',
-    };
+    const branding = await resolveQuoteBranding(quote);
 
     const quoteForRender = {
       ...quote,
-      // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
-      // the From block still renders (issued docs use the frozen column).
-      sellerSnapshot: quote.sellerSnapshot ?? (partner ? buildSellerSnapshot(partner) : null),
+      // Legacy/draft docs have no frozen snapshot; resolveQuoteBranding synthesizes
+      // one from the live partner so the From block still renders.
+      sellerSnapshot: branding.seller,
     };
 
     // Real image loader: pull bytes from quote_images, constrained to BOTH the

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -203,17 +203,17 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       const right = doc.page.width - doc.page.margins.right;
       const contentWidth = right - left;
 
-      // Header: partner name + INVOICE title.
-      doc.fillColor(primary).fontSize(20).font('Helvetica-Bold').text(branding.partnerName, left, 50, { width: contentWidth * 0.6 });
-      doc.fillColor('#111827').fontSize(18).font('Helvetica-Bold').text('INVOICE', left, 52, { width: contentWidth, align: 'right' });
-      doc.fillColor('#6b7280').fontSize(10).font('Helvetica').text(invoice.invoiceNumber ?? 'DRAFT', left, 74, { width: contentWidth, align: 'right' });
-      doc.moveTo(left, 96).lineTo(right, 96).lineWidth(2).strokeColor(primary).stroke();
+      // Header: partner wordmark (left) + accent INVOICE eyebrow + number (right).
+      doc.fillColor('#111827').fontSize(20).font('Helvetica-Bold').text(branding.partnerName, left, 50, { width: contentWidth * 0.55 });
+      doc.fillColor(primary).fontSize(10).font('Helvetica-Bold').text('INVOICE', left, 52, { width: contentWidth, align: 'right', characterSpacing: 1.5 });
+      doc.fillColor('#111827').fontSize(20).font('Helvetica-Bold').text(invoice.invoiceNumber ?? 'Draft', left, 66, { width: contentWidth, align: 'right' });
+      doc.moveTo(left, 100).lineTo(right, 100).lineWidth(2).strokeColor(primary).stroke();
 
       // From (seller) — left column; Bill To — right column; dates under Bill To.
       const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
       const rightX = left + contentWidth * 0.55;
       const rightW = contentWidth * 0.45;
-      let y = 112;
+      let y = 120;
 
       doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', left, y);
       doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? branding.partnerName, left, y + 12, { width: contentWidth * 0.5 });
@@ -242,12 +242,14 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       const colDescW = contentWidth * 0.60;
       const colNumW = contentWidth * 0.18;
 
-      doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold');
+      doc.save();
+      doc.rect(left - 6, y - 5, contentWidth + 12, 22).fill('#f8fafc');
+      doc.restore();
+      doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
       doc.text('DESCRIPTION', left, y);
       doc.text('QTY', colQtyX, y, { width: colNumW, align: 'right' });
       doc.text('AMOUNT', colAmtX, y, { width: colNumW, align: 'right' });
-      y += 14;
-      doc.moveTo(left, y).lineTo(right, y).lineWidth(1).strokeColor('#e5e7eb').stroke();
+      y += 18;
       y += 6;
 
       for (const group of groupVisibleLinesByTicket(lines)) {
@@ -271,18 +273,22 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       y += 8;
       const labelX = colQtyX;
       const labelW = colAmtX - colQtyX - 4;
-      const drawTotal = (label: string, amount: string | number, bold = false) => {
-        doc.font(bold ? 'Helvetica-Bold' : 'Helvetica').fontSize(bold ? 12 : 10).fillColor(bold ? '#111827' : '#6b7280');
+      const drawTotal = (label: string, amount: string | number, opts: { bold?: boolean; emphasis?: boolean } = {}) => {
+        const { bold = false, emphasis = false } = opts;
+        const strong = bold || emphasis;
+        doc.font(strong ? 'Helvetica-Bold' : 'Helvetica').fontSize(emphasis ? 14 : strong ? 12 : 10).fillColor(strong ? '#111827' : '#6b7280');
         doc.text(label, labelX, y, { width: labelW, align: 'left' });
-        doc.fillColor(bold ? '#111827' : '#1f2937').text(formatMoney(amount, currency), colAmtX, y, { width: colNumW, align: 'right' });
-        y += bold ? 18 : 14;
+        doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(formatMoney(amount, currency), colAmtX, y, { width: colNumW, align: 'right' });
+        y += emphasis ? 20 : strong ? 18 : 14;
       };
       drawTotal('Subtotal', invoice.subtotal);
       drawTotal(`Tax${invoice.taxRate ? ` (${(Number(invoice.taxRate) * 100).toFixed(2)}%)` : ''}`, invoice.taxTotal);
-      drawTotal('Total', invoice.total, true);
       if (Number(invoice.amountPaid) > 0) {
+        drawTotal('Total', invoice.total, { bold: true });
         drawTotal('Paid', invoice.amountPaid);
-        drawTotal('Balance due', invoice.balance, true);
+        drawTotal('Balance due', invoice.balance, { emphasis: true });
+      } else {
+        drawTotal('Total', invoice.total, { emphasis: true });
       }
 
       // Notes (memo) + Terms & Conditions + footer/terms.

--- a/apps/api/src/services/quoteBranding.test.ts
+++ b/apps/api/src/services/quoteBranding.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// resolveQuoteBranding runs two sequential reads: select(...).from(partners)...
+// then select(...).from(portal_branding)... Each `.limit(1)` chain resolves to
+// the next queued row-array, so dbRows.next = [[partner], [brand]] per test.
+const dbRows = vi.hoisted(() => ({ next: [] as unknown[][], i: 0 }));
+vi.mock('../db', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => Promise.resolve(dbRows.next[dbRows.i++] ?? []);
+  return { db: { select: () => chain } };
+});
+
+import { resolveQuoteBranding, type QuoteBrandingSource } from './quoteBranding';
+
+function queue(partner: unknown | null, brand: unknown | null): void {
+  dbRows.next = [partner ? [partner] : [], brand ? [brand] : []];
+  dbRows.i = 0;
+}
+
+const basePartner = {
+  name: 'Lantern IT', invoiceFooter: 'partner footer', currencyCode: 'EUR',
+  billingCompanyName: 'Lantern IT Services', billingEmail: 'b@x.io', billingPhone: null, billingWebsite: null,
+  billingAddressLine1: '1 St', billingAddressLine2: null, billingAddressCity: 'PDX',
+  billingAddressRegion: 'OR', billingAddressPostalCode: '97204', billingAddressCountry: 'US',
+};
+const baseBrand = { logoUrl: 'logo.png', primaryColor: '#1c8a9e', footerText: 'portal footer' };
+
+function source(overrides: Partial<QuoteBrandingSource> = {}): QuoteBrandingSource {
+  return { partnerId: 'p1', orgId: 'o1', currencyCode: 'USD', terms: null, sellerSnapshot: null, ...overrides };
+}
+
+beforeEach(() => { dbRows.next = []; dbRows.i = 0; });
+
+describe('resolveQuoteBranding', () => {
+  it('footer precedence: quote.terms wins over partner + portal footer', async () => {
+    queue(basePartner, baseBrand);
+    const b = await resolveQuoteBranding(source({ terms: 'quote terms' }));
+    expect(b.footer).toBe('quote terms');
+  });
+
+  it('footer precedence: partner invoiceFooter beats portal footer when terms null', async () => {
+    queue(basePartner, baseBrand);
+    const b = await resolveQuoteBranding(source({ terms: null }));
+    expect(b.footer).toBe('partner footer');
+  });
+
+  it('footer precedence: portal footerText used when terms + partner footer absent', async () => {
+    queue({ ...basePartner, invoiceFooter: null }, baseBrand);
+    const b = await resolveQuoteBranding(source());
+    expect(b.footer).toBe('portal footer');
+  });
+
+  it('currency: quote → partner → USD fallback', async () => {
+    queue(basePartner, baseBrand);
+    expect((await resolveQuoteBranding(source({ currencyCode: 'GBP' }))).currencyCode).toBe('GBP');
+    queue(basePartner, baseBrand);
+    expect((await resolveQuoteBranding(source({ currencyCode: null }))).currencyCode).toBe('EUR'); // partner
+    queue({ ...basePartner, currencyCode: null }, baseBrand);
+    expect((await resolveQuoteBranding(source({ currencyCode: null }))).currencyCode).toBe('USD');
+  });
+
+  it('partner absent → partnerName falls back to "Proposal", logo/color/seller null', async () => {
+    queue(null, baseBrand);
+    const b = await resolveQuoteBranding(source());
+    expect(b.partnerName).toBe('Proposal');
+    expect(b.seller).toBeNull();
+    // brand still resolves logo/color from the portal_branding read.
+    expect(b.logoUrl).toBe('logo.png');
+    expect(b.primaryColor).toBe('#1c8a9e');
+  });
+
+  it('frozen sellerSnapshot wins; buildSellerSnapshot is not synthesized', async () => {
+    queue(basePartner, baseBrand);
+    const frozen = { name: 'Frozen Co', address: null, phone: null, email: null, website: null };
+    const b = await resolveQuoteBranding(source({ sellerSnapshot: frozen }));
+    expect(b.seller).toEqual(frozen);
+  });
+
+  it('no frozen snapshot but partner present → seller synthesized from partner billing', async () => {
+    queue(basePartner, baseBrand);
+    const b = await resolveQuoteBranding(source({ sellerSnapshot: null }));
+    expect(b.seller?.name).toBe('Lantern IT Services'); // billingCompanyName
+    expect(b.seller?.email).toBe('b@x.io');
+  });
+
+  it('brand absent → logoUrl/primaryColor null', async () => {
+    queue(basePartner, null);
+    const b = await resolveQuoteBranding(source());
+    expect(b.logoUrl).toBeNull();
+    expect(b.primaryColor).toBeNull();
+  });
+});

--- a/apps/api/src/services/quoteBranding.ts
+++ b/apps/api/src/services/quoteBranding.ts
@@ -1,0 +1,70 @@
+// Resolves a quote's document branding — partner identity, portal logo/accent,
+// footer, currency, and the seller "From" snapshot. Shared by the PDF renderer
+// route and the quote-detail route so the downloadable PDF and the in-app /
+// customer web preview brand identically (one source of truth).
+//
+// Call only from a `partner`- or `system`-scoped route (the staff quotes API).
+// `partners` is a partner-axis RLS table: under an ORG-scoped context (e.g. a
+// portal route) `breeze_has_partner_access` is false and the read silently
+// returns 0 rows (#1375 class), degrading branding to the "Proposal" fallback.
+// Portal routes that need branding read `partners` themselves under
+// withSystemDbAccessContext — do NOT wire this helper into them as-is.
+
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { partners } from '../db/schema/orgs';
+import { portalBranding } from '../db/schema/portal';
+import { buildSellerSnapshot, type SellerSnapshot } from './sellerSnapshot';
+
+export interface QuoteBranding {
+  /** Partner display name; falls back to "Proposal" when the partner is absent. */
+  partnerName: string;
+  /** Portal logo URL (data: or hosted) rendered directly in an <img>, or null. */
+  logoUrl: string | null;
+  /** Partner brand accent (hex), or null to use the app's default accent. */
+  primaryColor: string | null;
+  /** Footer / terms line. Precedence: quote.terms → partner footer → portal footer. */
+  footer: string | null;
+  /** Resolved currency for money formatting. */
+  currencyCode: string;
+  /** Seller "From" block — the quote's frozen snapshot, or synthesized live for drafts. */
+  seller: SellerSnapshot | null;
+}
+
+/** Branding-relevant subset of a quote row (keeps the helper decoupled from the
+ *  full Drizzle row type so both routes can pass their already-loaded quote).
+ *  `sellerSnapshot` is the raw jsonb column (typed `unknown` by Drizzle); it's
+ *  narrowed to SellerSnapshot internally. */
+export interface QuoteBrandingSource {
+  partnerId: string;
+  orgId: string;
+  currencyCode: string | null;
+  terms: string | null;
+  sellerSnapshot: unknown;
+}
+
+export async function resolveQuoteBranding(quote: QuoteBrandingSource): Promise<QuoteBranding> {
+  const [partner] = await db
+    .select()
+    .from(partners)
+    .where(eq(partners.id, quote.partnerId))
+    .limit(1);
+  const [brand] = await db
+    .select({
+      logoUrl: portalBranding.logoUrl,
+      primaryColor: portalBranding.primaryColor,
+      footerText: portalBranding.footerText,
+    })
+    .from(portalBranding)
+    .where(eq(portalBranding.orgId, quote.orgId))
+    .limit(1);
+
+  return {
+    partnerName: partner?.name ?? 'Proposal',
+    logoUrl: brand?.logoUrl ?? null,
+    primaryColor: brand?.primaryColor ?? null,
+    footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null,
+    currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',
+    seller: (quote.sellerSnapshot as SellerSnapshot | null) ?? (partner ? buildSellerSnapshot(partner) : null),
+  };
+}

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -164,14 +164,16 @@ function renderLineTable(doc: PDFKit.PDFDocument, lines: QuoteLine[], currency: 
   const c = columnsFor(doc);
   let y = ensureSpace(doc, startY, 60);
 
-  // Header row.
-  doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold');
+  // Header row with a light fill bar.
+  doc.save();
+  doc.rect(c.left - 6, y - 5, c.contentWidth + 12, 22).fill('#f8fafc');
+  doc.restore();
+  doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
   doc.text('QTY', c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
   doc.text('DESCRIPTION', c.colQtyX + c.contentWidth * 0.12, y, { width: c.contentWidth * 0.46, align: 'left' });
   doc.text('UNIT', c.colUnitX, y, { width: c.colNumW, align: 'right' });
   doc.text('TOTAL', c.colAmtX, y, { width: c.colNumW, align: 'right' });
-  y += 14;
-  doc.moveTo(c.left, y).lineTo(c.right, y).lineWidth(1).strokeColor('#e5e7eb').stroke();
+  y += 18;
   y += 6;
 
   const descX = c.colQtyX + c.contentWidth * 0.12;
@@ -200,20 +202,30 @@ function renderLineTable(doc: PDFKit.PDFDocument, lines: QuoteLine[], currency: 
 // amount.
 // ---------------------------------------------------------------------------
 
-function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, startY: number): number {
+function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number): number {
   const c = columnsFor(doc);
   let y = ensureSpace(doc, startY + 6, 90);
 
-  doc.moveTo(c.colUnitX, y).lineTo(c.right, y).lineWidth(1).strokeColor('#e5e7eb').stroke();
+  // Wider label column than the line table's so the emphasised "Due on
+  // acceptance" figure (14pt) and the recurring labels never wrap/overlap.
+  const sumX = c.left + c.contentWidth * 0.40;
+  doc.moveTo(sumX, y).lineTo(c.right, y).lineWidth(1).strokeColor('#e5e7eb').stroke();
   y += 8;
 
-  const labelX = c.colUnitX;
-  const labelW = c.colAmtX - c.colUnitX - 4;
-  const drawRow = (label: string, amount: string | number | null | undefined, suffix: string, bold = false) => {
-    doc.font(bold ? 'Helvetica-Bold' : 'Helvetica').fontSize(bold ? 12 : 10).fillColor(bold ? '#111827' : '#6b7280');
+  const labelX = sumX;
+  const labelW = c.colAmtX - sumX - 8;
+  const drawRow = (
+    label: string,
+    amount: string | number | null | undefined,
+    suffix: string,
+    opts: { bold?: boolean; emphasis?: boolean } = {},
+  ) => {
+    const { bold = false, emphasis = false } = opts;
+    const strong = bold || emphasis;
+    doc.font(strong ? 'Helvetica-Bold' : 'Helvetica').fontSize(emphasis ? 14 : strong ? 12 : 10).fillColor(strong ? '#111827' : '#6b7280');
     doc.text(label, labelX, y, { width: labelW, align: 'left' });
-    doc.fillColor(bold ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
-    y += bold ? 18 : 14;
+    doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
+    y += emphasis ? 20 : strong ? 18 : 14;
   };
 
   drawRow('One-time', quote.oneTimeTotal, '');
@@ -224,11 +236,11 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
   }
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
-  // Bold primary figure = what accept invoices now. Fall back to the one-time
+  // Accent primary figure = what accept invoices now. Fall back to the one-time
   // total if the derived field is somehow absent.
-  drawRow('Due on acceptance', quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, '', true);
+  drawRow('Due on acceptance', quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, '', { emphasis: true });
   if (hasRecurring) {
-    drawRow('First-period total (incl. recurring)', quote.total, '');
+    drawRow('First-period total', quote.total, '');
   }
   return y;
 }
@@ -259,14 +271,14 @@ export async function renderQuotePdf(
 
   const c = columnsFor(doc);
 
-  // ---- Header: partner name + PROPOSAL title + quote number ----------------
-  doc.fillColor(primary).fontSize(20).font('Helvetica-Bold').text(partnerName, c.left, 50, { width: c.contentWidth * 0.6 });
-  doc.fillColor('#111827').fontSize(18).font('Helvetica-Bold').text('PROPOSAL', c.left, 52, { width: c.contentWidth, align: 'right' });
-  doc.fillColor('#6b7280').fontSize(10).font('Helvetica').text(quote.quoteNumber ?? 'DRAFT', c.left, 74, { width: c.contentWidth, align: 'right' });
-  doc.moveTo(c.left, 96).lineTo(c.right, 96).lineWidth(2).strokeColor(primary).stroke();
+  // ---- Header: partner wordmark (left) + accent PROPOSAL eyebrow + number ---
+  doc.fillColor('#111827').fontSize(20).font('Helvetica-Bold').text(partnerName, c.left, 50, { width: c.contentWidth * 0.55 });
+  doc.fillColor(primary).fontSize(10).font('Helvetica-Bold').text('PROPOSAL', c.left, 52, { width: c.contentWidth, align: 'right', characterSpacing: 1.5 });
+  doc.fillColor('#111827').fontSize(20).font('Helvetica-Bold').text(quote.quoteNumber ?? 'Draft', c.left, 66, { width: c.contentWidth, align: 'right' });
+  doc.moveTo(c.left, 100).lineTo(c.right, 100).lineWidth(2).strokeColor(primary).stroke();
 
   // ---- From (seller) left column; Prepared For + dates right column ---------
-  let y = 112;
+  let y = 120;
   const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? null;
   const rightX = c.left + c.contentWidth * 0.55;
   const rightW = c.contentWidth * 0.45;
@@ -351,7 +363,17 @@ export async function renderQuotePdf(
       }
     } else if (b.blockType === 'line_items') {
       const blockLines = lines.filter((l) => l.blockId === b.id);
-      if (blockLines.length) y = renderLineTable(doc, blockLines, currency, y);
+      if (blockLines.length) {
+        // Section label above the table (parity with the web document), e.g.
+        // "Recurring services" / "One-time".
+        const label = String((b.content as { label?: string }).label ?? '').trim();
+        if (label) {
+          y = ensureSpace(doc, y, 36);
+          doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
+          y = doc.y + 6;
+        }
+        y = renderLineTable(doc, blockLines, currency, y);
+      }
     }
   }
 
@@ -360,7 +382,7 @@ export async function renderQuotePdf(
   if (orphanLines.length) y = renderLineTable(doc, orphanLines, currency, y);
 
   // ---- Recurring summary footer -------------------------------------------
-  y = renderRecurringSummary(doc, quote, currency, y);
+  y = renderRecurringSummary(doc, quote, currency, primary, y);
 
   // ---- Terms & Conditions --------------------------------------------------
   if (quote.termsAndConditions) {

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import { ArrowLeft, AlertCircle, Download, CreditCard } from 'lucide-react';
 import { type InvoiceDetail, type InvoiceStatus, buildPortalApiUrl, portalApi } from '@/lib/api';
 import { STATUS_LABELS, statusColor } from '@/lib/invoiceStatus';
-import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
+import { DocumentPaper, DocumentHeader, DocumentTerms, type DocSeller } from './documentShell';
 
 // Invoice statuses that can be paid online (mirrors the API's PAYABLE set).
 const PAYABLE_STATUSES: ReadonlySet<InvoiceStatus> = new Set(['sent', 'partially_paid', 'overdue']);
@@ -90,8 +90,11 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   const currency = invoice.currencyCode;
   const canPay = PAYABLE_STATUSES.has(invoice.status) && Number(invoice.balance) > 0;
 
-  const seller = invoice.sellerSnapshot ?? null;
-  const sellerAddressLines = sellerLines(seller?.address ?? null);
+  const seller = (invoice.sellerSnapshot ?? null) as DocSeller | null;
+  const headerDates = [
+    { label: 'Issued', value: shortDate(invoice.issueDate) },
+    { label: 'Due', value: shortDate(invoice.dueDate) },
+  ];
 
   const payInvoice = async () => {
     if (paying) return;
@@ -142,24 +145,12 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   };
 
   return (
-    <div className="space-y-6">
-      <a href={withBase("/invoices")} className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
-        <ArrowLeft className="h-4 w-4" />
-        Back to invoices
-      </a>
-
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">{invoice.invoiceNumber ?? 'Invoice'}</h1>
-          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
-            <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(invoice.status))}>
-              {STATUS_LABELS[invoice.status]}
-            </span>
-            <span>Issued {shortDate(invoice.issueDate)}</span>
-            <span>·</span>
-            <span>Due {shortDate(invoice.dueDate)}</span>
-          </div>
-        </div>
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <a href={withBase("/invoices")} className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+          <ArrowLeft className="h-4 w-4" />
+          Back to invoices
+        </a>
         <div className="flex flex-wrap items-center gap-2">
           {canPay && (
             <button
@@ -207,70 +198,63 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{downloadError}</div>
       )}
 
-      <div className="flex flex-wrap gap-4">
-        {invoice.billToName && (
-          <div className="flex-1 rounded-lg border p-4">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Bill to</p>
-            <p className="mt-1 text-sm">{invoice.billToName}</p>
+      <DocumentPaper testId="invoice-document">
+        <DocumentHeader
+          seller={seller}
+          eyebrow="Invoice"
+          title={invoice.invoiceNumber ?? 'Invoice'}
+          statusLabel={STATUS_LABELS[invoice.status]}
+          statusClass={statusColor(invoice.status)}
+          dates={headerDates}
+          preparedForLabel="Bill to"
+          preparedForName={invoice.billToName ?? undefined}
+        />
+
+        <div className="overflow-hidden rounded-lg border bg-card">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[28rem] text-sm">
+              <thead>
+                <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+                  <th className="px-2 py-2.5 text-right font-medium">Qty</th>
+                  <th className="px-2 py-2.5 text-right font-medium">Price</th>
+                  <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lines.map((l) => (
+                  <tr key={l.id} className="border-b align-top last:border-0">
+                    <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{l.quantity}</td>
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{money(l.unitPrice, currency)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{money(l.lineTotal, currency)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        )}
+        </div>
 
-        {seller?.name && (
-          <div className="flex-1 rounded-lg border p-4" data-testid="invoice-from">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
-            <p className="mt-1 text-sm font-medium">{seller.name}</p>
-            {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
-            {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
-            {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
-            {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
+        <section className="flex justify-end">
+          <div className="w-full max-w-xs space-y-2.5">
+            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Subtotal</span><span className="tabular-nums text-foreground">{money(invoice.subtotal, currency)}</span></div>
+            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Tax</span><span className="tabular-nums text-foreground">{money(invoice.taxTotal, currency)}</span></div>
+            <div className="flex justify-between border-t pt-2.5 text-sm"><span className="font-medium text-foreground">Total</span><span className="font-medium tabular-nums text-foreground">{money(invoice.total, currency)}</span></div>
+            {Number(invoice.amountPaid) > 0 && (
+              <div className="flex justify-between text-sm"><span className="text-muted-foreground">Paid</span><span className="tabular-nums text-foreground">−{money(invoice.amountPaid, currency)}</span></div>
+            )}
+            <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
+              <span className="text-sm font-semibold text-foreground">Balance due</span>
+              <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }} data-testid="invoice-balance-due">{money(invoice.balance, currency)}</span>
+            </div>
           </div>
+        </section>
+
+        {invoice.notes && <DocumentTerms label="Notes">{invoice.notes}</DocumentTerms>}
+        {invoice.termsAndConditions && (
+          <DocumentTerms label="Terms & Conditions" testId="invoice-terms-conditions">{invoice.termsAndConditions}</DocumentTerms>
         )}
-      </div>
-
-      <div className="overflow-hidden rounded-lg border">
-        <table className="w-full">
-          <thead className="bg-muted/50">
-            <tr>
-              <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Description</th>
-              <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">Qty</th>
-              <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">Price</th>
-              <th className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">Total</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {lines.map((l) => (
-              <tr key={l.id}>
-                <td className="px-4 py-3 text-sm">{l.description}</td>
-                <td className="px-4 py-3 text-right text-sm">{l.quantity}</td>
-                <td className="px-4 py-3 text-right text-sm">{money(l.unitPrice, currency)}</td>
-                <td className="px-4 py-3 text-right text-sm">{money(l.lineTotal, currency)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="ml-auto max-w-xs space-y-1 text-sm">
-        <div className="flex justify-between"><span className="text-muted-foreground">Subtotal</span><span>{money(invoice.subtotal, currency)}</span></div>
-        <div className="flex justify-between"><span className="text-muted-foreground">Tax</span><span>{money(invoice.taxTotal, currency)}</span></div>
-        <div className="flex justify-between border-t pt-1 font-semibold"><span>Total</span><span>{money(invoice.total, currency)}</span></div>
-        <div className="flex justify-between"><span className="text-muted-foreground">Paid</span><span>{money(invoice.amountPaid, currency)}</span></div>
-        <div className="flex justify-between border-t pt-1 font-semibold"><span>Balance due</span><span>{money(invoice.balance, currency)}</span></div>
-      </div>
-
-      {invoice.notes && (
-        <div className="rounded-lg border p-4">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notes</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{invoice.notes}</p>
-        </div>
-      )}
-
-      {invoice.termsAndConditions && (
-        <div className="rounded-lg border p-4" data-testid="invoice-terms-conditions">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{invoice.termsAndConditions}</p>
-        </div>
-      )}
+      </DocumentPaper>
     </div>
   );
 }

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { portalApi, buildPortalApiUrl, type PublicQuoteDetail } from '@/lib/api';
-import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
 import { QuoteBlocks, money } from './quoteBlocks';
+import { DocumentPaper, DocumentHeader, DocumentTerms, type DocSeller } from './documentShell';
+import { SignaturePanel } from './SignaturePanel';
 
 interface PublicQuoteViewProps {
   token: string;
@@ -18,7 +19,6 @@ function shortDate(value: string | null | undefined): string {
 }
 
 export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps) {
-  const [name, setName] = useState('');
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState(initial?.quote.status ?? '');
   const [msg, setMsg] = useState<string | null>(null);
@@ -39,20 +39,28 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
 
-  const seller = quote.sellerSnapshot ?? null;
-  const sellerAddressLines = sellerLines(seller?.address ?? null);
+  const seller = (quote.sellerSnapshot ?? null) as DocSeller | null;
 
-  const accept = async () => {
-    if (busy) return;
-    if (!name.trim()) {
-      setMsg('Please type your full name to sign.');
-      setMsgError(true);
-      return;
-    }
+  const statusBadge =
+    status === 'accepted' || status === 'converted'
+      ? { label: 'Accepted', cls: 'bg-success/10 text-success' }
+      : status === 'declined'
+        ? { label: 'Declined', cls: 'bg-destructive/10 text-destructive' }
+        : status === 'expired'
+          ? { label: 'Expired', cls: 'bg-destructive/10 text-destructive' }
+          : null;
+
+  const headerDates = [
+    ...(quote.issueDate ? [{ label: 'Issued', value: shortDate(quote.issueDate) }] : []),
+    ...(quote.expiryDate ? [{ label: 'Valid until', value: shortDate(quote.expiryDate) }] : []),
+  ];
+
+  const accept = async (signerName: string) => {
+    if (busy || !signerName.trim()) return;
     setBusy(true);
     setMsg(null);
     setMsgError(false);
-    const res = await portalApi.acceptPublicQuote(token, name.trim());
+    const res = await portalApi.acceptPublicQuote(token, signerName.trim());
     setBusy(false);
     if (res.error) {
       setMsg(res.error);
@@ -90,93 +98,74 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   };
 
   return (
-    <div data-testid="public-quote" className="mx-auto w-full max-w-2xl space-y-6 p-2 sm:p-6">
-      <header className="flex items-center gap-3 border-b pb-4">
-        {branding.logoUrl && (
-          <img src={branding.logoUrl} alt={branding.partnerName} className="h-10 w-auto" />
-        )}
-        <div>
-          <h1 className="text-xl font-semibold">
-            Proposal {quote.quoteNumber ?? ''}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            from {branding.partnerName}
-            {quote.expiryDate ? ` · valid until ${shortDate(quote.expiryDate)}` : ''}
+    <div className="mx-auto w-full max-w-3xl space-y-5 p-2 sm:p-4">
+      <DocumentPaper primaryColor={branding.primaryColor} testId="public-quote">
+        <DocumentHeader
+          logoUrl={branding.logoUrl}
+          partnerName={branding.partnerName}
+          seller={seller}
+          eyebrow="Proposal"
+          title={quote.quoteNumber ?? 'Proposal'}
+          statusLabel={statusBadge?.label}
+          statusClass={statusBadge?.cls}
+          dates={headerDates}
+          preparedForName={quote.billToName ?? undefined}
+        />
+
+        {quote.introNotes && (
+          <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">
+            {quote.introNotes}
           </p>
-        </div>
-      </header>
-
-      {quote.introNotes && (
-        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
-      )}
-
-      {seller?.name && (
-        <div className="rounded-lg border p-4" data-testid="public-quote-from">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
-          <p className="mt-1 text-sm font-medium">{seller.name}</p>
-          {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
-          {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
-          {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
-          {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
-        </div>
-      )}
-
-      <QuoteBlocks
-        blocks={blocks}
-        lines={lines}
-        currency={currency}
-        imageUrl={(imageId) =>
-          buildPortalApiUrl(`/quotes/public/${encodeURIComponent(token)}/images/${imageId}`)
-        }
-      />
-
-      <div className="ml-auto max-w-xs space-y-1 text-sm">
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">One-time</span>
-          <span>{money(quote.oneTimeTotal ?? 0, currency)}</span>
-        </div>
-        {Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Monthly</span>
-            <span>{money(quote.monthlyRecurringTotal ?? 0, currency)}/mo</span>
-          </div>
         )}
-        {Number(quote.annualRecurringTotal ?? 0) > 0 && (
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Annual</span>
-            <span>{money(quote.annualRecurringTotal ?? 0, currency)}/yr</span>
-          </div>
-        )}
-        <div className="flex justify-between border-t pt-1 font-semibold">
-          <span>{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
-          <span>{money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}</span>
-        </div>
-        {hasRecurring && (
-          <>
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>First-period total (incl. recurring)</span>
-              <span>{money(quote.total, currency)}</span>
+
+        <QuoteBlocks
+          blocks={blocks}
+          lines={lines}
+          currency={currency}
+          imageUrl={(imageId) =>
+            buildPortalApiUrl(`/quotes/public/${encodeURIComponent(token)}/images/${imageId}`)
+          }
+        />
+
+        <section className="flex justify-end">
+          <div className="w-full max-w-xs space-y-2.5">
+            {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Monthly recurring</span>
+                <span className="tabular-nums text-foreground">{money(quote.monthlyRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/mo</span></span>
+              </div>
+            )}
+            {hasRecurring && Number(quote.annualRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Annual recurring</span>
+                <span className="tabular-nums text-foreground">{money(quote.annualRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/yr</span></span>
+              </div>
+            )}
+            <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
+              <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+              <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                {money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}
+              </span>
             </div>
-            <p className="pt-1 text-xs text-muted-foreground">
-              Accepting invoices only the one-time charges now. Recurring lines bill on their own schedule.
-            </p>
-          </>
+            {hasRecurring && (
+              <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">First-period total</span>
+                  <span className="tabular-nums text-foreground">{money(quote.total, currency)}</span>
+                </div>
+                <p className="pt-1 text-xs leading-relaxed text-muted-foreground">
+                  Accepting this proposal bills only the one-time charges now. Recurring lines bill on their own schedule.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {quote.terms && <DocumentTerms label="Terms">{quote.terms}</DocumentTerms>}
+        {quote.termsAndConditions && (
+          <DocumentTerms label="Terms & Conditions" testId="public-quote-terms-conditions">{quote.termsAndConditions}</DocumentTerms>
         )}
-      </div>
-
-      {quote.terms && (
-        <div className="rounded-lg border p-4">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
-        </div>
-      )}
-
-      {quote.termsAndConditions && (
-        <div className="rounded-lg border p-4" data-testid="public-quote-terms-conditions">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.termsAndConditions}</p>
-        </div>
-      )}
+      </DocumentPaper>
 
       {status === 'converted' && (
         <div data-testid="public-quote-accepted" className="space-y-3 rounded-md bg-success/10 p-4 text-sm text-success">
@@ -207,40 +196,12 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
       )}
 
       {open && (
-        <div className="space-y-3 rounded-md border p-4">
-          <label htmlFor="public-quote-signer" className="block text-sm font-medium">
-            Type your full name to accept &amp; sign
-          </label>
-          <input
-            id="public-quote-signer"
-            data-testid="public-quote-signer"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            disabled={busy}
-            className="w-full rounded-md border px-3 py-2 text-sm disabled:opacity-50"
-            placeholder="Your full name"
-          />
-          <div className="flex gap-3">
-            <button
-              type="button"
-              data-testid="public-quote-accept"
-              disabled={busy}
-              onClick={() => void accept()}
-              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {busy ? 'Working…' : 'Accept & sign'}
-            </button>
-            <button
-              type="button"
-              data-testid="public-quote-decline"
-              disabled={busy}
-              onClick={() => void decline()}
-              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-            >
-              Decline
-            </button>
-          </div>
-        </div>
+        <SignaturePanel
+          onAccept={(signerName) => void accept(signerName)}
+          onDecline={() => void decline()}
+          busy={busy}
+          testIdPrefix="public-quote"
+        />
       )}
     </div>
   );

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { ArrowLeft, AlertCircle, Download } from 'lucide-react';
 import { type QuoteDetail, buildPortalApiUrl, portalApi } from '@/lib/api';
-import { sellerLines } from '@/lib/sellerLines';
 import { cn } from '@/lib/utils';
 import { QuoteBlocks, money } from './quoteBlocks';
+import { DocumentPaper, DocumentHeader, DocumentTerms, type DocSeller } from './documentShell';
+import { SignaturePanel } from './SignaturePanel';
 
 interface QuoteDetailViewProps {
   detail: QuoteDetail | null;
@@ -68,15 +69,18 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
   const currency = quote.currencyCode;
   const open = status === 'sent' || status === 'viewed';
 
-  const seller = quote.sellerSnapshot ?? null;
-  const sellerAddressLines = sellerLines(seller?.address ?? null);
+  const seller = (quote.sellerSnapshot ?? null) as DocSeller | null;
+  const headerDates = [
+    { label: 'Issued', value: shortDate(quote.issueDate) },
+    ...(quote.expiryDate ? [{ label: 'Valid until', value: shortDate(quote.expiryDate) }] : []),
+  ];
 
-  const accept = async () => {
-    if (busy) return;
+  const accept = async (signerName: string) => {
+    if (busy || !signerName.trim()) return;
     setBusy(true);
     setMsg(null);
     setMsgError(false);
-    const res = await portalApi.acceptQuote(quote.id);
+    const res = await portalApi.acceptQuote(quote.id, signerName.trim());
     setBusy(false);
     if (res.error) {
       setMsg(res.error);
@@ -123,28 +127,12 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
 
   return (
-    <div className="space-y-6" data-testid="quote-detail">
-      <a href="/quotes" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
-        <ArrowLeft className="h-4 w-4" />
-        Back to proposals
-      </a>
-
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Proposal {quote.quoteNumber ?? ''}</h1>
-          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
-            <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(status))}>
-              {STATUS_LABELS[status] ?? status}
-            </span>
-            <span>Issued {shortDate(quote.issueDate)}</span>
-            {quote.expiryDate && (
-              <>
-                <span>·</span>
-                <span>Valid until {shortDate(quote.expiryDate)}</span>
-              </>
-            )}
-          </div>
-        </div>
+    <div className="space-y-5" data-testid="quote-detail">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <a href="/quotes" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+          <ArrowLeft className="h-4 w-4" />
+          Back to proposals
+        </a>
         <a
           href={buildPortalApiUrl(`/portal/quotes/${quote.id}/pdf`)}
           download={`${quote.quoteNumber ?? `quote-${quote.id}`}.pdf`}
@@ -158,79 +146,67 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
         </a>
       </div>
 
-      {quote.introNotes && (
-        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{quote.introNotes}</p>
-      )}
+      <DocumentPaper>
+        <DocumentHeader
+          seller={seller}
+          eyebrow="Proposal"
+          title={quote.quoteNumber ?? 'Proposal'}
+          statusLabel={STATUS_LABELS[status] ?? status}
+          statusClass={statusColor(status)}
+          dates={headerDates}
+          preparedForName={quote.billToName ?? undefined}
+        />
 
-      {seller?.name && (
-        <div className="rounded-lg border p-4" data-testid="quote-from">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">From</p>
-          <p className="mt-1 text-sm font-medium">{seller.name}</p>
-          {sellerAddressLines.map((l, i) => <p key={i} className="text-sm text-muted-foreground">{l}</p>)}
-          {seller.phone && <p className="text-sm text-muted-foreground">{seller.phone}</p>}
-          {seller.email && <p className="text-sm text-muted-foreground">{seller.email}</p>}
-          {seller.website && <p className="text-sm text-muted-foreground">{seller.website}</p>}
-        </div>
-      )}
-
-      <QuoteBlocks
-        blocks={blocks}
-        lines={lines}
-        currency={currency}
-        imageUrl={(imageId) => buildPortalApiUrl(`/portal/quotes/${quote.id}/images/${imageId}`)}
-      />
-
-      <div className="ml-auto max-w-xs space-y-1 text-sm">
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">One-time</span>
-          <span>{money(quote.oneTimeTotal ?? 0, currency)}</span>
-        </div>
-        {hasRecurring && (
-          <>
-            {Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Monthly</span>
-                <span>{money(quote.monthlyRecurringTotal ?? 0, currency)}/mo</span>
-              </div>
-            )}
-            {Number(quote.annualRecurringTotal ?? 0) > 0 && (
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Annual</span>
-                <span>{money(quote.annualRecurringTotal ?? 0, currency)}/yr</span>
-              </div>
-            )}
-          </>
+        {quote.introNotes && (
+          <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">{quote.introNotes}</p>
         )}
-        <div className="flex justify-between border-t pt-1 font-semibold">
-          <span>{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
-          <span>{money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}</span>
-        </div>
-        {hasRecurring && (
-          <>
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>First-period total (incl. recurring)</span>
-              <span>{money(quote.total, currency)}</span>
+
+        <QuoteBlocks
+          blocks={blocks}
+          lines={lines}
+          currency={currency}
+          imageUrl={(imageId) => buildPortalApiUrl(`/portal/quotes/${quote.id}/images/${imageId}`)}
+        />
+
+        <section className="flex justify-end">
+          <div className="w-full max-w-xs space-y-2.5">
+            {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Monthly recurring</span>
+                <span className="tabular-nums text-foreground">{money(quote.monthlyRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/mo</span></span>
+              </div>
+            )}
+            {hasRecurring && Number(quote.annualRecurringTotal ?? 0) > 0 && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Annual recurring</span>
+                <span className="tabular-nums text-foreground">{money(quote.annualRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/yr</span></span>
+              </div>
+            )}
+            <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
+              <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+              <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                {money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}
+              </span>
             </div>
-            <p className="pt-1 text-xs text-muted-foreground">
-              Accepting invoices only the one-time charges now. Recurring lines bill on their own schedule.
-            </p>
-          </>
+            {hasRecurring && (
+              <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">First-period total</span>
+                  <span className="tabular-nums text-foreground">{money(quote.total, currency)}</span>
+                </div>
+                <p className="pt-1 text-xs leading-relaxed text-muted-foreground">
+                  Accepting this proposal bills only the one-time charges now. Recurring lines bill on their own schedule.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {quote.terms && <DocumentTerms label="Terms">{quote.terms}</DocumentTerms>}
+        {quote.termsAndConditions && (
+          <DocumentTerms label="Terms & Conditions" testId="quote-terms-conditions">{quote.termsAndConditions}</DocumentTerms>
         )}
-      </div>
-
-      {quote.terms && (
-        <div className="rounded-lg border p-4">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.terms}</p>
-        </div>
-      )}
-
-      {quote.termsAndConditions && (
-        <div className="rounded-lg border p-4" data-testid="quote-terms-conditions">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{quote.termsAndConditions}</p>
-        </div>
-      )}
+      </DocumentPaper>
 
       {msg && (
         <div
@@ -245,26 +221,12 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
       )}
 
       {open && (
-        <div className="flex gap-3">
-          <button
-            type="button"
-            data-testid="quote-accept"
-            disabled={busy}
-            onClick={() => void accept()}
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          >
-            {busy ? 'Working…' : 'Accept & sign'}
-          </button>
-          <button
-            type="button"
-            data-testid="quote-decline"
-            disabled={busy}
-            onClick={() => void decline()}
-            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-          >
-            Decline
-          </button>
-        </div>
+        <SignaturePanel
+          onAccept={(signerName) => void accept(signerName)}
+          onDecline={() => void decline()}
+          busy={busy}
+          testIdPrefix="quote"
+        />
       )}
 
       {status === 'converted' && (

--- a/apps/portal/src/components/portal/SignaturePanel.tsx
+++ b/apps/portal/src/components/portal/SignaturePanel.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from 'react';
+
+const SIGNATURE_FONT = '"Snell Roundhand", "Brush Script MT", "Segoe Script", "Apple Chancery", cursive';
+
+function today(): string {
+  const d = new Date();
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+interface SignaturePanelProps {
+  /** Called with the typed signer name once name + agreement are provided. */
+  onAccept: (signerName: string) => void | Promise<void>;
+  onDecline: () => void;
+  busy: boolean;
+  /** Prefixes the data-testids so existing public/authed selectors keep working. */
+  testIdPrefix: string;
+}
+
+/**
+ * "Sign here" panel for accepting a proposal. The signer types their full legal
+ * name, sees it rendered as a signature on a dated signature line, and must tick
+ * the agreement box — typing the name is the electronic signature. The captured
+ * name flows to the accept endpoint (name + IP + timestamp are recorded server
+ * side in quote_acceptances). Shared by the public link and the authed portal so
+ * both sign identically.
+ */
+export function SignaturePanel({ onAccept, onDecline, busy, testIdPrefix }: SignaturePanelProps) {
+  const [name, setName] = useState('');
+  const [agreed, setAgreed] = useState(false);
+  const [touched, setTouched] = useState(false);
+  const date = useMemo(() => today(), []);
+
+  const trimmed = name.trim();
+  const canSign = trimmed.length > 0 && agreed && !busy;
+
+  const submit = () => {
+    setTouched(true);
+    if (!canSign) return;
+    void onAccept(trimmed);
+  };
+
+  return (
+    <div className="rounded-xl border bg-card p-5 shadow-sm sm:p-6" data-testid={`${testIdPrefix}-sign`}>
+      <h3 className="text-sm font-semibold text-foreground">Accept &amp; sign</h3>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+        Type your full legal name to sign and accept this proposal.
+      </p>
+
+      <div className="mt-4 space-y-1.5">
+        <label htmlFor={`${testIdPrefix}-signer`} className="text-xs font-medium text-foreground">Full name</label>
+        <input
+          id={`${testIdPrefix}-signer`}
+          data-testid={`${testIdPrefix}-signer`}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => setTouched(true)}
+          disabled={busy}
+          autoComplete="name"
+          placeholder="Your full name"
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+        />
+      </div>
+
+      {/* Signature line — the typed name rendered as a signature, with the date. */}
+      <div className="mt-4 rounded-lg border bg-muted/20 px-4 pb-3 pt-6">
+        <div className="flex min-h-[3rem] items-end border-b border-foreground/30 pb-1.5">
+          <span
+            data-testid={`${testIdPrefix}-signature-preview`}
+            style={{ fontFamily: SIGNATURE_FONT }}
+            className="text-3xl leading-none text-foreground"
+          >
+            {trimmed || ' '}
+          </span>
+        </div>
+        <div className="mt-2 flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
+          <span>Signature</span>
+          <span>{date}</span>
+        </div>
+      </div>
+
+      <label className="mt-4 flex cursor-pointer items-start gap-2.5 text-sm">
+        <input
+          type="checkbox"
+          checked={agreed}
+          onChange={(e) => setAgreed(e.target.checked)}
+          disabled={busy}
+          data-testid={`${testIdPrefix}-agree`}
+          className="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-primary/40"
+        />
+        <span className="leading-relaxed text-muted-foreground">
+          I have reviewed this proposal and agree to its terms. Typing my name above is my electronic signature.
+        </span>
+      </label>
+
+      {touched && !canSign && !busy && (
+        <p className="mt-2 text-xs text-destructive" data-testid={`${testIdPrefix}-sign-hint`}>
+          {trimmed.length === 0 ? 'Please type your full name to sign.' : 'Please confirm you agree to the terms.'}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-3">
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-accept`}
+          onClick={submit}
+          disabled={!canSign}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+        >
+          {busy ? 'Working…' : 'Accept & sign'}
+        </button>
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-decline`}
+          onClick={() => onDecline()}
+          disabled={busy}
+          className="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:opacity-50"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default SignaturePanel;

--- a/apps/portal/src/components/portal/documentShell.tsx
+++ b/apps/portal/src/components/portal/documentShell.tsx
@@ -1,0 +1,115 @@
+// Shared "paper" presentation for customer-facing documents (proposals +
+// invoices). Gives the portal quote/invoice views one premium, branded look:
+// an accent top rule, a logo/seller header, and a totals/terms rhythm. The
+// accent comes from the partner's brand color (portal branding.primaryColor)
+// with the app primary as the fallback. Mirrors the dashboard's QuoteDocument so
+// staff preview and customer view match.
+import type { CSSProperties, ReactNode } from 'react';
+import { sellerLines } from '@/lib/sellerLines';
+
+export interface DocSeller {
+  name: string | null;
+  address: { line1: string | null; line2: string | null; city: string | null; region: string | null; postalCode: string | null; country: string | null } | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+}
+
+function accentVars(primaryColor?: string | null): CSSProperties {
+  return { ['--doc-accent']: primaryColor || 'hsl(var(--primary))' } as CSSProperties;
+}
+
+/** The bordered document card with a partner-accent top rule. */
+export function DocumentPaper({
+  primaryColor, children, testId,
+}: { primaryColor?: string | null; children: ReactNode; testId?: string }) {
+  return (
+    <div
+      data-testid={testId}
+      style={accentVars(primaryColor)}
+      className="overflow-hidden rounded-xl border bg-card shadow-sm"
+    >
+      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
+      <div className="space-y-10 px-4 py-7 sm:px-10 sm:py-9">{children}</div>
+    </div>
+  );
+}
+
+/** Header band: logo/wordmark + seller "From" on the left; eyebrow + title +
+ *  status + dates on the right; optional "Prepared for / Bill to" line below. */
+export function DocumentHeader({
+  logoUrl, partnerName, seller, eyebrow, title, statusLabel, statusClass, dates,
+  preparedForLabel = 'Prepared for', preparedForName,
+}: {
+  logoUrl?: string | null;
+  partnerName?: string | null;
+  seller: DocSeller | null;
+  eyebrow: string;
+  title: string;
+  statusLabel?: string;
+  statusClass?: string;
+  dates: { label: string; value: string }[];
+  preparedForLabel?: string;
+  preparedForName?: string | null;
+}) {
+  const showSeller = seller && (seller.name || seller.email || seller.phone || seller.website || sellerLines(seller.address).length > 0);
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-3">
+          {logoUrl ? (
+            <img src={logoUrl} alt={partnerName ?? ''} className="h-11 w-auto max-w-[220px] object-contain" />
+          ) : partnerName ? (
+            <p className="text-xl font-semibold tracking-tight text-foreground">{partnerName}</p>
+          ) : null}
+          {showSeller && (
+            <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
+              {seller!.name && <p className="font-medium text-foreground/80">{seller!.name}</p>}
+              {sellerLines(seller!.address).map((l, i) => <p key={i}>{l}</p>)}
+              {seller!.phone && <p>{seller!.phone}</p>}
+              {seller!.email && <p>{seller!.email}</p>}
+              {seller!.website && <p>{seller!.website}</p>}
+            </address>
+          )}
+        </div>
+
+        <div className="space-y-2 sm:text-right">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>{eyebrow}</p>
+          <p className="text-2xl font-semibold tracking-tight text-foreground">{title}</p>
+          {statusLabel && (
+            <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${statusClass ?? 'bg-muted text-muted-foreground'}`}>
+              {statusLabel}
+            </span>
+          )}
+          <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
+            {dates.map((d, i) => (
+              <div key={i} className="flex gap-2"><dt>{d.label}</dt><dd className="font-medium text-foreground/80">{d.value}</dd></div>
+            ))}
+          </dl>
+        </div>
+      </header>
+
+      {preparedForName && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{preparedForLabel}</p>
+          <p className="mt-1 text-base font-medium text-foreground">{preparedForName}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A bordered terms/notes block under a horizontal rule. */
+export function DocumentTerms({ label, children, testId }: { label: string; children: ReactNode; testId?: string }) {
+  return (
+    <section className="space-y-2 border-t pt-6" data-testid={testId}>
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</h3>
+      <p className="max-w-prose whitespace-pre-wrap text-pretty text-xs leading-relaxed text-muted-foreground">{children}</p>
+    </section>
+  );
+}
+
+/** Centered footer line (partner footer text). */
+export function DocumentFooter({ children }: { children: ReactNode }) {
+  return <footer className="border-t pt-6 text-center text-xs leading-relaxed text-muted-foreground">{children}</footer>;
+}

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -1,6 +1,6 @@
 // Shared block/line rendering for the portal proposal views (authed
 // QuoteDetailView + public PublicQuoteView). Mirrors the block walk in the web
-// dashboard's QuoteDetail.tsx and the quote PDF renderer (quotePdf.ts): blocks
+// dashboard's QuoteDocument.tsx (DocBlock) and the quote PDF renderer (quotePdf.ts): blocks
 // are drawn in sortOrder, and a `line_items` block renders its own lines as a
 // pricing table grouped by recurrence (one-time / monthly / annual). Orphan
 // lines (no blockId) fall into a trailing default pricing table — same as the
@@ -24,16 +24,21 @@ export function money(value: string | number, currencyCode: string): string {
 // stripHtml + the web detail view, which also renders rich_text as text) and
 // preserve line breaks with whitespace-pre-wrap. This is the safe sanitization.
 function stripHtml(html: string): string {
-  return html
+  // Output is rendered as a React text node (auto-escaped), so this is display
+  // cleanup. Strip tags to a fixpoint so a split tag can't survive one pass, and
+  // decode `&amp;` LAST so it can't re-introduce an entity a later rule re-decodes.
+  let out = html
     .replace(/<\s*br\s*\/?\s*>/gi, '\n')
-    .replace(/<\/(p|div|h[1-6]|li)>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
+    .replace(/<\/(p|div|h[1-6]|li)>/gi, '\n');
+  let prev: string;
+  do { prev = out; out = out.replace(/<[^>]*>/g, ''); } while (out !== prev);
+  return out
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
+    .replace(/&amp;/gi, '&')
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
@@ -66,44 +71,47 @@ function PricingTable({
   return (
     <div className="overflow-hidden rounded-lg border bg-card" data-testid={testId}>
       {label && (
-        <h3 className="border-b px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="border-b bg-muted/40 px-4 py-2.5 text-sm font-semibold text-foreground sm:px-5">
           {label}
-        </h3>
+        </div>
       )}
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50">
-          <tr>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Description</th>
-            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Qty</th>
-            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Unit</th>
-            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">Total</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {grouped.map((g) => (
-            <Fragment key={g.key}>
-              {grouped.length > 1 && (
-                <tr className="bg-muted/30">
-                  <td colSpan={4} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {g.label}
-                  </td>
-                </tr>
-              )}
-              {g.rows.map((l) => (
-                <tr key={l.id} data-testid={`quote-line-${l.id}`}>
-                  <td className="px-4 py-3">{l.description}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{Number(l.quantity)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{money(l.unitPrice, currency)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">
-                    {money(l.lineTotal, currency)}
-                    {g.suffix}
-                  </td>
-                </tr>
-              ))}
-            </Fragment>
-          ))}
-        </tbody>
-      </table>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[30rem] text-sm">
+          <thead>
+            <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+              <th className="px-2 py-2.5 text-right font-medium">Qty</th>
+              <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {grouped.map((g) => (
+              <Fragment key={g.key}>
+                {grouped.length > 1 && (
+                  <tr className="bg-muted/20">
+                    <td colSpan={4} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:px-5">
+                      {g.label}
+                    </td>
+                  </tr>
+                )}
+                {g.rows.map((l) => (
+                  <tr key={l.id} data-testid={`quote-line-${l.id}`} className="border-b align-top last:border-0">
+                    <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{Number(l.quantity)}</td>
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                      {money(l.unitPrice, currency)}{g.suffix && <span className="text-xs">{g.suffix}</span>}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
+                      {money(l.lineTotal, currency)}{g.suffix && <span className="text-xs text-muted-foreground">{g.suffix}</span>}
+                    </td>
+                  </tr>
+                ))}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -688,11 +688,12 @@ export const portalApi = {
 
   acceptQuote: async (
     id: string,
+    signerName?: string,
     config: ApiRequestConfig = {}
   ): Promise<ApiResponse<{ data: { invoiceId: string; status: string } }>> => {
     return apiPost<{ data: { invoiceId: string; status: string } }>(
       `/portal/quotes/${id}/accept`,
-      {},
+      signerName ? { signerName } : {},
       config
     );
   },

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -23,8 +23,9 @@ const sentryIntegration = sentryDsn
 
 // HelpPanel.tsx embeds the docs site in an <iframe>; without an explicit
 // frame-src the browser falls back to `default-src 'self'` and blocks it.
-// `blob:` lets the quote PDF preview frame an auth-fetched, in-memory blob URL
-// (see resolveFrameSrcDirective in ./src/lib/csp.ts for the full rationale).
+// `blob:` is a defensive allowance for same-origin app-created blob iframes
+// (originally the quote PDF preview, since removed — see resolveFrameSrcDirective
+// in ./src/lib/csp.ts for the full rationale).
 // This config is plain ESM evaluated before the TS pipeline, so we can't reuse
 // resolveFrameSrcDirective from ./src/lib/csp.ts — keep the semantics in sync.
 const frameSrcDirective = (() => {

--- a/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { QuoteDocument } from './QuoteDocument';
+import QuoteDocumentPreview from './QuoteDocument';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// QuoteDocument is presentational, but its module imports the auth/org stores and
+// navigation (used by the preview wrapper + authed images). Mock them so the unit
+// renders without real store initialization or network.
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    selector({ organizations: [{ id: 'org-1', name: 'Acme Industries' }] }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+function makeDetail(overrides: Partial<QuoteDetailData> = {}): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: 'Q-1042', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'sent',
+      currencyCode: 'USD', issueDate: '2026-06-01', expiryDate: '2026-07-01', subtotal: '500.00', taxRate: null,
+      taxTotal: '0.00', total: '545.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '45.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '500.00', billToName: 'Acme Industries',
+      introNotes: 'Thanks for considering us.', terms: null, termsAndConditions: 'Net 30.',
+      sellerSnapshot: null, acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null,
+      sentAt: '2026-06-01T00:00:00Z', viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z',
+      updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [
+      { id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' },
+    ],
+    lines: [
+      { id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, description: 'Managed Workstation', quantity: '10', unitPrice: '45.00', taxable: false, customerVisible: true, lineTotal: '450.00', recurrence: 'monthly', termMonths: null, billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' },
+      { id: 'l-2', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, description: 'Onboarding', quantity: '1', unitPrice: '500.00', taxable: false, customerVisible: true, lineTotal: '500.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 1, createdAt: '2026-06-01T00:00:00Z' },
+    ],
+    branding: {
+      partnerName: 'Lantern IT', logoUrl: null, primaryColor: '#1c8a9e', footer: 'Thank you for your business.',
+      currencyCode: 'USD', seller: { name: 'Lantern IT', address: null, phone: null, email: 'hi@lantern.it', website: null },
+    },
+    ...overrides,
+  };
+}
+
+describe('QuoteDocument', () => {
+  it('renders the proposal inline (no PDF iframe) with number, customer, lines and due total', () => {
+    render(<QuoteDocument detail={makeDetail()} customerName="Acme Industries" />);
+
+    // Regression guard: the preview is inline HTML, never a downloaded/embedded PDF.
+    expect(document.querySelector('iframe')).toBeNull();
+
+    expect(screen.getByTestId('quote-document-number')).toHaveTextContent('Q-1042');
+    expect(screen.getByTestId('quote-document-customer')).toHaveTextContent('Acme Industries');
+    expect(screen.getByText('Managed Workstation')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-document-due')).toHaveTextContent('$500.00');
+    // Recurring summary surfaces the monthly figure.
+    expect(screen.getByText(/Monthly recurring/i)).toBeInTheDocument();
+    // Seller "From" block + footer render.
+    expect(screen.getByText('hi@lantern.it')).toBeInTheDocument();
+    expect(screen.getByText('Thank you for your business.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the proposal has no content', () => {
+    render(<QuoteDocument detail={makeDetail({ blocks: [], lines: [] })} customerName="Acme Industries" />);
+    expect(screen.getByText(/doesn’t have any content yet/i)).toBeInTheDocument();
+    // No totals block without content.
+    expect(screen.queryByTestId('quote-document-due')).toBeNull();
+  });
+
+  it('falls back to a draft label and partner wordmark when number/logo are absent', () => {
+    const d = makeDetail();
+    d.quote.quoteNumber = null;
+    render(<QuoteDocument detail={d} customerName="Acme Industries" />);
+    expect(screen.getByTestId('quote-document-number')).toHaveTextContent('Draft');
+    expect(screen.getByTestId('quote-document-wordmark')).toHaveTextContent('Lantern IT'); // no logoUrl → wordmark
+  });
+});
+
+describe('QuoteDocumentPreview', () => {
+  it('renders the customer document with a Download PDF action and resolves the org name', () => {
+    const d = makeDetail();
+    d.quote.billToName = null; // force org-list resolution
+    render(<QuoteDocumentPreview detail={d} />);
+    expect(screen.getByTestId('quote-preview')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-preview-download-pdf')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-document-customer')).toHaveTextContent('Acme Industries');
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -1,0 +1,402 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { fetchWithAuth } from '../../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { handleActionError } from '../../../lib/runAction';
+import { useOrgStore } from '../../../stores/orgStore';
+import { quotePdfUrl, quoteImageUrl } from '../../../lib/api/quotes';
+import {
+  type QuoteDetail as QuoteDetailData,
+  type QuoteBlock,
+  type QuoteLine,
+  STATUS_COLORS,
+  statusLabel,
+  formatDate,
+  formatMoney,
+  sellerLines,
+} from './quoteTypes';
+
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+
+// rich_text blocks store author HTML. We render the result as a React text node
+// (auto-escaped) — never via dangerouslySetInnerHTML — so this is display
+// cleanup, not a security boundary. The tag strip runs to a fixpoint so a split
+// tag (e.g. `<<script>script>`) can't survive a single pass, and `&amp;` is
+// decoded LAST so it can't re-introduce an entity that a later rule re-decodes.
+function stripHtml(html: string): string {
+  let out = html
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li)>/gi, '\n');
+  let prev: string;
+  do { prev = out; out = out.replace(/<[^>]*>/g, ''); } while (out !== prev);
+  return out
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&amp;/gi, '&')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+const RECURRENCE_LABEL: Record<QuoteLine['recurrence'], string> = {
+  one_time: '',
+  monthly: 'Monthly',
+  annual: 'Annual',
+};
+const RECURRENCE_SUFFIX: Record<QuoteLine['recurrence'], string> = {
+  one_time: '',
+  monthly: '/mo',
+  annual: '/yr',
+};
+
+/** Quote images require the Bearer header, so a bare <img src> would 401. Fetch
+ *  the authed bytes → blob → object URL, revoked on unmount/change. Mirrors the
+ *  editor's QuoteImagePreview. */
+function DocImage({ quoteId, imageId, caption }: { quoteId: string; imageId: string; caption?: string }) {
+  const [url, setUrl] = useState<string>();
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | undefined;
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetchWithAuth(quoteImageUrl(quoteId, imageId));
+        if (!res.ok) { if (active) setFailed(true); return; }
+        const blob = await res.blob();
+        objectUrl = window.URL.createObjectURL(blob);
+        if (active) setUrl(objectUrl);
+        else window.URL.revokeObjectURL(objectUrl);
+      } catch (err) {
+        console.error('[QuoteDocument] image load failed', imageId, err instanceof Error ? err.message : err);
+        if (active) setFailed(true);
+      }
+    })();
+    return () => { active = false; if (objectUrl) window.URL.revokeObjectURL(objectUrl); };
+  }, [quoteId, imageId]);
+
+  if (failed) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/40 px-4 py-8 text-center text-xs text-muted-foreground">
+        Image unavailable
+      </div>
+    );
+  }
+  if (!url) {
+    return <div className="h-40 animate-pulse rounded-lg bg-muted/60" aria-hidden />;
+  }
+  return (
+    <figure className="space-y-2">
+      <img src={url} alt={caption || 'Proposal image'} className="w-full rounded-lg border bg-card object-contain" />
+      {caption && <figcaption className="text-center text-xs text-muted-foreground">{caption}</figcaption>}
+    </figure>
+  );
+}
+
+function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency: string; label?: string }) {
+  if (lines.length === 0) return null;
+  const sorted = [...lines].sort((a, b) => a.sortOrder - b.sortOrder);
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {label && (
+        <div className="border-b bg-muted/40 px-4 py-2.5 text-sm font-semibold text-foreground sm:px-5">{label}</div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[30rem] text-sm">
+          <thead>
+            <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+              <th className="px-2 py-2.5 text-right font-medium">Qty</th>
+              <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((l) => {
+              const suffix = RECURRENCE_SUFFIX[l.recurrence];
+              const tag = RECURRENCE_LABEL[l.recurrence];
+              return (
+                <tr key={l.id} className="border-b align-top last:border-0">
+                  <td className="px-4 py-3 text-foreground sm:px-5">
+                    <span>{l.description}</span>
+                    {tag && (
+                      <span className="ml-2 inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        {tag}
+                      </span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{l.quantity}</td>
+                  <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                    {formatMoney(l.unitPrice, currency)}{suffix && <span className="text-xs">{suffix}</span>}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
+                    {formatMoney(l.lineTotal, currency)}{suffix && <span className="text-xs text-muted-foreground">{suffix}</span>}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DocBlock({ block, lines, currency }: { block: QuoteBlock; lines: QuoteLine[]; currency: string }) {
+  if (block.blockType === 'heading') {
+    const text = (block.content?.text as string | undefined)?.trim();
+    if (!text) return null;
+    return <h2 className="text-balance text-lg font-semibold text-foreground">{text}</h2>;
+  }
+  if (block.blockType === 'rich_text') {
+    const text = stripHtml((block.content?.html as string | undefined) ?? '');
+    if (!text) return null;
+    return <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">{text}</p>;
+  }
+  if (block.blockType === 'image') {
+    const imageId = (block.content?.imageId as string | undefined) ?? '';
+    const caption = (block.content?.caption as string | undefined) ?? '';
+    if (!imageId) return null;
+    return <DocImage quoteId={block.quoteId} imageId={imageId} caption={caption} />;
+  }
+  // line_items
+  const label = (block.content?.label as string | undefined)?.trim() || 'Pricing';
+  return <PricingTable lines={lines} currency={currency} label={label} />;
+}
+
+interface DocumentProps {
+  detail: QuoteDetailData;
+  /** Resolved customer/bill-to name (parent looks it up against the org list). */
+  customerName: string;
+}
+
+/** Pure, presentational customer-facing proposal document. Renders the same
+ *  content the customer sees on their portal link, branded with the partner's
+ *  logo/accent. Works for drafts (no portal round-trip). */
+export function QuoteDocument({ detail, customerName }: DocumentProps) {
+  const { quote, blocks, lines, branding } = detail;
+  const currency = branding?.currencyCode ?? quote.currencyCode;
+  const seller = branding?.seller ?? quote.sellerSnapshot ?? null;
+  const accent = branding?.primaryColor || 'hsl(var(--primary))';
+  const accentStyle = { ['--doc-accent']: accent } as CSSProperties;
+
+  const sortedBlocks = useMemo(() => [...blocks].sort((a, b) => a.sortOrder - b.sortOrder), [blocks]);
+  const linesForBlock = useCallback(
+    (blockId: string | null) => lines.filter((l) => l.blockId === blockId).sort((a, b) => a.sortOrder - b.sortOrder),
+    [lines],
+  );
+  const looseLines = useMemo(() => linesForBlock(null), [linesForBlock]);
+  const isEmpty = sortedBlocks.length === 0 && looseLines.length === 0;
+
+  const hasRecurring =
+    Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
+  const dueOnAcceptance = quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
+
+  return (
+    <div
+      style={accentStyle}
+      data-testid="quote-document"
+      className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-sm"
+    >
+      {/* Accent top rule */}
+      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
+
+      <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
+        {/* ── Header ─────────────────────────────────────────────── */}
+        <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            {branding?.logoUrl ? (
+              <img src={branding.logoUrl} alt={branding.partnerName} className="h-11 w-auto max-w-[220px] object-contain" />
+            ) : (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="quote-document-wordmark">
+                {branding?.partnerName ?? 'Proposal'}
+              </p>
+            )}
+            {seller && (
+              <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
+                {seller.name && <p className="font-medium text-foreground/80">{seller.name}</p>}
+                {sellerLines(seller.address).map((line, i) => <p key={i}>{line}</p>)}
+                {seller.phone && <p>{seller.phone}</p>}
+                {seller.email && <p>{seller.email}</p>}
+                {seller.website && <p>{seller.website}</p>}
+              </address>
+            )}
+          </div>
+
+          <div className="space-y-2 sm:text-right">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>
+              Proposal
+            </p>
+            <p className="text-2xl font-semibold tracking-tight text-foreground" data-testid="quote-document-number">
+              {quote.quoteNumber ?? 'Draft'}
+            </p>
+            <span
+              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
+            >
+              {statusLabel(quote)}
+            </span>
+            <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
+              <div className="flex gap-2"><dt>Issued</dt><dd className="font-medium text-foreground/80">{formatDate(quote.issueDate)}</dd></div>
+              {quote.expiryDate && (
+                <div className="flex gap-2"><dt>Valid until</dt><dd className="font-medium text-foreground/80">{formatDate(quote.expiryDate)}</dd></div>
+              )}
+            </dl>
+          </div>
+        </header>
+
+        {/* ── Prepared for + intro ───────────────────────────────── */}
+        <section className="space-y-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Prepared for</p>
+            <p className="mt-1 text-base font-medium text-foreground" data-testid="quote-document-customer">{customerName}</p>
+          </div>
+          {quote.introNotes?.trim() && (
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">
+              {quote.introNotes.trim()}
+            </p>
+          )}
+        </section>
+
+        {/* ── Body blocks ────────────────────────────────────────── */}
+        {isEmpty ? (
+          <div className="rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center text-sm text-muted-foreground">
+            This proposal doesn’t have any content yet.
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {sortedBlocks.map((block) => (
+              <DocBlock key={block.id} block={block} lines={linesForBlock(block.id)} currency={currency} />
+            ))}
+            {looseLines.length > 0 && <PricingTable lines={looseLines} currency={currency} label="Additional items" />}
+          </div>
+        )}
+
+        {/* ── Totals ─────────────────────────────────────────────── */}
+        {!isEmpty && (
+          <section className="flex justify-end">
+            <div className="w-full max-w-xs space-y-2.5">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span className="tabular-nums text-foreground">{formatMoney(quote.subtotal, currency)}</span>
+              </div>
+              {Number(quote.taxTotal) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax</span>
+                  <span className="tabular-nums text-foreground">{formatMoney(quote.taxTotal, currency)}</span>
+                </div>
+              )}
+              <div
+                className="flex items-baseline justify-between border-t pt-3"
+                style={{ borderColor: 'var(--doc-accent)' }}
+              >
+                <span className="text-sm font-semibold text-foreground">Due on acceptance</span>
+                <span
+                  className="text-2xl font-semibold tabular-nums"
+                  style={{ color: 'var(--doc-accent)' }}
+                  data-testid="quote-document-due"
+                >
+                  {formatMoney(dueOnAcceptance, currency)}
+                </span>
+              </div>
+
+              {hasRecurring && (
+                <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">
+                  {Number(quote.monthlyRecurringTotal) > 0 && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Monthly recurring</span>
+                      <span className="tabular-nums text-foreground">{formatMoney(quote.monthlyRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/mo</span></span>
+                    </div>
+                  )}
+                  {Number(quote.annualRecurringTotal) > 0 && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Annual recurring</span>
+                      <span className="tabular-nums text-foreground">{formatMoney(quote.annualRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/yr</span></span>
+                    </div>
+                  )}
+                  <p className="pt-1 text-xs leading-relaxed text-muted-foreground">
+                    Accepting this proposal bills the one-time charges now. Recurring lines bill on their own schedule.
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* ── Terms & footer ─────────────────────────────────────── */}
+        {quote.termsAndConditions?.trim() && (
+          <section className="space-y-2 border-t pt-6">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</h3>
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-xs leading-relaxed text-muted-foreground">
+              {quote.termsAndConditions.trim()}
+            </p>
+          </section>
+        )}
+        {branding?.footer?.trim() && (
+          <footer className="border-t pt-6 text-center text-xs leading-relaxed text-muted-foreground">
+            {branding.footer.trim()}
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Preview-tab wrapper: resolves the customer name from the loaded org list (same
+ *  source as QuoteDetail), renders the document, and offers a PDF download. */
+export default function QuoteDocumentPreview({ detail }: { detail: QuoteDetailData }) {
+  const { quote } = detail;
+  const organizations = useOrgStore((s) => s.organizations);
+  const [busy, setBusy] = useState(false);
+
+  const customerName = useMemo(() => {
+    const billTo = quote.billToName?.trim();
+    if (billTo) return billTo;
+    const resolved = organizations.find((o) => o.id === quote.orgId)?.name?.trim();
+    return resolved || quote.orgId.slice(0, 8);
+  }, [quote.billToName, quote.orgId, organizations]);
+
+  const downloadPdf = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetchWithAuth(quotePdfUrl(quote.id));
+      if (res.status === 401) return UNAUTHORIZED();
+      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the quote PDF.'); return; }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${quote.quoteNumber ?? `quote-${quote.id}`}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      handleActionError(err, 'Could not download the quote PDF.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, quote.id, quote.quoteNumber]);
+
+  return (
+    <div className="space-y-4" data-testid="quote-preview">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">This is what your customer sees on their proposal link.</p>
+        <button
+          type="button"
+          onClick={() => void downloadPdf()}
+          disabled={busy}
+          data-testid="quote-preview-download-pdf"
+          className="inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+        >
+          {busy ? 'Preparing…' : 'Download PDF'}
+        </button>
+      </div>
+      <div className="rounded-xl bg-muted/30 p-2 sm:p-8">
+        <QuoteDocument detail={detail} customerName={customerName} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { handleActionError } from '../../../lib/runAction';
-import { quotePdfUrl } from '../../../lib/api/quotes';
 import QuoteEditor from './QuoteEditor';
 import QuoteDetail from './QuoteDetail';
+import QuoteDocumentPreview from './QuoteDocument';
 import { type QuoteDetail as QuoteDetailData } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -136,70 +135,9 @@ export default function QuoteWorkspace({ id }: Props) {
         )
       )}
 
-      {tab === 'preview' && <QuotePreview id={detail.quote.id} />}
+      {tab === 'preview' && <QuoteDocumentPreview detail={detail} />}
 
       {tab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void load()} />}
     </div>
-  );
-}
-
-// The PDF route requires the auth header, so a bare `<iframe src=...>` (which the
-// browser fetches without our token) would 401. Mirror InvoiceDetail's PDF flow:
-// fetchWithAuth → blob → object URL → iframe. Revoke the URL on unmount/change.
-function QuotePreview({ id }: { id: string }) {
-  const [url, setUrl] = useState<string>();
-  const [loading, setLoading] = useState(true);
-  const [failed, setFailed] = useState(false);
-
-  const loadPdf = useCallback(async () => {
-    setLoading(true);
-    setFailed(false);
-    let objectUrl: string | undefined;
-    try {
-      const res = await fetchWithAuth(quotePdfUrl(id));
-      if (res.status === 401) { UNAUTHORIZED(); return; }
-      if (!res.ok) { setFailed(true); handleActionError(new Error('pdf'), 'Could not load the quote preview.'); return; }
-      const blob = await res.blob();
-      objectUrl = window.URL.createObjectURL(blob);
-      setUrl(objectUrl);
-    } catch (err) {
-      setFailed(true);
-      handleActionError(err, 'Could not load the quote preview.');
-    } finally {
-      setLoading(false);
-    }
-    return objectUrl;
-  }, [id]);
-
-  useEffect(() => {
-    let active: string | undefined;
-    void loadPdf().then((u) => { active = u; });
-    return () => { if (active) window.URL.revokeObjectURL(active); };
-  }, [loadPdf]);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-16" data-testid="quote-preview-loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-      </div>
-    );
-  }
-
-  if (failed || !url) {
-    return (
-      <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="quote-preview-error">
-        Could not load the preview.{' '}
-        <button type="button" onClick={() => void loadPdf()} className="underline hover:text-foreground">Retry</button>
-      </div>
-    );
-  }
-
-  return (
-    <iframe
-      src={url}
-      title="Quote PDF preview"
-      data-testid="quote-preview-frame"
-      className="h-[80vh] w-full rounded-lg border bg-card"
-    />
   );
 }

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -86,11 +86,25 @@ export interface QuoteLine {
   createdAt: string;
 }
 
-/** Shape of `GET /quotes/:id` — `{ data: { quote, blocks, lines } }`. */
+/** Document branding resolved server-side (mirrors the PDF renderer) so the
+ *  in-app Preview matches what the customer receives. Optional because test
+ *  fixtures and the list endpoint don't carry it. */
+export interface QuoteBranding {
+  partnerName: string;
+  logoUrl: string | null;
+  /** Partner brand accent (hex); null → fall back to the app's primary accent. */
+  primaryColor: string | null;
+  footer: string | null;
+  currencyCode: string;
+  seller: SellerSnapshot | null;
+}
+
+/** Shape of `GET /quotes/:id` — `{ data: { quote, blocks, lines, branding } }`. */
 export interface QuoteDetail {
   quote: Quote;
   blocks: QuoteBlock[];
   lines: QuoteLine[];
+  branding?: QuoteBranding;
 }
 
 export const STATUS_LABELS: Record<QuoteStatus, string> = {

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -68,16 +68,15 @@ function addFrameOrigin(sources: Set<string>, rawUrl: string | undefined): void 
  * Always allow the canonical hosted docs origin, plus a self-hosted docs
  * origin when `PUBLIC_DOCS_URL` is configured.
  *
- * `blob:` is allowed so the auth-gated quote PDF preview can be framed. The
- * quote preview fetches the server-generated PDF with a Bearer header
- * (`fetchWithAuth`), turns the response into an in-memory blob, and frames the
- * resulting `blob:` object URL (see `billing/quotes/QuoteWorkspace.tsx`'s
- * `QuotePreview`). A bare `<iframe src>` can't send the auth header, so the
- * blob-URL hop is required; without `blob:` in `frame-src` the browser blocks
- * it (it does not fall back to `img-src`/`worker-src`, which already allow
- * `blob:`). This only permits framing same-origin in-memory blobs the app
- * itself created — the `frame-ancestors` and `object-src` directives are
- * independent and unaffected, so it doesn't open arbitrary external framing.
+ * `blob:` is retained in frame-src as a defensive allowance for framing
+ * same-origin, in-memory blob URLs the app itself creates. It was originally
+ * required by the auth-gated quote PDF preview (`QuotePreview`), which fetched
+ * the PDF with a Bearer header and framed the resulting `blob:` object URL.
+ * That component has been removed — the quote preview now renders the document
+ * as HTML (`QuoteDocumentPreview`) and uses no iframe — so nothing currently
+ * depends on this. It permits only same-origin app-created blobs (the
+ * `frame-ancestors` and `object-src` directives are independent and
+ * unaffected); tighten/remove it when the CSP is next revisited.
  */
 export function resolveFrameSrcDirective(options: { env?: EnvMap }): string {
   const env = options.env ?? process.env;

--- a/docs/superpowers/specs/2026-06-23-quote-invoice-presentation-refresh.md
+++ b/docs/superpowers/specs/2026-06-23-quote-invoice-presentation-refresh.md
@@ -1,0 +1,85 @@
+# Quote & Invoice Presentation Refresh
+
+**Date:** 2026-06-23
+**Status:** Phase 1 implemented; Phases 2–3 planned
+**Branch:** worktree `quotes-pdf-preview-templates`
+
+## Problem
+
+1. **Preview regression.** The quote "Preview" tab fetched the PDF as a blob and
+   framed it in an `<iframe>`. Browsers delegate that to the built-in PDF viewer,
+   which *downloads* the file instead of rendering it whenever the user/Chrome is
+   set to "Download PDFs instead of opening them." The code and CSP were correct
+   and unchanged since the feature shipped — the regression is browser-side PDF
+   handling, not a code change.
+2. **Templates look unfinished.** The downloadable quote/invoice PDFs and the
+   customer-facing web views should look professional and complete.
+3. **No web preview of the customer view.** Staff had no way to preview what the
+   customer actually sees (the portal proposal page) from inside the dashboard —
+   the portal only serves *sent* quotes, so it can't preview drafts.
+
+## Approach
+
+Render the **customer-facing document as HTML** in the Preview tab instead of
+embedding a PDF. HTML always renders inline (kills the download regression), shows
+exactly what the customer sees, works for drafts, and is far easier to make
+beautiful. "Download PDF" stays for the actual file.
+
+One **premium visual language** — clean, typographic, generous whitespace, a
+single partner-brand accent, a commanding totals block (Stripe-invoice /
+PandaDoc-proposal sensibility) — applied across all renderers. The app is a
+product-UI register, but a customer-facing proposal/invoice is the one surface
+that earns a "Committed" accent (the partner's own `primaryColor`, app blue as
+fallback).
+
+**Code sharing:** no cross-app React infra (none exists; `@breeze/shared` is
+types/validators/utils). The PDF renderer is necessarily its own implementation
+(jsPDF), so the source of truth is this design spec, not shared components. Pure
+formatters are duplicated locally per repo convention.
+
+## Phase 1 — Preview tab → customer web view (DONE)
+
+- **API:** new `resolveQuoteBranding(quote)` (`apps/api/src/services/quoteBranding.ts`)
+  returns `{ partnerName, logoUrl, primaryColor, footer, currencyCode, seller }`.
+  `GET /quotes/:id` now returns `{ quote, blocks, lines, branding }`; the PDF route
+  was refactored to use the same helper (one source of truth, no second
+  round-trip). Reads run on the request's RLS-scoped `db`.
+- **Web types:** `QuoteBranding` + optional `branding` on `QuoteDetail`
+  (`quoteTypes.ts`).
+- **Web component:** `QuoteDocument.tsx` — presentational customer document
+  (accent top rule, logo/wordmark + seller "From", status + dates, "Prepared for",
+  intro, block walk incl. authed images, recurrence-tagged pricing tables, totals
+  with "Due on acceptance" + recurring breakdown, Terms, footer). Default export
+  `QuoteDocumentPreview` wraps it with org-name resolution + a Download PDF button.
+- **Wiring:** `QuoteWorkspace` Preview tab renders `QuoteDocumentPreview` (old
+  PDF-iframe `QuotePreview` removed).
+- **Tests:** `QuoteDocument.test.tsx` (inline render, no iframe, content/states).
+  Web quote suite 20/20, API quote suite 16/16, both typechecks clean.
+
+### Follow-up (cleanup, not blocking)
+- `apps/web/src/lib/csp.ts` + `astro.config.mjs` + `middleware.ts` still allow
+  `blob:` in `frame-src` (added in #1750 for the old PDF-iframe preview). The
+  preview no longer frames a blob PDF, so it's now only needed by the HelpPanel
+  docs iframe path. Left in place to avoid churning the CSP drift guard; the
+  comment referencing `QuotePreview` is stale and can be updated when CSP is next
+  touched.
+
+## Phase 2 — Customer web views polish (DONE)
+
+New shared `apps/portal/src/components/portal/documentShell.tsx` (`DocumentPaper` /
+`DocumentHeader` / `DocumentTerms` / `DocumentFooter`) gives the portal one premium
+"paper" look. `PublicQuoteView`, `QuoteDetailView`, and `InvoiceDetailView` now
+render through it (accent top rule from the partner color; app primary fallback;
+the authed portal views omit the logo since the portal chrome already carries the
+partner brand). Shared `quoteBlocks.tsx` pricing table gets the same overflow-safe,
+recurrence-grouped styling. Portal `astro check` clean; portal suite 52/52.
+
+## Phase 3 — PDF templates polish (DONE)
+
+`quotePdf.ts` and `invoicePdf.ts` (pdfkit, **not** jsPDF) refreshed: dark partner
+wordmark + accent eyebrow ("PROPOSAL"/"INVOICE") + larger document number, a filled
+table-header bar, an accent-emphasised primary figure ("Due on acceptance" /
+"Balance due" / "Total"), a widened quote-summary label column (fixes the 14pt
+"Due on acceptance" wrap/overlap), and pricing **section labels** in the quote PDF
+for parity with the web. Verified by rendering sample PDFs (pdftoppm). API PDF tests
+14/14 pass.


### PR DESCRIPTION
## Summary
Replaces the quote **Preview** tab's PDF‑iframe (browsers *downloaded* it instead of rendering when "open PDFs externally" is set) with an inline **HTML customer document**, and unifies one premium document look across every quote/invoice surface. Adds a typed‑name **e‑signature** to the accept flow.

## What changed
**Web**
- New `QuoteDocument` / `QuoteDocumentPreview` renders the customer‑facing document from the loaded `/quotes/:id` data (works for drafts); removes the old blob→iframe `QuotePreview`. Keeps Download PDF.
- `GET /quotes/:id` now returns `branding`; new `resolveQuoteBranding` helper is the single source of truth shared with the PDF route (partnerName / logo / accent / footer / currency / seller). Documented partner‑axis RLS scope caveat.

**Portal**
- Shared `documentShell` (`DocumentPaper`/`Header`/`Terms`/`Footer`) drives `PublicQuoteView`, `QuoteDetailView`, and `InvoiceDetailView` in one branded, responsive layout.

**PDF (pdfkit)**
- `quotePdf` / `invoicePdf`: accent eyebrow + larger number, filled table header, accent‑emphasised primary total, quote section labels.

**Signature**
- New `SignaturePanel`: type full legal name → rendered as a signature on a dated line + "I agree" gate. Wired into the public link and the authed portal; the authed accept route now records the typed `signerName` (falls back to identity). Name + IP + timestamp continue to be persisted in `quote_acceptances`.

## Tests
- `QuoteDocument` states (inline render / no iframe / empty / draft fallback).
- `quoteBranding` precedence & fallbacks (footer/currency/seller synthesis, partner/brand absence).
- API quote/PDF/route suites + web/portal typecheck all green locally.

## Notes for CI / review
- No schema or migrations changed (the `branding` field is an additive response shape).
- Touches a tenant‑scoped read path (`resolveQuoteBranding` reads `partners` under the **partner/system**‑scoped staff route only). The `Integration Tests` job — which runs the RLS / tenant‑cascade contracts — is **skipped on `pull_request`**; worth a manual `workflow_dispatch` run.
- Self‑reviewed with the pr-review‑toolkit agents (code / silent‑failure / tests / types / comments); their material findings are already folded in.

Spec: `docs/superpowers/specs/2026-06-23-quote-invoice-presentation-refresh.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)