### PR TITLE
feat(policies): per-device config-policy compliance route + device-detail section (#1876)

### DIFF
--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -15,7 +15,7 @@ import {
   listComplianceSchema,
   policyIdSchema,
 } from './schemas';
-import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
 import {
   getPagination,
   ensureOrgAccess,
@@ -481,6 +481,88 @@ complianceRoutes.get(
       trend: [],
       policies: allPolicies,
       nonCompliantDevices: allNonCompliantDevices,
+    });
+  }
+);
+
+// GET /policies/compliance/device/:deviceId
+//
+// Per-device config-policy compliance: how one device fares across every
+// config policy assigned to it. Registered BEFORE `/:id/compliance` so the
+// literal `/compliance/...` segment wins over the `:id` param.
+//
+// The underlying helper (`getConfigPolicyComplianceForDevice`) does NO
+// tenant/site authz, so this route is the only guard. Mirrors the device-access
+// gate at `monitoring.ts:872-889`: resolve the device's org/site, deny by org
+// (canAccessOrg), then deny by site (allowedSiteIds). DEVICES_READ is granted to
+// every device-viewing role and only serves to populate `permissions` so the
+// site narrowing below is live.
+complianceRoutes.get(
+  '/compliance/device/:deviceId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const deviceId = c.req.param('deviceId');
+
+    if (!deviceId) {
+      return c.json({ error: 'Device ID required' }, 400);
+    }
+
+    // Resolve the device's org/site for the authz gate.
+    const [device] = await db
+      .select({ orgId: devices.orgId, siteId: devices.siteId })
+      .from(devices)
+      .where(eq(devices.id, deviceId))
+      .limit(1);
+
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    // Org gate (RLS-independent authz; the helper does none of its own).
+    if (device.orgId === null || !ensureOrgAccess(device.orgId, auth)) {
+      return c.json({ error: 'Access to this device denied' }, 403);
+    }
+
+    // Site gate: RLS does not defend the site axis, so enforce `allowedSiteIds`
+    // here exactly as the sibling monitoring/device routes do.
+    if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+
+    // Scope the rule-info lookup to the device's own org only — we have already
+    // confirmed the caller may access it, and the rows are device-filtered.
+    const { rows, ruleInfoMap } = await getConfigPolicyComplianceForDevice(
+      deviceId,
+      [device.orgId]
+    );
+
+    // Serialize the rule-info map (keyed by feature-link id) so the web client
+    // can render rule names alongside each compliance row.
+    const serializedRuleInfo: Record<string, unknown[]> = {};
+    for (const [featureLinkId, infos] of ruleInfoMap.entries()) {
+      serializedRuleInfo[featureLinkId] = infos;
+    }
+
+    return c.json({
+      data: rows.map((row) => ({
+        id: row.id,
+        policyId: row.policyId,
+        configPolicyId: row.configPolicyId,
+        configItemName: row.configItemName,
+        deviceId: row.deviceId,
+        status: row.status,
+        details: row.details,
+        lastCheckedAt: row.lastCheckedAt?.toISOString() ?? null,
+        remediationAttempts: row.remediationAttempts,
+        updatedAt: row.updatedAt?.toISOString() ?? null,
+        deviceHostname: row.deviceHostname,
+        deviceStatus: row.deviceStatus,
+        deviceOsType: row.deviceOsType,
+      })),
+      ruleInfo: serializedRuleInfo,
     });
   }
 );

--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -539,8 +539,9 @@ complianceRoutes.get(
       [device.orgId]
     );
 
