### PR TITLE
Device overview UI polish: automated activity, collapsing Activity pane, clearer Reliability

### DIFF
--- a/apps/api/src/__tests__/integration/eventsAutomatedDedup.integration.test.ts
+++ b/apps/api/src/__tests__/integration/eventsAutomatedDedup.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Device events feed — includeAutomated dedup (issue: device-overview automated activity).
+ *
+ * What only a real Postgres can prove: the `includeAutomated` predicate surfaces
+ * automated `agent.command.*` rows (actor_type 'system'/'agent') while EXCLUDING
+ * the manual twin (actor_type 'user'). Manual command dispatches write both an
+ * `agent.command.*` audit AND a richer route audit (e.g. `script.execute`,
+ * `device.patch.*`); including the manual `agent.command.*` row would double-list
+ * the same action. The guard is a `LIKE ... AND actor_type IN (...)` predicate a
+ * Drizzle mock can't exercise — hence an integration test.
+ *
+ * Mirrors the predicate the route actually runs by importing buildActionConditions
+ * from the route module, so a future edit that drops the actor_type guard fails here.
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { and, or, eq } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { getTestDb } from './setup';
+import { auditLogs } from '../../db/schema';
+import { buildActionConditions } from '../../routes/devices/events';
+import { createPartner, createOrganization } from './db-utils';
+
+// commandQueue writes automated dispatches with the all-zero sentinel actor id.
+const SYSTEM_ACTOR = '00000000-0000-0000-0000-000000000000';
+
+describe('device events — includeAutomated dedup (agent.command.* actor scoping)', () => {
+  let orgId: string;
+  let deviceId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    orgId = org.id;
+    deviceId = randomUUID();
+
+    // Three audit rows for one device: an automated patch install (system),
+    // its manual twin (user), and a manual route audit matching `script.`.
+    await getTestDb()
+      .insert(auditLogs)
+      .values([
+        {
+          orgId,
+          actorType: 'system',
+          actorId: SYSTEM_ACTOR,
+          action: 'agent.command.install_patches',
+          resourceType: 'device',
+          resourceId: deviceId,
+          result: 'success',
+        },
+        {
+          orgId,
+          actorType: 'user',
+          actorId: randomUUID(),
+          action: 'agent.command.install_patches',
+          resourceType: 'device',
+          resourceId: deviceId,
+          result: 'success',
+        },
+        {
+          orgId,
+          actorType: 'user',
+          actorId: randomUUID(),
+          action: 'script.execute',
+          resourceType: 'device',
+          resourceId: deviceId,
+          result: 'success',
+        },
+      ]);
+  });
+
+  async function fetchActionKeys(actions: string[], includeAutomated: boolean): Promise<string[]> {
+    const clauses = buildActionConditions(actions, includeAutomated);
+    const rows = await getTestDb()
+      .select({ action: auditLogs.action, actorType: auditLogs.actorType })
+      .from(auditLogs)
+      .where(and(eq(auditLogs.resourceId, deviceId), or(...clauses)));
+    return rows.map((r) => `${r.action}:${r.actorType}`).sort();
+  }
+
+  it('includes the system-actor agent.command.* row but excludes the manual (user) twin', async () => {
+    const keys = await fetchActionKeys(['script.'], true);
+    expect(keys).toEqual(['agent.command.install_patches:system', 'script.execute:user']);
+    // The manual agent.command twin must never appear — its route-audit twin does.
+    expect(keys).not.toContain('agent.command.install_patches:user');
+  });
+
+  it('omits all agent.command.* rows when includeAutomated is false', async () => {
+    const keys = await fetchActionKeys(['script.'], false);
+    expect(keys).toEqual(['script.execute:user']);
+  });
+});

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -78,7 +78,7 @@ vi.mock('./helpers', () => ({
   SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
 }));
 
-import { eventsRoutes, likePrefixPattern } from './events';
+import { eventsRoutes, likePrefixPattern, formatActionMessage } from './events';
 
 describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
   it('appends a trailing wildcard for a clean dotted prefix', () => {
@@ -94,6 +94,29 @@ describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
 
   it('escapes all metacharacters in a single value', () => {
     expect(likePrefixPattern('a_b%c\\d')).toBe('a\\_b\\%c\\\\d%');
+  });
+});
+
+describe('formatActionMessage (automated command labels)', () => {
+  it('labels automated patch installs', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'success'))
+      .toBe('Patches installed — host-1');
+  });
+
+  it('labels automated script runs', () => {
+    expect(formatActionMessage('agent.command.script', null, 'success'))
+      .toBe('Script ran');
+  });
+
+  it('marks a failed automated patch install', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'failure'))
+      .toBe('Patches installed — host-1 (failed)');
+  });
+
+  it('labels rollback, uninstall, and update', () => {
+    expect(formatActionMessage('agent.command.rollback_patches', null, 'success')).toBe('Patches rolled back');
+    expect(formatActionMessage('agent.command.software_uninstall', null, 'success')).toBe('Software uninstalled');
+    expect(formatActionMessage('agent.command.software_update', null, 'success')).toBe('Software updated');
   });
 });
 
@@ -164,6 +187,30 @@ describe('GET /devices/:id/events validation', () => {
       );
       expect(res.status).toBe(200);
     }
