### PR TITLE
fix(api): serve breeze-user-helper from a server-relative download URL (#1878)

### DIFF
--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -636,6 +636,61 @@ describe("agentVersions routes", () => {
       }
     });
 
+    it("rewrites user-helper downloadUrl to the server-relative user-helper route (#1878 — sibling of #646)", async () => {
+      const checksum = "c".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        component: "user-helper",
+        platform: "windows",
+        arch: "amd64",
+        url: "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-user-helper-windows-amd64.exe",
+        checksum,
+        size: 1234,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "windows",
+                architecture: "amd64",
+                component: "user-helper",
+                downloadUrl:
+                  "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-user-helper-windows-amd64.exe",
+                checksum,
+                fileSize: BigInt(1234),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=windows&arch=amd64&component=user-helper",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // The bug (#1878): user-helper fell through to null in
+        // buildServerRelativeAgentDownloadUrl, so the response handed back the
+        // canonical github.com asset URL — which the agent's host-equality check
+        // rejects. It must resolve to the user-helper route, which is distinct
+        // from the Tauri /helper app route.
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/user-helper/windows/amd64",
+        );
+        expect(body.url).not.toContain("github.com");
+        expect(body.checksum).toBe(checksum);
+      } finally {
+        delete process.env.PUBLIC_API_URL;
+      }
+    });
+
     it("maps platform=macos to /darwin in the server-relative URL", async () => {
       const checksum = "b".repeat(64);
       const signed = makeSignedReleaseManifest({

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -265,17 +265,22 @@ function dbPlatformToRouteOs(dbPlatform: string): string {
 }
 
 // Construct the server-relative download URL the agent should use. Applies to
-// component=agent and component=helper: both are pulled by the agent's verified
-// downloader (updater.downloadFromURL), which enforces host equality with the
-// agent's configured ServerURL. Without this rewrite the response would hand
-// back the canonical github.com asset URL, which the agent rejects — and, more
-// importantly, the helper used to be fetched via an UNVERIFIED redirect to that
-// CDN and run as SYSTEM/root (the HIGH-severity RCE fixed alongside this).
-// Rewriting to the control-plane origin keeps the helper download inside the
-// trusted origin; the existing /download[/helper]/:os/:arch route then 302s to
-// github server-side, and the signed-manifest SHA-256 binds the bytes either
-// way. Returns null to signal "fall back to the canonical (github) URL"
-// (components without a server-relative route, or no configured origin).
+// component=agent, helper, user-helper, and watchdog: all are pulled by the
+// agent's verified downloader (updater.downloadFromURL), which enforces host
+// equality with the agent's configured ServerURL. Without this rewrite the
+// response would hand back the canonical github.com asset URL, which the agent
+// rejects — and, more importantly, the helper used to be fetched via an
+// UNVERIFIED redirect to that CDN and run as SYSTEM/root (the HIGH-severity RCE
+// fixed alongside this). Rewriting to the control-plane origin keeps the
+// download inside the trusted origin; the existing /download[/...]/:os/:arch
+// route then 302s to github server-side, and the signed-manifest SHA-256 binds
+// the bytes either way. Returns null to signal "fall back to the canonical
+// (github) URL" (components without a server-relative route, or no origin).
+//
+// NOTE: `user-helper` (breeze-user-helper.exe, the GUI-subsystem agent sibling)
+// is distinct from `helper` (the Tauri Helper app). It has its own route; it
+// was omitted here originally, so the agent fell back to the github URL and the
+// host check rejected the user-helper auto-update (#1878, sibling of #646).
 function buildServerRelativeAgentDownloadUrl(
   dbPlatform: string,
   architecture: string,
@@ -284,6 +289,7 @@ function buildServerRelativeAgentDownloadUrl(
   if (
     component !== "agent" &&
     component !== "helper" &&
+    component !== "user-helper" &&
     component !== "watchdog"
   ) {
     return null;
@@ -295,6 +301,9 @@ function buildServerRelativeAgentDownloadUrl(
   const os = dbPlatformToRouteOs(dbPlatform);
   if (component === "helper") {
     return `${origin}/api/v1/agents/download/helper/${os}/${architecture}`;
+  }
+  if (component === "user-helper") {
+    return `${origin}/api/v1/agents/download/user-helper/${os}/${architecture}`;
   }
   if (component === "watchdog") {
     return `${origin}/api/v1/agents/download/watchdog/${os}/${architecture}`;

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../services/binarySource', () => ({
   getGithubAgentUrl: vi.fn(),
   getGithubAgentPkgUrl: vi.fn(),
   getGithubHelperUrl: vi.fn(),
+  getGithubUserHelperUrl: vi.fn(),
   getGithubWatchdogUrl: vi.fn(),
   HELPER_FILENAMES: {
     linux: 'breeze-desktop-helper-linux-amd64',
@@ -29,7 +30,7 @@ import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { downloadRoutes } from './download';
-import { getBinarySource, getGithubAgentPkgUrl, getGithubWatchdogUrl } from '../../services/binarySource';
+import { getBinarySource, getGithubAgentPkgUrl, getGithubUserHelperUrl, getGithubWatchdogUrl } from '../../services/binarySource';
 import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
 
 describe('public agent binary downloads', () => {
@@ -117,6 +118,45 @@ describe('public agent binary downloads', () => {
     const badOs = await downloadRoutes.request('/download/watchdog/solaris/amd64');
     expect(badOs.status).toBe(400);
     const badArch = await downloadRoutes.request('/download/watchdog/linux/sparc');
+    expect(badArch.status).toBe(400);
+  });
+
+  // #1878: user-helper (breeze-user-helper.exe) is a distinct Go binary from the
+  // Tauri "helper" app, and its server-relative route must exist so the agent's
+  // verified updater is not handed a github.com URL its host check rejects.
+  it('does not disclose AGENT_BINARY_DIR in public user-helper 404 responses', async () => {
+    const res = await downloadRoutes.request('/download/user-helper/windows/amd64');
+    const body = await res.text();
+
+    expect(res.status).toBe(404);
+    expect(body).not.toContain('/tmp/breeze-secret-agent-binaries');
+    expect(console.warn).toHaveBeenCalledWith(
+      '[user-helper-download] Local binary missing',
+      { filename: 'breeze-user-helper-windows-amd64.exe' },
+    );
+  });
+
+  it('redirects user-helper downloads to GitHub in github mode (per-arch, .exe on windows)', async () => {
+    vi.mocked(getBinarySource).mockReturnValue('github');
+    vi.mocked(getGithubUserHelperUrl).mockImplementation(
+      (os: string, arch: string) =>
+        `https://github.test/${os}-${arch}/breeze-user-helper`,
+    );
+
+    try {
+      const win = await downloadRoutes.request('/download/user-helper/windows/amd64');
+      expect(win.status).toBe(302);
+      expect(win.headers.get('location')).toBe('https://github.test/windows-amd64/breeze-user-helper');
+      expect(getGithubUserHelperUrl).toHaveBeenCalledWith('windows', 'amd64');
+    } finally {
+      vi.mocked(getBinarySource).mockReturnValue('local');
+    }
+  });
+
+  it('rejects invalid OS/arch on the user-helper route', async () => {
+    const badOs = await downloadRoutes.request('/download/user-helper/solaris/amd64');
+    expect(badOs.status).toBe(400);
+    const badArch = await downloadRoutes.request('/download/user-helper/windows/sparc');
     expect(badArch.status).toBe(400);
   });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -213,6 +213,7 @@ describe('S3 transport failures surface as 500, not a masked 404 (issue #1802)',
     ['agent', '/download/linux/amd64', '[agent-download]'],
     ['helper', '/download/helper/linux/amd64', '[helper-download]'],
     ['watchdog', '/download/watchdog/linux/amd64', '[watchdog-download]'],
+    ['user-helper', '/download/user-helper/windows/amd64', '[user-helper-download]'],
   ])('returns 500 for the %s route on a non-NotFound S3 error', async (_name, path, logTag) => {
     const res = await downloadRoutes.request(path);
     const body = await res.text();
@@ -230,6 +231,7 @@ describe('S3 transport failures surface as 500, not a masked 404 (issue #1802)',
     ['agent', '/download/linux/amd64', '[agent-download]', 'NotFound'],
     ['helper', '/download/helper/linux/amd64', '[helper-download]', 'NoSuchKey'],
     ['watchdog', '/download/watchdog/linux/amd64', '[watchdog-download]', 'NotFound'],
+    ['user-helper', '/download/user-helper/windows/amd64', '[user-helper-download]', 'NotFound'],
   ])(
     'still falls back to disk and 404s for the %s route when the S3 object genuinely does not exist',
     async (_name, path, logTag, errName) => {

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -377,7 +377,8 @@ downloadRoutes.get('/download/watchdog/:os/:arch', async (c) => {
   });
 });
 
-// breeze-user-helper: the GUI-subsystem sibling of breeze-agent (Windows only),
+// breeze-user-helper: the GUI-subsystem sibling of breeze-agent (Windows in
+// practice; route stays OS-general like the watchdog route it mirrors),
 // spawned by the agent's sessionbroker into the interactive user session. It is
 // a distinct binary from the Tauri "helper" app (/download/helper) and is
 // fetched by the agent's verified updater (component=user-helper). Without this

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -3,7 +3,7 @@ import { statSync, createReadStream } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
 import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
-import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubWatchdogUrl, HELPER_FILENAMES } from '../../services/binarySource';
+import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, HELPER_FILENAMES } from '../../services/binarySource';
 
 export const downloadRoutes = new Hono();
 
@@ -360,6 +360,93 @@ downloadRoutes.get('/download/watchdog/:os/:arch', async (c) => {
       stream.on('end', () => { controller.close(); });
       stream.on('error', (err) => {
         console.error(`[watchdog-download] Stream error while serving ${filename}:`, err);
+        controller.error(err);
+      });
+    },
+    cancel() { stream.destroy(); },
+  });
+
+  return new Response(webStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Length': String(fileStat.size),
+      'Cache-Control': 'no-cache',
+    },
+  });
+});
+
+// breeze-user-helper: the GUI-subsystem sibling of breeze-agent (Windows only),
+// spawned by the agent's sessionbroker into the interactive user session. It is
+// a distinct binary from the Tauri "helper" app (/download/helper) and is
+// fetched by the agent's verified updater (component=user-helper). Without this
+// server-relative route the agent-versions response handed back the canonical
+// github.com asset URL, which the updater's host-equality check rejects (#1878).
+// Mirrors the watchdog route: github redirect / S3 presign / local disk.
+downloadRoutes.get('/download/user-helper/:os/:arch', async (c) => {
+  const os = c.req.param('os');
+  const arch = c.req.param('arch');
+
+  if (!VALID_OS.has(os)) {
+    return c.json({ error: 'Invalid OS', message: `Supported values: linux, darwin, windows. Got: ${os}` }, 400);
+  }
+
+  if (!VALID_ARCH.has(arch)) {
+    return c.json({ error: 'Invalid architecture', message: `Supported values: amd64, arm64. Got: ${arch}` }, 400);
+  }
+
+  const extension = os === 'windows' ? '.exe' : '';
+  const filename = `breeze-user-helper-${os}-${arch}${extension}`;
+
+  if (getBinarySource() === 'github') {
+    return c.redirect(getGithubUserHelperUrl(os, arch), 302);
+  }
+
+  if (isS3Configured()) {
+    try {
+      const s3Key = `user-helper/${filename}`;
+      const url = await getPresignedUrl(s3Key);
+      return c.redirect(url, 302);
+    } catch (err) {
+      if (!isS3NotFound(err)) {
+        console.error(`[user-helper-download] S3 presign failed for ${filename}:`, err);
+        return c.json({ error: 'Internal server error', message: 'Failed to retrieve binary file' }, 500);
+      }
+      console.warn(`[user-helper-download] S3 object missing for ${filename}, falling back to disk:`, err);
+    }
+  }
+
+  const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
+  const filePath = join(binaryDir, filename);
+
+  let fileStat: ReturnType<typeof statSync>;
+  let stream: ReturnType<typeof createReadStream>;
+  try {
+    fileStat = statSync(filePath);
+    stream = createReadStream(filePath);
+  } catch (err) {
+    const isNotFound = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isNotFound) {
+      console.error(`[user-helper-download] Failed to read binary ${filename}:`, err);
+      return c.json({ error: 'Internal server error', message: 'Failed to read binary file' }, 500);
+    }
+    console.warn('[user-helper-download] Local binary missing', { filename });
+    return c.json({
+      error: 'Binary not found',
+      message: `User-helper binary "${filename}" is not available.`,
+    }, 404);
+  }
+
+  const webStream = new ReadableStream({
+    start(controller) {
+      stream.on('data', (chunk: string | Buffer) => {
+        const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+        controller.enqueue(new Uint8Array(bytes));
+      });
+      stream.on('end', () => { controller.close(); });
+      stream.on('error', (err) => {
+        console.error(`[user-helper-download] Stream error while serving ${filename}:`, err);
         controller.error(err);
       });
     },

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -91,6 +91,15 @@ export function getGithubWatchdogUrl(os: string, arch: string): string {
   return `${githubDownloadBase()}/${filename}`;
 }
 
+// breeze-user-helper is the GUI-subsystem sibling of breeze-agent (Windows
+// only). It is a distinct release asset from the Tauri "helper" app served by
+// HELPER_FILENAMES — do not conflate the two (#1878).
+export function getGithubUserHelperUrl(os: string, arch: string): string {
+  const extension = os === 'windows' ? '.exe' : '';
+  const filename = `breeze-user-helper-${os}-${arch}${extension}`;
+  return `${githubDownloadBase()}/${filename}`;
+}
+
 export function getGithubRegularMsiUrl(): string {
   return `${githubDownloadBase()}/breeze-agent.msi`;
 }

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -91,9 +91,11 @@ export function getGithubWatchdogUrl(os: string, arch: string): string {
   return `${githubDownloadBase()}/${filename}`;
 }
 
-// breeze-user-helper is the GUI-subsystem sibling of breeze-agent (Windows
-// only). It is a distinct release asset from the Tauri "helper" app served by
-// HELPER_FILENAMES — do not conflate the two (#1878).
+// breeze-user-helper is the GUI-subsystem sibling of breeze-agent. The agent
+// only prefetches it on Windows today, but this mirrors the other per-(os,arch)
+// asset URL helpers and stays OS-general. It is a distinct release asset from
+// the Tauri "helper" app served by HELPER_FILENAMES — don't conflate the two
+// (#1878).
 export function getGithubUserHelperUrl(os: string, arch: string): string {
   const extension = os === 'windows' ? '.exe' : '';
   const filename = `breeze-user-helper-${os}-${arch}${extension}`;


### PR DESCRIPTION
## Summary

Closes #1878.

The agent's verified updater fetches the user-helper binary as **`component=user-helper`** and enforces **host-equality** with its configured `ServerURL`. But `buildServerRelativeAgentDownloadUrl` (`apps/api/src/routes/agentVersions.ts`) only rewrote `agent`/`helper`/`watchdog` to a server-relative URL — **`user-helper` fell through to `null`**, so the `/agent-versions/:v/download` response handed back the canonical `github.com` asset URL. The agent's host check then rejected it:

```
user-helper download failed; proceeding with agent-only upgrade
error="download URL host \"github.com\" does not match server \"us.2breeze.app\""
```

So the agent self-updated fine while the **user-helper stayed version-skewed** (observed on device GBG-LT: agent 0.83.1, user-helper stuck at 0.69.0). This is the sibling of the agent-binary fix #646 — the `user-helper` code path was simply never covered.

## Key distinction

`breeze-user-helper.exe` (the GUI-subsystem sibling of the agent, spawned into the interactive user session by the sessionbroker) is a **distinct binary** from the Tauri **"helper" app** (`breeze-helper-windows.msi`, served by `/download/helper`). Routing `user-helper` → the `helper` route would serve the wrong file, so it gets its own route.

## Fix (mirrors the `watchdog` path exactly)

- `getGithubUserHelperUrl(os, arch)` in `binarySource.ts`
- `GET /api/v1/agents/download/user-helper/:os/:arch` in `download.ts` — github redirect / S3 presign / local disk; in `BINARY_SOURCE=github` mode it 302s to github server-side, and the signed-manifest SHA-256 binds the bytes (same trust model as agent/watchdog).
- `buildServerRelativeAgentDownloadUrl` now maps `user-helper` to that route.

## Tests

- `download.test.ts`: github redirect (per-arch, `.exe` on windows), 404 that doesn't leak `AGENT_BINARY_DIR`, invalid OS/arch — mirroring the watchdog route tests.
- `agentVersions.test.ts`: the `/agent-versions/:v/download?component=user-helper` endpoint now returns the server-relative user-helper URL (and explicitly **not** a `github.com` URL) — the direct #1878 regression guard.

Affected unit suites green (`vitest run`, 77 passed); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)