-    // Serialize the rule-info map (keyed by feature-link id) so the web client
-    // can render rule names alongside each compliance row.
+    // Serialize the rule-info map (keyed by feature-link id) alongside the rows.
+    // Mirrors the `/:id/compliance` shape so clients can resolve rule names from
+    // a compliance row's `configPolicyId` (a feature-link id) when needed.
     const serializedRuleInfo: Record<string, unknown[]> = {};
     for (const [featureLinkId, infos] of ruleInfoMap.entries()) {
       serializedRuleInfo[featureLinkId] = infos;

--- a/apps/api/src/routes/policyManagement_compliance_device.test.ts
+++ b/apps/api/src/routes/policyManagement_compliance_device.test.ts
@@ -27,6 +27,25 @@ const DEVICE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 // Tests mutate this before issuing a request.
 let currentPermissions: { allowedSiteIds: string[] | null } | undefined;
 
+// Auth context applied by the (mocked) authMiddleware. Tests mutate this to
+// exercise organization / partner / system scopes. Mirrors the real shape the
+// middleware sets (auth.ts), incl. the `canAccessOrg` predicate.
+type TestAuth = {
+  scope: 'organization' | 'partner' | 'system';
+  orgId: string | null;
+  partnerId: string | null;
+  accessibleOrgIds: string[] | null;
+  canAccessOrg: (orgId: string) => boolean;
+};
+const orgScopeAuth = (): TestAuth => ({
+  scope: 'organization',
+  orgId: ORG_ID,
+  partnerId: null,
+  accessibleOrgIds: [ORG_ID],
+  canAccessOrg: (orgId: string) => orgId === ORG_ID,
+});
+let currentAuth: TestAuth = orgScopeAuth();
+
 vi.mock('../db', () => ({
   db: { select: vi.fn() },
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -73,14 +92,7 @@ vi.mock('./policyManagement/helpers', async (importOriginal) => {
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
-    c.set('auth', {
-      user: { id: 'user-123', email: 'test@example.com' },
-      scope: 'organization',
-      orgId: ORG_ID,
-      partnerId: null,
-      accessibleOrgIds: [ORG_ID],
-      canAccessOrg: (orgId: string) => orgId === ORG_ID,
-    });
+    c.set('auth', { user: { id: 'user-123', email: 'test@example.com' }, ...currentAuth });
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
@@ -113,6 +125,7 @@ describe('GET /policies/compliance/device/:deviceId (#1876)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     currentPermissions = undefined;
+    currentAuth = orgScopeAuth();
     app = new Hono();
     app.route('/policies', policyRoutes);
   });
@@ -165,5 +178,62 @@ describe('GET /policies/compliance/device/:deviceId (#1876)', () => {
     mockDeviceLookup({ orgId: ORG_ID, siteId: SITE_ID });
     const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
     expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when the device has a null org (orphaned device)', async () => {
+    // Defends the orphaned-device guard: a device with no owning org must never
+    // be readable, and `[device.orgId]` must never be passed to the helper as null.
+    mockDeviceLookup({ orgId: null, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).not.toHaveBeenCalled();
+  });
+
+  // --- Partner scope: this route is the sole tenant guard, so cross-tenant
+  // denial and the in-reach success path are both pinned. ---
+  it('returns 403 for a partner-scope caller when the device org is out of reach', async () => {
+    currentAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: '99999999-9999-4999-8999-999999999999',
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    };
+    mockDeviceLookup({ orgId: FOREIGN_ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 for a partner-scope caller when the device org is in reach', async () => {
+    currentAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: '99999999-9999-4999-8999-999999999999',
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    };
+    currentPermissions = { allowedSiteIds: null };
+    mockDeviceLookup({ orgId: ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).toHaveBeenCalledWith(DEVICE_ID, [ORG_ID]);
+  });
+
+  it('returns 200 for a system-scope caller across any org (no site restriction)', async () => {
+    // System callers reach every org (ensureOrgAccess returns true) and have no
+    // site restriction, so the site gate must not block them.
+    currentAuth = {
+      scope: 'system',
+      orgId: null,
+      partnerId: null,
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    };
+    currentPermissions = undefined; // system callers carry no allowedSiteIds
+    mockDeviceLookup({ orgId: FOREIGN_ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).toHaveBeenCalledWith(DEVICE_ID, [FOREIGN_ORG_ID]);
   });
 });

--- a/apps/api/src/routes/policyManagement_compliance_device.test.ts
+++ b/apps/api/src/routes/policyManagement_compliance_device.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Route tests for `GET /policies/compliance/device/:deviceId` (#1876).
+ *
+ * This route is the ONLY authz guard in front of
+ * `getConfigPolicyComplianceForDevice`, which does no tenant/site checks of its
+ * own. The gate mirrors the per-device monitoring routes (`monitoring.ts`):
+ *   1. resolve the device's org/site,
+ *   2. 404 if the device does not exist,
+ *   3. 403 if the caller cannot access the device's org (`ensureOrgAccess`),
+ *   4. 403 if the caller is site-restricted and lacks the device's site.
+ *
+ * Site is an app-layer concept (Postgres RLS does NOT defend it), and the site
+ * narrowing only runs when `requirePermission` has populated the `permissions`
+ * context — so these tests mock `requirePermission` to set `allowedSiteIds`,
+ * exactly as the live middleware chain does, and prove the gate fires.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const FOREIGN_ORG_ID = '22222222-2222-2222-2222-222222222222';
+const SITE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OTHER_SITE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const DEVICE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+// Permissions context applied by the (mocked) requirePermission middleware.
+// Tests mutate this before issuing a request.
+let currentPermissions: { allowedSiteIds: string[] | null } | undefined;
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  automationPolicies: { id: 'id', orgId: 'orgId' },
+  automationPolicyCompliance: { id: 'id', policyId: 'policyId' },
+  configPolicyFeatureLinks: { id: 'id', configPolicyId: 'configPolicyId' },
+  configurationPolicies: { id: 'id', orgId: 'orgId', name: 'name', status: 'status' },
+  devices: { id: 'id', orgId: 'orgId', siteId: 'siteId' },
+}));
+
+// Keep the real, pure authz helpers (ensureOrgAccess) but stub the DB-hitting
+// per-device compliance reader.
+vi.mock('./policyManagement/helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./policyManagement/helpers')>();
+  return {
+    ...actual,
+    getConfigPolicyComplianceForDevice: vi.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'row-1',
+          policyId: null,
+          configPolicyId: 'feature-link-1',
+          configItemName: 'USB storage block',
+          deviceId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+          status: 'compliant',
+          details: {},
+          lastCheckedAt: new Date('2026-06-24T00:00:00Z'),
+          remediationAttempts: 0,
+          updatedAt: new Date('2026-06-24T00:00:00Z'),
+          deviceHostname: 'WIN-TEST',
+          deviceStatus: 'online',
+          deviceOsType: 'windows',
+        },
+      ],
+      ruleInfoMap: new Map([['feature-link-1', [{ ruleName: 'USB storage block' }]]]),
+    }),
+  };
+});
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com' },
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      accessibleOrgIds: [ORG_ID],
+      canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  // The real requirePermission populates `permissions`; mirror that so the
+  // site-scope gate is LIVE (a no-op mock would make the gate dead and the
+  // 403-on-foreign-site test pass vacuously).
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (currentPermissions) c.set('permissions', currentPermissions);
+    return next();
+  }),
+}));
+
+import { db } from '../db';
+import { policyRoutes } from './policyManagement';
+import { getConfigPolicyComplianceForDevice } from './policyManagement/helpers';
+
+function mockDeviceLookup(device: { orgId: string | null; siteId: string | null } | undefined) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(device ? [device] : []),
+      }),
+    }),
+  } as any);
+}
+
+describe('GET /policies/compliance/device/:deviceId (#1876)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentPermissions = undefined;
+    app = new Hono();
+    app.route('/policies', policyRoutes);
+  });
+
+  it('returns 404 when the device does not exist', async () => {
+    mockDeviceLookup(undefined);
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(404);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the device belongs to an inaccessible org', async () => {
+    mockDeviceLookup({ orgId: FOREIGN_ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a site-restricted caller without the device\'s site', async () => {
+    // The site-scope gate is the load-bearing guard: a partner/org user limited
+    // to OTHER_SITE_ID must not read compliance for a device in SITE_ID even
+    // though the device is in their org.
+    currentPermissions = { allowedSiteIds: [OTHER_SITE_ID] };
+    mockDeviceLookup({ orgId: ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the device has no site and the caller is site-restricted', async () => {
+    currentPermissions = { allowedSiteIds: [SITE_ID] };
+    mockDeviceLookup({ orgId: ORG_ID, siteId: null });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with compliance rows for an in-site caller', async () => {
+    currentPermissions = { allowedSiteIds: [SITE_ID] };
+    mockDeviceLookup({ orgId: ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[]; ruleInfo: Record<string, unknown[]> };
+    expect(body.data).toHaveLength(1);
+    expect(body.ruleInfo['feature-link-1']).toBeDefined();
+    expect(vi.mocked(getConfigPolicyComplianceForDevice)).toHaveBeenCalledWith(DEVICE_ID, [ORG_ID]);
+  });
+
+  it('returns 200 with no site restriction (unrestricted org/partner caller)', async () => {
+    currentPermissions = { allowedSiteIds: null };
+    mockDeviceLookup({ orgId: ORG_ID, siteId: SITE_ID });
+    const res = await app.request(`/policies/compliance/device/${DEVICE_ID}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/src/components/devices/DeviceComplianceTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceComplianceTab.test.tsx
@@ -78,13 +78,33 @@ describe('DeviceComplianceTab', () => {
     expect(await screen.findByTestId('device-compliance-empty')).toBeInTheDocument();
   });
 
-  it('renders an error state when the request fails', async () => {
-    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 403));
+  it('surfaces the server-provided error message on a non-ok response', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ error: 'Access to this device denied' }, false, 403)
+    );
 
     render(<DeviceComplianceTab deviceId="dev-1" />);
 
     await waitFor(() => {
       expect(screen.getByTestId('device-compliance-error')).toBeInTheDocument();
     });
+    // The specific server reason is shown, not a generic fallback.
+    expect(screen.getByText('Access to this device denied')).toBeInTheDocument();
+  });
+
+  it('falls back to a status-coded message when the error body is unparseable', async () => {
+    fetchWithAuthMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'ERROR',
+      json: vi.fn().mockRejectedValue(new Error('bad json')),
+    } as unknown as Response);
+
+    render(<DeviceComplianceTab deviceId="dev-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-compliance-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Failed to load compliance status (500)')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/devices/DeviceComplianceTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceComplianceTab.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceComplianceTab from './DeviceComplianceTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('DeviceComplianceTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches per-device compliance and renders rows, failing first', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        data: [
+          {
+            id: 'c1',
+            policyId: null,
+            configPolicyId: 'fl-1',
+            configItemName: 'Chrome installed',
+            deviceId: 'dev-1',
+            status: 'compliant',
+            details: {},
+            lastCheckedAt: '2026-06-24T10:00:00.000Z',
+            remediationAttempts: 0,
+            updatedAt: '2026-06-24T10:00:00.000Z',
+          },
+          {
+            id: 'c2',
+            policyId: null,
+            configPolicyId: 'fl-2',
+            configItemName: 'USB storage blocked',
+            deviceId: 'dev-1',
+            status: 'non_compliant',
+            details: {},
+            lastCheckedAt: '2026-06-24T10:00:00.000Z',
+            remediationAttempts: 2,
+            updatedAt: '2026-06-24T10:00:00.000Z',
+          },
+        ],
+        ruleInfo: {},
+      })
+    );
+
+    render(<DeviceComplianceTab deviceId="dev-1" />);
+
+    await screen.findByText('USB storage blocked');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/policies/compliance/device/dev-1');
+    expect(screen.getByText('Chrome installed')).toBeInTheDocument();
+    expect(screen.getByText('Compliant')).toBeInTheDocument();
+    expect(screen.getByText('Non-compliant')).toBeInTheDocument();
+    expect(screen.getByText('1 failing')).toBeInTheDocument();
+    expect(screen.getAllByTestId('device-compliance-row')).toHaveLength(2);
+    // Non-compliant row is surfaced first.
+    expect(screen.getAllByTestId('device-compliance-row')[0]).toHaveTextContent('USB storage blocked');
+  });
+
+  it('renders an empty state when no compliance results are reported', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [], ruleInfo: {} }));
+
+    render(<DeviceComplianceTab deviceId="dev-1" />);
+
+    expect(await screen.findByTestId('device-compliance-empty')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the request fails', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 403));
+
+    render(<DeviceComplianceTab deviceId="dev-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-compliance-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/devices/DeviceComplianceTab.tsx
+++ b/apps/web/src/components/devices/DeviceComplianceTab.tsx
@@ -54,7 +54,13 @@ export default function DeviceComplianceTab({ deviceId, timezone }: DeviceCompli
     setError(undefined);
     try {
       const response = await fetchWithAuth(`/policies/compliance/device/${deviceId}`);
-      if (!response.ok) throw new Error('Failed to load compliance status');
+      if (!response.ok) {
+        // Surface the server's specific reason (e.g. "Access to this device
+        // denied") instead of a generic message — a 403 is not retryable and
+        // should read differently from a transient 5xx.
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `Failed to load compliance status (${response.status})`);
+      }
       const json = await response.json();
       setRows(Array.isArray(json?.data) ? json.data : []);
     } catch (err) {

--- a/apps/web/src/components/devices/DeviceComplianceTab.tsx
+++ b/apps/web/src/components/devices/DeviceComplianceTab.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ShieldCheck, RefreshCw } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+
+type ComplianceRow = {
+  id: string;
+  policyId: string | null;
+  configPolicyId: string | null;
+  configItemName: string | null;
+  deviceId: string;
+  status: 'compliant' | 'non_compliant' | 'pending' | 'error' | string;
+  details: unknown;
+  lastCheckedAt: string | null;
+  remediationAttempts?: number | null;
+  updatedAt: string | null;
+  deviceHostname?: string | null;
+  deviceStatus?: string | null;
+  deviceOsType?: string | null;
+};
+
+type DeviceComplianceTabProps = {
+  deviceId: string;
+  timezone?: string;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  compliant: 'bg-success/15 text-success border-success/30',
+  non_compliant: 'bg-destructive/15 text-destructive border-destructive/30',
+  pending: 'bg-warning/15 text-warning border-warning/30',
+  error: 'bg-destructive/15 text-destructive border-destructive/30',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  compliant: 'Compliant',
+  non_compliant: 'Non-compliant',
+  pending: 'Pending',
+  error: 'Error',
+};
+
+function formatTimestamp(value: string | null, timezone?: string): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], timezone ? { timeZone: timezone } : undefined);
+}
+
+export default function DeviceComplianceTab({ deviceId, timezone }: DeviceComplianceTabProps) {
+  const [rows, setRows] = useState<ComplianceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const fetchCompliance = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await fetchWithAuth(`/policies/compliance/device/${deviceId}`);
+      if (!response.ok) throw new Error('Failed to load compliance status');
+      const json = await response.json();
+      setRows(Array.isArray(json?.data) ? json.data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load compliance status');
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    fetchCompliance();
+  }, [fetchCompliance]);
+
+  const sorted = useMemo(
+    () =>
+      [...rows].sort((a, b) => {
+        // Surface non-compliant rows first, then by check name.
+        const aBad = a.status === 'non_compliant' || a.status === 'error' ? 0 : 1;
+        const bBad = b.status === 'non_compliant' || b.status === 'error' ? 0 : 1;
+        if (aBad !== bBad) return aBad - bBad;
+        return (a.configItemName ?? '').localeCompare(b.configItemName ?? '');
+      }),
+    [rows]
+  );
+
+  const nonCompliantCount = useMemo(
+    () => rows.filter((r) => r.status === 'non_compliant' || r.status === 'error').length,
+    [rows]
+  );
+
+  if (loading) {
+    return (
+      <div
+        data-testid="device-compliance-loading"
+        className="flex items-center justify-center rounded-lg border bg-card py-12 shadow-sm"
+      >
+        <div className="text-center">
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="mt-3 text-sm text-muted-foreground">Loading compliance status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        data-testid="device-compliance-error"
+        className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
+      >
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={fetchCompliance}
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="device-compliance-tab" className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-lg font-semibold">Configuration Policy Compliance</h3>
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{rows.length}</span>
+          {nonCompliantCount > 0 ? (
+            <span className="rounded-full bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
+              {nonCompliantCount} failing
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={fetchCompliance}
+          className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        How this device fares across every Configuration Policy compliance rule assigned to it.
+      </p>
+
+      <div className="mt-4 overflow-hidden rounded-md border">
+        <div className="max-h-[500px] overflow-auto">
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40 sticky top-0">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Check</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Remediation</th>
+                <th className="px-4 py-3">Last Checked</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {sorted.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    data-testid="device-compliance-empty"
+                    className="px-4 py-6 text-center text-sm text-muted-foreground"
+                  >
+                    No compliance results reported. Assign a Configuration Policy with compliance rules
+                    to this device, or wait for the next evaluation.
+                  </td>
+                </tr>
+              ) : (
+                sorted.map((row) => (
+                  <tr key={row.id} data-testid="device-compliance-row" className="text-sm hover:bg-muted/30">
+                    <td className="px-4 py-3 font-medium">{row.configItemName ?? 'Compliance rule'}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+                          STATUS_STYLES[row.status] ?? 'bg-muted text-muted-foreground border-border'
+                        }`}
+                      >
+                        {STATUS_LABELS[row.status] ?? row.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                      {typeof row.remediationAttempts === 'number' && row.remediationAttempts > 0
+                        ? `${row.remediationAttempts} attempt${row.remediationAttempts === 1 ? '' : 's'}`
+                        : '—'}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {formatTimestamp(row.lastCheckedAt, timezone)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -25,6 +25,7 @@ import {
   Ticket,
   TrendingUp,
   HeartPulse,
+  ShieldCheck,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
 import type { Device, DeviceStatus } from './DeviceList';
@@ -60,6 +61,7 @@ import DeviceTicketsTab from '../tickets/DeviceTicketsTab';
 import DeviceAnomaliesPanel from './DeviceAnomaliesPanel';
 import DeviceReliabilityPanel from './DeviceReliabilityPanel';
 import DeviceMonitoringTab from './DeviceMonitoringTab';
+import DeviceComplianceTab from './DeviceComplianceTab';
 
 type Tab =
   | 'overview'
@@ -77,6 +79,7 @@ type Tab =
   | 'performance'
   | 'eventlog'
   | 'monitoring'
+  | 'compliance'
   | 'activities'
   | 'connections'
   | 'filesystem'
@@ -134,7 +137,7 @@ function formatLastSeen(dateString: string, timezone?: string): string {
 const VALID_TABS: Tab[] = [
   'overview', 'details', 'hardware', 'software', 'patches', 'vulnerabilities', 'security',
   'management', 'effective-config', 'alerts', 'scripts', 'performance',
-  'anomalies', 'eventlog', 'monitoring', 'activities', 'connections', 'filesystem', 'ip-history',
+  'anomalies', 'eventlog', 'monitoring', 'compliance', 'activities', 'connections', 'filesystem', 'ip-history',
   'boot-performance', 'playbooks', 'peripherals', 'backup', 'tickets',
 ];
 
@@ -188,6 +191,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
     { id: 'tickets', label: 'Tickets', icon: <Ticket className="h-4 w-4" />, title: 'Tickets linked to this device' },
     { id: 'eventlog', label: 'Event Log', icon: <FileText className="h-4 w-4" />, title: 'Windows/macOS system event logs' },
     { id: 'monitoring', label: 'Monitoring', icon: <HeartPulse className="h-4 w-4" />, title: 'Service/process watch results from Configuration Policies' },
+    { id: 'compliance', label: 'Compliance', icon: <ShieldCheck className="h-4 w-4" />, title: 'Per-device Configuration Policy compliance results' },
     // --- Inventory ---
     { id: 'hardware', label: 'Hardware', icon: <Cpu className="h-4 w-4" />, separator: true },
     { id: 'software', label: 'Software', icon: <Package className="h-4 w-4" /> },
@@ -403,6 +407,10 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
 
       {activeTab === 'monitoring' && (
         <DeviceMonitoringTab deviceId={device.id} timezone={effectiveTimezone} />
+      )}
+
+      {activeTab === 'compliance' && (
+        <DeviceComplianceTab deviceId={device.id} timezone={effectiveTimezone} />
       )}
 
       {activeTab === 'activities' && (


### PR DESCRIPTION
## Summary

Closes #1876. Adds the missing piece from the #1874/#1875 split (originally item 4 of #1854): **per-device Configuration Policy compliance** — a new authz'd backend read route plus a Compliance section on the device detail page.

## API

- **New route** `GET /policies/compliance/device/:deviceId` in `complianceRoutes` (`apps/api/src/routes/policyManagement/compliance.ts`), registered **before** `/:id/compliance` so the literal `/compliance/...` segment wins over the `:id` param.
- Wires the previously **dead-code** helper `getConfigPolicyComplianceForDevice` (`helpers.ts:566`) — it was imported but never called.
- The helper performs **no tenant/site authz**, so this route is the only guard. It mirrors the device-access gate at `monitoring.ts:872-889`:
  1. resolve the device's `orgId`/`siteId` (404 if missing),
  2. deny by org via `ensureOrgAccess` (403),
  3. deny by site via `canAccessSite(perms.allowedSiteIds)` (403).
- `requirePermission(DEVICES_READ)` is in the chain so `permissions` is populated and the site gate is **live** (not a dead gate). DEVICES_READ is granted to every device-viewing role, so it adds no lockout.

## Web

- New `DeviceComplianceTab` (`apps/web/src/components/devices/DeviceComplianceTab.tsx`) consuming the route, plus a **"Compliance"** tab on `DeviceDetails.tsx` (mirrors the `DeviceMonitoringTab` pattern from #1875). Read-only GET — no `runAction` needed.

## Tests

- **`apps/api/src/routes/policyManagement_compliance_device.test.ts`** — the load-bearing site-scope gate test: 403 for a site-restricted caller without the device's site, 403 cross-org, 404 missing device, 200 + rows for in-site / unrestricted callers. `permissions` is mocked via a non-no-op `requirePermission` so the gate is exercised, not vacuous.
- The static `site-scope-coverage` contract test recognizes the new route as carrying a live site gate (passes, 7/7).
- **`DeviceComplianceTab.test.tsx`** — rows (failing-first ordering), empty, error states.

## Verification

- `apps/api`: `vitest run policyManagement_compliance_device.test.ts` → 6 passed; `test:site-scope-coverage` → 7 passed; `tsc --noEmit` clean.
- `apps/web`: `vitest run DeviceComplianceTab.test.tsx` → 3 passed; `astro check` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)