### PR TITLE
fix(patches): stop ring selection collapsing the patch list to 50

### DIFF
--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -11,6 +11,7 @@ import {
   devicePatches,
 } from '../db/schema';
 import { resolveRingDeviceCounts, resolveRingDeviceIds } from './updateRingsHelpers';
+import { getPagination } from './patches/helpers';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
@@ -30,11 +31,10 @@ updateRingRoutes.use('*', authMiddleware);
 // Helpers
 // ============================================
 
-function getPagination(query: { page?: string; limit?: string }) {
-  const page = Math.max(1, Number.parseInt(query.page ?? '1', 10) || 1);
-  const limit = Math.min(100, Math.max(1, Number.parseInt(query.limit ?? '50', 10) || 50));
-  return { page, limit, offset: (page - 1) * limit };
-}
+// Pagination is shared with the /patches list endpoints (patches/helpers.ts):
+// default 50, capped at MAX_PAGE_LIMIT (200). Previously a local copy here
+// capped at 100 and the web's ring path sent no `limit`, so selecting a ring
+// silently collapsed the visible patch list from the all-rings 200 down to 50.
 
 function resolvePartnerId(
   auth: { scope: 'system' | 'partner' | 'organization'; partnerId: string | null },

--- a/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
+++ b/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
@@ -228,6 +228,82 @@ describe('updateRings routes', () => {
       expect(body.pagination).toBeDefined();
     });
 
+    // Pagination regression (#1316 follow-up): the ring endpoint must share the
+    // /patches getPagination — default 50, capped at 200 (not the old local 100).
+    // Selecting a ring previously collapsed the visible list because the web sent
+    // no `limit` and this endpoint defaulted to 50. The web now sends ?limit=200.
+    function mockRingPatchesQuery() {
+      const limitSpy = vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue([]) // empty page → skips approval lookup
+      });
+      vi.mocked(db.select)
+        // ring lookup
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+            })
+          })
+        } as any)
+        // patches list
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({ limit: limitSpy })
+            })
+          })
+        } as any)
+        // count
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }])
+          })
+        } as any);
+      return limitSpy;
+    }
+
+    it('honors an explicit ?limit=200 (matches the web ring fetch)', async () => {
+      const limitSpy = mockRingPatchesQuery();
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches?limit=200`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(limitSpy).toHaveBeenCalledWith(200);
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(200);
+    });
+
+    it('caps ?limit at the shared 200, not the old local 100', async () => {
+      const limitSpy = mockRingPatchesQuery();
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches?limit=500`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(limitSpy).toHaveBeenCalledWith(200);
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(200);
+    });
+
+    it('defaults to a 50-row page when no ?limit is given', async () => {
+      const limitSpy = mockRingPatchesQuery();
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(limitSpy).toHaveBeenCalledWith(50);
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(50);
+    });
+
     it('should return 404 for non-existent ring', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -133,6 +133,75 @@ describe('PatchesPage', () => {
     expect(desktop().getAllByRole('button', { name: 'Review' })).toHaveLength(1);
   });
 
+  it('fetches the ring-scoped patches with ?limit=200 when a ring is selected', async () => {
+    // Regression: selecting a ring previously fetched `/update-rings/:id/patches`
+    // with NO limit, so the endpoint defaulted to a 50-row page and the visible
+    // list collapsed from the all-rings 200 down to 50. The ring path must now
+    // send the same `?limit=200` as the all-rings path.
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === '/update-rings') {
+        return makeJsonResponse({
+          data: [
+            { id: 'ring-1', name: 'Pilot', ringOrder: 1, deferralDays: 0, enabled: true },
+          ],
+        });
+      }
+
+      if (url === '/patches?limit=200') {
+        return makeJsonResponse({
+          data: [
+            {
+              id: 'patch-1',
+              title: 'All-Rings Patch',
+              severity: 'critical',
+              source: 'microsoft',
+              os: 'windows',
+              releaseDate: '2026-04-01T00:00:00.000Z',
+              approvalStatus: 'pending',
+            },
+          ],
+        });
+      }
+
+      if (url === '/update-rings/ring-1/patches?limit=200') {
+        return makeJsonResponse({
+          data: [
+            {
+              id: 'patch-2',
+              title: 'Ring Scoped Patch',
+              severity: 'important',
+              source: 'microsoft',
+              os: 'windows',
+              releaseDate: '2026-04-02T00:00:00.000Z',
+              approvalStatus: 'approved',
+            },
+          ],
+          pagination: { page: 1, limit: 200, total: 1 },
+        });
+      }
+
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    await screen.findAllByText('All-Rings Patch');
+
+    // The RingSelector's <select> owns the "All Rings" option; switch it to the ring.
+    const ringOption = await screen.findByRole('option', { name: /All Rings/ });
+    const ringSelect = ringOption.closest('select') as HTMLSelectElement;
+    fireEvent.change(ringSelect, { target: { value: 'ring-1' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/update-rings/ring-1/patches?limit=200');
+    });
+    // The ring path must never be fetched without the limit (the old bug).
+    expect(fetchMock).not.toHaveBeenCalledWith('/update-rings/ring-1/patches');
+    await screen.findAllByText('Ring Scoped Patch');
+  });
+
   it('partner scope: allows bulk approve in all-orgs mode (no org, no ring) — request fires partner-wide', async () => {
     // After the partner-scoping migration, the API derives the partner from
     // auth.partnerId. A partner user in all-orgs mode (no org, no ring) is valid —

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -148,9 +148,11 @@ export default function PatchesPage() {
       // are never fetched. Note: this never sends sortBy/sortDir, so the
       // server-side sort added to the API (list.ts / schemas.ts) is NOT yet
       // consumed by the web; wiring it up is a follow-up (see list.ts comment).
-      // Ring-scoped patches use a dedicated endpoint with its own bounded set.
+      // Ring-scoped patches use a dedicated endpoint; send the same `limit=200`
+      // so selecting a ring doesn't collapse the list to the endpoint's default
+      // page of 50 (the ring endpoint now shares the /patches 200 cap).
       const url = selectedRingId
-        ? `/update-rings/${selectedRingId}/patches`
+        ? `/update-rings/${selectedRingId}/patches?limit=200`
         : '/patches?limit=200';
       const response = await fetchWithAuth(url);
       if (!response.ok) {


### PR DESCRIPTION
## Problem

On the Patches page → Patches tab, selecting a deployment **ring** dropped the visible update list dramatically — from the all-rings ~200 down to exactly **50**. The drop is not a real ring filter; it was a pagination-default artifact.

## Root cause

Both code paths query the **same global `patches` catalog** — the ring only changes the approval-status overlay, not which patches exist. The count difference came entirely from page-size mismatch:

- **All Rings** → web fetches `/patches?limit=200` → up to 200 rows.
- **Ring selected** → web fetched `/update-rings/:id/patches` with **no `limit`**, and that endpoint had a *local copy* of `getPagination` defaulting to **50** (and capped at **100**, vs the shared `/patches` cap of 200).

## Fix

- `apps/api/src/routes/updateRings.ts` — delete the duplicate `getPagination`; import the shared one from `patches/helpers.ts` (default 50, cap `MAX_PAGE_LIMIT` = 200).
- `apps/web/.../PatchesPage.tsx` — the ring fetch now sends `?limit=200`, matching the all-rings path.

The two tabs now load the same bounded set; `PatchList` sorts/paginates client-side over it as before.

## Tests

`updateRings_patches_compliance_scope.test.ts` — 3 new cases (12/12 pass):
- honors `?limit=200`
- caps `?limit=500` at 200 (regression for the old local 100 cap)
- defaults to a 50-row page when no `limit` is given

API + web typecheck clean.

## Out of scope (pre-existing, unchanged)

- The ring endpoint still returns the **global catalog** with a ring-scoped approval overlay — it does not narrow to the ring's devices. If ring selection should scope to ring membership, that's a separate semantic change.
- True server-side pagination/sort for orgs with **>200** patches (the web still fetch-200-then-paginate-client-side) remains a follow-up (#1316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)