### PR TITLE
feat(installer): MSI filename-bootstrap enrollment (Windows parity)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,19 +541,7 @@ jobs:
           $msiPath = Join-Path $root "dist\breeze-agent.msi"
           & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath
 
-      - name: Build Template MSI
-        shell: pwsh
-        run: |
-          $root = $env:GITHUB_WORKSPACE
-          $version = "${{ steps.version.outputs.version }}"
-          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
-          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
-          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
-          $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
-          $msiPath = Join-Path $root "dist\breeze-agent-template.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath -Template
-
-      # Only sign the regular MSI — template MSI is re-signed server-side by jsign after patching
+      # Sign the agent MSI (Azure Trusted Signing).
       - name: Sign MSI (stable profile)
         if: ${{ !contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
@@ -627,13 +615,6 @@ jobs:
         with:
           name: breeze-agent-windows-msi
           path: dist/breeze-agent.msi
-          retention-days: 30
-
-      - name: Upload Template MSI artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: breeze-agent-template-msi
-          path: dist/breeze-agent-template.msi
           retention-days: 30
 
       - name: Upload signed backup EXE artifact
@@ -2029,11 +2010,6 @@ jobs:
           )
 
           def platform_trust(name):
-              # *-template.msi is intentionally unsigned here; per-tenant
-              # property injection happens server-side and the resulting
-              # MSI is signed there.
-              if name.endswith("-template.msi"):
-                  return "release-workflow-produced"
               if name.endswith(".msi") or name.endswith(".exe"):
                   return "windows-authenticode-required"
               if (

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -369,7 +369,7 @@
            EnrollAgent path above). SetBootstrapData (immediate) must run before
            the deferred BootstrapEnroll so CustomActionData is populated. -->
       <Custom Action="SetBootstrapData" Before="BootstrapEnroll" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
-      <Custom Action="BootstrapEnroll" Before="InstallServices" After="EnrollAgent" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
+      <Custom Action="BootstrapEnroll" Before="InstallServices" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
       <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
     </InstallExecuteSequence>
 

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -60,6 +60,7 @@
     <?else?>
     <Property Id="ENROLLMENT_SECRET" Secure="yes" Hidden="yes" />
     <?endif?>
+    <Property Id="BOOTSTRAP_TOKEN" Secure="yes" Hidden="yes" />
     <Property Id="ARPNOREPAIR" Value="1" />
     <Property Id="POWERSHELL_EXE" Secure="yes" />
     <Property Id="BREEZE_KILL_CMD" Secure="yes" />
@@ -296,6 +297,25 @@
       Return="check"
       HideTarget="yes" />
 
+    <!-- Capture the launched MSI path + bootstrap inputs while the original
+         session properties are still readable (immediate CA). OriginalDatabase
+         points at the user's downloaded file here; by deferred execution the
+         package is cached to C:\Windows\Installer and the [TOKEN@HOST] name is
+         gone. Packed pipe-delimited because deferred CAs only see CustomActionData. -->
+    <CustomAction
+      Id="SetBootstrapData"
+      Property="BootstrapEnroll"
+      Value="[OriginalDatabase]|[BOOTSTRAP_TOKEN]|[SERVER_URL]" />
+
+    <CustomAction
+      Id="BootstrapEnroll"
+      FileRef="filBreezeAgentExe"
+      ExeCommand="bootstrap --install-data &quot;[CustomActionData]&quot; --quiet"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check"
+      HideTarget="yes" />
+
     <InstallExecuteSequence>
       <!-- Run on every install path EXCEPT uninstall. Broadened from the
            original `WIX_UPGRADE_DETECTED OR Installed` (which skipped fresh
@@ -344,6 +364,12 @@
            restart. This is the intended flow for imaged/sysprep'd
            deployments. -->
       <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
+      <!-- Filename/property bootstrap enrollment: only when explicit
+           SERVER_URL+ENROLLMENT_KEY were NOT supplied (those take the
+           EnrollAgent path above). SetBootstrapData (immediate) must run before
+           the deferred BootstrapEnroll so CustomActionData is populated. -->
+      <Custom Action="SetBootstrapData" Before="BootstrapEnroll" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
+      <Custom Action="BootstrapEnroll" Before="InstallServices" After="EnrollAgent" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
       <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
     </InstallExecuteSequence>
 

--- a/agent/installer/build-msi.ps1
+++ b/agent/installer/build-msi.ps1
@@ -15,9 +15,7 @@ param(
     [string]$UserHelperExePath = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "",
-
-    [switch]$Template
+    [string]$OutputPath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -83,20 +81,6 @@ if (-not (Test-Path $outputDir)) {
     New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
 }
 
-$templateArgs = @()
-if ($Template) {
-    $pad = 512
-    # Pad with spaces (not nulls) — MSI string pool strips null bytes but preserves spaces
-    $serverPlaceholder = "@@BREEZE_SERVER_URL@@".PadRight($pad, ' ')
-    $keyPlaceholder = "@@BREEZE_ENROLLMENT_KEY@@".PadRight($pad, ' ')
-    $secretPlaceholder = "@@BREEZE_ENROLLMENT_SECRET@@".PadRight($pad, ' ')
-    $templateArgs = @(
-        "-d", "ServerUrlDefault=$serverPlaceholder",
-        "-d", "EnrollmentKeyDefault=$keyPlaceholder",
-        "-d", "EnrollmentSecretDefault=$secretPlaceholder"
-    )
-}
-
 $wixArgs = @(
     "build",
     "$installerPath",
@@ -110,7 +94,7 @@ $wixArgs = @(
     "-d", "InstallUserHelperScriptPath=$installUserHelperScriptPath",
     "-d", "RemoveUserHelperScriptPath=$removeUserHelperScriptPath",
     "-o", "$OutputPath"
-) + $templateArgs
+)
 
 & wix @wixArgs
 if ($LASTEXITCODE -ne 0) {

--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -119,10 +119,10 @@ func runBootstrap() {
 	}
 
 	// Hand off to the existing enroll path via the package globals it reads.
+	// siteId is NOT forwarded here: enrollDevice does not read enrollSiteID for
+	// the resolved key — the server derives the site from the (child) key and
+	// returns it in the enroll response (cfg.SiteID = enrollResp.SiteID).
 	serverURL = res.ServerURL
 	enrollmentSecret = res.EnrollmentSecret
-	if res.SiteID != "" {
-		enrollSiteID = res.SiteID
-	}
 	enrollDevice(res.EnrollmentKey)
 }

--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -1,0 +1,128 @@
+package agentapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/logging"
+)
+
+var errNoBootstrapInput = errors.New("no bootstrap token from filename or properties")
+
+// bootstrapInstallData is the WiX CustomActionData payload, packed by the
+// SetBootstrapData type-51 CA as "<OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>".
+var bootstrapInstallData string
+
+type bootstrapResult struct {
+	ServerURL        string `json:"serverUrl"`
+	EnrollmentKey    string `json:"enrollmentKey"`
+	EnrollmentSecret string `json:"enrollmentSecret"`
+	SiteID           string `json:"siteId"`
+}
+
+// resolveBootstrapInputs decides which token/server to use. Property token +
+// server take precedence (explicit silent-install intent); otherwise the
+// [TOKEN@HOST] in the installer filename is used, with the host promoted to an
+// https:// server URL. Mirrors the macOS payload-then-filename precedence.
+func resolveBootstrapInputs(data string) (token, server string, err error) {
+	parts := strings.SplitN(data, "|", 3)
+	var installerPath, propToken, propServer string
+	if len(parts) > 0 {
+		installerPath = parts[0]
+	}
+	if len(parts) > 1 {
+		propToken = strings.TrimSpace(parts[1])
+	}
+	if len(parts) > 2 {
+		propServer = strings.TrimSpace(parts[2])
+	}
+
+	if propToken != "" && propServer != "" {
+		return propToken, propServer, nil
+	}
+
+	if tok, host, ferr := parseInstallerFilenameToken(installerPath); ferr == nil {
+		return tok, "https://" + host, nil
+	}
+	return "", "", errNoBootstrapInput
+}
+
+// redeemBootstrapToken exchanges a single-use token for a child enrollment key.
+func redeemBootstrapToken(server, token string) (*bootstrapResult, error) {
+	url := strings.TrimRight(server, "/") + "/api/v1/installer/bootstrap"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Breeze-Bootstrap-Token", token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bootstrap redeem failed: %d %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out bootstrapResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("bootstrap redeem: bad response: %w", err)
+	}
+	if out.EnrollmentKey == "" {
+		return nil, errors.New("bootstrap redeem: response missing enrollmentKey")
+	}
+	if out.ServerURL == "" {
+		out.ServerURL = server
+	}
+	return &out, nil
+}
+
+// runBootstrap resolves enrollment inputs, redeems the token, and enrolls.
+// Soft-exits 0 when there is genuinely no token (manual install with no token
+// and no properties), so the install completes with an unenrolled agent that
+// idles in the wait-for-enrollment loop. A present-but-bad token is a real
+// error and exits non-zero so the MSI rolls back cleanly.
+func runBootstrap() {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		cfg = config.Default()
+	}
+	initEnrollLogging(cfg, quietEnroll)
+	bsLog := logging.L("bootstrap")
+
+	token, server, err := resolveBootstrapInputs(bootstrapInstallData)
+	if err != nil {
+		bsLog.Info("no bootstrap token present; skipping enrollment (agent will idle until enrolled)")
+		if !quietEnroll {
+			fmt.Println("No enrollment token found; install will complete unenrolled.")
+		}
+		return // exit 0 — soft
+	}
+
+	bsLog.Info("redeeming bootstrap token", "server", server)
+	res, err := redeemBootstrapToken(server, token)
+	if err != nil {
+		bsLog.Error("bootstrap token redemption failed", "error", err.Error())
+		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
+		os.Exit(1) // hard — roll back the install
+	}
+
+	// Hand off to the existing enroll path via the package globals it reads.
+	serverURL = res.ServerURL
+	enrollmentSecret = res.EnrollmentSecret
+	if res.SiteID != "" {
+		enrollSiteID = res.SiteID
+	}
+	enrollDevice(res.EnrollmentKey)
+}

--- a/agent/internal/agentapp/bootstrap_test.go
+++ b/agent/internal/agentapp/bootstrap_test.go
@@ -1,0 +1,80 @@
+package agentapp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveBootstrapInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		data       string
+		wantToken  string
+		wantServer string
+		wantErr    error
+	}{
+		{
+			name:       "filename token only",
+			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi||`,
+			wantToken:  "ABCDE12345",
+			wantServer: "https://eu.2breeze.app",
+		},
+		{
+			name:       "property token + server wins over filename",
+			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|https://us.2breeze.app`,
+			wantToken:  "ZZZZZ99999",
+			wantServer: "https://us.2breeze.app",
+		},
+		{
+			name:    "no token anywhere",
+			data:    `C:\dl\breeze-agent.msi||`,
+			wantErr: errNoBootstrapInput,
+		},
+		{
+			name:       "property token without server falls back to filename",
+			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|`,
+			wantToken:  "ABCDE12345",
+			wantServer: "https://eu.2breeze.app",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, server, err := resolveBootstrapInputs(tc.data)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want err %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantToken || server != tc.wantServer {
+				t.Fatalf("got (%q,%q), want (%q,%q)", tok, server, tc.wantToken, tc.wantServer)
+			}
+		})
+	}
+}
+
+func TestRedeemBootstrapToken(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Breeze-Bootstrap-Token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"serverUrl":"` + "http://x" + `","enrollmentKey":"deadbeef","enrollmentSecret":"s","siteId":"site1"}`))
+	}))
+	defer srv.Close()
+
+	res, err := redeemBootstrapToken(srv.URL, "ABCDE12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotToken != "ABCDE12345" {
+		t.Fatalf("token header not sent, got %q", gotToken)
+	}
+	if res.EnrollmentKey != "deadbeef" || res.SiteID != "site1" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -1,0 +1,25 @@
+package agentapp
+
+import (
+	"errors"
+	"regexp"
+)
+
+// errNoFilenameToken is returned when a filename carries no [TOKEN@HOST] group.
+var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
+
+// installerTokenRe mirrors FilenameTokenParser.swift: a 10-char base36 token
+// and a host, wrapped in square brackets. The token charset is uppercase to
+// avoid ambiguity; the host allows letters, digits, dots, and hyphens.
+var installerTokenRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
+
+// parseInstallerFilenameToken extracts the bootstrap token and API host from an
+// installer path or basename. It searches anywhere in the string, so a browser
+// "(1)" dedup suffix or a full path does not break matching.
+func parseInstallerFilenameToken(name string) (token string, host string, err error) {
+	m := installerTokenRe.FindStringSubmatch(name)
+	if m == nil {
+		return "", "", errNoFilenameToken
+	}
+	return m[1], m[2], nil
+}

--- a/agent/internal/agentapp/installer_filename_test.go
+++ b/agent/internal/agentapp/installer_filename_test.go
@@ -1,0 +1,39 @@
+package agentapp
+
+import "testing"
+
+func TestParseInstallerFilenameToken(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantTok   string
+		wantHost  string
+		wantError bool
+	}{
+		{"clean", "Breeze Agent [ABCDE12345@eu.2breeze.app].msi", "ABCDE12345", "eu.2breeze.app", false},
+		{"browser dup suffix", "Breeze Agent [ABCDE12345@us.2breeze.app] (1).msi", "ABCDE12345", "us.2breeze.app", false},
+		{"full path", `C:\Users\me\Downloads\Breeze Agent [Z9Y8X7W6V5@host.example.com].msi`, "Z9Y8X7W6V5", "host.example.com", false},
+		{"host with hyphen", "Breeze Agent [ABCDE12345@my-rmm.example].msi", "ABCDE12345", "my-rmm.example", false},
+		{"no brackets", "breeze-agent.msi", "", "", true},
+		{"token too short", "Breeze Agent [ABCDE1234@host].msi", "", "", true},
+		{"token lowercase", "Breeze Agent [abcde12345@host].msi", "", "", true},
+		{"empty", "", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, host, err := parseInstallerFilenameToken(tc.input)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got token=%q host=%q", tok, host)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantTok || host != tc.wantHost {
+				t.Fatalf("got (%q,%q), want (%q,%q)", tok, host, tc.wantTok, tc.wantHost)
+			}
+		})
+	}
+}

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -174,6 +174,15 @@ var enrollCmd = &cobra.Command{
 	},
 }
 
