### PR TITLE
fix(test): treat file-level use('*', requirePermission) as a live perms source

### DIFF
--- a/apps/api/src/__tests__/helpers/routeScan.test.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.test.ts
@@ -292,6 +292,55 @@ describe('analyzeRouteSource — dead permissions-sourced site gate detector', (
     expect(route.sitePermsGateDead).toBe(false);
   });
 
+  it('does NOT flag when a requirePermission-bound const is mounted file-level via .use(\'*\', …)', () => {
+    // The vulnerabilities.ts idiom (#1889): apply the perms middleware once as
+    // file-level `router.use('*', requireXRead)` instead of inline per-route.
+    // It populates c.get('permissions') for EVERY route, but the `.use(...)` call
+    // sits above each per-route slice — so the per-route scan must consult the
+    // file-level source or it false-flags the gate as dead.
+    const src = [
+      `const requireVulnRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);`,
+      `router.use('*', authMiddleware);`,
+      `router.use('*', requireScope('organization', 'partner', 'system'));`,
+      `router.use('*', requireVulnRead);`,
+      `router.get(`,
+      `  '/',`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, asset.siteId)) return c.json({}, 403);`,
+      `    return c.json(results);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:GET /",
+    )!;
+    expect(route.sitePermsGateDead).toBe(false);
+  });
+
+  it('STILL flags when the file-level .use() is a non-wildcard path (does not cover all routes)', () => {
+    // `.use('/admin', requireXRead)` only mounts on the /admin subtree, so a
+    // sibling route reading `permissions` is still ungated — must NOT be
+    // suppressed by the file-level source.
+    const src = [
+      `const requireVulnRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);`,
+      `router.use('/admin', requireVulnRead);`,
+      `router.get(`,
+      `  '/',`,
+      `  requireScope('organization', 'partner', 'system'),`,
+      `  async (c) => {`,
+      `    const perms = c.get('permissions') as UserPermissions | undefined;`,
+      `    if (perms?.allowedSiteIds && !canAccessSite(perms, asset.siteId)) return c.json({}, 403);`,
+      `    return c.json(results);`,
+      `  }`,
+      `);`,
+    ].join('\n');
+    const route = analyzeRouteSource('routes/x.ts', src, DEVICE_TABLES).find(
+      (r) => r.id === "routes/x.ts:GET /",
+    )!;
+    expect(route.sitePermsGateDead).toBe(true);
+  });
+
   it('does NOT flag when requireSiteAccess middleware is in the chain', () => {
     // requireSiteAccess self-resolves perms (getUserPermissions fallback) and
     // does its own canAccessSite check — so the route is gated live.

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -345,6 +345,22 @@ export function analyzeRouteSource(
         )
       : LIVE_PERMS_SOURCE;
 
+  // File-level live source: a wildcard `.use('*', X)` / `.use('/*', X)` mounts X
+  // on EVERY route in the file. When X is a live perms source (inline
+  // requirePermission/getUserPermissions, or a requirePermission-bound const like
+  // `requireVulnerabilityRead`), `c.get('permissions')` is populated for all
+  // routes — but the `.use(...)` call sits ABOVE every per-route slice, so the
+  // per-route scan below can't see it and would false-flag the gate as dead.
+  // Detect it once per file. Only pure-wildcard paths ('*', '/*', '/') count —
+  // `.use('/specific', X)` does not cover all routes and must not suppress the
+  // dead-gate check.
+  const hasFileLevelLivePermsSource = text.split('\n').some((ln) => {
+    const trimmed = ln.trim();
+    // Skip comment lines so a commented-out `.use(...)` can't suppress the check.
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) return false;
+    return /\.use\(\s*(['"`])[/*]+\1\s*,/.test(ln) && livePermsPattern.test(ln);
+  });
+
   // File-level: a non-user-session auth guard anywhere in the file implies the
   // router authenticates a non-user principal (agent/helper/portal/viewer/admin).
   // The whole `routes/agents/` tree is mounted under agentAuthMiddleware at
@@ -401,7 +417,10 @@ export function analyzeRouteSource(
       (PERMS_CONTEXT_READ.test(slice) && PERMS_SITE_TOKEN.test(slice)) ||
       (permsHelperCallPattern !== null && permsHelperCallPattern.test(slice));
     const sitePermsGateDead =
-      permsSiteGate && !livePermsPattern.test(slice) && !FAIL_CLOSED_PERMS.test(slice);
+      permsSiteGate &&
+      !livePermsPattern.test(slice) &&
+      !hasFileLevelLivePermsSource &&
+      !FAIL_CLOSED_PERMS.test(slice);
 
     const line = text.slice(0, cur.index).split('\n').length;
 


### PR DESCRIPTION
## Problem — main is red on Test API

The site-scope **dead-perms-gate** contract test (`site-scope-coverage.integration.test.ts`, via `routeScan.ts`) is failing on `main`, flagging:

```
routes/vulnerabilities.ts:GET /  (routes/vulnerabilities.ts:342)
```

This is a **false positive**. The route is gated by a file-level middleware:

```ts
const requireVulnerabilityRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
vulnerabilityRoutes.use('*', requireVulnerabilityRead);   // ← populates c.get('permissions') for every route
```

So `c.get('permissions')` **is** live at runtime and the site-axis gate (`perms?.allowedSiteIds`) works. But the detector scans each route's slice starting at its `.get('/')` definition, and the `.use('*', …)` call sits *above* that slice — so it couldn't see the source and flagged the gate as dead.

Introduced by #1889 (which applied the perms middleware file-level rather than inline per-route). Its own CI was cancelled when #1895 landed on top, so the red slipped into main and now blocks every PR branched from it.

## Fix

`routeScan.ts`: compute a file-level live-perms-source flag once per file — any wildcard `.use('*' | '/*' | '/', X)` whose `X` is a live perms source (inline `requirePermission(`/`getUserPermissions(`, or a requirePermission-bound const) — and factor it into `sitePermsGateDead`.

Guards:
- Only **pure wildcard** paths count. `.use('/admin', X)` does not cover all routes and must not suppress the check.
- Comment lines are skipped, so a commented-out `.use(...)` can't mask a real dead gate.

This fixes the false positive at the root for the whole `.use('*', perms)` idiom, not just `vulnerabilities.ts`.

## Tests

`routeScan.test.ts` — 2 new `analyzeRouteSource` cases (27/27 pass):
- file-level wildcard `.use('*', requireXRead)` → **not** flagged (the fix; verified it fails without the change)
- non-wildcard `.use('/admin', requireXRead)` → **still** flagged

Contract suite (`site-scope-coverage`) returns to **0 offenders**; the shrink-only ratchet confirms the existing `eventWs.ts:POST /ws-ticket` exempt entry is untouched. API typecheck clean.

## Note
Pure detector/test-harness change — no runtime/route code touched. The `vulnerabilities.ts` site gate was already correct; this only teaches the static scanner to see it. Unblocks #1897 and the rest of the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)