### PR TITLE
test(api): raise timeout on flaky mcpServer C4 site-axis alerts test

### DIFF
--- a/apps/api/src/routes/mcpServer.effectiveTier.test.ts
+++ b/apps/api/src/routes/mcpServer.effectiveTier.test.ts
@@ -487,7 +487,11 @@ describe('MCP resources/read site-axis enforcement (FIX 3)', () => {
     expect(text).not.toContain('a-b');
     // The alert-list query must have received a site-narrowing condition.
     expect(capturedAlertConds.length).toBeGreaterThan(0);
-  });
+    // Same shape as the devices test above (real async MCP resources/read +
+    // permission re-mock); borderline-slow under full-suite parallel load, so
+    // give the same 15s headroom over the 5s default. Passes well under 1s in
+    // isolation — this only prevents flakes when the suite is saturated.
+  }, 15_000);
 
   // C4 — single-device read breeze://devices/{id}. A site-A-restricted caller
   // reading an out-of-site device id (d-b on site-B) gets 'Device not found'


### PR DESCRIPTION
**Follow-up to #1900.** That PR bumped one load-flaky site-axis test to a 15s timeout and noted its sibling `C4: …site-B alerts…` is the identical pattern and would want the same treatment if it flaked next. This applies it pre-emptively for symmetry, rather than waiting for the next red Test API run.

**The test** — `mcpServer.effectiveTier.test.ts` → `C4: site-restricted caller does not see site-B alerts via resources/read` (`apps/api/src/routes/mcpServer.effectiveTier.test.ts:472`). Same shape as the devices test #1900 fixed: real async MCP `resources/read` + a `vi.doMock` permission re-mock + dynamic `import('./mcpServer')`. Passes 16/16 in isolation in <1s, but is borderline-slow under full-suite parallel load and can time out at the 5s default.

**Change** — one line: `}, 15_000)` on that `it(...)`, plus an explanatory comment. No behavior change. The timeout is a pure ceiling — it only matters when the suite is saturated; the test still asserts the exact same site-axis enforcement.

**Verification** — `vitest run src/routes/mcpServer.effectiveTier.test.ts` → 16/16 pass (9.2s file total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)