+  });
+
+  it('accepts includeAutomated=true', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?includeAutomated=true',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts includeAutomated=false', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?includeAutomated=false',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an invalid includeAutomated value with 400', async () => {
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?includeAutomated=maybe',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(400);
   });
 
   it('rejects an actions value over 500 chars with 400', async () => {

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -45,6 +45,39 @@ export function likePrefixPattern(prefix: string): string {
   return prefix.replace(/[%_\\]/g, '\\$&') + '%';
 }
 
+// Build the OR-group of action conditions for the deliberate-action filter:
+// each supplied action prefix, plus (opt-in) automated agent-dispatched
+// commands. Exported so the includeAutomated dedup can be exercised against a
+// live Postgres (the actor_type guard is a LIKE/IN predicate a Drizzle mock
+// can't prove). Returns the disjuncts; the caller OR-combines them.
+export function buildActionConditions(
+  actions: string[] | undefined,
+  includeAutomated: boolean
+): SQL[] {
+  const actionClauses: SQL[] = [];
+  if (actions && actions.length > 0) {
+    // `LIKE` with an escaped prefix keeps it index-friendly and avoids ILIKE's
+    // case-fold cost — audit action keys are already lowercase dotted ids.
+    for (const prefix of actions) {
+      actionClauses.push(sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`);
+    }
+  }
+  if (includeAutomated) {
+    // Automated patch runs / automations are written by commandQueue as
+    // `agent.command.<type>` with actor_type 'system' (commandQueue emits
+    // 'system' for any unattended dispatch, never a real user) and have no
+    // route-audit twin. Manual commands (actor_type 'user') are excluded —
+    // they're already represented by their richer route audit (e.g.
+    // script.execute, device.patch.*, device.software.*), so this avoids
+    // double-listing. The 'agent' arm is defensive; only 'system' is emitted
+    // today.
+    actionClauses.push(
+      sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} IN ('system','agent'))`
+    );
+  }
+  return actionClauses;
+}
+
 const eventsQuerySchema = z.object({
   search: z.string().max(200).optional(),
   category: eventCategoryEnum.optional(),
@@ -139,24 +172,7 @@ eventsRoutes.get(
 
     // The overview "deliberate action" filter: any supplied action prefix, plus
     // (opt-in) automated agent-dispatched commands. Both go into one OR group.
-    const actionClauses: SQL[] = [];
-    if (actions && actions.length > 0) {
-      // `LIKE` with an escaped prefix keeps it index-friendly and avoids ILIKE's
-      // case-fold cost — audit action keys are already lowercase dotted ids.
-      for (const prefix of actions) {
-        actionClauses.push(sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`);
-      }
-    }
-    if (includeAutomated) {
-      // Automated patch runs / automations are written by commandQueue as
-      // `agent.command.<type>` with actor_type 'system'/'agent' and no
-      // route-audit twin. Manual commands (actor_type 'user') are excluded —
-      // they're already represented by their richer route audit
-      // (script.execute, device.patch.*), so this avoids double-listing.
-      actionClauses.push(
-        sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} IN ('system','agent'))`
-      );
-    }
+    const actionClauses = buildActionConditions(actions, includeAutomated);
     if (actionClauses.length > 0) {
       conditions.push(or(...actionClauses)!);
     }

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -72,6 +72,12 @@ const eventsQuerySchema = z.object({
             .filter(Boolean)
         : undefined
     ),
+  // Opt-in to also surface automated agent.command.* commands.
+  includeAutomated: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false')
+    .transform((v) => v === 'true'),
   // Whether to run the parallel unbounded count(*) over the same predicate.
   // Defaults to false so the common "last N" feed read does not pay for a full
   // history count on every load (issue #1726). When false, pagination.total is
@@ -93,7 +99,7 @@ eventsRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const { id: deviceId } = c.req.valid('param');
-    const { search, category, result, initiatedBy, from, to, page, limit, actions, withTotal } =
+    const { search, category, result, initiatedBy, from, to, page, limit, actions, withTotal, includeAutomated } =
       c.req.valid('query');
     const offset = (page - 1) * limit;
 
@@ -131,14 +137,28 @@ eventsRoutes.get(
       conditions.push(ilike(auditLogs.action, `${category}.%`));
     }
 
+    // The overview "deliberate action" filter: any supplied action prefix, plus
+    // (opt-in) automated agent-dispatched commands. Both go into one OR group.
+    const actionClauses: SQL[] = [];
     if (actions && actions.length > 0) {
-      // Match any of the supplied action prefixes (server-side equivalent of the
-      // overview pane's "deliberate action" filter). `LIKE` with an escaped
-      // prefix keeps it index-friendly and avoids ILIKE's case-fold cost — audit
-      // action keys are already lowercase dotted identifiers.
-      conditions.push(
-        or(...actions.map((prefix) => sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`))!
+      // `LIKE` with an escaped prefix keeps it index-friendly and avoids ILIKE's
+      // case-fold cost — audit action keys are already lowercase dotted ids.
+      for (const prefix of actions) {
+        actionClauses.push(sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`);
+      }
+    }
+    if (includeAutomated) {
+      // Automated patch runs / automations are written by commandQueue as
+      // `agent.command.<type>` with actor_type 'system'/'agent' and no
+      // route-audit twin. Manual commands (actor_type 'user') are excluded —
+      // they're already represented by their richer route audit
+      // (script.execute, device.patch.*), so this avoids double-listing.
+      actionClauses.push(
+        sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} IN ('system','agent'))`
       );
+    }
+    if (actionClauses.length > 0) {
+      conditions.push(or(...actionClauses)!);
     }
 
     if (result) {
@@ -280,6 +300,11 @@ const actionLabels: Record<string, string> = {
   'device.maintenance.disable': 'Maintenance mode disabled',
   'script.execute': 'Script executed',
   'script.execution.cancel': 'Script execution cancelled',
+  'agent.command.install_patches': 'Patches installed',
+  'agent.command.rollback_patches': 'Patches rolled back',
+  'agent.command.script': 'Script ran',
+  'agent.command.software_uninstall': 'Software uninstalled',
+  'agent.command.software_update': 'Software updated',
   'alert.acknowledge': 'Alert acknowledged',
   'alert.resolve': 'Alert resolved',
   'alert.suppress': 'Alert suppressed',
@@ -305,7 +330,7 @@ const actionLabels: Record<string, string> = {
   'maintenance_occurrence.end': 'Maintenance window ended',
 };
 
-function formatActionMessage(action: string, resourceName: string | null, result: string): string {
+export function formatActionMessage(action: string, resourceName: string | null, result: string): string {
   const label = actionLabels[action];
   if (label) {
     const suffix = result === 'failure' ? ' (failed)' : result === 'denied' ? ' (denied)' : '';

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -24,18 +24,21 @@ function mockFeed(events: unknown[], alerts: unknown[] = []) {
 describe('DeviceActivityFeed', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('requests automated activity', async () => {
+  it('requests automated activity but never sends agent.command.* as plain action prefixes', async () => {
     mockFeed([]);
     render(<DeviceActivityFeed deviceId="dev-1" />);
-    await waitFor(() =>
-      expect(fetchWithAuthMock).toHaveBeenCalledWith(
-        expect.stringContaining('includeAutomated=true'),
-        expect.anything()
-      )
-    );
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    const eventsCall = fetchWithAuthMock.mock.calls.find(([url]) => String(url).includes('/events'));
+    expect(eventsCall).toBeDefined();
+    const url = String(eventsCall![0]);
+    expect(url).toContain('includeAutomated=true');
+    // agent.command.* rows must arrive only via the actor-scoped includeAutomated
+    // predicate, never as plain action prefixes — otherwise the manual
+    // (actor_type='user') twins would be re-admitted and double-listed.
+    expect(url).not.toContain('agent.command');
   });
 
-  it('shows an Automated chip for a system-initiated row with no initiatedBy', async () => {
+  it('shows an Automated chip for an automated row and drops the redundant "System" label', async () => {
     mockFeed([
       {
         id: 'e1',
@@ -50,6 +53,27 @@ describe('DeviceActivityFeed', () => {
     render(<DeviceActivityFeed deviceId="dev-1" />);
     expect(await screen.findByText('Patches installed — host-1')).toBeInTheDocument();
     expect(screen.getByText('Automated')).toBeInTheDocument();
+    // The "Automated" chip conveys the actor; the generic "System" must not also show.
+    expect(screen.queryByText('System')).toBeNull();
+  });
+
+  it('does NOT tag a non-automated system-actor row as Automated', async () => {
+    // A system-actor row whose action is not agent.command.* (e.g. a route audit)
+    // must not be mislabeled — the chip is keyed on the action, not actor.type.
+    mockFeed([
+      {
+        id: 'e1',
+        action: 'device.maintenance.enable',
+        message: 'Maintenance mode enabled',
+        result: 'success',
+        initiatedBy: null,
+        timestamp: new Date().toISOString(),
+        actor: { type: 'system', name: 'System' },
+      },
+    ]);
+    render(<DeviceActivityFeed deviceId="dev-1" />);
+    expect(await screen.findByText('Maintenance mode enabled')).toBeInTheDocument();
+    expect(screen.queryByText('Automated')).toBeNull();
   });
 
   it('reports no content when the feed is empty', async () => {
@@ -71,6 +95,15 @@ describe('DeviceActivityFeed', () => {
         actor: { type: 'system', name: 'System' },
       },
     ]);
+    const onHasContentChange = vi.fn();
+    render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
+    await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(true));
+  });
+
+  it('reports content when there are no events but active alerts exist', async () => {
+    // The pinned active-alerts banner is content too — the rail must not collapse
+    // while an alert is showing.
+    mockFeed([], [{ id: 'a1', status: 'active' }]);
     const onHasContentChange = vi.fn();
     render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
     await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(true));

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceActivityFeed from './DeviceActivityFeed';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// Route the events call vs the alerts call by URL.
+function mockFeed(events: unknown[], alerts: unknown[] = []) {
+  fetchWithAuthMock.mockImplementation((url: string) =>
+    Promise.resolve(
+      url.includes('/events')
+        ? jsonResponse({ data: events, pagination: { page: 1, limit: 10, total: null } })
+        : jsonResponse({ data: alerts })
+    )
+  );
+}
+
+describe('DeviceActivityFeed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('requests automated activity', async () => {
+    mockFeed([]);
+    render(<DeviceActivityFeed deviceId="dev-1" />);
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        expect.stringContaining('includeAutomated=true'),
+        expect.anything()
+      )
+    );
+  });
+
+  it('shows an Automated chip for a system-initiated row with no initiatedBy', async () => {
+    mockFeed([
+      {
+        id: 'e1',
+        action: 'agent.command.install_patches',
+        message: 'Patches installed — host-1',
+        result: 'success',
+        initiatedBy: null,
+        timestamp: new Date().toISOString(),
+        actor: { type: 'system', name: 'System' },
+      },
+    ]);
+    render(<DeviceActivityFeed deviceId="dev-1" />);
+    expect(await screen.findByText('Patches installed — host-1')).toBeInTheDocument();
+    expect(screen.getByText('Automated')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -51,4 +51,34 @@ describe('DeviceActivityFeed', () => {
     expect(await screen.findByText('Patches installed — host-1')).toBeInTheDocument();
     expect(screen.getByText('Automated')).toBeInTheDocument();
   });
+
+  it('reports no content when the feed is empty', async () => {
+    mockFeed([], []);
+    const onHasContentChange = vi.fn();
+    render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
+    await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('reports content when there are events', async () => {
+    mockFeed([
+      {
+        id: 'e1',
+        action: 'agent.command.script',
+        message: 'Script ran',
+        result: 'success',
+        initiatedBy: null,
+        timestamp: new Date().toISOString(),
+        actor: { type: 'system', name: 'System' },
+      },
+    ]);
+    const onHasContentChange = vi.fn();
+    render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
+    await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(true));
+  });
+
+  it('renders a compact one-line empty state in strip layout', async () => {
+    mockFeed([], []);
+    render(<DeviceActivityFeed deviceId="dev-1" layout="strip" />);
+    expect(await screen.findByTestId('activity-empty-strip')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -53,10 +53,12 @@ const ACTION_RULES: { prefix: string; icon: LucideIcon }[] = [
   { prefix: 'device.decommission', icon: Trash2 },
   { prefix: 'device.permanent_delete', icon: Trash2 },
   { prefix: 'device.restore', icon: RotateCcw },
-  // Automated agent-dispatched commands (scheduled patches, automations). These
-  // are written as `agent.command.<type>` with no route-audit twin; the server
-  // only returns them when includeAutomated=true (and scoped to system/agent
-  // actors), so they don't duplicate the manual route audits above.
+  // Automated agent-dispatched commands (scheduled patches, automations). Listed
+  // here ONLY so ruleFor() can pick an icon — they are deliberately excluded
+  // from ACTION_PREFIXES below. The server surfaces these solely via the
+  // actor-scoped includeAutomated predicate (system actors, no manual twin);
+  // sending them as plain action prefixes would re-admit the manual
+  // (actor_type='user') twin rows and double-list them.
   { prefix: 'agent.command.install_patches', icon: Download },
   { prefix: 'agent.command.rollback_patches', icon: RotateCcw },
   { prefix: 'agent.command.script', icon: Terminal },
@@ -64,15 +66,21 @@ const ACTION_RULES: { prefix: string; icon: LucideIcon }[] = [
   { prefix: 'agent.command.software_update', icon: Package },
 ];
 
+const AUTOMATED_ACTION_PREFIX = 'agent.command.';
+
 function ruleFor(action?: string) {
   if (!action) return undefined;
   return ACTION_RULES.find((r) => action.startsWith(r.prefix));
 }
 
-// The same prefix set, sent to the API so the "deliberate action" filter runs
+// The deliberate-action prefix set, sent to the API so the filter runs
 // server-side (index-backed) instead of over-fetching raw rows and discarding
-// most of them client-side (issue #1726).
-const ACTION_PREFIXES = ACTION_RULES.map((r) => r.prefix).join(',');
+// most of them client-side (issue #1726). The agent.command.* rules are
+// excluded — those rows arrive only through the actor-scoped includeAutomated
+// predicate, never as plain prefix matches (see the comment above).
+const ACTION_PREFIXES = ACTION_RULES.filter((r) => !r.prefix.startsWith(AUTOMATED_ACTION_PREFIX))
+  .map((r) => r.prefix)
+  .join(',');
 
 // How many filtered rows to request per page. Small fixed window for a fast,
 // predictable first paint; "Load more" pulls the next page on demand.
@@ -209,11 +217,13 @@ export default function DeviceActivityFeed({
   }, [loadPage]);
 
   // Report whether the pane has anything worth showing so the parent can collapse
-  // the rail when it's empty. Only meaningful once the initial load settles.
+  // the rail when it's empty. Skip while loading OR errored: an error is not
+  // "no content", and collapsing on error would shove the "Couldn't load /
+  // Retry" pane into a narrow strip. On error the parent keeps its prior layout.
   useEffect(() => {
-    if (loading) return;
+    if (loading || error) return;
     onHasContentChange?.(events.length > 0 || activeAlerts > 0);
-  }, [loading, events.length, activeAlerts, onHasContentChange]);
+  }, [loading, error, events.length, activeAlerts, onHasContentChange]);
 
   // Retry the whole pane from page 1 on a fresh controller (the mount effect's
   // controller is aborted once its cleanup runs).
@@ -301,13 +311,14 @@ export default function DeviceActivityFeed({
               const Icon = ruleFor(e.action)?.icon ?? Activity;
               const initiator = e.initiatedBy ? INITIATOR_LABELS[e.initiatedBy] : undefined;
               const failed = e.result === 'failure' || e.result === 'denied';
-              // System/agent-dispatched commands carry no initiatedBy; surface them
-              // as "Automated" so an unattended patch run / automation is legible.
-              const automated =
-                !initiator && (e.actor?.type === 'system' || e.actor?.type === 'agent');
+              // Tag the automated-dispatch rows (the agent.command.* family the
+              // server returns only for non-user actors) as "Automated". Keyed on
+              // the action, not actor.type, so other system-actor rows aren't
+              // mislabeled — and an explicit initiatedBy label still wins.
+              const automated = !initiator && (e.action ?? '').startsWith(AUTOMATED_ACTION_PREFIX);
               const namedActor = e.actor?.name && e.actor.name !== 'System' ? e.actor.name : undefined;
               // For automated rows the "Automated" chip already conveys the actor,
-              // so drop the generic "System"/"Agent" label and keep only a real name.
+              // so drop the generic "System" label and keep only a real name.
               const who = automated ? namedActor : namedActor ?? initiator ?? e.actor?.name;
               return (
                 <li key={e.id} className="flex gap-3">

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -46,6 +46,15 @@ const ACTION_RULES: { prefix: string; icon: LucideIcon }[] = [
   { prefix: 'device.decommission', icon: Trash2 },
   { prefix: 'device.permanent_delete', icon: Trash2 },
   { prefix: 'device.restore', icon: RotateCcw },
+  // Automated agent-dispatched commands (scheduled patches, automations). These
+  // are written as `agent.command.<type>` with no route-audit twin; the server
+  // only returns them when includeAutomated=true (and scoped to system/agent
+  // actors), so they don't duplicate the manual route audits above.
+  { prefix: 'agent.command.install_patches', icon: Download },
+  { prefix: 'agent.command.rollback_patches', icon: RotateCcw },
+  { prefix: 'agent.command.script', icon: Terminal },
+  { prefix: 'agent.command.software_uninstall', icon: Package },
+  { prefix: 'agent.command.software_update', icon: Package },
 ];
 
 function ruleFor(action?: string) {
@@ -133,7 +142,7 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
         setLoadMoreError(false);
       }
       try {
-        const eventsUrl = `/devices/${deviceId}/events?limit=${PAGE_SIZE}&page=${page}&actions=${encodeURIComponent(
+        const eventsUrl = `/devices/${deviceId}/events?limit=${PAGE_SIZE}&page=${page}&includeAutomated=true&actions=${encodeURIComponent(
           ACTION_PREFIXES
         )}`;
         // The active-alert count is only needed on the initial load.
@@ -260,8 +269,15 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
             {visible.map((e) => {
               const Icon = ruleFor(e.action)?.icon ?? Activity;
               const initiator = e.initiatedBy ? INITIATOR_LABELS[e.initiatedBy] : undefined;
-              const who = e.actor?.name && e.actor.name !== 'System' ? e.actor.name : initiator ?? e.actor?.name;
               const failed = e.result === 'failure' || e.result === 'denied';
+              // System/agent-dispatched commands carry no initiatedBy; surface them
+              // as "Automated" so an unattended patch run / automation is legible.
+              const automated =
+                !initiator && (e.actor?.type === 'system' || e.actor?.type === 'agent');
+              const namedActor = e.actor?.name && e.actor.name !== 'System' ? e.actor.name : undefined;
+              // For automated rows the "Automated" chip already conveys the actor,
+              // so drop the generic "System"/"Agent" label and keep only a real name.
+              const who = automated ? namedActor : namedActor ?? initiator ?? e.actor?.name;
               return (
                 <li key={e.id} className="flex gap-3">
                   <div
@@ -281,6 +297,11 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
                       {initiator && who !== initiator && (
                         <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                           {initiator}
+                        </span>
+                      )}
+                      {automated && (
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          Automated
                         </span>
                       )}
                       {who && <span aria-hidden="true">·</span>}

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -29,6 +29,13 @@ type ActivityEvent = {
 type DeviceActivityFeedProps = {
   deviceId: string;
   timezone?: string;
+  // 'rail' is the right-column card (default). 'strip' is the full-width
+  // placement used when the parent collapses the rail; its empty state is a
+  // single compact line rather than the stacked heading/paragraph/link.
+  layout?: 'rail' | 'strip';
+  // Reports whether the pane has anything worth showing (events or active
+  // alerts) so the parent can collapse the rail when it's empty.
+  onHasContentChange?: (hasContent: boolean) => void;
 };
 
 // "Deliberate actions taken on this endpoint." An event is shown only if its
@@ -102,7 +109,12 @@ function absoluteTime(value?: string, timezone?: string): string | undefined {
   return formatDateTime(d, timezone ? { timeZone: timezone } : undefined);
 }
 
-export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivityFeedProps) {
+export default function DeviceActivityFeed({
+  deviceId,
+  timezone,
+  layout = 'rail',
+  onHasContentChange,
+}: DeviceActivityFeedProps) {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [activeAlerts, setActiveAlerts] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -196,6 +208,13 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
     return () => controller.abort();
   }, [loadPage]);
 
+  // Report whether the pane has anything worth showing so the parent can collapse
+  // the rail when it's empty. Only meaningful once the initial load settles.
+  useEffect(() => {
+    if (loading) return;
+    onHasContentChange?.(events.length > 0 || activeAlerts > 0);
+  }, [loading, events.length, activeAlerts, onHasContentChange]);
+
   // Retry the whole pane from page 1 on a fresh controller (the mount effect's
   // controller is aborted once its cleanup runs).
   const reload = useCallback(() => {
@@ -263,7 +282,19 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
             </button>
           </p>
         ) : visible.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No recent actions on this device.</p>
+          layout === 'strip' ? (
+            <div
+              data-testid="activity-empty-strip"
+              className="flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground"
+            >
+              <span>No recent actions on this device.</span>
+              <a href="#activities" className="font-medium text-primary hover:underline">
+                View all activity →
+              </a>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No recent actions on this device.</p>
+          )
         ) : (
           <ul className="space-y-3">
             {visible.map((e) => {
@@ -332,7 +363,7 @@ export default function DeviceActivityFeed({ deviceId, timezone }: DeviceActivit
         )}
       </div>
 
-      {!loading && !error && (
+      {!loading && !error && !(layout === 'strip' && visible.length === 0) && (
         <a
           href="#activities"
           className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -151,6 +151,10 @@ function getAnomalyIdFromHash(): string | undefined {
 export default function DeviceDetails({ device, timezone, onBack, onAction }: DeviceDetailsProps) {
   const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
   const [focusedAnomalyId, setFocusedAnomalyId] = useState<string | undefined>(getAnomalyIdFromHash);
+  // Whether the Overview Activity pane has anything to show. Defaults to true so
+  // the common (populated) layout never flashes; the feed reports false to
+  // collapse the right rail and place Activity as a full-width bottom strip.
+  const [activityHasContent, setActivityHasContent] = useState(true);
 
   useEffect(() => {
     const onHashChange = () => {
@@ -243,8 +247,8 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
       <OverflowTabs tabs={tabs} activeTab={activeTab} onTabChange={(id) => switchTab(id as Tab)} />
 
       {activeTab === 'overview' && (
-        <div className="grid gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2 space-y-6">
+        <div className={activityHasContent ? 'grid gap-6 lg:grid-cols-3' : 'space-y-6'}>
+          <div className={`space-y-6 ${activityHasContent ? 'lg:col-span-2' : ''}`}>
             {/* Two groups — Health (CPU/RAM/Uptime) and Activity (Last Seen/
                 User/Idle) — divided on ≥sm. Stats are content-sized (flex, not
                 an equal-width grid) with non-wrapping labels and values so e.g.
@@ -303,7 +307,12 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
             <DeviceWarrantyCard deviceId={device.id} compact />
           </div>
 
-          <DeviceActivityFeed deviceId={device.id} timezone={effectiveTimezone} />
+          <DeviceActivityFeed
+            deviceId={device.id}
+            timezone={effectiveTimezone}
+            layout={activityHasContent ? 'rail' : 'strip'}
+            onHasContentChange={setActivityHasContent}
+          />
         </div>
       )}
 

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -356,4 +356,32 @@ describe('DeviceReliabilityPanel', () => {
     fireEvent.click(atRiskHelp.querySelector('button')!);
     expect(await screen.findByText(/Biggest drag: Uptime/)).toBeInTheDocument();
   });
+
+  it('At-risk tooltip falls back to the top issue when there are no drivers', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 48,
+          trendDirection: 'degrading',
+          trendConfidence: 0.6,
+          uptime30d: 92.0,
+          crashCount30d: 5,
+          hangCount30d: 0,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: null,
+          topIssues: [{ type: 'crashes', count: 5, severity: 'critical' }],
+          drivers: [],
+          computedAt: '2026-06-23T19:00:00Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+    const atRiskHelp = await screen.findByTestId('reliability-atrisk-help');
+    fireEvent.click(atRiskHelp.querySelector('button')!);
+    expect(await screen.findByText(/Biggest drag: Crashes/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -298,4 +298,62 @@ describe('DeviceReliabilityPanel', () => {
     expect(fetchWithAuthMock).not.toHaveBeenCalledWith('/reliability/dev-1');
     expect(screen.queryByTestId('reliability-outcome-trigger')).toBeNull();
   });
+
+  it('labels factor scores as Health N/100 (not a bare count)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 55,
+          trendDirection: 'stable',
+          trendConfidence: 0.7,
+          uptime30d: 16.8,
+          crashCount30d: 0,
+          hangCount30d: 4,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: 7,
+          topIssues: [],
+          drivers: [
+            { factor: 'crashes', label: 'Crashes', score: 100, weight: 25, lostPoints: 0, evidence: { crashCount7d: 0 } },
+          ],
+          computedAt: '2026-06-23T19:00:00Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+    expect(await screen.findByText('Health 100/100')).toBeInTheDocument();
+  });
+
+  it('shows an At-risk explainer tooltip naming the top drag factor', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 55,
+          trendDirection: 'stable',
+          trendConfidence: 0.7,
+          uptime30d: 16.8,
+          crashCount30d: 0,
+          hangCount30d: 4,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: 7,
+          topIssues: [],
+          drivers: [
+            { factor: 'uptime', label: 'Uptime', score: 0, weight: 30, lostPoints: 30, evidence: {} },
+          ],
+          computedAt: '2026-06-23T19:00:00Z',
+        },
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+    const atRiskHelp = await screen.findByTestId('reliability-atrisk-help');
+    fireEvent.click(atRiskHelp.querySelector('button')!);
+    expect(await screen.findByText(/Biggest drag: Uptime/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -8,6 +8,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { useMlFeatureFlags } from '../../hooks/useMlFeatureFlags';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useAiStore } from '../../stores/aiStore';
+import HelpTooltip from '../shared/HelpTooltip';
 
 type ReliabilityTopIssue = {
   type: 'crashes' | 'hangs' | 'services' | 'hardware' | 'uptime';
@@ -86,6 +87,16 @@ function scoreBandLabel(score: number): string {
   if (score <= 70) return 'poor';
   if (score <= 85) return 'fair';
   return 'good';
+}
+
+// The factor most responsible for dragging the score down — the first driver
+// (already ordered by lost points) or, when no drivers exist, the first top
+// issue. Used by the "At risk" explainer tooltip.
+function topDragLabel(snapshot: ReliabilitySnapshot): string | null {
+  const driver = (snapshot.drivers ?? [])[0];
+  if (driver) return driver.label;
+  const issue = snapshot.topIssues[0];
+  return issue ? issueLabels[issue.type] : null;
 }
 
 function buildReliabilitySeedPrompt(snapshot: ReliabilitySnapshot, drivers: ReliabilityDriver[]): string {
@@ -270,15 +281,29 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
             <ShieldCheck className="h-5 w-5 text-muted-foreground" />
             <h3 className="text-base font-semibold">Reliability</h3>
             {snapshot.reliabilityScore <= 70 && (
-              <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
-                <AlertTriangle className="h-3.5 w-3.5" />
-                At risk
+              <span className="inline-flex items-center gap-1" data-testid="reliability-atrisk-help">
+                <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  At risk
+                </span>
+                <HelpTooltip
+                  text={
+                    topDragLabel(snapshot)
+                      ? `Shown when the reliability score is ≤ 70. Biggest drag: ${topDragLabel(snapshot)}.`
+                      : 'Shown when the reliability score is ≤ 70.'
+                  }
+                />
               </span>
             )}
           </div>
           <div className="mt-3 flex flex-wrap items-end gap-x-5 gap-y-2">
             <div>
-              <div className="text-xs text-muted-foreground">Score</div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                Score
+                <HelpTooltip
+                  text={`Reliability score ${snapshot.reliabilityScore}/100 — ${scoreBandLabel(snapshot.reliabilityScore)}. Bands: ≤50 critical, ≤70 poor, ≤85 fair, else good.`}
+                />
+              </div>
               <div className={`text-3xl font-semibold tabular-nums ${scoreClass(snapshot.reliabilityScore)}`}>
                 {snapshot.reliabilityScore}
               </div>
@@ -371,7 +396,14 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
                 <p className="truncate text-sm font-medium">{driver.label}</p>
                 <p className="text-xs text-muted-foreground">{driver.weight}% weight</p>
               </div>
-              <span className={`text-sm font-semibold tabular-nums ${scoreClass(driver.score)}`}>{driver.score}</span>
+              <span className="flex items-center gap-1">
+                <span className={`text-sm font-semibold tabular-nums ${scoreClass(driver.score)}`}>
+                  Health {driver.score}/100
+                </span>
+                <HelpTooltip
+                  text={`Factor health 0–100; 100 = no issues detected. Counts to ${driver.weight}% of the overall reliability score. The raw counts are listed below.`}
+                />
+              </span>
             </div>
             <div className="mt-3 space-y-1 text-xs text-muted-foreground">
               {Object.entries(driver.evidence).slice(0, 3).map(([key, value]) => (

--- a/docs/superpowers/plans/2026-06-24-device-overview-ui-polish.md
+++ b/docs/superpowers/plans/2026-06-24-device-overview-ui-polish.md
@@ -1,0 +1,793 @@
+# Device Overview UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Device → Overview tab clearer: surface automated activity (scheduled patches, automations) in the Activity feed, collapse the Activity pane when empty, and de-confuse the Reliability card (`Health N/100` labels + tooltips).
+
+**Architecture:** Four focused changes. (1) The events API gains an opt-in `includeAutomated` flag that ORs in `agent.command.%` rows scoped to `actor_type IN ('system','agent')` (the dedup discriminator). (2) The Reliability panel relabels factor scores and adds `HelpTooltip` explainers. (3) The Activity feed renders those automated rows with an "Automated" chip. (4) The feed reports content state up so `DeviceDetails` collapses the right rail when empty.
+
+**Tech Stack:** Hono + Drizzle + Zod (API, Vitest), Astro/React + Tailwind (web, Vitest + jsdom + Testing Library), Lucide icons.
+
+## Global Constraints
+
+- API tests: Vitest with shallow Drizzle mocks — see `apps/api/src/routes/devices/events.test.ts`. No real DB in the unit job.
+- Web tests: Vitest + jsdom + `@testing-library/react`; mock `fetchWithAuth` from `../../stores/auth`.
+- Reuse the shared tooltip primitive `apps/web/src/components/shared/HelpTooltip.tsx` (`<HelpTooltip text={...} />`) — do not build a new one.
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Run web tests with: `pnpm --filter @breeze/web test -- <path>`. Run API tests with: `pnpm --filter @breeze/api exec vitest run <path>`.
+- Branch: `worktree-device-overview-ui` (already created; spec at `docs/superpowers/specs/2026-06-24-device-overview-ui-polish-design.md`).
+
+---
+
+## File Structure
+
+- `apps/api/src/routes/devices/events.ts` — add `includeAutomated` query param + predicate; add 5 `agent.command.*` labels; `export` `formatActionMessage`.
+- `apps/api/src/routes/devices/events.test.ts` — validation + label-formatting tests.
+- `apps/web/src/components/devices/DeviceReliabilityPanel.tsx` — `Health N/100` factor labels; tooltips on factor cards, Score, At-risk badge.
+- `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx` — extend.
+- `apps/web/src/components/devices/DeviceActivityFeed.tsx` — `includeAutomated=true`; automated icons; "Automated" chip; `onHasContentChange` + `layout` props.
+- `apps/web/src/components/devices/DeviceActivityFeed.test.tsx` — new file.
+- `apps/web/src/components/devices/DeviceDetails.tsx` — collapse the Overview right rail when the feed is empty.
+
+---
+
+## Task 1: API — `includeAutomated` filter + automated-command labels
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/events.ts`
+- Test: `apps/api/src/routes/devices/events.test.ts`
+
+**Interfaces:**
+- Produces: `GET /devices/:id/events?includeAutomated=true` — when set, the response also includes rows whose `action LIKE 'agent.command.%'` AND `actor_type IN ('system','agent')`. New `actionLabels` entries for `agent.command.{install_patches,rollback_patches,script,software_uninstall,software_update}`. `formatActionMessage` becomes an exported function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/devices/events.test.ts`. First extend the import on line 81:
+
+```ts
+import { eventsRoutes, likePrefixPattern, formatActionMessage } from './events';
+```
+
+Then add two new `describe` blocks (place after the existing `likePrefixPattern` describe):
+
+```ts
+describe('formatActionMessage (automated command labels)', () => {
+  it('labels automated patch installs', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'success'))
+      .toBe('Patches installed — host-1');
+  });
+  it('labels automated script runs', () => {
+    expect(formatActionMessage('agent.command.script', null, 'success'))
+      .toBe('Script ran');
+  });
+  it('marks a failed automated patch install', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'failure'))
+      .toBe('Patches installed — host-1 (failed)');
+  });
+  it('labels rollback, uninstall, and update', () => {
+    expect(formatActionMessage('agent.command.rollback_patches', null, 'success')).toBe('Patches rolled back');
+    expect(formatActionMessage('agent.command.software_uninstall', null, 'success')).toBe('Software uninstalled');
+    expect(formatActionMessage('agent.command.software_update', null, 'success')).toBe('Software updated');
+  });
+});
+```
+
+And inside the existing `describe('GET /devices/:id/events validation', ...)` block, add:
+
+```ts
+  it('accepts includeAutomated=true', async () => {
+    const res = await app.request('/00000000-0000-0000-0000-000000000001/events?includeAutomated=true');
+    expect(res.status).toBe(200);
+  });
+  it('accepts includeAutomated=false', async () => {
+    const res = await app.request('/00000000-0000-0000-0000-000000000001/events?includeAutomated=false');
+    expect(res.status).toBe(200);
+  });
+  it('rejects an invalid includeAutomated value with 400', async () => {
+    const res = await app.request('/00000000-0000-0000-0000-000000000001/events?includeAutomated=maybe');
+    expect(res.status).toBe(400);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/devices/events.test.ts`
+Expected: FAIL — `formatActionMessage` is not exported (import error) and the `includeAutomated=maybe` case returns 200 (no validation yet).
+
+- [ ] **Step 3: Add the query param, predicate, labels, and export**
+
+In `apps/api/src/routes/devices/events.ts`:
+
+(a) In `eventsQuerySchema` (after the `actions` field, before `withTotal`), add:
+
+```ts
+  // Opt-in: also surface automated agent-dispatched commands (scheduled
+  // patches, automations) that are written as `agent.command.<type>` with
+  // actor_type 'system'/'agent'. Off by default so existing callers are
+  // unaffected (issue: device-overview automated activity).
+  includeAutomated: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false')
+    .transform((v) => v === 'true'),
+```
+
+(b) Update the destructure (currently lines ~96-97) to include it:
+
+```ts
+    const { search, category, result, initiatedBy, from, to, page, limit, actions, withTotal, includeAutomated } =
+      c.req.valid('query');
+```
+
+(c) Replace the existing `actions` filter block:
+
+```ts
+    if (actions && actions.length > 0) {
+      // Match any of the supplied action prefixes (server-side equivalent of the
+      // overview pane's "deliberate action" filter). `LIKE` with an escaped
+      // prefix keeps it index-friendly and avoids ILIKE's case-fold cost — audit
+      // action keys are already lowercase dotted identifiers.
+      conditions.push(
+        or(...actions.map((prefix) => sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`))!
+      );
+    }
+```
+
+with:
+
+```ts
+    // The overview "deliberate action" filter: any supplied action prefix, plus
+    // (opt-in) automated agent-dispatched commands. Both go into one OR group.
+    const actionClauses: SQL[] = [];
+    if (actions && actions.length > 0) {
+      // `LIKE` with an escaped prefix keeps it index-friendly and avoids ILIKE's
+      // case-fold cost — audit action keys are already lowercase dotted ids.
+      for (const prefix of actions) {
+        actionClauses.push(sql`${auditLogs.action} LIKE ${likePrefixPattern(prefix)}`);
+      }
+    }
+    if (includeAutomated) {
+      // Automated patch runs / automations are written by commandQueue as
+      // `agent.command.<type>` with actor_type 'system'/'agent' and no
+      // route-audit twin. Manual commands (actor_type 'user') are excluded —
+      // they're already represented by their richer route audit
+      // (script.execute, device.patch.*), so this avoids double-listing.
+      actionClauses.push(
+        sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} IN ('system','agent'))`
+      );
+    }
+    if (actionClauses.length > 0) {
+      conditions.push(or(...actionClauses)!);
+    }
+```
+
+(d) Add the five labels to the `actionLabels` map (e.g. right after the `'script.execution.cancel'` entry):
+
+```ts
+  'agent.command.install_patches': 'Patches installed',
+  'agent.command.rollback_patches': 'Patches rolled back',
+  'agent.command.script': 'Script ran',
+  'agent.command.software_uninstall': 'Software uninstalled',
+  'agent.command.software_update': 'Software updated',
+```
+
+(e) Export `formatActionMessage` — change its declaration from
+`function formatActionMessage(` to `export function formatActionMessage(`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/devices/events.test.ts`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/devices/events.ts apps/api/src/routes/devices/events.test.ts
+git commit -m "feat(api): surface automated agent-command activity in device events feed
+
+Adds opt-in includeAutomated flag that ORs in agent.command.% rows scoped
+to actor_type system/agent (dedup vs manual route audits), plus labels for
+automated patch/script/software commands.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Reliability panel — `Health N/100` + explainer tooltips
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceReliabilityPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `HelpTooltip` from `../shared/HelpTooltip` (`<HelpTooltip text={string} />`), `scoreBandLabel` (already in file).
+- Produces: factor cards render `Health {score}/100`; a Score tooltip and an At-risk tooltip with computed text.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx`. The existing `renders reliability score drivers` test seeds a snapshot with `score: 20` for the Crashes driver; add assertions in a new test that reuses the same fetch setup. Append inside the `describe('DeviceReliabilityPanel', ...)` block:
+
+```ts
+  it('labels factor scores as Health N/100 (not a bare count)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 55,
+          trendDirection: 'stable',
+          trendConfidence: 0.7,
+          uptime30d: 16.8,
+          crashCount30d: 0,
+          hangCount30d: 4,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: 7,
+          topIssues: [],
+          drivers: [
+            { factor: 'crashes', label: 'Crashes', score: 100, weight: 25, lostPoints: 0, evidence: { crashCount7d: 0 } },
+          ],
+          computedAt: '2026-06-23T19:00:00Z',
+        },
+      })
+    );
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+    expect(await screen.findByText('Health 100/100')).toBeInTheDocument();
+  });
+
+  it('shows an At-risk explainer tooltip naming the top drag factor', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: {
+          deviceId: 'dev-1',
+          reliabilityScore: 55,
+          trendDirection: 'stable',
+          trendConfidence: 0.7,
+          uptime30d: 16.8,
+          crashCount30d: 0,
+          hangCount30d: 4,
+          serviceFailureCount30d: 0,
+          hardwareErrorCount30d: 0,
+          mtbfHours: 7,
+          topIssues: [],
+          drivers: [
+            { factor: 'uptime', label: 'Uptime', score: 0, weight: 30, lostPoints: 30, evidence: {} },
+          ],
+          computedAt: '2026-06-23T19:00:00Z',
+        },
+      })
+    );
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+    // The At-risk help icon reveals its tooltip text on hover/click.
+    const atRiskHelp = await screen.findByTestId('reliability-atrisk-help');
+    fireEvent.click(atRiskHelp.querySelector('button')!);
+    expect(await screen.findByText(/Biggest drag: Uptime/)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceReliabilityPanel.test.tsx`
+Expected: FAIL — "Health 100/100" and `reliability-atrisk-help` don't exist yet.
+
+- [ ] **Step 3: Implement the panel changes**
+
+In `apps/web/src/components/devices/DeviceReliabilityPanel.tsx`:
+
+(a) Add the import at the top (with the other component imports):
+
+```ts
+import HelpTooltip from '../shared/HelpTooltip';
+```
+
+(b) Add a helper to compute the top-drag factor label (place near the other top-level helpers, after `scoreBandLabel`):
+
+```ts
+function topDragLabel(snapshot: ReliabilitySnapshot): string | null {
+  const driver = (snapshot.drivers ?? [])[0];
+  if (driver) return driver.label;
+  const issue = snapshot.topIssues[0];
+  return issue ? issueLabels[issue.type] : null;
+}
+```
+
+(c) Wrap the Score block (currently the `<div className="text-xs text-muted-foreground">Score</div>` group) so the label carries a tooltip. Replace:
+
+```tsx
+            <div>
+              <div className="text-xs text-muted-foreground">Score</div>
+              <div className={`text-3xl font-semibold tabular-nums ${scoreClass(snapshot.reliabilityScore)}`}>
+                {snapshot.reliabilityScore}
+              </div>
+            </div>
+```
+
+with:
+
+```tsx
+            <div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                Score
+                <HelpTooltip
+                  text={`Reliability score ${snapshot.reliabilityScore}/100 — ${scoreBandLabel(snapshot.reliabilityScore)}. Bands: ≤50 critical, ≤70 poor, ≤85 fair, else good.`}
+                />
+              </div>
+              <div className={`text-3xl font-semibold tabular-nums ${scoreClass(snapshot.reliabilityScore)}`}>
+                {snapshot.reliabilityScore}
+              </div>
+            </div>
+```
+
+(d) Add a tooltip beside the At-risk badge. Replace:
+
+```tsx
+            {snapshot.reliabilityScore <= 70 && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                At risk
+              </span>
+            )}
+```
+
+with:
+
+```tsx
+            {snapshot.reliabilityScore <= 70 && (
+              <span className="inline-flex items-center gap-1" data-testid="reliability-atrisk-help">
+                <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  At risk
+                </span>
+                <HelpTooltip
+                  text={
+                    topDragLabel(snapshot)
+                      ? `Shown when the reliability score is ≤ 70. Biggest drag: ${topDragLabel(snapshot)}.`
+                      : 'Shown when the reliability score is ≤ 70.'
+                  }
+                />
+              </span>
+            )}
+```
+
+(e) Relabel the factor-card score. Replace:
+
+```tsx
+              <span className={`text-sm font-semibold tabular-nums ${scoreClass(driver.score)}`}>{driver.score}</span>
+```
+
+with:
+
+```tsx
+              <span className="flex items-center gap-1">
+                <span className={`text-sm font-semibold tabular-nums ${scoreClass(driver.score)}`}>
+                  Health {driver.score}/100
+                </span>
+                <HelpTooltip
+                  text={`Factor health 0–100; 100 = no issues detected. Counts to ${driver.weight}% of the overall reliability score. The raw counts are listed below.`}
+                />
+              </span>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceReliabilityPanel.test.tsx`
+Expected: PASS (existing + new). Note: the existing `renders reliability score drivers` test asserts the driver score `20` is shown — verify it still passes; if it asserted the bare text `'20'`, update that assertion to `'Health 20/100'`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceReliabilityPanel.tsx apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+git commit -m "feat(web): clarify reliability card (Health N/100 + explainer tooltips)
+
+Factor cards now read 'Health N/100' so a perfect '100' no longer reads as a
+count; adds HelpTooltips on the Score and At-risk badge explaining the bands
+and the top drag factor.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Activity feed — render automated rows + "Automated" chip
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceActivityFeed.tsx`
+- Test: `apps/web/src/components/devices/DeviceActivityFeed.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `GET /devices/:id/events?...&includeAutomated=true` (Task 1).
+- Produces: feed rows for `agent.command.*` actions with sensible icons; an "Automated" chip when `initiatedBy` is null and `actor.type` is `system`/`agent`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/devices/DeviceActivityFeed.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceActivityFeed from './DeviceActivityFeed';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// Route the events call vs the alerts call by URL.
+function mockFeed(events: unknown[], alerts: unknown[] = []) {
+  fetchWithAuthMock.mockImplementation((url: string) =>
+    Promise.resolve(
+      url.includes('/events')
+        ? jsonResponse({ data: events, pagination: { page: 1, limit: 10, total: null } })
+        : jsonResponse({ data: alerts })
+    )
+  );
+}
+
+describe('DeviceActivityFeed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('requests automated activity', async () => {
+    mockFeed([]);
+    render(<DeviceActivityFeed deviceId="dev-1" />);
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        expect.stringContaining('includeAutomated=true'),
+        expect.anything()
+      )
+    );
+  });
+
+  it('shows an Automated chip for a system-initiated row with no initiatedBy', async () => {
+    mockFeed([
+      {
+        id: 'e1',
+        action: 'agent.command.install_patches',
+        message: 'Patches installed — host-1',
+        result: 'success',
+        initiatedBy: null,
+        timestamp: new Date().toISOString(),
+        actor: { type: 'system', name: 'System' },
+      },
+    ]);
+    render(<DeviceActivityFeed deviceId="dev-1" />);
+    expect(await screen.findByText('Patches installed — host-1')).toBeInTheDocument();
+    expect(screen.getByText('Automated')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceActivityFeed.test.tsx`
+Expected: FAIL — request lacks `includeAutomated=true` and no "Automated" chip is rendered.
+
+- [ ] **Step 3: Implement the feed changes**
+
+In `apps/web/src/components/devices/DeviceActivityFeed.tsx`:
+
+(a) Add icons for automated commands to `ACTION_RULES` (append after the existing entries, before the closing `];`):
+
+```ts
+  { prefix: 'agent.command.install_patches', icon: Download },
+  { prefix: 'agent.command.rollback_patches', icon: RotateCcw },
+  { prefix: 'agent.command.script', icon: Terminal },
+  { prefix: 'agent.command.software_uninstall', icon: Package },
+  { prefix: 'agent.command.software_update', icon: Package },
+```
+
+(b) Add `&includeAutomated=true` to the events URL. Change the `eventsUrl` template:
+
+```ts
+        const eventsUrl = `/devices/${deviceId}/events?limit=${PAGE_SIZE}&page=${page}&includeAutomated=true&actions=${encodeURIComponent(
+          ACTION_PREFIXES
+        )}`;
+```
+
+(c) Derive an "Automated" chip when there's no `initiatedBy` but the actor is system/agent. In the row render, the existing code computes `initiator`. Just below it add:
+
+```ts
+              const automated =
+                !initiator && (e.actor?.type === 'system' || e.actor?.type === 'agent');
+```
+
+Then change the chip-rendering block. Replace:
+
+```tsx
+                      {/* Show the initiator chip only when it isn't already the "who". */}
+                      {initiator && who !== initiator && (
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          {initiator}
+                        </span>
+                      )}
+```
+
+with:
+
+```tsx
+                      {/* Show the initiator chip only when it isn't already the "who". */}
+                      {initiator && who !== initiator && (
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          {initiator}
+                        </span>
+                      )}
+                      {/* System/agent-dispatched commands carry no initiatedBy; mark them Automated. */}
+                      {automated && (
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          Automated
+                        </span>
+                      )}
+```
+
+Note: `ACTION_PREFIXES` (line ~59) is derived from `ACTION_RULES`, so the new `agent.command.*` prefixes are automatically included in the `actions=` param. Keep `includeAutomated=true` as the explicit server-side opt-in (the server applies the `actor_type` dedup that the prefix list alone cannot).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceActivityFeed.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceActivityFeed.tsx apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+git commit -m "feat(web): show automated activity in device feed with an Automated chip
+
+Requests includeAutomated=true, renders agent.command.* rows with icons, and
+tags system/agent-dispatched rows (no initiatedBy) as 'Automated'.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Activity feed — collapse the rail when empty
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceActivityFeed.tsx`
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx`
+- Test: `apps/web/src/components/devices/DeviceActivityFeed.test.tsx`
+
+**Interfaces:**
+- Consumes: `DeviceActivityFeed` from Task 3.
+- Produces: `DeviceActivityFeed` accepts `onHasContentChange?: (hasContent: boolean) => void` and `layout?: 'rail' | 'strip'` (default `'rail'`). `DeviceDetails` Overview renders full-width main + bottom strip when the feed reports no content.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/web/src/components/devices/DeviceActivityFeed.test.tsx`:
+
+```tsx
+  it('reports no content when the feed is empty', async () => {
+    mockFeed([], []);
+    const onHasContentChange = vi.fn();
+    render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
+    await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('reports content when there are events', async () => {
+    mockFeed([
+      {
+        id: 'e1',
+        action: 'agent.command.script',
+        message: 'Script ran',
+        result: 'success',
+        initiatedBy: null,
+        timestamp: new Date().toISOString(),
+        actor: { type: 'system', name: 'System' },
+      },
+    ]);
+    const onHasContentChange = vi.fn();
+    render(<DeviceActivityFeed deviceId="dev-1" onHasContentChange={onHasContentChange} />);
+    await waitFor(() => expect(onHasContentChange).toHaveBeenLastCalledWith(true));
+  });
+
+  it('renders a compact one-line empty state in strip layout', async () => {
+    mockFeed([], []);
+    render(<DeviceActivityFeed deviceId="dev-1" layout="strip" />);
+    expect(await screen.findByTestId('activity-empty-strip')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceActivityFeed.test.tsx`
+Expected: FAIL — props don't exist; no `activity-empty-strip` testid.
+
+- [ ] **Step 3: Implement the feed prop changes**
+
+In `apps/web/src/components/devices/DeviceActivityFeed.tsx`:
+
+(a) Extend the props type:
+
+```ts
+type DeviceActivityFeedProps = {
+  deviceId: string;
+  timezone?: string;
+  layout?: 'rail' | 'strip';
+  onHasContentChange?: (hasContent: boolean) => void;
+};
+```
+
+(b) Update the component signature:
+
+```ts
+export default function DeviceActivityFeed({
+  deviceId,
+  timezone,
+  layout = 'rail',
+  onHasContentChange,
+}: DeviceActivityFeedProps) {
+```
+
+(c) Report content state after each settled load. Add an effect after the existing mount effect (after the `useEffect` that calls `loadPage(1, ...)`):
+
+```ts
+  // Report whether the pane has anything worth showing so the parent can
+  // collapse the right rail when it's empty. Only meaningful once loaded.
+  useEffect(() => {
+    if (loading) return;
+    onHasContentChange?.(events.length > 0 || activeAlerts > 0);
+  }, [loading, events.length, activeAlerts, onHasContentChange]);
+```
+
+(d) Render a compact empty state in `strip` layout. Replace the empty-state line:
+
+```tsx
+        ) : visible.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No recent actions on this device.</p>
+        ) : (
+```
+
+with:
+
+```tsx
+        ) : visible.length === 0 ? (
+          layout === 'strip' ? (
+            <div data-testid="activity-empty-strip" className="flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
+              <span>No recent actions on this device.</span>
+              <a href="#activities" className="font-medium text-primary hover:underline">
+                View all activity →
+              </a>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No recent actions on this device.</p>
+          )
+        ) : (
+```
+
+Note: in `strip` layout the empty state already includes its own "View all activity" link, and the bottom `View all activity` link (rendered when `!loading && !error`) would duplicate it. Guard that bottom link so it's hidden when the strip empty-state is shown. Change:
+
+```tsx
+      {!loading && !error && (
+        <a
+          href="#activities"
+```
+
+to:
+
+```tsx
+      {!loading && !error && !(layout === 'strip' && visible.length === 0) && (
+        <a
+          href="#activities"
+```
+
+- [ ] **Step 4: Run the feed tests to verify they pass**
+
+Run: `pnpm --filter @breeze/web test -- src/components/devices/DeviceActivityFeed.test.tsx`
+Expected: PASS (all feed tests, including Task 3's).
+
+- [ ] **Step 5: Wire the collapse into DeviceDetails**
+
+In `apps/web/src/components/devices/DeviceDetails.tsx`:
+
+(a) Add an `activityHasContent` state inside the component (near the other `useState`s; default `true` so the populated case never flashes):
+
+```ts
+  const [activityHasContent, setActivityHasContent] = useState(true);
+```
+
+(b) Replace the Overview grid block (currently the `{activeTab === 'overview' && ( ... )}` region, the `grid gap-6 lg:grid-cols-3` wrapper through `<DeviceActivityFeed ... />`):
+
+```tsx
+      {activeTab === 'overview' && (
+        <div className={activityHasContent ? 'grid gap-6 lg:grid-cols-3' : 'space-y-6'}>
+          <div className={`space-y-6 ${activityHasContent ? 'lg:col-span-2' : ''}`}>
+            {/* ... existing CPU/RAM/Uptime + Last Seen/User/Idle stat card ... */}
+            {/* ... existing DeviceReliabilityPanel / DevicePerformanceGraphs / DeviceWarrantyCard ... */}
+          </div>
+
+          {activityHasContent ? (
+            <DeviceActivityFeed
+              deviceId={device.id}
+              timezone={effectiveTimezone}
+              onHasContentChange={setActivityHasContent}
+            />
+          ) : (
+            <DeviceActivityFeed
+              deviceId={device.id}
+              timezone={effectiveTimezone}
+              layout="strip"
+              onHasContentChange={setActivityHasContent}
+            />
+          )}
+        </div>
+      )}
+```
+
+Keep the existing inner stat-card and panel JSX exactly as-is inside the left `<div>` — only the wrapper `className`s and the `DeviceActivityFeed` invocation change. The empty case puts the strip feed full-width at the bottom of the `space-y-6` stack.
+
+- [ ] **Step 6: Build-check the web app (type safety on the layout change)**
+
+Run: `pnpm --filter @breeze/web exec astro check 2>&1 | tail -20`
+Expected: no new type errors in `DeviceDetails.tsx` / `DeviceActivityFeed.tsx`. (If `astro check` is slow/unavailable, run `pnpm --filter @breeze/web exec tsc --noEmit` on the web package instead.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/devices/DeviceActivityFeed.tsx apps/web/src/components/devices/DeviceDetails.tsx apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+git commit -m "feat(web): collapse the device Activity rail when empty
+
+The feed reports content state up; DeviceDetails spans the Overview main
+column full-width and drops Activity to a compact bottom strip when there are
+no recent actions and no active alerts.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification + spec sync
+
+**Files:** none (verification only), plus optional doc touch-ups.
+
+- [ ] **Step 1: Run all touched test suites**
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/routes/devices/events.test.ts
+pnpm --filter @breeze/web test -- src/components/devices/DeviceActivityFeed.test.tsx src/components/devices/DeviceReliabilityPanel.test.tsx
+```
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke (optional but recommended)**
+
+Bring up the worktree stack (see `worktree-stack` skill) or `make dev-push`, open a device with no recent actions, confirm: Activity collapses to a bottom strip and the Overview content spans full width; open a device with automated patch/automation history and confirm automated rows show with an "Automated" chip; confirm the Reliability factor cards read `Health N/100` and the Score / At-risk tooltips appear on hover.
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin worktree-device-overview-ui
+gh pr create --title "Device overview UI polish: automated activity, collapsing Activity pane, clearer Reliability" --body "$(cat <<'EOF'
+## Summary
+- Surface automated activity (scheduled patches, automations) in the device Activity feed, tagged with an **Automated** chip. Server adds an opt-in `includeAutomated` flag that ORs in `agent.command.%` rows scoped to `actor_type IN ('system','agent')` — manual commands are excluded (already shown via their route audits), so no double-listing.
+- Collapse the Activity rail when a device has no recent actions and no active alerts: the Overview main column goes full-width and Activity drops to a compact bottom strip.
+- De-confuse the Reliability card: factor scores now read **`Health N/100`** (a green `100` no longer reads as a crash count), with `HelpTooltip` explainers on the Score and the **At risk** badge.
+
+Spec: `docs/superpowers/specs/2026-06-24-device-overview-ui-polish-design.md`
+Plan: `docs/superpowers/plans/2026-06-24-device-overview-ui-polish.md`
+
+## Out of scope (follow-ups)
+- Fine-grained `initiatedBy` (schedule vs automation vs policy) plumbed through `queueCommand` call sites for richer-than-"Automated" badges.
+- macOS↔Linux reliability factor order/weight inconsistency (WIP).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Automated activity in feed → Task 1 (API) + Task 3 (web). ✓
+- Alerts already in pane → no change needed (documented in spec findings). ✓
+- Collapse empty Activity pane → Task 4. ✓
+- Reliability `Health N/100` → Task 2. ✓
+- At-risk + Score tooltips → Task 2. ✓
+- Dedup hazard (manual double-listing) → Task 1 `actor_type` guard. ✓
+- Out-of-scope items → captured in PR body. ✓
+
+**Placeholder scan:** All steps contain concrete code/commands. The one `{/* ... existing ... */}` marker in Task 4 Step 5 is an explicit "leave this JSX unchanged" instruction, not a missing implementation. ✓
+
+**Type consistency:** `onHasContentChange: (hasContent: boolean) => void` and `layout?: 'rail' | 'strip'` are used identically in the feed (Tasks 3–4) and `DeviceDetails` (Task 4). `formatActionMessage(action, resourceName, result)` signature matches its definition in `events.ts`. `topDragLabel(snapshot)` returns `string | null`, handled in both call sites. ✓

--- a/docs/superpowers/specs/2026-06-24-device-overview-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-06-24-device-overview-ui-polish-design.md
@@ -1,0 +1,149 @@
+# Device Overview UI polish — design
+
+**Date:** 2026-06-24
+**Branch:** `worktree-device-overview-ui`
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+User feedback on the Device Details → Overview tab (from a hosted MSP, on v0.83.1):
+
+1. **Activity pane is supposed to show automated activity, not just human actions** — automated
+   patching, automations, scheduled scripts, etc. Verify whether it does, and surface it if not. The
+   pane is also supposed to include Alerts.
+2. **Empty Activity pane wastes horizontal real estate.** When a device has no recent actions, the
+   right-hand Activity column still reserves ~1/3 of the width on large screens, leaving a tall empty
+   gap. Make it dynamic until it's replaced with richer content later.
+3. **Reliability card is confusing:**
+   - Each factor card (Crashes / Application hangs / Uptime) shows a bare `0–100` number. Next to the
+     word "Crashes", a green **`100`** reads like "100 crashes" when it actually means a perfect
+     factor health score (no crashes). Users expect "0 crashes = good".
+   - The "At risk" badge and the overall Score have no explanation — no tooltip, no click-through.
+   - (macOS↔Linux factor order/weight inconsistency — explicitly **out of scope**; work-in-progress
+     is acceptable for now.)
+
+## Findings (current behavior)
+
+### Activity feed
+- Component: `apps/web/src/components/devices/DeviceActivityFeed.tsx`. Reads
+  `GET /devices/:id/events` (`apps/api/src/routes/devices/events.ts`), source table `audit_logs`.
+- It filters server-side on a fixed set of action prefixes (`ACTION_RULES`):
+  `device.command`, `script.`, `device.remote_access`, `device.patch`, `device.software`,
+  `device.maintenance`, `device.filesystem.cleanup`, `device.decommission`,
+  `device.permanent_delete`, `device.restore`.
+- It already surfaces an `initiatedBy` chip (Automation / Policy / Schedule / AI / Integration) when
+  present, and already shows a pinned **active-alerts banner** at the top of the card
+  (`GET /devices/:id/alerts?status=active`). So "Alerts in the pane" already exists; it only renders
+  when there are active alerts.
+- **Gap:** Automated patch runs and automation/scheduled scripts are written by
+  `services/commandQueue.ts → queueCommand()` as `agent.command.<type>` (e.g.
+  `agent.command.install_patches`, `agent.command.script`) with `actorType: 'system'` and **no
+  `initiatedBy`**. `agent.command.%` is **not** in the feed's filter, so automated activity never
+  appears. It also wouldn't carry an Automation badge as-is (null `initiatedBy`).
+- **Dedup hazard:** A *manual* patch/script run writes BOTH a route audit
+  (`device.patch.install.queue`, `script.execute` — `actorType: 'user'`) AND an `agent.command.*`
+  row. Naively adding `agent.command.*` to the feed would double-list manual actions. The clean
+  discriminator is `actor_type = 'system'`: automated commands have no route-audit twin; manual ones
+  are already represented by their richer route audit.
+
+### Reliability panel
+- Component: `apps/web/src/components/devices/DeviceReliabilityPanel.tsx`. Reads
+  `GET /reliability/:id`. Factor cards render `driver.score` (0–100), colored by `scoreClass()`
+  (≤50 destructive, ≤70 warning, ≤85 info, else success). The crash/hang counts are the evidence
+  rows beneath. The "At risk" badge renders when `reliabilityScore <= 70`. No tooltips exist.
+- Shared tooltip primitive available: `apps/web/src/components/shared/HelpTooltip.tsx` — a
+  hover+click help-icon tooltip taking a `text: string` and optional `className`.
+
+## Design
+
+### 1. Reliability factor cards — `Health N/100`
+In `DeviceReliabilityPanel.tsx`, change each driver card's bare `{driver.score}` to an explicit
+**`Health {driver.score}/100`** label, keeping the `scoreClass()` color (green = good, amber/red =
+bad). Add a `HelpTooltip` per card:
+
+> "Factor health 0–100; 100 = no issues detected. Counts to {weight}% of the overall reliability
+> score. The raw counts are listed below."
+
+The crash/hang/uptime **counts** remain in the evidence rows (unchanged) — those are the real
+numbers users want. This removes the "is 100 a crash count?" misread without discarding the weighted
+scoring model. The `topIssues` fallback card (renders `issue.count` with a severity label) is **not**
+ambiguous and is left unchanged.
+
+### 2. Reliability "At risk" + Score explainers
+Add accessible `HelpTooltip`s (hover + focus/click):
+- **Score** — next to the "Score" label:
+  > "Reliability score {score}/100 — {band}. Bands: ≤50 critical, ≤70 poor, ≤85 fair, else good."
+  (`band` from the existing `scoreBandLabel()`.)
+- **At risk badge** — a help icon beside the badge:
+  > "Shown when the reliability score is ≤ 70. Biggest drag: {top driver label} (health {n})."
+  Top driver = first of `drivers` (already sorted by lost points) or, if no drivers, the first
+  `topIssues` entry's label. Guard for the no-driver case.
+
+### 3. Activity pane — collapse when empty
+`DeviceActivityFeed` gains an optional callback `onHasContentChange?(hasContent: boolean)`, invoked
+after each load with `events.length > 0 || activeAlerts > 0`. `DeviceDetails.tsx` holds an
+`activityHasContent` state (default `true` to avoid a flash on the common populated case) and chooses
+the Overview layout:
+
+- **Has content** → unchanged: `grid gap-6 lg:grid-cols-3`, main `lg:col-span-2`, Activity as the
+  right rail.
+- **Empty** → main content spans full width (single column), and Activity renders as a **slim
+  full-width strip** at the bottom.
+
+To support the strip, `DeviceActivityFeed` takes a `layout?: 'rail' | 'strip'` prop. In `strip`
+layout the empty state is a single compact inline row (icon · "No recent actions on this device" ·
+"View all activity →") instead of the stacked heading/paragraph/link. The `rail` layout is the
+current rendering. When the feed is non-empty it always uses the rail layout (and the grid stays
+3-col), so the strip only ever shows the compact empty state.
+
+Reflow: during the initial load the rail layout is assumed; if the feed resolves empty, the layout
+collapses once. This one-time reflow on empty devices is acceptable.
+
+### 4. Automated activity in the feed
+**API — `apps/api/src/routes/devices/events.ts`:**
+- Add an opt-in boolean query param `includeAutomated` (`'true'|'false'`, default `false`).
+- When `true`, OR an extra condition into the existing action-prefix group:
+  `(action LIKE 'agent.command.%' AND actor_type IN ('system','agent'))`. The `actor_type` guard is
+  the dedup — manual `agent.command.*` rows (`actor_type='user'`) are excluded because they are
+  already shown via their route audit.
+- Add labels to `actionLabels` for the surfaced automated commands:
+  - `agent.command.install_patches` → "Patches installed"
+  - `agent.command.rollback_patches` → "Patches rolled back"
+  - `agent.command.script` → "Script ran"
+  - `agent.command.software_uninstall` → "Software uninstalled"
+  - `agent.command.software_update` → "Software updated"
+
+**Web — `DeviceActivityFeed.tsx`:**
+- Request with `&includeAutomated=true`.
+- Extend `ACTION_RULES` with icons for the new `agent.command.*` prefixes (Download for patches,
+  Terminal for script, Package for software), so each row gets a sensible icon.
+- **Badge:** when `initiatedBy` is null but `actor.type` is `system`/`agent`, render an **"Automated"**
+  chip (re-using the existing initiator-chip styling). Existing `initiatedBy` labels still take
+  precedence when present.
+
+**Why "Automated" and not "Schedule"/"Automation":** the audit row for a system-dispatched command
+carries no reliable `initiatedBy`, and `queueCommand` can't always distinguish schedule vs automation
+vs policy. "Automated" is honest. Plumbing fine-grained `initiatedBy` through the `queueCommand` call
+sites is a deliberate follow-up (below).
+
+## Out of scope (follow-ups)
+- Fine-grained `initiatedBy` (schedule vs automation vs policy) plumbed through `queueCommand` call
+  sites (`patchJobExecutor.ts`, `automationRuntime.ts`, BullMQ workers) for richer badges.
+- macOS↔Linux reliability factor order/weight inconsistency (user said WIP is fine).
+
+## Testing
+- **API:** unit test for `events.ts` `includeAutomated` — asserts the `agent.command.% AND
+  actor_type IN ('system','agent')` predicate is added only when the flag is set, and that a manual
+  `agent.command.*` row (`actor_type='user'`) is excluded while a system one is included. Add label
+  coverage for the new `actionLabels` entries via `formatActionMessage`.
+- **Web:** `DeviceActivityFeed` tests — `onHasContentChange` fires with correct boolean; `strip`
+  layout renders the compact empty state; the "Automated" chip appears for a null-`initiatedBy`
+  system row. `DeviceReliabilityPanel` tests — factor card shows `Health N/100`; tooltips render
+  expected text for the At-risk and Score explainers.
+- Follow the `breeze-testing` skill conventions (Vitest + Drizzle mocks for API, jsdom for web).
+
+## Files touched
+- `apps/api/src/routes/devices/events.ts` (+ test)
+- `apps/web/src/components/devices/DeviceActivityFeed.tsx` (+ test)
+- `apps/web/src/components/devices/DeviceReliabilityPanel.tsx` (+ test)
+- `apps/web/src/components/devices/DeviceDetails.tsx` (layout switch)


### PR DESCRIPTION
## Summary
Addresses Device → Overview tab feedback from a hosted MSP (reported on v0.83.1).

- **Automated activity in the feed.** The Activity feed now surfaces automated actions (scheduled patches, automations), tagged with an **Automated** chip. The events API gains an opt-in `includeAutomated` flag that ORs in `agent.command.%` rows scoped to `actor_type IN ('system','agent')`. The `actor_type` guard is the dedup: automated commands have no route-audit twin, while manual commands (`actor_type='user'`) are already represented by their richer route audits (`script.execute`, `device.patch.*`) — so no double-listing. (Previously these were logged as `agent.command.*` and never reached the feed at all.)
- **Activity pane collapses when empty.** When a device has no recent actions and no active alerts, the Overview main column spans full width and Activity drops to a compact full-width bottom strip — reclaiming the wasted right-rail real estate. The rail returns automatically when there's content.
- **Reliability card de-confused.** Factor cards now read **`Health N/100`** so a green `100` next to "Crashes" no longer reads as a crash count (it's a 0–100 factor health score; the raw counts remain in the evidence rows). Added `HelpTooltip` explainers on the **Score** (band thresholds) and the **At risk** badge (names the top drag factor).

## Already correct (verified, no change needed)
- Alerts *are* already shown in the Activity pane (pinned active-alerts banner) — it only renders when the device has active alerts.

## Out of scope (follow-ups)
- Fine-grained `initiatedBy` (schedule vs automation vs policy) plumbed through `queueCommand` call sites, for richer-than-"Automated" badges.
- macOS↔Linux reliability factor order/weight inconsistency (work-in-progress, acceptable for now).

## Testing
- API: `events.test.ts` — 21 passed (incl. `includeAutomated` validation + automated-command label formatting).
- Web: `DeviceActivityFeed.test.tsx` (new) + `DeviceReliabilityPanel.test.tsx` — 15 passed (automated chip, `includeAutomated=true` request, content-reporting + strip empty state, `Health N/100`, At-risk tooltip).
- `astro check`: 0 errors.
- Not yet run: live visual smoke test on a real device page.

Spec: `docs/superpowers/specs/2026-06-24-device-overview-ui-polish-design.md`
Plan: `docs/superpowers/plans/2026-06-24-device-overview-ui-polish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)