+var bootstrapCmd = &cobra.Command{
+	Use:    "bootstrap",
+	Short:  "Redeem an installer bootstrap token and enroll (used by the MSI)",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		runBootstrap()
+	},
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
@@ -218,12 +227,15 @@ func init() {
 	enrollCmd.Flags().StringVar(&enrollDeviceRole, "device-role", "", "Device role override (e.g. workstation, server)")
 	enrollCmd.Flags().BoolVar(&forceEnroll, "force", false, "Re-enroll even if already enrolled; replaces AgentID/AuthToken on success (no-op on failure)")
 	enrollCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr). Intended for unattended installs.")
+	bootstrapCmd.Flags().StringVar(&bootstrapInstallData, "install-data", "", "Packed WiX CustomActionData: <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>")
+	bootstrapCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr)")
 	userHelperCmd.Flags().StringVar(&helperRole, "role", "user", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
 	desktopHelperCmd.Flags().StringVar(&desktopContext, "context", ipc.DesktopContextUserSession, "Desktop context: 'user_session' or 'login_window'")
 
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(enrollCmd)
+	rootCmd.AddCommand(bootstrapCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(userHelperCmd)

--- a/apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql
+++ b/apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql
@@ -1,0 +1,6 @@
+-- Carry the installer platform on the bootstrap token so the lazily-created
+-- child enrollment key can record whether it came from a Windows or macOS
+-- installer. Nullable + no default: existing rows and macOS callers leave it
+-- null/"macos"; the Windows download path sets "windows".
+ALTER TABLE installer_bootstrap_tokens
+  ADD COLUMN IF NOT EXISTS installer_platform text;

--- a/apps/api/src/db/schema/installerBootstrapTokens.ts
+++ b/apps/api/src/db/schema/installerBootstrapTokens.ts
@@ -46,6 +46,7 @@ export const installerBootstrapTokens = pgTable(
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     consumedAt: timestamp("consumed_at", { withTimezone: true }),
     consumedFromIp: text("consumed_from_ip"),
+    installerPlatform: text("installer_platform"),
   },
   (t) => ({
     expiresIdx: index("idx_installer_bootstrap_tokens_expires").on(t.expiresAt),

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -83,6 +83,14 @@ vi.mock("../services/installerBuilder", () => ({
   fetchRegularMsi: vi.fn(async () => Buffer.from("regular-msi")),
   assertMacosInstallerPkgsReachable: vi.fn(async () => {}),
   fetchMacosInstallerAppZip: vi.fn(async () => null),
+  serveWindowsBootstrapMsi: vi.fn((c: any, args: { msi: Buffer; token: string; apiHost: string }) => {
+    const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+    c.header("Content-Type", "application/octet-stream");
+    c.header("Content-Disposition", `attachment; filename="${filename}"`);
+    c.header("Content-Length", String(args.msi.length));
+    c.header("Cache-Control", "no-store");
+    return c.body(args.msi);
+  }),
 }));
 
 vi.mock("../services/installerAppZip", () => ({
@@ -440,7 +448,7 @@ describe("GET /s/:code", () => {
     });
     const childRow = makeChildKeyRow({ installerPlatform: "windows" });
 
-    // select: look up by shortCode
+    // select: look up by shortCode; issueBootstrapTokenForKey also selects the child row
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -465,14 +473,23 @@ describe("GET /s/:code", () => {
       }),
     } as any);
 
-    // serveInstaller also calls db.update to increment child key usage
-    // (second update call is handled by same mock — returns the same shape)
+    // serveInstaller (Windows) now calls issueBootstrapTokenForKey — spy it
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-1",
+        token: "ABC1234567",
+        expiresAt: new Date(Date.now() + 3_600_000),
+        parentKeyName: "Test Key",
+      });
 
     const res = await app.request("/s/abc1234567");
 
     expect(res.status).toBe(200);
     const buf = await res.arrayBuffer();
     expect(buf.byteLength).toBeGreaterThan(0);
+
+    issueSpy.mockRestore();
   });
 
   it("returns 404 for unknown code", async () => {
@@ -791,28 +808,30 @@ describe("GET /public-download/:platform", () => {
       );
     });
 
+    // serveInstaller (Windows) now calls issueBootstrapTokenForKey
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-1",
+        token: "ABC1234567",
+        expiresAt: new Date(Date.now() + 3_600_000),
+        parentKeyName: "Test Key",
+      });
+
     const res = await app.request(
       `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
     );
 
     expect(res.status).toBe(200);
     expect(db.update).not.toHaveBeenCalled();
+
+    issueSpy.mockRestore();
   });
 
-  it("uses the remote signing service (no local binary fetch) when configured", async () => {
-    // Regression guard for the most-hit installer path in production. When
-    // MsiSigningService is configured, serveInstaller must:
-    //   1. NOT call fetchRegularMsi / macOS reachability probe / anything local,
-    //   2. call buildAndSignMsi with the correct version + properties,
-    //   3. serve the result as application/octet-stream.
-    process.env.BINARY_VERSION = "0.62.24";
-
-    const buildAndSignMsi = vi.fn(async () => Buffer.from("signed-msi-bytes"));
-    vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-      buildAndSignMsi,
-      probe: vi.fn(async () => {}),
-    } as any);
-
+  it("public windows download serves a static MSI named with the bootstrap token", async () => {
+    // Verifies that the public download path uses the bootstrap-token flow:
+    // issueBootstrapTokenForKey → fetchRegularMsi → serveWindowsBootstrapMsi
+    // with the token embedded in the Content-Disposition filename.
     const row = makeKeyRow({
       shortCode: "pubcode1234",
       installerPlatform: "windows",
@@ -828,47 +847,28 @@ describe("GET /public-download/:platform", () => {
       }),
     } as any);
 
-    const { fetchRegularMsi, assertMacosInstallerPkgsReachable } =
-      await import("../services/installerBuilder");
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-1",
+        token: "ABCDE12345",
+        expiresAt: new Date(Date.now() + 3_600_000),
+        parentKeyName: "Test Key",
+      });
 
-    consumeDownloadHandleMock.mockResolvedValueOnce(
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
     const res = await app.request(
       `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
     );
 
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
-    expect(res.headers.get("Content-Disposition")).toContain(
-      "breeze-agent.msi",
+    expect(res.headers.get("Content-Disposition")).toMatch(
+      /^attachment; filename="Breeze Agent \[ABCDE12345@api\.example\.com\]\.msi"$/,
     );
+    // No db.update — download does not consume enrollment slots
+    expect(db.update).not.toHaveBeenCalled();
 
-    expect(fetchRegularMsi).not.toHaveBeenCalled();
-    expect(assertMacosInstallerPkgsReachable).not.toHaveBeenCalled();
-
-    expect(buildAndSignMsi).toHaveBeenCalledTimes(1);
-    const req = (
-      buildAndSignMsi.mock.calls[0] as unknown as [
-        {
-          version: string;
-          properties: {
-            SERVER_URL: string;
-            ENROLLMENT_KEY: string;
-            ENROLLMENT_SECRET?: string;
-          };
-        },
-      ]
-    )[0];
-    // Signing service uses GitHub release tags (v-prefixed) as cache keys
-    expect(req.version).toBe("v0.62.24");
-    expect(req.properties.SERVER_URL).toBe("https://api.example.com");
-    // The token resolved from the one-time handle is embedded as ENROLLMENT_KEY.
-    expect(req.properties.ENROLLMENT_KEY).toBe(
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
-
-    delete process.env.BINARY_VERSION;
+    issueSpy.mockRestore();
   });
 
   it("rejects legacy raw token query downloads by default", async () => {

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -25,7 +25,6 @@ import {
 } from "../services/clientIp";
 import {
   buildMacosInstallerZip,
-  buildWindowsInstallerZip,
   fetchRegularMsi,
   assertMacosInstallerPkgsReachable,
   fetchMacosInstallerAppZip,
@@ -36,8 +35,6 @@ import {
   issueBootstrapTokenForKey,
   BootstrapTokenIssuanceError,
 } from "../services/installerBootstrapTokenIssuance";
-import { MsiSigningService } from "../services/msiSigning";
-import { getGithubReleaseVersion } from "../services/binarySource";
 import { captureException } from "../services/sentry";
 
 // ============================================================
@@ -120,19 +117,6 @@ function generateEnrollmentKey(): string {
 function freshChildExpiresAt(ttlMinutes?: number): Date {
   const minutes = ttlMinutes ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES;
   return new Date(Date.now() + minutes * 60 * 1000);
-}
-
-/**
- * Version string to send to the signing service. The signing service keys
- * its template cache by GitHub release tag (e.g. `v0.62.24`), matching the
- * download URL convention used elsewhere in binarySource.ts. We store bare
- * semver in BREEZE_VERSION / BINARY_VERSION and prepend the `v` here.
- * `"latest"` is passed through — the server will surface its own rejection.
- */
-function signingServiceVersion(): string {
-  const v = getGithubReleaseVersion();
-  if (v === "latest" || v.startsWith("v")) return v;
-  return `v${v}`;
 }
 
 /**
@@ -1128,9 +1112,6 @@ enrollmentKeyRoutes.get(
       return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
     }
 
-    // Determine signing availability — macOS only reaches here.
-    const signingService = MsiSigningService.fromEnv();
-
     // Signing-spend cap — enforce BEFORE child key creation or any signing
     // operation so an authenticated user cannot drive unbounded (costly,
     // rate-limited-upstream) signing calls. Two overlapping caps:
@@ -1432,37 +1413,23 @@ enrollmentKeyRoutes.post(
       );
     }
 
-    // Verify the build pipeline is reachable before creating a child key —
-    // otherwise a misconfigured MSI_SIGNING_URL, expired CF Access token,
-    // or downed signing VM would produce a link that looks fine at creation
-    // time but 500s for every customer who clicks it. The probe is a cheap
-    // TCP/TLS + /health liveness check (GET /health with 5s timeout) when
-    // signing is configured; otherwise a local binary fetch.
-    try {
-      if (platform === "windows") {
-        const signingService = MsiSigningService.fromEnv();
-        if (signingService) {
-          await signingService.probe();
-        } else {
-          await fetchRegularMsi();
-        }
-      } else {
-        // macOS installer downloads the arch-matched pkg at install time —
-        // validate BOTH architectures are reachable, not just arm64.
+    // For macOS, validate that both architecture PKGs are reachable before
+    // creating a child key — prevents links that 500 on every click.
+    // Windows uses the bootstrap path (no signing dependency), so no probe needed.
+    if (platform === "macos") {
+      try {
         await assertMacosInstallerPkgsReachable();
+      } catch (err) {
+        console.error(
+          `[installer-link] pre-flight check failed for ${platform}:`,
+          err,
+        );
+        captureException(err, c);
+        return c.json(
+          { error: "macOS PKG not reachable" },
+          503,
+        );
       }
-    } catch (err) {
-      console.error(
-        `[installer-link] pre-flight check failed for ${platform}:`,
-        err,
-      );
-      captureException(err, c);
-      return c.json(
-        {
-          error: `${platform === "windows" ? "MSI build pipeline" : "macOS PKG"} not reachable`,
-        },
-        503,
-      );
     }
 
     // Generate a child enrollment key with a fresh TTL independent of parent
@@ -1714,66 +1681,67 @@ async function serveInstaller(
 
   const globalSecret = process.env.AGENT_ENROLLMENT_SECRET || "";
 
-  // Fetch binary only for the local-build paths. When the remote signing
-  // service is configured for Windows, it builds and signs the MSI from
-  // scratch using its own cached templates — the API doesn't need to fetch
-  // anything.
-  const signingService = MsiSigningService.fromEnv();
-  let binaryBuffer: Buffer | null = null;
-  try {
-    if (platform === "windows" && !signingService) {
-      binaryBuffer = await fetchRegularMsi();
+  // ----------------------------------------------------------------
+  // Windows — bootstrap path: issue a single-use bootstrap token,
+  // fetch the static signed MSI, and embed the token in the filename.
+  // No per-customer signing and no child key created here.
+  // ----------------------------------------------------------------
+  if (platform === "windows") {
+    let issued;
+    try {
+      issued = await issueBootstrapTokenForKey({
+        parentEnrollmentKeyId: keyRow.id,
+        createdByUserId: keyRow.createdBy ?? "",
+        maxUsage: 1,
+        installerPlatform: "windows",
+      });
+    } catch (err) {
+      if (err instanceof BootstrapTokenIssuanceError) {
+        if (err.code === "parent_not_found")
+          return c.json({ error: err.message }, 404);
+        return c.json({ error: err.message }, 410);
+      }
+      throw err;
     }
-    // macOS no longer fetches a binary here — the bundled install.sh downloads
-    // the architecture-matched pkg at install time.
-  } catch (err) {
-    console.error(`[public-download] Failed to fetch ${platform} binary:`, err);
-    return c.json({ error: "Installer binary not available" }, 503);
+
+    let msi: Buffer;
+    try {
+      msi = await fetchRegularMsi();
+    } catch (err) {
+      console.error("[public-download] Failed to fetch MSI:", err);
+      return c.json({ error: "MSI not available" }, 503);
+    }
+
+    const apiHost = new URL(serverUrl).host;
+
+    createAuditLogAsync({
+      orgId: keyRow.orgId,
+      actorId: "public",
+      action: "enrollment_key.public_download",
+      resourceType: "enrollment_key",
+      resourceId: keyRow.id,
+      resourceName: keyRow.name,
+      details: { platform, ip, signed: false },
+      ipAddress: ip,
+      userAgent: c.req.header("user-agent"),
+      result: "success",
+    });
+
+    return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
   }
 
-  // Build installer BEFORE incrementing usage (don't burn usage on build failure)
+  // ----------------------------------------------------------------
+  // macOS — build zip BEFORE incrementing usage (don't burn usage on
+  // build failure). install.sh downloads the arch-matched pkg at
+  // install time; nothing is bundled (one zip serves Intel + Apple Silicon).
+  // ----------------------------------------------------------------
   try {
-    let resultBuffer: Buffer;
-    let contentType: string;
-    let filename: string;
-
-    if (platform === "windows") {
-      if (signingService) {
-        resultBuffer = await signingService.buildAndSignMsi({
-          version: signingServiceVersion(),
-          properties: {
-            SERVER_URL: serverUrl,
-            ENROLLMENT_KEY: rawToken,
-            ...(globalSecret ? { ENROLLMENT_SECRET: globalSecret } : {}),
-          },
-        });
-        contentType = "application/octet-stream";
-        filename = "breeze-agent.msi";
-      } else {
-        resultBuffer = await buildWindowsInstallerZip(
-          ensureBuffer(binaryBuffer, "public-download/windows zip"),
-          {
-            serverUrl,
-            enrollmentKey: rawToken,
-            enrollmentSecret: globalSecret,
-            siteId: keyRow.siteId,
-          },
-        );
-        contentType = "application/zip";
-        filename = "breeze-agent-windows.zip";
-      }
-    } else {
-      // macOS — install.sh downloads the architecture-matched pkg at install
-      // time; nothing is bundled (one zip serves Intel + Apple Silicon).
-      resultBuffer = await buildMacosInstallerZip({
-        serverUrl,
-        enrollmentKey: rawToken,
-        enrollmentSecret: globalSecret,
-        siteId: keyRow.siteId,
-      });
-      contentType = "application/zip";
-      filename = "breeze-agent-macos.zip";
-    }
+    const resultBuffer = await buildMacosInstallerZip({
+      serverUrl,
+      enrollmentKey: rawToken,
+      enrollmentSecret: globalSecret,
+      siteId: keyRow.siteId,
+    });
 
     // NOTE: we DO NOT bump keyRow.usageCount here. The child key's
     // max_usage semantic is "max successful enrollments," not "max
@@ -1792,14 +1760,14 @@ async function serveInstaller(
       resourceType: "enrollment_key",
       resourceId: keyRow.id,
       resourceName: keyRow.name,
-      details: { platform, ip, signed: !!signingService },
+      details: { platform, ip, signed: false },
       ipAddress: ip,
       userAgent: c.req.header("user-agent"),
       result: "success",
     });
 
-    c.header("Content-Type", contentType);
-    c.header("Content-Disposition", `attachment; filename="${filename}"`);
+    c.header("Content-Type", "application/zip");
+    c.header("Content-Disposition", `attachment; filename="breeze-agent-macos.zip"`);
     c.header("Content-Length", String(resultBuffer.length));
     c.header("Cache-Control", "no-store");
     return c.body(resultBuffer as unknown as ArrayBuffer);

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -29,6 +29,7 @@ import {
   fetchRegularMsi,
   assertMacosInstallerPkgsReachable,
   fetchMacosInstallerAppZip,
+  serveWindowsBootstrapMsi,
 } from "../services/installerBuilder";
 import { renameAppInZip } from "../services/installerAppZip";
 import {
@@ -1078,27 +1079,57 @@ enrollmentKeyRoutes.get(
       // Falls through to legacy path below.
     }
 
-    // Determine signing availability and fetch the binary BEFORE creating
-    // child key. When the remote signing service is configured for Windows,
-    // it builds and signs the MSI from scratch using its own cached
-    // templates — the API doesn't need to fetch anything.
-    const signingService = MsiSigningService.fromEnv();
-    let binaryBuffer: Buffer | null = null;
-    try {
-      if (platform === "windows" && !signingService) {
-        binaryBuffer = await fetchRegularMsi();
+    // ----------------------------------------------------------------
+    // Windows — static signed MSI + bootstrap token in the filename.
+    // No per-customer signing, no child key here; the bootstrap endpoint
+    // mints the child key lazily on consume (mirrors the macOS path above).
+    // ----------------------------------------------------------------
+    if (platform === "windows") {
+      let issued;
+      try {
+        issued = await issueBootstrapTokenForKey({
+          parentEnrollmentKeyId: parentKey.id,
+          createdByUserId: auth.user.id,
+          maxUsage: childMaxUsage,
+          installerPlatform: "windows",
+        });
+      } catch (err) {
+        if (err instanceof BootstrapTokenIssuanceError) {
+          if (err.code === "parent_not_found")
+            return c.json({ error: err.message }, 404);
+          return c.json({ error: err.message }, 410);
+        }
+        throw err;
       }
-      // macOS no longer fetches a binary here — the bundled install.sh downloads
-      // the architecture-matched pkg at install time.
-    } catch (err) {
-      console.error(`[installer] Failed to fetch ${platform} binary:`, err);
-      return c.json(
-        {
-          error: `${platform === "windows" ? "MSI" : "macOS PKG"} not available`,
+
+      let msi: Buffer;
+      try {
+        msi = await fetchRegularMsi();
+      } catch (err) {
+        console.error("[installer] failed to fetch signed MSI:", err);
+        return c.json({ error: "MSI not available" }, 503);
+      }
+
+      const apiHost = new URL(serverUrl).host;
+
+      writeEnrollmentKeyAudit(c, auth, {
+        orgId: parentKey.orgId,
+        action: "enrollment_key.installer_download",
+        keyId: parentKey.id,
+        keyName: parentKey.name,
+        details: {
+          platform,
+          mode: "bootstrap-msi",
+          tokenId: issued.id,
+          count: childMaxUsage,
         },
-        503,
-      );
+      });
+
+      return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
     }
+
+    // Determine signing availability — macOS only reaches here.
+    const signingService = MsiSigningService.fromEnv();
 
     // Signing-spend cap — enforce BEFORE child key creation or any signing
     // operation so an authenticated user cannot drive unbounded (costly,
@@ -1183,62 +1214,9 @@ enrollmentKeyRoutes.get(
       return c.json({ error: "Failed to generate installer key" }, 500);
     }
 
-    // Build the installer — wrap in try/catch to clean up orphaned child key on failure
+    // Build the macOS installer — wrap in try/catch to clean up orphaned child key on failure.
+    // Windows early-returns above; this block is macOS-only.
     try {
-      if (platform === "windows") {
-        let resultBuffer: Buffer;
-        let contentType: string;
-        let filename: string;
-
-        if (signingService) {
-          // Signing configured: ask the remote service to build and sign
-          // an MSI from its cached template for this version.
-          resultBuffer = await signingService.buildAndSignMsi({
-            version: signingServiceVersion(),
-            properties: {
-              SERVER_URL: serverUrl,
-              ENROLLMENT_KEY: rawChildKey,
-              ...(globalSecret ? { ENROLLMENT_SECRET: globalSecret } : {}),
-            },
-          });
-          contentType = "application/octet-stream";
-          filename = "breeze-agent.msi";
-        } else {
-          // No signing: zip bundle with unmodified signed MSI + enrollment.json + install.bat
-          resultBuffer = await buildWindowsInstallerZip(
-            ensureBuffer(binaryBuffer, "installer/windows zip"),
-            {
-              serverUrl,
-              enrollmentKey: rawChildKey,
-              enrollmentSecret: globalSecret,
-              siteId: parentKey.siteId,
-            },
-          );
-          contentType = "application/zip";
-          filename = "breeze-agent-windows.zip";
-        }
-
-        writeEnrollmentKeyAudit(c, auth, {
-          orgId: parentKey.orgId,
-          action: "enrollment_key.installer_download",
-          keyId: parentKey.id,
-          keyName: parentKey.name,
-          details: {
-            platform,
-            childKeyId: childKey.id,
-            shortCode,
-            count: childMaxUsage,
-            signed: !!signingService,
-          },
-        });
-
-        c.header("Content-Type", contentType);
-        c.header("Content-Disposition", `attachment; filename="${filename}"`);
-        c.header("Content-Length", String(resultBuffer.length));
-        c.header("Cache-Control", "no-store");
-        return c.body(resultBuffer as unknown as ArrayBuffer);
-      }
-
       // macOS — install.sh downloads the architecture-matched pkg at install
       // time, so no binary is bundled here (one zip serves Intel + Apple Silicon).
       const zipBuffer = await buildMacosInstallerZip({

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -70,6 +70,15 @@ vi.mock('../services/installerBuilder', () => ({
   assertMacosInstallerPkgsReachable: vi.fn(async () => {}),
   // Plan C — returns null so macOS tests fall through to the legacy pkg path.
   fetchMacosInstallerAppZip: vi.fn(async () => null),
+  // Windows bootstrap path — serves static MSI with token in the filename.
+  serveWindowsBootstrapMsi: vi.fn((c: any, args: { msi: Buffer; token: string; apiHost: string }) => {
+    const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+    c.header('Content-Type', 'application/octet-stream');
+    c.header('Content-Disposition', `attachment; filename="${filename}"`);
+    c.header('Content-Length', String(args.msi.length));
+    c.header('Cache-Control', 'no-store');
+    return c.body(args.msi);
+  }),
 }));
 
 // Plan C imports — mocked so Vitest can resolve them even though neither is
@@ -106,6 +115,7 @@ import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
 import { MsiSigningService } from '../services/msiSigning';
 import { rateLimiter } from '../services/rate-limit';
+import { issueBootstrapTokenForKey } from '../services/installerBootstrapTokenIssuance';
 
 const ORG_ID = 'org-111';
 const KEY_ID = '11111111-1111-1111-1111-111111111111';
@@ -171,6 +181,13 @@ describe('enrollment key routes — installer download', () => {
     // that set mockReturnValue for fromEnv would otherwise leak into
     // subsequent tests. Explicitly reset fromEnv to "signing disabled".
     vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);
+    // Default: Windows bootstrap token issuance succeeds.
+    vi.mocked(issueBootstrapTokenForKey).mockResolvedValue({
+      id: 'tok-1',
+      token: 'ABCDE12345',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      parentKeyName: 'Test Key',
+    } as any);
     process.env.PUBLIC_API_URL = 'https://breeze.example.com';
     app = new Hono();
     app.route('/enrollment-keys', enrollmentKeyRoutes);
@@ -271,11 +288,10 @@ describe('enrollment key routes — installer download', () => {
       expect(body.error).toMatch(/server url/i);
     });
 
-    it('returns zip bundle for windows when signing not configured', async () => {
+    it('windows download serves a static MSI named with the bootstrap token', async () => {
+      // issueBootstrapTokenForKey default mock returns { token: 'ABCDE12345', ... }
+      // PUBLIC_API_URL = 'https://breeze.example.com' → apiHost = 'breeze.example.com'
       mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
 
       const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
         method: 'GET',
@@ -283,148 +299,86 @@ describe('enrollment key routes — installer download', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(res.headers.get('Content-Type')).toBe('application/zip');
-      expect(res.headers.get('Content-Disposition')).toContain('breeze-agent-windows.zip');
+      expect(res.headers.get('content-type')).toBe('application/octet-stream');
+      expect(res.headers.get('content-disposition')).toBe(
+        'attachment; filename="Breeze Agent [ABCDE12345@breeze.example.com].msi"',
+      );
+      // The static signed MSI bytes are served as-is.
+      const body = Buffer.from(await res.arrayBuffer());
+      expect(body.length).toBeGreaterThan(0);
     });
 
-    it('returns signed MSI for windows when signing configured', async () => {
-      process.env.BINARY_VERSION = '0.62.24';
-      const buildAndSignMsi = vi.fn(async () => Buffer.from('signed-msi-content'));
-      vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-        buildAndSignMsi,
-        probe: vi.fn(async () => {}),
-      } as any);
-
+    it('windows bootstrap download does not create a child enrollment key', async () => {
+      // Windows early-returns after issueBootstrapTokenForKey — no db.insert for a child key.
       mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
 
-      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
         method: 'GET',
         headers: { Authorization: 'Bearer token' },
       });
 
-      expect(res.status).toBe(200);
-      expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
-      expect(res.headers.get('Content-Disposition')).toContain('breeze-agent.msi');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
 
-      // When signing is configured, the route must NOT fetch any local
-      // binary — the signing service owns template fetching.
+    it('windows bootstrap download uses issueBootstrapTokenForKey with windows platform', async () => {
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(issueBootstrapTokenForKey).toHaveBeenCalledWith(
+        expect.objectContaining({ installerPlatform: 'windows' }),
+      );
+    });
+
+    it('windows bootstrap returns 503 when MSI fetch fails', async () => {
       const { fetchRegularMsi } = await import('../services/installerBuilder');
-      expect(fetchRegularMsi).not.toHaveBeenCalled();
-
-      delete process.env.BINARY_VERSION;
-    });
-
-    it('passes v-prefixed version and 64-hex key to buildAndSignMsi', async () => {
-      process.env.BINARY_VERSION = '0.62.24';
-      const buildAndSignMsi = vi.fn(async () => Buffer.from('signed-msi-content'));
-      vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-        buildAndSignMsi,
-        probe: vi.fn(async () => {}),
-      } as any);
+      vi.mocked(fetchRegularMsi).mockRejectedValueOnce(new Error('GitHub 404'));
 
       mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
-
-      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
-        method: 'GET',
-        headers: { Authorization: 'Bearer token' },
-      });
-
-      expect(buildAndSignMsi).toHaveBeenCalledTimes(1);
-      const req = (buildAndSignMsi.mock.calls[0] as unknown as [{
-        version: string;
-        properties: { SERVER_URL: string; ENROLLMENT_KEY: string; ENROLLMENT_SECRET?: string };
-      }])[0];
-      // Signing service uses GitHub release tags (v-prefixed) as cache keys
-      expect(req.version).toBe('v0.62.24');
-      expect(req.properties.SERVER_URL).toBe('https://breeze.example.com');
-      expect(req.properties.ENROLLMENT_KEY).toMatch(/^[a-f0-9]{64}$/);
-
-      delete process.env.BINARY_VERSION;
-    });
-
-    it('omits ENROLLMENT_SECRET when AGENT_ENROLLMENT_SECRET is unset', async () => {
-      delete process.env.AGENT_ENROLLMENT_SECRET;
-      process.env.BINARY_VERSION = '0.62.24';
-      const buildAndSignMsi = vi.fn(async () => Buffer.from('signed-msi-content'));
-      vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-        buildAndSignMsi,
-        probe: vi.fn(async () => {}),
-      } as any);
-
-      mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
-
-      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
-        method: 'GET',
-        headers: { Authorization: 'Bearer token' },
-      });
-
-      const req = (buildAndSignMsi.mock.calls[0] as unknown as [{
-        properties: Record<string, unknown>;
-      }])[0];
-      expect(req.properties).not.toHaveProperty('ENROLLMENT_SECRET');
-
-      delete process.env.BINARY_VERSION;
-    });
-
-    it('passes ENROLLMENT_SECRET when AGENT_ENROLLMENT_SECRET is set', async () => {
-      process.env.AGENT_ENROLLMENT_SECRET = 'deployment-wide-secret';
-      process.env.BINARY_VERSION = '0.62.24';
-      const buildAndSignMsi = vi.fn(async () => Buffer.from('signed-msi-content'));
-      vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-        buildAndSignMsi,
-        probe: vi.fn(async () => {}),
-      } as any);
-
-      mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
-
-      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
-        method: 'GET',
-        headers: { Authorization: 'Bearer token' },
-      });
-
-      const req = (buildAndSignMsi.mock.calls[0] as unknown as [{
-        properties: { ENROLLMENT_SECRET?: string };
-      }])[0];
-      expect(req.properties.ENROLLMENT_SECRET).toBe('deployment-wide-secret');
-
-      delete process.env.AGENT_ENROLLMENT_SECRET;
-      delete process.env.BINARY_VERSION;
-    });
-
-    it('returns 500 with error detail when signing configured but fails', async () => {
-      vi.mocked(MsiSigningService.fromEnv).mockReturnValue({
-        buildAndSignMsi: vi.fn(async () => { throw new Error('signing service returned 401: CF Access denied'); }),
-        probe: vi.fn(async () => {}),
-      } as any);
-
-      mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
-      ]);
-      mockDeleteWhere(); // for orphan cleanup
 
       const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
         method: 'GET',
         headers: { Authorization: 'Bearer token' },
       });
 
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(503);
       const body = await res.json();
-      expect(body.error).toBe('Failed to build installer');
-      // Route is MFA-gated — admin debugging a misconfig sees the cause.
-      expect(body.detail).toContain('CF Access denied');
+      expect(body.error).toMatch(/MSI not available/i);
+    });
+
+    it('windows bootstrap returns 404 when issueBootstrapTokenForKey reports parent_not_found', async () => {
+      const { BootstrapTokenIssuanceError } = await import('../services/installerBootstrapTokenIssuance');
+      vi.mocked(issueBootstrapTokenForKey).mockRejectedValueOnce(
+        new BootstrapTokenIssuanceError('parent_not_found', 'Key not found'),
+      );
+
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('windows bootstrap returns 410 when issueBootstrapTokenForKey reports key_expired', async () => {
+      const { BootstrapTokenIssuanceError } = await import('../services/installerBootstrapTokenIssuance');
+      vi.mocked(issueBootstrapTokenForKey).mockRejectedValueOnce(
+        new BootstrapTokenIssuanceError('key_expired', 'Key expired'),
+      );
+
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(410);
     });
 
     it('returns zip for macos platform', async () => {
@@ -443,14 +397,14 @@ describe('enrollment key routes — installer download', () => {
       expect(res.headers.get('Content-Disposition')).toContain('breeze-agent-macos.zip');
     });
 
-    it('creates child key with maxUsage=1 by default', async () => {
+    it('creates child key with maxUsage=1 by default (macos)', async () => {
       const parentKey = makeEnrollmentKey();
       mockSelectFromWhereLimit([parentKey]);
       mockInsertValuesReturning([
         makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
       ]);
 
-      await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+      await app.request(`/enrollment-keys/${KEY_ID}/installer/macos`, {
         method: 'GET',
         headers: { Authorization: 'Bearer token' },
       });
@@ -468,12 +422,8 @@ describe('enrollment key routes — installer download', () => {
       );
     });
 
-    it('creates child key with count query param', async () => {
-      const parentKey = makeEnrollmentKey();
-      mockSelectFromWhereLimit([parentKey]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer x5)', maxUsage: 5 }),
-      ]);
+    it('windows bootstrap passes maxUsage to issueBootstrapTokenForKey (count query param)', async () => {
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
 
       const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows?count=5`, {
         method: 'GET',
@@ -481,18 +431,14 @@ describe('enrollment key routes — installer download', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(db.insert).toHaveBeenCalledTimes(1);
-      const insertMock = vi.mocked(db.insert).mock.results[0]!.value;
-      const valuesFn = insertMock.values;
-      expect(valuesFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          maxUsage: 5,
-          name: 'Test Key (installer x5)',
-        })
+      expect(issueBootstrapTokenForKey).toHaveBeenCalledWith(
+        expect.objectContaining({ maxUsage: 5 }),
       );
+      // Windows bootstrap does NOT create a child key (no db.insert)
+      expect(db.insert).not.toHaveBeenCalled();
     });
 
-    it('child key honors the ttlMinutes query param (per-link picker)', async () => {
+    it('child key honors the ttlMinutes query param (per-link picker) (macos)', async () => {
       const parentKey = makeEnrollmentKey(); // parent: 1h remaining
       mockSelectFromWhereLimit([parentKey]);
       mockInsertValuesReturning([
@@ -502,7 +448,7 @@ describe('enrollment key routes — installer download', () => {
       const ttlMinutes = 43200; // 30 days
       const before = Date.now();
       const res = await app.request(
-        `/enrollment-keys/${KEY_ID}/installer/windows?ttlMinutes=${ttlMinutes}`,
+        `/enrollment-keys/${KEY_ID}/installer/macos?ttlMinutes=${ttlMinutes}`,
         { method: 'GET', headers: { Authorization: 'Bearer token' } },
       );
       const after = Date.now();
@@ -576,11 +522,8 @@ describe('enrollment key routes — installer download', () => {
       expect(res.status).toBe(400);
     });
 
-    it('emits audit log with count for installer download', async () => {
+    it('emits audit log with count for windows bootstrap installer download', async () => {
       mockSelectFromWhereLimit([makeEnrollmentKey()]);
-      mockInsertValuesReturning([
-        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer x3)', maxUsage: 3 }),
-      ]);
 
       await app.request(`/enrollment-keys/${KEY_ID}/installer/windows?count=3`, {
         method: 'GET',
@@ -590,7 +533,7 @@ describe('enrollment key routes — installer download', () => {
       expect(createAuditLogAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'enrollment_key.installer_download',
-          details: expect.objectContaining({ count: 3 }),
+          details: expect.objectContaining({ count: 3, mode: 'bootstrap-msi' }),
         })
       );
     });
@@ -607,14 +550,17 @@ describe('enrollment key routes — installer download', () => {
         vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 10, resetAt: new Date() });
       });
 
-      it('allows signing when both per-user and per-key caps are under limit', async () => {
+      // Signing-spend cap applies to the macOS legacy path (child key creation).
+      // Windows early-returns before the cap — it does not go through signing.
+
+      it('allows macOS installer when both per-user and per-key caps are under limit', async () => {
         // Default mock: rateLimiter always returns allowed=true
         mockSelectFromWhereLimit([makeEnrollmentKey()]);
         mockInsertValuesReturning([
           makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
         ]);
 
-        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/macos`, {
           method: 'GET',
           headers: { Authorization: 'Bearer token' },
         });
@@ -624,7 +570,7 @@ describe('enrollment key routes — installer download', () => {
         expect(db.insert).toHaveBeenCalledTimes(1);
       });
 
-      it('returns 429 and does NOT create child key when per-user cap is exceeded', async () => {
+      it('returns 429 and does NOT create child key when per-user cap is exceeded (macos)', async () => {
         // First rateLimiter call (per-user) returns denied; second should never be reached
         vi.mocked(rateLimiter)
           .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date(Date.now() + 3600_000) })
@@ -633,7 +579,7 @@ describe('enrollment key routes — installer download', () => {
         mockSelectFromWhereLimit([makeEnrollmentKey()]);
         // No insert mock needed — child key must NOT be created
 
-        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/macos`, {
           method: 'GET',
           headers: { Authorization: 'Bearer token' },
         });
@@ -646,7 +592,7 @@ describe('enrollment key routes — installer download', () => {
         expect(db.insert).not.toHaveBeenCalled();
       });
 
-      it('returns 429 and does NOT create child key when per-parent-key cap is exceeded', async () => {
+      it('returns 429 and does NOT create child key when per-parent-key cap is exceeded (macos)', async () => {
         // First rateLimiter call (per-user) passes; second (per-key) is denied
         vi.mocked(rateLimiter)
           .mockResolvedValueOnce({ allowed: true, remaining: 5, resetAt: new Date() })
@@ -655,7 +601,7 @@ describe('enrollment key routes — installer download', () => {
         mockSelectFromWhereLimit([makeEnrollmentKey()]);
         // No insert mock needed — child key must NOT be created
 
-        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/macos`, {
           method: 'GET',
           headers: { Authorization: 'Bearer token' },
         });
@@ -668,13 +614,13 @@ describe('enrollment key routes — installer download', () => {
         expect(db.insert).not.toHaveBeenCalled();
       });
 
-      it('returns 503 and does NOT create child key when Redis is unavailable', async () => {
+      it('returns 503 and does NOT create child key when Redis is unavailable (macos)', async () => {
         const { getRedis } = await import('../services');
         vi.mocked(getRedis).mockReturnValueOnce(null as any);
 
         mockSelectFromWhereLimit([makeEnrollmentKey()]);
 
-        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/macos`, {
           method: 'GET',
           headers: { Authorization: 'Bearer token' },
         });
@@ -682,6 +628,19 @@ describe('enrollment key routes — installer download', () => {
         expect(res.status).toBe(503);
         // No child enrollment key created
         expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('windows download bypasses signing-spend cap entirely', async () => {
+        // Windows early-returns before the rate limiter — rateLimiter should not be called.
+        mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+        const res = await app.request(`/enrollment-keys/${KEY_ID}/installer/windows`, {
+          method: 'GET',
+          headers: { Authorization: 'Bearer token' },
+        });
+
+        expect(res.status).toBe(200);
+        expect(rateLimiter).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -365,10 +365,10 @@ describe('enrollment key routes — installer download', () => {
       expect(res.status).toBe(404);
     });
 
-    it('windows bootstrap returns 410 when issueBootstrapTokenForKey reports key_expired', async () => {
+    it('windows bootstrap returns 410 when issueBootstrapTokenForKey reports parent_expired', async () => {
       const { BootstrapTokenIssuanceError } = await import('../services/installerBootstrapTokenIssuance');
       vi.mocked(issueBootstrapTokenForKey).mockRejectedValueOnce(
-        new BootstrapTokenIssuanceError('key_expired', 'Key expired'),
+        new BootstrapTokenIssuanceError('parent_expired', 'Key expired'),
       );
 
       mockSelectFromWhereLimit([makeEnrollmentKey()]);

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -228,6 +228,82 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(body.enrollmentKey).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("propagates installer_platform from token to child enrollment key", async () => {
+    process.env.PUBLIC_API_URL = "https://us.2breeze.app";
+    process.env.AGENT_ENROLLMENT_SECRET = "shared-secret-test";
+
+    const tokenRow = {
+      id: "t2",
+      token: "FFFFFFFFFF",
+      orgId: "o1",
+      parentEnrollmentKeyId: "pk1",
+      siteId: "s1",
+      maxUsage: 1,
+      createdBy: "u1",
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      installerPlatform: "windows",
+    };
+    const parentKey = {
+      id: "pk1",
+      name: "Acme parent",
+      orgId: "o1",
+      siteId: "s1",
+      keySecretHash: "parent-secret-hash",
+      expiresAt: new Date(Date.now() + 60_000 * 60),
+    };
+    const org = { id: "o1", name: "Acme Corp" };
+
+    // Select call order: (1) token row, (2) parent key, (3) org name
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([tokenRow]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([parentKey]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([org]) }),
+        }),
+      } as any);
+
+    // Capture values passed to INSERT child key
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return {
+          returning: () =>
+            Promise.resolve([{ id: "ck2", orgId: "o1", siteId: "s1" }]),
+        };
+      },
+    } as any);
+
+    // UPDATE consume (returns consumed row)
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({
+        where: () => ({
+          returning: () =>
+            Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]),
+        }),
+      }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "FFFFFFFFFF" },
+    });
+    expect(res.status).toBe(200);
+    expect(capturedChildKeyValues).not.toBeNull();
+    expect((capturedChildKeyValues as Record<string, unknown>).installerPlatform).toBe("windows");
+  });
+
   it("rejects legacy GET bootstrap by default", async () => {
     const app = makeApp();
     const res = await app.request("/api/v1/installer/bootstrap/DDDDDDDDDD");

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -301,7 +301,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
     });
     expect(res.status).toBe(200);
     expect(capturedChildKeyValues).not.toBeNull();
-    expect((capturedChildKeyValues as Record<string, unknown>).installerPlatform).toBe("windows");
+    expect((capturedChildKeyValues as unknown as Record<string, unknown>).installerPlatform).toBe("windows");
   });
 
   it("rejects legacy GET bootstrap by default", async () => {

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -167,7 +167,7 @@ async function redeemBootstrapToken(c: Context, token: string) {
         maxUsage: row.maxUsage,
         expiresAt: childExpiresAt,
         createdBy: row.createdBy,
-        installerPlatform: "macos",
+        installerPlatform: row.installerPlatform ?? "macos",
       })
       .returning();
 

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -156,12 +156,13 @@ async function redeemBootstrapToken(c: Context, token: string) {
     // If the consume UPDATE loses a race, we'll DELETE this row below.
     const rawChildKey = generateChildEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
+    const platformLabel = row.installerPlatform === "windows" ? "win-installer" : "mac-installer";
     const [childKey] = await db
       .insert(enrollmentKeys)
       .values({
         orgId: row.orgId,
         siteId: row.siteId,
-        name: `${parent.name} (mac-installer ${hashTokenForLog(token)})`,
+        name: `${parent.name} (${platformLabel} ${hashTokenForLog(token)})`,
         key: childKeyHash,
         keySecretHash: parent.keySecretHash,
         maxUsage: row.maxUsage,

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -11,6 +11,7 @@ export interface IssueBootstrapTokenInput {
   parentEnrollmentKeyId: string;
   createdByUserId: string;
   maxUsage?: number;
+  installerPlatform?: "windows" | "macos";
 }
 
 export interface IssuedBootstrapToken {
@@ -77,6 +78,7 @@ export async function issueBootstrapTokenForKey(
     maxUsage: input.maxUsage ?? 1,
     createdBy: input.createdByUserId,
     expiresAt,
+    installerPlatform: input.installerPlatform ?? "macos",
   }).returning();
   if (!row) {
     throw new Error('installerBootstrapTokens insert returned no row');

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono';
 import archiver from 'archiver';
 import { readFile, stat } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
@@ -384,4 +385,22 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
     });
     return false;
   }
+}
+
+/**
+ * Serves the static, CI-signed MSI with the bootstrap token embedded in the
+ * download filename — the Windows analogue of the macOS renamed-app zip. The
+ * MSI bytes are never modified, so the Authenticode signature stays intact and
+ * every customer shares one file hash (SmartScreen reputation accrues).
+ */
+export function serveWindowsBootstrapMsi(
+  c: Context,
+  args: { msi: Buffer; token: string; apiHost: string },
+): Response {
+  const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+  c.header('Content-Type', 'application/octet-stream');
+  c.header('Content-Disposition', `attachment; filename="${filename}"`);
+  c.header('Content-Length', String(args.msi.length));
+  c.header('Cache-Control', 'no-store');
+  return c.body(args.msi as unknown as ArrayBuffer);
 }

--- a/docs/superpowers/plans/2026-06-24-msi-filename-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-24-msi-filename-bootstrap.md
@@ -1,0 +1,969 @@
+# MSI Filename-Bootstrap Enrollment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve one static, CI-signed `breeze-agent.msi` and carry enrollment in a single-use bootstrap token embedded in the download filename, eliminating the per-download signing-VM round-trip — full parity with the macOS `.app` flow.
+
+**Architecture:** The Windows download handler stops calling `MsiSigningService.buildAndSignMsi` and instead issues a bootstrap token (reusing the macOS `installerBootstrapTokens` infrastructure), serving the unmodified signed MSI with a `Content-Disposition` filename of `Breeze Agent [TOKEN@HOST].msi`. At install time a WiX immediate custom action captures the launched MSI path; a deferred CA runs a new `breeze-agent.exe bootstrap` command that parses `[TOKEN@HOST]` from the filename (or a `BOOTSTRAP_TOKEN` property), redeems it at `POST /api/v1/installer/bootstrap` for a fresh child enrollment key, and enrolls. Explicit `msiexec` property installs keep the existing direct-enroll path.
+
+**Tech Stack:** Hono + Drizzle (API, TypeScript), Go + Cobra (agent), WiX v4 (MSI), GitHub Actions + PowerShell (CI), Vitest (API tests), Go `testing` (agent tests).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-24-msi-filename-bootstrap-design.md` — authoritative; re-read before each task.
+- **Migrations:** hand-written SQL in `apps/api/migrations/`, named `YYYY-MM-DD-<slug>.sql`, idempotent (`ADD COLUMN IF NOT EXISTS`, `pg_policies`/`DO $$` guards), no inner `BEGIN;`/`COMMIT;`, never edit a shipped migration. Run `pnpm db:check-drift` after schema edits.
+- **No new tenant table** is created (only a column added to the existing `installer_bootstrap_tokens`), so no `rls-coverage.integration.test.ts` allowlist change is required.
+- **Go:** `cd agent && go test -race ./...`; table-driven tests; tests alongside source.
+- **API tests:** Vitest, alongside source; mock Drizzle/services as the existing `enrollmentKeys_installer.test.ts` and `installer.test.ts` do.
+- **Versions:** bare semver, no `v` prefix in copy.
+- **Scope guard:** Do **not** delete `MsiSigningService`, its env vars, or the signing VM — only remove its download-path call sites. Deletion is a deferred follow-up PR (spec Non-goals).
+- **Commits:** end messages with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Branch:** all work on `spec/msi-filename-bootstrap` (already checked out).
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql` | Add `installer_platform` to bootstrap tokens | Create |
+| `apps/api/src/db/schema/installerBootstrapTokens.ts` | Drizzle schema for bootstrap tokens | Modify |
+| `apps/api/src/services/installerBootstrapTokenIssuance.ts` | Token issuance helper | Modify (accept + persist platform) |
+| `apps/api/src/routes/installer.ts` | `/bootstrap` redemption | Modify (propagate platform to child key) |
+| `apps/api/src/services/installerBuilder.ts` | Installer asset helpers | Modify (add `serveWindowsBootstrapMsi` helper) |
+| `apps/api/src/routes/enrollmentKeys.ts` | Installer download routes | Modify (Windows → bootstrap path; remove signing call sites) |
+| `apps/api/src/routes/enrollmentKeys_installer.test.ts` | Download-route tests | Modify |
+| `apps/api/src/routes/installer.test.ts` | Redemption tests | Modify |
+| `agent/internal/agentapp/installer_filename.go` | Parse `[TOKEN@HOST]` from MSI filename | Create |
+| `agent/internal/agentapp/installer_filename_test.go` | Parser tests | Create |
+| `agent/internal/agentapp/bootstrap.go` | `bootstrap` command + redeem client | Create |
+| `agent/internal/agentapp/bootstrap_test.go` | Bootstrap resolution + redeem tests | Create |
+| `agent/internal/agentapp/main.go` | Register `bootstrapCmd` | Modify |
+| `agent/installer/breeze.wxs` | `BOOTSTRAP_TOKEN` property + capture/deferred CAs | Modify |
+| `.github/workflows/release.yml` | Drop template MSI build/upload/skip | Modify |
+| `agent/installer/build-msi.ps1` | Remove `-Template` mode | Modify |
+
+---
+
+## Task 1: Carry installer platform on the bootstrap token
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql`
+- Modify: `apps/api/src/db/schema/installerBootstrapTokens.ts`
+- Modify: `apps/api/src/services/installerBootstrapTokenIssuance.ts`
+- Modify: `apps/api/src/routes/installer.ts:159-171` (child-key insert), `apps/api/src/routes/installer.ts:75` (signature area)
+- Test: `apps/api/src/routes/installer.test.ts`
+
+**Interfaces:**
+- Produces: `issueBootstrapTokenForKey(input: { parentEnrollmentKeyId, createdByUserId, maxUsage?, installerPlatform?: "windows" | "macos" })` — persists `installerPlatform` (default `"macos"` for back-compat). The redeemed child enrollment key gets `installerPlatform` from the token row.
+
+- [ ] **Step 1: Write the failing migration drift expectation**
+
+Add the column to the Drizzle schema first so drift detection has a target. In `apps/api/src/db/schema/installerBootstrapTokens.ts`, add to the table definition (alongside the existing columns):
+
+```ts
+  installerPlatform: text("installer_platform"),
+```
+
+- [ ] **Step 2: Write the migration**
+
+Create `apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql`:
+
+```sql
+-- Carry the installer platform on the bootstrap token so the lazily-created
+-- child enrollment key can record whether it came from a Windows or macOS
+-- installer. Nullable + no default: existing rows and macOS callers leave it
+-- null/"macos"; the Windows download path sets "windows".
+ALTER TABLE installer_bootstrap_tokens
+  ADD COLUMN IF NOT EXISTS installer_platform text;
+```
+
+- [ ] **Step 3: Verify no drift**
+
+Run: `cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift`
+Expected: no drift reported (schema matches migrations).
+
+- [ ] **Step 4: Write the failing test for platform propagation**
+
+In `apps/api/src/routes/installer.test.ts`, add a test asserting that redeeming a token whose row has `installerPlatform: "windows"` creates a child enrollment key with `installerPlatform: "windows"`. Follow the file's existing mock style for the token row and `enrollmentKeys` insert capture. Skeleton:
+
+```ts
+it("propagates installer_platform from token to child enrollment key", async () => {
+  // Arrange: token row with installerPlatform "windows", non-consumed, unexpired,
+  // parent key resolvable (reuse the file's existing happy-path mock setup).
+  // Capture the .values() passed to db.insert(enrollmentKeys).
+  // Act: POST /bootstrap with the token.
+  // Assert: captured child-key values include installerPlatform: "windows".
+  expect(capturedChildKeyValues.installerPlatform).toBe("windows");
+});
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/installer.test.ts -t "propagates installer_platform"`
+Expected: FAIL — child key currently hardcodes `installerPlatform: "macos"`.
+
+- [ ] **Step 6: Plumb platform through issuance**
+
+In `apps/api/src/services/installerBootstrapTokenIssuance.ts`, extend the input interface and the insert:
+
+```ts
+export interface IssueBootstrapTokenInput {
+  parentEnrollmentKeyId: string;
+  createdByUserId: string;
+  maxUsage?: number;
+  installerPlatform?: "windows" | "macos";
+}
+```
+
+In the `db.insert(installerBootstrapTokens).values({ ... })` call, add:
+
+```ts
+    installerPlatform: input.installerPlatform ?? "macos",
+```
+
+- [ ] **Step 7: Use the token's platform on redemption**
+
+In `apps/api/src/routes/installer.ts`, the child-key insert (currently hardcoded `installerPlatform: "macos"` at ~line 170) becomes:
+
+```ts
+        installerPlatform: row.installerPlatform ?? "macos",
+```
+
+(`row` is the selected `installerBootstrapTokens` row already in scope.)
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/installer.test.ts`
+Expected: PASS (new test + existing redemption tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/api/migrations/2026-06-24-installer-bootstrap-token-platform.sql \
+  apps/api/src/db/schema/installerBootstrapTokens.ts \
+  apps/api/src/services/installerBootstrapTokenIssuance.ts \
+  apps/api/src/routes/installer.ts \
+  apps/api/src/routes/installer.test.ts
+git commit -m "feat(installer): carry installer platform on bootstrap token
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Windows download serves static MSI with a filename bootstrap token
+
+**Files:**
+- Modify: `apps/api/src/services/installerBuilder.ts` (add helper)
+- Modify: `apps/api/src/routes/enrollmentKeys.ts:1068-1171` (authed download `GET /:id/installers/:platform`)
+- Test: `apps/api/src/routes/enrollmentKeys_installer.test.ts`
+
+**Interfaces:**
+- Consumes: `issueBootstrapTokenForKey({ ..., installerPlatform: "windows" })` (Task 1), `fetchRegularMsi()` (existing, `installerBuilder.ts`).
+- Produces: `serveWindowsBootstrapMsi(c, { msi: Buffer, token: string, apiHost: string }): Response` — sets `Content-Type: application/octet-stream`, `Content-Disposition: attachment; filename="Breeze Agent [<token>@<apiHost>].msi"`, `Content-Length`, `Cache-Control: no-store`, returns the MSI body.
+
+- [ ] **Step 1: Write the failing test — no signing-service call, token filename**
+
+In `apps/api/src/routes/enrollmentKeys_installer.test.ts`, add a test for the Windows download with **no** signing service configured (its current default mock) asserting the response now serves a raw MSI named with the token, and that `buildAndSignMsi` is never called. Reuse the file's existing parent-key + auth mocks. Skeleton:
+
+```ts
+it("windows download serves a static MSI named with the bootstrap token", async () => {
+  // issueBootstrapTokenForKey mock returns { id: "tok1", token: "ABCDE12345", expiresAt, parentKeyName }
+  // PUBLIC_API_URL = "https://eu.2breeze.app"
+  const res = await app.request(`/enrollment-keys/${keyId}/installers/windows`, { headers: authHeaders });
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toBe("application/octet-stream");
+  expect(res.headers.get("content-disposition")).toBe(
+    'attachment; filename="Breeze Agent [ABCDE12345@eu.2breeze.app].msi"',
+  );
+  // The static signed MSI is served as-is.
+  const body = Buffer.from(await res.arrayBuffer());
+  expect(body.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Write the failing test — no child enrollment key created at download**
+
+Add a test asserting the Windows bootstrap download does **not** insert an `enrollmentKeys` child row (the child key is minted on redemption, not download):
+
+```ts
+it("windows bootstrap download does not create a child enrollment key", async () => {
+  await app.request(`/enrollment-keys/${keyId}/installers/windows`, { headers: authHeaders });
+  expect(enrollmentKeysInsertSpy).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/enrollmentKeys_installer.test.ts -t "bootstrap"`
+Expected: FAIL — current Windows path builds a zip / signs and creates a child key.
+
+- [ ] **Step 4: Add the `serveWindowsBootstrapMsi` helper**
+
+In `apps/api/src/services/installerBuilder.ts`, add (near the other Windows helpers):
+
+```ts
+import type { Context } from "hono";
+
+/**
+ * Serves the static, CI-signed MSI with the bootstrap token embedded in the
+ * download filename — the Windows analogue of the macOS renamed-app zip. The
+ * MSI bytes are never modified, so the Authenticode signature stays intact and
+ * every customer shares one file hash (SmartScreen reputation accrues).
+ */
+export function serveWindowsBootstrapMsi(
+  c: Context,
+  args: { msi: Buffer; token: string; apiHost: string },
+): Response {
+  const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+  c.header("Content-Type", "application/octet-stream");
+  c.header("Content-Disposition", `attachment; filename="${filename}"`);
+  c.header("Content-Length", String(args.msi.length));
+  c.header("Cache-Control", "no-store");
+  return c.body(args.msi as unknown as ArrayBuffer);
+}
+```
+
+- [ ] **Step 5: Rewrite the Windows branch of the authed download handler**
+
+In `apps/api/src/routes/enrollmentKeys.ts`, add `serveWindowsBootstrapMsi` to the `installerBuilder` import. Then insert a Windows bootstrap path that runs **before** the existing signing/child-key block — mirroring the macOS block at lines 978-1066. Place it immediately after the macOS block (after line 1066), before the `signingService`/`binaryBuffer` fetch:
+
+```ts
+    // ----------------------------------------------------------------
+    // Windows — static signed MSI + bootstrap token in the filename.
+    // No per-customer signing, no child key here; the bootstrap endpoint
+    // mints the child key lazily on consume (mirrors the macOS path above).
+    // ----------------------------------------------------------------
+    if (platform === "windows") {
+      let issued;
+      try {
+        issued = await issueBootstrapTokenForKey({
+          parentEnrollmentKeyId: parentKey.id,
+          createdByUserId: auth.user.id,
+          maxUsage: childMaxUsage,
+          installerPlatform: "windows",
+        });
+      } catch (err) {
+        if (err instanceof BootstrapTokenIssuanceError) {
+          if (err.code === "parent_not_found")
+            return c.json({ error: err.message }, 404);
+          return c.json({ error: err.message }, 410);
+        }
+        throw err;
+      }
+
+      let msi: Buffer;
+      try {
+        msi = await fetchRegularMsi();
+      } catch (err) {
+        console.error("[installer] failed to fetch signed MSI:", err);
+        return c.json({ error: "MSI not available" }, 503);
+      }
+
+      const apiHost = new URL(serverUrl).host;
+
+      writeEnrollmentKeyAudit(c, auth, {
+        orgId: parentKey.orgId,
+        action: "enrollment_key.installer_download",
+        keyId: parentKey.id,
+        keyName: parentKey.name,
+        details: {
+          platform,
+          mode: "bootstrap-msi",
+          tokenId: issued.id,
+          count: childMaxUsage,
+        },
+      });
+
+      return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
+    }
+```
+
+- [ ] **Step 6: Remove the now-dead Windows signing/zip branch**
+
+In the same file, delete the `if (platform === "windows") { ... }` block inside the post-child-key `try` (the `signingService ? buildAndSignMsi : buildWindowsInstallerZip` branch, ~lines 1119-1171). The new early-return Windows path above replaces it entirely; the remaining code after the child-key insert is macOS-only. Also remove the now-unreachable `if (platform === "windows" && !signingService)` binary fetch at ~line 1075 (Windows no longer reaches the child-key block).
+
+Verify after editing: the only `buildAndSignMsi` references left in this file are in the public `serveInstaller` path and the installer-link probe (handled in Task 3).
+
+Run: `cd /Users/toddhebebrand/breeze && grep -n "buildAndSignMsi\|buildWindowsInstallerZip" apps/api/src/routes/enrollmentKeys.ts`
+Expected: matches only at the `serveInstaller` (~1695) and probe (~1396) sites.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/enrollmentKeys_installer.test.ts`
+Expected: PASS. Update any pre-existing Windows-path assertions in this file that assumed the zip/`.msi` signed output to expect the new bootstrap behavior.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/api/src/services/installerBuilder.ts \
+  apps/api/src/routes/enrollmentKeys.ts \
+  apps/api/src/routes/enrollmentKeys_installer.test.ts
+git commit -m "feat(installer): windows download serves static MSI with filename bootstrap token
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Convert the public download + installer-link probe paths
+
+**Files:**
+- Modify: `apps/api/src/routes/enrollmentKeys.ts` — `serveInstaller` (~1597-1760) and the installer-link probe (~1395-1415)
+- Test: `apps/api/src/routes/enrollmentKeys_installer.test.ts`
+
+**Interfaces:**
+- Consumes: `serveWindowsBootstrapMsi`, `issueBootstrapTokenForKey` (Task 2).
+
+- [ ] **Step 1: Write the failing test for the public download path**
+
+Add a test exercising the public `serveInstaller` Windows path (the short-code / public-download route this helper backs) asserting the same token-filename MSI response and no `buildAndSignMsi` call. Mirror the Task 2 test but drive it through the public route the file already tests.
+
+```ts
+it("public windows download serves a static MSI named with the bootstrap token", async () => {
+  const res = await app.request(publicWindowsDownloadPath, {});
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-disposition")).toMatch(
+    /^attachment; filename="Breeze Agent \[[A-Z0-9]{10}@[^\]]+\]\.msi"$/,
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/enrollmentKeys_installer.test.ts -t "public windows"`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite the `serveInstaller` Windows branch**
+
+In `serveInstaller` (~1674-1716), replace the Windows `signingService ? buildAndSignMsi : buildWindowsInstallerZip` branch with the bootstrap flow. `serveInstaller` takes a resolved parent key (`row`) and a `platform`; for `platform === "windows"`:
+
+```ts
+    if (platform === "windows") {
+      const issued = await issueBootstrapTokenForKey({
+        parentEnrollmentKeyId: row.id,
+        createdByUserId: row.createdBy,
+        maxUsage: 1,
+        installerPlatform: "windows",
+      });
+      const msi = await fetchRegularMsi();
+      const apiHost = new URL(serverUrl).host;
+      // audit as elsewhere in serveInstaller, then:
+      return serveWindowsBootstrapMsi(c, { msi, token: issued.token, apiHost });
+    }
+```
+
+Match `serveInstaller`'s existing variable names (`row`, `serverUrl`, audit helper) when wiring this in; keep the macOS branch untouched.
+
+- [ ] **Step 4: Remove the Windows signing probe from installer-link creation**
+
+In the installer-link creation route (~1395-1415), the Windows branch currently does `const signingService = MsiSigningService.fromEnv(); if (signingService) await signingService.probe();` then 503s when unreachable. The bootstrap path has no signing dependency, so a Windows installer link is always serviceable. Replace the Windows branch body so it no longer probes or 503s on signing — issuing a link only requires a valid parent key (already validated above this block). Leave the macOS branch unchanged.
+
+Run: `cd /Users/toddhebebrand/breeze && grep -n "buildAndSignMsi\|signingService\|MsiSigningService" apps/api/src/routes/enrollmentKeys.ts`
+Expected: no remaining references in `enrollmentKeys.ts` (the import of `MsiSigningService` can now be removed from this file).
+
+- [ ] **Step 5: Remove the now-unused import**
+
+Delete the `import { MsiSigningService } from "../services/msiSigning";` line from `enrollmentKeys.ts`. (The service file itself stays — deletion is the deferred follow-up per Global Constraints.)
+
+- [ ] **Step 6: Run the full installer + enrollmentKeys test suites**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/enrollmentKeys_installer.test.ts src/routes/installer.test.ts src/routes/enrollmentKeys.test.ts src/modules/mcpInvites/inviteLandingRoutes.test.ts`
+Expected: PASS. Fix any remaining tests that asserted the old signed-MSI/zip Windows output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add apps/api/src/routes/enrollmentKeys.ts apps/api/src/routes/enrollmentKeys_installer.test.ts
+git commit -m "feat(installer): bootstrap windows MSI on public + installer-link paths; drop signing probe
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Agent filename-token parser
+
+**Files:**
+- Create: `agent/internal/agentapp/installer_filename.go`
+- Test: `agent/internal/agentapp/installer_filename_test.go`
+
+**Interfaces:**
+- Produces: `parseInstallerFilenameToken(name string) (token string, host string, err error)` — extracts the first `[TOKEN@HOST]` group from a basename. `token` is exactly 10 chars of `[A-Z0-9]`; `host` matches `[a-zA-Z0-9.\-]+`. Returns `errNoFilenameToken` when no match. Mirrors `FilenameTokenParser.swift`'s regex `\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `agent/internal/agentapp/installer_filename_test.go`:
+
+```go
+package agentapp
+
+import "testing"
+
+func TestParseInstallerFilenameToken(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantTok   string
+		wantHost  string
+		wantError bool
+	}{
+		{"clean", "Breeze Agent [ABCDE12345@eu.2breeze.app].msi", "ABCDE12345", "eu.2breeze.app", false},
+		{"browser dup suffix", "Breeze Agent [ABCDE12345@us.2breeze.app] (1).msi", "ABCDE12345", "us.2breeze.app", false},
+		{"full path", `C:\Users\me\Downloads\Breeze Agent [Z9Y8X7W6V5@host.example.com].msi`, "Z9Y8X7W6V5", "host.example.com", false},
+		{"host with hyphen", "Breeze Agent [ABCDE12345@my-rmm.example].msi", "ABCDE12345", "my-rmm.example", false},
+		{"no brackets", "breeze-agent.msi", "", "", true},
+		{"token too short", "Breeze Agent [ABCDE1234@host].msi", "", "", true},
+		{"token lowercase", "Breeze Agent [abcde12345@host].msi", "", "", true},
+		{"empty", "", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, host, err := parseInstallerFilenameToken(tc.input)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got token=%q host=%q", tok, host)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantTok || host != tc.wantHost {
+				t.Fatalf("got (%q,%q), want (%q,%q)", tok, host, tc.wantTok, tc.wantHost)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/agentapp/ -run TestParseInstallerFilenameToken`
+Expected: FAIL — `parseInstallerFilenameToken` undefined.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `agent/internal/agentapp/installer_filename.go`:
+
+```go
+package agentapp
+
+import (
+	"errors"
+	"regexp"
+)
+
+// errNoFilenameToken is returned when a filename carries no [TOKEN@HOST] group.
+var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
+
+// installerTokenRe mirrors FilenameTokenParser.swift: a 10-char base36 token
+// and a host, wrapped in square brackets. The token charset is uppercase to
+// avoid ambiguity; the host allows letters, digits, dots, and hyphens.
+var installerTokenRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
+
+// parseInstallerFilenameToken extracts the bootstrap token and API host from an
+// installer path or basename. It searches anywhere in the string, so a browser
+// "(1)" dedup suffix or a full path does not break matching.
+func parseInstallerFilenameToken(name string) (token string, host string, err error) {
+	m := installerTokenRe.FindStringSubmatch(name)
+	if m == nil {
+		return "", "", errNoFilenameToken
+	}
+	return m[1], m[2], nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/agentapp/ -run TestParseInstallerFilenameToken`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/agentapp/installer_filename.go agent/internal/agentapp/installer_filename_test.go
+git commit -m "feat(agent): parse [TOKEN@HOST] from installer filename
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Agent `bootstrap` command
+
+**Files:**
+- Create: `agent/internal/agentapp/bootstrap.go`
+- Test: `agent/internal/agentapp/bootstrap_test.go`
+- Modify: `agent/internal/agentapp/main.go:168-230` (command registration)
+
+**Interfaces:**
+- Consumes: `parseInstallerFilenameToken` (Task 4), `enrollDevice` + the `serverURL`/`enrollmentSecret`/`enrollSiteID` package globals (existing, `main.go`).
+- Produces:
+  - `resolveBootstrapInputs(installData string) (token, server string, err error)` — pure resolver over the WiX `--install-data` payload `"<OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>"`. Precedence: (1) `BOOTSTRAP_TOKEN`+`SERVER_URL` properties; (2) filename `[TOKEN@HOST]` → `https://HOST`. Returns `errNoBootstrapInput` when neither resolves.
+  - `redeemBootstrapToken(server, token string) (*bootstrapResult, error)` — `POST {server}/api/v1/installer/bootstrap` with header `X-Breeze-Bootstrap-Token`; returns `{ServerURL, EnrollmentKey, EnrollmentSecret string}`.
+  - `bootstrapCmd` Cobra command: `breeze-agent bootstrap --install-data <payload> [--quiet]`. On `errNoBootstrapInput`, logs and exits 0 (soft — install proceeds unenrolled). On redeem/enroll failure, exits non-zero (rollback).
+
+- [ ] **Step 1: Write the failing resolver tests**
+
+Create `agent/internal/agentapp/bootstrap_test.go`:
+
+```go
+package agentapp
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveBootstrapInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		data       string
+		wantToken  string
+		wantServer string
+		wantErr    error
+	}{
+		{
+			name:       "filename token only",
+			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi||`,
+			wantToken:  "ABCDE12345",
+			wantServer: "https://eu.2breeze.app",
+		},
+		{
+			name:       "property token + server wins over filename",
+			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|https://us.2breeze.app`,
+			wantToken:  "ZZZZZ99999",
+			wantServer: "https://us.2breeze.app",
+		},
+		{
+			name:    "no token anywhere",
+			data:    `C:\dl\breeze-agent.msi||`,
+			wantErr: errNoBootstrapInput,
+		},
+		{
+			name:    "property token without server falls back to filename",
+			data:    `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|`,
+			wantToken:  "ABCDE12345",
+			wantServer: "https://eu.2breeze.app",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, server, err := resolveBootstrapInputs(tc.data)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want err %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantToken || server != tc.wantServer {
+				t.Fatalf("got (%q,%q), want (%q,%q)", tok, server, tc.wantToken, tc.wantServer)
+			}
+		})
+	}
+}
+
+func TestRedeemBootstrapToken(t *testing.T) {
+	// httptest server returns a fixed payload; assert the header is sent and
+	// the response fields are parsed.
+	// (Implement against redeemBootstrapToken using net/http/httptest.)
+}
+```
+
+- [ ] **Step 2: Run the resolver test to verify it fails**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/agentapp/ -run TestResolveBootstrapInputs`
+Expected: FAIL — `resolveBootstrapInputs` / `errNoBootstrapInput` undefined.
+
+- [ ] **Step 3: Implement the resolver, redeem client, and command**
+
+Create `agent/internal/agentapp/bootstrap.go`:
+
+```go
+package agentapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"breeze-agent/internal/config"
+	"breeze-agent/internal/logging"
+)
+
+var errNoBootstrapInput = errors.New("no bootstrap token from filename or properties")
+
+// bootstrapInstallData is the WiX CustomActionData payload, packed by the
+// SetBootstrapData type-51 CA as "<OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>".
+var bootstrapInstallData string
+
+type bootstrapResult struct {
+	ServerURL        string `json:"serverUrl"`
+	EnrollmentKey    string `json:"enrollmentKey"`
+	EnrollmentSecret string `json:"enrollmentSecret"`
+	SiteID           string `json:"siteId"`
+}
+
+// resolveBootstrapInputs decides which token/server to use. Property token +
+// server take precedence (explicit silent-install intent); otherwise the
+// [TOKEN@HOST] in the installer filename is used, with the host promoted to an
+// https:// server URL. Mirrors the macOS payload-then-filename precedence.
+func resolveBootstrapInputs(data string) (token, server string, err error) {
+	parts := strings.SplitN(data, "|", 3)
+	var installerPath, propToken, propServer string
+	if len(parts) > 0 {
+		installerPath = parts[0]
+	}
+	if len(parts) > 1 {
+		propToken = strings.TrimSpace(parts[1])
+	}
+	if len(parts) > 2 {
+		propServer = strings.TrimSpace(parts[2])
+	}
+
+	if propToken != "" && propServer != "" {
+		return propToken, propServer, nil
+	}
+
+	if tok, host, ferr := parseInstallerFilenameToken(installerPath); ferr == nil {
+		return tok, "https://" + host, nil
+	}
+	return "", "", errNoBootstrapInput
+}
+
+// redeemBootstrapToken exchanges a single-use token for a child enrollment key.
+func redeemBootstrapToken(server, token string) (*bootstrapResult, error) {
+	url := strings.TrimRight(server, "/") + "/api/v1/installer/bootstrap"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Breeze-Bootstrap-Token", token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bootstrap redeem failed: %d %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out bootstrapResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("bootstrap redeem: bad response: %w", err)
+	}
+	if out.EnrollmentKey == "" {
+		return nil, errors.New("bootstrap redeem: response missing enrollmentKey")
+	}
+	if out.ServerURL == "" {
+		out.ServerURL = server
+	}
+	return &out, nil
+}
+
+// runBootstrap resolves enrollment inputs, redeems the token, and enrolls.
+// Soft-exits 0 when there is genuinely no token (manual install with no token
+// and no properties), so the install completes with an unenrolled agent that
+// idles in the wait-for-enrollment loop. A present-but-bad token is a real
+// error and exits non-zero so the MSI rolls back cleanly.
+func runBootstrap() {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		cfg = config.Default()
+	}
+	initEnrollLogging(cfg, quietEnroll)
+	log := logging.L("bootstrap")
+
+	token, server, err := resolveBootstrapInputs(bootstrapInstallData)
+	if err != nil {
+		log.Info("no bootstrap token present; skipping enrollment (agent will idle until enrolled)")
+		if !quietEnroll {
+			fmt.Println("No enrollment token found; install will complete unenrolled.")
+		}
+		return // exit 0 — soft
+	}
+
+	log.Info("redeeming bootstrap token", "server", server)
+	res, err := redeemBootstrapToken(server, token)
+	if err != nil {
+		log.Error("bootstrap token redemption failed", "error", err.Error())
+		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
+		os.Exit(1) // hard — roll back the install
+	}
+
+	// Hand off to the existing enroll path via the package globals it reads.
+	serverURL = res.ServerURL
+	enrollmentSecret = res.EnrollmentSecret
+	if res.SiteID != "" {
+		enrollSiteID = res.SiteID
+	}
+	enrollDevice(res.EnrollmentKey)
+}
+```
+
+- [ ] **Step 4: Register the command in `main.go`**
+
+In `agent/internal/agentapp/main.go`, add the command var (near `enrollCmd`, ~line 175):
+
+```go
+var bootstrapCmd = &cobra.Command{
+	Use:    "bootstrap",
+	Short:  "Redeem an installer bootstrap token and enroll (used by the MSI)",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		runBootstrap()
+	},
+}
+```
+
+In `init()` add the flags + registration (alongside the `enrollCmd` block, ~lines 216-226):
+
+```go
+	bootstrapCmd.Flags().StringVar(&bootstrapInstallData, "install-data", "", "Packed WiX CustomActionData: <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>")
+	bootstrapCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr)")
+```
+
+```go
+	rootCmd.AddCommand(bootstrapCmd)
+```
+
+Note: `quietEnroll` is the existing package global already bound by `enrollCmd`. Cobra binds per-command flag sets, so binding the same variable on `bootstrapCmd` is fine — each command parses only its own invocation.
+
+- [ ] **Step 5: Implement `TestRedeemBootstrapToken` against httptest**
+
+Fill in the stub from Step 1:
+
+```go
+func TestRedeemBootstrapToken(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Breeze-Bootstrap-Token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"serverUrl":"` + "http://x" + `","enrollmentKey":"deadbeef","enrollmentSecret":"s","siteId":"site1"}`))
+	}))
+	defer srv.Close()
+
+	res, err := redeemBootstrapToken(srv.URL, "ABCDE12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotToken != "ABCDE12345" {
+		t.Fatalf("token header not sent, got %q", gotToken)
+	}
+	if res.EnrollmentKey != "deadbeef" || res.SiteID != "site1" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+```
+
+Add the `net/http`, `net/http/httptest` imports to the test file.
+
+- [ ] **Step 6: Run the agent tests + build**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/agentapp/ -run "TestResolveBootstrapInputs|TestRedeemBootstrapToken|TestParseInstallerFilenameToken" && go build ./...`
+Expected: PASS + clean build.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/internal/agentapp/bootstrap.go agent/internal/agentapp/bootstrap_test.go agent/internal/agentapp/main.go
+git commit -m "feat(agent): bootstrap command redeems filename token and enrolls
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: WiX custom actions for filename bootstrap
+
+**Files:**
+- Modify: `agent/installer/breeze.wxs:46-64` (properties), `agent/installer/breeze.wxs:290-348` (custom actions + sequence)
+
+**Interfaces:**
+- Consumes: `breeze-agent.exe bootstrap --install-data` (Task 5).
+- The deferred CA receives `CustomActionData = "<OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>"`.
+
+- [ ] **Step 1: Declare the `BOOTSTRAP_TOKEN` property**
+
+In `agent/installer/breeze.wxs`, after the `ENROLLMENT_SECRET` property block (~line 62), add:
+
+```xml
+    <Property Id="BOOTSTRAP_TOKEN" Secure="yes" Hidden="yes" />
+```
+
+- [ ] **Step 2: Add the capture + deferred bootstrap custom actions**
+
+After the `EnrollAgent` custom action (~line 297), add:
+
+```xml
+    <!-- Capture the launched MSI path + bootstrap inputs while the original
+         session properties are still readable (immediate CA). OriginalDatabase
+         points at the user's downloaded file here; by deferred execution the
+         package is cached to C:\Windows\Installer and the [TOKEN@HOST] name is
+         gone. Packed pipe-delimited because deferred CAs only see CustomActionData. -->
+    <CustomAction
+      Id="SetBootstrapData"
+      Property="BootstrapEnroll"
+      Value="[OriginalDatabase]|[BOOTSTRAP_TOKEN]|[SERVER_URL]" />
+
+    <CustomAction
+      Id="BootstrapEnroll"
+      FileRef="filBreezeAgentExe"
+      ExeCommand="bootstrap --install-data &quot;[CustomActionData]&quot; --quiet"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check"
+      HideTarget="yes" />
+```
+
+- [ ] **Step 3: Sequence the new actions**
+
+In `<InstallExecuteSequence>`, immediately after the existing `EnrollAgent` line (~line 346), add:
+
+```xml
+      <!-- Filename/property bootstrap enrollment: only when explicit
+           SERVER_URL+ENROLLMENT_KEY were NOT supplied (those take the
+           EnrollAgent path above). SetBootstrapData (immediate) must run before
+           the deferred BootstrapEnroll so CustomActionData is populated. -->
+      <Custom Action="SetBootstrapData" Before="BootstrapEnroll" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
+      <Custom Action="BootstrapEnroll" Before="InstallServices" After="EnrollAgent" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
+```
+
+(Both run `Before="InstallServices"` so the service starts with a valid `agent.yaml`, exactly like `EnrollAgent`. The two enrollment CAs are mutually exclusive via opposite `SERVER_URL AND ENROLLMENT_KEY` conditions.)
+
+- [ ] **Step 4: Validate the WiX source builds (CI / Windows VM)**
+
+This step requires a Windows + WiX v4 environment (the Windows test VM, Tailscale `100.101.150.55`, or CI). The plan's local checkpoint is a structural lint; the authoritative build happens in CI (Task 7 runs the same `build-msi.ps1`).
+
+Local check (non-Windows): confirm the XML is well-formed and the new IDs are referenced consistently. Use `xmllint` (no external-entity resolution) rather than a Python stdlib parser.
+
+Run: `cd /Users/toddhebebrand/breeze && xmllint --noout --nonet agent/installer/breeze.wxs && echo well-formed && grep -c "BootstrapEnroll" agent/installer/breeze.wxs`
+Expected: `well-formed` and a count of `3` (CA `Property` target, CA `Id`, sequence ref); also confirm `SetBootstrapData` appears as both a CA `Id` and a sequence ref.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add agent/installer/breeze.wxs
+git commit -m "feat(installer): WiX bootstrap CAs read filename token at install time
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Drop the template MSI from CI and the build script
+
+**Files:**
+- Modify: `.github/workflows/release.yml:544-554` (Build Template MSI step), `:632-636` (template upload), `:2030-2036` (publish skip), `:556` (comment)
+- Modify: `agent/installer/build-msi.ps1:20,86-98,113` (`-Template` switch + padding args)
+
+**Interfaces:** none (build/release only).
+
+- [ ] **Step 1: Remove the `-Template` mode from `build-msi.ps1`**
+
+In `agent/installer/build-msi.ps1`:
+- Delete the `[switch]$Template` parameter (line 20).
+- Delete the `$templateArgs = @() ... }` block (lines 86-98).
+- Change the `$wixArgs` assignment to drop `+ $templateArgs` (line 113 becomes just the array, no concatenation).
+
+- [ ] **Step 2: Remove the Build Template MSI + upload + skip from `release.yml`**
+
+In `.github/workflows/release.yml`:
+- Delete the entire `- name: Build Template MSI` step (lines 544-554).
+- Update the comment at line 556 from "Only sign the regular MSI — template MSI is re-signed server-side by jsign after patching" to: `# Sign the agent MSI (Azure Trusted Signing).`
+- Delete the template artifact upload step (the `name: breeze-agent-template-msi` / `path: dist/breeze-agent-template.msi` block, ~lines 633-636 with its enclosing `- uses: actions/upload-artifact` step).
+- In the release-asset publish logic (~lines 2030-2036), delete the `if name.endswith("-template.msi"): ...skip...` branch and its comment, since no template MSI is produced anymore.
+
+- [ ] **Step 3: Verify no lingering template references**
+
+Run: `cd /Users/toddhebebrand/breeze && grep -rn "template.msi\|Template MSI\|breeze-agent-template\|\$Template\|-Template" .github/workflows/release.yml agent/installer/build-msi.ps1`
+Expected: no matches.
+
+- [ ] **Step 4: Lint the workflow YAML**
+
+Run: `cd /Users/toddhebebrand/breeze && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('valid yaml')"`
+Expected: `valid yaml`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add .github/workflows/release.yml agent/installer/build-msi.ps1
+git commit -m "chore(release): drop template MSI; ship one signed breeze-agent.msi
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Full-suite verification + manual VM matrix
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the API test suite for touched areas**
+
+Run: `cd /Users/toddhebebrand/breeze && pnpm --filter @breeze/api exec vitest run src/routes/enrollmentKeys_installer.test.ts src/routes/installer.test.ts src/routes/enrollmentKeys.test.ts src/modules/mcpInvites/inviteLandingRoutes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 2: Run the agent suite with race detector**
+
+Run: `cd /Users/toddhebebrand/breeze/agent && go test -race ./internal/agentapp/... && go build ./...`
+Expected: PASS + clean build.
+
+- [ ] **Step 3: Schema drift check**
+
+Run: `cd /Users/toddhebebrand/breeze && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift`
+Expected: no drift.
+
+- [ ] **Step 4: Manual install matrix on the Windows test VM**
+
+On the Windows test VM (Tailscale `100.101.150.55`, see the `windows_test_vm` memory), build a signed MSI via CI (or the VM), then verify each row enrolls/behaves as expected. Record PASS/FAIL per row:
+
+| Scenario | Command / action | Expected |
+|---|---|---|
+| Filename token (double-click) | Save as `Breeze Agent [TOKEN@HOST].msi`, double-click | Enrolls; device appears in console |
+| Browser dup suffix | Rename to `... [TOKEN@HOST] (1).msi`, install | Enrolls (regex tolerates suffix) |
+| Silent properties | `msiexec /i breeze-agent.msi SERVER_URL=https://HOST ENROLLMENT_KEY=<64hex> /qn` | Enrolls via legacy `EnrollAgent` CA |
+| Property token | `msiexec /i breeze-agent.msi BOOTSTRAP_TOKEN=<token> SERVER_URL=https://HOST /qn` | Enrolls via `BootstrapEnroll` CA |
+| No token, no props | Rename to `breeze-agent.msi`, double-click | Installs; agent idles unenrolled; **no 1603 rollback** |
+| Expired token | Use a token past TTL | Install rolls back (1603); `enroll-last-error.txt` / `agent.log` explain |
+
+- [ ] **Step 5: Confirm the served filename end-to-end**
+
+From a browser against a dev/staging API, download a Windows installer and confirm the saved file is `Breeze Agent [TOKEN@HOST].msi` and that `MSI_SIGNING_URL` need not be set for the download to succeed.
+
+- [ ] **Step 6: Final commit (if any verification fixups were needed)**
+
+```bash
+cd /Users/toddhebebrand/breeze
+git add -A
+git commit -m "test(installer): verification fixups for filename-bootstrap MSI
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §Components 1 (server download) → Tasks 2-3; 2 (agent bootstrap) → Tasks 4-5; 3 (WiX) → Task 6; 4 (retire signing path) → Tasks 2-3 (call sites) + Task 7 (template MSI); the dormant `MsiSigningService` deletion is explicitly out of scope per Non-goals. §Testing → Tasks 1-8. §Risks: `OriginalDatabase` timing (Task 6 immediate CA), fail-soft #411 boundary (Task 5 soft-exit + Task 8 manual rows), filename survival (Task 4 tests + Task 8), cross-region host (Task 5 `https://HOST` from filename), platform on child key (Task 1).
+- **Type consistency:** `serveWindowsBootstrapMsi(c, {msi, token, apiHost})`, `parseInstallerFilenameToken(name) → (token, host, err)`, `resolveBootstrapInputs(data) → (token, server, err)`, `redeemBootstrapToken(server, token) → (*bootstrapResult, err)`, `issueBootstrapTokenForKey({..., installerPlatform})` are used identically across tasks.
+- **Deferred:** deletion of `apps/api/src/services/msiSigning.ts`, its env vars, and signing-VM decommission — tracked as a follow-up PR.

