### PR TITLE
fix(peripheral): stop shipping empty policies[] on enqueue-before-commit race (#1879)

### DIFF
--- a/apps/api/src/jobs/peripheralJobs.distribution.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.distribution.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Chainable Drizzle mock: db.select().from(table).where().orderBy() resolves to
+// the rows registered for that table. .from() picks the result by table identity
+// (the same sentinel objects the schema mock exports), so Promise.all ordering
+// doesn't matter.
+const tableResults = new Map<unknown, unknown[]>();
+function selectBuilder() {
+  let rows: unknown[] = [];
+  const builder: Record<string, unknown> = {
+    from(table: unknown) {
+      rows = tableResults.get(table) ?? [];
+      return builder;
+    },
+    where() {
+      return builder;
+    },
+    orderBy() {
+      return builder;
+    },
+    then(resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) {
+      return Promise.resolve(rows).then(resolve, reject);
+    }
+  };
+  return builder;
+}
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn(function QueueMock() {
+    return { add: vi.fn(), getJob: vi.fn() };
+  }),
+  Worker: vi.fn(function WorkerMock() {
+    return { on: vi.fn(), close: vi.fn() };
+  }),
+  Job: class {}
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true)
+}));
+
+vi.mock('../db', () => ({
+  db: { select: () => selectBuilder() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn())
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { __table: 'devices' },
+  peripheralEvents: { __table: 'peripheral_events' },
+  peripheralPolicies: { __table: 'peripheral_policies' }
+}));
+
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));
+
+const queueCommand = vi.fn();
+const queueCommandForExecution = vi.fn();
+vi.mock('../services/commandQueue', () => ({
+  CommandTypes: { PERIPHERAL_POLICY_SYNC: 'peripheral_policy_sync' },
+  queueCommand: (...args: unknown[]) => queueCommand(...args),
+  queueCommandForExecution: (...args: unknown[]) => queueCommandForExecution(...args)
+}));
+
+import { findUncommittedPolicyIds, processPolicyDistribution } from './peripheralJobs';
+import { devices as devicesTable, peripheralPolicies as policiesTable } from '../db/schema';
+
+const activePolicyRow = {
+  id: 'p1',
+  orgId: 'org-1',
+  name: 'Block USB storage',
+  deviceClass: 'storage',
+  action: 'block',
+  targetType: 'organization',
+  targetIds: {},
+  exceptions: [],
+  isActive: true,
+  updatedAt: new Date('2026-06-24T00:00:00.000Z')
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tableResults.clear();
+});
+
+describe('findUncommittedPolicyIds', () => {
+  it('returns changed ids that are not visible in the DB (uncommitted race)', () => {
+    expect(findUncommittedPolicyIds(['p1', 'p2'], ['p1'])).toEqual(['p2']);
+  });
+
+  it('returns empty when all changed ids are visible (incl. disabled ones)', () => {
+    expect(findUncommittedPolicyIds(['p1', 'p2'], ['p2', 'p1', 'p3'])).toEqual([]);
+  });
+
+  it('returns empty when nothing changed', () => {
+    expect(findUncommittedPolicyIds([], ['p1'])).toEqual([]);
+  });
+});
+
+describe('processPolicyDistribution race handling', () => {
+  it('throws (so BullMQ retries) when a changed policy is not yet visible — the enqueue-before-commit race', async () => {
+    // Producer txn not committed yet: the changed policy id is absent from the DB.
+    tableResults.set(policiesTable, []);
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+
+    await expect(
+      processPolicyDistribution({
+        type: 'policy-distribution',
+        orgId: 'org-1',
+        changedPolicyIds: ['p1'],
+        reason: 'policy-created',
+        queuedAt: '2026-06-24T00:00:00.000Z'
+      })
+    ).rejects.toThrow(/not yet visible|raced/i);
+
+    // Must NOT have shipped an (empty) policy set to any device.
+    expect(queueCommandForExecution).not.toHaveBeenCalled();
+    expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  it('distributes the policy once it is visible (post-commit / retry)', async () => {
+    tableResults.set(policiesTable, [activePolicyRow]);
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+    queueCommandForExecution.mockResolvedValue({ command: { id: 'cmd-1' } });
+
+    const result = await processPolicyDistribution({
+      type: 'policy-distribution',
+      orgId: 'org-1',
+      changedPolicyIds: ['p1'],
+      reason: 'policy-created',
+      queuedAt: '2026-06-24T00:00:00.000Z'
+    });
+
+    expect(queueCommandForExecution).toHaveBeenCalledTimes(1);
+    const payload = queueCommandForExecution.mock.calls[0]![2] as { policies: Array<{ id: string }> };
+    expect(payload.policies).toHaveLength(1);
+    expect(payload.policies[0]!.id).toBe('p1');
+    expect(result.queued).toBe(1);
+  });
+
+  it('excludes disabled policies from the payload but does not treat them as a race', async () => {
+    const disabled = { ...activePolicyRow, id: 'p2', isActive: false };
+    tableResults.set(policiesTable, [activePolicyRow, disabled]);
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+    queueCommandForExecution.mockResolvedValue({ command: { id: 'cmd-1' } });
+
+    await processPolicyDistribution({
+      type: 'policy-distribution',
+      orgId: 'org-1',
+      changedPolicyIds: ['p2'], // the just-disabled policy — exists, so not a race
+      reason: 'policy-disabled',
+      queuedAt: '2026-06-24T00:00:00.000Z'
+    });
+
+    const payload = queueCommandForExecution.mock.calls[0]![2] as { policies: Array<{ id: string }> };
+    const ids = payload.policies.map((p) => p.id);
+    expect(ids).toEqual(['p1']); // active only; disabled p2 excluded, no throw
+  });
+});

--- a/apps/api/src/jobs/peripheralJobs.distribution.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.distribution.test.ts
@@ -159,3 +159,92 @@ describe('processPolicyDistribution race handling', () => {
     expect(ids).toEqual(['p1']); // active only; disabled p2 excluded, no throw
   });
 });
