### PR TITLE
fix(test): unbreak main Test API — auth.test.ts last_login_at .returning() mock (#1379)

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -100,7 +100,14 @@ vi.mock('../db', () => ({
     })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve())
+        where: vi.fn(() => ({
+          // login.ts wraps the last_login_at write in dbWriteExpectingRows,
+          // which calls .returning() (#1379 A2). Bare `.where()` is also
+          // awaited directly by routes that don't use .returning(), so keep
+          // the object thenable for those paths too.
+          returning: vi.fn(() => Promise.resolve([{ id: 'user-1' }])),
+          then: (resolve: (v: unknown) => unknown) => resolve(undefined)
+        }))
       }))
     }))
   },


### PR DESCRIPTION
**Root cause:** #1379 A2 wrapped the `/login` `last_login_at` write in `dbWriteExpectingRows`, which calls `.update().set().where().returning()` (`apps/api/src/routes/auth/login.ts:500`). The sibling test `apps/api/src/routes/auth.test.ts` still mocked the default `db.update` chain with `.where()` returning a bare `Promise.resolve()` — no `.returning()` — so the login path threw `TypeError: ...returning is not a function`. Both `should login successfully` and `clears the failure counter on a successful login` returned 500 instead of 200.

A2 updated the dedicated `routes/auth/login.test.ts` but missed this older sibling that *also* exercises `POST /login` — the [[auth_sibling_test_files_resolve_context]] class. Main's Test API has been red since the observability stack merged.

**Fix:** mirror `login.test.ts` — the default `update` mock's `.where()` now returns `{ returning, then }`: `returning` resolves a 1-row array (the `dbWriteExpectingRows` path, non-empty so no 0-row warning), and the `then` keeps the object thenable for routes that `await .where()` directly without `.returning()`.

**Verification:** full `auth.test.ts` 61/61 locally (was 2 failed). Test-only change, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)