### PR TITLE
fix(api): add missing authz/authn gates (security RBAC, step-up, signing caps)

### DIFF
--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -341,9 +341,9 @@ describe('approver device routes', () => {
     expect(dbState.updateSets).toContainEqual(expect.objectContaining({ label: 'New Name' }));
   });
 
-  // --- Passwordless registration (POST /devices) — activates on first signature ---
+  // --- Mobile hardware-key registration (POST /devices) — password step-up required, activates on first signature ---
 
-  it('registers a mobile_hw_key with no password and stores it pending', async () => {
+  it('registers a mobile_hw_key after the current-password step-up and stores it pending', async () => {
     dbState.insertReturning = [
       {
         ...deviceRow,
@@ -359,13 +359,21 @@ describe('approver device routes', () => {
     const res = await app.request('/authenticator/devices', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
+      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
     });
 
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.device.id).toBe('mobile-pending-1');
     expect(body.device.label).toBe('iPhone');
+
+    // Step-up must have been called before insert, matching the sibling's key prefix.
+    expect(helperMocks.requireCurrentPasswordStepUp).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-123',
+      'correct-password',
+      'authenticator:pwd',
+    );
 
     const inserted = dbState.insertValues[0];
     expect(inserted).toMatchObject({
@@ -381,14 +389,44 @@ describe('approver device routes', () => {
     // stays null until the first approval signature flips it active (server-side,
     // in the assurance path).
     expect(inserted).not.toHaveProperty('lastUsedAt');
-    // No proof-of-possession at registration time — the password step-up and the
-    // PoP nonce are gone; the first signature is the deferred proof.
     expect(mobileHwKeyMocks.verifyMobileSignature).not.toHaveBeenCalled();
-    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
     expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ action: 'auth.authenticator.device.register' }),
     );
+  });
+
+  it('rejects mobile_hw_key registration when currentPassword is missing (400)', async () => {
+    const res = await app.request('/authenticator/devices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
+    });
+    expect(res.status).toBe(400);
+    expect(helperMocks.requireCurrentPasswordStepUp).not.toHaveBeenCalled();
+    expect(dbState.insertValues).toHaveLength(0);
+  });
+
+  it('rejects mobile_hw_key registration when the password step-up fails (401)', async () => {
+    helperMocks.requireCurrentPasswordStepUp.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Invalid credentials' }), { status: 401 }),
+    );
+
+    const res = await app.request('/authenticator/devices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'wrong-password' }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(helperMocks.requireCurrentPasswordStepUp).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-123',
+      'wrong-password',
+      'authenticator:pwd',
+    );
+    // No insert should happen when the step-up is rejected.
+    expect(dbState.insertValues).toHaveLength(0);
   });
 
   it('records the per-install mobileDeviceId from the header on registration', async () => {
@@ -410,7 +448,7 @@ describe('approver device routes', () => {
         Authorization: 'Bearer access-token',
         'X-Breeze-Mobile-Device-Id': '11111111-2222-3333-4444-555555555555',
       },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
+      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
     });
 
     expect(res.status).toBe(201);
@@ -418,21 +456,21 @@ describe('approver device routes', () => {
     expect(inserted).toMatchObject({ kind: 'mobile_hw_key', mobileDeviceId: '11111111-2222-3333-4444-555555555555' });
   });
 
-  it('requires authentication for passwordless registration', async () => {
+  it('requires authentication for mobile_hw_key registration', async () => {
     const res = await app.request('/authenticator/devices', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
+      body: JSON.stringify({ kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
     });
     expect(res.status).toBe(401);
     expect(dbState.insertValues).toHaveLength(0);
   });
 
-  it('rejects passwordless registration with a missing publicKey (400)', async () => {
+  it('rejects mobile_hw_key registration with a missing publicKey (400)', async () => {
     const res = await app.request('/authenticator/devices', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
-      body: JSON.stringify({ kind: 'mobile_hw_key', label: 'iPhone', isPlatformBound: true }),
+      body: JSON.stringify({ kind: 'mobile_hw_key', label: 'iPhone', isPlatformBound: true, currentPassword: 'correct-password' }),
     });
     expect(res.status).toBe(400);
     expect(dbState.insertValues).toHaveLength(0);

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -35,9 +35,10 @@ const registerVerifySchema = z.object({
   label: deviceLabelSchema.optional(),
 });
 
-// Mobile hardware-key registration (passwordless, deferred proof-of-possession):
-// the phone POSTs only its freshly generated Secure-Enclave / Keystore SPKI
-// public key + a label. No password step-up and no registration-time signature —
+// Mobile hardware-key registration — requires a current-password step-up.
+// The phone POSTs its freshly generated Secure-Enclave / Keystore SPKI public
+// key + a label, plus the account password to prove the caller controls the
+// account (not merely a stolen access token). No registration-time signature —
 // the key is stored PENDING (last_used_at null) and ACTIVATES on its first
 // approval signature, which is verified in the assurance path.
 //
@@ -45,9 +46,12 @@ const registerVerifySchema = z.object({
 // discriminators (the mobile client sends them); we tolerate but do NOT trust
 // them — the server forces kind='mobile_hw_key' and is_platform_bound=true. The
 // authoritative `publicKey` + `label` are re-validated through the shared
-// `mobileHwKeyRegisterSchema` (`.strict()`) before insert.
+// `mobileHwKeyRegisterSchema` (`.strict()`) before insert; `currentPassword` is
+// intentionally stripped prior to that parse so the strict schema doesn't reject
+// the field.
 const mobileRegisterSchema = z
   .object({
+    currentPassword: z.string().min(1).max(256),
     kind: z.literal('mobile_hw_key').optional(),
     isPlatformBound: z.boolean().optional(),
   })
@@ -185,10 +189,11 @@ authenticatorRoutes.post(
   }
 );
 
-// Mobile hardware-key registration — passwordless, single step. The phone POSTs
-// its Secure-Enclave / Keystore public key the moment it has one (right after
-// login); there is NO password step-up and NO registration-time proof-of-
-// possession. The row is inserted PENDING (`last_used_at` null) and is ACTIVATED
+// Mobile hardware-key registration — password step-up required, then deferred PoP.
+// The phone POSTs its Secure-Enclave / Keystore public key plus the account
+// password (step-up), which proves the caller controls the account and not merely
+// a stolen access token. There is NO registration-time proof-of-possession
+// signature — the row is inserted PENDING (`last_used_at` null) and is ACTIVATED
 // on its first real approval signature, verified in
 // `authenticatorAssurance.verifyMobileFactor` (which sets `last_used_at`). The
 // deferred-PoP design means a registered-but-never-used key can never satisfy an
@@ -200,6 +205,19 @@ authenticatorRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
+
+    // Password step-up mirrors /devices/webauthn/options — registering an
+    // approver device with a stolen access token is the attack this guards
+    // against. The caller proves they know the account password before any SPKI
+    // key is stored. `currentPassword` is validated by the outer
+    // `mobileRegisterSchema` (required, non-empty) before reaching here.
+    const passwordError = await requireCurrentPasswordStepUp(
+      c,
+      auth.user.id,
+      body.currentPassword,
+      'authenticator:pwd'
+    );
+    if (passwordError) return passwordError;
 
     // Re-validate the authoritative fields through the shared strict schema; the
     // client-asserted kind/isPlatformBound discriminators are ignored (the server

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -39,6 +39,19 @@ import { MsiSigningService } from "../services/msiSigning";
 import { getGithubReleaseVersion } from "../services/binarySource";
 import { captureException } from "../services/sentry";
 
+// ============================================================
+// Signing-spend caps for the authenticated installer endpoint.
+// These bound how many costly MSI-sign / child-key operations
+// a single user or a single parent enrollment key can trigger.
+// ============================================================
+
+/** Max authenticated installer-signing requests per user per hour. */
+const INSTALLER_SIGN_USER_LIMIT = 10;
+/** Max authenticated installer-signing requests per parent enrollment key per hour. */
+const INSTALLER_SIGN_KEY_LIMIT = 30;
+/** Sliding window (seconds) for both authenticated signing-spend caps. */
+const INSTALLER_SIGN_WINDOW_SECONDS = 60 * 60; // 1 hour
+
 /**
  * Narrow `Buffer | null` to `Buffer`, throwing an actionable error when
  * null. Replaces non-null assertions so a future code change that adds a
@@ -1085,6 +1098,62 @@ enrollmentKeyRoutes.get(
         },
         503,
       );
+    }
+
+    // Signing-spend cap — enforce BEFORE child key creation or any signing
+    // operation so an authenticated user cannot drive unbounded (costly,
+    // rate-limited-upstream) signing calls. Two overlapping caps:
+    //   1. Per-user:       INSTALLER_SIGN_USER_LIMIT / INSTALLER_SIGN_WINDOW_SECONDS
+    //   2. Per-parent-key: INSTALLER_SIGN_KEY_LIMIT  / INSTALLER_SIGN_WINDOW_SECONDS
+    // Both fail closed on Redis errors to prevent a Redis outage from
+    // disabling the cap.
+    {
+      const { getRedis } = await import("../services");
+      const { rateLimiter } = await import("../services/rate-limit");
+      const redis = getRedis();
+      if (!redis) {
+        console.error(
+          "[installer] sign-spend rate-limit unavailable: redis client missing",
+        );
+        return c.json({ error: "Service temporarily unavailable" }, 503);
+      }
+
+      // Per-user cap
+      const userResult = await rateLimiter(
+        redis,
+        `rl:installer-sign:user:${auth.user.id}`,
+        INSTALLER_SIGN_USER_LIMIT,
+        INSTALLER_SIGN_WINDOW_SECONDS,
+      );
+      if (!userResult.allowed) {
+        return c.json(
+          {
+            error:
+              "Installer signing rate limit reached. Try again later.",
+            retryAfter: userResult.resetAt.toISOString(),
+          },
+          429,
+        );
+      }
+
+      // Per-parent-key cap (reuses the same bucket as the public route so
+      // combined public + authenticated spend is bounded together).
+      const keyResult = await rateLimiter(
+        redis,
+        `install-sign:${parentKey.id}`,
+        INSTALLER_SIGN_KEY_LIMIT,
+        INSTALLER_SIGN_WINDOW_SECONDS,
+      );
+      if (!keyResult.allowed) {
+        return c.json(
+          {
+            error:
+              "Installer signing rate limit reached for this enrollment key. Try again later.",
+            retryAfter: keyResult.resetAt.toISOString(),
+          },
+          429,
+        );
+      }
     }
 
     // Generate a child enrollment key. Child gets a FRESH TTL independent

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -93,7 +93,7 @@ vi.mock('../services/msiSigning', () => ({
   },
 }));
 
-vi.mock('../services/redis', () => ({
+vi.mock('../services', () => ({
   getRedis: vi.fn(() => ({})),
 }));
 
@@ -105,6 +105,7 @@ import { enrollmentKeyRoutes } from './enrollmentKeys';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
 import { MsiSigningService } from '../services/msiSigning';
+import { rateLimiter } from '../services/rate-limit';
 
 const ORG_ID = 'org-111';
 const KEY_ID = '11111111-1111-1111-1111-111111111111';
@@ -592,6 +593,96 @@ describe('enrollment key routes — installer download', () => {
           details: expect.objectContaining({ count: 3 }),
         })
       );
+    });
+
+    // ============================================================
+    // Signing-spend cap tests (per-user and per-parent-key limits)
+    // ============================================================
+    describe('signing-spend cap', () => {
+      beforeEach(() => {
+        // clearAllMocks does NOT drain mockResolvedValueOnce queues — reset rateLimiter
+        // and restore the allowed-by-default impl so an unconsumed `Once` value from a
+        // prior cap test cannot bleed into the next one's per-user/per-key sequence.
+        vi.mocked(rateLimiter).mockReset();
+        vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 10, resetAt: new Date() });
+      });
+
+      it('allows signing when both per-user and per-key caps are under limit', async () => {
+        // Default mock: rateLimiter always returns allowed=true
+        mockSelectFromWhereLimit([makeEnrollmentKey()]);
+        mockInsertValuesReturning([
+          makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
+        ]);
+
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' },
+        });
+
+        expect(res.status).toBe(200);
+        // Child key was created
+        expect(db.insert).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns 429 and does NOT create child key when per-user cap is exceeded', async () => {
+        // First rateLimiter call (per-user) returns denied; second should never be reached
+        vi.mocked(rateLimiter)
+          .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date(Date.now() + 3600_000) })
+          .mockResolvedValueOnce({ allowed: true, remaining: 20, resetAt: new Date() });
+
+        mockSelectFromWhereLimit([makeEnrollmentKey()]);
+        // No insert mock needed — child key must NOT be created
+
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' },
+        });
+
+        expect(res.status).toBe(429);
+        const body = await res.json();
+        expect(body.error).toMatch(/rate limit/i);
+        expect(body.retryAfter).toBeDefined();
+        // No child enrollment key created, no signing triggered
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('returns 429 and does NOT create child key when per-parent-key cap is exceeded', async () => {
+        // First rateLimiter call (per-user) passes; second (per-key) is denied
+        vi.mocked(rateLimiter)
+          .mockResolvedValueOnce({ allowed: true, remaining: 5, resetAt: new Date() })
+          .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date(Date.now() + 3600_000) });
+
+        mockSelectFromWhereLimit([makeEnrollmentKey()]);
+        // No insert mock needed — child key must NOT be created
+
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' },
+        });
+
+        expect(res.status).toBe(429);
+        const body = await res.json();
+        expect(body.error).toMatch(/rate limit/i);
+        expect(body.retryAfter).toBeDefined();
+        // No child enrollment key created, no signing triggered
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('returns 503 and does NOT create child key when Redis is unavailable', async () => {
+        const { getRedis } = await import('../services');
+        vi.mocked(getRedis).mockReturnValueOnce(null as any);
+
+        mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' },
+        });
+
+        expect(res.status).toBe(503);
+        // No child enrollment key created
+        expect(db.insert).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/api/src/routes/security/dashboard.test.ts
+++ b/apps/api/src/routes/security/dashboard.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  securityStatus: {},
+  securityThreats: {},
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {},
+  queueCommand: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../services/securityPosture', () => ({
+  listLatestSecurityPosture: vi.fn(async () => []),
+  getSecurityPostureTrend: vi.fn(async () => []),
+}));
+
+const { getUserPermissionsMock } = vi.hoisted(() => ({
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return {
+    ...actual,
+    getUserPermissions: getUserPermissionsMock,
+  };
+});
+
+// Keep requireScope as a passthrough; use real requirePermission so RBAC
+// is actually enforced in tests.
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<any>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+import { dashboardRoutes } from './dashboard';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      canAccessOrg: () => true,
+      orgCondition: () => undefined,
+    } as any);
+    await next();
+  });
+  app.route('/security', dashboardRoutes);
+  return app;
+}
+
+describe('GET /dashboard — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request('/security/dashboard', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/dashboard', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/dashboard', { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe('GET /score-breakdown — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request('/security/score-breakdown', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/score-breakdown', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/score-breakdown', { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/dashboard.ts
+++ b/apps/api/src/routes/security/dashboard.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import {
   listLatestSecurityPosture,
   getSecurityPostureTrend
@@ -26,6 +26,7 @@ export const dashboardRoutes = new Hono();
 dashboardRoutes.get(
   '/dashboard',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('query', dashboardQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -167,6 +168,7 @@ dashboardRoutes.get(
 dashboardRoutes.get(
   '/score-breakdown',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   async (c) => {
     const auth = c.get('auth');
     const scope = resolveScopedOrgIds(auth);

--- a/apps/api/src/routes/security/posture.test.ts
+++ b/apps/api/src/routes/security/posture.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+  },
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {},
+  queueCommand: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../services/securityPosture', () => ({
+  listLatestSecurityPosture: vi.fn(async () => []),
+  getLatestSecurityPostureForDevice: vi.fn(async () => null),
+}));
+
+const { getUserPermissionsMock } = vi.hoisted(() => ({
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return {
+    ...actual,
+    getUserPermissions: getUserPermissionsMock,
+  };
+});
+
+// Keep requireScope as a passthrough; use real requirePermission so RBAC
+// is actually enforced in tests.
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<any>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+import { db } from '../../db';
+import { postureRoutes } from './posture';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      canAccessOrg: () => true,
+      orgCondition: () => undefined,
+    } as any);
+    await next();
+  });
+  app.route('/security', postureRoutes);
+  return app;
+}
+
+describe('GET /posture — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request('/security/posture', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/posture', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/posture', { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe('GET /posture/:deviceId — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request(`/security/posture/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request(`/security/posture/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    // db.select for device lookup will return empty — device not found → 404
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    } as any);
+    const app = buildApp();
+
+    const res = await app.request(`/security/posture/${DEVICE_ID}`, { method: 'GET' });
+
+    // 404 (device not found) or 200 — either way the permission check passed
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/posture.test.ts
+++ b/apps/api/src/routes/security/posture.test.ts
@@ -160,3 +160,74 @@ describe('GET /posture/:deviceId — requirePermission(devices, read)', () => {
     expect(res.status).not.toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Site-scope gate tests for GET /posture/:deviceId
+//
+// posture.ts fetches the device row (including siteId) in the SAME db.select
+// call as the org/device lookup. The gate checks userPerms.allowedSiteIds
+// against device.siteId immediately after the device row is loaded — there is
+// no separate siteId lookup. getLatestSecurityPostureForDevice is already
+// mocked to return null (→ 404) in the module-level mock above, which is
+// enough for the IN-SITE success case to resolve without 403.
+// ---------------------------------------------------------------------------
+
+describe('GET /posture/:deviceId — site-scope gate', () => {
+  const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockDeviceLookup(siteId: string | null) {
+    // Backs db.select({ id, orgId, siteId }).from(devices).where(...).limit(1)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: DEVICE_ID,
+            orgId: ORG_ID,
+            siteId,
+          }]),
+        }),
+      }),
+    } as any);
+  }
+
+  it('returns 403 with a site error when the caller site allowlist excludes the device site', async () => {
+    // Caller has devices:read but is restricted to SITE_A; device lives in SITE_B.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockDeviceLookup(SITE_B);
+    const app = buildApp();
+
+    const res = await app.request(`/security/posture/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    // Must be the site gate error, not the RBAC "Permission denied" message
+    expect(body.error).toMatch(/site/i);
+    // The protected posture data must not be present
+    expect(body.data).toBeUndefined();
+  });
+
+  it('returns non-403 when the device site is in the caller site allowlist', async () => {
+    // Caller has devices:read and is restricted to SITE_A; device also lives in SITE_A.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockDeviceLookup(SITE_A);
+    const app = buildApp();
+
+    const res = await app.request(`/security/posture/${DEVICE_ID}`, { method: 'GET' });
+
+    // Site gate passed — must not be 403. getLatestSecurityPostureForDevice is
+    // mocked to return null so the handler returns 404 ("No security posture
+    // available"), which is the expected non-403 outcome.
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/posture.ts
+++ b/apps/api/src/routes/security/posture.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { devices } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import {
   getLatestSecurityPostureForDevice,
   listLatestSecurityPosture
@@ -18,6 +18,7 @@ export const postureRoutes = new Hono();
 postureRoutes.get(
   '/posture',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('query', postureQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -79,6 +80,7 @@ postureRoutes.get(
 postureRoutes.get(
   '/posture/:deviceId',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('param', deviceIdParamSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/security/scans.test.ts
+++ b/apps/api/src/routes/security/scans.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
+  },
+  securityScans: {
+    id: 'securityScans.id',
+    deviceId: 'securityScans.deviceId',
+    orgId: 'securityScans.orgId',
+    scanType: 'securityScans.scanType',
+    status: 'securityScans.status',
+    startedAt: 'securityScans.startedAt',
+    completedAt: 'securityScans.completedAt',
+    threatsFound: 'securityScans.threatsFound',
+    duration: 'securityScans.duration',
+    initiatedBy: 'securityScans.initiatedBy',
+  },
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: { SECURITY_SCAN: 'security_scan' },
+  queueCommand: vi.fn(async () => undefined),
+}));
+
+const { getUserPermissionsMock } = vi.hoisted(() => ({
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return {
+    ...actual,
+    getUserPermissions: getUserPermissionsMock,
+  };
+});
+
+// requirePermission calls getUserPermissions internally; use the real
+// implementation so permission checks are actually enforced in tests.
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<any>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+import { db } from '../../db';
+import { scansRoutes } from './scans';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      canAccessOrg: () => true,
+      orgCondition: () => undefined,
+    } as any);
+    await next();
+  });
+  app.route('/security', scansRoutes);
+  return app;
+}
+
+function mockDeviceSelect() {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{
+          id: DEVICE_ID,
+          hostname: 'test-host',
+          orgId: ORG_ID,
+          siteId: null,
+        }]),
+      }),
+    }),
+  } as any);
+}
+
+function mockScansSelect() {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as any);
+}
+
+describe('GET /scans/:deviceId — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller lacks devices:read permission', async () => {
+    // User has no permissions at all
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request(`/security/scans/${DEVICE_ID}`, {
+      method: 'GET',
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller has permissions but not devices:read', async () => {
+    // User has some permissions but devices resource is absent
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request(`/security/scans/${DEVICE_ID}`, {
+      method: 'GET',
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read permission', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    mockDeviceSelect();
+    mockScansSelect();
+    const app = buildApp();
+
+    const res = await app.request(`/security/scans/${DEVICE_ID}`, {
+      method: 'GET',
+    });
+
+    // 200 on success, or 404 if device not matched by RLS — either way not 403
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/scans.test.ts
+++ b/apps/api/src/routes/security/scans.test.ts
@@ -157,3 +157,77 @@ describe('GET /scans/:deviceId — requirePermission(devices, read)', () => {
     expect(res.status).not.toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Site-scope gate tests for GET /scans/:deviceId
+//
+// scans.ts calls canAccessDeviceSite(c, auth, device.siteId) right after the
+// device row is fetched (the same row includes siteId). canAccessDeviceSite
+// calls getUserPermissions internally then delegates to canAccessSite (the
+// real implementation imported via vi.importActual). After the gate passes the
+// handler issues a second db.select for the scans list.
+// ---------------------------------------------------------------------------
+
+describe('GET /scans/:deviceId — site-scope gate', () => {
+  const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockDeviceSelectWithSite(siteId: string | null) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{
+            id: DEVICE_ID,
+            hostname: 'test-host',
+            orgId: ORG_ID,
+            siteId,
+          }]),
+        }),
+      }),
+    } as any);
+  }
+
+  it('returns 403 with a site error when the caller site allowlist excludes the device site', async () => {
+    // Caller has devices:read but is restricted to SITE_A; device lives in SITE_B.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockDeviceSelectWithSite(SITE_B);
+    const app = buildApp();
+
+    const res = await app.request(`/security/scans/${DEVICE_ID}`, {
+      method: 'GET',
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    // Must be the site gate error, not the RBAC "Permission denied" message
+    expect(body.error).toMatch(/site/i);
+    // The protected scan list must not be present
+    expect(body.data).toBeUndefined();
+  });
+
+  it('returns non-403 when the device site is in the caller site allowlist', async () => {
+    // Caller has devices:read and is restricted to SITE_A; device also lives in SITE_A.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockDeviceSelectWithSite(SITE_A);
+    // Back the subsequent scans SELECT with an empty list so the handler resolves cleanly.
+    mockScansSelect();
+    const app = buildApp();
+
+    const res = await app.request(`/security/scans/${DEVICE_ID}`, {
+      method: 'GET',
+    });
+
+    // Site gate passed — must not be 403
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/scans.ts
+++ b/apps/api/src/routes/security/scans.ts
@@ -113,6 +113,7 @@ scansRoutes.post(
 scansRoutes.get(
   '/scans/:deviceId',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('param', deviceIdParamSchema),
   zValidator('query', listScansQuerySchema),
   async (c) => {

--- a/apps/api/src/routes/security/status.test.ts
+++ b/apps/api/src/routes/security/status.test.ts
@@ -148,3 +148,105 @@ describe('GET /status/:deviceId — requirePermission(devices, read)', () => {
     expect(res.status).not.toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Site-scope gate tests for GET /status/:deviceId
+//
+// The gate fires when userPerms.allowedSiteIds is set. It fetches the device's
+// siteId from DB and calls canAccessSite (real implementation from actual
+// permissions module). listStatusRows uses db.select().from().leftJoin().where()
+// while the site-id lookup uses db.select().from().where().limit().
+// ---------------------------------------------------------------------------
+
+import { db } from '../../db';
+
+describe('GET /status/:deviceId — site-scope gate', () => {
+  const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockListStatusRows(deviceSiteId: string | null) {
+    // Backs listStatusRows: db.select({...}).from(devices).leftJoin(...).where(...)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            deviceId: DEVICE_ID,
+            orgId: ORG_ID,
+            deviceName: 'test-host',
+            os: 'windows',
+            deviceState: 'online',
+            provider: 'defender',
+            providerVersion: '1.0',
+            definitionsVersion: '1.0',
+            definitionsDate: null,
+            realTimeProtection: true,
+            threatCount: 0,
+            firewallEnabled: true,
+            encryptionStatus: 'encrypted',
+            encryptionDetails: null,
+            localAdminSummary: null,
+            passwordPolicySummary: null,
+            gatekeeperEnabled: null,
+            lastScan: null,
+            lastScanType: null,
+            siteId: deviceSiteId,
+          }]),
+        }),
+      }),
+    } as any);
+  }
+
+  function mockSiteIdLookup(siteId: string | null) {
+    // Backs db.select({ siteId }).from(devices).where(...).limit(1)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(siteId !== null ? [{ siteId }] : [{ siteId: null }]),
+        }),
+      }),
+    } as any);
+  }
+
+  it('returns 403 with a site error when the caller site allowlist excludes the device site', async () => {
+    // Caller has devices:read but is restricted to SITE_A; device lives in SITE_B.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockListStatusRows(SITE_B);
+    mockSiteIdLookup(SITE_B);
+    const app = buildApp();
+
+    const res = await app.request(`/security/status/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    // Must be the site gate error, not the RBAC "Permission denied" message
+    expect(body.error).toMatch(/site/i);
+    // The protected status data must not be present
+    expect(body.data).toBeUndefined();
+  });
+
+  it('returns non-403 when the device site is in the caller site allowlist', async () => {
+    // Caller has devices:read and is restricted to SITE_A; device also lives in SITE_A.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_A],
+    });
+    mockListStatusRows(SITE_A);
+    mockSiteIdLookup(SITE_A);
+    const app = buildApp();
+
+    const res = await app.request(`/security/status/${DEVICE_ID}`, { method: 'GET' });
+
+    // Site gate passed — must not be 403 (will be 200 with the status data)
+    expect(res.status).not.toBe(403);
+    const body = await res.json();
+    expect(body.data).toBeDefined();
+    expect(body.data.deviceId).toBe(DEVICE_ID);
+  });
+});

--- a/apps/api/src/routes/security/status.test.ts
+++ b/apps/api/src/routes/security/status.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    hostname: 'devices.hostname',
+  },
+  securityStatus: {},
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: {},
+  queueCommand: vi.fn(async () => undefined),
+}));
+
+const { getUserPermissionsMock } = vi.hoisted(() => ({
+  getUserPermissionsMock: vi.fn(),
+}));
+
+vi.mock('../../services/permissions', async () => {
+  const actual = await vi.importActual<any>('../../services/permissions');
+  return {
+    ...actual,
+    getUserPermissions: getUserPermissionsMock,
+  };
+});
+
+// Keep requireScope as a passthrough; use real requirePermission so RBAC
+// is actually enforced in tests.
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<any>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+import { statusRoutes } from './status';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      canAccessOrg: () => true,
+      orgCondition: () => undefined,
+    } as any);
+    await next();
+  });
+  app.route('/security', statusRoutes);
+  return app;
+}
+
+describe('GET /status — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request('/security/status', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/status', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/status', { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe('GET /status/:deviceId — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the caller has no permissions', async () => {
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request(`/security/status/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request(`/security/status/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    // Device won't be found in the mocked helpers — expect 404 (not 403)
+    const res = await app.request(`/security/status/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/status.ts
+++ b/apps/api/src/routes/security/status.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { devices } from '../../db/schema';
-import { requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope } from '../../middleware/auth';
 import { canAccessSite, getUserPermissions, type UserPermissions } from '../../services/permissions';
 import { listStatusQuerySchema, deviceIdParamSchema } from './schemas';
 import { getPagination, paginate, listStatusRows, toStatusResponse } from './helpers';
@@ -14,6 +14,7 @@ export const statusRoutes = new Hono();
 statusRoutes.get(
   '/status',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('query', listStatusQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -60,6 +61,7 @@ statusRoutes.get(
 statusRoutes.get(
   '/status/:deviceId',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('param', deviceIdParamSchema),
   async (c) => {
     const auth = c.get('auth');

--- a/apps/api/src/routes/security/threats.test.ts
+++ b/apps/api/src/routes/security/threats.test.ts
@@ -35,11 +35,15 @@ vi.mock('../../db/schema', () => ({
   auditLogs: {},
 }));
 
-vi.mock('../../middleware/auth', () => ({
-  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
-}));
+// Use the real requirePermission so RBAC is actually enforced; only stub
+// requireScope (tenancy check) to a passthrough for unit-test simplicity.
+vi.mock('../../middleware/auth', async () => {
+  const actual = await vi.importActual<any>('../../middleware/auth');
+  return {
+    ...actual,
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
 
 const { queueCommandMock, getUserPermissionsMock } = vi.hoisted(() => ({
   queueCommandMock: vi.fn(async () => undefined),
@@ -72,7 +76,7 @@ const THREAT_ID = '33333333-3333-4333-8333-333333333333';
 const SITE_ALLOWED = '44444444-4444-4444-8444-444444444444';
 const SITE_FORBIDDEN = '55555555-5555-4555-8555-555555555555';
 
-function buildApp(permissions?: { allowedSiteIds?: string[] }): Hono {
+function buildApp(): Hono {
   const app = new Hono();
   app.use('*', async (c, next) => {
     c.set('auth', {
@@ -84,7 +88,6 @@ function buildApp(permissions?: { allowedSiteIds?: string[] }): Hono {
       canAccessOrg: () => true,
       orgCondition: () => undefined,
     } as any);
-    if (permissions) c.set('permissions', permissions as any);
     await next();
   });
   app.route('/security', threatsRoutes);
@@ -116,12 +119,20 @@ function mockThreatSelect(siteId: string | null) {
 describe('security threats action routes (site-scope enforcement)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getUserPermissionsMock.mockResolvedValue(null);
+    // Provide devices:execute so real requirePermission passes the POST routes.
+    // Tests that need site-scope restrictions override allowedSiteIds below.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'execute' }],
+      allowedSiteIds: [SITE_ALLOWED],
+    });
   });
 
   it('rejects quarantine when the threat device is outside the caller site allowlist', async () => {
+    // getUserPermissions returns a site-restricted list that excludes SITE_FORBIDDEN.
+    // requirePermission stores these permissions in context; queueThreatAction
+    // enforces the site allowlist and rejects SITE_FORBIDDEN.
     mockThreatSelect(SITE_FORBIDDEN);
-    const app = buildApp({ allowedSiteIds: [SITE_ALLOWED] });
+    const app = buildApp();
 
     const res = await app.request(`/security/threats/${THREAT_ID}/quarantine`, {
       method: 'POST',
@@ -142,7 +153,7 @@ describe('security threats action routes (site-scope enforcement)', () => {
         where: vi.fn().mockResolvedValue(undefined),
       }),
     } as any);
-    const app = buildApp({ allowedSiteIds: [SITE_ALLOWED] });
+    const app = buildApp();
 
     const res = await app.request(`/security/threats/${THREAT_ID}/quarantine`, {
       method: 'POST',
@@ -156,10 +167,13 @@ describe('security threats action routes (site-scope enforcement)', () => {
     expect(queueCommandMock).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects remove for an out-of-site device even when permissions are fetched lazily', async () => {
+  it('rejects remove for an out-of-site device', async () => {
     mockThreatSelect(SITE_FORBIDDEN);
-    // No permissions set in context; handler must fetch them.
-    getUserPermissionsMock.mockResolvedValue({ allowedSiteIds: [SITE_ALLOWED] });
+    // permissions restrict to SITE_ALLOWED only; SITE_FORBIDDEN is denied.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'execute' }],
+      allowedSiteIds: [SITE_ALLOWED],
+    });
     const app = buildApp();
 
     const res = await app.request(`/security/threats/${THREAT_ID}/remove`, {
@@ -178,8 +192,12 @@ describe('security threats action routes (site-scope enforcement)', () => {
         where: vi.fn().mockResolvedValue(undefined),
       }),
     } as any);
-    // permissions has no allowedSiteIds → unrestricted
-    const app = buildApp({});
+    // No allowedSiteIds → unrestricted; SITE_FORBIDDEN is allowed.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'execute' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
 
     const res = await app.request(`/security/threats/${THREAT_ID}/restore`, {
       method: 'POST',
@@ -188,5 +206,94 @@ describe('security threats action routes (site-scope enforcement)', () => {
 
     expect(res.status).toBe(200);
     expect(queueCommandMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// RBAC tests: verify that GET /threats and GET /threats/:deviceId enforce
+// requirePermission('devices', 'read'). The real requirePermission is used
+// (via vi.importActual in the auth mock above) so getUserPermissions controls
+// the outcome — null → 403, missing devices:read → 403, present → pass.
+describe('security threats GET routes — requirePermission(devices, read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserPermissionsMock.mockResolvedValue(null);
+  });
+
+  it('GET /threats returns 403 when the caller has no permissions', async () => {
+    // getUserPermissions returns null → real requirePermission → 403
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request('/security/threats', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    // DB must not have been reached
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /threats returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/threats', { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    // DB must not have been reached
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /threats returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request('/security/threats', { method: 'GET' });
+
+    // Permission check passed; any status other than 403 is acceptable here.
+    expect(res.status).not.toBe(403);
+  });
+
+  it('GET /threats/:deviceId returns 403 when the caller has no permissions', async () => {
+    // getUserPermissions returns null → real requirePermission → 403
+    getUserPermissionsMock.mockResolvedValue(null);
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    // DB must not have been reached
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /threats/:deviceId returns 403 when the caller lacks devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'scripts', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    // DB must not have been reached
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('GET /threats/:deviceId returns non-403 when the caller has devices:read', async () => {
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: undefined,
+    });
+    // listStatusRows will return empty → device not found → 404, which is not 403.
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).not.toBe(403);
   });
 });

--- a/apps/api/src/routes/security/threats.test.ts
+++ b/apps/api/src/routes/security/threats.test.ts
@@ -297,3 +297,120 @@ describe('security threats GET routes — requirePermission(devices, read)', () 
     expect(res.status).not.toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Site-scope gate tests for GET /threats/:deviceId
+//
+// threats.ts calls listStatusRows(auth) first to confirm the device is visible,
+// then — when userPerms.allowedSiteIds is set — fetches { siteId } from devices
+// and calls canAccessSite. The mocks here use the real canAccessSite (from
+// vi.importActual) so the allowedSiteIds check behaves exactly as in production.
+//
+// db.select call order for the 403 path:
+//   1. listStatusRows  → .from().leftJoin().where()        → row with deviceId
+//   2. site gate       → .from().where().limit()           → { siteId }
+//
+// db.select call order for the 200 path (in-site):
+//   1. listStatusRows  → .from().leftJoin().where()        → row with deviceId
+//   2. site gate       → .from().where().limit()           → { siteId }
+//   3. listThreatRows  → .from().innerJoin().where().orderBy() → []
+// ---------------------------------------------------------------------------
+
+describe('GET /threats/:deviceId — site-scope gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockListStatusRowsForDevice() {
+    // Backs listStatusRows: db.select({...}).from(devices).leftJoin(...).where(...)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{
+            deviceId: DEVICE_ID,
+            orgId: ORG_ID,
+            deviceName: 'test-host',
+            os: 'windows',
+            deviceState: 'online',
+            provider: 'defender',
+            providerVersion: '1.0',
+            definitionsVersion: '1.0',
+            definitionsDate: null,
+            realTimeProtection: true,
+            threatCount: 0,
+            firewallEnabled: true,
+            encryptionStatus: 'encrypted',
+            encryptionDetails: null,
+            localAdminSummary: null,
+            passwordPolicySummary: null,
+            gatekeeperEnabled: null,
+            lastScan: null,
+            lastScanType: null,
+          }]),
+        }),
+      }),
+    } as any);
+  }
+
+  function mockSiteIdLookup(siteId: string | null) {
+    // Backs db.select({ siteId }).from(devices).where(...).limit(1)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(siteId !== null ? [{ siteId }] : [{ siteId: null }]),
+        }),
+      }),
+    } as any);
+  }
+
+  function mockListThreatRowsEmpty() {
+    // Backs listThreatRows: db.select({...}).from(securityThreats).innerJoin(...).where(...).orderBy(...)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    } as any);
+  }
+
+  it('returns 403 with a site error when the caller site allowlist excludes the device site', async () => {
+    // Caller has devices:read but is restricted to SITE_ALLOWED; device is in SITE_FORBIDDEN.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_ALLOWED],
+    });
+    mockListStatusRowsForDevice();
+    mockSiteIdLookup(SITE_FORBIDDEN);
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${DEVICE_ID}`, { method: 'GET' });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    // Must be the site gate error, not the RBAC "Permission denied" message
+    expect(body.error).toMatch(/site/i);
+    // The protected threats data must not be present
+    expect(body.data).toBeUndefined();
+  });
+
+  it('returns non-403 when the device site is in the caller site allowlist', async () => {
+    // Caller has devices:read and is restricted to SITE_ALLOWED; device is also in SITE_ALLOWED.
+    getUserPermissionsMock.mockResolvedValue({
+      permissions: [{ resource: 'devices', action: 'read' }],
+      allowedSiteIds: [SITE_ALLOWED],
+    });
+    mockListStatusRowsForDevice();
+    mockSiteIdLookup(SITE_ALLOWED);
+    // Back the subsequent listThreatRows call with an empty set so the handler resolves.
+    mockListThreatRowsEmpty();
+    const app = buildApp();
+
+    const res = await app.request(`/security/threats/${DEVICE_ID}`, { method: 'GET' });
+
+    // Site gate passed — must not be 403
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/routes/security/threats.ts
+++ b/apps/api/src/routes/security/threats.ts
@@ -27,6 +27,7 @@ export const threatsRoutes = new Hono();
 threatsRoutes.get(
   '/threats',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('query', listThreatsQuerySchema),
   async (c) => {
     const auth = c.get('auth');
@@ -103,6 +104,7 @@ threatsRoutes.get(
 threatsRoutes.get(
   '/threats/:deviceId',
   requireScope('organization', 'partner', 'system'),
+  requirePermission('devices', 'read'),
   zValidator('param', deviceIdParamSchema),
   zValidator('query', listThreatsQuerySchema),
   async (c) => {


### PR DESCRIPTION
## Missing authz/authn gates on existing routes

- **security read RBAC** — `security/{threats,scans,status,dashboard,posture}` GET routes gated only on `requireScope` (tenancy tier, not role). Added `requirePermission('devices','read')`, matching the mutating routes + the `peripheralControl.ts` precedent. A low-privilege in-org role could read the org's threat inventory/posture.
- **authenticator step-up** — `POST /authenticator/devices` (mobile approver-device registration) had no current-password step-up, so a stolen-session attacker could enroll a self-approval factor (satisfying L2/L3 approval assurance). Added `requireCurrentPasswordStepUp`, matching the sibling WebAuthn path.
- **installer signing caps** — the authenticated installer-download GET could mint child keys + trigger MSI signing with no spend cap. Added per-user/per-key sliding-window caps (429), reusing the existing `rateLimiter` (fail-closed on Redis down).

**Verification:** API package `tsc --noEmit` clean; all changed-file unit suites green (single-fork). RLS contract + integration tests not run locally (need DB) — rely on CI.
Origin: `/security-review` playbook entry 1 (multi-tenant RLS + authz) two-pass workflow + Codex review pass.
