### PR TITLE
fix(api,secrets): encrypt webhook URLs at rest + mask on read

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -238,6 +238,8 @@ import { initializeTicketSlaWorker, shutdownTicketSlaWorker } from './jobs/ticke
 import { initializeInboundEmailWorker, shutdownInboundEmailWorker } from './jobs/inboundEmailWorker';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
+import { decryptForColumn } from './services/secretCrypto';
+import { decryptWebhookHeaders } from './services/notificationChannelSecrets';
 import { initializeTransferCleanup, stopTransferCleanup } from './workers/transferCleanup';
 import { closeRedis, getRedis, isRedisAvailable } from './services/redis';
 import { shutdownEventDispatcher } from './services/eventDispatcher';
@@ -1036,10 +1038,16 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
             id: webhook.id,
             orgId: webhook.orgId,
             name: webhook.name,
-            url: webhook.url,
-            secret: webhook.secret ?? undefined,
+            // url/secret/headers are encrypted at rest (encryptedColumnRegistry).
+            // Decrypt them here so the delivery worker fetches the real endpoint,
+            // signs with the real secret, and sends real header values. Legacy
+            // plaintext rows pass through decryptForColumn unchanged.
+            url: decryptForColumn('webhooks', 'url', webhook.url) ?? webhook.url,
+            secret: webhook.secret
+              ? decryptForColumn('webhooks', 'secret', webhook.secret) ?? undefined
+              : undefined,
             events: webhook.events ?? [],
-            headers: headersToRecord(webhook.headers),
+            headers: headersToRecord(decryptWebhookHeaders(webhook.headers)),
             retryPolicy: (webhook.retryPolicy ?? undefined) as {
               maxRetries: number;
               backoffMultiplier: number;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1034,27 +1034,42 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
             const events = webhook.events ?? [];
             return events.includes(eventType) || events.includes('*');
           })