+
+describe('processPolicyDistribution race edge cases', () => {
+  it('throws when only SOME changed ids are visible (partial race in a coalesced burst)', async () => {
+    tableResults.set(policiesTable, [activePolicyRow]); // p1 visible, p2 not
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+
+    await expect(
+      processPolicyDistribution({
+        type: 'policy-distribution',
+        orgId: 'org-1',
+        changedPolicyIds: ['p1', 'p2'],
+        reason: 'policy-created',
+        queuedAt: '2026-06-24T00:00:00.000Z'
+      })
+    ).rejects.toThrow(/p2/);
+    expect(queueCommandForExecution).not.toHaveBeenCalled();
+    expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  it('still throws on the race even when the org has zero devices (ordering locked: race check precedes the empty-devices short-circuit)', async () => {
+    tableResults.set(policiesTable, []);
+    tableResults.set(devicesTable, []);
+
+    await expect(
+      processPolicyDistribution({
+        type: 'policy-distribution',
+        orgId: 'org-1',
+        changedPolicyIds: ['p1'],
+        reason: 'policy-created',
+        queuedAt: '2026-06-24T00:00:00.000Z'
+      })
+    ).rejects.toThrow();
+  });
+
+  it('does NOT throw when there are no changed ids (manual/periodic distribution)', async () => {
+    tableResults.set(policiesTable, []);
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+    queueCommandForExecution.mockResolvedValue({ command: { id: 'cmd-1' } });
+
+    const result = await processPolicyDistribution({
+      type: 'policy-distribution',
+      orgId: 'org-1',
+      changedPolicyIds: [],
+      reason: 'manual',
+      queuedAt: '2026-06-24T00:00:00.000Z'
+    });
+    expect(result.queued).toBe(1);
+    const payload = queueCommandForExecution.mock.calls[0]![2] as { policies: unknown[] };
+    expect(payload.policies).toHaveLength(0);
+  });
+
+  it('on the FINAL attempt degrades instead of throwing — distributes the current active set, excluding the vanished id', async () => {
+    tableResults.set(policiesTable, [activePolicyRow]); // p1 present; pX gone
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+    queueCommandForExecution.mockResolvedValue({ command: { id: 'cmd-1' } });
+
+    const result = await processPolicyDistribution(
+      {
+        type: 'policy-distribution',
+        orgId: 'org-1',
+        changedPolicyIds: ['p1', 'pX-deleted'],
+        reason: 'policy-created',
+        queuedAt: '2026-06-24T00:00:00.000Z'
+      },
+      { isFinalAttempt: true }
+    );
+
+    expect(result.queued).toBe(1);
+    const payload = queueCommandForExecution.mock.calls[0]![2] as { policies: Array<{ id: string }> };
+    expect(payload.policies.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('throws when EVERY device enqueue fails (no silent drop of a correct payload)', async () => {
+    tableResults.set(policiesTable, [activePolicyRow]);
+    tableResults.set(devicesTable, [{ id: 'd1', status: 'online' }]);
+    queueCommandForExecution.mockResolvedValue({}); // no command -> falls through
+    queueCommand.mockRejectedValue(new Error('redis down'));
+
+    await expect(
+      processPolicyDistribution({
+        type: 'policy-distribution',
+        orgId: 'org-1',
+        changedPolicyIds: ['p1'],
+        reason: 'policy-created',
+        queuedAt: '2026-06-24T00:00:00.000Z'
+      })
+    ).rejects.toThrow(/all 1 device enqueue/i);
+  });
+});

--- a/apps/api/src/jobs/peripheralJobs.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.test.ts
@@ -92,6 +92,10 @@ describe('schedulePeripheralPolicyDistribution', () => {
     expect(addCall?.[0]).toBe('policy-distribution');
     expect(addCall?.[1]?.changedPolicyIds).toEqual(['pA', 'pB']);
     expect(addCall?.[2]?.jobId).toBe('policy-distribution-org-2');
+    // Retry config is the other half of the race fix: without it the worker's
+    // throw-to-retry would just fail the job permanently. Lock it down.
+    expect(addCall?.[2]?.attempts).toBe(6);
+    expect(addCall?.[2]?.backoff).toEqual({ type: 'exponential', delay: 250 });
   });
 
   it('removes stale completed job before creating a new one', async () => {

--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -137,11 +137,18 @@ async function processAnomalyScan(_data: AnomalyScanJobData): Promise<{ alerts: 
 
 /**
  * Returns the changed policy ids that are NOT present in the DB snapshot the
- * worker just read. With no hard-delete path for peripheral policies, a changed
- * id that is absent can only mean the producer's request transaction has not
- * committed yet (the enqueue-before-commit race) — so the worker should retry
- * rather than ship an incomplete policy set. Disabled policies still exist as
- * rows, so they are correctly treated as visible (not a race).
+ * worker just read.
+ *
+ * Individual policies are only ever soft-deleted (isActive=false) — the routes
+ * have no per-policy hard-delete, and disabled policies remain rows, so they're
+ * "visible" here (not a race). The only hard DELETE is whole-org/partner cascade
+ * erasure (services/tenantCascade.ts), which also removes the org's devices, so
+ * such a job no-ops at the orgDevices check. Therefore, for a live org within
+ * the commit window, an absent changed id means the producer's request
+ * transaction hasn't committed yet (the enqueue-before-commit race) and the
+ * worker should retry rather than ship an incomplete policy set. On the final
+ * attempt the caller stops retrying and distributes the current active set —
+ * see processPolicyDistribution's `isFinalAttempt` handling.
  */
 export function findUncommittedPolicyIds(
   changedPolicyIds: string[],
@@ -151,7 +158,10 @@ export function findUncommittedPolicyIds(
   return changedPolicyIds.filter((id) => !existing.has(id));
 }
 
-export async function processPolicyDistribution(data: PolicyDistributionJobData): Promise<{
+export async function processPolicyDistribution(
+  data: PolicyDistributionJobData,
+  options: { isFinalAttempt?: boolean } = {}
+): Promise<{
   queued: number;
   immediate: number;
   failed: number;
@@ -187,17 +197,31 @@ export async function processPolicyDistribution(data: PolicyDistributionJobData)
     orgPolicies.map((policy) => policy.id)
   );
   if (uncommitted.length > 0) {
-    // The producing request transaction hasn't committed yet. Throw so BullMQ
-    // retries with backoff; by the next attempt the rows are visible and the
-    // re-read above produces the correct payload. Shipping policies:[] here
-    // would silently leave agents unenforced.
-    throw new Error(
-      `peripheral policy distribution raced the producer commit for org ${data.orgId}; `
-      + `changed policy id(s) not yet visible: ${uncommitted.join(', ')} — retrying`
+    if (!options.isFinalAttempt) {
+      // The producing request transaction hasn't committed yet. Throw so BullMQ
+      // retries with backoff; by the next attempt the rows are visible and the
+      // re-read above produces the correct payload. Shipping policies:[] here
+      // would silently leave agents unenforced.
+      throw new Error(
+        `peripheral policy distribution raced the producer commit for org ${data.orgId}; `
+        + `changed policy id(s) not yet visible: ${uncommitted.join(', ')} — retrying`
+      );
+    }
+    // Final attempt: the changed ids never became visible across all retries.
+    // This is no longer a commit race (a normal txn commits in well under the
+    // retry budget) — the policies were rolled back or hard-deleted (e.g. org
+    // cascade). Don't throw into a silent terminal failure; distribute the
+    // CURRENT active set, which correctly excludes the vanished ids.
+    console.warn(
+      `[PeripheralJobs] org ${data.orgId}: changed policy id(s) ${uncommitted.join(', ')} still not `
+      + `visible after final attempt — treating as rolled-back/deleted and distributing current active set`
     );
   }
 
   if (orgDevices.length === 0) {
+    console.log(
+      `[PeripheralJobs] org ${data.orgId} has no eligible devices; nothing to distribute`
+    );
     return { queued: 0, immediate: 0, failed: 0 };
   }
 
@@ -206,7 +230,7 @@ export async function processPolicyDistribution(data: PolicyDistributionJobData)
   const payload = {
     generatedAt: new Date().toISOString(),
     reason: data.reason,
-    changedPolicyIds: data.changedPolicyIds,
+    changedPolicyIds,
     policies: activePolicies.map((policy) => ({
       id: policy.id,
       name: policy.name,
@@ -257,6 +281,16 @@ export async function processPolicyDistribution(data: PolicyDistributionJobData)
     );
   }
 
+  // If EVERY device enqueue failed we built a correct payload and then dropped
+  // it — throw so BullMQ retries rather than reporting a successful no-op (mirrors
+  // processAnomalyScan's all-failed guard). Policy sync is idempotent, so the
+  // retry safely re-enqueues the devices that may have already succeeded.
+  if (orgDevices.length > 0 && failed === orgDevices.length) {
+    throw new Error(
+      `peripheral policy distribution: all ${failed} device enqueue(s) failed for org ${data.orgId} — retrying`
+    );
+  }
+
   return { queued, immediate, failed };
 }
 
@@ -279,8 +313,13 @@ function createPeripheralPolicyDistributionWorker(): Worker<PolicyDistributionJo
   return new Worker<PolicyDistributionJobData>(
     PERIPHERAL_POLICY_DISTRIBUTION_QUEUE,
     async (job: Job<PolicyDistributionJobData>) => {
+      // attemptsMade counts prior failures, so this run is attempt
+      // (attemptsMade + 1); on the last one we stop retrying the commit-race and
+      // distribute the current active set instead of failing silently.
+      const maxAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade + 1 >= maxAttempts;
       return runWithSystemDbAccess(async () => {
-        return processPolicyDistribution(job.data);
+        return processPolicyDistribution(job.data, { isFinalAttempt });
       });
     },
     {
@@ -362,8 +401,11 @@ export async function schedulePeripheralPolicyDistribution(
       jobId,
       // Retry so a run that loses the enqueue-before-commit race (changed policy
       // not yet visible → processPolicyDistribution throws) re-runs after the
-      // producer txn commits. Exponential backoff from 250ms covers the brief
-      // commit window without delaying healthy distributions.
+      // producer txn commits. Healthy (non-raced) runs succeed on attempt 1 with
+      // no added delay. Exponential backoff is ~250ms, 500ms, 1s, 2s, 4s — the
+      // first attempts cover the normal sub-second commit window; the rest are
+      // headroom. On the final attempt the worker degrades instead of failing
+      // (distributes the current active set) — see processPolicyDistribution.
       attempts: 6,
       backoff: { type: 'exponential', delay: 250 },
       removeOnComplete: { count: 100 },

--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -135,21 +135,37 @@ async function processAnomalyScan(_data: AnomalyScanJobData): Promise<{ alerts: 
   return { alerts, failed };
 }
 
-async function processPolicyDistribution(data: PolicyDistributionJobData): Promise<{
+/**
+ * Returns the changed policy ids that are NOT present in the DB snapshot the
+ * worker just read. With no hard-delete path for peripheral policies, a changed
+ * id that is absent can only mean the producer's request transaction has not
+ * committed yet (the enqueue-before-commit race) — so the worker should retry
+ * rather than ship an incomplete policy set. Disabled policies still exist as
+ * rows, so they are correctly treated as visible (not a race).
+ */
+export function findUncommittedPolicyIds(
+  changedPolicyIds: string[],
+  existingPolicyIds: Iterable<string>
+): string[] {
+  const existing = new Set(existingPolicyIds);
+  return changedPolicyIds.filter((id) => !existing.has(id));
+}
+
+export async function processPolicyDistribution(data: PolicyDistributionJobData): Promise<{
   queued: number;
   immediate: number;
   failed: number;
 }> {
-  const [activePolicies, orgDevices] = await Promise.all([
+  // Read the org's full policy set (active AND inactive) plus its devices. The
+  // full set lets us both (a) detect the enqueue-before-commit race — a changed
+  // policy id missing here means the producer txn hasn't committed yet — and
+  // (b) build the payload from the *current* active subset (re-read each run so
+  // coalesced bursts always send the latest state).
+  const [orgPolicies, orgDevices] = await Promise.all([
     db
       .select()
       .from(peripheralPolicies)
-      .where(
-        and(
-          eq(peripheralPolicies.orgId, data.orgId),
-          eq(peripheralPolicies.isActive, true)
-        )
-      )
+      .where(eq(peripheralPolicies.orgId, data.orgId))
       .orderBy(peripheralPolicies.updatedAt),
     db
       .select({
@@ -165,9 +181,27 @@ async function processPolicyDistribution(data: PolicyDistributionJobData): Promi
       )
   ]);
 
+  const changedPolicyIds = data.changedPolicyIds ?? [];
+  const uncommitted = findUncommittedPolicyIds(
+    changedPolicyIds,
+    orgPolicies.map((policy) => policy.id)
+  );
+  if (uncommitted.length > 0) {
+    // The producing request transaction hasn't committed yet. Throw so BullMQ
+    // retries with backoff; by the next attempt the rows are visible and the
+    // re-read above produces the correct payload. Shipping policies:[] here
+    // would silently leave agents unenforced.
+    throw new Error(
+      `peripheral policy distribution raced the producer commit for org ${data.orgId}; `
+      + `changed policy id(s) not yet visible: ${uncommitted.join(', ')} — retrying`
+    );
+  }
+
   if (orgDevices.length === 0) {
     return { queued: 0, immediate: 0, failed: 0 };
   }
+
+  const activePolicies = orgPolicies.filter((policy) => policy.isActive);
 
   const payload = {
     generatedAt: new Date().toISOString(),
@@ -326,6 +360,12 @@ export async function schedulePeripheralPolicyDistribution(
     },
     {
       jobId,
+      // Retry so a run that loses the enqueue-before-commit race (changed policy
+      // not yet visible → processPolicyDistribution throws) re-runs after the
+      // producer txn commits. Exponential backoff from 250ms covers the brief
+      // commit window without delaying healthy distributions.
+      attempts: 6,
+      backoff: { type: 'exponential', delay: 250 },
       removeOnComplete: { count: 100 },
       removeOnFail: { count: 200 }
     }


### PR DESCRIPTION
Fixes #1879.

## Problem

`processPolicyDistribution` (BullMQ worker) re-reads `peripheral_policies` to build the `peripheral_policy_sync` payload, but `schedulePeripheralPolicyDistribution` enqueues the job **inside the producer's request transaction** (`middleware/auth.ts` wraps the handler in `withDbAccessContext`, a real txn). The worker can read **before that transaction commits**, so the just-created/updated policy is invisible → the command ships **`policies:[]`** and agents save zero policies and enforce/log nothing.

It's intermittent (a race) and silent — the API returns success. Confirmed empirically (a distributed command had `changedPolicyIds:[…]` populated but `policies:[]`, while `orgDevices` was full) and it is **not** RLS (`breeze_has_org_access` returns TRUE under the worker's system scope; the sibling `devices` read in the same job returns rows). Full root-cause in #1879.

## Fix

- Read the org's **full** policy set (active + inactive) in one query; derive the active payload subset in JS, and use the full set as a commit-visibility snapshot.
- **`findUncommittedPolicyIds()`** — a changed policy id absent from that snapshot means the producer txn hasn't committed yet (there is no hard-delete path for peripheral policies, so *absent == uncommitted*). When any are missing, **throw** so BullMQ retries; by the next attempt the rows are visible and the re-read builds the correct payload. Disabled policies still exist as rows, so they're never misread as a race (and are correctly excluded from the active payload).
- Give the distribution job **`attempts: 6` + exponential backoff (250 ms)** so the retry actually fires. The commit window is sub-second, so a healthy distribution still goes out on the first attempt.

This preserves the existing "re-read latest on each run" design (which coalesces bursts) — it just makes the read wait for the producer commit instead of racing it.

## Tests

`apps/api/src/jobs/peripheralJobs.distribution.test.ts`:
- `findUncommittedPolicyIds` unit cases.
- `processPolicyDistribution` **throws** (→ retry) when a changed policy isn't visible, and queues **no** command.
- distributes the policy once visible; payload contains it.
- disabled-policy path: excluded from payload, **not** treated as a race.

Existing `peripheralJobs.test.ts` (5) still green; `tsc --noEmit` and eslint clean on the changed files.

## Not included
A through-the-route integration assertion (the issue's "create via route → assert payload") — the race is nondeterministic, so the deterministic guard lives in the worker unit tests above. The agent side was separately validated end-to-end on a real Windows host (see #1871).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
