### PR TITLE
feat(tickets): selectable + editable requester, clickable device link

### DIFF
--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -16,6 +16,7 @@ const { serviceMocks, ticketTriageMocks, dbSelectMock, dbGroupByMock, authRef, l
       getAssigneeForValidation: vi.fn(),
       editTicketComment: vi.fn(),
       deleteTicketComment: vi.fn(),
+      listRequestersForOrg: vi.fn(),
     },
     ticketTriageMocks: {
       getTicketTriageSuggestion: vi.fn(),
@@ -446,6 +447,41 @@ describe('POST /tickets', () => {
     const body = await res.json();
     expect(body).toHaveProperty('error', 'Access to this organization denied');
     expect(serviceMocks.createTicket).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /tickets/requesters', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('returns the org requesters for an accessible org', async () => {
+    serviceMocks.listRequestersForOrg.mockResolvedValue([
+      { id: 'pu-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }
+    ]);
+    const res = await makeApp().request(`/tickets/requesters?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([{ id: 'pu-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]);
+    expect(serviceMocks.listRequestersForOrg).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it('403s when the caller cannot access the org (cross-tenant)', async () => {
+    authRef.current = { ...DEFAULT_AUTH, canAccessOrg: () => false };
+    const res = await makeApp().request(`/tickets/requesters?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(serviceMocks.listRequestersForOrg).not.toHaveBeenCalled();
+  });
+
+  it('400s on a missing or malformed orgId', async () => {
+    expect((await makeApp().request('/tickets/requesters')).status).toBe(400);
+    expect((await makeApp().request('/tickets/requesters?orgId=not-a-uuid')).status).toBe(400);
+    expect(serviceMocks.listRequestersForOrg).not.toHaveBeenCalled();
+  });
+
+  it('is not captured by the /:id param route', async () => {
+    serviceMocks.listRequestersForOrg.mockResolvedValue([]);
+    const res = await makeApp().request(`/tickets/requesters?orgId=${ORG_ID}`);
+    // A 200 (not the 400 that an :id uuid-param would produce for "requesters") proves ordering.
+    expect(res.status).toBe(200);
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -16,7 +16,7 @@ import {
 import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
-  editTicketComment, deleteTicketComment,
+  editTicketComment, deleteTicketComment, listRequestersForOrg,
   TicketServiceError
 } from '../../services/ticketService';
 import {
@@ -402,6 +402,25 @@ ticketsRoutes.post(
     } catch (err) {
       return handleServiceError(c, err);
     }
+  }
+);
+
+// GET /tickets/requesters?orgId= — selectable requesters (active portal users)
+// for the ticket create/edit picker. Registered before GET /:id so the static
+// segment isn't captured by the :id param (which would 400 on uuid validation).
+ticketsRoutes.get(
+  '/requesters',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action),
+  zValidator('query', z.object({ orgId: z.string().guid() })),
+  async (c) => {
+    const auth = c.get('auth');
+    const { orgId } = c.req.valid('query');
+    if (!auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Access to this organization denied' }, 403);
+    }
+    const data = await listRequestersForOrg(orgId);
+    return c.json({ data });
   }
 );
 

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -112,6 +112,7 @@ vi.mock('../db/schema', () => ({
   devices: { id: 'id', orgId: 'orgId' },
   users: { id: 'id', partnerId: 'partnerId' },
   ticketCategories: { id: 'id', partnerId: 'partnerId', responseSlaMinutes: 'responseSlaMinutes', resolutionSlaMinutes: 'resolutionSlaMinutes' },
+  portalUsers: { id: 'id', orgId: 'orgId', name: 'name', email: 'email', status: 'status' },
   ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] }
 }));
@@ -234,6 +235,89 @@ describe('createTicket', () => {
       submitterEmail: null,
       submittedBy: null
     });
+  });
+
+  it('manual ticket with a picked portal-user requester stamps submittedBy + backfilled name/email', async () => {
+    // selects in order: org, portal user
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: 'o-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-6', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket({ orgId: 'o-1', subject: 'Crash', source: 'manual', submittedBy: 'pu-1' }, actor);
+
+    const insertPayload = valuesMock.mock.calls[0]![0];
+    expect(insertPayload).toMatchObject({
+      submittedBy: 'pu-1',
+      submitterName: 'Gail Goodman',
+      submitterEmail: 'gail@lgpc.com'
+    });
+  });
+
+  it('manual ticket with explicit submitterName/email overrides the portal-user backfill', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: 'o-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-7', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket(
+      { orgId: 'o-1', subject: 'Crash', source: 'manual', submittedBy: 'pu-1', submitterName: 'Gail (front desk)', submitterEmail: 'frontdesk@lgpc.com' },
+      actor
+    );
+
+    expect(valuesMock.mock.calls[0]![0]).toMatchObject({
+      submittedBy: 'pu-1',
+      submitterName: 'Gail (front desk)',
+      submitterEmail: 'frontdesk@lgpc.com'
+    });
+  });
+
+  it('manual ticket with a free-text requester (no portal user) stamps name/email, no submittedBy', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ id: 'o-1', partnerId: 'p-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 't-8', orgId: 'o-1', internalNumber: 'T-2026-0042', status: 'new' }]);
+
+    await createTicket(
+      { orgId: 'o-1', subject: 'Crash', source: 'manual', submitterName: 'Walk-in User', submitterEmail: 'walkin@lgpc.com' },
+      actor
+    );
+
+    // Only ONE select consumed (org) — no portal-user lookup for free-text.
+    expect(dbMocks.selectResult).toHaveBeenCalledTimes(1);
+    expect(valuesMock.mock.calls[0]![0]).toMatchObject({
+      submittedBy: null,
+      submitterName: 'Walk-in User',
+      submitterEmail: 'walkin@lgpc.com'
+    });
+  });
+
+  it('rejects a requester portal user from a different org (cross-tenant) and writes nothing', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([{ id: 'pu-x', orgId: 'o-OTHER', name: 'Intruder', email: 'x@evil.com' }]);
+
+    const err = await createTicket(
+      { orgId: 'o-1', subject: 'Crash', source: 'manual', submittedBy: 'pu-x' }, actor
+    ).catch(e => e);
+
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/organization/i);
+    expect(allocateMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown requester portal user with a 404', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 'o-1', partnerId: 'p-1' }])
+      .mockResolvedValueOnce([]); // portal user lookup: no row
+
+    const err = await createTicket(
+      { orgId: 'o-1', subject: 'Crash', source: 'manual', submittedBy: 'pu-missing' }, actor
+    ).catch(e => e);
+
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+    expect(valuesMock).not.toHaveBeenCalled();
   });
 
   it('non-portal ticket sets both submitter fields to null when actor has no name/email', async () => {
@@ -972,6 +1056,62 @@ describe('updateTicketFields', () => {
   it('treats deep-equal tags as a no-op', async () => {
     dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, tags: ['vip', 'hardware'] }]);
     await updateTicketFields('t-1', { tags: ['vip', 'hardware'] }, actor);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('editing the requester to a portal user backfills name/email and records a "requester" change', async () => {
+    // selects in order: ticket, portal user
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ ...BASE_TICKET, submittedBy: null, submitterName: 'Tess Tech', submitterEmail: null }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: 'o-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, submittedBy: 'pu-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { submittedBy: 'pu-1' }, actor);
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload).toMatchObject({
+      submittedBy: 'pu-1',
+      submitterName: 'Gail Goodman',
+      submitterEmail: 'gail@lgpc.com'
+    });
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated requester' }));
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'ticket.updated' }));
+  });
+
+  it('editing the requester to free text clears the portal link', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, submittedBy: 'pu-1', submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, submittedBy: null }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { submittedBy: null, submitterName: 'Walk-in', submitterEmail: null }, actor);
+
+    // No portal-user lookup needed when clearing — only the ticket select.
+    expect(dbMocks.selectResult).toHaveBeenCalledTimes(1);
+    expect(setMock.mock.calls[0]![0]).toMatchObject({
+      submittedBy: null,
+      submitterName: 'Walk-in',
+      submitterEmail: null
+    });
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated requester' }));
+  });
+
+  it('rejects a requester portal user from another org on update and writes nothing', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([BASE_TICKET])
+      .mockResolvedValueOnce([{ id: 'pu-x', orgId: 'o-OTHER', name: 'Intruder', email: 'x@evil.com' }]);
+
+    const err = await updateTicketFields('t-1', { submittedBy: 'pu-x' }, actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(400);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(valuesMock).not.toHaveBeenCalled();
+  });
+
+  it('no-op when the requester is unchanged', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, submittedBy: null, submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' }]);
+    await updateTicketFields('t-1', { submittedBy: null, submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' }, actor);
     expect(setMock).not.toHaveBeenCalled();
     expect(emitMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -1080,6 +1080,40 @@ describe('updateTicketFields', () => {
     expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'ticket.updated' }));
   });
 
+  it('editing the requester to a portal user with explicit name/email overrides the backfill', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ ...BASE_TICKET, submittedBy: null, submitterName: 'Tess Tech', submitterEmail: null }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: 'o-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, submittedBy: 'pu-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields(
+      't-1',
+      { submittedBy: 'pu-1', submitterName: 'Gail (front desk)', submitterEmail: 'frontdesk@lgpc.com' },
+      actor
+    );
+
+    expect(setMock.mock.calls[0]![0]).toMatchObject({
+      submittedBy: 'pu-1',
+      submitterName: 'Gail (front desk)',
+      submitterEmail: 'frontdesk@lgpc.com'
+    });
+  });
+
+  it('records a field change AND a requester change in one update (combined feed/event)', async () => {
+    dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, submittedBy: null, submitterName: 'Pat', submitterEmail: null }]);
+    dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, priority: 'high', submitterName: 'Walk-in' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await updateTicketFields('t-1', { priority: 'high', submittedBy: null, submitterName: 'Walk-in', submitterEmail: null }, actor);
+
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated priority, requester' }));
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'ticket.updated',
+      payload: { changed: ['priority', 'requester'] }
+    }));
+  });
+
   it('editing the requester to free text clears the portal link', async () => {
     dbMocks.selectResult.mockResolvedValue([{ ...BASE_TICKET, submittedBy: 'pu-1', submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' }]);
     dbMocks.updateReturning.mockResolvedValue([{ ...BASE_TICKET, submittedBy: null }]);

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,7 +1,7 @@
-import { and, eq, gt, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, isNull, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, ticketStatusEnum, ticketSourceEnum } from '../db/schema';
+import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, portalUsers, ticketStatusEnum, ticketSourceEnum } from '../db/schema';
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
@@ -31,6 +31,8 @@ export type TicketServiceErrorStatus = 400 | 403 | 404 | 409 | 500;
 export type TicketServiceErrorCode =
   | 'ASSIGNEE_NOT_FOUND'
   | 'ASSIGNEE_WRONG_PARTNER'
+  | 'REQUESTER_NOT_FOUND'
+  | 'REQUESTER_WRONG_ORG'
   | 'CATEGORY_NOT_FOUND'
   | 'CATEGORY_WRONG_PARTNER'
   | 'TICKET_PARTNER_UNRESOLVABLE'
@@ -138,6 +140,63 @@ async function assertAssigneeInPartner(assigneeId: string, partnerId: string | n
 }
 
 /**
+ * Look up a prospective requester (portal user) for tenant validation. Runs in
+ * a system-scope DB context for the same reason as getAssigneeForValidation:
+ * portal_users is org-axis RLS, and the security boundary is the explicit
+ * org comparison the caller makes — not the read. Exported for the route's
+ * pre-validation if ever needed.
+ */
+export async function getPortalUserForValidation(
+  portalUserId: string
+): Promise<{ id: string; orgId: string; name: string | null; email: string } | null> {
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({ id: portalUsers.id, orgId: portalUsers.orgId, name: portalUsers.name, email: portalUsers.email })
+        .from(portalUsers)
+        .where(eq(portalUsers.id, portalUserId))
+        .limit(1)
+    )
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * List the selectable requesters (active portal users) for an org. Runs in a
+ * system-scope DB context — the security boundary is the caller's canAccessOrg
+ * check plus the explicit org filter here, mirroring the validation reads above.
+ * Capped at 500; the picker is a convenience, not an exhaustive directory.
+ */
+export async function listRequestersForOrg(
+  orgId: string
+): Promise<Array<{ id: string; name: string | null; email: string }>> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({ id: portalUsers.id, name: portalUsers.name, email: portalUsers.email })
+        .from(portalUsers)
+        .where(and(eq(portalUsers.orgId, orgId), eq(portalUsers.status, 'active')))
+        .orderBy(asc(portalUsers.name))
+        .limit(500)
+    )
+  );
+}
+
+/**
+ * Tenant guard: a requester (portal user) must belong to the ticket's org.
+ * portal_users.org_id scopes every portal account to exactly one organization,
+ * so a same-org equality check is the complete cross-tenant boundary.
+ */
+async function assertRequesterInOrg(portalUserId: string, orgId: string) {
+  const portalUser = await getPortalUserForValidation(portalUserId);
+  if (!portalUser) throw new TicketServiceError('Requester not found', 404, 'REQUESTER_NOT_FOUND');
+  if (portalUser.orgId !== orgId) {
+    throw new TicketServiceError('Requester must belong to the ticket organization', 400, 'REQUESTER_WRONG_ORG');
+  }
+  return portalUser;
+}
+
+/**
  * Tenant guard: a ticket's category must belong to the ticket's partner.
  * The read runs in a system-scope DB context for the same reason as
  * getAssigneeForValidation: ticket_categories is partner-axis RLS, invisible
@@ -181,10 +240,13 @@ interface BaseCreateTicketInput {
 
 // portal source carries the requester; the worker emails submitterEmail on public replies/resolution.
 // email source also carries the sender address so outbound replies/autoresponses (PR3) have a recipient.
+// Other sources (manual/alert/api/ai) may OPTIONALLY name a requester: pick a
+// portal user (submittedBy) and/or supply a free-text name/email. When none are
+// given the requester defaults to the acting staff member's name (no email).
 export type CreateTicketInput =
   | (BaseCreateTicketInput & { source: 'portal'; submittedBy: string; submitterEmail: string; submitterName?: string })
   | (BaseCreateTicketInput & { source: 'email'; submitterEmail: string; submitterName?: string; submittedBy?: string })
-  | (BaseCreateTicketInput & { source: Exclude<TicketSource, 'portal' | 'email'> });
+  | (BaseCreateTicketInput & { source: Exclude<TicketSource, 'portal' | 'email'>; submittedBy?: string; submitterEmail?: string; submitterName?: string });
 
 // NOTE: emitTicketEvent and createAuditLogAsync below are called while the
 // surrounding request transaction is still open. If the transaction later rolls
@@ -225,6 +287,35 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     category = await assertCategoryInPartner(input.categoryId, org.partnerId);
   }
 
+  // Resolve the requester before number allocation (a rejected requester must
+  // not burn a counter value). Portal/email sources carry it via their required
+  // fields. Other sources may name one: a picked portal user (validated same-org,
+  // backfills name/email) and/or free text; otherwise the acting staff member's
+  // name is stamped with NO email (preserves "no external requester" semantics —
+  // the notify worker emails submitterEmail on every public comment/resolution).
+  const isPortalOrEmail = input.source === 'portal' || input.source === 'email';
+  let resolvedSubmittedBy: string | null;
+  let resolvedSubmitterName: string | null;
+  let resolvedSubmitterEmail: string | null;
+  if (isPortalOrEmail) {
+    resolvedSubmittedBy = input.submittedBy ?? null;
+    resolvedSubmitterName = input.submitterName ?? null;
+    resolvedSubmitterEmail = input.submitterEmail ?? null;
+  } else if (input.submittedBy) {
+    const portalUser = await assertRequesterInOrg(input.submittedBy, input.orgId);
+    resolvedSubmittedBy = portalUser.id;
+    resolvedSubmitterName = input.submitterName ?? portalUser.name ?? null;
+    resolvedSubmitterEmail = input.submitterEmail ?? portalUser.email ?? null;
+  } else if (input.submitterName || input.submitterEmail) {
+    resolvedSubmittedBy = null;
+    resolvedSubmitterName = input.submitterName ?? null;
+    resolvedSubmitterEmail = input.submitterEmail ?? null;
+  } else {
+    resolvedSubmittedBy = null;
+    resolvedSubmitterName = actor.name ?? null;
+    resolvedSubmitterEmail = null;
+  }
+
   const priority = input.priority ?? 'normal';
   const initialCoreStatus: TicketStatus = input.assigneeId ? 'open' : 'new';
 
@@ -246,7 +337,6 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
 
   const internalNumber = await allocateInternalTicketNumber(org.partnerId);
 
-  const isPortal = input.source === 'portal';
   const insertValues = {
     orgId: input.orgId,
     partnerId: org.partnerId,
@@ -262,15 +352,9 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     status: initialCoreStatus,
     statusId: statusId ?? null,
     source: input.source,
-    submittedBy: isPortal ? input.submittedBy : (input.source === 'email' ? (input.submittedBy ?? null) : null),
-    // Non-portal/non-email tickets show the acting user as the requester NAME only (fixes
-    // "Unknown" requester in the UI). submitterEmail deliberately stays null for
-    // those sources: the notify worker emails submitterEmail on every public
-    // comment/resolution with portal-oriented copy and no self-actor suppression,
-    // so staff-created tickets must keep "no external requester" semantics.
-    // Email-sourced tickets carry submitterEmail so outbound replies/autoresponses (PR3) have a recipient.
-    submitterEmail: isPortal ? input.submitterEmail : (input.source === 'email' ? input.submitterEmail : null),
-    submitterName: (isPortal || input.source === 'email') ? (input.submitterName ?? null) : (actor.name ?? null),
+    submittedBy: resolvedSubmittedBy,
+    submitterEmail: resolvedSubmitterEmail,
+    submitterName: resolvedSubmitterName,
     category: null,
     responseSlaMinutes: slaTargets.responseMinutes,
     resolutionSlaMinutes: slaTargets.resolutionMinutes
@@ -500,10 +584,21 @@ export interface UpdateTicketFieldsInput {
   resolutionSlaMinutes?: number | null;
   deviceId?: string | null;
   tags?: string[];
+  // Requester edit. Handled outside UPDATE_FIELD_LABELS' generic diff loop:
+  // picking a portal user (submittedBy) backfills name/email, and the three
+  // columns surface as one "requester" change in the feed. submittedBy=null
+  // clears the portal link (free-text requester).
+  submittedBy?: string | null;
+  submitterName?: string | null;
+  submitterEmail?: string | null;
 }
 
+// Fields handled by the generic diff loop. The requester triple is excluded —
+// it's resolved/diffed separately (portal-user backfill, single "requester" label).
+type DiffFieldKey = Exclude<keyof UpdateTicketFieldsInput, 'submittedBy' | 'submitterName' | 'submitterEmail'>;
+
 /** Humanized labels for the system feed entry, in canonical field order. */
-const UPDATE_FIELD_LABELS: Record<keyof UpdateTicketFieldsInput, string> = {
+const UPDATE_FIELD_LABELS: Record<DiffFieldKey, string> = {
   subject: 'subject',
   description: 'description',
   categoryId: 'category',
@@ -515,7 +610,7 @@ const UPDATE_FIELD_LABELS: Record<keyof UpdateTicketFieldsInput, string> = {
   tags: 'tags'
 };
 
-function ticketFieldChanged(key: keyof UpdateTicketFieldsInput, oldValue: unknown, newValue: unknown): boolean {
+function ticketFieldChanged(key: DiffFieldKey, oldValue: unknown, newValue: unknown): boolean {
   if (key === 'dueDate') {
     const oldMs = oldValue instanceof Date ? oldValue.getTime() : null;
     const newMs = newValue instanceof Date ? newValue.getTime() : null;
@@ -569,21 +664,53 @@ export async function updateTicketFields(
     await assertCategoryInPartner(fields.categoryId, await resolveTicketPartnerId(ticket));
   }
 
+  // Requester edit: resolve (and tenant-validate) before the change diff so a
+  // cross-org portal user is rejected even when nothing else changed. The client
+  // sends a coherent triple — a uuid submittedBy links a portal user (same-org,
+  // backfills name/email); null clears the link for a free-text requester.
+  const requesterEdit =
+    fields.submittedBy !== undefined ||
+    fields.submitterName !== undefined ||
+    fields.submitterEmail !== undefined;
+  const requesterPatch: { submittedBy?: string | null; submitterName?: string | null; submitterEmail?: string | null } = {};
+  if (requesterEdit) {
+    if (typeof fields.submittedBy === 'string') {
+      const portalUser = await assertRequesterInOrg(fields.submittedBy, ticket.orgId);
+      requesterPatch.submittedBy = portalUser.id;
+      requesterPatch.submitterName = fields.submitterName !== undefined ? fields.submitterName : (portalUser.name ?? null);
+      requesterPatch.submitterEmail = fields.submitterEmail !== undefined ? fields.submitterEmail : (portalUser.email ?? null);
+    } else {
+      if (fields.submittedBy === null) requesterPatch.submittedBy = null;
+      if (fields.submitterName !== undefined) requesterPatch.submitterName = fields.submitterName;
+      if (fields.submitterEmail !== undefined) requesterPatch.submitterEmail = fields.submitterEmail;
+    }
+  }
+  const tRow = ticket as Record<string, unknown>;
+  const requesterChanged =
+    ('submittedBy' in requesterPatch && (requesterPatch.submittedBy ?? null) !== (tRow.submittedBy ?? null)) ||
+    ('submitterName' in requesterPatch && (requesterPatch.submitterName ?? null) !== (tRow.submitterName ?? null)) ||
+    ('submitterEmail' in requesterPatch && (requesterPatch.submitterEmail ?? null) !== (tRow.submitterEmail ?? null));
+
   // Compute the actually-changed fields; ignore no-op keys so the feed and
   // event stream don't accumulate noise from idempotent saves.
-  const changed: (keyof UpdateTicketFieldsInput)[] = [];
-  for (const key of Object.keys(UPDATE_FIELD_LABELS) as (keyof UpdateTicketFieldsInput)[]) {
+  const changed: DiffFieldKey[] = [];
+  for (const key of Object.keys(UPDATE_FIELD_LABELS) as DiffFieldKey[]) {
     if (fields[key] === undefined) continue;
     if (ticketFieldChanged(key, (ticket as Record<string, unknown>)[key], fields[key])) {
       changed.push(key);
     }
   }
-  if (changed.length === 0) return ticket;
+  if (changed.length === 0 && !requesterChanged) return ticket;
+
+  // Feed/event labels: typed field keys plus a single "requester" token.
+  const changedForLog: string[] = [...changed, ...(requesterChanged ? ['requester'] : [])];
+  const changedLabels: string[] = [...changed.map((k) => UPDATE_FIELD_LABELS[k]), ...(requesterChanged ? ['requester'] : [])];
 
   const patch: Partial<typeof tickets.$inferInsert> = { updatedAt: new Date() };
   for (const key of changed) {
     (patch as Record<string, unknown>)[key] = fields[key] ?? null;
   }
+  if (requesterChanged) Object.assign(patch, requesterPatch);
 
   const updated = await db
     .update(tickets)
@@ -600,7 +727,7 @@ export async function updateTicketFields(
     authorName: actor.name ?? null,
     authorType: 'internal',
     commentType: 'system',
-    content: `Updated ${changed.map((k) => UPDATE_FIELD_LABELS[k]).join(', ')}`,
+    content: `Updated ${changedLabels.join(', ')}`,
     isPublic: false
   });
 
@@ -610,7 +737,7 @@ export async function updateTicketFields(
     orgId: ticket.orgId,
     partnerId: ticket.partnerId ?? null,
     actorUserId: actor.userId,
-    payload: { changed }
+    payload: { changed: changedForLog }
   });
   await createAuditLogAsync({
     orgId: ticket.orgId,
@@ -618,7 +745,7 @@ export async function updateTicketFields(
     action: 'ticket.update',
     resourceType: 'ticket',
     resourceId: ticketId,
-    details: { changed },
+    details: { changed: changedForLog },
     result: 'success'
   });
   if (changed.includes('categoryId')) {

--- a/apps/web/src/components/tickets/CreateTicketPage.test.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.test.tsx
@@ -44,6 +44,9 @@ function mockOptionsApi() {
     if (url.startsWith('/devices?orgId=')) {
       return makeJsonResponse({ data: [{ id: 'dev-1', displayName: 'PC-1' }] });
     }
+    if (url.startsWith('/tickets/requesters?orgId=')) {
+      return makeJsonResponse({ data: [{ id: 'pu-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }] });
+    }
     if (url === '/tickets' && init?.method === 'POST') {
       return makeJsonResponse({ data: { id: 'tk-9', internalNumber: 'T-2026-0009' } });
     }
@@ -141,6 +144,69 @@ describe('CreateTicketPage', () => {
     await screen.findByTestId('create-ticket-form');
     expect(screen.queryByTestId('create-ticket-load-error')).toBeNull();
     expect(screen.getByText('Org A')).toBeInTheDocument();
+  });
+
+  describe('requester picker', () => {
+    it('submits submittedBy when a portal user is picked', async () => {
+      mockOptionsApi();
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      fireEvent.change(screen.getByTestId('create-ticket-org-input'), { target: { value: 'org-a' } });
+      // Requester options load for the org.
+      await screen.findByRole('option', { name: 'Gail Goodman (gail@lgpc.com)' });
+      fireEvent.change(screen.getByTestId('create-ticket-requester-input'), { target: { value: 'pu-1' } });
+      fireEvent.change(screen.getByTestId('create-ticket-subject-input'), { target: { value: 'Crash' } });
+      fireEvent.click(screen.getByTestId('create-ticket-submit'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/tickets', expect.objectContaining({ method: 'POST' }));
+      });
+      const postCall = fetchMock.mock.calls.find(([url, init]) => String(url) === '/tickets' && init?.method === 'POST');
+      const body = JSON.parse(String(postCall?.[1]?.body)) as Record<string, unknown>;
+      expect(body.submittedBy).toBe('pu-1');
+      expect(body).not.toHaveProperty('submitterName');
+    });
+
+    it('submits free-text name/email for "Someone else"', async () => {
+      mockOptionsApi();
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      fireEvent.change(screen.getByTestId('create-ticket-org-input'), { target: { value: 'org-a' } });
+      await screen.findByRole('option', { name: 'Gail Goodman (gail@lgpc.com)' });
+      fireEvent.change(screen.getByTestId('create-ticket-requester-input'), { target: { value: '__manual__' } });
+      fireEvent.change(screen.getByTestId('create-ticket-requester-name-input'), { target: { value: 'Walk-in User' } });
+      fireEvent.change(screen.getByTestId('create-ticket-requester-email-input'), { target: { value: 'walkin@lgpc.com' } });
+      fireEvent.change(screen.getByTestId('create-ticket-subject-input'), { target: { value: 'Crash' } });
+      fireEvent.click(screen.getByTestId('create-ticket-submit'));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/tickets', expect.objectContaining({ method: 'POST' }));
+      });
+      const postCall = fetchMock.mock.calls.find(([url, init]) => String(url) === '/tickets' && init?.method === 'POST');
+      const body = JSON.parse(String(postCall?.[1]?.body)) as Record<string, unknown>;
+      expect(body.submitterName).toBe('Walk-in User');
+      expect(body.submitterEmail).toBe('walkin@lgpc.com');
+      expect(body).not.toHaveProperty('submittedBy');
+    });
+
+    it('resets the requester when switching organizations', async () => {
+      mockOptionsApi();
+      render(<CreateTicketPage />);
+      await screen.findByTestId('create-ticket-form');
+
+      fireEvent.change(screen.getByTestId('create-ticket-org-input'), { target: { value: 'org-a' } });
+      await screen.findByRole('option', { name: 'Gail Goodman (gail@lgpc.com)' });
+      fireEvent.change(screen.getByTestId('create-ticket-requester-input'), { target: { value: 'pu-1' } });
+      expect(screen.getByTestId('create-ticket-requester-input')).toHaveValue('pu-1');
+
+      fireEvent.change(screen.getByTestId('create-ticket-org-input'), { target: { value: 'org-b' } });
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/tickets/requesters?orgId=org-b');
+      });
+      expect(screen.getByTestId('create-ticket-requester-input')).toHaveValue('');
+    });
   });
 
   describe('org-scope fixes', () => {

--- a/apps/web/src/components/tickets/CreateTicketPage.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.tsx
@@ -110,16 +110,21 @@ export default function CreateTicketPage() {
   useEffect(() => {
     setRequesterId(''); setRequesterName(''); setRequesterEmail('');
     if (!orgId) { setRequesters([]); return; }
+    // `cancelled` guards against a late response from a previous org clobbering
+    // the current list (mirrors the device effect's reset intent).
+    let cancelled = false;
     void (async () => {
-      const res = await fetchWithAuth(`/tickets/requesters?orgId=${orgId}`);
-      if (res.ok) {
-        const b = await res.json();
-        setRequesters((b.data ?? []) as RequesterOption[]);
-      } else {
+      try {
+        const res = await fetchWithAuth(`/tickets/requesters?orgId=${orgId}`);
+        const b = res.ok ? await res.json() : null;
+        if (cancelled) return;
         // Requester is optional — degrade to free-text entry rather than blocking.
-        setRequesters([]);
+        setRequesters((b?.data ?? []) as RequesterOption[]);
+      } catch {
+        if (!cancelled) setRequesters([]);
       }
     })();
+    return () => { cancelled = true; };
   }, [orgId]);
 
   const submit = useCallback(async (e: React.FormEvent) => {

--- a/apps/web/src/components/tickets/CreateTicketPage.tsx
+++ b/apps/web/src/components/tickets/CreateTicketPage.tsx
@@ -7,6 +7,10 @@ import type { TicketPriority } from './ticketConfig';
 
 interface Option { id: string; name: string }
 interface CategoryOption { id: string; name: string; parentId: string | null }
+interface RequesterOption { id: string; name: string | null; email: string }
+
+// Sentinel for the "type a requester manually" choice in the select.
+const MANUAL_REQUESTER = '__manual__';
 
 export default function CreateTicketPage() {
   const [orgs, setOrgs] = useState<Option[]>([]);
@@ -19,6 +23,10 @@ export default function CreateTicketPage() {
   const [deviceId, setDeviceId] = useState('');
   const [categoryId, setCategoryId] = useState('');
   const [priority, setPriority] = useState<TicketPriority>('normal');
+  const [requesters, setRequesters] = useState<RequesterOption[]>([]);
+  const [requesterId, setRequesterId] = useState('');
+  const [requesterName, setRequesterName] = useState('');
+  const [requesterEmail, setRequesterEmail] = useState('');
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState(false);
 
@@ -96,6 +104,24 @@ export default function CreateTicketPage() {
     })();
   }, [orgId]);
 
+  // Requester options follow the org (a portal user is scoped to one org). Reset
+  // the selection on org change so a stale requester from the previous org can't
+  // be submitted — the API rejects a cross-org requester, but clear it up front.
+  useEffect(() => {
+    setRequesterId(''); setRequesterName(''); setRequesterEmail('');
+    if (!orgId) { setRequesters([]); return; }
+    void (async () => {
+      const res = await fetchWithAuth(`/tickets/requesters?orgId=${orgId}`);
+      if (res.ok) {
+        const b = await res.json();
+        setRequesters((b.data ?? []) as RequesterOption[]);
+      } else {
+        // Requester is optional — degrade to free-text entry rather than blocking.
+        setRequesters([]);
+      }
+    })();
+  }, [orgId]);
+
   const submit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     if (!orgId || !subject.trim()) return;
@@ -110,7 +136,13 @@ export default function CreateTicketPage() {
             description: description.trim() || undefined,
             deviceId: deviceId || undefined,
             categoryId: categoryId || undefined,
-            priority
+            priority,
+            // Requester: a picked portal user, or a free-text name/email. Omit
+            // everything when left blank — the API then defaults the requester to
+            // the creating staff member (legacy behaviour).
+            ...(requesterId && requesterId !== MANUAL_REQUESTER ? { submittedBy: requesterId } : {}),
+            ...(requesterId === MANUAL_REQUESTER && requesterName.trim() ? { submitterName: requesterName.trim() } : {}),
+            ...(requesterId === MANUAL_REQUESTER && requesterEmail.trim() ? { submitterEmail: requesterEmail.trim() } : {})
           })
         }),
         errorFallback: 'Ticket creation failed. Retry.',
@@ -123,7 +155,7 @@ export default function CreateTicketPage() {
     } finally {
       setSaving(false);
     }
-  }, [orgId, subject, description, deviceId, categoryId, priority]);
+  }, [orgId, subject, description, deviceId, categoryId, priority, requesterId, requesterName, requesterEmail]);
 
   const selectCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
 
@@ -158,6 +190,46 @@ export default function CreateTicketPage() {
       <div>
         <label className="text-sm font-medium" htmlFor="ct-desc">Description</label>
         <textarea id="ct-desc" value={description} onChange={(e) => setDescription(e.target.value)} rows={5} className={selectCls} data-testid="create-ticket-description-input" />
+      </div>
+      <div>
+        <label className="text-sm font-medium" htmlFor="ct-requester">Requester (optional)</label>
+        <select
+          id="ct-requester"
+          value={requesterId}
+          onChange={(e) => setRequesterId(e.target.value)}
+          disabled={!orgId}
+          className={selectCls}
+          data-testid="create-ticket-requester-input"
+        >
+          <option value="">Default (you)</option>
+          {requesters.map((r) => (
+            <option key={r.id} value={r.id}>{r.name ? `${r.name} (${r.email})` : r.email}</option>
+          ))}
+          <option value={MANUAL_REQUESTER}>Someone else…</option>
+        </select>
+        {requesterId === MANUAL_REQUESTER && (
+          <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <input
+              value={requesterName}
+              onChange={(e) => setRequesterName(e.target.value)}
+              maxLength={255}
+              placeholder="Name"
+              aria-label="Requester name"
+              className={selectCls}
+              data-testid="create-ticket-requester-name-input"
+            />
+            <input
+              type="email"
+              value={requesterEmail}
+              onChange={(e) => setRequesterEmail(e.target.value)}
+              maxLength={255}
+              placeholder="Email (optional)"
+              aria-label="Requester email"
+              className={selectCls}
+              data-testid="create-ticket-requester-email-input"
+            />
+          </div>
+        )}
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div>

--- a/apps/web/src/components/tickets/SlaTimers.test.tsx
+++ b/apps/web/src/components/tickets/SlaTimers.test.tsx
@@ -26,6 +26,7 @@ const mkTicket = (overrides: Partial<TicketDetail> = {}): TicketDetail => ({
   createdAt: new Date(NOW.getTime() - 10 * 60_000).toISOString(),
   updatedAt: NOW.toISOString(),
   description: null,
+  submittedBy: null,
   submitterName: null,
   submitterEmail: null,
   pendingReason: null,

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -54,6 +54,7 @@ const makeTicket = (overrides: Partial<TicketDetail> = {}): TicketDetail => ({
   createdAt: '2026-06-01T10:00:00.000Z',
   updatedAt: '2026-06-01T10:00:00.000Z',
   description: null,
+  submittedBy: null,
   submitterName: 'Pat',
   submitterEmail: null,
   pendingReason: null,
@@ -1552,6 +1553,85 @@ describe('TicketWorkbench device link/unlink', () => {
 
     await screen.findByTestId('ticket-workbench-device');
     expect(screen.queryByTestId('ticket-workbench-device-unlink')).toBeNull();
+  });
+});
+
+// ─── Requester editing + clickable device link ────────────────────────────────
+
+describe('TicketWorkbench requester editing + device link', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  function mockApiWithRequesters(
+    ticket: TicketDetail,
+    requesters: Array<{ id: string; name: string | null; email: string }>
+  ) {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (!init?.method || init.method === 'GET') {
+        if (url.startsWith('/tickets/requesters?orgId=')) {
+          return makeJsonResponse({ data: requesters });
+        }
+        const m = url.match(/^\/tickets\/([^/?]+)$/);
+        if (m && m[1] === ticket.id) return makeJsonResponse({ data: ticket });
+      }
+      return makeJsonResponse({ success: true });
+    });
+  }
+
+  it('renders the device hostname as a link to the device page', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: 'dev-1', deviceHostname: 'DESKTOP-123' }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const link = await screen.findByTestId('ticket-workbench-device-link');
+    expect(link).toHaveAttribute('href', '/devices/dev-1');
+    expect(link).toHaveTextContent('DESKTOP-123');
+  });
+
+  it('renders no device link when the ticket has no device', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ deviceId: null, deviceHostname: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench-device');
+    expect(screen.queryByTestId('ticket-workbench-device-link')).toBeNull();
+  });
+
+  it('edits the requester to a picked portal user (PATCHes submittedBy + backfilled name/email)', async () => {
+    mockApiWithRequesters(
+      makeTicket({ submittedBy: null, submitterName: 'Pat', submitterEmail: null }),
+      [{ id: 'pu-1', name: 'Gail Goodman', email: 'gail@lgpc.com' }]
+    );
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-requester-edit'));
+    await screen.findByRole('option', { name: 'Gail Goodman (gail@lgpc.com)' });
+    fireEvent.change(screen.getByTestId('ticket-workbench-requester-select'), { target: { value: 'pu-1' } });
+    fireEvent.click(screen.getByTestId('ticket-workbench-requester-save'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1', expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ submittedBy: 'pu-1', submitterName: 'Gail Goodman', submitterEmail: 'gail@lgpc.com' })
+      }));
+    });
+  });
+
+  it('edits the requester to free text (PATCHes submittedBy:null + name)', async () => {
+    mockTicketApi({ 'tk-1': makeTicket({ submittedBy: null, submitterName: 'Pat', submitterEmail: null }) });
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-workbench-requester-edit'));
+    fireEvent.change(screen.getByTestId('ticket-workbench-requester-select'), { target: { value: '__manual__' } });
+    fireEvent.change(screen.getByTestId('ticket-workbench-requester-name'), { target: { value: 'Walk-in User' } });
+    fireEvent.click(screen.getByTestId('ticket-workbench-requester-save'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1', expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ submittedBy: null, submitterName: 'Walk-in User', submitterEmail: null })
+      }));
+    });
   });
 });
 

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -94,6 +94,9 @@ interface Props {
 const STATUS_OPTIONS: TicketStatus[] = ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'];
 const PRIORITY_OPTIONS: TicketPriority[] = ['urgent', 'high', 'normal', 'low'];
 
+// Sentinel for the "type a requester manually" choice in the requester editor.
+const MANUAL_REQUESTER = '__manual__';
+
 type TicketTriageSuggestion = {
   modelVersion: string;
   confidence: number;
@@ -125,6 +128,12 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const [config, setConfig] = useState<TicketConfig | null>(null);
   const [editingDescription, setEditingDescription] = useState(false);
   const descriptionTextareaRef = useRef<HTMLTextAreaElement>(null);
+  // Requester editor: picker options (portal users for the org) + edit state.
+  const [requesters, setRequesters] = useState<Array<{ id: string; name: string | null; email: string }>>([]);
+  const [editingRequester, setEditingRequester] = useState(false);
+  const [reqSel, setReqSel] = useState('');
+  const [reqName, setReqName] = useState('');
+  const [reqEmail, setReqEmail] = useState('');
   const [triageSuggestion, setTriageSuggestion] = useState<TicketTriageSuggestion | null>(null);
   const [triageLoading, setTriageLoading] = useState(false);
   const [applyingTriage, setApplyingTriage] = useState(false);
@@ -255,6 +264,23 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       .catch(() => { /* degrade gracefully */ });
     return () => { cancelled = true; };
   }, []);