-          .map((webhook) => ({
-            id: webhook.id,
-            orgId: webhook.orgId,
-            name: webhook.name,
-            // url/secret/headers are encrypted at rest (encryptedColumnRegistry).
-            // Decrypt them here so the delivery worker fetches the real endpoint,
-            // signs with the real secret, and sends real header values. Legacy
-            // plaintext rows pass through decryptForColumn unchanged.
-            url: decryptForColumn('webhooks', 'url', webhook.url) ?? webhook.url,
-            secret: webhook.secret
-              ? decryptForColumn('webhooks', 'secret', webhook.secret) ?? undefined
-              : undefined,
-            events: webhook.events ?? [],
-            headers: headersToRecord(decryptWebhookHeaders(webhook.headers)),
-            retryPolicy: (webhook.retryPolicy ?? undefined) as {
-              maxRetries: number;
-              backoffMultiplier: number;
-              initialDelayMs: number;
-              maxDelayMs: number;
-            } | undefined
-          }));
+          // Decrypt PER ROW inside a try/catch. url/secret/headers are encrypted
+          // at rest (encryptedColumnRegistry); decryptForColumn THROWS on a row
+          // that looks encrypted but can't be decrypted (key/AAD mismatch,
+          // partial migration, corruption). Without per-row isolation a single
+          // bad row would abort the whole .map and silently drop delivery for
+          // EVERY webhook in the org. Skip only the offending webhook (delivering
+          // with unusable credentials is worse) and surface it to Sentry. Legacy
+          // plaintext rows pass through decryptForColumn unchanged.
+          .flatMap((webhook) => {
+            try {
+              return [{
+                id: webhook.id,
+                orgId: webhook.orgId,
+                name: webhook.name,
+                url: decryptForColumn('webhooks', 'url', webhook.url) ?? webhook.url,
+                secret: webhook.secret
+                  ? decryptForColumn('webhooks', 'secret', webhook.secret) ?? undefined
+                  : undefined,
+                events: webhook.events ?? [],
+                headers: headersToRecord(decryptWebhookHeaders(webhook.headers)),
+                retryPolicy: (webhook.retryPolicy ?? undefined) as {
+                  maxRetries: number;
+                  backoffMultiplier: number;
+                  initialDelayMs: number;
+                  maxDelayMs: number;
+                } | undefined
+              }];
+            } catch (err) {
+              console.error(
+                `[webhookDelivery] failed to decrypt webhook ${webhook.id} (org ${webhook.orgId}); skipping delivery for this webhook only`,
+                err
+              );
+              captureException(err instanceof Error ? err : new Error(String(err)));
+              return [];
+            }
+          });
       });
     },
     async (webhook, event) => {

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -646,4 +646,86 @@ describe('webhook routes', () => {
 
     expect(res.status).toBe(403);
   });
+
+  // -------------------------------------------------------------------------
+  // Cross-org isolation tests
+  //
+  // getWebhookWithOrgCheck fetches the webhook by id unconditionally, then
+  // gates on auth.canAccessOrg(webhook.orgId). A foreign-org webhook must
+  // never leak its contents — the only acceptable response is 404.
+  // -------------------------------------------------------------------------
+
+  const FOREIGN_ORG_ID = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+  const FOREIGN_WEBHOOK_ID = '55555555-5555-5555-5555-555555555555';
+
+  const foreignWebhookRow = {
+    id: FOREIGN_WEBHOOK_ID,
+    orgId: FOREIGN_ORG_ID,
+    name: 'Foreign Hook',
+    url: 'https://attacker:secret@foreign.example.com/hook?token=leak-me',
+    secret: 'foreign-secret-should-not-leak',
+    events: ['device.created'],
+    headers: [],
+    status: 'active',
+    createdBy: 'foreign-user',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastDeliveryAt: null,
+    retryPolicy: null,
+    successCount: 0,
+    failureCount: 0,
+    lastSuccessAt: null
+  };
+
+  it('GET /:id — returns 404 and leaks nothing for a webhook belonging to a different org', async () => {
+    // getWebhookWithOrgCheck calls .select().from().where().limit(1)
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectLimit([foreignWebhookRow]) as any);
+
+    const res = await app.request(`/webhooks/${FOREIGN_WEBHOOK_ID}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(404);
+    const text = await res.text();
+    expect(text).not.toContain('attacker');
+    expect(text).not.toContain('leak-me');
+    expect(text).not.toContain('foreign-secret-should-not-leak');
+    expect(text).not.toContain(FOREIGN_ORG_ID);
+  });
+
+  it('PATCH /:id — returns 404 and leaks nothing for a webhook belonging to a different org', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectLimit([foreignWebhookRow]) as any);
+
+    const res = await app.request(`/webhooks/${FOREIGN_WEBHOOK_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'Renamed' })
+    });
+
+    expect(res.status).toBe(404);
+    const text = await res.text();
+    expect(text).not.toContain('attacker');
+    expect(text).not.toContain('leak-me');
+    expect(text).not.toContain('foreign-secret-should-not-leak');
+    // db.update must not have been called — no mutation on foreign resource
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /:id — returns 404 and leaks nothing for a webhook belonging to a different org', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectLimit([foreignWebhookRow]) as any);
+
+    const res = await app.request(`/webhooks/${FOREIGN_WEBHOOK_ID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(404);
+    const text = await res.text();
+    expect(text).not.toContain('attacker');
+    expect(text).not.toContain('leak-me');
+    expect(text).not.toContain('foreign-secret-should-not-leak');
+    // db.delete must not have been called — no mutation on foreign resource
+    expect(db.delete).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -22,7 +22,21 @@ vi.mock('../services/auditEvents', () => ({
 }));
 
 vi.mock('../services/notificationSenders/webhookSender', () => ({
-  validateWebhookUrlSafetyWithDns: validateWebhookUrlSafetyWithDnsMock
+  validateWebhookUrlSafetyWithDns: validateWebhookUrlSafetyWithDnsMock,
+  // Real implementation: strips userinfo/query/hash so masked responses keep
+  // scheme+host+path. Kept in sync with the production helper.
+  redactUrlForLogs: (rawUrl: string) => {
+    try {
+      const parsed = new URL(rawUrl);
+      parsed.username = '';
+      parsed.password = '';
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString().replace(/\/$/, '');
+    } catch {
+      return '[invalid-url]';
+    }
+  }
 }));
 
 vi.mock('../db', () => ({
@@ -242,6 +256,163 @@ describe('webhook routes', () => {
       hasSecret: true,
       masked: '********'
     });
+  });
+
+  it('encrypts the delivery URL at rest and masks credentials in the response', async () => {
+    const credentialUrl = 'https://user:pass@example.com/hook?token=secret-token-xyz';
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn((values: any) => ({
+        returning: vi.fn(() => Promise.resolve([{
+          id: WEBHOOK_ID_1,
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Cred Hook',
+          // Echo back what the handler actually persisted (encrypted form).
+          url: values.url,
+          secret: values.secret,
+          events: ['device.created'],
+          headers: [],
+          status: 'active',
+          createdBy: 'user-123',
+          createdAt: new Date('2026-02-07T13:00:00.000Z'),
+          updatedAt: new Date('2026-02-07T13:00:00.000Z'),
+          lastDeliveryAt: null
+        }]))
+      }))
+    } as any);
+
+    const res = await app.request('/webhooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Cred Hook',
+        url: credentialUrl,
+        secret: 'secret-123',
+        events: ['device.created']
+      })
+    });
+
+    expect(res.status).toBe(201);
+
+    // 1. Persisted URL is encrypted, not plaintext.
+    const insertValues = vi.mocked(db.insert).mock.results[0]?.value.values.mock.calls[0][0];
+    expect(insertValues.url).not.toBe(credentialUrl);
+    expect(String(insertValues.url)).toMatch(/^enc:v[123]:/);
+
+    // 2. API response masks the credential-bearing parts of the URL.
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toContain('secret-token-xyz');
+    expect(JSON.stringify(body)).not.toContain('user:pass');
+    expect(body.url).toBe('https://example.com/hook');
+  });
+
+  it('decrypts the delivery URL for internal delivery use', async () => {
+    const { encryptSecret } = await import('../services/secretCrypto');
+    const encryptedUrl = encryptSecret('https://user:pass@example.com/deliver?token=abc') as string;
+    expect(encryptedUrl).toMatch(/^enc:v[123]:/);
+
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectLimit([
+      {
+        id: WEBHOOK_ID_1,
+        orgId: '11111111-1111-1111-1111-111111111111',
+        name: 'Device Alerts',
+        url: encryptedUrl,
+        secret: null,
+        events: ['device.created'],
+        headers: [],
+        status: 'active',
+        createdBy: 'user-123',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastDeliveryAt: null,
+        retryPolicy: null
+      }
+    ]) as any);
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([{
+          id: DELIVERY_ID_1,
+          webhookId: WEBHOOK_ID_1,
+          eventType: 'webhook.test',
+          eventId: 'event-1',
+          payload: { test: true },
+          status: 'pending',
+          attempts: 0,
+          createdAt: new Date(),
+          deliveredAt: null
+        }]))
+      }))
+    } as any);
+
+    queueDeliveryMock.mockResolvedValueOnce(DELIVERY_ID_1);
+
+    const res = await app.request(`/webhooks/${WEBHOOK_ID_1}/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ payload: { test: true } })
+    });
+
+    expect(res.status).toBe(202);
+    // The worker config passed to queueDelivery must carry the decrypted URL.
+    const workerConfig = (queueDeliveryMock.mock.calls as any[])[0][0];
+    expect(workerConfig.url).toBe('https://user:pass@example.com/deliver?token=abc');
+  });
+
+  it('keeps the stored URL when an update re-submits the masked form', async () => {
+    const { encryptSecret } = await import('../services/secretCrypto');
+    const storedPlain = 'https://user:pass@example.com/hook?token=keepme';
+    const encryptedUrl = encryptSecret(storedPlain) as string;
+
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectLimit([
+      {
+        id: WEBHOOK_ID_1,
+        orgId: '11111111-1111-1111-1111-111111111111',
+        name: 'Device Alerts',
+        url: encryptedUrl,
+        secret: null,
+        events: ['device.created'],
+        headers: [],
+        status: 'active',
+        createdBy: 'user-123',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastDeliveryAt: null
+      }
+    ]) as any);
+
+    const updateValuesSpy = vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([{
+          id: WEBHOOK_ID_1,
+          orgId: '11111111-1111-1111-1111-111111111111',
+          name: 'Renamed',
+          url: encryptedUrl,
+          secret: null,
+          events: ['device.created'],
+          headers: [],
+          status: 'active',
+          createdBy: 'user-123',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          lastDeliveryAt: null
+        }]))
+      }))
+    }));
+    vi.mocked(db.update).mockReturnValueOnce({ set: updateValuesSpy } as any);
+
+    // Editor re-submits the masked URL we previously returned.
+    const res = await app.request(`/webhooks/${WEBHOOK_ID_1}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'Renamed', url: 'https://example.com/hook' })
+    });
+
+    expect(res.status).toBe(200);
+    // url must NOT be overwritten (would otherwise strip credentials).
+    const setPayload = (updateValuesSpy.mock.calls as any[])[0][0];
+    expect(setPayload.url).toBeUndefined();
+    expect(setPayload.name).toBe('Renamed');
   });
 
   it('rejects unsafe webhook URLs', async () => {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -7,7 +7,7 @@ import { db } from '../db';
 import { webhookDeliveries, webhooks as webhooksTable } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
-import { validateWebhookUrlSafetyWithDns } from '../services/notificationSenders/webhookSender';
+import { redactUrlForLogs, validateWebhookUrlSafetyWithDns } from '../services/notificationSenders/webhookSender';
 import { getWebhookWorker, type WebhookConfig as WorkerWebhookConfig } from '../workers/webhookDelivery';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
@@ -90,6 +90,19 @@ function headersToRecord(headers: unknown): Record<string, string> {
   return sanitizeOutboundHeaders(headerRecord);
 }
 
+// The delivery URL can embed credentials (basic-auth userinfo, signed query
+// tokens), so it is encrypted at rest via the encryptedColumnRegistry. Decrypt
+// it only for internal delivery use; legacy plaintext rows pass through
+// unchanged (decryptForColumn is a no-op for non-encrypted values).
+function decryptWebhookUrl(webhook: typeof webhooksTable.$inferSelect): string {
+  try {
+    return decryptForColumn('webhooks', 'url', webhook.url) ?? webhook.url;
+  } catch (error) {
+    console.error(`[webhooks] Failed to decrypt url for webhook ${webhook.id}:`, error);
+    return webhook.url;
+  }
+}
+
 function toWorkerWebhookConfig(webhook: typeof webhooksTable.$inferSelect): WorkerWebhookConfig {
   const retryPolicy = (webhook.retryPolicy ?? undefined) as WorkerWebhookConfig['retryPolicy'];
   let secret: string | undefined;
@@ -106,7 +119,7 @@ function toWorkerWebhookConfig(webhook: typeof webhooksTable.$inferSelect): Work
     id: webhook.id,
     orgId: webhook.orgId,
     name: webhook.name,
-    url: webhook.url,
+    url: decryptWebhookUrl(webhook),
     secret,
     events: webhook.events ?? [],
     headers: headersToRecord(decryptWebhookHeaders(webhook.headers)),
@@ -115,11 +128,15 @@ function toWorkerWebhookConfig(webhook: typeof webhooksTable.$inferSelect): Work
 }
 
 function sanitizeWebhook(webhook: typeof webhooksTable.$inferSelect) {
+  // Never return credentials embedded in the delivery URL (basic-auth userinfo,
+  // signed query tokens). redactUrlForLogs strips username/password/query/hash
+  // while keeping scheme+host+path so the URL stays recognizable and editable.
+  const decryptedUrl = decryptWebhookUrl(webhook);
   return {
     id: webhook.id,
     orgId: webhook.orgId,
     name: webhook.name,
-    url: webhook.url,
+    url: redactUrlForLogs(decryptedUrl),
     events: webhook.events ?? [],
     headers: normalizeHeaders(redactWebhookHeaders(webhook.headers)),
     status: mapDbStatusToApi(webhook.status as DbWebhookStatus),
@@ -381,7 +398,7 @@ webhookRoutes.post(
       .values({
         orgId,
         name: data.name,
-        url: data.url,
+        url: encryptSecret(data.url) ?? data.url,
         secret: encryptSecret(data.secret),
         events: data.events,
         headers: encryptWebhookHeaders(data.headers ?? []),
@@ -403,7 +420,7 @@ webhookRoutes.post(
       resourceId: created.id,
       resourceName: created.name,
       details: {
-        urlHost: URL.canParse(created.url) ? new URL(created.url).hostname : 'redacted',
+        urlHost: URL.canParse(data.url) ? new URL(data.url).hostname : 'redacted',
         eventCount: created.events?.length ?? 0
       }
     });
@@ -457,7 +474,15 @@ webhookRoutes.patch(
       return c.json({ error: 'Webhook not found' }, 404);
     }
 
-    if (data.url) {
+    // The editor pre-fills the masked URL we returned and re-submits it on save.
+    // If the incoming URL is unchanged from the masked form of the stored URL,
+    // the user didn't edit it — keep the existing encrypted value (which may
+    // carry credentials) instead of overwriting with the credential-stripped
+    // form. Mirrors the isMaskedIntegrationSecret no-clobber guard for `secret`.
+    const urlUnchanged =
+      data.url !== undefined && data.url === redactUrlForLogs(decryptWebhookUrl(webhook));
+
+    if (data.url && !urlUnchanged) {
       const urlErrors = await validateWebhookUrlSafetyWithDns(data.url);
       if (urlErrors.length > 0) {
         return c.json({ error: 'Invalid webhook URL', details: urlErrors }, 400);
@@ -469,7 +494,9 @@ webhookRoutes.patch(
     };
 
     if (data.name !== undefined) updatePayload.name = data.name;
-    if (data.url !== undefined) updatePayload.url = data.url;
+    if (data.url !== undefined && !urlUnchanged) {
+      updatePayload.url = encryptSecret(data.url) ?? data.url;
+    }
     if (data.secret !== undefined && !isMaskedIntegrationSecret(data.secret)) {
       updatePayload.secret = encryptSecret(data.secret);
     }

--- a/apps/api/src/services/aiToolsIntegrations.test.ts
+++ b/apps/api/src/services/aiToolsIntegrations.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for credential-masking in aiToolsIntegrations.ts
+ *
+ * Guards against regressions where maskWebhookUrl() is removed or bypassed,
+ * which would leak credential-bearing URLs to the AI model surface.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any imports that pull in the module
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  dbSelect: vi.fn(),
+  dbInsert: vi.fn(),
+  decryptForColumn: vi.fn(),
+  redactUrlForLogs: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: mocks.dbSelect,
+    insert: mocks.dbInsert,
+  },
+}));
+
+// Mock the schema so Drizzle column references resolve without a real DB.
+vi.mock('../db/schema/integrations', () => ({
+  webhooks: {
+    id: 'id',
+    orgId: 'orgId',
+    name: 'name',
+    url: 'url',
+    status: 'status',
+    events: 'events',
+    successCount: 'successCount',
+    failureCount: 'failureCount',
+    lastDeliveryAt: 'lastDeliveryAt',
+    lastSuccessAt: 'lastSuccessAt',
+    createdAt: 'createdAt',
+  },
+  webhookDeliveries: {
+    id: 'id',
+    webhookId: 'webhookId',
+    eventType: 'eventType',
+    eventId: 'eventId',
+    payload: 'payload',
+    status: 'status',
+    attempts: 'attempts',
+    createdAt: 'createdAt',
+    deliveredAt: 'deliveredAt',
+    responseStatus: 'responseStatus',
+    responseTimeMs: 'responseTimeMs',
+    errorMessage: 'errorMessage',
+  },
+  psaConnections: {
+    id: 'id',
+    orgId: 'orgId',
+    provider: 'provider',
+    name: 'name',
+    enabled: 'enabled',
+    lastSyncAt: 'lastSyncAt',
+    lastSyncStatus: 'lastSyncStatus',
+    lastSyncError: 'lastSyncError',
+    createdAt: 'createdAt',
+  },
+  psaTicketMappings: {
+    id: 'id',
+    connectionId: 'connectionId',
+  },
+}));
+
+vi.mock('./secretCrypto', () => ({
+  decryptForColumn: mocks.decryptForColumn,
+}));
+
+vi.mock('./notificationSenders/webhookSender', () => ({
+  redactUrlForLogs: mocks.redactUrlForLogs,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerIntegrationTools } from './aiToolsIntegrations';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const WEBHOOK_ID = '22222222-2222-2222-2222-222222222222';
+const DELIVERY_ID = '44444444-4444-4444-4444-444444444444';
+
+/** Real redactUrlForLogs behaviour — strip userinfo/query/hash */
+function realRedact(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return '[invalid-url]';
+  }
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'user@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: vi.fn(() => undefined),
+  } as any;
+}
+
+function buildToolMap(): Map<string, AiTool> {
+  const map = new Map<string, AiTool>();
+  registerIntegrationTools(map);
+  return map;
+}
+
+/** Fluent select chain that resolves to `rows` after .from().where().orderBy().limit() */
+function makeSelectChain(rows: unknown[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.then = (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+/** Fluent insert chain that resolves to `rows` after .values().returning() */
+function makeInsertChain(rows: unknown[]) {
+  const chain: any = {};
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+// ---------------------------------------------------------------------------
+// Suite: query_webhooks credential masking
+// ---------------------------------------------------------------------------
+
+describe('aiToolsIntegrations — query_webhooks credential masking', () => {
+  let toolMap: Map<string, AiTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toolMap = buildToolMap();
+
+    // Default: decryptForColumn returns its input unchanged (plaintext path).
+    mocks.decryptForColumn.mockImplementation((_table: string, _col: string, val: string) => val);
+    // Default: redactUrlForLogs strips userinfo and query.
+    mocks.redactUrlForLogs.mockImplementation((url: string) => realRedact(url));
+  });
+
+  it('masks credential-bearing URL — secret substring absent from JSON output', async () => {
+    const credentialUrl = 'https://user:pass@webhook.example.com/hook?token=super-secret-abc';
+
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      {
+        id: WEBHOOK_ID,
+        name: 'My Hook',
+        url: credentialUrl,
+        status: 'active',
+        events: ['device.created'],
+        successCount: 0,
+        failureCount: 0,
+        lastDeliveryAt: null,
+        lastSuccessAt: null,
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+      },
+    ]));
+
+    const result = await toolMap.get('query_webhooks')!.handler({}, makeAuth());
+    const parsed = JSON.parse(result);
+
+    // Raw secrets must not appear anywhere in the output.
+    expect(result).not.toContain('super-secret-abc');
+    expect(result).not.toContain('user:pass');
+    // The host+path portion should still be present.
+    expect(parsed.webhooks[0].url).toBe('https://webhook.example.com/hook');
+  });
+
+  it('masks encrypted URL — decrypted-then-redacted, raw ciphertext absent', async () => {
+    const encryptedUrl = 'enc:v1:someciphertextblob';
+    const decryptedPlain = 'https://bot:hunter2@hooks.example.com/path?sig=abc';
+
+    mocks.decryptForColumn.mockImplementation(() => decryptedPlain);
+
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      {
+        id: WEBHOOK_ID,
+        name: 'Enc Hook',
+        url: encryptedUrl,
+        status: 'active',
+        events: ['alert.triggered'],
+        successCount: 1,
+        failureCount: 0,
+        lastDeliveryAt: null,
+        lastSuccessAt: null,
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+      },
+    ]));
+
+    const result = await toolMap.get('query_webhooks')!.handler({}, makeAuth());
+    const parsed = JSON.parse(result);
+
+    // Credentials from the decrypted form must not appear.
+    expect(result).not.toContain('hunter2');
+    expect(result).not.toContain('bot:');
+    expect(result).not.toContain('sig=abc');
+    // Raw ciphertext must not appear either.
+    expect(result).not.toContain('enc:v1:someciphertextblob');
+    // Safe host+path should be present.
+    expect(parsed.webhooks[0].url).toBe('https://hooks.example.com/path');
+  });
+
+  it('decrypt-failure fallback — raw ciphertext not emitted when decryptForColumn throws', async () => {
+    const encryptedUrl = 'enc:v1:GIBBERISH_CIPHERTEXT';
+
+    // Simulate decryption failure (wrong key, corruption, etc.)
+    mocks.decryptForColumn.mockImplementation(() => {
+      throw new Error('decryption failed: invalid tag');
+    });
+
+    // On decrypt failure the code falls back to the stored string, which is
+    // then passed to redactUrlForLogs. redactUrlForLogs on a non-URL returns
+    // [invalid-url] — we still must not emit the raw ciphertext.
+    mocks.redactUrlForLogs.mockImplementation((val: string) => {
+      // A real URL parse of enc:v1:… will throw; return a safe placeholder.
+      return realRedact(val);
+    });
+
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      {
+        id: WEBHOOK_ID,
+        name: 'Broken Hook',
+        url: encryptedUrl,
+        status: 'error',
+        events: [],
+        successCount: 0,
+        failureCount: 3,
+        lastDeliveryAt: null,
+        lastSuccessAt: null,
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+      },
+    ]));
+
+    const result = await toolMap.get('query_webhooks')!.handler({}, makeAuth());
+
+    // The ciphertext blob itself must not appear in the output.
+    expect(result).not.toContain('GIBBERISH_CIPHERTEXT');
+    // The output must still be valid JSON.
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: test_webhook credential masking
+// ---------------------------------------------------------------------------
+
+describe('aiToolsIntegrations — test_webhook credential masking', () => {
+  let toolMap: Map<string, AiTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toolMap = buildToolMap();
+
+    mocks.decryptForColumn.mockImplementation((_table: string, _col: string, val: string) => val);
+    mocks.redactUrlForLogs.mockImplementation((url: string) => realRedact(url));
+  });
+
+  it('masks credential-bearing webhookUrl in the test_webhook response', async () => {
+    const credentialUrl = 'https://admin:s3cr3t@hooks.example.com/test?api_key=mysecret';
+
+    // First select: fetch the webhook row.
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      { id: WEBHOOK_ID, name: 'Test Hook', url: credentialUrl },
+    ]));
+
+    // Insert: create delivery record.
+    mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
+      { id: DELIVERY_ID, createdAt: new Date('2026-06-01T00:00:00Z') },
+    ]));
+
+    const result = await toolMap.get('test_webhook')!.handler(
+      { webhookId: WEBHOOK_ID },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    // The echoed webhookUrl must be masked.
+    expect(parsed.webhookUrl).toBeDefined();
+    expect(result).not.toContain('s3cr3t');
+    expect(result).not.toContain('admin:');
+    expect(result).not.toContain('mysecret');
+    expect(parsed.webhookUrl).toBe('https://hooks.example.com/test');
+  });
+
+  it('masks encrypted URL in test_webhook — ciphertext not echoed', async () => {
+    const encryptedUrl = 'enc:v1:CIPHERTEXT_XYZ';
+    const decryptedUrl = 'https://user:token99@hooks.example.com/cb';
+
+    mocks.decryptForColumn.mockImplementation(() => decryptedUrl);
+
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      { id: WEBHOOK_ID, name: 'Enc Test Hook', url: encryptedUrl },
+    ]));
+
+    mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
+      { id: DELIVERY_ID, createdAt: new Date('2026-06-01T00:00:00Z') },
+    ]));
+
+    const result = await toolMap.get('test_webhook')!.handler(
+      { webhookId: WEBHOOK_ID },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(result).not.toContain('token99');
+    expect(result).not.toContain('CIPHERTEXT_XYZ');
+    expect(parsed.webhookUrl).toBe('https://hooks.example.com/cb');
+  });
+
+  it('decrypt-failure in test_webhook — raw ciphertext not emitted', async () => {
+    const encryptedUrl = 'enc:v1:BADKEY_CIPHERTEXT';
+
+    mocks.decryptForColumn.mockImplementation(() => {
+      throw new Error('bad decrypt');
+    });
+    mocks.redactUrlForLogs.mockImplementation((val: string) => realRedact(val));
+
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      { id: WEBHOOK_ID, name: 'Broken Hook', url: encryptedUrl },
+    ]));
+
+    mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
+      { id: DELIVERY_ID, createdAt: new Date('2026-06-01T00:00:00Z') },
+    ]));
+
+    const result = await toolMap.get('test_webhook')!.handler(
+      { webhookId: WEBHOOK_ID },
+      makeAuth(),
+    );
+
+    expect(result).not.toContain('BADKEY_CIPHERTEXT');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('returns not-found when the webhook select returns empty', async () => {
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([]));
+
+    const result = await toolMap.get('test_webhook')!.handler(
+      { webhookId: WEBHOOK_ID },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toMatch(/not found|access denied/i);
+  });
+});

--- a/apps/api/src/services/aiToolsIntegrations.ts
+++ b/apps/api/src/services/aiToolsIntegrations.ts
@@ -23,11 +23,16 @@ import { redactUrlForLogs } from './notificationSenders/webhookSender';
 // display then strip userinfo/query/hash so the AI tool never sees a token.
 // Plaintext legacy rows pass through decryptForColumn unchanged.
 function maskWebhookUrl(stored: string): string {
-  let decrypted = stored;
+  let decrypted: string;
   try {
+    // Legacy plaintext rows pass through decryptForColumn unchanged (no throw).
     decrypted = decryptForColumn('webhooks', 'url', stored) ?? stored;
   } catch {
-    decrypted = stored;
+    // An encrypted value we cannot decrypt (key/AAD mismatch, corruption). Do NOT
+    // fall back to the raw ciphertext: redactUrlForLogs treats `enc:...` as an
+    // opaque URL and would surface the ciphertext blob to the model. Emit a fixed
+    // placeholder instead.
+    return '[encrypted]';
   }
   return redactUrlForLogs(decrypted);
 }

--- a/apps/api/src/services/aiToolsIntegrations.ts
+++ b/apps/api/src/services/aiToolsIntegrations.ts
@@ -16,6 +16,21 @@ import {
 import { eq, and, desc, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { decryptForColumn } from './secretCrypto';
+import { redactUrlForLogs } from './notificationSenders/webhookSender';
+
+// webhooks.url is encrypted at rest and may embed credentials. Decrypt for
+// display then strip userinfo/query/hash so the AI tool never sees a token.
+// Plaintext legacy rows pass through decryptForColumn unchanged.
+function maskWebhookUrl(stored: string): string {
+  let decrypted = stored;
+  try {
+    decrypted = decryptForColumn('webhooks', 'url', stored) ?? stored;
+  } catch {
+    decrypted = stored;
+  }
+  return redactUrlForLogs(decrypted);
+}
 
 type IntegrationHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
@@ -104,13 +119,15 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
         .orderBy(desc(webhooks.createdAt))
         .limit(limit);
 
+      const maskedRows = rows.map((row) => ({ ...row, url: maskWebhookUrl(row.url) }));
+
       if (!includeDeliveries) {
-        return JSON.stringify({ webhooks: rows, count: rows.length });
+        return JSON.stringify({ webhooks: maskedRows, count: maskedRows.length });
       }
 
       // Fetch last 10 deliveries per webhook
       const webhooksWithDeliveries = await Promise.all(
-        rows.map(async (webhook) => {
+        maskedRows.map(async (webhook) => {
           const deliveries = await db
             .select({
               id: webhookDeliveries.id,
@@ -257,7 +274,7 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
         message: `Test delivery queued for webhook "${webhook.name}"`,
         deliveryId: delivery.id,
         webhookId: webhook.id,
-        webhookUrl: webhook.url,
+        webhookUrl: maskWebhookUrl(webhook.url),
         createdAt: delivery.createdAt,
       });
     }),

--- a/apps/api/src/services/encryptedColumnRegistry.ts
+++ b/apps/api/src/services/encryptedColumnRegistry.ts
@@ -46,6 +46,7 @@ export const encryptedColumnRegistry: EncryptedColumnSpec[] = [
   { table: 'c2c_connections', column: 'client_secret', kind: 'text', description: 'C2C OAuth client secret' },
   { table: 'c2c_connections', column: 'refresh_token', kind: 'text', description: 'C2C OAuth refresh token' },
   { table: 'c2c_connections', column: 'access_token', kind: 'text', description: 'C2C OAuth access token' },
+  { table: 'webhooks', column: 'url', kind: 'text', description: 'outbound webhook delivery URL (may embed credentials in userinfo/query)' },
   { table: 'webhooks', column: 'secret', kind: 'text', description: 'outbound webhook signing secret' },
   { table: 'webhooks', column: 'headers', kind: 'json', description: 'outbound webhook encrypted headers' },
   { table: 'notification_channels', column: 'config', kind: 'json', description: 'notification channel secret config' },


### PR DESCRIPTION
## Encrypt credential-bearing webhook URLs at rest (⚠️ touches delivery hot path)

Webhook delivery URLs can embed credentials (basic-auth userinfo, signed query tokens) but were stored **and returned** in plaintext. Now encrypted in-place via the existing `encryptedColumnRegistry` (same convention as `webhooks.secret`/`headers`), with credentials masked on read (scheme+host+path preserved so the editor stays usable).

**⚠️ Reviewer note:** this also fixes a **latent pre-existing bug** — the event-bus delivery path in `apps/api/src/index.ts` was passing `secret`/`headers` to the worker **un-decrypted** (HMAC signed over ciphertext, encrypted headers sent literally). Encrypting `url` would have hard-broken delivery, so `url`/`secret`/`headers` are now decrypted at the single delivery chokepoint. **Please exercise webhook delivery before merge.**

No migration — legacy plaintext rows decrypt-pass-through until the re-encrypt walker runs.

**Verification:** API package `tsc --noEmit` clean; all changed-file unit suites green (single-fork). RLS contract + integration tests not run locally (need DB) — rely on CI.
Origin: `/security-review` playbook entry 1 (multi-tenant RLS + authz) two-pass workflow + Codex review pass.
