### PR TITLE
fix(api): block cross-tenant destructive DR command injection

### DIFF
--- a/apps/api/src/routes/dr.test.ts
+++ b/apps/api/src/routes/dr.test.ts
@@ -63,6 +63,10 @@ vi.mock('../db/schema', () => ({
     createdAt: 'dr_executions.created_at',
     status: 'dr_executions.status',
   },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.org_id',
+  },
 }));
 
 vi.mock('../services/auditEvents', () => ({
@@ -154,6 +158,8 @@ describe('dr routes', () => {
       name: 'Primary Site Failover',
       status: 'draft',
     }]));
+    // device-ownership check returns the assigned device as owned by this org
+    selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID }]));
     insertMock.mockReturnValueOnce(chainMock([{
       id: GROUP_ID,
       planId: PLAN_ID,
@@ -454,6 +460,87 @@ describe('dr routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.status).toBe('aborted');
+  });
+
+  it('rejects group create with a foreign-org device', async () => {
+    // plan exists and belongs to org
+    selectMock.mockReturnValueOnce(chainMock([{
+      id: PLAN_ID,
+      orgId: ORG_ID,
+      name: 'Primary Site Failover',
+      status: 'draft',
+    }]));
+    // device-ownership check returns 0 rows: device is not in this org
+    selectMock.mockReturnValueOnce(chainMock([]));
+
+    const res = await app.request(`/dr/plans/${PLAN_ID}/groups`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        name: 'Tier 1 Apps',
+        devices: [DEVICE_ID],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('do not belong to this organization');
+    // must not persist the foreign device
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects group update with a foreign-org device', async () => {
+    // group exists and belongs to org
+    selectMock.mockReturnValueOnce(chainMock([{
+      id: GROUP_ID,
+      planId: PLAN_ID,
+      orgId: ORG_ID,
+      name: 'Tier 1 Apps',
+      sequence: 1,
+    }]));
+    // device-ownership check returns 0 rows: device is not in this org
+    selectMock.mockReturnValueOnce(chainMock([]));
+
+    const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ devices: [DEVICE_ID] }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('do not belong to this organization');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('allows group update that does not change devices (no ownership check)', async () => {
+    // group exists and belongs to org
+    selectMock.mockReturnValueOnce(chainMock([{
+      id: GROUP_ID,
+      planId: PLAN_ID,
+      orgId: ORG_ID,
+      name: 'Tier 1 Apps',
+      sequence: 1,
+    }]));
+    updateMock.mockReturnValueOnce(chainMock([{
+      id: GROUP_ID,
+      planId: PLAN_ID,
+      orgId: ORG_ID,
+      name: 'Renamed',
+      sequence: 1,
+    }]));
+
+    const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe('Renamed');
+    // only the group-existence select runs; no device-ownership select
+    expect(selectMock).toHaveBeenCalledTimes(1);
   });
 
   it('should reject aborting a completed execution', async () => {

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, and, desc, asc } from 'drizzle-orm';
+import { eq, and, desc, asc, inArray } from 'drizzle-orm';
 import { db } from '../db';
-import { drPlans, drPlanGroups, drExecutions } from '../db/schema';
+import { drPlans, drPlanGroups, drExecutions, devices } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import {
@@ -35,6 +35,23 @@ drRoutes.use('*', authMiddleware);
 
 const idParamSchema = z.object({ id: z.string().guid() });
 const groupParamSchema = z.object({ id: z.string().guid(), gid: z.string().guid() });
+
+/**
+ * Confirm every device id assigned to a DR group belongs to the plan's org.
+ * DR group commands are dispatched under withSystemDbAccessContext (RLS off), so
+ * a foreign-org device id slipping into devices[] would let a destructive restore
+ * command target another tenant's device. Validate ownership with the
+ * request-scoped RLS `db` before persisting. Returns true when all ids are owned.
+ */
+async function allDevicesBelongToOrg(deviceIds: string[], orgId: string): Promise<boolean> {
+  if (deviceIds.length === 0) return true;
+  const uniqueIds = [...new Set(deviceIds)];
+  const owned = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(and(inArray(devices.id, uniqueIds), eq(devices.orgId, orgId)));
+  return owned.length === uniqueIds.length;
+}
 
 function resolveOrgId(
   auth: {
@@ -257,6 +274,10 @@ drRoutes.post(
     if (!plan) return c.json({ error: 'Plan not found' }, 404);
 
     const payload = c.req.valid('json');
+    if (payload.devices && !(await allDevicesBelongToOrg(payload.devices, orgId))) {
+      return c.json({ error: 'One or more devices do not belong to this organization' }, 403);
+    }
+
     const [row] = await db
       .insert(drPlanGroups)
       .values({
@@ -304,6 +325,10 @@ drRoutes.patch(
       .limit(1);
 
     if (!existing) return c.json({ error: 'Group not found' }, 404);
+
+    if (payload.devices !== undefined && !(await allDevicesBelongToOrg(payload.devices, orgId))) {
+      return c.json({ error: 'One or more devices do not belong to this organization' }, 403);
+    }
 
     const updateData: Record<string, unknown> = {};
     if (payload.name !== undefined) updateData.name = payload.name;

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -9,6 +9,7 @@ import {
   DEVICE_UNREACHABLE_ERROR,
   SEND_RETRY_ATTEMPTS,
   CommandTypes,
+  queueCommandForExecution,
 } from './commandQueue';
 import { db } from '../db';
 import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
@@ -711,6 +712,63 @@ describe('command queue service', () => {
       expect(result.status).toBe('completed');
       // Dispatch path is skipped entirely because preferHeartbeat is true.
       expect(sendCommandToAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('queueCommandForExecution expectedOrgId guard', () => {
+    function mockDeviceLookup(device: unknown) {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(device ? [device] : []),
+          }),
+        }),
+      } as any);
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('refuses a device whose orgId differs from expectedOrgId', async () => {
+      mockDeviceLookup({ id: 'dev-foreign', status: 'online', orgId: 'org-evil' });
+
+      const result = await queueCommandForExecution(
+        'dev-foreign',
+        CommandTypes.BACKUP_RESTORE,
+        {},
+        { expectedOrgId: 'org-victim' },
+      );
+
+      // Matches the adjacent "Device not found" contract — no info leak.
+      expect(result.error).toBe('Device not found');
+      // Must not have proceeded to queue the command.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('passes the org gate when device.orgId matches expectedOrgId', async () => {
+      // offline so it short-circuits AFTER the org check passes, proving the
+      // org gate did not reject a same-org device.
+      mockDeviceLookup({ id: 'dev-mine', status: 'offline', orgId: 'org-victim' });
+
+      const result = await queueCommandForExecution(
+        'dev-mine',
+        CommandTypes.BACKUP_RESTORE,
+        {},
+        { expectedOrgId: 'org-victim' },
+      );
+
+      expect(result.error).toBe('Device is offline, cannot execute command');
+    });
+
+    it('is unaffected when expectedOrgId is omitted (existing callers)', async () => {
+      // Foreign org, but no expectedOrgId passed: gate is inert, falls through
+      // to the normal status check.
+      mockDeviceLookup({ id: 'dev-any', status: 'offline', orgId: 'org-whatever' });
+
+      const result = await queueCommandForExecution('dev-any', CommandTypes.BACKUP_RESTORE, {});
+
+      expect(result.error).toBe('Device is offline, cannot execute command');
     });
   });
 });

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -495,9 +495,10 @@ export async function queueCommandForExecution(
   options: {
     userId?: string;
     preferHeartbeat?: boolean;
+    expectedOrgId?: string;
   } = {}
 ): Promise<QueueCommandForExecutionResult> {
-  const { userId, preferHeartbeat = false } = options;
+  const { userId, preferHeartbeat = false, expectedOrgId } = options;
 
   const [device] = await db
     .select()
@@ -506,6 +507,13 @@ export async function queueCommandForExecution(
     .limit(1);
 
   if (!device) {
+    return { error: 'Device not found' };
+  }
+
+  // Defense-in-depth: this lookup can run under withSystemDbAccessContext (RLS off),
+  // so callers that know the expected owning org (e.g. DR dispatch) pass expectedOrgId
+  // to prevent a cross-tenant device id from receiving a destructive command.
+  if (expectedOrgId !== undefined && device.orgId !== expectedOrgId) {
     return { error: 'Device not found' };
   }
 

--- a/apps/api/src/services/drExecutionService.test.ts
+++ b/apps/api/src/services/drExecutionService.test.ts
@@ -143,7 +143,9 @@ describe('drExecutionService', () => {
         drPlanId: PLAN_ID,
         drGroupId: GROUP_ID,
       }),
-      { userId: 'user-1' }
+      // expectedOrgId threads the plan's org through to commandQueue's
+      // cross-tenant guard so a foreign device id in devices[] is refused.
+      { userId: 'user-1', expectedOrgId: ORG_ID }
     );
     expect(execution?.status).toBe('running');
     expect(enqueueDrExecutionReconcile).toHaveBeenCalledWith(EXECUTION_ID, 2000);

--- a/apps/api/src/services/drExecutionService.ts
+++ b/apps/api/src/services/drExecutionService.ts
@@ -360,7 +360,7 @@ async function dispatchGroup(
         groupName: group.name,
         ...payload,
       },
-      { userId: execution.initiatedBy ?? undefined }
+      { userId: execution.initiatedBy ?? undefined, expectedOrgId: execution.orgId }
     );
 
     if (error || !command) {


### PR DESCRIPTION
## DR cross-tenant destructive command injection (HIGH)

A DR plan group's `devices[]` (JSONB) was stored **unvalidated**, then dispatched under `withSystemDbAccessContext` (RLS off) — so an Org-A operator could stuff an Org-B device UUID into a group and have a destructive restore command (`vm_restore_from_backup`, `bmr_recover`, `hyperv_restore`, `mssql_restore`) sent to another tenant's device.

**Fix — defense in depth, both layers:**
1. `dr.ts` group create/update validates every `devices[]` id belongs to the plan's org (request-scoped RLS `db`), 403 otherwise.
2. `commandQueue.queueCommandForExecution` gains an optional `expectedOrgId` guard asserting `device.orgId === expectedOrgId` even under system context; `drExecutionService` threads `execution.orgId`.

> Note: `commandQueue.ts` is a shared hot sink — the new param is optional so the ~30 existing callers are unaffected.

**Verification:** API package `tsc --noEmit` clean; all changed-file unit suites green (single-fork). RLS contract + integration tests not run locally (need DB) — rely on CI.
Origin: `/security-review` playbook entry 1 (multi-tenant RLS + authz) two-pass workflow + Codex review pass.
