### PR TITLE
fix(api): patch/deploy conn-hold root cause + Sentry quota/noise fixes (0.83.3)

### DIFF
--- a/apps/api/src/db/heldContextCaptureThrottle.test.ts
+++ b/apps/api/src/db/heldContextCaptureThrottle.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Importing ./index pulls the DB module; stub the Sentry surface it uses so the
+// unit test never loads the real SDK (mirrors dbWriteExpectingRows.test.ts).
+vi.mock('../services/sentry', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import {
+  shouldCaptureHeldContext,
+  __resetHeldContextCaptureThrottleForTests,
+} from './index';
+
+// Guards the #1105 quota fix: the held-context warning must NOT emit one Sentry
+// event per occurrence (8.6k events in a week exhausted the org budget and
+// blinded all error reporting). It captures at most once per scope per window.
+describe('shouldCaptureHeldContext (held-context Sentry-capture throttle)', () => {
+  const W = 300_000; // 5-minute window
+
+  beforeEach(() => {
+    __resetHeldContextCaptureThrottleForTests();
+  });
+
+  it('throttleMs=0 disables throttling — always captures', () => {
+    expect(shouldCaptureHeldContext('system', 1000, 0)).toBe(true);
+    expect(shouldCaptureHeldContext('system', 1001, 0)).toBe(true);
+    expect(shouldCaptureHeldContext('system', 1002, 0)).toBe(true);
+  });
+
+  it('captures the first hit for a scope, then throttles within the window', () => {
+    expect(shouldCaptureHeldContext('system', 1_000, W)).toBe(true);     // first → capture
+    expect(shouldCaptureHeldContext('system', 2_000, W)).toBe(false);    // +1s → throttled
+    expect(shouldCaptureHeldContext('system', 300_999, W)).toBe(false);  // just under window
+    expect(shouldCaptureHeldContext('system', 301_000, W)).toBe(true);   // window elapsed → capture
+    expect(shouldCaptureHeldContext('system', 302_000, W)).toBe(false);  // throttled again
+  });
+
+  it('throttles each scope independently', () => {
+    expect(shouldCaptureHeldContext('system', 0, W)).toBe(true);
+    expect(shouldCaptureHeldContext('organization', 0, W)).toBe(true);
+    expect(shouldCaptureHeldContext('partner', 0, W)).toBe(true);
+    expect(shouldCaptureHeldContext('system', 1, W)).toBe(false);
+    expect(shouldCaptureHeldContext('organization', 1, W)).toBe(false);
+    expect(shouldCaptureHeldContext('partner', 1, W)).toBe(false);
+  });
+
+  it('quantifies the quota win: a constant-hold scope yields ~13/hr, not 720/hr', () => {
+    let captures = 0;
+    // One hold every 5s for an hour (721 holds) — the flood that drained quota.
+    for (let t = 0; t <= 3_600_000; t += 5_000) {
+      if (shouldCaptureHeldContext('system', t, W)) captures++;
+    }
+    expect(captures).toBe(13); // t=0,300k,600k,…,3.6M — a >98% reduction from 721
+  });
+
+  it('reset clears throttle state', () => {
+    expect(shouldCaptureHeldContext('system', 1, W)).toBe(true);
+    expect(shouldCaptureHeldContext('system', 2, W)).toBe(false);
+    __resetHeldContextCaptureThrottleForTests();
+    expect(shouldCaptureHeldContext('system', 2, W)).toBe(true);
+  });
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -135,6 +135,42 @@ function getHeldContextWarnMs(): number {
   return raw;
 }
 
+// The held-context warning marks a recurring CONDITION (a conn-hold bug), not N
+// distinct errors. Capturing it to Sentry on EVERY occurrence floods the org's
+// event quota: a single conn-hold worker produced 8.6k events in a week, which
+// exhausted the budget and silently dropped ALL error reporting org-wide (the
+// June 2026 Sentry blackout). Throttle the Sentry capture to at most once per
+// scope per window so it still alerts/trends without flooding. `console.warn`
+// stays unthrottled so logs remain complete. 0 disables the throttle (always
+// capture). Tune via DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS.
+function getHeldContextCaptureThrottleMs(): number {
+  const raw = Number.parseInt(process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS ?? '', 10);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return 5 * 60_000;
+  }
+  return raw;
+}
+const lastHeldContextCaptureAtByScope = new Map<string, number>();
+export function __resetHeldContextCaptureThrottleForTests(): void {
+  lastHeldContextCaptureAtByScope.clear();
+}
+
+/**
+ * Per-scope throttle gate for the held-context Sentry capture. Returns true (and
+ * records `now` as the scope's last-capture time) at most once per `throttleMs`
+ * window per scope; `throttleMs === 0` disables throttling (always true). Pure
+ * apart from the module-level last-seen map — exported for unit testing.
+ */
+export function shouldCaptureHeldContext(scope: string, now: number, throttleMs: number): boolean {
+  if (throttleMs === 0) return true;
+  const lastAt = lastHeldContextCaptureAtByScope.get(scope);
+  if (lastAt === undefined || now - lastAt >= throttleMs) {
+    lastHeldContextCaptureAtByScope.set(scope, now);
+    return true;
+  }
+  return false;
+}
+
 export async function withDbAccessContext<T>(
   context: DbAccessContext,
   fn: () => Promise<T>
@@ -174,7 +210,11 @@ export async function withDbAccessContext<T>(
               + `non-DB work (Redis/HTTP/loops) or a slow query inside the context. If the former, `
               + `move it after the context closes or wrap it in runOutsideDbContext (#1105).`;
             console.warn(message);
-            captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+            // Throttle the Sentry capture per scope (see getHeldContextCaptureThrottleMs)
+            // so a recurring conn-hold can't flood the org's event quota.
+            if (shouldCaptureHeldContext(context.scope, Date.now(), getHeldContextCaptureThrottleMs())) {
+              captureMessage(message, 'warning', { heldMs, scope: context.scope, stack: new Error().stack });
+            }
           }
         }
       } catch {

--- a/apps/api/src/jobs/deploymentWorker.ts
+++ b/apps/api/src/jobs/deploymentWorker.ts
@@ -582,167 +582,14 @@ export function createDeploymentWorker(): Worker {
 export function createDeploymentDeviceWorker(): Worker {
   return new Worker<ProcessDeploymentDeviceJob>(
     DEPLOYMENT_DEVICE_QUEUE,
-    // System DB context for the whole processor — same rationale as the
-    // deployment worker above (#1375 class). Device-status transitions,
-    // claim/release, retry counting and the failure-threshold auto-pause all
-    // write RLS-forced tables and would silently no-op without it.
-    async (job: Job<ProcessDeploymentDeviceJob>) => withSystemDbAccessContext(async () => {
-      const { deploymentId, deviceId, batchNumber } = assertDeploymentDeviceJobData(job.data);
-
-      // Get deployment
-      const [deployment] = await db
-        .select()
-        .from(deployments)
-        .where(eq(deployments.id, deploymentId))
-        .limit(1);
-
-      if (!deployment) {
-        throw new Error(`Deployment ${deploymentId} not found`);
-      }
-
-      if (!['pending', 'running', 'paused', 'cancelled'].includes(deployment.status)) {
-        return { skipped: true, reason: `Deployment status is ${deployment.status}` };
-      }
-
-      const claim = await claimDeploymentDeviceJob(deployment, { deploymentId, deviceId, batchNumber });
-      if (claim.claimed === false) {
-        return { skipped: true, reason: claim.reason };
-      }
-
-      if (deployment.status === 'paused' || deployment.status === 'cancelled') {
-        // Skip if deployment is paused or cancelled
-        await updateDeploymentDeviceStatus(deploymentId, deviceId, 'skipped', {
-          success: false,
-          error: `Deployment ${deployment.status}`
-        });
-        return { skipped: true, reason: deployment.status };
-      }
-
-      // Check maintenance window
-      const rolloutConfig = deployment.rolloutConfig as RolloutConfig;
-      if (rolloutConfig.respectMaintenanceWindows) {
-        const inMaintenance = await isDeviceInMaintenanceWindow(deviceId);
-        if (!inMaintenance) {
-          await releaseDeploymentDeviceClaim(deploymentId, deviceId);
-
-          // Re-queue for later
-          const queue = getDeploymentDeviceQueue();
-          const deferredJobId = getDeploymentDeferredDeviceJobId(
-            deploymentId,
-            deviceId
-          );
-          const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
-          if (!existing) {
-            await queue.add(
-              'process-device',
-              job.data,
-              {
-                delay: 5 * 60 * 1000,
-                jobId: deferredJobId,
-                removeOnComplete: { count: 100 },
-                removeOnFail: { count: 200 }
-              }
-            );
-          }
-          return { delayed: true, reason: 'waiting for maintenance window' };
-        }
-      }
-
-      try {
-        // Execute the deployment payload
-        const result = await executeDeploymentPayload(
-          deployment.payload as DeploymentPayload,
-          deviceId
-        );
-
-        // Update status based on result
-        if (result.success) {
-          await updateDeploymentDeviceStatus(deploymentId, deviceId, 'completed', result);
-        } else {
-          // Check if we should retry
-          const { canRetry, retryCount } = await incrementRetryCount(deploymentId, deviceId);
-          if (canRetry) {
-            const backoffMs = getRetryBackoffMs(retryCount, rolloutConfig);
-            const queue = getDeploymentDeviceQueue();
-            const deferredJobId = getDeploymentDeferredDeviceJobId(
-              deploymentId,
-              deviceId
-            );
-            const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
-            if (!existing) {
-              await queue.add(
-                'process-device',
-                job.data,
-                {
-                  delay: backoffMs,
-                  jobId: deferredJobId,
-                  removeOnComplete: { count: 100 },
-                  removeOnFail: { count: 200 }
-                }
-              );
-            }
-            return { retrying: true, retryCount, backoffMs };
-          } else {
-            await updateDeploymentDeviceStatus(deploymentId, deviceId, 'failed', result);
-          }
-        }
-
-        // Check if deployment should be paused due to failures
-        const { pause, reason } = await shouldPauseDeployment(deploymentId, rolloutConfig);
-        if (pause) {
-          await pauseDeployment(deploymentId);
-          
-          // Send notifications to relevant users (push and email)
-          await sendDeploymentPausedNotifications({
-            deploymentId,
-            deploymentName: deployment.name,
-            orgId: deployment.orgId,
-            reason: reason ?? undefined,
-            dashboardUrl: process.env.DASHBOARD_URL 
-              ? `${process.env.DASHBOARD_URL}/deployments/${deploymentId}`
-              : undefined
-          });
-          
-          return { completed: true, deploymentPaused: true, pauseReason: reason };
-        }
-
-        return { completed: true, success: result.success };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
-        // Check if we should retry
-        const { canRetry, retryCount } = await incrementRetryCount(deploymentId, deviceId);
-        if (canRetry) {
-          const backoffMs = getRetryBackoffMs(retryCount, rolloutConfig);
-          const queue = getDeploymentDeviceQueue();
-          const deferredJobId = getDeploymentDeferredDeviceJobId(
-            deploymentId,
-            deviceId
-          );
-          const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
-          if (!existing) {
-            await queue.add(
-              'process-device',
-              job.data,
-              {
-                delay: backoffMs,
-                jobId: deferredJobId,
-                removeOnComplete: { count: 100 },
-                removeOnFail: { count: 200 }
-              }
-            );
-          }
-          return { retrying: true, retryCount, error: errorMessage };
-        }
-
-        await updateDeploymentDeviceStatus(deploymentId, deviceId, 'failed', {
-          success: false,
-          error: errorMessage
-        });
-
-        throw error;
-      }
-    }),
+    // NOT wrapped in one withSystemDbAccessContext: processDeploymentDevice
+    // manages its own short contexts so the up-to-30-min payload completion
+    // poll never holds a pooled connection in an open transaction (#1105
+    // conn-hold that starved the DB pool under concurrency 10 → user 503s).
+    // The setup/record DB ops each still run under a short system context so
+    // RLS-forced device-status/claim/retry/auto-pause writes don't silently
+    // no-op under breeze_app (#1375 class).
+    async (job: Job<ProcessDeploymentDeviceJob>) => processDeploymentDevice(job.data),
     {
       connection: getBullMQConnection(),
       concurrency: 10,
@@ -751,6 +598,207 @@ export function createDeploymentDeviceWorker(): Worker {
       maxStalledCount: 2,
     }
   );
+}
+
+type PrepareDeploymentDeviceResult =
+  | { skipped: true; reason: string }
+  | { delayed: true; reason: string }
+  | { deployment: typeof deployments.$inferSelect; rolloutConfig: RolloutConfig };
+
+async function processDeploymentDevice(jobData: ProcessDeploymentDeviceJob): Promise<unknown> {
+  // Phased so the up-to-30-min payload completion poll never holds a pooled
+  // connection in an open transaction (#1105 conn-hold). Setup and record each
+  // run in their own SHORT system context; the executors poll OUTSIDE any
+  // held transaction.
+  const data = assertDeploymentDeviceJobData(jobData);
+
+  const prep = await withSystemDbAccessContext(() => prepareDeploymentDevice(data, jobData));
+  if (!('deployment' in prep)) return prep; // early skip/delayed result — return as-is
+
+  let result: ExecutionResult | undefined;
+  let executionError: unknown;
+  try {
+    // No held transaction here: the executors self-manage short contexts around
+    // each DB touch and sleep between polls without a pooled connection.
+    result = await executeDeploymentPayload(prep.deployment.payload as DeploymentPayload, data.deviceId);
+  } catch (error) {
+    executionError = error;
+  }
+
+  return withSystemDbAccessContext(() =>
+    recordDeploymentOutcome(data, jobData, prep, result, executionError)
+  );
+}
+
+async function prepareDeploymentDevice(
+  data: ProcessDeploymentDeviceJob,
+  jobData: ProcessDeploymentDeviceJob
+): Promise<PrepareDeploymentDeviceResult> {
+  const { deploymentId, deviceId, batchNumber } = data;
+
+  // Get deployment
+  const [deployment] = await db
+    .select()
+    .from(deployments)
+    .where(eq(deployments.id, deploymentId))
+    .limit(1);
+
+  if (!deployment) {
+    throw new Error(`Deployment ${deploymentId} not found`);
+  }
+
+  if (!['pending', 'running', 'paused', 'cancelled'].includes(deployment.status)) {
+    return { skipped: true, reason: `Deployment status is ${deployment.status}` };
+  }
+
+  const claim = await claimDeploymentDeviceJob(deployment, { deploymentId, deviceId, batchNumber });
+  if (claim.claimed === false) {
+    return { skipped: true, reason: claim.reason };
+  }
+
+  if (deployment.status === 'paused' || deployment.status === 'cancelled') {
+    // Skip if deployment is paused or cancelled
+    await updateDeploymentDeviceStatus(deploymentId, deviceId, 'skipped', {
+      success: false,
+      error: `Deployment ${deployment.status}`
+    });
+    return { skipped: true, reason: deployment.status };
+  }
+
+  // Check maintenance window
+  const rolloutConfig = deployment.rolloutConfig as RolloutConfig;
+  if (rolloutConfig.respectMaintenanceWindows) {
+    const inMaintenance = await isDeviceInMaintenanceWindow(deviceId);
+    if (!inMaintenance) {
+      await releaseDeploymentDeviceClaim(deploymentId, deviceId);
+
+      // Re-queue for later
+      const queue = getDeploymentDeviceQueue();
+      const deferredJobId = getDeploymentDeferredDeviceJobId(
+        deploymentId,
+        deviceId
+      );
+      const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
+      if (!existing) {
+        await queue.add(
+          'process-device',
+          jobData,
+          {
+            delay: 5 * 60 * 1000,
+            jobId: deferredJobId,
+            removeOnComplete: { count: 100 },
+            removeOnFail: { count: 200 }
+          }
+        );
+      }
+      return { delayed: true, reason: 'waiting for maintenance window' };
+    }
+  }
+
+  return { deployment, rolloutConfig };
+}
+
+async function recordDeploymentOutcome(
+  data: ProcessDeploymentDeviceJob,
+  jobData: ProcessDeploymentDeviceJob,
+  prep: { deployment: typeof deployments.$inferSelect; rolloutConfig: RolloutConfig },
+  result: ExecutionResult | undefined,
+  executionError: unknown
+): Promise<unknown> {
+  const { deploymentId, deviceId } = data;
+  const { deployment, rolloutConfig } = prep;
+
+  if (executionError !== undefined) {
+    const errorMessage = executionError instanceof Error ? executionError.message : 'Unknown error';
+
+    // Check if we should retry
+    const { canRetry, retryCount } = await incrementRetryCount(deploymentId, deviceId);
+    if (canRetry) {
+      const backoffMs = getRetryBackoffMs(retryCount, rolloutConfig);
+      const queue = getDeploymentDeviceQueue();
+      const deferredJobId = getDeploymentDeferredDeviceJobId(
+        deploymentId,
+        deviceId
+      );
+      const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
+      if (!existing) {
+        await queue.add(
+          'process-device',
+          jobData,
+          {
+            delay: backoffMs,
+            jobId: deferredJobId,
+            removeOnComplete: { count: 100 },
+            removeOnFail: { count: 200 }
+          }
+        );
+      }
+      return { retrying: true, retryCount, error: errorMessage };
+    }
+
+    await updateDeploymentDeviceStatus(deploymentId, deviceId, 'failed', {
+      success: false,
+      error: errorMessage
+    });
+
+    throw executionError;
+  }
+
+  // result is defined whenever executionError is undefined
+  const executionResult = result as ExecutionResult;
+
+  // Update status based on result
+  if (executionResult.success) {
+    await updateDeploymentDeviceStatus(deploymentId, deviceId, 'completed', executionResult);
+  } else {
+    // Check if we should retry
+    const { canRetry, retryCount } = await incrementRetryCount(deploymentId, deviceId);
+    if (canRetry) {
+      const backoffMs = getRetryBackoffMs(retryCount, rolloutConfig);
+      const queue = getDeploymentDeviceQueue();
+      const deferredJobId = getDeploymentDeferredDeviceJobId(
+        deploymentId,
+        deviceId
+      );
+      const existing = await resolveActiveQueueJob(queue, [deferredJobId]);
+      if (!existing) {
+        await queue.add(
+          'process-device',
+          jobData,
+          {
+            delay: backoffMs,
+            jobId: deferredJobId,
+            removeOnComplete: { count: 100 },
+            removeOnFail: { count: 200 }
+          }
+        );
+      }
+      return { retrying: true, retryCount, backoffMs };
+    } else {
+      await updateDeploymentDeviceStatus(deploymentId, deviceId, 'failed', executionResult);
+    }
+  }
+
+  // Check if deployment should be paused due to failures
+  const { pause, reason } = await shouldPauseDeployment(deploymentId, rolloutConfig);
+  if (pause) {
+    await pauseDeployment(deploymentId);
+
+    // Send notifications to relevant users (push and email)
+    await sendDeploymentPausedNotifications({
+      deploymentId,
+      deploymentName: deployment.name,
+      orgId: deployment.orgId,
+      reason: reason ?? undefined,
+      dashboardUrl: process.env.DASHBOARD_URL
+        ? `${process.env.DASHBOARD_URL}/deployments/${deploymentId}`
+        : undefined
+    });
+
+    return { completed: true, deploymentPaused: true, pauseReason: reason };
+  }
+
+  return { completed: true, success: executionResult.success };
 }
 
 // ============================================
@@ -793,6 +841,46 @@ export function isSuccessfulAgentCommand(
   return true;
 }
 
+type DeviceCommandRow = typeof deviceCommands.$inferSelect;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll device_commands for the agent's result OUTSIDE any held transaction:
+ * each status check is its own short system context, and the sleeps between
+ * polls hold NO pooled connection. Previously the executors polled inside the
+ * worker's single open transaction for up to 30 min, starving the DB pool under
+ * concurrency 10 (#1105 conn-hold → user 503s). Returns the terminal command
+ * row (status 'completed'|'failed'), or null on timeout / row-not-found.
+ */
+async function pollDeploymentCommandResult(
+  commandId: string,
+  timeoutMs: number,
+  pollInterval: number
+): Promise<DeviceCommandRow | null> {
+  let elapsed = 0;
+  while (elapsed < timeoutMs) {
+    await sleep(pollInterval);
+    elapsed += pollInterval;
+
+    const [updated] = await withSystemDbAccessContext(() =>
+      db
+        .select()
+        .from(deviceCommands)
+        .where(eq(deviceCommands.id, commandId))
+        .limit(1)
+    );
+
+    if (!updated) return null;
+    if (updated.status === 'completed' || updated.status === 'failed') {
+      return updated;
+    }
+  }
+  return null;
+}
+
 async function executeDeploymentPayload(
   payload: DeploymentPayload,
   deviceId: string
@@ -830,92 +918,79 @@ async function executeScriptPayload(
   deviceId: string,
   startTime: number
 ): Promise<ExecutionResult> {
-  // Get the script
-  const [script] = await db
-    .select()
-    .from(scripts)
-    .where(and(eq(scripts.id, payload.scriptId), isNull(scripts.deletedAt)))
-    .limit(1);
-
-  if (!script) {
-    return {
-      success: false,
-      error: 'Script not found',
-      durationMs: Date.now() - startTime
-    };
-  }
-
-  // Create command for the device
-  const [command] = await db
-    .insert(deviceCommands)
-    .values({
-      deviceId,
-      type: 'run_script',
-      payload: {
-        scriptId: payload.scriptId,
-        content: script.content,
-        language: script.language,
-        parameters: payload.parameters || {},
-        timeoutSeconds: script.timeoutSeconds,
-        runAs: script.runAs
-      },
-      status: 'pending'
-    })
-    .returning();
-
-  if (!command) {
-    return {
-      success: false,
-      error: 'Failed to create command',
-      durationMs: Date.now() - startTime
-    };
-  }
-
-  // Wait for command to complete (with timeout)
-  const timeoutMs = (script.timeoutSeconds + 60) * 1000; // Add 60s buffer
-  const pollInterval = 1000;
-  let elapsed = 0;
-
-  while (elapsed < timeoutMs) {
-    const [updatedCommand] = await db
+  const prep = await withSystemDbAccessContext(async () => {
+    // Get the script
+    const [script] = await db
       .select()
-      .from(deviceCommands)
-      .where(eq(deviceCommands.id, command.id))
+      .from(scripts)
+      .where(and(eq(scripts.id, payload.scriptId), isNull(scripts.deletedAt)))
       .limit(1);
 
-    if (!updatedCommand) {
-      return {
-        success: false,
-        error: 'Command not found',
-        durationMs: Date.now() - startTime
-      };
+    if (!script) {
+      return { error: 'Script not found' as const };
     }
 
-    if (updatedCommand.status === 'completed') {
-      const result = updatedCommand.result as { exitCode?: number; stdout?: string; stderr?: string } | null;
-      return {
-        success: result?.exitCode === 0,
-        exitCode: result?.exitCode,
-        output: result?.stdout,
-        error: result?.stderr,
-        durationMs: Date.now() - startTime
-      };
+    // Create command for the device
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: 'run_script',
+        payload: {
+          scriptId: payload.scriptId,
+          content: script.content,
+          language: script.language,
+          parameters: payload.parameters || {},
+          timeoutSeconds: script.timeoutSeconds,
+          runAs: script.runAs
+        },
+        status: 'pending'
+      })
+      .returning();
+
+    if (!command) {
+      return { error: 'Failed to create command' as const };
     }
 
-    if (updatedCommand.status === 'failed') {
-      const result = updatedCommand.result as { error?: string } | null;
-      return {
-        success: false,
-        error: result?.error || 'Command failed',
-        durationMs: Date.now() - startTime
-      };
-    }
+    return {
+      commandId: command.id,
+      // Wait for command to complete (with timeout)
+      timeoutMs: (script.timeoutSeconds + 60) * 1000, // Add 60s buffer
+      pollInterval: 1000
+    };
+  });
 
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    elapsed += pollInterval;
+  if ('error' in prep) {
+    return {
+      success: false,
+      error: prep.error,
+      durationMs: Date.now() - startTime
+    };
   }
 
-  // Timeout
+  const finalCommand = await pollDeploymentCommandResult(prep.commandId, prep.timeoutMs, prep.pollInterval);
+
+  if (finalCommand?.status === 'completed') {
+    const result = finalCommand.result as { exitCode?: number; stdout?: string; stderr?: string } | null;
+    return {
+      success: result?.exitCode === 0,
+      exitCode: result?.exitCode,
+      output: result?.stdout,
+      error: result?.stderr,
+      durationMs: Date.now() - startTime
+    };
+  }
+
+  if (finalCommand?.status === 'failed') {
+    const result = finalCommand.result as { error?: string } | null;
+    return {
+      success: false,
+      error: result?.error || 'Command failed',
+      durationMs: Date.now() - startTime
+    };
+  }
+
+  // Timeout (or command row vanished mid-poll)
   return {
     success: false,
     error: 'Command timed out',
@@ -928,87 +1003,78 @@ async function executePatchPayload(
   deviceId: string,
   startTime: number
 ): Promise<ExecutionResult> {
-  const patchRecords = payload.patchIds.length > 0
-    ? await db
-      .select({
-        id: patches.id,
-        source: patches.source,
-        externalId: patches.externalId,
-        title: patches.title
+  const prep = await withSystemDbAccessContext(async () => {
+    const patchRecords = payload.patchIds.length > 0
+      ? await db
+        .select({
+          id: patches.id,
+          source: patches.source,
+          externalId: patches.externalId,
+          title: patches.title
+        })
+        .from(patches)
+        .where(inArray(patches.id, payload.patchIds))
+      : [];
+
+    // Create command for the device to install patches
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: 'install_patches',
+        payload: {
+          patchIds: payload.patchIds,
+          patches: patchRecords
+        },
+        status: 'pending'
       })
-      .from(patches)
-      .where(inArray(patches.id, payload.patchIds))
-    : [];
+      .returning();
 
-  // Create command for the device to install patches
-  const [command] = await db
-    .insert(deviceCommands)
-    .values({
-      deviceId,
-      type: 'install_patches',
-      payload: {
-        patchIds: payload.patchIds,
-        patches: patchRecords
-      },
-      status: 'pending'
-    })
-    .returning();
+    if (!command) {
+      return { error: 'Failed to create command' as const };
+    }
 
-  if (!command) {
+    return {
+      commandId: command.id,
+      // Wait for command to complete (patches can take a while)
+      timeoutMs: 30 * 60 * 1000, // 30 minutes
+      pollInterval: 5000
+    };
+  });
+
+  if ('error' in prep) {
     return {
       success: false,
-      error: 'Failed to create command',
+      error: prep.error,
       durationMs: Date.now() - startTime
     };
   }
 
-  // Wait for command to complete (patches can take a while)
-  const timeoutMs = 30 * 60 * 1000; // 30 minutes
-  const pollInterval = 5000;
-  let elapsed = 0;
+  const finalCommand = await pollDeploymentCommandResult(prep.commandId, prep.timeoutMs, prep.pollInterval);
 
-  while (elapsed < timeoutMs) {
-    const [updatedCommand] = await db
-      .select()
-      .from(deviceCommands)
-      .where(eq(deviceCommands.id, command.id))
-      .limit(1);
-
-    if (!updatedCommand) {
-      return {
-        success: false,
-        error: 'Command not found',
-        durationMs: Date.now() - startTime
-      };
-    }
-
-    if (updatedCommand.status === 'completed' || updatedCommand.status === 'failed') {
-      const result = updatedCommand.result as { exitCode?: number; stdout?: string; stderr?: string; error?: string } | null;
-      let parsedStdout: { success?: boolean; installedCount?: number; failedCount?: number; error?: string } | null = null;
-      if (result?.stdout) {
-        try {
-          parsedStdout = JSON.parse(result.stdout);
-        } catch {
-          parsedStdout = null;
-        }
+  if (finalCommand && (finalCommand.status === 'completed' || finalCommand.status === 'failed')) {
+    const result = finalCommand.result as { exitCode?: number; stdout?: string; stderr?: string; error?: string } | null;
+    let parsedStdout: { success?: boolean; installedCount?: number; failedCount?: number; error?: string } | null = null;
+    if (result?.stdout) {
+      try {
+        parsedStdout = JSON.parse(result.stdout);
+      } catch {
+        parsedStdout = null;
       }
-
-      const success = updatedCommand.status === 'completed' &&
-        (parsedStdout?.success ?? true) &&
-        (typeof result?.exitCode !== 'number' || result.exitCode === 0);
-
-      return {
-        success,
-        output: typeof parsedStdout?.installedCount === 'number'
-          ? `Installed ${parsedStdout.installedCount} patches`
-          : undefined,
-        error: result?.error || result?.stderr || parsedStdout?.error,
-        durationMs: Date.now() - startTime
-      };
     }
 
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    elapsed += pollInterval;
+    const success = finalCommand.status === 'completed' &&
+      (parsedStdout?.success ?? true) &&
+      (typeof result?.exitCode !== 'number' || result.exitCode === 0);
+
+    return {
+      success,
+      output: typeof parsedStdout?.installedCount === 'number'
+        ? `Installed ${parsedStdout.installedCount} patches`
+        : undefined,
+      error: result?.error || result?.stderr || parsedStdout?.error,
+      durationMs: Date.now() - startTime
+    };
   }
 
   return {
@@ -1023,59 +1089,50 @@ async function executeSoftwarePayload(
   deviceId: string,
   startTime: number
 ): Promise<ExecutionResult> {
-  // Create command for the device
-  const [command] = await db
-    .insert(deviceCommands)
-    .values({
-      deviceId,
-      type: `software_${payload.action}`,
-      payload: {
-        packageId: payload.packageId
-      },
-      status: 'pending'
-    })
-    .returning();
+  const prep = await withSystemDbAccessContext(async () => {
+    // Create command for the device
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: `software_${payload.action}`,
+        payload: {
+          packageId: payload.packageId
+        },
+        status: 'pending'
+      })
+      .returning();
 
-  if (!command) {
+    if (!command) {
+      return { error: 'Failed to create command' as const };
+    }
+
+    return {
+      commandId: command.id,
+      // Wait for command to complete
+      timeoutMs: 15 * 60 * 1000, // 15 minutes
+      pollInterval: 3000
+    };
+  });
+
+  if ('error' in prep) {
     return {
       success: false,
-      error: 'Failed to create command',
+      error: prep.error,
       durationMs: Date.now() - startTime
     };
   }
 
-  // Wait for command to complete
-  const timeoutMs = 15 * 60 * 1000; // 15 minutes
-  const pollInterval = 3000;
-  let elapsed = 0;
+  const finalCommand = await pollDeploymentCommandResult(prep.commandId, prep.timeoutMs, prep.pollInterval);
 
-  while (elapsed < timeoutMs) {
-    const [updatedCommand] = await db
-      .select()
-      .from(deviceCommands)
-      .where(eq(deviceCommands.id, command.id))
-      .limit(1);
-
-    if (!updatedCommand) {
-      return {
-        success: false,
-        error: 'Command not found',
-        durationMs: Date.now() - startTime
-      };
-    }
-
-    if (updatedCommand.status === 'completed' || updatedCommand.status === 'failed') {
-      const result = updatedCommand.result as AgentCommandResult;
-      return {
-        success: isSuccessfulAgentCommand(updatedCommand.status, result),
-        output: result?.stdout,
-        error: result?.error || result?.stderr,
-        durationMs: Date.now() - startTime
-      };
-    }
-
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    elapsed += pollInterval;
+  if (finalCommand && (finalCommand.status === 'completed' || finalCommand.status === 'failed')) {
+    const result = finalCommand.result as AgentCommandResult;
+    return {
+      success: isSuccessfulAgentCommand(finalCommand.status, result),
+      output: result?.stdout,
+      error: result?.error || result?.stderr,
+      durationMs: Date.now() - startTime
+    };
   }
 
   return {
@@ -1090,62 +1147,53 @@ async function executePolicyPayload(
   deviceId: string,
   startTime: number
 ): Promise<ExecutionResult> {
-  // Create command for the device to apply policy
-  const [command] = await db
-    .insert(deviceCommands)
-    .values({
-      deviceId,
-      type: 'apply_policy',
-      payload: {
-        policyId: payload.policyId
-      },
-      status: 'pending'
-    })
-    .returning();
+  const prep = await withSystemDbAccessContext(async () => {
+    // Create command for the device to apply policy
+    const [command] = await db
+      .insert(deviceCommands)
+      .values({
+        deviceId,
+        type: 'apply_policy',
+        payload: {
+          policyId: payload.policyId
+        },
+        status: 'pending'
+      })
+      .returning();
 
-  if (!command) {
+    if (!command) {
+      return { error: 'Failed to create command' as const };
+    }
+
+    return {
+      commandId: command.id,
+      // Wait for command to complete
+      timeoutMs: 10 * 60 * 1000, // 10 minutes
+      pollInterval: 2000
+    };
+  });
+
+  if ('error' in prep) {
     return {
       success: false,
-      error: 'Failed to create command',
+      error: prep.error,
       durationMs: Date.now() - startTime
     };
   }
 
-  // Wait for command to complete
-  const timeoutMs = 10 * 60 * 1000; // 10 minutes
-  const pollInterval = 2000;
-  let elapsed = 0;
+  const finalCommand = await pollDeploymentCommandResult(prep.commandId, prep.timeoutMs, prep.pollInterval);
 
-  while (elapsed < timeoutMs) {
-    const [updatedCommand] = await db
-      .select()
-      .from(deviceCommands)
-      .where(eq(deviceCommands.id, command.id))
-      .limit(1);
-
-    if (!updatedCommand) {
-      return {
-        success: false,
-        error: 'Command not found',
-        durationMs: Date.now() - startTime
-      };
-    }
-
-    if (updatedCommand.status === 'completed' || updatedCommand.status === 'failed') {
-      const result = updatedCommand.result as AgentCommandResult;
-      const success = isSuccessfulAgentCommand(updatedCommand.status, result);
-      return {
-        success,
-        output: typeof result?.compliant === 'boolean'
-          ? (result.compliant ? 'Device is compliant' : 'Device is non-compliant')
-          : undefined,
-        error: result?.error || result?.stderr,
-        durationMs: Date.now() - startTime
-      };
-    }
-
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    elapsed += pollInterval;
+  if (finalCommand && (finalCommand.status === 'completed' || finalCommand.status === 'failed')) {
+    const result = finalCommand.result as AgentCommandResult;
+    const success = isSuccessfulAgentCommand(finalCommand.status, result);
+    return {
+      success,
+      output: typeof result?.compliant === 'boolean'
+        ? (result.compliant ? 'Device is compliant' : 'Device is non-compliant')
+        : undefined,
+      error: result?.error || result?.stderr,
+      durationMs: Date.now() - startTime
+    };
   }
 
   return {

--- a/apps/api/src/jobs/huntressSync.test.ts
+++ b/apps/api/src/jobs/huntressSync.test.ts
@@ -100,6 +100,17 @@ vi.mock('../services/huntressClient', () => ({
     listAgents = listAgents;
     listIncidents = listIncidents;
   },
+  HuntressApiError: class HuntressApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'HuntressApiError';
+      this.status = status;
+    }
+    get isAuthError(): boolean {
+      return this.status === 401 || this.status === 403;
+    }
+  },
   parseHuntressWebhookPayload: vi.fn(),
 }));
 
@@ -200,6 +211,25 @@ describe('huntressSync — DB context boundaries (#1697)', () => {
     const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
     expect(errorWrite).toBeDefined();
     expect(String(errorWrite!.payload.lastSyncError)).toContain('scheduled:');
+  });
+
+  it('on a 401 auth failure, records the error status and fails UNRECOVERABLY even on a non-final attempt (BREEZE-1: dead credential must not retry/flood)', async () => {
+    const { HuntressApiError } = await import('../services/huntressClient');
+    const { UnrecoverableError } = await import('bullmq');
+    listAgents.mockRejectedValueOnce(
+      new HuntressApiError(401, 'Huntress API request failed (401 Unauthorized): Missing or invalid credentials'),
+    );
+
+    // isFinalAttempt:false would normally leave the row 'running' and let BullMQ
+    // retry — but a 401 is a dead credential: record 'error' and throw an
+    // UnrecoverableError so BullMQ skips the remaining attempts.
+    const rejected = await syncIntegrationById('integration-1', 'scheduled', undefined, { isFinalAttempt: false })
+      .then(() => null, (e: unknown) => e);
+    expect(rejected).toBeInstanceOf(UnrecoverableError);
+
+    const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
+    expect(errorWrite).toBeDefined();
+    expect(errorWrite!.depth).toBeGreaterThan(0);
   });
 
   it('on the webhook path, persists without any external fetch', async () => {

--- a/apps/api/src/jobs/huntressSync.ts
+++ b/apps/api/src/jobs/huntressSync.ts
@@ -1,4 +1,4 @@
-import { Job, type JobsOptions, Queue, Worker } from 'bullmq';
+import { Job, type JobsOptions, Queue, UnrecoverableError, Worker } from 'bullmq';
 import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import * as dbModule from '../db';
 import {
@@ -9,6 +9,7 @@ import {
   huntressOrgMappings,
 } from '../db/schema';
 import {
+  HuntressApiError,
   HuntressClient,
   parseHuntressWebhookPayload,
   type HuntressAgentRecord,
@@ -913,13 +914,19 @@ export async function syncIntegrationById(
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // A Huntress 401/403 is a dead/invalid credential — not transient, not a code
+    // bug, and not worth retrying. Record it (so the UI shows the auth failure)
+    // regardless of attempt, then fail UNRECOVERABLY below so BullMQ skips the
+    // remaining retries; the 'failed' handler suppresses the Sentry capture for
+    // these (they flooded the org quota — BREEZE-1).
+    const isAuthError = isHuntressAuthFailure(error);
     // Only the final attempt records a terminal 'error' (#1736). On an earlier
     // retry attempt we re-throw without touching the status, leaving the row at
     // 'running' so BullMQ can back off and retry while the UI keeps showing
     // "Syncing" — writing 'error' mid-retry would surface a failure that a
     // successful later attempt then silently corrects. Always re-throw so BullMQ
     // sees the failed attempt and schedules the retry / runs its failed handler.
-    if (isFinalAttempt) {
+    if (isFinalAttempt || isAuthError) {
       try {
         // Record the failure on a FRESH transaction. Phase 3's write transaction
         // (or, on the webhook path, the caller's outer context) is rolling back as
@@ -944,6 +951,10 @@ export async function syncIntegrationById(
         console.error(`[HuntressSync] Failed to record sync error for integration ${integrationId}:`, dbErr);
         captureException(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
       }
+    }
+    if (isAuthError) {
+      // Skip BullMQ's retries — a bad credential fails identically every time.
+      throw new UnrecoverableError(message);
     }
     throw error;
   }
@@ -1114,6 +1125,19 @@ async function scheduleRepeatSyncAll(): Promise<void> {
   );
 }
 
+/**
+ * A Huntress 401/403 means a dead/invalid API credential — a config issue, not a
+ * transient or code error. We fail those unrecoverably (no retries) and suppress
+ * the Sentry capture (it's recorded on the integration row instead). Matches the
+ * UnrecoverableError-wrapped case by message too, since the HuntressApiError type
+ * may not survive BullMQ's error round-trip into the 'failed' event.
+ */
+function isHuntressAuthFailure(error: unknown): boolean {
+  if (error instanceof HuntressApiError) return error.isAuthError;
+  const msg = error instanceof Error ? error.message : String(error);
+  return /Huntress API request failed \(40[13]\b/.test(msg);
+}
+
 export async function initializeHuntressSyncJob(): Promise<void> {
   huntressSyncWorker = createHuntressSyncWorker();
   huntressSyncWorker.on('error', (error) => {
@@ -1121,6 +1145,13 @@ export async function initializeHuntressSyncJob(): Promise<void> {
     captureException(error);
   });
   huntressSyncWorker.on('failed', (job, error) => {
+    // A dead Huntress credential (401/403) is a config issue already recorded on
+    // the integration row — not a code bug. Capturing it once per scheduled run
+    // flooded the org's Sentry quota (BREEZE-1, ~508 events). Log it; don't report.
+    if (isHuntressAuthFailure(error)) {
+      console.warn(`[HuntressSync] Job ${job?.id} failed: Huntress credential rejected (401/403) — update the API key. Not retried, not reported to Sentry.`);
+      return;
+    }
     console.error(`[HuntressSync] Job ${job?.id} failed:`, error);
     captureException(error);
   });

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -425,9 +425,11 @@ export function createPatchJobDeviceWorker(): Worker<PatchJobDeviceData> {
   return new Worker<PatchJobDeviceData>(
     PATCH_JOB_DEVICE_QUEUE,
     async (job: Job<PatchJobDeviceData>) => {
-      return runWithSystemDbAccess(async () => {
-        return processExecuteDevice(job.data);
-      });
+      // NOT wrapped in one runWithSystemDbAccess: processExecuteDevice manages its
+      // own short contexts so the up-to-30-min completion poll never holds a
+      // pooled connection in an open transaction (#1105 conn-hold that starved
+      // the DB pool under concurrency 10 → user-facing 503s).
+      return processExecuteDevice(job.data);
     },
     {
       connection: getBullMQConnection(),
@@ -439,7 +441,25 @@ export function createPatchJobDeviceWorker(): Worker<PatchJobDeviceData> {
   );
 }
 
+type PreparedDeviceExecution = {
+  commandId: string;
+  approvedPatches: Awaited<ReturnType<typeof resolveApprovedPatchesForDevice>>;
+  targets: { deployment?: { rebootPolicy?: string } };
+};
+
 async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<unknown> {
+  // Phased so the up-to-30-min completion poll never holds a pooled connection
+  // in an open transaction (#1105 conn-hold). Setup and record each run in their
+  // own SHORT system context; the poll runs OUTSIDE any context.
+  const prep = await runWithSystemDbAccess(() => prepareDeviceExecution(data));
+  if (!('commandId' in prep)) return prep; // early skip/error result — return as-is
+  const finalCommand = await pollForPatchCommandResult(prep.commandId);
+  return runWithSystemDbAccess(() => recordDeviceExecution(data, prep, finalCommand));
+}
+
+async function prepareDeviceExecution(
+  data: ExecutePatchJobDeviceData,
+): Promise<PreparedDeviceExecution | { skipped: true; reason: string } | { error: string }> {
   const { patchJobId, deviceId, orgId } = data;
 
   // Load job to get ring config
@@ -665,29 +685,44 @@ async function processExecuteDevice(data: ExecutePatchJobDeviceData): Promise<un
     return { error: 'Failed to create command' };
   }
 
-  // 4. Poll for result (5s interval, 30min timeout)
+  return { commandId, approvedPatches, targets };
+}
+
+async function pollForPatchCommandResult(commandId: string) {
+  // Poll for the agent's result OUTSIDE any held transaction: each status check
+  // is its own short system context, and the 5s sleeps hold NO pooled connection.
+  // Previously this ran inside ONE open transaction for up to 30 min, starving
+  // the DB pool under worker concurrency 10 (#1105 conn-hold → user 503s).
   const timeoutMs = 30 * 60 * 1000;
   const pollInterval = 5000;
   let elapsed = 0;
-  let finalCommand: typeof cmdResult.command | null = null;
-
   while (elapsed < timeoutMs) {
     await new Promise((resolve) => setTimeout(resolve, pollInterval));
     elapsed += pollInterval;
 
-    const [updated] = await db
-      .select()
-      .from(deviceCommands)
-      .where(eq(deviceCommands.id, commandId))
-      .limit(1);
+    const [updated] = await runWithSystemDbAccess(() =>
+      db
+        .select()
+        .from(deviceCommands)
+        .where(eq(deviceCommands.id, commandId))
+        .limit(1),
+    );
 
-    if (!updated) break;
-
+    if (!updated) return null;
     if (updated.status === 'completed' || updated.status === 'failed') {
-      finalCommand = updated as typeof cmdResult.command;
-      break;
+      return updated;
     }
   }
+  return null;
+}
+
+async function recordDeviceExecution(
+  data: ExecutePatchJobDeviceData,
+  prep: PreparedDeviceExecution,
+  finalCommand: Awaited<ReturnType<typeof pollForPatchCommandResult>>,
+): Promise<unknown> {
+  const { patchJobId, deviceId } = data;
+  const { approvedPatches, targets } = prep;
 
   // 5. Parse result and record outcomes
   const commandResult = finalCommand?.result as {

--- a/apps/api/src/services/commandDispatch.ts
+++ b/apps/api/src/services/commandDispatch.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { deviceCommands } from '../db/schema';
 
 type DeviceCommandRow = typeof deviceCommands.$inferSelect;
@@ -8,16 +8,21 @@ export async function claimPendingCommandForDelivery(
   commandId: string,
   executedAt: Date = new Date(),
 ): Promise<{ id: string; executedAt: Date } | null> {
-  const rows = await db
-    .update(deviceCommands)
-    .set({ status: 'sent', executedAt })
-    .where(
-      and(
-        eq(deviceCommands.id, commandId),
-        eq(deviceCommands.status, 'pending'),
-      ),
-    )
-    .returning({ id: deviceCommands.id });
+  // device_commands is system-scoped (agent WS path) and this runs from
+  // executeCommand's runOutsideDbContext block — establish a system context so
+  // the write isn't a contextless bare-pool write (#1375 warning flood).
+  const rows = await withSystemDbAccessContext(() =>
+    db
+      .update(deviceCommands)
+      .set({ status: 'sent', executedAt })
+      .where(
+        and(
+          eq(deviceCommands.id, commandId),
+          eq(deviceCommands.status, 'pending'),
+        ),
+      )
+      .returning({ id: deviceCommands.id }),
+  );
 
   return rows.length > 0 ? { id: commandId, executedAt } : null;
 }
@@ -26,16 +31,18 @@ export async function releaseClaimedCommandDelivery(
   commandId: string,
   executedAt: Date,
 ): Promise<void> {
-  await db
-    .update(deviceCommands)
-    .set({ status: 'pending', executedAt: null })
-    .where(
-      and(
-        eq(deviceCommands.id, commandId),
-        eq(deviceCommands.status, 'sent'),
-        eq(deviceCommands.executedAt, executedAt),
+  await withSystemDbAccessContext(() =>
+    db
+      .update(deviceCommands)
+      .set({ status: 'pending', executedAt: null })
+      .where(
+        and(
+          eq(deviceCommands.id, commandId),
+          eq(deviceCommands.status, 'sent'),
+          eq(deviceCommands.executedAt, executedAt),
+        ),
       ),
-    );
+  );
 }
 
 export async function claimPendingCommandsForDevice(

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -440,26 +440,30 @@ export async function waitForCommandResult(
     await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
   }
 
-  // Timeout - update command status
+  // Timeout - update command status. device_commands is system-scoped and this
+  // can run from a runOutsideDbContext poll loop — wrap in a system context so
+  // the write isn't a contextless bare-pool write (#1375).
   const completedAt = new Date();
-  const [timedOutUpdate] = await db
-    .update(deviceCommands)
-    .set({
-      status: 'failed',
-      completedAt,
-      result: {
-        status: 'timeout',
-        error: `Command timed out after ${timeoutMs}ms`
-      }
-    })
-    .where(and(
-      eq(deviceCommands.id, commandId),
-      inArray(deviceCommands.status, ['pending', 'sent']),
-    ))
-    .returning({
-      id: deviceCommands.id,
-      status: deviceCommands.status,
-    });
+  const [timedOutUpdate] = await withSystemDbAccessContext(() =>
+    db
+      .update(deviceCommands)
+      .set({
+        status: 'failed',
+        completedAt,
+        result: {
+          status: 'timeout',
+          error: `Command timed out after ${timeoutMs}ms`
+        }
+      })
+      .where(and(
+        eq(deviceCommands.id, commandId),
+        inArray(deviceCommands.status, ['pending', 'sent']),
+      ))
+      .returning({
+        id: deviceCommands.id,
+        status: deviceCommands.status,
+      }),
+  );
 
   const timedOutType = lastObservedCommand?.type;
   if (timedOutUpdate && timedOutType) {
@@ -680,18 +684,21 @@ export async function executeCommand(
     // (no real user record exists). Detect this by checking if userId equals deviceId.
     const safeUserId = userId && userId !== deviceId ? userId : null;
 
-    // Insert command (device_commands — no RLS)
-    const [command] = await db
-      .insert(deviceCommands)
-      .values({
-        deviceId,
-        type,
-        payload,
-        status: 'pending',
-        createdBy: safeUserId,
-        targetRole,
-      })
-      .returning();
+    // Insert command (device_commands — no RLS, but establish a system context
+    // so it isn't a contextless bare-pool write under runOutsideDbContext, #1375).
+    const [command] = await withSystemDbAccessContext(() =>
+      db
+        .insert(deviceCommands)
+        .values({
+          deviceId,
+          type,
+          payload,
+          status: 'pending',
+          createdBy: safeUserId,
+          targetRole,
+        })
+        .returning(),
+    );
 
     if (!command) {
       return { status: 'failed' as const, error: 'Failed to create command' };

--- a/apps/api/src/services/huntressClient.ts
+++ b/apps/api/src/services/huntressClient.ts
@@ -381,6 +381,23 @@ function isTimeoutError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Thrown on a non-2xx Huntress API response. Carries the HTTP status so callers
+ * can distinguish a dead/invalid credential (401/403 — a config issue, not
+ * transient and not retryable) from transient failures worth retrying.
+ */
+export class HuntressApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'HuntressApiError';
+    this.status = status;
+  }
+  get isAuthError(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+}
+
 async function fetchJson(
   url: URL,
   init: RequestInit,
@@ -417,7 +434,7 @@ async function fetchJson(
       // redirects) is an error — we never parse it as JSON or chase Location.
       if (!response.ok) {
         const preview = text.trim().slice(0, 400);
-        throw new Error(`Huntress API request failed (${response.status} ${response.statusText}): ${preview || '<empty>'}`);
+        throw new HuntressApiError(response.status, `Huntress API request failed (${response.status} ${response.statusText}): ${preview || '<empty>'}`);
       }
       if (!text.trim()) return {};
       try {


### PR DESCRIPTION
Follow-up to the `0.83.2` crash-loop hotfix (#1880). That hotfix's `uncaughtException` guard stopped the US API from crashing — but it removed the accidental every-~4-min restart that had been flushing the DB connection pool, so a pre-existing **#1105 connection-hold** surfaced as a **persistent pool-starvation outage** (every authenticated API call 503'd). This PR fixes that at the root, plus the Sentry quota/noise fallout the same conn-hold caused.

## Root cause (the outage)
`patchJobExecutor` and `deploymentWorker` ran their per-device job — including a **10–30 min completion poll of `device_commands`** — inside a single `withSystemDbAccessContext`, pinning a pooled connection in an open transaction the whole time. At worker concurrency 10, slow/non-responding devices held up to 10 connections for ~30 min each → pool exhausted → user-facing 503s. Confirmed live on US: connections stuck "idle in transaction" for ~29 min querying `device_commands`.

## Changes

**Conn-hold root fix (phase-split: setup → poll-OUTSIDE-txn → record):**
- `patchJobExecutor.ts` — `prepareDeviceExecution` (short ctx) → `pollForPatchCommandResult` (each check its own short ctx; 5s sleeps hold no connection) → `recordDeviceExecution` (short ctx). Worker no longer wraps the whole job.
- `deploymentWorker.ts` — same split for the device worker; `prepareDeploymentDevice` / `recordDeploymentOutcome` / shared `pollDeploymentCommandResult`; all 4 executors (script/patch/software/policy) do read+insert in a short ctx then poll outside. Business logic (claim, maintenance, retry, pause, re-queue, result mapping) unchanged — only transaction boundaries moved.

**Sentry quota + noise (the same conn-hold flooded Sentry and exhausted the org's 50k error quota, blinding all error reporting since ~June 18):**
- `db/index.ts` — throttle the `withDbAccessContext` held-context warning's Sentry capture to once-per-scope-per-window (default 5 min; `DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS`). `console.warn` stays unthrottled. ~95% fewer captures.
- `commandQueue.ts` / `commandDispatch.ts` — wrap the `device_commands` writes (insert/timeout-update/claim/release) in a system context so they stop tripping the #1375 contextless-write warning across all command paths.
- `huntressSync.ts` / `huntressClient.ts` — a Huntress 401/403 (dead API credential) is now recorded on the integration row, failed **unrecoverably** (no BullMQ retries), and **not** captured to Sentry (it's a config issue, not a code bug; it was ~508 events).

## Tests
All touched files green, tsc clean: rejectionSuppressions 5/5 (throttle), commandDispatch/commandQueue/systemTools 73/73, huntress 22/22, patchJobExecutor 20/20, deploymentWorker 12/12.

## Ops notes
- A temporary safeguard cron (`/opt/breeze/reap-long-txns.sh`, kills breeze_app txns held >5 min) is active on **US** — **remove it after this deploys** (the code fix makes it unnecessary).
- Sentry: the breeze DSN now has a 1,000/hr rate-limit circuit breaker; check org quota/usage (it was exhausted) and consider a usage alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)