### PR TITLE
fix(web): Breeze Assist tab — show tray toggles when deploy off + honest badge (#1863)

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
@@ -6,6 +6,13 @@ type FeatureTabShellProps = {
   description: string;
   icon: ReactNode;
   isConfigured: boolean;
+  /**
+   * When the tab is configured (a feature link exists) but the feature is not
+   * actually being deployed/enabled, pass true so the badge reflects "saved but
+   * inactive" instead of a green "Configured". Optional; does not affect the
+   * Remove control, which still keys off isConfigured (#1863).
+   */
+  configuredButInactive?: boolean;
   saving: boolean;
   error?: string;
   onSave: () => void;
@@ -24,6 +31,7 @@ export default function FeatureTabShell({
   description,
   icon,
   isConfigured,
+  configuredButInactive,
   saving,
   error,
   onSave,
@@ -33,17 +41,23 @@ export default function FeatureTabShell({
   onRevert,
   children,
 }: FeatureTabShellProps) {
+  const savedInactive = !isInherited && isConfigured && !!configuredButInactive;
+
   const badgeText = isInherited
     ? 'Configured (inherited)'
-    : isConfigured
-      ? 'Configured'
-      : 'Not configured';
+    : savedInactive
+      ? 'Saved (not deployed)'
+      : isConfigured
+        ? 'Configured'
+        : 'Not configured';
 
   const badgeClass = isInherited
     ? 'border-blue-500/40 bg-blue-500/20 text-blue-700'
-    : isConfigured
-      ? 'border-green-500/40 bg-green-500/20 text-green-700'
-      : 'border-muted bg-muted/50 text-muted-foreground';
+    : savedInactive
+      ? 'border-amber-500/40 bg-amber-500/20 text-amber-700'
+      : isConfigured
+        ? 'border-green-500/40 bg-green-500/20 text-green-700'
+        : 'border-muted bg-muted/50 text-muted-foreground';
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/components/configurationPolicies/featureTabs/HelperTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/HelperTab.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import HelperTab from './HelperTab';
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: vi.fn(async () => ({ id: 'link-1' })),
+    remove: vi.fn(async () => true),
+    saving: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+import type { FeatureTabProps, FeatureLink } from './types';
+
+const baseProps: FeatureTabProps = {
+  policyId: 'policy-1',
+  existingLink: undefined,
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+const helperLink = (enabled: boolean): FeatureLink => ({
+  id: 'link-1',
+  featureType: 'helper',
+  featurePolicyId: null,
+  inlineSettings: { enabled },
+});
+
+describe('HelperTab', () => {
+  it('keeps tray-menu options visible but disabled when deploy is off (#1863)', () => {
+    render(<HelperTab {...baseProps} />);
+
+    // The toggles are discoverable (rendered), not hidden...
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes.length).toBe(3);
+    // ...but disabled until deploy is enabled, with a hint explaining why.
+    expect(checkboxes.every((c) => c.disabled)).toBe(true);
+    expect(screen.getByText(/Enable "Deploy Breeze Assist to devices" above/i)).toBeTruthy();
+  });
+
+  it('shows a "Saved (not deployed)" badge when a link exists but deploy is off', () => {
+    render(<HelperTab {...baseProps} existingLink={helperLink(false)} />);
+    expect(screen.getByText('Saved (not deployed)')).toBeTruthy();
+    expect(screen.queryByText('Configured')).toBeNull();
+  });
+
+  it('shows "Configured" and enables the toggles when deploy is on', () => {
+    render(<HelperTab {...baseProps} existingLink={helperLink(true)} />);
+    expect(screen.getByText('Configured')).toBeTruthy();
+    expect(screen.queryByText('Saved (not deployed)')).toBeNull();
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes.every((c) => !c.disabled)).toBe(true);
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/HelperTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/HelperTab.tsx
@@ -84,6 +84,7 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
       description={meta.description}
       icon={<LifeBuoy className="h-5 w-5" />}
       isConfigured={!!existingLink || isInherited}
+      configuredButInactive={!!existingLink && !settings.enabled}
       saving={saving}
       error={error}
       onSave={handleSave}
@@ -108,16 +109,30 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
           </button>
         </div>
 
-        {settings.enabled && (
-          <div className="space-y-4">
+        {/*
+          Tray Menu Options stay visible even when deploy is off, in a disabled
+          state, so the available configuration is discoverable rather than
+          appearing as "nothing else to configure" (#1863).
+        */}
+        <div className="space-y-4">
+          <div>
             <h3 className="text-sm font-semibold">Tray Menu Options</h3>
             <p className="text-xs text-muted-foreground">Configure which items appear in the Breeze Assist right-click context menu. Exit is always available.</p>
+            {!settings.enabled && (
+              <p className="mt-1 text-xs italic text-muted-foreground">Enable "Deploy Breeze Assist to devices" above to apply these options.</p>
+            )}
+          </div>
 
+          <div
+            className={`space-y-4 ${settings.enabled ? '' : 'pointer-events-none opacity-50'}`}
+            aria-disabled={!settings.enabled}
+          >
             {/* Open Portal */}
             <label className="flex items-center gap-3 rounded-md border bg-background px-4 py-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={settings.showOpenPortal}
+                disabled={!settings.enabled}
                 onChange={(e) => update('showOpenPortal', e.target.checked)}
                 className="h-4 w-4 rounded border-border"
               />
@@ -132,6 +147,7 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
               <input
                 type="checkbox"
                 checked={settings.showDeviceInfo}
+                disabled={!settings.enabled}
                 onChange={(e) => update('showDeviceInfo', e.target.checked)}
                 className="h-4 w-4 rounded border-border"
               />
@@ -146,6 +162,7 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
               <input
                 type="checkbox"
                 checked={settings.showRequestSupport}
+                disabled={!settings.enabled}
                 onChange={(e) => update('showRequestSupport', e.target.checked)}
                 className="h-4 w-4 rounded border-border"
               />
@@ -161,6 +178,7 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
               <input
                 type="text"
                 value={settings.portalUrl ?? ''}
+                disabled={!settings.enabled}
                 onChange={(e) => update('portalUrl', e.target.value)}
                 placeholder="https://portal.example.com (defaults to server URL)"
                 className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -168,7 +186,7 @@ export default function HelperTab({ policyId, existingLink, onLinkChanged, linke
               <p className="mt-1 text-xs text-muted-foreground">Leave blank to use the default Breeze server URL.</p>
             </div>
           </div>
-        )}
+        </div>
       </div>
     </FeatureTabShell>
   );


### PR DESCRIPTION
Closes #1863. Two display-only papercuts in the Config Policy → **Breeze Assist** tab (surfaced during the #1854 triage; **not** the #1856 `--config` functional bug).

## Nit 1 — tray toggles invisible until deploy is on
`HelperTab.tsx` rendered the Tray Menu Options only behind `{settings.enabled && ...}`, so with "Deploy Breeze Assist to devices" off the tab showed just the deploy toggle — reading as "nothing else to configure." Now the options **always render**, in a disabled/greyed state (`pointer-events-none opacity-50`, inputs `disabled`, `aria-disabled`) when deploy is off, with a hint: *Enable "Deploy Breeze Assist to devices" above to apply these options.*

## Nit 2 — green "Configured" badge even when deploy is off
The badge was driven solely by `isConfigured={!!existingLink || isInherited}`, so a saved link with `enabled:false` still showed green "Configured." 

Fixed via a **new optional `configuredButInactive` prop** on `FeatureTabShell`: when set (HelperTab passes `!!existingLink && !settings.enabled`), the badge shows an amber **"Saved (not deployed)"** instead. Crucially, `isConfigured` is left unchanged — it also gates the Remove button (`FeatureTabShell` line ~105), so keying the badge off a separate prop avoids hiding Remove for a saved-but-disabled link (no regression). The prop is optional and unused by the other feature tabs, so their behavior is unchanged.

## Verification
- New `HelperTab.test.tsx`: toggles render-but-disabled + hint when deploy off; "Saved (not deployed)" badge for a saved+disabled link; "Configured" + enabled toggles when deploy on. **vitest 3/3.**
- `eslint` clean; `astro check` 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)