### PR TITLE
test(api): raise timeout on flaky mcpServer effectiveTier site-axis test

### DIFF
--- a/apps/api/src/routes/mcpServer.effectiveTier.test.ts
+++ b/apps/api/src/routes/mcpServer.effectiveTier.test.ts
@@ -406,7 +406,10 @@ describe('MCP resources/read site-axis enforcement (FIX 3)', () => {
     // The device-list query must have received a site-narrowing condition
     // (in addition to the org condition) — proves the route applied the axis.
     expect(capturedDeviceListConds.length).toBeGreaterThan(0);
-  });
+    // Borderline-slow under full-suite parallel load (real async MCP resources/read
+    // + permission re-mock); give headroom over the 5s default so it doesn't flake
+    // when the suite is saturated. Passes in well under 1s in isolation.
+  }, 15_000);
 
   // C4 — alerts list site axis. Alert a-a is on site-A device d-a; a-b is on
   // site-B device d-b. A site-A-restricted caller must see a-a but not a-b. We


### PR DESCRIPTION
One-line test-infra fix. `mcpServer.effectiveTier.test.ts` → 'site-restricted caller does not see site-B devices via resources/read' passes 16/16 in isolation (<1s) but times out at the 5s default under full-suite parallel load, redding Test API intermittently (surfaced after the recent merge train raised suite load). Bumps that test to a 15s timeout — no behavior change.

Note: the sibling 'C4: …site-B alerts…' test (~line 415) is the same pattern and may need the same treatment if it flakes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)