--- a/docs/superpowers/specs/2026-06-24-msi-filename-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-06-24-msi-filename-bootstrap-design.md
@@ -1,0 +1,230 @@
+# MSI Filename-Bootstrap Enrollment (macOS parity for Windows)
+
+**Date:** 2026-06-24
+**Status:** Design — approved, pending spec review
+**Owner:** Todd Hebebrand
+
+## Problem
+
+Every Windows MSI download currently triggers a per-customer build-and-sign round-trip
+to a remote Windows signing VM (`apps/api/src/services/msiSigning.ts` →
+`buildAndSignMsi` → POST to the signing service behind a Cloudflare Access tunnel). The
+service injects `SERVER_URL` / `ENROLLMENT_KEY` / `ENROLLMENT_SECRET` as MSI properties
+and Authenticode-signs the result. This has three costs:
+
+1. **Per-download dependency on on-prem infra** — a ~120s round-trip to a Windows VM that
+   must stay alive, reachable, and credentialed (Azure Trusted Signing on the VM, CF Access
+   tokens on the API).
+2. **Permanent SmartScreen zero-reputation** — every customer MSI has a unique file hash, so
+   each one starts at zero reputation and gets flagged on manual browser download (documented
+   in the MSI signing pipeline notes).
+3. **Larger secret exposure** — a 64-char enrollment key is baked into the binary handed to
+   the customer.
+
+macOS already solved the equivalent problem the simple way: ship **one** generic, CI-signed
+(and notarized) `Breeze Installer.app`, and carry enrollment in a single-use **bootstrap
+token** embedded in the download filename (`Breeze Installer [TOKEN@HOST].app`). The app reads
+the token from its own filename, redeems it at `POST /api/v1/installer/bootstrap` for a fresh
+child enrollment key, and enrolls. No per-customer signing.
+
+This spec ports that pattern to Windows.
+
+## Key existing facts this builds on
+
+- **CI already signs a generic `breeze-agent.msi`** with Azure Trusted Signing via
+  `azure/artifact-signing-action@v2` in `.github/workflows/release.yml`, gated by
+  `vars.ENABLE_WINDOWS_SIGNING == 'true'`. All six secrets are present:
+  `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SIGNING_ENDPOINT`,
+  `AZURE_SIGNING_ACCOUNT_NAME`, `AZURE_CERT_PROFILE_PROD`, `AZURE_CERT_PROFILE_PRERELEASE`.
+  The static signed artifact we need **already exists** — this is not "add CI signing."
+- CI also builds an unsigned `breeze-agent-template.msi` explicitly marked for
+  "re-signed server-side after patching" (`release.yml`, `agent/installer/build-msi.ps1`).
+  This artifact and the server-side signing path are what we retire.
+- The server-side bootstrap infrastructure is already platform-agnostic and in production for
+  macOS: the `installerBootstrapTokens` table, `issueBootstrapTokenForKey()`
+  (`apps/api/src/routes/enrollmentKeys.ts`), and `redeemBootstrapToken()` /
+  `POST /api/v1/installer/bootstrap` (`apps/api/src/routes/installer.ts`). Redemption mints a
+  child enrollment key with a **fresh TTL independent of the parent** — the bug that bit the
+  MSI direct-enroll path is already avoided here.
+- The macOS filename parser is `agent/installer/macos-app/Sources/BreezeInstaller/FilenameTokenParser.swift`,
+  regex `\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`. The Go side mirrors this.
+
+## Goals
+
+- Serve one static, CI-signed MSI per release; never modify it server-side.
+- Carry enrollment via a single-use, short-TTL bootstrap token in the download filename.
+- Preserve enterprise/mass-deploy enrollment via explicit `msiexec` properties.
+- Eliminate the per-download signing-VM round-trip and the template MSI.
+
+## Non-goals
+
+- Changing the self-hosted zip fallback (`buildWindowsInstallerZip`) — it stays as-is for
+  installs where no signed MSI is available.
+- Changing macOS behavior.
+- Adding new CI signing infrastructure (it already exists).
+- Rotating or migrating Azure Trusted Signing credentials.
+
+## Architecture
+
+```
+Today:
+  download → mint child enrollment key → POST signing VM → build+sign per-customer MSI
+            (unique hash, baked-in 64-char key) → serve
+
+Target:
+  download → mint single-use bootstrap token → serve the static CI-signed breeze-agent.msi
+            renamed "Breeze Agent [TOKEN@HOST].msi" (one shared hash, no baked-in key)
+  install  → WiX immediate CA captures the launched MSI path
+           → WiX deferred CA runs `breeze-agent.exe bootstrap`
+           → POST /api/v1/installer/bootstrap (redeem token)
+           → server mints fresh child enrollment key
+           → agent enrolls
+```
+
+## Components
+
+### 1. Server download handler — `apps/api/src/routes/enrollmentKeys.ts` (Windows branch, ~line 1119)
+
+- **Remove** the `signingService.buildAndSignMsi({ version, properties: { SERVER_URL,
+  ENROLLMENT_KEY, ENROLLMENT_SECRET } })` call for the Windows MSI path.
+- **Replace** with the macOS-style flow:
+  - `issueBootstrapTokenForKey()` to mint a single-use token (set `installerPlatform: "windows"`).
+  - Serve the static signed `breeze-agent.msi` (from the GitHub release / on-disk binary cache —
+    same source the zip fallback already uses) with
+    `Content-Disposition: attachment; filename="Breeze Agent [<TOKEN>@<apiHost>].msi"`.
+- **No child enrollment key is created at download time** — the child key is minted on
+  redemption inside `redeemBootstrapToken()`, exactly as macOS does.
+- The token format and host derivation match macOS: 10-char `[A-Z0-9]` token, `apiHost` from the
+  same source macOS uses (`allowLegacyMacosInstallerFilenameToken()` host logic / `PUBLIC_API_URL`).
+
+### 2. Agent `bootstrap` subcommand — `agent/internal/agentapp/main.go`
+
+New `breeze-agent.exe bootstrap` Cobra command. Resolves enrollment inputs by precedence:
+
+1. **Explicit properties** — if `--server` and an enrollment key are supplied, use the existing
+   direct `enroll` path (the `enrollDevice` logic) unchanged. (Covers `msiexec /i ...
+   SERVER_URL=... ENROLLMENT_KEY=...`.)
+2. **`--token`** — a bootstrap token passed from the `BOOTSTRAP_TOKEN` MSI property; redeem at
+   `POST /api/v1/installer/bootstrap`.
+3. **`--installer-path`** — parse `[TOKEN@HOST]` from the MSI file's basename (Go port of the
+   Swift regex `\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`); redeem.
+
+Redemption returns `{ serverUrl, enrollmentKey, enrollmentSecret }`; the command then calls the
+existing `enrollDevice` logic with those values. Errors are written to `agent.log` via the
+existing `initEnrollLogging` helper; `--quiet` is honored as in `enroll`.
+
+The filename parser is a pure, testable helper (`parseInstallerFilenameToken(name string)
+(token, host string, err error)`) so it can be unit-tested without an MSI, mirroring
+`TestTrimEnrollInputs`.
+
+### 3. WiX wiring — `agent/installer/breeze.wxs`
+
+The deferred CA cannot reliably read the launched MSI path: by deferred execution the package
+has been cached to `C:\Windows\Installer\*.msi` (renamed, token gone). The launched path is only
+trustworthy during immediate execution via the `OriginalDatabase` property. Standard
+capture-then-defer pattern:
+
+- **Immediate** type-51 CA `CaptureInstallerPath`: sets the deferred CA's property
+  (`BootstrapEnroll`) = `[OriginalDatabase]`. Scheduled after `CostFinalize`, before `InstallFiles`.
+- **Deferred** type-18 CA `BootstrapEnroll` (Execute="deferred", Impersonate="no", Return="check"):
+  `enroll`-style invocation — `breeze-agent.exe bootstrap --installer-path "[CustomActionData]"
+  --token "[BOOTSTRAP_TOKEN]" --quiet`. Scheduled `Before="InstallServices"`.
+- Keep the existing `EnrollAgent` CA for explicit-property installs.
+- Condition the two so **exactly one** fires:
+  - `EnrollAgent`: `Condition = NOT Installed AND SERVER_URL AND ENROLLMENT_KEY`
+  - `BootstrapEnroll`: `Condition = NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)`
+- Declare a `BOOTSTRAP_TOKEN` property (`Secure="yes"`) alongside the existing
+  `SERVER_URL` / `ENROLLMENT_KEY` / `ENROLLMENT_SECRET`.
+
+`build-msi.ps1` continues to produce the regular MSI; only the `-Template` variant is removed
+(see §4).
+
+### 4. Retire the per-download signing path
+
+- **API:** delete the `buildAndSignMsi` call site; the `MsiSigningService` and its env vars
+  (`MSI_SIGNING_URL`, `MSI_SIGNING_CF_ACCESS_ID`, `MSI_SIGNING_CF_ACCESS_SECRET`) become dead.
+  Remove the service and its references once the call site is gone. The on-prem signing VM and
+  its Cloudflare tunnel are no longer in the download path (decommission tracked separately).
+- **CI:** stop building and publishing `breeze-agent-template.msi` in `release.yml`; remove the
+  `-Template` branch from `agent/installer/build-msi.ps1`. The signed `breeze-agent.msi` step is
+  unchanged.
+- **Self-hosted zip fallback** (`buildWindowsInstallerZip`) stays unchanged for installs with no
+  signed MSI available.
+
+## Data flow (target, double-click install)
+
+1. Admin clicks "Download Windows installer" in the UI.
+2. API mints a single-use bootstrap token (parent enrollment key → `installerBootstrapTokens`
+   row, `installerPlatform:"windows"`), serves the static signed `breeze-agent.msi` named
+   `Breeze Agent [TOKEN@HOST].msi`.
+3. Admin runs the MSI. Immediate CA captures `OriginalDatabase`; deferred CA runs
+   `breeze-agent.exe bootstrap --installer-path "...Breeze Agent [TOKEN@HOST].msi"`.
+4. Agent parses `TOKEN`/`HOST` from the basename, POSTs the token to
+   `https://HOST/api/v1/installer/bootstrap` (`X-Breeze-Bootstrap-Token` header).
+5. Server validates+consumes the token, mints a fresh-TTL child enrollment key, returns
+   `{ serverUrl, enrollmentKey, enrollmentSecret }`.
+6. Agent enrolls via the existing `enrollDevice` path; service starts with a valid `agent.yaml`.
+
+## Wins
+
+- **SmartScreen reputation:** one shared MSI hash accrues reputation instead of every customer
+  starting at zero.
+- **No on-prem dependency** in the download path; no 120s round-trip; no VM/tunnel to keep alive.
+- **Smaller secret exposure:** 10-char single-use, short-TTL token in the filename vs. a 64-char
+  enrollment key baked into the binary.
+- **Fewer moving parts:** template MSI and server-side signing service removed.
+
+## Testing
+
+### Go (`agent/...`)
+- Table-driven `parseInstallerFilenameToken` tests: clean name, browser `(1)` suffix
+  (`Breeze Agent [TOKEN@HOST] (1).msi`), missing/malformed brackets, wrong token length, host
+  with dots/hyphens, non-MSI path. Mirror `TestTrimEnrollInputs`.
+- `bootstrap` precedence resolution: explicit-properties > `--token` > `--installer-path`.
+- Bootstrap redemption: happy path, expired token, already-consumed token (each surfaces a
+  distinct logged outcome; HTTP error mapping).
+
+### API (`apps/api/...`)
+- Windows download serves the static MSI with the correct `[TOKEN@HOST]` `Content-Disposition`
+  filename and makes **no** signing-service call.
+- Download mints exactly one `installerBootstrapTokens` row with `installerPlatform:"windows"`
+  and creates **no** child enrollment key at download time.
+- `/installer/bootstrap` mints a child key with a fresh TTL independent of the parent for the
+  Windows-platform token (reuse the existing macOS coverage shape).
+
+### Manual (Windows test VM — Tailscale 100.101.150.55)
+- Double-click install with `[TOKEN@HOST]` filename → enrolls.
+- Browser `(1)`-suffixed filename → still parses and enrolls.
+- Silent `msiexec /i ... SERVER_URL=... ENROLLMENT_KEY=... /qn` → property fallback enrolls.
+- Renamed file with no token and no properties → no crash; logged "no enrollment input" outcome;
+  MSI install still completes (does not 1603 the whole install — see risks).
+
+## Risks & mitigations
+
+- **Filename survival:** double-click and mainstream browsers preserve `[TOKEN@HOST]`; brackets,
+  `@`, dots, and spaces are all legal in Windows filenames and the regex matches the bracket
+  group anywhere in the name (so the `(1)` suffix is fine). Mass-deploy tooling that renames the
+  file must use the property fallback — documented and supported.
+- **`OriginalDatabase` timing:** the launched path is only valid in an immediate CA before
+  caching — verified on the test VM before shipping. If capture fails, the agent falls back to
+  the `BOOTSTRAP_TOKEN` property (when supplied).
+- **Install rollback on enrollment failure (#411):** `<ServiceInstall Vital="yes">` +
+  `ServiceControl Start` makes a failed enrollment roll back the whole install with 1603. The
+  `BootstrapEnroll` CA must fail soft (log and continue) when there is genuinely no enrollment
+  input, so a token-less manual install still produces an installed-but-unenrolled agent rather
+  than a 1603. Enrollment failure with a *present-but-bad* token is a real error and may fail the
+  install (matches current behavior). This boundary is decided during implementation and covered
+  by the manual matrix above.
+- **Cross-region:** EU / US / self-host each serve their own static signed MSI; the `HOST` in the
+  token disambiguates which `apiHost` the agent redeems against.
+- **Token expiry race:** mitigated by the existing fresh-TTL-on-redeem behavior in
+  `redeemBootstrapToken()` — the child key TTL starts at redemption, not at download.
+
+## Rollout
+
+- Ship behind the existing release flow; no new env vars required on droplets (the change removes
+  env vars rather than adding them).
+- Old per-customer MSIs already in the wild keep working — they carry baked-in enrollment and
+  never call the bootstrap endpoint.
+- Decommission the signing VM + Cloudflare tunnel only after a release has verified the static
+  MSI path in EU and US.

--- a/docs/superpowers/specs/2026-06-24-msi-filename-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-06-24-msi-filename-bootstrap-design.md
@@ -63,6 +63,9 @@ This spec ports that pattern to Windows.
 - Changing macOS behavior.
 - Adding new CI signing infrastructure (it already exists).
 - Rotating or migrating Azure Trusted Signing credentials.
+- Deleting the dormant `MsiSigningService` / its env vars, or decommissioning the signing VM —
+  deferred to a follow-up PR. This effort only removes the call site so the download path stops
+  using it.
 
 ## Architecture
 
@@ -141,10 +144,12 @@ capture-then-defer pattern:
 
 ### 4. Retire the per-download signing path
 
-- **API:** delete the `buildAndSignMsi` call site; the `MsiSigningService` and its env vars
-  (`MSI_SIGNING_URL`, `MSI_SIGNING_CF_ACCESS_ID`, `MSI_SIGNING_CF_ACCESS_SECRET`) become dead.
-  Remove the service and its references once the call site is gone. The on-prem signing VM and
-  its Cloudflare tunnel are no longer in the download path (decommission tracked separately).
+- **API:** remove the `buildAndSignMsi` **call site** in the Windows download branch so the
+  download path no longer hits the signing VM. **Leave `MsiSigningService` and its env vars
+  (`MSI_SIGNING_URL`, `MSI_SIGNING_CF_ACCESS_ID`, `MSI_SIGNING_CF_ACCESS_SECRET`) in place but
+  dormant** — deleting the now-unused service, its references, and the env vars is deferred to a
+  follow-up PR. The on-prem signing VM and its Cloudflare tunnel are no longer in the download
+  path (decommission tracked separately).
 - **CI:** stop building and publishing `breeze-agent-template.msi` in `release.yml`; remove the
   `-Template` branch from `agent/installer/build-msi.ps1`. The signed `breeze-agent.msi` step is
   unchanged.


### PR DESCRIPTION
## Summary

Brings Windows MSI enrollment to parity with the macOS filename-bootstrap flow. Instead of building and signing a per-download templated MSI, the installer download serves a single static, signed `breeze-agent.msi` and carries the enrollment token in the **filename** (`breeze-agent[TOKEN@HOST].msi`). At install time, WiX custom actions read the token from the filename and the agent redeems it to enroll.

This removes the per-request MSI signing path (and its signing probe), so downloads are faster and there's exactly one signed artifact to ship and trust.

## What changed

**Agent (Go)**
- Parse `[TOKEN@HOST]` out of the installer filename (`installer_filename.go`).
- New `bootstrap` command that redeems the filename token and enrolls (`bootstrap.go`), wired into `main.go`.
- Dropped a no-op `enrollSiteID` assignment in bootstrap.

**Installer (WiX)**
- Bootstrap custom actions read the filename token at install time (`breeze.wxs`, `build-msi.ps1`).
- Fix: a WiX `Custom` element can't set both `Before` and `After` on `BootstrapEnroll`.
- Release pipeline ships one signed `breeze-agent.msi`; template MSI dropped (`release.yml`).

**API**
- Windows download serves the static MSI with a filename bootstrap token; dropped the signing probe on public + installer-link paths.
- Bootstrap token now carries the installer platform (new migration `2026-06-24-installer-bootstrap-token-platform.sql` + schema/issuance/builder updates).

**Docs**
- Design spec and implementation plan under `docs/superpowers/`.

## Test plan
- `agent`: `go test -race ./internal/agentapp/...` (filename parse + bootstrap unit tests added).
- `apps/api`: installer + enrollment-key route tests updated/added.
- Migration is idempotent (`IF NOT EXISTS`); run `pnpm db:check-drift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
