### PR TITLE
fix(api): fail-closed mid-session revocation for tunnel + event WS

### DIFF
--- a/apps/api/src/routes/eventWs.test.ts
+++ b/apps/api/src/routes/eventWs.test.ts
@@ -9,6 +9,37 @@ vi.mock('../services/redis', () => ({
   resolveRedisUrl: vi.fn(() => 'redis://localhost:6379'),
 }));
 
+// DB mock — `isEventWsUserActive` selects the user's status under system
+// scope. Tests drive the returned row via `setUserStatusRow`.
+let userStatusRow: { status: string } | undefined = { status: 'active' };
+function setUserStatusRow(row: { status: string } | undefined) {
+  userStatusRow = row;
+}
+let throwOnSelect = false;
+function setThrowOnSelect(v: boolean) {
+  throwOnSelect = v;
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => {
+            if (throwOnSelect) throw new Error('db down');
+            return userStatusRow ? [userStatusRow] : [];
+          }),
+        })),
+      })),
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  users: {},
+}));
+
 vi.mock('../services/eventDispatcher', () => {
   const register = vi.fn();
   const unregister = vi.fn();
@@ -38,6 +69,8 @@ import {
   consumeTicket,
   createEventWsTicketRoute,
   buildSiteFilter,
+  isEventWsUserActive,
+  createEventWsHandlers,
   _clearTicketStore,
 } from './eventWs';
 
@@ -48,6 +81,137 @@ import {
 beforeEach(() => {
   _clearTicketStore();
   vi.clearAllMocks();
+  setUserStatusRow({ status: 'active' });
+  setThrowOnSelect(false);
+});
+
+// -------------------------------------------------------------------
+// Tests: mid-session user revalidation (revocation gap)
+//
+// The WS ticket snapshots the user's org access at consume time; the
+// connection then delivers events indefinitely. `isEventWsUserActive` is the
+// authoritative recheck used by the revalidation interval to tear the socket
+// down once a user is deactivated/suspended/deleted. It must FAIL CLOSED.
+// -------------------------------------------------------------------
+
+describe('isEventWsUserActive', () => {
+  it('returns true while the user is still active', async () => {
+    setUserStatusRow({ status: 'active' });
+    await expect(isEventWsUserActive('user-1')).resolves.toBe(true);
+  });
+
+  it('returns false when the user has been deactivated/suspended', async () => {
+    setUserStatusRow({ status: 'suspended' });
+    await expect(isEventWsUserActive('user-1')).resolves.toBe(false);
+  });
+
+  it('returns false when the user row no longer exists (deleted)', async () => {
+    setUserStatusRow(undefined);
+    await expect(isEventWsUserActive('user-1')).resolves.toBe(false);
+  });
+});
+
+describe('event WS mid-session revocation (handler interval)', () => {
+  function makeWs() {
+    return {
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+    } as any;
+  }
+
+  async function openConnection(ws: any) {
+    const { ticket } = await createEventWsTicket('user-1', 'org-1');
+    const handlers = createEventWsHandlers(ticket);
+    await handlers.onOpen(undefined, ws);
+    return handlers;
+  }
+
+  it('closes the socket fail-closed once the user is revoked, and unregisters from the dispatcher (stops delivery)', async () => {
+    const { getEventDispatcher } = await import('../services/eventDispatcher');
+    const dispatcher = getEventDispatcher() as any;
+
+    vi.useFakeTimers();
+    try {
+      const ws = makeWs();
+      await openConnection(ws);
+
+      // Registered for delivery on open.
+      expect(dispatcher.register).toHaveBeenCalledWith('org-1', expect.anything());
+      expect(ws.close).not.toHaveBeenCalled();
+
+      // User is revoked mid-session.
+      setUserStatusRow({ status: 'suspended' });
+
+      // Advance to the revalidation tick and flush the async check.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      // Socket torn down fail-closed and delivery stopped (unregistered).
+      expect(ws.close).toHaveBeenCalledWith(4003, 'Access revoked');
+      expect(dispatcher.unregister).toHaveBeenCalledWith('org-1', expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails closed when the revalidation DB check throws', async () => {
+    vi.useFakeTimers();
+    try {
+      const ws = makeWs();
+      await openConnection(ws);
+
+      setThrowOnSelect(true);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(ws.close).toHaveBeenCalledWith(4003, 'Access revoked');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a still-valid connection open and registered across revalidation ticks', async () => {
+    const { getEventDispatcher } = await import('../services/eventDispatcher');
+    const dispatcher = getEventDispatcher() as any;
+
+    vi.useFakeTimers();
+    try {
+      const ws = makeWs();
+      await openConnection(ws);
+
+      // User stays active across multiple revalidation ticks.
+      setUserStatusRow({ status: 'active' });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(dispatcher.unregister).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the revalidation interval on close (no leak, no post-close revocation)', async () => {
+    const { getEventDispatcher } = await import('../services/eventDispatcher');
+    const dispatcher = getEventDispatcher() as any;
+
+    vi.useFakeTimers();
+    try {
+      const ws = makeWs();
+      const handlers = await openConnection(ws);
+
+      await handlers.onClose(undefined, ws);
+      expect(dispatcher.unregister).toHaveBeenCalledWith('org-1', expect.anything());
+
+      // After close, a revoked user must not trigger another close() call —
+      // the interval was cleared.
+      setUserStatusRow({ status: 'suspended' });
+      ws.close.mockClear();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(ws.close).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // -------------------------------------------------------------------

--- a/apps/api/src/routes/eventWs.ts
+++ b/apps/api/src/routes/eventWs.ts
@@ -1,7 +1,10 @@
 import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
 import { randomBytes } from 'crypto';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { db, withSystemDbAccessContext } from '../db';
+import { users } from '../db/schema';
 import { getRedis } from '../services/redis';
 import { getEventDispatcher, type ClientEntry } from '../services/eventDispatcher';
 import { authMiddleware, resolveOrgAccess } from '../middleware/auth';
@@ -14,6 +17,14 @@ const TICKET_TTL_MS = 30 * 1000; // 30 seconds
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const REDIS_KEY_PREFIX = 'event:ws_ticket:';
 const EVENT_TYPE_RE = /^(\*|[a-z]+\.\*|[a-z]+\.[a-z_]+)$/;
+
+// Mid-session revalidation cadence. The ticket snapshots the user's org access
+// at consume time and the connection then delivers events indefinitely with no
+// further authorization check — so a user whose status/access is revoked keeps
+// receiving live org events until idle/disconnect. Re-check the user is still
+// active on this interval and tear the socket down fail-closed if not. Matches
+// the desktop/terminal WS ~30s revocation cadence.
+const REVALIDATE_INTERVAL_MS = 30 * 1000; // 30 seconds
 
 // ---------------------------------------------------------------------------
 // Ticket store (in-memory for dev, Redis for production)
@@ -249,6 +260,30 @@ function extractEventSiteId(event: Record<string, unknown>): string | undefined 
   return undefined;
 }
 
+/**
+ * Mid-session revalidation: confirm the connection's user is still active.
+ *
+ * The WS ticket carries only `userId` + the org set captured at mint time, so
+ * we re-check the authoritative "access revoked" signal the rest of the system
+ * uses — `users.status === 'active'` (see `authMiddleware`, which 403s an
+ * inactive user). A deactivated/suspended user, or a deleted row, must stop
+ * receiving events. Runs under system DB scope because the WS path bypasses
+ * JWT middleware (no RLS context set).
+ *
+ * Fails CLOSED: a thrown DB error resolves to `false` (revoked) at the call
+ * site so a transient failure tears the socket down rather than leaking events.
+ */
+export async function isEventWsUserActive(userId: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [user] = await db
+      .select({ status: users.status })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    return !!user && user.status === 'active';
+  });
+}
+
 function sendJson(ws: WSContext, payload: Record<string, unknown>): void {
   try {
     ws.send(JSON.stringify(payload));
@@ -332,10 +367,13 @@ export function createEventWsRoutes(upgradeWebSocket: Function): Hono {
 // WebSocket handler factory
 // ---------------------------------------------------------------------------
 
-function createEventWsHandlers(ticket: string | undefined) {
+// Exported for tests: drives the WS lifecycle (onOpen/onClose) so the
+// mid-session revalidation interval can be exercised without a real socket.
+export function createEventWsHandlers(ticket: string | undefined) {
   let client: ClientEntry | null = null;
   let registeredOrgIds: string[] = [];
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let revalidateTimer: ReturnType<typeof setInterval> | null = null;
 
   function resetIdleTimer(ws: WSContext) {
     if (idleTimer) clearTimeout(idleTimer);
@@ -350,6 +388,10 @@ function createEventWsHandlers(ticket: string | undefined) {
       clearTimeout(idleTimer);
       idleTimer = null;
     }
+    if (revalidateTimer) {
+      clearInterval(revalidateTimer);
+      revalidateTimer = null;
+    }
     if (client && registeredOrgIds.length > 0) {
       const dispatcher = getEventDispatcher();
       for (const id of registeredOrgIds) {
@@ -358,6 +400,43 @@ function createEventWsHandlers(ticket: string | undefined) {
       client = null;
       registeredOrgIds = [];
     }
+  }
+
+  /**
+   * Tear the connection down because the user's access was revoked
+   * mid-session. Unregisters from the dispatcher FIRST (stops delivery
+   * synchronously — the dispatch loop can't pick a client it no longer holds),
+   * then closes the socket fail-closed.
+   */
+  function closeRevoked(ws: WSContext, reason: string) {
+    console.warn(`[EventWs] Connection revoked mid-session (${reason}), closing socket`);
+    cleanup(ws);
+    try {
+      sendJson(ws, { type: 'error', message: 'Access revoked' });
+      ws.close(4003, 'Access revoked');
+    } catch (err) {
+      console.error('[EventWs] Failed to close revoked socket:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  function startRevalidation(ws: WSContext, userId: string) {
+    revalidateTimer = setInterval(() => {
+      // Fail CLOSED: any inactive/deleted user OR a thrown DB error closes the
+      // socket within at most one revalidation interval. Nothing else
+      // re-checks authorization once the connection is delivering events.
+      void isEventWsUserActive(userId)
+        .then((active) => {
+          if (!active && client) {
+            closeRevoked(ws, 'User no longer active');
+          }
+        })
+        .catch((err) => {
+          if (client) {
+            console.error('[EventWs] Revalidation check failed, closing socket (fail-closed):', err instanceof Error ? err.message : err);
+            closeRevoked(ws, 'Revalidation check failed');
+          }
+        });
+    }, REVALIDATE_INTERVAL_MS);
   }
 
   return {
@@ -391,10 +470,16 @@ function createEventWsHandlers(ticket: string | undefined) {
           dispatcher.register(id, client);
         }
         resetIdleTimer(ws);
+        // Mid-session revalidation: stop delivering and close fail-closed once
+        // the user's access is revoked (status flipped inactive / row deleted).
+        startRevalidation(ws, identity.userId);
 
         sendJson(ws, { type: 'connected', userId: identity.userId, orgIds: registeredOrgIds });
       } catch (err) {
         console.error('[EventWs] onOpen error:', err);
+        // Tear down any partial state (dispatcher registration, timers) so a
+        // throw after register() doesn't leak a delivering client / interval.
+        cleanup(ws);
         sendJson(ws, { type: 'error', message: 'Internal error' });
         ws.close(4001, 'Internal error');
       }

--- a/apps/api/src/routes/tunnelWs.test.ts
+++ b/apps/api/src/routes/tunnelWs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // DB mock supporting both the simple user-status select and the
 // tunnelSessions⋈devices join used by `revalidateTunnelSession`. Tests drive
@@ -90,13 +90,41 @@ vi.mock('../services/rate-limit', () => ({
   })),
 }));
 
+import { sendCommandToAgent } from './agentWs';
 import { rateLimiter } from '../services/rate-limit';
 import { getRedis } from '../services/redis';
 import { checkRemoteAccess } from '../services/remoteAccessPolicy';
-import { isViewerSessionRevoked } from '../services/viewerTokenRevocation';
-import { isUserTunnelWsRateLimited, revalidateTunnelSession, validateTunnelTextRelayFrame } from './tunnelWs';
+import { isViewerSessionRevoked, revokeViewerSession } from '../services/viewerTokenRevocation';
+import {
+  __setTunnelConnectionForTest,
+  enforceTunnelRevocation,
+  isUserTunnelWsRateLimited,
+  revalidateTunnelSession,
+  validateTunnelTextRelayFrame,
+} from './tunnelWs';
 
 const liveConn = { userId: 'user-1', deviceId: 'dev-1', tunnelType: 'vnc' as const };
+
+// Minimal fake WSContext: only `close` is exercised by enforceTunnelRevocation.
+function makeFakeWs() {
+  return { close: vi.fn(), send: vi.fn() } as const;
+}
+
+// A registered active connection, as `onOpen` would have stored. The revocation
+// gate only acts when a connection is present in the module map, so tests seed
+// one via the test-only helper.
+function registerLiveConnection(tunnelId: string, ws: { close: ReturnType<typeof vi.fn> }) {
+  __setTunnelConnectionForTest(tunnelId, {
+    userWs: ws as never,
+    agentId: 'agent-1',
+    userId: 'user-1',
+    deviceId: 'dev-1',
+    orgId: 'org-1',
+    tunnelType: 'vnc',
+    startedAt: new Date(),
+    lastPongAt: Date.now(),
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -221,5 +249,115 @@ describe('revalidateTunnelSession', () => {
     vi.mocked(checkRemoteAccess).mockResolvedValue({ allowed: false, reason: 'Disabled by policy' });
     await revalidateTunnelSession('tunnel-1', { ...liveConn, tunnelType: 'proxy' });
     expect(checkRemoteAccess).toHaveBeenCalledWith('dev-1', 'proxy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-session revocation TEARDOWN: enforceTunnelRevocation is what the ping
+// loop actually calls each interval to close a live socket. It must close with
+// 4003 and run the lifecycle teardown (notify agent + revoke viewer session)
+// for ALL THREE triggers, and FAIL CLOSED if the check throws. A still-valid
+// tunnel must be left open.
+// ---------------------------------------------------------------------------
+
+describe('enforceTunnelRevocation', () => {
+  afterEach(() => {
+    // Drop any seeded connection so cross-test state never leaks.
+    __setTunnelConnectionForTest('tunnel-1', undefined);
+  });
+
+  it('returns false and leaves the socket open when access is still valid', async () => {
+    const ws = makeFakeWs();
+    registerLiveConnection('tunnel-1', ws);
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(false);
+    expect(ws.close).not.toHaveBeenCalled();
+    // No teardown: agent is not notified and the viewer session is not revoked.
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(revokeViewerSession).not.toHaveBeenCalled();
+  });
+
+  it('returns false without closing when no connection is registered', async () => {
+    const ws = makeFakeWs();
+    // No registerLiveConnection — the map has no entry for this tunnel.
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(false);
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it('closes 4003 and tears down on the cross-instance Redis revoke flag', async () => {
+    // The currently-dead branch: isViewerSessionRevoked → true. This must close
+    // even though the DB revalidation would otherwise pass.
+    vi.mocked(isViewerSessionRevoked).mockResolvedValue(true);
+    const ws = makeFakeWs();
+    registerLiveConnection('tunnel-1', ws);
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(true);
+    expect(ws.close).toHaveBeenCalledWith(4003, 'Tunnel revoked');
+    // Lifecycle teardown fired: agent notified of close + viewer session revoked.
+    expect(sendCommandToAgent).toHaveBeenCalledWith(
+      'agent-1',
+      expect.objectContaining({ type: 'tunnel_close', payload: { tunnelId: 'tunnel-1' } }),
+    );
+    expect(revokeViewerSession).toHaveBeenCalledWith('tunnel-1');
+  });
+
+  it('closes 4003 and tears down when the DB predicate revokes (device offline)', async () => {
+    // Redis flag clear, but revalidateTunnelSession returns not-ok.
+    vi.mocked(isViewerSessionRevoked).mockResolvedValue(false);
+    setJoinRow({
+      session: { userId: 'user-1', status: 'active', deviceId: 'dev-1' },
+      device: { id: 'dev-1', status: 'offline' },
+    });
+    const ws = makeFakeWs();
+    registerLiveConnection('tunnel-1', ws);
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(true);
+    expect(ws.close).toHaveBeenCalledWith(4003, 'Access revoked');
+    expect(sendCommandToAgent).toHaveBeenCalledWith(
+      'agent-1',
+      expect.objectContaining({ type: 'tunnel_close', payload: { tunnelId: 'tunnel-1' } }),
+    );
+    expect(revokeViewerSession).toHaveBeenCalledWith('tunnel-1');
+  });
+
+  it('closes 4003 and tears down when the DB predicate revokes (user inactive)', async () => {
+    vi.mocked(isViewerSessionRevoked).mockResolvedValue(false);
+    setUserRow({ id: 'user-1', status: 'suspended' });
+    const ws = makeFakeWs();
+    registerLiveConnection('tunnel-1', ws);
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(true);
+    expect(ws.close).toHaveBeenCalledWith(4003, 'Access revoked');
+    expect(revokeViewerSession).toHaveBeenCalledWith('tunnel-1');
+  });
+
+  it('FAILS CLOSED: closes 4003 when the revalidation lookup throws', async () => {
+    // A DB error mid-check must NOT leave the tunnel relaying.
+    vi.mocked(isViewerSessionRevoked).mockResolvedValue(false);
+    setThrowOnJoin(true);
+    const ws = makeFakeWs();
+    registerLiveConnection('tunnel-1', ws);
+
+    const closed = await enforceTunnelRevocation('tunnel-1', ws as never);
+
+    expect(closed).toBe(true);
+    expect(ws.close).toHaveBeenCalledWith(4003, 'Revocation check failed');
+    // Even on the fail-closed path the lifecycle teardown runs.
+    expect(sendCommandToAgent).toHaveBeenCalledWith(
+      'agent-1',
+      expect.objectContaining({ type: 'tunnel_close', payload: { tunnelId: 'tunnel-1' } }),
+    );
+    expect(revokeViewerSession).toHaveBeenCalledWith('tunnel-1');
   });
 });

--- a/apps/api/src/routes/tunnelWs.test.ts
+++ b/apps/api/src/routes/tunnelWs.test.ts
@@ -1,7 +1,52 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// DB mock supporting both the simple user-status select and the
+// tunnelSessions⋈devices join used by `revalidateTunnelSession`. Tests drive
+// the returned rows via the setters below.
+let userRow: { id: string; status: string } | undefined = { id: 'user-1', status: 'active' };
+let joinRow:
+  | { session: { userId: string; status: string; deviceId: string }; device: { id: string; status: string } }
+  | undefined = {
+  session: { userId: 'user-1', status: 'active', deviceId: 'dev-1' },
+  device: { id: 'dev-1', status: 'online' },
+};
+let throwOnJoin = false;
+
+function setUserRow(row: typeof userRow) {
+  userRow = row;
+}
+function setJoinRow(row: typeof joinRow) {
+  joinRow = row;
+}
+function setThrowOnJoin(v: boolean) {
+  throwOnJoin = v;
+}
 
 vi.mock('../db', () => ({
-  db: {},
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        // Plain user-status query: .from().where().limit()
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => (userRow ? [userRow] : [])),
+        })),
+        // Join query: .from().innerJoin().where().limit()
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => {
+              if (throwOnJoin) throw new Error('db down');
+              return joinRow ? [joinRow] : [];
+            }),
+          })),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => undefined),
+      })),
+    })),
+  },
   withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
 }));
 
@@ -30,6 +75,7 @@ vi.mock('../services/remoteAccessPolicy', () => ({
 
 vi.mock('../services/viewerTokenRevocation', () => ({
   revokeViewerSession: vi.fn(async () => undefined),
+  isViewerSessionRevoked: vi.fn(async () => false),
 }));
 
 vi.mock('../services/redis', () => ({
@@ -46,7 +92,23 @@ vi.mock('../services/rate-limit', () => ({
 
 import { rateLimiter } from '../services/rate-limit';
 import { getRedis } from '../services/redis';
-import { isUserTunnelWsRateLimited, validateTunnelTextRelayFrame } from './tunnelWs';
+import { checkRemoteAccess } from '../services/remoteAccessPolicy';
+import { isViewerSessionRevoked } from '../services/viewerTokenRevocation';
+import { isUserTunnelWsRateLimited, revalidateTunnelSession, validateTunnelTextRelayFrame } from './tunnelWs';
+
+const liveConn = { userId: 'user-1', deviceId: 'dev-1', tunnelType: 'vnc' as const };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setUserRow({ id: 'user-1', status: 'active' });
+  setJoinRow({
+    session: { userId: 'user-1', status: 'active', deviceId: 'dev-1' },
+    device: { id: 'dev-1', status: 'online' },
+  });
+  setThrowOnJoin(false);
+  vi.mocked(checkRemoteAccess).mockResolvedValue({ allowed: true });
+  vi.mocked(isViewerSessionRevoked).mockResolvedValue(false);
+});
 
 describe('isUserTunnelWsRateLimited', () => {
   it('uses the shared Redis-backed limiter for tunnel websocket upgrades', async () => {
@@ -89,5 +151,75 @@ describe('validateTunnelTextRelayFrame', () => {
     if (!result.ok) {
       expect(result.error).toMatch(/decoded|encoded/i);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-session revalidation (revocation gap): an active tunnel must be torn
+// down when the user/device/session/policy access that authorised it is
+// revoked. The ping loop calls this on each interval; it must FAIL CLOSED.
+// ---------------------------------------------------------------------------
+
+describe('revalidateTunnelSession', () => {
+  it('keeps a still-valid tunnel (active user, online device, owned session, policy allowed)', async () => {
+    await expect(revalidateTunnelSession('tunnel-1', liveConn)).resolves.toEqual({ ok: true });
+  });
+
+  it('revokes when the user is no longer active', async () => {
+    setUserRow({ id: 'user-1', status: 'suspended' });
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/user/i);
+  });
+
+  it('revokes when the user row is gone (deleted)', async () => {
+    setUserRow(undefined);
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+  });
+
+  it('revokes when the tunnel session no longer belongs to the user', async () => {
+    setJoinRow({
+      session: { userId: 'someone-else', status: 'active', deviceId: 'dev-1' },
+      device: { id: 'dev-1', status: 'online' },
+    });
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/owned/i);
+  });
+
+  it('revokes when the session has been ended/disconnected elsewhere', async () => {
+    setJoinRow({
+      session: { userId: 'user-1', status: 'disconnected', deviceId: 'dev-1' },
+      device: { id: 'dev-1', status: 'online' },
+    });
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+  });
+
+  it('revokes when the device has gone offline/quarantined', async () => {
+    setJoinRow({
+      session: { userId: 'user-1', status: 'active', deviceId: 'dev-1' },
+      device: { id: 'dev-1', status: 'offline' },
+    });
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/device/i);
+  });
+
+  it('revokes when the remote-access policy is disabled mid-session', async () => {
+    vi.mocked(checkRemoteAccess).mockResolvedValue({ allowed: false, reason: 'Disabled by policy' });
+    const result = await revalidateTunnelSession('tunnel-1', liveConn);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/policy/i);
+
+    // Uses the capability matching the tunnel type.
+    expect(checkRemoteAccess).toHaveBeenCalledWith('dev-1', 'vncRelay');
+  });
+
+  it('checks the proxy capability for proxy tunnels', async () => {
+    vi.mocked(checkRemoteAccess).mockResolvedValue({ allowed: false, reason: 'Disabled by policy' });
+    await revalidateTunnelSession('tunnel-1', { ...liveConn, tunnelType: 'proxy' });
+    expect(checkRemoteAccess).toHaveBeenCalledWith('dev-1', 'proxy');
   });
 });

--- a/apps/api/src/routes/tunnelWs.ts
+++ b/apps/api/src/routes/tunnelWs.ts
@@ -355,7 +355,7 @@ export async function revalidateTunnelSession(
  * socket down so a revoked user/device cannot keep forwarding traffic.
  * Returns `true` when the socket was closed.
  */
-async function enforceTunnelRevocation(tunnelId: string, ws: WSContext): Promise<boolean> {
+export async function enforceTunnelRevocation(tunnelId: string, ws: WSContext): Promise<boolean> {
   const conn = activeTunnelConnections.get(tunnelId);
   if (!conn) return false;
 
@@ -385,6 +385,24 @@ async function enforceTunnelRevocation(tunnelId: string, ws: WSContext): Promise
     await closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: 'Revocation check failed' });
     try { ws.close(4003, 'Revocation check failed'); } catch { /* already closing */ }
     return true;
+  }
+}
+
+/**
+ * Test-only seam: register/clear an entry in the module-private
+ * `activeTunnelConnections` map so unit tests can drive
+ * `enforceTunnelRevocation` (which only acts on a registered connection)
+ * without standing up the full `onOpen` validation flow. Not used by any
+ * production code path.
+ */
+export function __setTunnelConnectionForTest(
+  tunnelId: string,
+  conn: TunnelConnection | undefined,
+): void {
+  if (conn) {
+    activeTunnelConnections.set(tunnelId, conn);
+  } else {
+    activeTunnelConnections.delete(tunnelId);
   }
 }
 

--- a/apps/api/src/routes/tunnelWs.ts
+++ b/apps/api/src/routes/tunnelWs.ts
@@ -7,7 +7,7 @@ import { consumeWsTicket } from '../services/remoteSessionAuth';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
 import { captureException } from '../services/sentry';
 import { checkRemoteAccess } from '../services/remoteAccessPolicy';
-import { revokeViewerSession } from '../services/viewerTokenRevocation';
+import { isViewerSessionRevoked, revokeViewerSession } from '../services/viewerTokenRevocation';
 import { getTrustedClientIp } from '../services/clientIp';
 import { createAuditLogAsync } from '../services/auditService';
 import { getRedis } from '../services/redis';
@@ -284,6 +284,111 @@ async function closeTunnelLifecycle(tunnelId: string, options: { notifyAgent: bo
 }
 
 /**
+ * Mid-session revalidation: re-check that an active tunnel's user is still
+ * active, still owns the session, the device is still online, and the
+ * remote-access policy still permits the relay. Mirrors the connect-time
+ * checks in `validateTunnelAccess` minus the one-time ticket (already
+ * consumed). Returns `{ ok: false, reason }` when access has been revoked
+ * so the caller can tear the socket down fail-closed.
+ *
+ * Ticket consumption is the only connect-time auth boundary for a tunnel WS,
+ * and the user↔agent relay re-checks nothing once forwarding — so without
+ * this a revoke (operator suspended, device offline/quarantined, policy
+ * disabled, session ended elsewhere) keeps traffic flowing to the agent until
+ * the pong timeout, or indefinitely while the client stays live.
+ */
+export async function revalidateTunnelSession(
+  tunnelId: string,
+  conn: Pick<TunnelConnection, 'userId' | 'deviceId' | 'tunnelType'>,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  return withSystemDbAccessContext(async () => {
+    const [user] = await db
+      .select({ id: users.id, status: users.status })
+      .from(users)
+      .where(eq(users.id, conn.userId))
+      .limit(1);
+
+    if (!user || user.status !== 'active') {
+      return { ok: false as const, reason: 'User no longer active' };
+    }
+
+    const [result] = await db
+      .select({ session: tunnelSessions, device: devices })
+      .from(tunnelSessions)
+      .innerJoin(devices, eq(tunnelSessions.deviceId, devices.id))
+      .where(eq(tunnelSessions.id, tunnelId))
+      .limit(1);
+
+    if (!result) {
+      return { ok: false as const, reason: 'Tunnel session not found' };
+    }
+
+    const { session, device } = result;
+
+    if (session.userId !== user.id) {
+      return { ok: false as const, reason: 'Tunnel session no longer owned by user' };
+    }
+
+    if (!['pending', 'connecting', 'active'].includes(session.status)) {
+      return { ok: false as const, reason: `Tunnel session is ${session.status}` };
+    }
+
+    if (device.status !== 'online') {
+      return { ok: false as const, reason: 'Device is no longer online' };
+    }
+
+    const tunnelCapability = conn.tunnelType === 'vnc' ? 'vncRelay' as const : 'proxy' as const;
+    const policyCheck = await checkRemoteAccess(device.id, tunnelCapability);
+    if (!policyCheck.allowed) {
+      return { ok: false as const, reason: policyCheck.reason ?? 'Tunnel access disabled by policy' };
+    }
+
+    return { ok: true as const };
+  });
+}
+
+/**
+ * Mid-session revocation gate for a live tunnel socket. Combines the
+ * cross-instance Redis revoke flag (`isViewerSessionRevoked`, set by
+ * `revokeViewerSession` on teardown elsewhere) with the DB revalidation
+ * above. Fails CLOSED: any thrown error or revoked/invalid state tears the
+ * socket down so a revoked user/device cannot keep forwarding traffic.
+ * Returns `true` when the socket was closed.
+ */
+async function enforceTunnelRevocation(tunnelId: string, ws: WSContext): Promise<boolean> {
+  const conn = activeTunnelConnections.get(tunnelId);
+  if (!conn) return false;
+
+  try {
+    const revoked = await isViewerSessionRevoked(tunnelId);
+    if (revoked) {
+      console.warn(`[TunnelWs] Tunnel ${tunnelId} revoked mid-session, closing socket`);
+      await closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: 'Tunnel revoked' });
+      try { ws.close(4003, 'Tunnel revoked'); } catch { /* already closing */ }
+      return true;
+    }
+
+    const check = await revalidateTunnelSession(tunnelId, conn);
+    if (!check.ok) {
+      console.warn(`[TunnelWs] Tunnel ${tunnelId} access revoked mid-session (${check.reason}), closing socket`);
+      await closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: check.reason });
+      try { ws.close(4003, 'Access revoked'); } catch { /* already closing */ }
+      return true;
+    }
+
+    return false;
+  } catch (err) {
+    // Fail CLOSED: a thrown error (Redis down already resolves `true` above,
+    // but a DB error here must not leave the tunnel relaying) tears the
+    // socket down this tick.
+    console.error(`[TunnelWs] Revocation check failed for tunnel ${tunnelId}, closing socket (fail-closed):`, err);
+    await closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: 'Revocation check failed' });
+    try { ws.close(4003, 'Revocation check failed'); } catch { /* already closing */ }
+    return true;
+  }
+}
+
+/**
  * Create WebSocket handlers for a tunnel session.
  */
 function createTunnelWsHandlers(
@@ -372,11 +477,19 @@ function createTunnelWsHandlers(
             return;
           }
 
-          try {
-            ws.send(JSON.stringify({ type: 'ping' }));
-          } catch {
-            void closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: 'Relay ping failed' });
-          }
+          // Mid-session revocation enforcement: re-check user/device/session/
+          // policy on each ping interval and tear the socket down fail-closed
+          // if access is gone. A revoked tunnel closes within at most one ping
+          // interval (~PING_INTERVAL_MS). Nothing else re-checks authorization
+          // once the relay is forwarding.
+          void enforceTunnelRevocation(tunnelId, ws).then((closed) => {
+            if (closed) return;
+            try {
+              ws.send(JSON.stringify({ type: 'ping' }));
+            } catch {
+              void closeTunnelLifecycle(tunnelId, { notifyAgent: true, reason: 'Relay ping failed' });
+            }
+          });
         }, PING_INTERVAL_MS);
 
         // Only transition to active if the tunnel_open succeeded (status = connecting).


### PR DESCRIPTION
## Fail-closed mid-session revocation for tunnel + event WebSockets

Both WS routes authorized at connect time (one-time ticket / org snapshot) and then kept forwarding/delivering after the user/device/policy was revoked.

- **`tunnelWs.ts`** — added `revalidateTunnelSession` + `enforceTunnelRevocation` wired into the existing ping loop (user still active, session still owned, status valid, device online, `checkRemoteAccess` policy + viewer-revocation Redis flag); tears down via the existing lifecycle close. Fails closed on error.
- **`eventWs.ts`** — periodic re-check of `users.status==='active'` under system ctx; unregisters from the dispatcher then closes `4003` when revoked.

Mirrors the existing revocation loops in `desktopWs.ts`/`terminalWs.ts` (30s cadence, 4003 close code).

**Verification:** API package `tsc --noEmit` clean; all changed-file unit suites green (single-fork). RLS contract + integration tests not run locally (need DB) — rely on CI.
Origin: `/security-review` playbook entry 1 (multi-tenant RLS + authz) two-pass workflow + Codex review pass.
