### PR TITLE
fix(api): enforce app-layer site axis on reads + PAM rule writes

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { mobileRoutes } from './mobile';
 
+// Partial-mock drizzle-orm so `inArray` is a spy while every other operator
+// (and/eq/sql/...) stays real. The /summary site-narrowing tests assert that
+// device stats build inArray(devices.siteId, allowedSiteIds) and alert stats
+// build inArray(alerts.deviceId, resolvedDeviceIds). Removing either production
+// narrowing line makes the matching assertion fail.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)),
+  };
+});
+
 const { publishEventMock, setCooldownMock, emitAlertStateFeedbackMock, rateLimitState, authState } = vi.hoisted(() => ({
   publishEventMock: vi.fn().mockResolvedValue('event-1'),
   setCooldownMock: vi.fn().mockResolvedValue(undefined),
@@ -78,6 +91,8 @@ vi.mock('../middleware/userRateLimit', () => ({
 }));
 
 import { db } from '../db';
+import { inArray } from 'drizzle-orm';
+import { devices, alerts } from '../db/schema';
 import { authMiddleware, requirePermission } from '../middleware/auth';
 
 const mockSelectLimitChain = (result: unknown) => ({
@@ -1429,6 +1444,7 @@ describe('mobile routes', () => {
 
       it('applies siteId inArray to device stats and uses resolveSiteAllowedDeviceIds for alert stats when site-restricted', async () => {
         authState.permissions = { allowedSiteIds: ['site-1'] };
+        vi.mocked(inArray).mockClear();
 
         const selectMock = vi.mocked(db.select);
         // Call order:
@@ -1449,6 +1465,14 @@ describe('mobile routes', () => {
         expect(body.alerts.total).toBe(1);
         // Three db.select calls: device-agg, device-site-lookup, alert-agg
         expect(selectMock).toHaveBeenCalledTimes(3);
+
+        // Load-bearing site narrowing. These prove the actual filters were built;
+        // deleting either production line drops the matching inArray call.
+        //   - device stats narrow on the real devices.siteId column with the allowlist
+        //   - alert stats narrow on the real alerts.deviceId column with the device IDs
+        //     resolveSiteAllowedDeviceIds yields for the allowed site (['dev-1'])
+        expect(inArray).toHaveBeenCalledWith(devices.siteId, ['site-1']);
+        expect(inArray).toHaveBeenCalledWith(alerts.deviceId, ['dev-1']);
       });
 
       it('returns zero alerts (but real device counts) when resolveSiteAllowedDeviceIds returns empty', async () => {

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1399,6 +1399,79 @@ describe('mobile routes', () => {
       expect(body.devices.total).toBe(0);
       expect(body.alerts.total).toBe(0);
     });
+
+    describe('site-axis narrowing', () => {
+      // Helper: summary device/alert aggregate queries return a single row.
+      const mockAggregateChain = (row: unknown) => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([row])
+        })
+      });
+      // Helper: resolveSiteAllowedDeviceIds device lookup chain (returns array of {id, siteId}).
+      const mockDeviceSiteChain = (rows: unknown[]) => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      });
+
+      it('returns zeros for both devices and alerts when site-restricted caller has empty allowedSiteIds (fail-closed)', async () => {
+        authState.permissions = { allowedSiteIds: [] };
+
+        const res = await app.request('/mobile/summary', { method: 'GET' });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Empty allowedSiteIds → early return zeros for everything
+        expect(body.devices.total).toBe(0);
+        expect(body.alerts.total).toBe(0);
+        // db.select should not have been called (short-circuit before any query)
+        expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+      });
+
+      it('applies siteId inArray to device stats and uses resolveSiteAllowedDeviceIds for alert stats when site-restricted', async () => {
+        authState.permissions = { allowedSiteIds: ['site-1'] };
+
+        const selectMock = vi.mocked(db.select);
+        // Call order:
+        //   1. device stats aggregate (from devices, where includes siteId inArray)
+        //   2. resolveSiteAllowedDeviceIds: select {id, siteId} from devices where orgId
+        //   3. alert stats aggregate (from alerts, where includes deviceId inArray)
+        selectMock
+          .mockReturnValueOnce(mockAggregateChain({ total: 3, online: 2, offline: 1, maintenance: 0 }) as any)
+          .mockReturnValueOnce(mockDeviceSiteChain([{ id: 'dev-1', siteId: 'site-1' }]) as any)
+          .mockReturnValueOnce(mockAggregateChain({ total: 1, active: 1, acknowledged: 0, resolved: 0, critical: 1 }) as any);
+
+        const res = await app.request('/mobile/summary', { method: 'GET' });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Device stats reflect the allowed-site devices
+        expect(body.devices.total).toBe(3);
+        // Alert stats reflect the allowed device IDs
+        expect(body.alerts.total).toBe(1);
+        // Three db.select calls: device-agg, device-site-lookup, alert-agg
+        expect(selectMock).toHaveBeenCalledTimes(3);
+      });
+
+      it('returns zero alerts (but real device counts) when resolveSiteAllowedDeviceIds returns empty', async () => {
+        authState.permissions = { allowedSiteIds: ['site-1'] };
+
+        const selectMock = vi.mocked(db.select);
+        // Device stats: some devices returned
+        selectMock
+          .mockReturnValueOnce(mockAggregateChain({ total: 2, online: 1, offline: 1, maintenance: 0 }) as any)
+          // resolveSiteAllowedDeviceIds: no devices in the allowed site
+          .mockReturnValueOnce(mockDeviceSiteChain([]) as any);
+
+        const res = await app.request('/mobile/summary', { method: 'GET' });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Device stats already computed before the site-device resolution
+        expect(body.devices.total).toBe(2);
+        // Alert stats zeroed because no in-scope device IDs
+        expect(body.alerts.total).toBe(0);
+        // Only two db.select calls: no alert-agg issued (short-circuited)
+        expect(selectMock).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 
   describe('GET /mobile/search', () => {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1161,6 +1161,19 @@ mobileRoutes.get(
       deviceConditions.push(inArray(devices.orgId, orgCheck.orgIds));
     }
 
+    // Site-axis narrowing (app-layer only; RLS does NOT enforce site isolation).
+    // Mirrors /devices list (~891-897) and /alerts/inbox (~595-601) in this file.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    if (perms?.allowedSiteIds) {
+      if (perms.allowedSiteIds.length === 0) {
+        return c.json({
+          devices: { total: 0, online: 0, offline: 0, maintenance: 0 },
+          alerts: { total: 0, active: 0, acknowledged: 0, resolved: 0, critical: 0 }
+        });
+      }
+      deviceConditions.push(inArray(devices.siteId, perms.allowedSiteIds));
+    }
+
     const deviceWhere = deviceConditions.length > 0 ? and(...deviceConditions) : undefined;
 
     const deviceStats = await db
@@ -1176,6 +1189,23 @@ mobileRoutes.get(
     const alertConditions: ReturnType<typeof eq>[] = [];
     if (orgCheck.orgIds !== null) {
       alertConditions.push(inArray(alerts.orgId, orgCheck.orgIds));
+    }
+    // Alert site-axis: use resolveSiteAllowedDeviceIds (mirrors /alerts/inbox).
+    // Only restrict when we have an org context (partner/system spans multiple orgs).
+    if (perms?.allowedSiteIds && auth.orgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+      if (!allowedDeviceIds || allowedDeviceIds.length === 0) {
+        return c.json({
+          devices: {
+            total: Number(deviceStats[0]?.total ?? 0),
+            online: Number(deviceStats[0]?.online ?? 0),
+            offline: Number(deviceStats[0]?.offline ?? 0),
+            maintenance: Number(deviceStats[0]?.maintenance ?? 0)
+          },
+          alerts: { total: 0, active: 0, acknowledged: 0, resolved: 0, critical: 0 }
+        });
+      }
+      alertConditions.push(inArray(alerts.deviceId, allowedDeviceIds));
     }
     const alertWhere = alertConditions.length > 0 ? and(...alertConditions) : undefined;
 

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -5,6 +5,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+// Partial-mock drizzle-orm so `inArray` is a spy while every other operator
+// (and/or/eq/sql/...) stays real. The GET /rules site-narrowing test asserts
+// inArray(pamRules.siteId, allowedSiteIds) was actually built — removing the
+// production narrowing line makes that assertion fail.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)),
+  };
+});
+
 const authMocks = vi.hoisted(() => ({
   authMiddlewareMock: vi.fn(),
   requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
@@ -173,6 +185,7 @@ vi.mock('./softwarePolicies', () => ({
 }));
 
 import { db } from '../db';
+import { inArray } from 'drizzle-orm';
 import { pamRoutes } from './pam';
 import { assertApprovalAssurance, StepUpRequiredError, ReauthRequiredError } from '../services/authenticatorAssurance';
 import { requireCurrentPasswordStepUp } from './auth/helpers';
@@ -1597,6 +1610,7 @@ describe('PAM rules — site-axis enforcement', () => {
 
   it('site-restricted tech GET /rules narrows to allowed sites (other-site/org-wide hidden)', async () => {
     setSiteRestrictedAuth();
+    vi.mocked(inArray).mockClear();
     // The mock db ignores the WHERE predicate; assert the route builds a where
     // (inArray on pamRules.siteId) and returns the rows the DB layer would yield.
     const allowedRule = { id: RULE_ID, orgId: ORG_ID, siteId: ALLOWED_SITE, name: 'mine' };
@@ -1613,10 +1627,16 @@ describe('PAM rules — site-axis enforcement', () => {
     expect(body.rules).toEqual([allowedRule]);
     // A site-scoping WHERE predicate was applied (not just the bare org condition).
     expect(chain.where).toHaveBeenCalled();
+    // Load-bearing: the narrowing MUST be inArray(pamRules.siteId, allowedSiteIds).
+    // The schema mock exposes pamRules.siteId as the literal 'siteId'. If the
+    // production `inArray(pamRules.siteId, perms.allowedSiteIds)` line were
+    // removed, inArray would never be called with the site column and this fails.
+    expect(inArray).toHaveBeenCalledWith('siteId', [ALLOWED_SITE]);
   });
 
   it('unrestricted caller GET /rules returns rules without a site filter', async () => {
     // Default setAuth() => no allowedSiteIds.
+    vi.mocked(inArray).mockClear();
     const orgWide = { id: RULE_ID, orgId: ORG_ID, siteId: null, name: 'org-wide' };
     const chain: any = Promise.resolve([orgWide]);
     chain.from = vi.fn(() => chain);
@@ -1628,6 +1648,9 @@ describe('PAM rules — site-axis enforcement', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.rules).toEqual([orgWide]);
+    // No site narrowing for an unrestricted caller: inArray is never invoked
+    // with the pam_rules site column.
+    expect(inArray).not.toHaveBeenCalledWith('siteId', expect.anything());
   });
 });
 

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -65,6 +65,7 @@ vi.mock('../db/schema', () => ({
   pamRules: {
     id: 'id',
     orgId: 'orgId',
+    siteId: 'siteId',
     priority: 'priority',
     createdAt: 'createdAt',
     matchSignerGroupId: 'matchSignerGroupId',
@@ -1352,6 +1353,281 @@ describe('PATCH /pam/rules/:id shape validation (Phase 1)', () => {
     });
     expect(res.status).toBe(400);
     expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================
+// Rules CRUD — site-axis enforcement (intra-tenant site privilege escalation).
+// pam_rules is RLS Shape-1 (org_id only), so the SITE axis is app-layer-only.
+// A site-restricted tech (allowedSiteIds=[siteA]) with PAM write + MFA must not
+// author / modify / delete / read org-wide (siteId null) or other-site rules.
+// Unrestricted callers (no allowedSiteIds — the default setAuth()) keep org-wide
+// ability. Mirrors the canAccessSite gate already on the elevation handlers.
+// ============================================================
+describe('PAM rules — site-axis enforcement', () => {
+  const ALLOWED_SITE = '7b41c9a2-0000-4000-8000-000000000010';
+  const OTHER_SITE = '7b41c9a2-0000-4000-8000-000000000011';
+  const RULE_ID = '7b41c9a2-0000-4000-8000-000000000012';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+  });
+
+  afterEach(() => {
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.insert).mockReset();
+    vi.mocked(db.update).mockReset();
+    vi.mocked(db.delete).mockReset();
+  });
+
+  /** Auth as a tech restricted to ALLOWED_SITE only. */
+  function setSiteRestrictedAuth() {
+    authMocks.authMiddlewareMock.mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: USER_ID, email: 't@example.com' },
+        scope: 'organization',
+        orgId: ORG_ID,
+        canAccessOrg: (orgId: string) => orgId === ORG_ID,
+        orgCondition: () => undefined,
+      });
+      c.set('permissions', { allowedSiteIds: [ALLOWED_SITE] });
+      return next();
+    });
+  }
+
+  function mockExistingRule(rule: Record<string, unknown>) {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([rule]),
+        })),
+      })),
+    } as any);
+  }
+
+  function mockInsertReturning() {
+    const returning = vi.fn().mockResolvedValue([
+      { id: RULE_ID, name: 'r', verdict: 'auto_approve', priority: 100 },
+    ]);
+    vi.mocked(db.insert).mockReturnValue({ values: vi.fn(() => ({ returning })) } as any);
+  }
+
+  // ---- POST /rules ----
+
+  it('site-restricted tech is DENIED creating an org-wide (null siteId) rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockInsertReturning();
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'org-wide', verdict: 'auto_approve', matchHash: 'a'.repeat(64) }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Site access denied');
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech is DENIED creating an other-site rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockInsertReturning();
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'other-site',
+        verdict: 'auto_approve',
+        matchHash: 'a'.repeat(64),
+        siteId: OTHER_SITE,
+      }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Site access denied');
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech CAN create a rule for an allowed site (201)', async () => {
+    setSiteRestrictedAuth();
+    mockInsertReturning();
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'allowed-site',
+        verdict: 'auto_approve',
+        matchHash: 'a'.repeat(64),
+        siteId: ALLOWED_SITE,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { siteId: string };
+    expect(valuesArg.siteId).toBe(ALLOWED_SITE);
+  });
+
+  it('unrestricted caller CAN still create an org-wide (null siteId) rule (201)', async () => {
+    // Default setAuth() => permissions undefined (no allowedSiteIds).
+    mockInsertReturning();
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'org-wide', verdict: 'auto_approve', matchHash: 'a'.repeat(64) }),
+    });
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { siteId: string | null };
+    expect(valuesArg.siteId).toBeNull();
+  });
+
+  // ---- PATCH /rules/:id ----
+
+  it('site-restricted tech is DENIED patching an other-site rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({
+      id: RULE_ID,
+      orgId: ORG_ID,
+      siteId: OTHER_SITE,
+      matchHash: 'a'.repeat(64),
+      verdict: 'auto_approve',
+    });
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Site access denied');
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech is DENIED patching an org-wide (null siteId) rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({
+      id: RULE_ID,
+      orgId: ORG_ID,
+      siteId: null,
+      matchHash: 'a'.repeat(64),
+      verdict: 'auto_approve',
+    });
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech is DENIED moving an allowed-site rule to an other site (403)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({
+      id: RULE_ID,
+      orgId: ORG_ID,
+      siteId: ALLOWED_SITE,
+      matchHash: 'a'.repeat(64),
+      verdict: 'auto_approve',
+    });
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ siteId: OTHER_SITE }),
+    });
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech CAN patch an allowed-site rule (200)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({
+      id: RULE_ID,
+      orgId: ORG_ID,
+      siteId: ALLOWED_SITE,
+      matchHash: 'a'.repeat(64),
+      verdict: 'auto_approve',
+    });
+    const set = vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: RULE_ID }]) })) }));
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(db.update)).toHaveBeenCalled();
+  });
+
+  // ---- DELETE /rules/:id ----
+
+  it('site-restricted tech is DENIED deleting an other-site rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({ id: RULE_ID, orgId: ORG_ID, siteId: OTHER_SITE, name: 'other' });
+    const res = await app().request(`/pam/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Site access denied');
+    expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech is DENIED deleting an org-wide (null siteId) rule (403)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({ id: RULE_ID, orgId: ORG_ID, siteId: null, name: 'org-wide' });
+    const res = await app().request(`/pam/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+  });
+
+  it('site-restricted tech CAN delete an allowed-site rule (200)', async () => {
+    setSiteRestrictedAuth();
+    mockExistingRule({ id: RULE_ID, orgId: ORG_ID, siteId: ALLOWED_SITE, name: 'allowed' });
+    vi.mocked(db.delete).mockReturnValue({ where: vi.fn() } as any);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(db.delete)).toHaveBeenCalled();
+  });
+
+  it('unrestricted caller CAN still delete an org-wide rule (200)', async () => {
+    // Default setAuth() => no allowedSiteIds.
+    mockExistingRule({ id: RULE_ID, orgId: ORG_ID, siteId: null, name: 'org-wide' });
+    vi.mocked(db.delete).mockReturnValue({ where: vi.fn() } as any);
+    const res = await app().request(`/pam/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(db.delete)).toHaveBeenCalled();
+  });
+
+  // ---- GET /rules ----
+
+  it('site-restricted tech GET /rules narrows to allowed sites (other-site/org-wide hidden)', async () => {
+    setSiteRestrictedAuth();
+    // The mock db ignores the WHERE predicate; assert the route builds a where
+    // (inArray on pamRules.siteId) and returns the rows the DB layer would yield.
+    const allowedRule = { id: RULE_ID, orgId: ORG_ID, siteId: ALLOWED_SITE, name: 'mine' };
+    const chain: any = Promise.resolve([allowedRule]);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => chain);
+    vi.mocked(db.select).mockReturnValue(chain);
+
+    const res = await app().request('/pam/rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.rules).toEqual([allowedRule]);
+    // A site-scoping WHERE predicate was applied (not just the bare org condition).
+    expect(chain.where).toHaveBeenCalled();
+  });
+
+  it('unrestricted caller GET /rules returns rules without a site filter', async () => {
+    // Default setAuth() => no allowedSiteIds.
+    const orgWide = { id: RULE_ID, orgId: ORG_ID, siteId: null, name: 'org-wide' };
+    const chain: any = Promise.resolve([orgWide]);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => chain);
+    vi.mocked(db.select).mockReturnValue(chain);
+
+    const res = await app().request('/pam/rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rules).toEqual([orgWide]);
   });
 });
 

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -946,21 +946,47 @@ const previewRuleSchema = z
 
 pamRoutes.get('/rules', requirePamRead, async (c) => {
   const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+
+  // Site narrowing for site-restricted technicians (pam_rules is RLS Shape-1
+  // org-only, so the site axis is app-layer-only). Mirrors siteScopeCondition,
+  // bound to pamRules.siteId. Org-wide rules (siteId IS NULL) are hidden from a
+  // restricted caller since they govern every site, including ones it can't reach.
+  const where = and(
+    ...[
+      auth.orgCondition(pamRules.orgId),
+      !perms?.allowedSiteIds
+        ? undefined
+        : perms.allowedSiteIds.length === 0
+          ? sql`false`
+          : inArray(pamRules.siteId, perms.allowedSiteIds),
+    ].filter((cond): cond is SQL => cond !== undefined),
+  );
+
   const rows = await db
     .select()
     .from(pamRules)
-    .where(auth.orgCondition(pamRules.orgId))
+    .where(where)
     .orderBy(pamRules.priority, pamRules.createdAt);
   return c.json({ success: true, rules: rows });
 });
 
 pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', createRuleSchema), async (c) => {
   const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
   const payload = c.req.valid('json');
 
   const resolvedOrg = resolveOrgIdForWrite(auth, payload.orgId ?? c.req.query('orgId') ?? undefined);
   if (!resolvedOrg.orgId) {
     return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+  }
+
+  // Site axis is app-layer-only for pam_rules (RLS Shape-1 org-only). A
+  // site-restricted tech must not author org-wide (siteId null → '') or
+  // other-site rules. Unrestricted callers (no allowedSiteIds) keep org-wide
+  // ability. Mirrors the canAccessSite gate on the elevation handlers.
+  if (perms?.allowedSiteIds && !canAccessSite(perms, payload.siteId ?? '')) {
+    return c.json({ error: 'Site access denied' }, 403);
   }
 
   const [created] = await db
@@ -1159,6 +1185,7 @@ const updateRuleSchema = ruleBaseSchema.partial().omit({ orgId: true });
 
 pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', updateRuleSchema), async (c) => {
   const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
   const id = c.req.param('id');
   const payload = c.req.valid('json');
   if (!z.string().guid().safeParse(id).success) {
@@ -1168,6 +1195,19 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
   const [existing] = await db.select().from(pamRules).where(eq(pamRules.id, id!)).limit(1);
   if (!existing || !auth.canAccessOrg(existing.orgId)) {
     return c.json({ error: 'Rule not found' }, 404);
+  }
+
+  // Site axis is app-layer-only (pam_rules RLS Shape-1 org-only). A site-restricted
+  // tech must be able to reach BOTH the existing rule's site and any new target
+  // site (org-wide null → '' which a restricted caller never holds). Unrestricted
+  // callers keep org-wide ability. Mirrors canAccessSite on the elevation handlers.
+  if (perms?.allowedSiteIds) {
+    if (!canAccessSite(perms, existing.siteId ?? '')) {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
+    if (payload.siteId !== undefined && !canAccessSite(perms, payload.siteId ?? '')) {
+      return c.json({ error: 'Site access denied' }, 403);
+    }
   }
 
   // The merged result must still be a valid rule shape (criterion present,
@@ -1230,6 +1270,7 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
 
 pamRoutes.delete('/rules/:id', requirePamWrite, requireMfa(), async (c) => {
   const auth = c.get('auth');
+  const perms = c.get('permissions') as UserPermissions | undefined;
   const id = c.req.param('id');
   if (!z.string().guid().safeParse(id).success) {
     return c.json({ error: 'Invalid rule id' }, 400);
@@ -1238,6 +1279,13 @@ pamRoutes.delete('/rules/:id', requirePamWrite, requireMfa(), async (c) => {
   const [existing] = await db.select().from(pamRules).where(eq(pamRules.id, id!)).limit(1);
   if (!existing || !auth.canAccessOrg(existing.orgId)) {
     return c.json({ error: 'Rule not found' }, 404);
+  }
+
+  // Site axis is app-layer-only (pam_rules RLS Shape-1 org-only). A site-restricted
+  // tech must reach the target rule's site (org-wide null → '' which a restricted
+  // caller never holds). Unrestricted callers keep org-wide ability.
+  if (perms?.allowedSiteIds && !canAccessSite(perms, existing.siteId ?? '')) {
+    return c.json({ error: 'Site access denied' }, 403);
   }
 
   await db.delete(pamRules).where(eq(pamRules.id, id!));

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -74,6 +74,7 @@ vi.mock('../services/permissions', () => ({
 }));
 
 import { db } from '../db';
+import { getUserPermissions } from '../services/permissions';
 
 describe('search routes', () => {
   let app: Hono;
@@ -209,5 +210,126 @@ describe('search routes', () => {
   it('validates required query parameter', async () => {
     const res = await app.request('/search');
     expect(res.status).toBe(400);
+  });
+
+  describe('site-axis narrowing for device search', () => {
+    it('returns empty device results when site-restricted caller has empty allowedSiteIds (fail-closed)', async () => {
+      // Override getUserPermissions to simulate a site-restricted caller with no in-scope sites.
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [
+          { resource: 'devices', action: 'read' },
+          { resource: 'scripts', action: 'read' },
+          { resource: 'alerts', action: 'read' },
+          { resource: 'users', action: 'read' },
+        ],
+        allowedSiteIds: [],
+        partnerId: null,
+        orgId: 'org-1',
+        roleId: 'role-1',
+        scope: 'organization',
+      } as any);
+
+      // scripts and alerts return empty; device query must include sql`false` site condition
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as never);
+
+      const res = await app.request('/search?q=host');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // No device results — site filter is sql`false` for empty allowedSiteIds
+      expect(body.results.filter((r: { type?: string }) => r.type === 'devices')).toHaveLength(0);
+    });
+
+    it('passes allowedSiteIds condition through to device query for site-restricted callers', async () => {
+      // Override getUserPermissions to simulate a site-restricted caller with one allowed site.
+      vi.mocked(getUserPermissions).mockResolvedValueOnce({
+        permissions: [
+          { resource: 'devices', action: 'read' },
+          { resource: 'scripts', action: 'read' },
+          { resource: 'alerts', action: 'read' },
+        ],
+        allowedSiteIds: ['site-abc'],
+        partnerId: null,
+        orgId: 'org-1',
+        roleId: 'role-1',
+        scope: 'organization',
+      } as any);
+
+      const selectSpy = vi.mocked(db.select);
+      let capturedDeviceWhere: unknown;
+      selectSpy
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation((condition: unknown) => {
+              capturedDeviceWhere = condition;
+              return { limit: vi.fn().mockResolvedValue([]) };
+            })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        } as never);
+
+      const res = await app.request('/search?q=anything');
+      expect(res.status).toBe(200);
+      // A non-null where condition was passed (includes the site inArray filter)
+      expect(capturedDeviceWhere).toBeDefined();
+    });
+
+    it('unrestricted caller (no allowedSiteIds) returns device results normally', async () => {
+      // Default mock has no allowedSiteIds — no site restriction.
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                { id: 'dev-1', title: 'Workstation', hostname: 'ws-01', status: 'online', lastUser: null }
+              ])
+            })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        } as never);
+
+      const res = await app.request('/search?q=ws');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results.some((r: { type?: string }) => r.type === 'devices')).toBe(true);
+    });
   });
 });

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -2,6 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { searchRoutes } from './search';
 
+// Partial-mock drizzle-orm so `inArray` is a spy while every other operator
+// (and/or/ilike/isNull/sql) stays real. This lets the site-narrowing tests
+// prove that the device branch actually calls inArray(devices.siteId,
+// allowedSiteIds) — deleting that production line makes the assertion fail.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)),
+  };
+});
+
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -15,6 +27,7 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
     hostname: 'devices.hostname',
     displayName: 'devices.displayName',
     status: 'devices.status'
@@ -74,6 +87,7 @@ vi.mock('../services/permissions', () => ({
 }));
 
 import { db } from '../db';
+import { inArray } from 'drizzle-orm';
 import { getUserPermissions } from '../services/permissions';
 
 describe('search routes', () => {
@@ -260,7 +274,8 @@ describe('search routes', () => {
       expect(body.results.filter((r: { type?: string }) => r.type === 'devices')).toHaveLength(0);
     });
 
-    it('passes allowedSiteIds condition through to device query for site-restricted callers', async () => {
+    it('narrows the device query with inArray(devices.siteId, allowedSiteIds) for site-restricted callers', async () => {
+      vi.mocked(inArray).mockClear();
       // Override getUserPermissions to simulate a site-restricted caller with one allowed site.
       vi.mocked(getUserPermissions).mockResolvedValueOnce({
         permissions: [
@@ -301,6 +316,10 @@ describe('search routes', () => {
       expect(res.status).toBe(200);
       // A non-null where condition was passed (includes the site inArray filter)
       expect(capturedDeviceWhere).toBeDefined();
+      // Load-bearing: the device branch MUST narrow on the site column. If the
+      // production `inArray(devices.siteId, allowedSiteIds)` line were removed,
+      // this assertion fails (inArray would never be called with the site column).
+      expect(inArray).toHaveBeenCalledWith('devices.siteId', ['site-abc']);
     });
 
     it('unrestricted caller (no allowedSiteIds) returns device results normally', async () => {

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, ilike, isNull, or } from 'drizzle-orm';
+import { and, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { db } from '../db';
 import { alerts, devices, scripts } from '../db/schema';
 import { authMiddleware, type AuthContext } from '../middleware/auth';
-import { getUserPermissions, hasPermission, PERMISSIONS } from '../services/permissions';
+import { getUserPermissions, hasPermission, PERMISSIONS, type UserPermissions } from '../services/permissions';
 
 const searchQuerySchema = z.object({
   q: z.string().trim().min(1).max(100),
@@ -79,6 +79,15 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
     return auth.orgCondition(column);
   };
 
+  // Site-axis narrowing (app-layer only; RLS does NOT enforce site isolation).
+  // mirrors core.ts:~424-435 / reports/data.ts:~67-72.
+  const allowedSiteIds = (userPerms as UserPermissions | null)?.allowedSiteIds;
+  const deviceSiteCondition = allowedSiteIds
+    ? allowedSiteIds.length > 0
+      ? inArray(devices.siteId, allowedSiteIds)
+      : sql`false`
+    : undefined;
+
   const deviceQuery = or(
     ilike(devices.hostname, searchTerm),
     ilike(devices.displayName, searchTerm),
@@ -96,6 +105,12 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
     ilike(alerts.message, searchTerm)
   );
 
+  const deviceWhereCondition = and(
+    orgConditionFor(devices.orgId),
+    deviceSiteCondition,
+    deviceQuery,
+  );
+
   const [deviceRows, scriptRows, alertRows] = await Promise.all([
     canReadDevices
       ? db
@@ -107,7 +122,7 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
             lastUser: devices.lastUser
           })
           .from(devices)
-          .where(orgConditionFor(devices.orgId) ? and(orgConditionFor(devices.orgId) as never, deviceQuery as never) : deviceQuery)
+          .where(deviceWhereCondition)
           .limit(perCategoryLimit)
       : Promise.resolve([]),
     canReadScripts

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -5,6 +5,8 @@ import { Hono } from 'hono';
 // the repo's usual pass-through mock, this one actually consults the set so the
 // test faithfully verifies WHICH permission gates WHICH route.
 const granted = new Set<string>();
+// Mutable permissions object set by requirePermission (mirrors authMiddleware production behaviour).
+const permissionsState: { allowedSiteIds?: string[] } = {};
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: (c: any, next: any) => {
@@ -21,7 +23,11 @@ vi.mock('../middleware/auth', () => ({
   requireScope: () => (_c: any, next: any) => next(),
   requireMfa: () => (_c: any, next: any) => next(),
   requirePermission: (resource: string, action: string) => (c: any, next: any) => {
-    if (granted.has(`${resource}:${action}`) || granted.has('*:*')) return next();
+    if (granted.has(`${resource}:${action}`) || granted.has('*:*')) {
+      // Mirror prod: requirePermission populates the `permissions` context variable.
+      c.set('permissions', { ...permissionsState });
+      return next();
+    }
     return c.json({ error: 'Forbidden' }, 403);
   },
 }));
@@ -77,6 +83,8 @@ const future = new Date(Date.now() + 7 * 864e5).toISOString();
 
 beforeEach(() => {
   granted.clear();
+  // Reset site-restriction state (unrestricted by default).
+  delete permissionsState.allowedSiteIds;
   // Reaching any route requires the router-level devices:read gate.
   granted.add('devices:read');
 });
@@ -110,5 +118,74 @@ describe('vulnerability accept-risk / reopen RBAC', () => {
     granted.add('devices:write');
     const res = await post(`/${ID}/mitigate`, { note: 'compensating control' });
     expect(res.status).toBe(404);
+  });
+});
+
+import { db } from '../db';
+
+describe('vulnerability fleet GET / — site-axis narrowing', () => {
+  function fleetApp() {
+    const a = new Hono();
+    a.route('/vulnerabilities', vulnerabilityRoutes);
+    return a;
+  }
+
+  beforeEach(() => {
+    granted.clear();
+    delete permissionsState.allowedSiteIds;
+    granted.add('devices:read');
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('returns empty fleet for site-restricted caller with empty allowedSiteIds (fail-closed)', async () => {
+    permissionsState.allowedSiteIds = [];
+    // listVulnerabilities short-circuits before querying when allowedSiteIds is empty.
+    const res = await fleetApp().request('/vulnerabilities');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    // db.select should not have been called (early return path).
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+
+  it('queries allowed device ids by site then filters deviceVulnerabilities for a site-restricted caller', async () => {
+    permissionsState.allowedSiteIds = ['site-1'];
+    const selectMock = vi.mocked(db.select);
+
+    // First call: resolve device IDs in the allowed site.
+    selectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: 'dev-abc' }]),
+      }),
+    } as never);
+    // Second call: query deviceVulnerabilities (returns empty → no findings).
+    selectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as never);
+
+    const res = await fleetApp().request('/vulnerabilities');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    // Both the device-id resolution query and the vulnerabilities query were issued.
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips site narrowing for unrestricted caller (no allowedSiteIds)', async () => {
+    // No allowedSiteIds set → no device-id resolution query.
+    const selectMock = vi.mocked(db.select);
+    // Only one select: deviceVulnerabilities (no site device-id lookup).
+    selectMock.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as never);
+
+    const res = await fleetApp().request('/vulnerabilities');
+    expect(res.status).toBe(200);
+    // Only one db.select call: the deviceVulnerabilities query, no site-device lookup.
+    expect(selectMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -6,7 +6,7 @@ import { and, desc, eq, ilike, inArray, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
 import { writeRouteAudit } from '../services/auditEvents';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
@@ -230,6 +230,9 @@ async function listVulnerabilities(filters: {
   deviceId?: string;
   severity?: string;
   cve?: string;
+  /** Site-axis narrowing: when set, only return findings for devices in these sites.
+   *  Empty array = caller has no in-scope sites → return nothing (fail-closed). */
+  allowedSiteIds?: string[];
 }) {
   const conditions: SQL[] = [];
   // 'all' means no status filter — return every status. Any other value is
@@ -239,6 +242,23 @@ async function listVulnerabilities(filters: {
   }
   if (filters.deviceId) {
     conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));
+  }
+  // Site-axis (app-layer only; RLS does NOT enforce site isolation). Mirrors
+  // assertDeviceSiteAccess used by per-device routes in this file and
+  // the allowedSiteIds filter pattern in reports/data.ts.
+  if (filters.allowedSiteIds !== undefined) {
+    if (filters.allowedSiteIds.length === 0) {
+      return [];
+    }
+    const allowedDeviceRows = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .where(inArray(devices.siteId, filters.allowedSiteIds));
+    const allowedDeviceIds = allowedDeviceRows.map((r) => r.id);
+    if (allowedDeviceIds.length === 0) {
+      return [];
+    }
+    conditions.push(inArray(deviceVulnerabilities.deviceId, allowedDeviceIds));
   }
 
   const deviceRows = await db
@@ -321,7 +341,14 @@ vulnerabilityRoutes.use('*', requireVulnerabilityRead);
 
 vulnerabilityRoutes.get('/', zValidator('query', listQuerySchema), async (c) => {
   const query = c.req.valid('query');
-  const items = await listVulnerabilities(query);
+  // Site-axis narrowing for the fleet view: per-device routes already gate via
+  // assertDeviceSiteAccess; this fleet (all-devices) query must also restrict to
+  // the caller's allowed sites. Mirrors the site-filter pattern in core.ts.
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const items = await listVulnerabilities({
+    ...query,
+    allowedSiteIds: perms?.allowedSiteIds,
+  });
   return c.json({ items: aggregateFleet(items) });
 });
 

--- a/apps/api/src/services/aiToolsMonitoring.test.ts
+++ b/apps/api/src/services/aiToolsMonitoring.test.ts
@@ -1,0 +1,307 @@
+/**
+ * aiToolsMonitoring — manage_monitors site-axis gate tests.
+ *
+ * Verifies that the manage_monitors tool's get/update/delete actions enforce
+ * the intra-org site axis for site-restricted callers (auth.canAccessSite set).
+ * The list action (query_monitors) has its own site gate; these tests cover the
+ * per-monitor CRUD actions that previously skipped the axis entirely.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema/monitors', () => ({
+  networkMonitors: {
+    id: 'nm.id',
+    orgId: 'nm.orgId',
+    name: 'nm.name',
+    assetId: 'nm.assetId',
+  },
+  networkMonitorResults: {
+    id: 'nmr.id',
+    monitorId: 'nmr.monitorId',
+    status: 'nmr.status',
+    responseMs: 'nmr.responseMs',
+    statusCode: 'nmr.statusCode',
+    error: 'nmr.error',
+    details: 'nmr.details',
+    timestamp: 'nmr.timestamp',
+  },
+  networkMonitorAlertRules: {
+    id: 'nmar.id',
+    monitorId: 'nmar.monitorId',
+    condition: 'nmar.condition',
+    threshold: 'nmar.threshold',
+    severity: 'nmar.severity',
+    message: 'nmar.message',
+    isActive: 'nmar.isActive',
+  },
+}));
+
+vi.mock('../db/schema/serviceProcessMonitoring', () => ({
+  serviceProcessCheckResults: {},
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceChangeLog: {},
+  discoveredAssets: {
+    id: 'da.id',
+    orgId: 'da.orgId',
+    siteId: 'da.siteId',
+  },
+}));
+
+import { db } from '../db';
+import { registerMonitoringTools } from './aiToolsMonitoring';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+// Build the aiTools registry and extract manage_monitors handler.
+function buildManageMonitors(): (input: Record<string, unknown>, auth: AuthContext) => Promise<string> {
+  const map = new Map<string, AiTool>();
+  registerMonitoringTools(map);
+  const tool = map.get('manage_monitors');
+  if (!tool) throw new Error('manage_monitors not registered');
+  return tool.handler as (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
+}
+
+// Unrestricted org-scope caller.
+function makeUnrestrictedAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'u@example.com', name: 'U', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as AuthContext;
+}
+
+// Site-restricted caller: only allowed into site-1.
+function makeSiteRestrictedAuth(): AuthContext {
+  return {
+    ...makeUnrestrictedAuth(),
+    allowedSiteIds: ['site-1'],
+    canAccessSite: (siteId: string | null | undefined) => siteId === 'site-1',
+  };
+}
+
+const MONITOR_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const ASSET_ALLOWED = 'bbbbbbbb-0000-0000-0000-000000000001';
+const ASSET_DENIED  = 'cccccccc-0000-0000-0000-000000000002';
+
+// A monitor whose linked asset is in site-1 (allowed).
+const monitorInAllowedSite = { id: MONITOR_ID, orgId: 'org-1', assetId: ASSET_ALLOWED, name: 'Allowed Monitor', updatedAt: new Date() };
+// A monitor whose linked asset is in site-2 (denied) or has no asset.
+const monitorInDeniedSite  = { id: MONITOR_ID, orgId: 'org-1', assetId: ASSET_DENIED,  name: 'Denied Monitor',  updatedAt: new Date() };
+const monitorNoAsset       = { id: MONITOR_ID, orgId: 'org-1', assetId: null,           name: 'Assetless',       updatedAt: new Date() };
+
+// Chain for networkMonitors lookup (select().from().where().limit() → [monitor]).
+function monitorLookup(monitor: typeof monitorInAllowedSite | typeof monitorNoAsset | null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(monitor ? [monitor] : []) }),
+    }),
+  } as any;
+}
+
+// Chain for discoveredAssets lookup (select().from().where().limit() → [{siteId}]).
+function assetLookup(siteId: string | null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(siteId ? [{ siteId }] : []) }),
+    }),
+  } as any;
+}
+
+// Chain for networkMonitorResults/networkMonitorAlertRules (select().from().where().orderBy().limit()).
+function resultsLookup() {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }) }),
+    }),
+  } as any;
+}
+
+// Chain for networkMonitorAlertRules (select().from().where()).
+function rulesLookup() {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([]),
+    }),
+  } as any;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('manage_monitors — site-axis enforcement', () => {
+  let handle: (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
+
+  beforeEach(() => {
+    handle = buildManageMonitors();
+  });
+
+  // ─── get action ──────────────────────────────────────────────────────────
+
+  describe('action: get', () => {
+    it('allows unrestricted caller to read a monitor (no site check)', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInDeniedSite)) // monitor row
+        .mockReturnValueOnce(resultsLookup())                    // recent results
+        .mockReturnValueOnce(rulesLookup());                     // alert rules
+
+      const out = JSON.parse(await handle({ action: 'get', monitorId: MONITOR_ID }, makeUnrestrictedAuth()));
+      expect(out).not.toHaveProperty('error');
+      expect(out.monitor).toBeDefined();
+    });
+
+    it('denies site-restricted caller when monitor asset is in a forbidden site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInDeniedSite)) // monitor row
+        .mockReturnValueOnce(assetLookup('site-2'));             // asset lookup → site-2 (denied)
+
+      const out = JSON.parse(await handle({ action: 'get', monitorId: MONITOR_ID }, makeSiteRestrictedAuth()));
+      expect(out.error).toMatch(/not found or access denied/i);
+    });
+
+    it('denies site-restricted caller when monitor has no linked asset (fail-closed)', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorNoAsset)); // monitor row (assetId null)
+      // No asset lookup needed — assertMonitorSiteAccess returns false immediately.
+
+      const out = JSON.parse(await handle({ action: 'get', monitorId: MONITOR_ID }, makeSiteRestrictedAuth()));
+      expect(out.error).toMatch(/not found or access denied/i);
+    });
+
+    it('allows site-restricted caller when monitor asset is in an allowed site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInAllowedSite)) // monitor row
+        .mockReturnValueOnce(assetLookup('site-1'))               // asset lookup → site-1 (allowed)
+        .mockReturnValueOnce(resultsLookup())                     // recent results
+        .mockReturnValueOnce(rulesLookup());                      // alert rules
+
+      const out = JSON.parse(await handle({ action: 'get', monitorId: MONITOR_ID }, makeSiteRestrictedAuth()));
+      expect(out).not.toHaveProperty('error');
+      expect(out.monitor).toBeDefined();
+    });
+  });
+
+  // ─── update action ───────────────────────────────────────────────────────
+
+  describe('action: update', () => {
+    it('denies site-restricted caller updating a monitor in a forbidden site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInDeniedSite)) // monitor row
+        .mockReturnValueOnce(assetLookup('site-2'));             // asset → site-2 (denied)
+
+      const out = JSON.parse(await handle(
+        { action: 'update', monitorId: MONITOR_ID, name: 'hacked' },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.error).toMatch(/not found or access denied/i);
+      // db.update must NOT have been called
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('denies site-restricted caller updating a monitor with no asset (fail-closed)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(monitorLookup(monitorNoAsset));
+
+      const out = JSON.parse(await handle(
+        { action: 'update', monitorId: MONITOR_ID, name: 'hacked' },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.error).toMatch(/not found or access denied/i);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('allows site-restricted caller to update a monitor in an allowed site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInAllowedSite)) // monitor row
+        .mockReturnValueOnce(assetLookup('site-1'));              // asset → site-1 (allowed)
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      } as any);
+
+      const out = JSON.parse(await handle(
+        { action: 'update', monitorId: MONITOR_ID, name: 'renamed' },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.success).toBe(true);
+      expect(vi.mocked(db.update)).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ─── delete action ───────────────────────────────────────────────────────
+
+  describe('action: delete', () => {
+    it('denies site-restricted caller deleting a monitor in a forbidden site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInDeniedSite))
+        .mockReturnValueOnce(assetLookup('site-2'));
+
+      const out = JSON.parse(await handle(
+        { action: 'delete', monitorId: MONITOR_ID },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.error).toMatch(/not found or access denied/i);
+      expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+    });
+
+    it('denies site-restricted caller deleting a monitor with no asset (fail-closed)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(monitorLookup(monitorNoAsset));
+
+      const out = JSON.parse(await handle(
+        { action: 'delete', monitorId: MONITOR_ID },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.error).toMatch(/not found or access denied/i);
+      expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+    });
+
+    it('allows site-restricted caller to delete a monitor in an allowed site', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInAllowedSite))
+        .mockReturnValueOnce(assetLookup('site-1'));
+      vi.mocked(db.delete).mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const out = JSON.parse(await handle(
+        { action: 'delete', monitorId: MONITOR_ID },
+        makeSiteRestrictedAuth(),
+      ));
+      expect(out.success).toBe(true);
+      expect(vi.mocked(db.delete)).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ─── unrestricted caller invariant ───────────────────────────────────────
+
+  describe('unrestricted caller bypass', () => {
+    it('get action: unrestricted caller always passes site check regardless of asset siteId', async () => {
+      // For an unrestricted caller, assertMonitorSiteAccess returns true without
+      // querying discoveredAssets — only the monitor lookup + results + rules queries run.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(monitorLookup(monitorInDeniedSite)) // monitor row
+        .mockReturnValueOnce(resultsLookup())                    // results (no asset lookup between)
+        .mockReturnValueOnce(rulesLookup());                     // rules
+
+      const out = JSON.parse(await handle({ action: 'get', monitorId: MONITOR_ID }, makeUnrestrictedAuth()));
+      expect(out).not.toHaveProperty('error');
+      // Exactly 3 select calls — no asset lookup issued
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/apps/api/src/services/aiToolsMonitoring.ts
+++ b/apps/api/src/services/aiToolsMonitoring.ts
@@ -171,6 +171,27 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
       const action = input.action as string;
       const orgId = getOrgId(auth);
 
+      /**
+       * Site-axis check for a loaded monitor (app-layer; RLS does NOT enforce
+       * site isolation). Mirrors hasMonitorSiteAccess in routes/monitors.ts:
+       * resolve the monitor's linked asset's siteId, then check canAccessSite.
+       * A monitor with no linked asset is denied for a site-restricted caller
+       * (fail-closed — same as query_monitors list handler ~101-113).
+       * Unrestricted callers (canAccessSite undefined) always pass.
+       */
+      async function assertMonitorSiteAccess(
+        monitor: { id: string; assetId: string | null; orgId: string },
+      ): Promise<boolean> {
+        if (!auth.canAccessSite) return true; // unrestricted caller
+        if (!monitor.assetId) return false;   // no asset → fail-closed
+        const [asset] = await db
+          .select({ siteId: discoveredAssets.siteId })
+          .from(discoveredAssets)
+          .where(and(eq(discoveredAssets.id, monitor.assetId), eq(discoveredAssets.orgId, monitor.orgId)))
+          .limit(1);
+        return typeof asset?.siteId === 'string' && auth.canAccessSite(asset.siteId);
+      }
+
       if (action === 'get') {
         if (!input.monitorId) return JSON.stringify({ error: 'monitorId is required' });
 
@@ -180,6 +201,11 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
 
         const [monitor] = await db.select().from(networkMonitors).where(and(...conditions)).limit(1);
         if (!monitor) return JSON.stringify({ error: 'Monitor not found or access denied' });
+
+        // Site-axis gate — deny same as "not found" (no oracle).
+        if (!(await assertMonitorSiteAccess(monitor))) {
+          return JSON.stringify({ error: 'Monitor not found or access denied' });
+        }
 
         // Get recent check results
         const historyLimit = Math.min(Math.max(1, Number(input.limit) || 50), 100);
@@ -240,6 +266,11 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
         const [existing] = await db.select().from(networkMonitors).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Monitor not found or access denied' });
 
+        // Site-axis gate — deny same as "not found" (no oracle).
+        if (!(await assertMonitorSiteAccess(existing))) {
+          return JSON.stringify({ error: 'Monitor not found or access denied' });
+        }
+
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;
         if (typeof input.target === 'string') updates.target = input.target;
@@ -261,6 +292,11 @@ export function registerMonitoringTools(aiTools: Map<string, AiTool>): void {
 
         const [existing] = await db.select().from(networkMonitors).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Monitor not found or access denied' });
+
+        // Site-axis gate — deny same as "not found" (no oracle).
+        if (!(await assertMonitorSiteAccess(existing))) {
+          return JSON.stringify({ error: 'Monitor not found or access denied' });
+        }
 
         // Cascade delete handles results and alert rules via FK onDelete: 'cascade'
         await db.delete(networkMonitors).where(eq(networkMonitors.id, existing.id));


### PR DESCRIPTION
## App-layer site-axis enforcement (RLS is org-only)

`devices` RLS is **org-axis only**; site restriction (`allowedSiteIds`) is app-layer. A site-restricted user holds legit org access, so RLS returns all-org rows — the missing `inArray(devices.siteId, allowedSiteIds)` / `canAccessSite` is the only control. These skipped it:

- **search** `GET /search` — leaked out-of-site device hostname/lastUser/status.
- **vulnerabilities** fleet `GET /vulnerabilities` — leaked other sites' CVE posture.
- **mobile** `GET /mobile/summary` — leaked org-wide device/alert counts (incl. # CRITICAL).
- **aiTools `manage_monitors`** get/update/delete — could read/rewrite/delete another site's monitor (the `list` action already enforced it).
- **PAM rules CRUD** *(HIGH)* — a site-restricted tech could author org-wide/cross-site `auto_approve` rules, flip/weaken cross-site rules, delete protective `auto_deny` rules. Now mirrors the site enforcement already on the elevation handlers.

**Verification:** API package `tsc --noEmit` clean; all changed-file unit suites green (single-fork). RLS contract + integration tests not run locally (need DB) — rely on CI.
Origin: `/security-review` playbook entry 1 (multi-tenant RLS + authz) two-pass workflow + Codex review pass.
