### PR TITLE
fix(devices): stop reboot-pending dot wrapping under Down pill

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -652,4 +652,18 @@ describe('DeviceList — pending reboot badge', () => {
     expect(screen.queryByTestId(`device-${explicitFalse.id}-pending-reboot-badge`)).toBeNull();
     expect(screen.queryByTestId(`device-${baseDevice.id}-pending-reboot-badge`)).toBeNull();
   });
+
+  it('suppresses the dot on an offline device even when pendingReboot is true (stale/unactionable)', () => {
+    const device: Device = {
+      ...baseDevice,
+      id: '55555555-5555-5555-5555-555555555555',
+      hostname: 'host-offline-needs-reboot',
+      status: 'offline',
+      pendingReboot: true,
+    };
+
+    render(<DeviceList devices={[device]} />);
+
+    expect(screen.queryByTestId(`device-${device.id}-pending-reboot-badge`)).toBeNull();
+  });
 });

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -797,7 +797,7 @@ export default function DeviceList({
       header: () => sortHeader('status', 'Status', 'Sort by status'),
       cell: (device) => (
         <td key="status" className="px-3 py-3 text-sm">
-          <div className="flex flex-wrap items-center gap-1">
+          <div className="flex items-center gap-1">
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusColors[device.status]}`}
               title={statusFullLabels[device.status]}
@@ -813,7 +813,10 @@ export default function DeviceList({
                 Agent silent · {formatSilentDuration(device.mainAgentSilentSince!)}
               </span>
             )}
-            {device.pendingReboot && (
+            {/* Pending-reboot is only actionable while the box is reachable. On an
+                offline device the flag is stale and unactionable, so suppress the
+                dot rather than wrap it under the wider "Down" pill. */}
+            {device.pendingReboot && device.status !== 'offline' && (
               <span
                 data-testid={`device-${device.id}-pending-reboot-badge`}
                 title="The OS reports a pending reboot (Windows registry / Linux reboot-required markers)."


### PR DESCRIPTION
## What

The device-list **Status** cell rendered the "reboot pending" indicator as a bare solid-amber dot inside a `flex flex-wrap` container. The wider **Down** pill plus the `shrink-0` dot exceeded the column's content width on offline rows, so the dot wrapped to a second line — making **Down** rows taller and ragged while **Up** rows stayed inline.

Reported from production (us.2breeze.app devices list).

## Changes (`apps/web/src/components/devices/DeviceList.tsx`)

1. **`flex flex-wrap` → `flex`** on the status cell — the pill + dot (+ the rare "Agent silent" badge) now stay on one line.
2. **Gate the dot on `status !== 'offline'`** — a pending-reboot flag is stale and unactionable on a box that's already Down, so showing it was pure noise. This also removes the wrap at its source, since the wrapping rows were the offline ones.

The intentional **Down + "Agent silent"** pairing (main agent wedged, watchdog still alive — #800) is untouched; that badge is already gated to the watchdog-alive case.

## Tests

Added a case asserting the dot is suppressed for an offline device with `pendingReboot: true`. Full file green: 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)