+
+  // Requester options track the ticket's org (a portal user is org-scoped).
+  // Failure degrades the editor to free-text only.
+  useEffect(() => {
+    const orgId = ticket?.orgId;
+    if (!orgId) return;
+    let cancelled = false;
+    void fetchWithAuth(`/tickets/requesters?orgId=${orgId}`)
+      .then(async (r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled || !body) return;
+        const rows = (body as { data?: Array<{ id: string; name: string | null; email: string }> }).data;
+        if (Array.isArray(rows)) setRequesters(rows.filter((u) => u.id));
+      })
+      .catch(() => { /* free-text fallback */ });
+    return () => { cancelled = true; };
+  }, [ticket?.orgId]);
 
   // Fetch ticket config once (module-cached across islands). Failure leaves
   // config null, which keeps the six-core-status fallback select fully working.
@@ -448,6 +474,28 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
     }).then(() => afterMutation(patch as Partial<TicketDetail>)).catch((err) => { if (!(err instanceof ActionError)) throw err; });
   }, [ticketId, afterMutation]);
+
+  const openRequesterEditor = useCallback(() => {
+    if (!ticket) return;
+    setReqSel(ticket.submittedBy ?? ((ticket.submitterName || ticket.submitterEmail) ? MANUAL_REQUESTER : ''));
+    setReqName(ticket.submitterName ?? '');
+    setReqEmail(ticket.submitterEmail ?? '');
+    setEditingRequester(true);
+  }, [ticket]);
+
+  const saveRequester = useCallback(() => {
+    if (reqSel && reqSel !== MANUAL_REQUESTER) {
+      // Picked a portal user — send its name/email too so the local optimistic
+      // patch shows the new requester immediately (the API backfills the same).
+      const opt = requesters.find((r) => r.id === reqSel);
+      handleFieldSave({ submittedBy: reqSel, submitterName: opt?.name ?? null, submitterEmail: opt?.email ?? null });
+    } else if (reqSel === MANUAL_REQUESTER) {
+      handleFieldSave({ submittedBy: null, submitterName: reqName.trim() || null, submitterEmail: reqEmail.trim() || null });
+    } else {
+      handleFieldSave({ submittedBy: null, submitterName: null, submitterEmail: null });
+    }
+    setEditingRequester(false);
+  }, [reqSel, reqName, reqEmail, requesters, handleFieldSave]);
 
   const handleEditComment = useCallback((commentId: string, content: string) => {
     void runAction({
@@ -898,7 +946,83 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
               <TicketTimeBilling ticketId={ticket.id} />
               <TicketPartsCard ticketId={ticket.id} />
               <dl className="space-y-3">
-                <div><dt className="text-xs text-muted-foreground">Requester</dt><dd>{ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}</dd></div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Requester</dt>
+                  <dd>
+                    {editingRequester ? (
+                      <div className="space-y-2">
+                        <select
+                          value={reqSel}
+                          onChange={(e) => setReqSel(e.target.value)}
+                          className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+                          data-testid="ticket-workbench-requester-select"
+                          aria-label="Requester"
+                        >
+                          <option value="">Unknown</option>
+                          {requesters.map((r) => (
+                            <option key={r.id} value={r.id}>{r.name ? `${r.name} (${r.email})` : r.email}</option>
+                          ))}
+                          <option value={MANUAL_REQUESTER}>Someone else…</option>
+                        </select>
+                        {reqSel === MANUAL_REQUESTER && (
+                          <div className="space-y-1">
+                            <input
+                              value={reqName}
+                              onChange={(e) => setReqName(e.target.value)}
+                              maxLength={255}
+                              placeholder="Name"
+                              aria-label="Requester name"
+                              className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+                              data-testid="ticket-workbench-requester-name"
+                            />
+                            <input
+                              type="email"
+                              value={reqEmail}
+                              onChange={(e) => setReqEmail(e.target.value)}
+                              maxLength={255}
+                              placeholder="Email (optional)"
+                              aria-label="Requester email"
+                              className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+                              data-testid="ticket-workbench-requester-email"
+                            />
+                          </div>
+                        )}
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setEditingRequester(false)}
+                            className="rounded-md border px-2 py-0.5 text-xs hover:bg-muted"
+                            data-testid="ticket-workbench-requester-cancel"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={saveRequester}
+                            className="rounded-md bg-primary px-2 py-0.5 text-xs font-medium text-white"
+                            data-testid="ticket-workbench-requester-save"
+                          >
+                            Save
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="group flex items-start gap-2">
+                        <span className="flex-1" data-testid="ticket-workbench-requester">
+                          {ticket.submitterName ?? ticket.submitterEmail ?? 'Unknown'}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={openRequesterEditor}
+                          className="shrink-0 rounded px-1 text-xs text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100"
+                          data-testid="ticket-workbench-requester-edit"
+                        >
+                          Edit
+                        </button>
+                      </div>
+                    )}
+                  </dd>
+                </div>
                 <div><dt className="text-xs text-muted-foreground">Source</dt><dd className="capitalize">{ticket.source}</dd></div>
                 <div><dt className="text-xs text-muted-foreground">Created</dt><dd>{formatDateTime(ticket.createdAt)}</dd></div>
                 <div>
@@ -929,7 +1053,17 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                   <dt className="text-xs text-muted-foreground">Device</dt>
                   <dd>
                     <div data-testid="ticket-workbench-device" className="flex items-center gap-2 text-xs">
-                      <span>{ticket.deviceHostname ?? 'No device'}</span>
+                      {ticket.deviceId ? (
+                        <a
+                          href={`/devices/${ticket.deviceId}`}
+                          className="text-primary hover:underline"
+                          data-testid="ticket-workbench-device-link"
+                        >
+                          {ticket.deviceHostname ?? ticket.deviceId}
+                        </a>
+                      ) : (
+                        <span>No device</span>
+                      )}
                       {ticket.deviceId && (
                         <button
                           type="button"

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -51,6 +51,10 @@ export interface TicketComment {
 
 export interface TicketDetail extends TicketSummary {
   description: string | null;
+  // Requester. submittedBy links a portal_users row (portal/picked requester);
+  // submitterName/Email are the display name + reply address (also set for
+  // free-text requesters that have no portal account).
+  submittedBy: string | null;
   submitterName: string | null;
   submitterEmail: string | null;
   pendingReason: string | null;

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -125,6 +125,11 @@ describe('ticket validators', () => {
     it('updateTicketSchema rejects a malformed requester email', () => {
       expect(updateTicketSchema.safeParse({ submitterEmail: 'bad' }).success).toBe(false);
     });
+
+    it('updateTicketSchema rejects an empty submitterName (clear via null, not "")', () => {
+      expect(updateTicketSchema.safeParse({ submitterName: '' }).success).toBe(false);
+      expect(updateTicketSchema.safeParse({ submitterName: null }).success).toBe(true);
+    });
   });
 
   it('updateTicketSchema accepts SLA override minutes', () => {

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -96,6 +96,37 @@ describe('ticket validators', () => {
     expect(() => listTicketsQuerySchema.parse({ slaState: 'nope' })).toThrow();
   });
 
+  describe('requester fields', () => {
+    const ORG = '3f2f1d8e-1111-4222-8333-444455556666';
+    const PORTAL_USER = '5a6b7c8d-1234-4321-abcd-000011112222';
+
+    it('createTicketSchema accepts a portal-user requester (submittedBy)', () => {
+      const r = createTicketSchema.safeParse({ orgId: ORG, subject: 'x', submittedBy: PORTAL_USER });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.submittedBy).toBe(PORTAL_USER);
+    });
+
+    it('createTicketSchema accepts a free-text requester (name + email)', () => {
+      const r = createTicketSchema.safeParse({ orgId: ORG, subject: 'x', submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' });
+      expect(r.success).toBe(true);
+    });
+
+    it('createTicketSchema rejects a non-uuid submittedBy and a malformed email', () => {
+      expect(createTicketSchema.safeParse({ orgId: ORG, subject: 'x', submittedBy: 'nope' }).success).toBe(false);
+      expect(createTicketSchema.safeParse({ orgId: ORG, subject: 'x', submitterEmail: 'not-an-email' }).success).toBe(false);
+    });
+
+    it('updateTicketSchema accepts requester changes incl null to clear the portal link', () => {
+      expect(updateTicketSchema.safeParse({ submittedBy: PORTAL_USER }).success).toBe(true);
+      expect(updateTicketSchema.safeParse({ submittedBy: null, submitterName: 'Gail', submitterEmail: 'gail@lgpc.com' }).success).toBe(true);
+      expect(updateTicketSchema.safeParse({ submitterName: null, submitterEmail: null }).success).toBe(true);
+    });
+
+    it('updateTicketSchema rejects a malformed requester email', () => {
+      expect(updateTicketSchema.safeParse({ submitterEmail: 'bad' }).success).toBe(false);
+    });
+  });
+
   it('updateTicketSchema accepts SLA override minutes', () => {
     expect(updateTicketSchema.parse({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 }))
       .toEqual({ responseSlaMinutes: 30, resolutionSlaMinutes: 120 });

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -14,7 +14,14 @@ export const createTicketSchema = z.object({
   categoryId: z.string().guid().optional(),
   priority: ticketPrioritySchema.default('normal'),
   dueDate: z.coerce.date().optional(),
-  assigneeId: z.string().guid().optional()
+  assigneeId: z.string().guid().optional(),
+  // Requester: pick an existing portal user (submittedBy) and/or supply a
+  // free-text name/email. When all three are absent the service falls back to
+  // the acting staff member's name (legacy behaviour). Picking a portal user
+  // backfills name/email from that row when they aren't supplied here.
+  submittedBy: z.string().guid().optional(),
+  submitterName: z.string().min(1).max(255).optional(),
+  submitterEmail: z.string().email().max(255).optional()
 });
 
 export const updateTicketSchema = z.object({
@@ -26,7 +33,12 @@ export const updateTicketSchema = z.object({
   responseSlaMinutes: z.number().int().positive().nullable().optional(),
   resolutionSlaMinutes: z.number().int().positive().nullable().optional(),
   deviceId: z.string().guid().nullable().optional(),
-  tags: z.array(z.string().max(50)).max(20).optional()
+  tags: z.array(z.string().max(50)).max(20).optional(),
+  // Requester edit. submittedBy=null clears the portal link (free-text requester);
+  // a uuid links a portal user and backfills name/email when those are omitted.
+  submittedBy: z.string().guid().nullable().optional(),
+  submitterName: z.string().max(255).nullable().optional(),
+  submitterEmail: z.string().email().max(255).nullable().optional()
 });
 
 export const changeTicketStatusSchema = z.object({

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -36,8 +36,9 @@ export const updateTicketSchema = z.object({
   tags: z.array(z.string().max(50)).max(20).optional(),
   // Requester edit. submittedBy=null clears the portal link (free-text requester);
   // a uuid links a portal user and backfills name/email when those are omitted.
+  // submitterName mirrors create's min(1) (use null to clear, not an empty string).
   submittedBy: z.string().guid().nullable().optional(),
-  submitterName: z.string().max(255).nullable().optional(),
+  submitterName: z.string().min(1).max(255).nullable().optional(),
   submitterEmail: z.string().email().max(255).nullable().optional()
 });
 


### PR DESCRIPTION
## Problem

Creating a ticket forced the **creator** to be the requester (e.g. "Breeze Admin" / your own name), with no way to pick an end-user from the company and no way to edit it afterward. Root cause: `ticketService.createTicket` hard-coded `submitterName = actor.name` for `source: 'manual'`, the create form had no requester field, and the workbench rendered the requester as read-only text.

Reported via screenshot — requester stuck as the logged-in admin.

## Changes

**Requester — set on create, edit anytime** ("pick or type"):
- `createTicketSchema` / `updateTicketSchema` accept `submittedBy` (portal user, uuid), `submitterName`, `submitterEmail`.
- `createTicket` resolves the requester before number allocation: a picked portal user is tenant-validated (same-org) and backfills name/email; else free-text name/email; else the legacy actor-name default with **no email** (preserves "no external requester" semantics).
- `updateTicketFields` handles requester edits as one `requester` change (portal-user backfill, cross-org rejection, feed/audit entry).
- New `GET /tickets/requesters?orgId=` lists an org's active portal users via a system-context read behind `canAccessOrg` (mirrors the assignee/category validation pattern). Registered before `/:id` so the static segment isn't captured by the param route.

**Web**
- `CreateTicketPage`: *Requester* dropdown of the org's portal users + "Someone else…" free-text name/email. Default "you" keeps legacy behavior.
- `TicketWorkbench`: inline-editable Requester (same picker), and the device hostname is now a link to `/devices/:id`.

## Behavior note

The notify worker emails `submitterEmail` on public replies/resolution. Manual tickets previously never had one (never emailed). Now, **setting a requester email means that person is emailed on public replies/resolution** — intended helpdesk behavior. Leaving the requester unset (or name-only) keeps the prior no-email semantics. The reply copy still says "Sign in to the portal to view it," which is slightly off for a free-text requester without a portal account (minor follow-up).

## Tests

All green; typecheck (shared/api/web) + ESLint clean. Built from a fresh worktree off `main`.
- shared validators: requester accept/reject (uuid, email)
- API service: portal-user backfill, explicit-override, free-text, cross-org reject (create + update), legacy default preserved
- API route: `GET /tickets/requesters` happy path, cross-org 403, validation 400, `/:id` ordering
- web: create-form picker (portal user / free text / org reset), workbench requester edit (portal / free text), device link

🤖 Generated with [Claude Code](https://claude.com/claude-code)