### PR TITLE
fix(test): repair auth.test.ts db.update mock for #1825 .returning() (main is red)

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -100,7 +100,12 @@ vi.mock('../db', () => ({
     })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve())
+        // `.where()` is awaitable (resolves undefined) for callers that don't
+        // chain, and exposes `.returning()` for the last_login_at write added
+        // in #1825 (dbWriteExpectingRows expects a non-empty row set back).
+        where: vi.fn(() => Object.assign(Promise.resolve(), {
+          returning: vi.fn(() => Promise.resolve([{ id: 'user-1' }]))
+        }))
       }))
     }))
   },
@@ -136,7 +141,12 @@ vi.mock('../db/schema', () => ({
   refreshTokenFamilies: {
     familyId: 'refreshTokenFamilies.familyId',
     userId: 'refreshTokenFamilies.userId'
-  }
+  },
+  // Referenced by best-effort log-and-swallow paths in the login handler
+  // (audit write, OAuth artifact revocation). Present here so a missing-export
+  // warning doesn't masquerade as the real failure.
+  auditLogs: {},
+  oauthRefreshTokens: {}
 }));
 
 vi.mock('../services/tenantStatus', () => ({
@@ -434,7 +444,9 @@ describe('auth routes', () => {
       } as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -921,7 +933,9 @@ describe('auth routes', () => {
       } as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -1678,7 +1692,9 @@ describe('auth routes', () => {
       vi.mocked(getRedis).mockReturnValue(mockRedis as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -1778,7 +1794,9 @@ describe('auth routes', () => {
       vi.mocked(getRedis).mockReturnValue(mockRedis as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -1813,7 +1831,9 @@ describe('auth routes', () => {
       } as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -1889,7 +1909,9 @@ describe('auth routes', () => {
         } as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 
@@ -2020,7 +2042,9 @@ describe('auth routes', () => {
         } as any);
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined)
+          where: vi.fn(() => Object.assign(Promise.resolve(undefined), {
+            returning: vi.fn().mockResolvedValue([{ id: 'user-1' }])
+          }))
         })
       } as any);
 


### PR DESCRIPTION
## Problem
`main` Test API is red: `apps/api/src/routes/auth.test.ts` fails two cases — "should login successfully" (line ~450) and "Task 10: clears the failure counter on a successful login" (~934) — both `AssertionError: expected 500 to be 200`.

## Root cause
**PR #1825** (`dbWriteExpectingRows` / last_login_at, commit `3f4098540`) added a `.returning({ id })` to the `last_login_at` update in `apps/api/src/routes/auth/login.ts`, but the `db.update` mock in `auth.test.ts` ended its chain at `.where()`. On successful login `.where(...).returning` is `undefined` → `TypeError` → caught by the handler → HTTP 500.

This is **deterministic and pre-existing** — it reproduces in isolation and at the pre-merge commit `ada484ace`. It surfaced on `main` once #1825 landed; it is **not** caused by the PRs merged around the same time (#1858/#1859/#1860), whose code doesn't touch the auth path. The `No "auditLogs"/"oauthRefreshTokens" export` lines in CI are a red herring from auth.test.ts's own partial schema mock on best-effort log-and-swallow paths.

## Fix (test-only)
- `db.update` mock `.where()` now returns an awaitable that also exposes `.returning()` (resolves a non-empty row set) — default mock + per-test overrides.
- Added `auditLogs` / `oauthRefreshTokens` to the `../db/schema` mock so the swallowed-warning noise stops masquerading as the failure.

No production code changed.

## Verification
`pnpm --filter @breeze/api exec vitest run src/routes/auth.test.ts` → **61 passed**.

Refs #1825