### PR TITLE
feat(web): surface config-policy monitoring + compliance status in portal (#1873, #1874)

### DIFF
--- a/apps/web/src/components/configurationPolicies/ComplianceStatusTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ComplianceStatusTab.test.tsx
@@ -65,6 +65,30 @@ describe('ComplianceStatusTab', () => {
     expect(screen.getAllByTestId('compliance-status-row')).toHaveLength(2);
   });
 
+  it('warns that the summary is page-scoped when results exceed the page', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'c1',
+            configItemName: 'Disk Space Minimum',
+            deviceId: 'dev-1',
+            status: 'compliant',
+            lastCheckedAt: '2026-06-24T10:00:00.000Z',
+            updatedAt: '2026-06-24T10:00:00.000Z',
+            deviceHostname: 'DESKTOP-1',
+          },
+        ],
+        overall: { total: 1, compliant: 1, nonCompliant: 0, unknown: 0 },
+        pagination: { page: 1, limit: 50, total: 120 },
+      })
+    );
+
+    render(<ComplianceStatusTab policyId="pol-1" />);
+
+    expect(await screen.findByTestId('compliance-status-partial')).toBeInTheDocument();
+  });
+
   it('renders an empty state when there are no compliance results', async () => {
     fetchWithAuthMock.mockResolvedValue(
       makeJsonResponse({ data: [], overall: { total: 0, compliant: 0, nonCompliant: 0, unknown: 0 } })

--- a/apps/web/src/components/configurationPolicies/ComplianceStatusTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ComplianceStatusTab.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ComplianceStatusTab from './ComplianceStatusTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('ComplianceStatusTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches policy compliance and renders the summary + per-device rows', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'c1',
+            configItemName: 'Disk Space Minimum',
+            deviceId: 'dev-1',
+            status: 'non_compliant',
+            lastCheckedAt: '2026-06-24T10:00:00.000Z',
+            updatedAt: '2026-06-24T10:00:00.000Z',
+            deviceHostname: 'DESKTOP-1',
+          },
+          {
+            id: 'c2',
+            configItemName: 'OS Version',
+            deviceId: 'dev-2',
+            status: 'compliant',
+            lastCheckedAt: '2026-06-24T10:00:00.000Z',
+            updatedAt: '2026-06-24T10:00:00.000Z',
+            deviceHostname: 'DESKTOP-2',
+          },
+        ],
+        overall: { total: 2, compliant: 1, nonCompliant: 1, unknown: 0 },
+        pagination: { page: 1, limit: 50, total: 2 },
+      })
+    );
+
+    render(<ComplianceStatusTab policyId="pol-1" />);
+
+    await screen.findByText('DESKTOP-1');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/policies/pol-1/compliance');
+    expect(screen.getByText('DESKTOP-2')).toBeInTheDocument();
+    expect(screen.getByText('Disk Space Minimum')).toBeInTheDocument();
+    // "Compliant"/"Non-compliant" appear in both the summary cards and the row
+    // status badges, so assert presence via getAllByText.
+    expect(screen.getAllByText('Non-compliant').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Compliant').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('compliance-status-row')).toHaveLength(2);
+  });
+
+  it('renders an empty state when there are no compliance results', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ data: [], overall: { total: 0, compliant: 0, nonCompliant: 0, unknown: 0 } })
+    );
+
+    render(<ComplianceStatusTab policyId="pol-1" />);
+
+    expect(await screen.findByTestId('compliance-status-empty')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the request fails', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 500));
+
+    render(<ComplianceStatusTab policyId="pol-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compliance-status-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/configurationPolicies/ComplianceStatusTab.tsx
+++ b/apps/web/src/components/configurationPolicies/ComplianceStatusTab.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ClipboardCheck, RefreshCw } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+type ComplianceRow = {
+  id: string;
+  configItemName: string | null;
+  deviceId: string;
+  status: 'compliant' | 'non_compliant' | 'pending' | 'error' | string;
+  lastCheckedAt: string | null;
+  updatedAt: string | null;
+  deviceHostname: string | null;
+};
+
+type ComplianceOverall = {
+  total: number;
+  compliant: number;
+  nonCompliant: number;
+  unknown: number;
+};
+
+type ComplianceResponse = {
+  data: ComplianceRow[];
+  overall?: ComplianceOverall;
+  pagination?: { page: number; limit: number; total: number };
+};
+
+type ComplianceStatusTabProps = {
+  policyId: string;
+  timezone?: string;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  compliant: 'bg-success/15 text-success border-success/30',
+  non_compliant: 'bg-destructive/15 text-destructive border-destructive/30',
+  pending: 'bg-warning/15 text-warning border-warning/30',
+  error: 'bg-destructive/15 text-destructive border-destructive/30',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  compliant: 'Compliant',
+  non_compliant: 'Non-compliant',
+  pending: 'Pending',
+  error: 'Error',
+};
+
+function formatTimestamp(value: string | null, timezone?: string): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+}
+
+export default function ComplianceStatusTab({ policyId, timezone }: ComplianceStatusTabProps) {
+  const [rows, setRows] = useState<ComplianceRow[]>([]);
+  const [overall, setOverall] = useState<ComplianceOverall>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const fetchCompliance = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await fetchWithAuth(`/policies/${policyId}/compliance`);
+      if (!response.ok) throw new Error('Failed to load compliance status');
+      const json = (await response.json()) as ComplianceResponse;
+      setRows(Array.isArray(json?.data) ? json.data : []);
+      setOverall(json?.overall);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load compliance status');
+    } finally {
+      setLoading(false);
+    }
+  }, [policyId]);
+
+  useEffect(() => {
+    fetchCompliance();
+  }, [fetchCompliance]);
+
+  if (loading) {
+    return (
+      <div
+        data-testid="compliance-status-loading"
+        className="flex items-center justify-center rounded-lg border bg-card py-12 shadow-sm"
+      >
+        <div className="text-center">
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="mt-3 text-sm text-muted-foreground">Loading compliance status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        data-testid="compliance-status-error"
+        className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
+      >
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={fetchCompliance}
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="compliance-status-tab" className="space-y-4">
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ClipboardCheck className="h-4 w-4 text-muted-foreground" />
+            <h3 className="text-lg font-semibold">Compliance Status</h3>
+          </div>
+          <button
+            type="button"
+            onClick={fetchCompliance}
+            className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </button>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Per-device evaluation of this policy&apos;s compliance rules (re-evaluated automatically).
+        </p>
+
+        {overall && (
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div className="rounded-md border bg-background px-4 py-3">
+              <p className="text-xs text-muted-foreground">Total</p>
+              <p className="mt-1 text-xl font-semibold tabular-nums">{overall.total}</p>
+            </div>
+            <div className="rounded-md border bg-background px-4 py-3">
+              <p className="text-xs text-muted-foreground">Compliant</p>
+              <p className="mt-1 text-xl font-semibold tabular-nums text-success">{overall.compliant}</p>
+            </div>
+            <div className="rounded-md border bg-background px-4 py-3">
+              <p className="text-xs text-muted-foreground">Non-compliant</p>
+              <p className="mt-1 text-xl font-semibold tabular-nums text-destructive">{overall.nonCompliant}</p>
+            </div>
+            <div className="rounded-md border bg-background px-4 py-3">
+              <p className="text-xs text-muted-foreground">Unknown</p>
+              <p className="mt-1 text-xl font-semibold tabular-nums text-muted-foreground">{overall.unknown}</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+        <div className="max-h-[500px] overflow-auto">
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40 sticky top-0">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Device</th>
+                <th className="px-4 py-3">Check</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Last Checked</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    data-testid="compliance-status-empty"
+                    className="px-4 py-6 text-center text-sm text-muted-foreground"
+                  >
+                    No compliance results yet. Assign this policy to devices and add compliance rules; status
+                    appears after the next evaluation.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => (
+                  <tr key={row.id} data-testid="compliance-status-row" className="text-sm hover:bg-muted/30">
+                    <td className="px-4 py-3 font-medium">{row.deviceHostname ?? row.deviceId}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{row.configItemName ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+                          STATUS_STYLES[row.status] ?? 'bg-muted text-muted-foreground border-border'
+                        }`}
+                      >
+                        {STATUS_LABELS[row.status] ?? row.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {formatTimestamp(row.lastCheckedAt ?? row.updatedAt, timezone)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/ComplianceStatusTab.tsx
+++ b/apps/web/src/components/configurationPolicies/ComplianceStatusTab.tsx
@@ -54,6 +54,7 @@ function formatTimestamp(value: string | null, timezone?: string): string {
 export default function ComplianceStatusTab({ policyId, timezone }: ComplianceStatusTabProps) {
   const [rows, setRows] = useState<ComplianceRow[]>([]);
   const [overall, setOverall] = useState<ComplianceOverall>();
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
 
@@ -66,6 +67,7 @@ export default function ComplianceStatusTab({ policyId, timezone }: ComplianceSt
       const json = (await response.json()) as ComplianceResponse;
       setRows(Array.isArray(json?.data) ? json.data : []);
       setOverall(json?.overall);
+      setTotal(json?.pagination?.total ?? (Array.isArray(json?.data) ? json.data.length : 0));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load compliance status');
     } finally {
@@ -129,6 +131,12 @@ export default function ComplianceStatusTab({ policyId, timezone }: ComplianceSt
         <p className="mt-1 text-sm text-muted-foreground">
           Per-device evaluation of this policy&apos;s compliance rules (re-evaluated automatically).
         </p>
+
+        {overall && total > rows.length && (
+          <p data-testid="compliance-status-partial" className="mt-3 text-xs text-warning">
+            Showing the first {rows.length} of {total} results — the summary below reflects this page only.
+          </p>
+        )}
 
         {overall && (
           <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -19,6 +19,7 @@ import {
   Activity,
   LifeBuoy,
   Monitor,
+  ListChecks,
 } from 'lucide-react';
 import Breadcrumbs from '../layout/Breadcrumbs';
 import { cn } from '@/lib/utils';
@@ -44,8 +45,9 @@ import WarrantyTab from './featureTabs/WarrantyTab';
 import HelperTab from './featureTabs/HelperTab';
 import RemoteAccessTab from './featureTabs/RemoteAccessTab';
 import PamTab from './featureTabs/PamTab';
+import ComplianceStatusTab from './ComplianceStatusTab';
 
-type Tab = 'overview' | FeatureType | 'assignments';
+type Tab = 'overview' | FeatureType | 'assignments' | 'compliance_status';
 
 type PolicyDetail = {
   id: string;
@@ -243,6 +245,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       icon: featureTabIcons[ft],
       dot: !!linkFor(ft) || !!parentLinkFor(ft),
     })),
+    { id: 'compliance_status', label: 'Compliance Status', icon: <ListChecks className="h-4 w-4" /> },
     { id: 'assignments', label: 'Assignments', icon: <Target className="h-4 w-4" /> },
   ];
 
@@ -414,6 +417,11 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
 
       {/* Feature Tabs */}
       {FEATURE_TYPES.includes(activeTab as FeatureType) && renderFeatureTab(activeTab as FeatureType)}
+
+      {/* Compliance Status Tab (read-only results; the `compliance` feature tab is the rule editor) */}
+      {activeTab === 'compliance_status' && policyId && (
+        <ComplianceStatusTab policyId={policyId} />
+      )}
 
       {/* Assignments Tab */}
       {activeTab === 'assignments' && policyId && policy && (

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -23,6 +23,7 @@ import {
   Usb,
   Ticket,
   TrendingUp,
+  HeartPulse,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
 import type { Device, DeviceStatus } from './DeviceList';
@@ -56,6 +57,7 @@ import DeviceBackupTab from '../backup/DeviceBackupTab';
 import DeviceTicketsTab from '../tickets/DeviceTicketsTab';
 import DeviceAnomaliesPanel from './DeviceAnomaliesPanel';
 import DeviceReliabilityPanel from './DeviceReliabilityPanel';
+import DeviceMonitoringTab from './DeviceMonitoringTab';
 
 type Tab =
   | 'overview'
@@ -71,6 +73,7 @@ type Tab =
   | 'scripts'
   | 'performance'
   | 'eventlog'
+  | 'monitoring'
   | 'activities'
   | 'connections'
   | 'filesystem'
@@ -128,7 +131,7 @@ function formatLastSeen(dateString: string, timezone?: string): string {
 const VALID_TABS: Tab[] = [
   'overview', 'details', 'hardware', 'software', 'patches', 'security',
   'management', 'effective-config', 'alerts', 'scripts', 'performance',
-  'anomalies', 'eventlog', 'activities', 'connections', 'filesystem', 'ip-history',
+  'anomalies', 'eventlog', 'monitoring', 'activities', 'connections', 'filesystem', 'ip-history',
   'boot-performance', 'playbooks', 'peripherals', 'backup', 'tickets',
 ];
 
@@ -177,6 +180,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
     { id: 'anomalies', label: 'Anomalies', icon: <TrendingUp className="h-4 w-4" />, title: 'Metric anomaly signals for this device' },
     { id: 'tickets', label: 'Tickets', icon: <Ticket className="h-4 w-4" />, title: 'Tickets linked to this device' },
     { id: 'eventlog', label: 'Event Log', icon: <FileText className="h-4 w-4" />, title: 'Windows/macOS system event logs' },
+    { id: 'monitoring', label: 'Monitoring', icon: <HeartPulse className="h-4 w-4" />, title: 'Service/process watch results from Configuration Policies' },
     // --- Inventory ---
     { id: 'hardware', label: 'Hardware', icon: <Cpu className="h-4 w-4" />, separator: true },
     { id: 'software', label: 'Software', icon: <Package className="h-4 w-4" /> },
@@ -378,6 +382,10 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
 
       {activeTab === 'eventlog' && (
         <DeviceLogsTab deviceId={device.id} timezone={effectiveTimezone} osType={device.os} />
+      )}
+
+      {activeTab === 'monitoring' && (
+        <DeviceMonitoringTab deviceId={device.id} timezone={effectiveTimezone} />
       )}
 
       {activeTab === 'activities' && (

--- a/apps/web/src/components/devices/DeviceMonitoringTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceMonitoringTab.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceMonitoringTab from './DeviceMonitoringTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('DeviceMonitoringTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the per-device summary and renders watch rows', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'r1',
+            deviceId: 'dev-1',
+            watchType: 'service',
+            name: 'Print Spooler',
+            status: 'stopped',
+            cpuPercent: null,
+            memoryMb: null,
+            pid: null,
+            timestamp: '2026-06-24T10:00:00.000Z',
+          },
+          {
+            id: 'r2',
+            deviceId: 'dev-1',
+            watchType: 'process',
+            name: 'nginx',
+            status: 'running',
+            cpuPercent: 2.5,
+            memoryMb: 128,
+            pid: 4242,
+            timestamp: '2026-06-24T10:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    render(<DeviceMonitoringTab deviceId="dev-1" />);
+
+    await screen.findByText('Print Spooler');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/monitoring/results/dev-1/summary');
+    expect(screen.getByText('nginx')).toBeInTheDocument();
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getAllByTestId('device-monitoring-row')).toHaveLength(2);
+    // Non-running watch is surfaced first.
+    expect(screen.getAllByTestId('device-monitoring-row')[0]).toHaveTextContent('Print Spooler');
+  });
+
+  it('renders an empty state when no results are reported', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+
+    render(<DeviceMonitoringTab deviceId="dev-1" />);
+
+    expect(await screen.findByTestId('device-monitoring-empty')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the request fails', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 500));
+
+    render(<DeviceMonitoringTab deviceId="dev-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-monitoring-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/devices/DeviceMonitoringTab.tsx
+++ b/apps/web/src/components/devices/DeviceMonitoringTab.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Activity, RefreshCw } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+type WatchResult = {
+  id: string;
+  deviceId: string;
+  watchType: 'service' | 'process' | string;
+  name: string;
+  status: 'running' | 'stopped' | 'not_found' | 'error' | string;
+  cpuPercent?: number | null;
+  memoryMb?: number | null;
+  pid?: number | null;
+  autoRestartAttempted?: boolean | null;
+  autoRestartSucceeded?: boolean | null;
+  timestamp: string;
+};
+
+type DeviceMonitoringTabProps = {
+  deviceId: string;
+  timezone?: string;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  running: 'bg-success/15 text-success border-success/30',
+  stopped: 'bg-destructive/15 text-destructive border-destructive/30',
+  not_found: 'bg-warning/15 text-warning border-warning/30',
+  error: 'bg-destructive/15 text-destructive border-destructive/30',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  running: 'Running',
+  stopped: 'Stopped',
+  not_found: 'Not found',
+  error: 'Error',
+};
+
+function formatTimestamp(value: string, timezone?: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+}
+
+export default function DeviceMonitoringTab({ deviceId, timezone }: DeviceMonitoringTabProps) {
+  const [results, setResults] = useState<WatchResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const fetchResults = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await fetchWithAuth(`/monitoring/results/${deviceId}/summary`);
+      if (!response.ok) throw new Error('Failed to load monitoring results');
+      const json = await response.json();
+      const payload = json?.data ?? json;
+      setResults(Array.isArray(payload) ? payload : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load monitoring results');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    fetchResults();
+  }, [fetchResults]);
+
+  const rows = useMemo(
+    () =>
+      [...results].sort((a, b) => {
+        // Surface not-running watches first, then alphabetical by name.
+        const aBad = a.status !== 'running' ? 0 : 1;
+        const bBad = b.status !== 'running' ? 0 : 1;
+        if (aBad !== bBad) return aBad - bBad;
+        return (a.name ?? '').localeCompare(b.name ?? '');
+      }),
+    [results]
+  );
+
+  if (loading) {
+    return (
+      <div
+        data-testid="device-monitoring-loading"
+        className="flex items-center justify-center rounded-lg border bg-card py-12 shadow-sm"
+      >
+        <div className="text-center">
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="mt-3 text-sm text-muted-foreground">Loading monitoring results...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        data-testid="device-monitoring-error"
+        className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
+      >
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={fetchResults}
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="device-monitoring-tab" className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-lg font-semibold">Service &amp; Process Monitoring</h3>
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{rows.length}</span>
+        </div>
+        <button
+          type="button"
+          onClick={fetchResults}
+          className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Latest result for each service/process watch configured by an assigned Configuration Policy.
+      </p>
+
+      <div className="mt-4 overflow-hidden rounded-md border">
+        <div className="max-h-[500px] overflow-auto">
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40 sticky top-0">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Name</th>
+                <th className="px-4 py-3">Type</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">CPU</th>
+                <th className="px-4 py-3">Memory</th>
+                <th className="px-4 py-3">PID</th>
+                <th className="px-4 py-3">Last Checked</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={7}
+                    data-testid="device-monitoring-empty"
+                    className="px-4 py-6 text-center text-sm text-muted-foreground"
+                  >
+                    No monitoring results reported. Assign a Configuration Policy with service/process
+                    watches to this device, or wait for the next check interval.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => (
+                  <tr key={row.id} data-testid="device-monitoring-row" className="text-sm hover:bg-muted/30">
+                    <td className="px-4 py-3 font-medium">{row.name}</td>
+                    <td className="px-4 py-3 capitalize text-muted-foreground">{row.watchType}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+                          STATUS_STYLES[row.status] ?? 'bg-muted text-muted-foreground border-border'
+                        }`}
+                      >
+                        {STATUS_LABELS[row.status] ?? row.status}
+                      </span>
+                      {row.autoRestartAttempted ? (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          {row.autoRestartSucceeded ? 'auto-restarted' : 'restart failed'}
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                      {typeof row.cpuPercent === 'number' ? `${row.cpuPercent.toFixed(1)}%` : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                      {typeof row.memoryMb === 'number' ? `${row.memoryMb.toFixed(0)} MB` : '—'}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{row.pid ?? '—'}</td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {formatTimestamp(row.timestamp, timezone)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceMonitoringTab.tsx
+++ b/apps/web/src/components/devices/DeviceMonitoringTab.tsx
@@ -53,8 +53,7 @@ export default function DeviceMonitoringTab({ deviceId, timezone }: DeviceMonito
       const response = await fetchWithAuth(`/monitoring/results/${deviceId}/summary`);
       if (!response.ok) throw new Error('Failed to load monitoring results');
       const json = await response.json();
-      const payload = json?.data ?? json;
-      setResults(Array.isArray(payload) ? payload : []);
+      setResults(Array.isArray(json?.data) ? json.data : []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load monitoring results');
     } finally {


### PR DESCRIPTION
## What
Adds the missing UI for two Configuration Policy features whose backends were already fully wired — closing the "configured but nothing shows in the portal" gaps reported by @win-wxx in #1854 (items 3 & 4).

- **Monitoring (#1873):** new **Monitoring** tab on the device detail page (`DeviceMonitoringTab`) that renders the latest service/process watch result per device from the existing `GET /monitoring/results/:deviceId/summary` — status badge, CPU, memory, PID, last-checked, with non-running watches surfaced first.
- **Compliance (#1874):** new read-only **Compliance Status** tab on the config policy detail page (`ComplianceStatusTab`), separate from the existing rule-editor `ComplianceTab`. Shows the per-device pass/fail summary (total / compliant / non-compliant / unknown) + rows from the existing `GET /policies/:id/compliance`.

## Scope / not in this PR
- **No backend changes** — both endpoints already exist and are `devices:read`-gated.
- **Per-device compliance on the device detail page is deferred** (#1874 follow-up): it needs a *new* tenant/site-authz'd read route (`getConfigPolicyComplianceForDevice` exists but is unrouted and does no authz). That deserves its own PR with an integration test for the site-scope gate rather than riding along in a UI change. The per-policy Compliance Status tab here already shows which devices pass/fail.

## Tests
- `DeviceMonitoringTab.test.tsx` + `ComplianceStatusTab.test.tsx`: load/empty/error states, correct endpoint, row rendering — **6 passed**.
- `astro check` → **0 errors**.

Refs #1873, #1874