### PR TITLE
fix(api): survive postgres connection-teardown write race (US crash-loop hotfix)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -144,7 +144,7 @@ import { adminRoutes } from './routes/admin';
 import { internalSyntheticRoutes } from './routes/internal/synthetic';
 import { bootstrapPlatformAdmins } from './services/platformAdminBootstrap';
 import { captureException, flushSentry, initSentry } from './services/sentry';
-import { isBenignRejection } from './services/rejectionSuppressions';
+import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
 
@@ -1392,6 +1392,12 @@ function installSignalHandlers(): void {
       console.warn('[SDK] Suppressed benign unhandled rejection (session already closed):', message);
       return;
     }
+    if (isRecoverablePostgresConnectionTeardown(reason)) {
+      console.error('[db] Suppressed postgres connection-teardown write race; pool will reconnect (#1105):',
+        reason instanceof Error ? reason.message : String(reason));
+      captureException(reason instanceof Error ? reason : new Error(String(reason)));
+      return;
+    }
     console.error('[FATAL] Unhandled rejection:', reason);
     captureException(reason instanceof Error ? reason : new Error(String(reason)));
   });
@@ -1402,6 +1408,15 @@ function installSignalHandlers(): void {
   process.on('uncaughtException', (err) => {
     if (isBenignRejection(err)) {
       console.warn('[SDK] Suppressed benign uncaught exception:', err.message);
+      return;
+    }
+    // A dropped DB connection's orphaned buffered write (postgres@3) throws
+    // outside every async frame. The driver already discards the connection
+    // and reconnects, so surviving it keeps the API up instead of crash-
+    // looping and logging out every active session on restart (#1105).
+    if (isRecoverablePostgresConnectionTeardown(err)) {
+      console.error('[db] Suppressed postgres connection-teardown write race; pool will reconnect (#1105):', err.message);
+      captureException(err);
       return;
     }
     console.error('[FATAL] Uncaught exception:', err);

--- a/apps/api/src/services/rejectionSuppressions.test.ts
+++ b/apps/api/src/services/rejectionSuppressions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isBenignRejection } from './rejectionSuppressions';
+import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './rejectionSuppressions';
 
 describe('isBenignRejection', () => {
   it('suppresses ProcessTransport-not-ready', () => {
@@ -14,5 +14,60 @@ describe('isBenignRejection', () => {
   });
   it('does NOT suppress a real error', () => {
     expect(isBenignRejection(new Error('TypeError: cannot read x of undefined'))).toBe(false);
+  });
+});
+
+// Builds a TypeError shaped like the one postgres@3 throws from the orphaned
+// `nextWrite` Immediate when the backend connection is torn down (idle-in-
+// transaction timeout firing during slow non-DB work, #1105) while a write is
+// still buffered. The throw escapes every async frame → uncaughtException.
+function pgTeardownError(message: string, stack: string): TypeError {
+  const err = new TypeError(message);
+  err.stack = `TypeError: ${message}\n${stack}`;
+  return err;
+}
+
+const PG_STACK_FRAME =
+  '    at Immediate.nextWrite (/app/node_modules/.pnpm/postgres@3.4.9/node_modules/postgres/cjs/src/connection.js:255:22)\n' +
+  '    at process.processImmediate (node:internal/timers:504:21)';
+
+describe('isRecoverablePostgresConnectionTeardown', () => {
+  it('suppresses the postgres null-socket write teardown (modern V8 message)', () => {
+    expect(isRecoverablePostgresConnectionTeardown(
+      pgTeardownError("Cannot read properties of null (reading 'write')", PG_STACK_FRAME)
+    )).toBe(true);
+  });
+
+  it('suppresses the legacy V8 phrasing of the same teardown', () => {
+    expect(isRecoverablePostgresConnectionTeardown(
+      pgTeardownError("Cannot read property 'write' of null", PG_STACK_FRAME)
+    )).toBe(true);
+  });
+
+  it('does NOT suppress an identical message from NON-postgres code (real bug)', () => {
+    expect(isRecoverablePostgresConnectionTeardown(
+      pgTeardownError(
+        "Cannot read properties of null (reading 'write')",
+        '    at Object.handler (/app/apps/api/src/routes/devices.ts:42:10)'
+      )
+    )).toBe(false);
+  });
+
+  it('does NOT suppress an unrelated null-read inside postgres (only the write teardown)', () => {
+    expect(isRecoverablePostgresConnectionTeardown(
+      pgTeardownError("Cannot read properties of null (reading 'query')", PG_STACK_FRAME)
+    )).toBe(false);
+  });
+
+  it('does NOT suppress a plain Error or non-error value', () => {
+    expect(isRecoverablePostgresConnectionTeardown(new Error('boom'))).toBe(false);
+    expect(isRecoverablePostgresConnectionTeardown('nope')).toBe(false);
+    expect(isRecoverablePostgresConnectionTeardown(null)).toBe(false);
+  });
+
+  it('is covered by neither predicate for ordinary errors (no cross-suppression)', () => {
+    const real = new Error('ordinary failure');
+    expect(isBenignRejection(real)).toBe(false);
+    expect(isRecoverablePostgresConnectionTeardown(real)).toBe(false);
   });
 });

--- a/apps/api/src/services/rejectionSuppressions.ts
+++ b/apps/api/src/services/rejectionSuppressions.ts
@@ -11,3 +11,35 @@ export function isBenignRejection(reason: unknown): boolean {
     (message.includes('Operation aborted') && message.includes('Transport'))
   );
 }
+
+// Both V8 phrasings of "tried to read .write off a null value": Node >=16 says
+// "Cannot read properties of null (reading 'write')"; older engines said
+// "Cannot read property 'write' of null". Anchored to `null` + `write` so it
+// can't match arbitrary other null-property reads.
+const NULL_WRITE_MESSAGE_RE =
+  /Cannot read propert(?:y 'write' of null|ies of null \(reading 'write'\))/;
+
+/**
+ * True for the specific, recoverable crash postgres@3 throws when the backend
+ * connection is torn down (DB idle-in-transaction timeout firing during slow
+ * non-DB work inside an open context, #1105 — or any mid-flight socket close)
+ * while a write is still buffered. The orphaned `nextWrite` Immediate then does
+ * `socket.write(...)` on a nulled socket and throws a TypeError that escapes
+ * every async frame, so it surfaces as an uncaughtException and (absent a
+ * handler) kills the whole API — logging out every active session on the
+ * restart.
+ *
+ * The driver has already discarded the dead connection and the pool reconnects
+ * on the next query, so suppressing this lets the process survive a transient
+ * connection loss instead of crash-looping. Scoped tightly to the postgres
+ * driver's own stack frame so an identically-worded bug in application code
+ * still fails loudly.
+ */
+export function isRecoverablePostgresConnectionTeardown(reason: unknown): boolean {
+  if (!(reason instanceof TypeError)) return false;
+  if (!NULL_WRITE_MESSAGE_RE.test(reason.message)) return false;
+  const stack = reason.stack ?? '';
+  // Must originate inside the postgres driver's connection module — not any
+  // app-level null-write with the same message.
+  return stack.includes('postgres') && stack.includes('connection.js');
+}


### PR DESCRIPTION
## Incident

Prod **US** (`143.198.144.173`, 0.83.1) was crash-looping every **~4–5 min** — `RestartCount=236`, with **236 / 236** restarts immediately preceded by the same crash. Users reported being **logged out at random times**, noticing only on refresh.

## Root cause

1. A `scope=system` background job (`s1Sync` action poll / `patchSchedulerWorker`, both every 60s) wraps slow **non-DB work (S1 HTTP calls / per-device loops)** *inside* an open DB transaction — the #1105 conn-hold anti-pattern. Observed holds: **~180,000–207,000 ms**.
2. The managed Postgres kills the **idle-in-transaction** backend at `idle_in_transaction_session_timeout = 60s`.
3. `postgres@3.4.9`'s orphaned `nextWrite` Immediate then writes to the now-null socket:
   ```
   TypeError: Cannot read properties of null (reading 'write')
       at Immediate.nextWrite (.../postgres/cjs/src/connection.js:255:22)
   ```
   This throw escapes every async frame → **uncaughtException** → the whole API exits and `restart: unless-stopped` relaunches it.
4. During the ~15–20s restart/drain window, active sessions 401, their cookie refresh fails, and the web store clears auth **without redirect** (`apps/web/src/stores/auth.ts:564-565`) → silent deauth, noticed only on refresh.

## This change (containment)

The driver already discards the dead connection and the pool reconnects, so this throw is **recoverable**. Add `isRecoverablePostgresConnectionTeardown(err)` and **suppress-and-continue** in both the `uncaughtException` and `unhandledRejection` handlers — scoped tightly to the postgres driver's own stack frame (`postgres` + `connection.js`), so an identically-worded null-write bug in application code still fails loudly. Matches both V8 message phrasings.

With this, a transient connection loss no longer crash-loops the API and no longer logs users out.

## Not addressed here (follow-up)

The underlying conn-hold in `s1Sync` / `patchSchedulerWorker` (slow work inside a system DB context) is the root cause and is being fixed in a separate, carefully-tested PR. The guard makes the crash survivable; the refactor removes the condition.

## Tests

- `apps/api/src/services/rejectionSuppressions.test.ts` — 10/10 pass (6 new): both V8 phrasings suppressed; identical message from non-postgres stack **not** suppressed; unrelated null-read in postgres **not** suppressed; no cross-suppression with `isBenignRejection`.
- `tsc --noEmit -p apps/api/tsconfig.json` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)