### PR TITLE
feat(viewer): interactive update prompt instead of silent auto-close

### DIFF
--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -62,6 +62,11 @@ struct DeviceMap(Mutex<HashMap<String, String>>);
 /// Monotonic counter for unique window labels.
 struct WindowCounter(Mutex<u32>);
 
+/// A downloaded-but-not-yet-applied update, awaiting the user's choice in the
+/// `Ready` prompt. The `Update` handle is retained because `install()` is a
+/// method on it. Only ever holds a value when no remote session is active.
+struct PendingUpdate(Mutex<Option<(tauri_plugin_updater::Update, Vec<u8>)>>);
+
 fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, name: &str) -> MutexGuard<'a, T> {
     match mutex.lock() {
         Ok(guard) => guard,
@@ -295,6 +300,68 @@ fn update_session_hostname(
             entry.hostname = Some(hostname);
             return;
         }
+    }
+}
+
+/// "Restart & update": apply the stashed update now. On macOS/Linux this swaps
+/// the binary and restarts; on Windows `install()` launches the installer and
+/// the process exits. No-op if nothing is pending (e.g. a double click).
+#[tauri::command]
+fn apply_pending_update(app: tauri::AppHandle, pending: tauri::State<'_, PendingUpdate>) {
+    let taken = {
+        let mut slot = lock_or_recover(&pending.0, "pending_update");
+        slot.take()
+    };
+    let Some((update, bytes)) = taken else {
+        return;
+    };
+    let version = update.version.clone();
+
+    #[cfg(target_os = "windows")]
+    {
+        emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
+        // install() launches the installer and terminates the process; on
+        // success nothing after this runs. Reaching past it means it failed.
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Update install failed: {}", e);
+            emit_update_status(&app, UpdateStatus::Failed { version });
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Update install failed: {}", e);
+            emit_update_status(&app, UpdateStatus::Failed { version });
+            return;
+        }
+        emit_update_status(&app, UpdateStatus::Restarting { version });
+        app.restart();
+    }
+}
+
+/// "Remind me later": discard the prompt. On macOS/Linux swap the binary on
+/// disk so the next launch is updated; on Windows drop the download (re-checks
+/// next launch). No-op if nothing is pending.
+#[tauri::command]
+fn dismiss_pending_update(pending: tauri::State<'_, PendingUpdate>) {
+    let taken = {
+        let mut slot = lock_or_recover(&pending.0, "pending_update");
+        slot.take()
+    };
+    let Some((update, bytes)) = taken else {
+        return;
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Deferred update disk-swap failed: {}", e);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        drop((update, bytes));
     }
 }
 
@@ -565,47 +632,46 @@ async fn auto_update(app: tauri::AppHandle) {
         }
     };
 
-    eprintln!("Update {} downloaded, installing...", update.version);
-    // On Windows install() does not return (process exits after launching the
-    // installer), so this "Installing…" notice is the last thing the user sees
-    // — which is exactly the point: a labelled exit, not a silent crash.
-    emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
+    eprintln!("Update {} downloaded", update.version);
 
-    // install() behaviour varies by platform — see doc comment above.
-    // On Windows this call does not return (process exits after launching installer).
-    if let Err(e) = update.install(bytes) {
-        eprintln!("Update install failed: {}", e);
-        // On Windows install() doesn't return on success; reaching here means it
-        // failed, so clear the pinned "Installing…" banner with a failure notice.
-        emit_update_status(&app, UpdateStatus::Failed { version: version.clone() });
+    // Decide what to do with the download based on whether a remote session is
+    // live. Restarting/installing mid-session would kill it, so an active
+    // session always defers; otherwise we hand the choice to the user.
+    let has_active_sessions = app
+        .try_state::<SessionMap>()
+        .map(|s| {
+            let map = lock_or_recover(&s.0, "session_map");
+            !map.is_empty()
+        })
+        .unwrap_or(false);
+
+    if has_active_sessions {
+        // Don't interrupt a live session. macOS/Linux can swap the binary on
+        // disk now (takes effect next launch); Windows can't install without
+        // exiting, so drop the download and re-check on next launch.
+        #[cfg(not(target_os = "windows"))]
+        {
+            if let Err(e) = update.install(bytes) {
+                eprintln!("Deferred update disk-swap failed: {}", e);
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            drop((update, bytes));
+        }
+        eprintln!("Active remote session — deferring update to next launch");
+        emit_update_status(&app, UpdateStatus::Deferred { version });
         return;
     }
 
-    eprintln!("Update {} installed successfully", update.version);
-
-    // On macOS/Linux, the binary is replaced on disk but the running process
-    // continues with the old version in memory. Restart automatically so the
-    // user gets the new version without manual intervention.
-    // If a remote desktop session is active, skip the restart to avoid
-    // interrupting the user — they'll pick up the update on next launch.
-    #[cfg(not(target_os = "windows"))]
-    {
-        let has_active_sessions = app
-            .try_state::<SessionMap>()
-            .map(|s| {
-                let map = lock_or_recover(&s.0, "session_map");
-                !map.is_empty()
-            })
-            .unwrap_or(false);
-
-        if has_active_sessions {
-            eprintln!("Active remote session detected — deferring restart to next launch");
-            emit_update_status(&app, UpdateStatus::Deferred { version: version.clone() });
-        } else {
-            eprintln!("No active sessions — restarting to apply update");
-            emit_update_status(&app, UpdateStatus::Restarting { version: version.clone() });
-            app.restart();
-        }
+    // No active session — stash the download and let the user choose via the
+    // Ready prompt (apply_pending_update / dismiss_pending_update).
+    if let Some(pending) = app.try_state::<PendingUpdate>() {
+        *lock_or_recover(&pending.0, "pending_update") = Some((update, bytes));
+        eprintln!("Update {} ready — awaiting user choice", version);
+        emit_update_status(&app, UpdateStatus::Ready { version });
+    } else {
+        eprintln!("PendingUpdate state missing; cannot present update prompt");
     }
 }
 
@@ -624,6 +690,8 @@ pub fn run() {
             unregister_session,
             register_device,
             update_session_hostname,
+            apply_pending_update,
+            dismiss_pending_update,
         ]);
 
     // Single instance plugin (desktop only) — ensures deep links open in existing
@@ -683,6 +751,7 @@ pub fn run() {
             app.manage(SessionMap(Mutex::new(HashMap::new())));
             app.manage(DeviceMap(Mutex::new(HashMap::new())));
             app.manage(WindowCounter(Mutex::new(0)));
+            app.manage(PendingUpdate(Mutex::new(None)));
 
             // If launched with a deep link, defer session window creation to
             // the first event loop tick (setup runs before the loop starts).

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -672,6 +672,10 @@ async fn auto_update(app: tauri::AppHandle) {
         emit_update_status(&app, UpdateStatus::Ready { version });
     } else {
         eprintln!("PendingUpdate state missing; cannot present update prompt");
+        // Defensive: clear the banner so a (theoretically impossible) missing
+        // state doesn't leave it pinned on "Downloading…" — the silent-look
+        // this feature exists to remove.
+        emit_update_status(&app, UpdateStatus::Failed { version });
     }
 }
 

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -460,6 +460,9 @@ enum UpdateStatus {
     Restarting { version: String },
     Deferred { version: String },
     Failed { version: String },
+    /// Downloaded and waiting for the user to choose Restart & update or
+    /// Remind me later. Only emitted when no remote session is active.
+    Ready { version: String },
 }
 
 /// Best-effort broadcast of update status. Emit failures are non-fatal — the
@@ -844,6 +847,10 @@ mod tests {
             (
                 UpdateStatus::Failed { version: v.clone() },
                 json!({ "phase": "failed", "version": "1.2.3" }),
+            ),
+            (
+                UpdateStatus::Ready { version: v.clone() },
+                json!({ "phase": "ready", "version": "1.2.3" }),
             ),
         ];
         for (status, expected) in cases {

--- a/apps/viewer/src-tauri/src/lib.rs
+++ b/apps/viewer/src-tauri/src/lib.rs
@@ -64,7 +64,9 @@ struct WindowCounter(Mutex<u32>);
 
 /// A downloaded-but-not-yet-applied update, awaiting the user's choice in the
 /// `Ready` prompt. The `Update` handle is retained because `install()` is a
-/// method on it. Only ever holds a value when no remote session is active.
+/// method on it. Only populated when no remote session was active at download
+/// time (an active session defers instead); a session may start afterwards
+/// while a value is still staged, so `is_some()` does not imply "no session now".
 struct PendingUpdate(Mutex<Option<(tauri_plugin_updater::Update, Vec<u8>)>>);
 
 fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, name: &str) -> MutexGuard<'a, T> {
@@ -305,64 +307,70 @@ fn update_session_hostname(
 
 /// "Restart & update": apply the stashed update now. On macOS/Linux this swaps
 /// the binary and restarts; on Windows `install()` launches the installer and
-/// the process exits. No-op if nothing is pending (e.g. a double click).
+/// the process exits. Returns `Err` if nothing is staged (e.g. invoked after
+/// the slot was already taken) or if the install fails, so the caller's promise
+/// rejects instead of silently resolving and stranding the prompt's buttons.
 #[tauri::command]
-fn apply_pending_update(app: tauri::AppHandle, pending: tauri::State<'_, PendingUpdate>) {
+fn apply_pending_update(
+    app: tauri::AppHandle,
+    pending: tauri::State<'_, PendingUpdate>,
+) -> Result<(), String> {
     let taken = {
         let mut slot = lock_or_recover(&pending.0, "pending_update");
         slot.take()
     };
     let Some((update, bytes)) = taken else {
-        return;
+        return Err("no pending update to apply".to_string());
     };
     let version = update.version.clone();
 
+    // On Windows install() launches the installer and terminates the process,
+    // so emit a labelled "Installing" first — the exit is then a known step,
+    // not a silent crash. (macOS/Linux swap in place and emit "Restarting" below.)
     #[cfg(target_os = "windows")]
-    {
-        emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
-        // install() launches the installer and terminates the process; on
-        // success nothing after this runs. Reaching past it means it failed.
-        if let Err(e) = update.install(bytes) {
-            eprintln!("Update install failed: {}", e);
-            emit_update_status(&app, UpdateStatus::Failed { version });
-        }
+    emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
+
+    if let Err(e) = update.install(bytes) {
+        eprintln!("Update install failed: {}", e);
+        emit_update_status(&app, UpdateStatus::Failed { version });
+        return Err(e.to_string());
     }
 
+    // macOS/Linux: the binary was swapped on disk but the running process still
+    // holds the old version — restart to apply. (On Windows the line above
+    // already exited the process on success.)
     #[cfg(not(target_os = "windows"))]
     {
-        if let Err(e) = update.install(bytes) {
-            eprintln!("Update install failed: {}", e);
-            emit_update_status(&app, UpdateStatus::Failed { version });
-            return;
-        }
         emit_update_status(&app, UpdateStatus::Restarting { version });
-        app.restart();
+        app.restart()
     }
+    #[cfg(target_os = "windows")]
+    Ok(())
 }
 
 /// "Remind me later": discard the prompt. On macOS/Linux swap the binary on
 /// disk so the next launch is updated; on Windows drop the download (re-checks
-/// next launch). No-op if nothing is pending.
+/// next launch). Idempotent — `Ok` even when nothing is staged. The disk-swap
+/// is best-effort: a failure is logged but not surfaced, since the next launch
+/// re-checks regardless.
 #[tauri::command]
-fn dismiss_pending_update(pending: tauri::State<'_, PendingUpdate>) {
+fn dismiss_pending_update(pending: tauri::State<'_, PendingUpdate>) -> Result<(), String> {
     let taken = {
         let mut slot = lock_or_recover(&pending.0, "pending_update");
         slot.take()
     };
     let Some((update, bytes)) = taken else {
-        return;
+        return Ok(());
     };
 
     #[cfg(not(target_os = "windows"))]
-    {
-        if let Err(e) = update.install(bytes) {
-            eprintln!("Deferred update disk-swap failed: {}", e);
-        }
+    if let Err(e) = update.install(bytes) {
+        eprintln!("Deferred update disk-swap failed: {}", e);
     }
     #[cfg(target_os = "windows")]
-    {
-        drop((update, bytes));
-    }
+    drop((update, bytes));
+
+    Ok(())
 }
 
 /// Focus the highest-numbered session window, or do nothing if none exist.

--- a/apps/viewer/src/components/UpdateIndicator.tsx
+++ b/apps/viewer/src/components/UpdateIndicator.tsx
@@ -93,6 +93,11 @@ export default function UpdateIndicator() {
               setActing(true);
               applyPendingUpdate().catch((e) => {
                 console.error('Failed to apply update', e);
+                // The command rejected (install failed, or nothing staged) and
+                // may not have emitted a status event — surface a failure notice
+                // so the user isn't stranded on a dead prompt. It auto-dismisses
+                // and the update retries on next launch.
+                setStatus({ phase: 'failed', version: status.version });
                 setActing(false);
               });
             }}

--- a/apps/viewer/src/components/UpdateIndicator.tsx
+++ b/apps/viewer/src/components/UpdateIndicator.tsx
@@ -9,6 +9,7 @@ import {
   shouldAutoDismiss,
   type UpdateStatus,
 } from '../lib/updateStatus';
+import { applyPendingUpdate, dismissPendingUpdate } from '../lib/updateActions';
 
 /** How long a deferred-update notice lingers before auto-dismissing (ms). */
 const DEFERRED_DISMISS_MS = 10_000;
@@ -24,6 +25,7 @@ const DEFERRED_DISMISS_MS = 10_000;
  */
 export default function UpdateIndicator() {
   const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [acting, setActing] = useState(false);
 
   useEffect(() => {
     const unlisten = listen<unknown>('update-status', (event) => {
@@ -71,10 +73,10 @@ export default function UpdateIndicator() {
       data-testid="update-indicator"
       role="status"
       aria-live="polite"
-      className="fixed top-3 left-1/2 -translate-x-1/2 z-50 max-w-[90vw]
+      className={`fixed top-3 left-1/2 -translate-x-1/2 z-50 max-w-[90vw]
                  flex flex-col gap-1 px-3 py-2 rounded-lg shadow-lg
                  bg-gray-800/95 border border-gray-700 text-gray-100
-                 backdrop-blur-sm pointer-events-none"
+                 backdrop-blur-sm ${status.phase === 'ready' ? 'pointer-events-auto' : 'pointer-events-none'}`}
     >
       <div className="flex items-center gap-2 text-xs">
         <Icon
@@ -82,6 +84,39 @@ export default function UpdateIndicator() {
         />
         <span className="whitespace-nowrap">{message}</span>
       </div>
+      {status.phase === 'ready' && (
+        <div className="flex items-center gap-2 mt-0.5">
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => {
+              setActing(true);
+              applyPendingUpdate().catch((e) => {
+                console.error('Failed to apply update', e);
+                setActing(false);
+              });
+            }}
+            className="px-2 py-0.5 rounded bg-blue-600 hover:bg-blue-500
+                       disabled:opacity-50 text-xs font-medium"
+          >
+            Restart &amp; update
+          </button>
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => {
+              setActing(true);
+              dismissPendingUpdate()
+                .catch((e) => console.error('Failed to dismiss update', e))
+                .finally(() => setStatus(null));
+            }}
+            className="px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600
+                       disabled:opacity-50 text-xs"
+          >
+            Remind me later
+          </button>
+        </div>
+      )}
       {active && (
         <div className="h-1 w-full rounded bg-gray-700 overflow-hidden">
           {percent == null ? (

--- a/apps/viewer/src/lib/updateActions.test.ts
+++ b/apps/viewer/src/lib/updateActions.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { applyPendingUpdate, dismissPendingUpdate } from './updateActions';
+
+beforeEach(() => {
+  invoke.mockReset();
+  invoke.mockResolvedValue(undefined);
+});
+
+describe('updateActions', () => {
+  it('applyPendingUpdate invokes the apply command', async () => {
+    await applyPendingUpdate();
+    expect(invoke).toHaveBeenCalledWith('apply_pending_update');
+  });
+
+  it('dismissPendingUpdate invokes the dismiss command', async () => {
+    await dismissPendingUpdate();
+    expect(invoke).toHaveBeenCalledWith('dismiss_pending_update');
+  });
+});

--- a/apps/viewer/src/lib/updateActions.ts
+++ b/apps/viewer/src/lib/updateActions.ts
@@ -1,0 +1,19 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * "Restart & update": apply the downloaded update now. On macOS/Linux the
+ * viewer reinstalls and restarts; on Windows the installer launches and the
+ * process exits. Backed by the `apply_pending_update` Tauri command.
+ */
+export function applyPendingUpdate(): Promise<void> {
+  return invoke('apply_pending_update');
+}
+
+/**
+ * "Remind me later": dismiss the update prompt. macOS/Linux swaps the binary
+ * on disk for next launch; Windows re-checks on next launch. Backed by the
+ * `dismiss_pending_update` Tauri command.
+ */
+export function dismissPendingUpdate(): Promise<void> {
+  return invoke('dismiss_pending_update');
+}

--- a/apps/viewer/src/lib/updateStatus.test.ts
+++ b/apps/viewer/src/lib/updateStatus.test.ts
@@ -113,6 +113,26 @@ describe('shouldAutoDismiss', () => {
   });
 });
 
+describe('ready phase', () => {
+  const ready: UpdateStatus = { phase: 'ready', version: '1.2.3' };
+
+  it('messages as a downloaded-and-waiting prompt', () => {
+    expect(updateStatusMessage(ready)).toBe('Update 1.2.3 downloaded');
+  });
+
+  it('is not "active" (no progress affordance)', () => {
+    expect(isUpdateActive(ready)).toBe(false);
+  });
+
+  it('does not auto-dismiss (stays pinned until the user acts)', () => {
+    expect(shouldAutoDismiss(ready)).toBe(false);
+  });
+
+  it('is accepted by the IPC-boundary guard', () => {
+    expect(isUpdateStatus({ phase: 'ready', version: '1.2.3' })).toBe(true);
+  });
+});
+
 describe('isUpdateStatus', () => {
   it('accepts every well-formed phase payload', () => {
     const valid: UpdateStatus[] = [

--- a/apps/viewer/src/lib/updateStatus.test.ts
+++ b/apps/viewer/src/lib/updateStatus.test.ts
@@ -142,6 +142,7 @@ describe('isUpdateStatus', () => {
       { phase: 'restarting', version: '1.0.0' },
       { phase: 'deferred', version: '1.0.0' },
       { phase: 'failed', version: '1.0.0' },
+      { phase: 'ready', version: '1.2.3' },
     ];
     for (const v of valid) {
       expect(isUpdateStatus(v)).toBe(true);

--- a/apps/viewer/src/lib/updateStatus.ts
+++ b/apps/viewer/src/lib/updateStatus.ts
@@ -18,7 +18,8 @@ export type UpdateStatus =
   | { phase: 'installing'; version: string }
   | { phase: 'restarting'; version: string }
   | { phase: 'deferred'; version: string }
-  | { phase: 'failed'; version: string };
+  | { phase: 'failed'; version: string }
+  | { phase: 'ready'; version: string };
 
 /** Compile-time exhaustiveness guard: a new phase that isn't handled becomes a type error. */
 function assertNever(value: never): never {
@@ -37,6 +38,7 @@ const KNOWN_PHASES: Record<UpdateStatus['phase'], true> = {
   restarting: true,
   deferred: true,
   failed: true,
+  ready: true,
 };
 
 /**
@@ -89,6 +91,8 @@ export function updateStatusMessage(status: UpdateStatus): string {
       return `Update ${status.version} ready — applies when this session ends.`;
     case 'failed':
       return `Update ${status.version} failed — will retry on next launch.`;
+    case 'ready':
+      return `Update ${status.version} downloaded`;
     default:
       return assertNever(status);
   }
@@ -108,6 +112,7 @@ export function isUpdateActive(status: UpdateStatus): boolean {
       return true;
     case 'deferred':
     case 'failed':
+    case 'ready':
       return false;
     default:
       return assertNever(status);

--- a/docs/superpowers/plans/2026-06-25-viewer-update-prompt.md
+++ b/docs/superpowers/plans/2026-06-25-viewer-update-prompt.md
@@ -1,0 +1,535 @@
+# Viewer Interactive Update Prompt — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the viewer's silent auto-restart/auto-close with an interactive "Update X downloaded — [Restart & update] [Remind me later]" prompt when no remote session is active.
+
+**Architecture:** After the Rust auto-updater finishes downloading, it no longer installs/restarts automatically. With no active session it stashes the downloaded `Update` + bytes in managed state and emits a new `Ready` phase; the React banner shows two buttons that call back into Rust via Tauri commands (`apply_pending_update` / `dismiss_pending_update`). With an active session it keeps the existing silent deferral (and, on Windows, no longer interrupts the session to install).
+
+**Tech Stack:** Rust (Tauri v2, `tauri-plugin-updater`), React + TypeScript, Vitest (jsdom).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-25-viewer-update-prompt-design.md` — implement exactly that behavior matrix.
+- **Copy (verbatim):** banner text `Update {version} downloaded`; buttons `Restart & update` and `Remind me later`.
+- **Windows "Remind me later":** drop the downloaded bytes (no install); the updater re-checks next launch.
+- **Active remote session:** keep showing the existing `Deferred` notice ("applies when this session ends"); never show the interactive prompt or restart mid-session.
+- **Serde tag contract:** the Rust `UpdateStatus` enum is `#[serde(tag = "phase", rename_all = "lowercase")]`; every variant must stay mirrored in `src/lib/updateStatus.ts`, locked by the `update_status_serializes_to_expected_shape` test.
+- **`invoke` import path:** `@tauri-apps/api/core` (matches `src/App.tsx`).
+- **No component tests:** the viewer has no `@testing-library/react`; test pure logic in `src/lib/*.test.ts` only. Do NOT add testing-library.
+- **Worktree setup:** before running frontend tests, run `pnpm install` once from the worktree root (`/Users/toddhebebrand/breeze-worktrees/viewer-update-prompt`) — a fresh worktree has no `node_modules`.
+- **Pinned Node:** use the repo's pinned Node (v22.20.0); do not use Node 23 (breaks `engine-strict`).
+
+---
+
+### Task 1: Add the `Ready` update phase to the Rust enum (+ contract test)
+
+**Files:**
+- Modify: `apps/viewer/src-tauri/src/lib.rs:452-463` (enum), `:807-852` (serialize test)
+
+**Interfaces:**
+- Produces: `UpdateStatus::Ready { version: String }` serializing to `{"phase":"ready","version":"…"}`.
+
+- [ ] **Step 1: Add the failing test case**
+
+In `apps/viewer/src-tauri/src/lib.rs`, inside `update_status_serializes_to_expected_shape`, add a `Ready` case to the `cases` array (after the `Failed` case, before the closing `]`):
+
+```rust
+            (
+                UpdateStatus::Ready { version: v.clone() },
+                json!({ "phase": "ready", "version": "1.2.3" }),
+            ),
+```
+
+- [ ] **Step 2: Run the test — verify it FAILS to compile**
+
+Run: `cd apps/viewer/src-tauri && cargo test update_status_serializes_to_expected_shape`
+Expected: FAIL — `no variant named Ready found for enum UpdateStatus`.
+
+- [ ] **Step 3: Add the `Ready` variant**
+
+In the `UpdateStatus` enum (`lib.rs:452`), add the variant after `Failed { version: String },`:
+
+```rust
+    Failed { version: String },
+    /// Downloaded and waiting for the user to choose Restart & update or
+    /// Remind me later. Only emitted when no remote session is active.
+    Ready { version: String },
+```
+
+- [ ] **Step 4: Run the test — verify it PASSES**
+
+Run: `cd apps/viewer/src-tauri && cargo test update_status_serializes_to_expected_shape`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/viewer/src-tauri/src/lib.rs
+git commit -m "feat(viewer): add Ready phase to UpdateStatus enum"
+```
+
+---
+
+### Task 2: Hold the download and gate install/restart behind user commands
+
+**Files:**
+- Modify: `apps/viewer/src-tauri/src/lib.rs` — add `PendingUpdate` state struct (near the other state structs, ~`:56`), restructure `auto_update` tail (`:565-607`), add two commands (near the other `#[tauri::command]`s, ~`:262`), register them in the `invoke_handler` (`:617-624`), manage the state in `.setup()` (`:679-682`).
+
+**Interfaces:**
+- Consumes: `UpdateStatus::Ready` (Task 1); existing `emit_update_status`, `lock_or_recover`, `SessionMap`, `UpdateStatus::{Installing,Restarting,Failed,Deferred}`.
+- Produces: Tauri commands `apply_pending_update` and `dismiss_pending_update` (called by the frontend in Task 4).
+
+> No unit test — Tauri command + `#[cfg]` platform branches aren't unit-testable without a live updater. The deliverable is verified by `cargo build` + `cargo test` (the serialize test from Task 1 must still pass) and the manual checks in the spec. Keep the platform logic thin.
+
+- [ ] **Step 1: Add the `PendingUpdate` state struct**
+
+Near the other managed-state structs in `lib.rs` (e.g. just after `struct SessionMap(...)` at `:56`), add:
+
+```rust
+/// A downloaded-but-not-yet-applied update, awaiting the user's choice in the
+/// `Ready` prompt. The `Update` handle is retained because `install()` is a
+/// method on it. Only ever holds a value when no remote session is active.
+struct PendingUpdate(Mutex<Option<(tauri_plugin_updater::Update, Vec<u8>)>>);
+```
+
+- [ ] **Step 2: Manage the state in `.setup()`**
+
+In the `.setup()` closure where the other states are managed (`lib.rs:679-682`), add after `app.manage(WindowCounter(Mutex::new(0)));`:
+
+```rust
+            app.manage(PendingUpdate(Mutex::new(None)));
+```
+
+- [ ] **Step 3: Restructure the `auto_update` tail**
+
+Replace everything from the `eprintln!("Update {} downloaded, installing...", …)` line (`lib.rs:565`) through the end of the `#[cfg(not(target_os = "windows"))]` block (`:606`) — i.e. the old unconditional `install()` and the restart block — with:
+
+```rust
+    eprintln!("Update {} downloaded", update.version);
+
+    // Decide what to do with the download based on whether a remote session is
+    // live. Restarting/installing mid-session would kill it, so an active
+    // session always defers; otherwise we hand the choice to the user.
+    let has_active_sessions = app
+        .try_state::<SessionMap>()
+        .map(|s| {
+            let map = lock_or_recover(&s.0, "session_map");
+            !map.is_empty()
+        })
+        .unwrap_or(false);
+
+    if has_active_sessions {
+        // Don't interrupt a live session. macOS/Linux can swap the binary on
+        // disk now (takes effect next launch); Windows can't install without
+        // exiting, so drop the download and re-check on next launch.
+        #[cfg(not(target_os = "windows"))]
+        {
+            if let Err(e) = update.install(bytes) {
+                eprintln!("Deferred update disk-swap failed: {}", e);
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            drop((update, bytes));
+        }
+        eprintln!("Active remote session — deferring update to next launch");
+        emit_update_status(&app, UpdateStatus::Deferred { version });
+        return;
+    }
+
+    // No active session — stash the download and let the user choose via the
+    // Ready prompt (apply_pending_update / dismiss_pending_update).
+    if let Some(pending) = app.try_state::<PendingUpdate>() {
+        *lock_or_recover(&pending.0, "pending_update") = Some((update, bytes));
+        eprintln!("Update {} ready — awaiting user choice", version);
+        emit_update_status(&app, UpdateStatus::Ready { version });
+    } else {
+        eprintln!("PendingUpdate state missing; cannot present update prompt");
+    }
+```
+
+> Note: `version` is the `let version = update.version.clone();` already bound at `lib.rs:520`. The old `emit_update_status(&app, UpdateStatus::Installing …)` at `:569` is removed here — `Installing` is now emitted by `apply_pending_update` instead.
+
+- [ ] **Step 4: Add the two commands**
+
+After the existing commands (e.g. after `update_session_hostname`, ~`lib.rs:262`), add:
+
+```rust
+/// "Restart & update": apply the stashed update now. On macOS/Linux this swaps
+/// the binary and restarts; on Windows `install()` launches the installer and
+/// the process exits. No-op if nothing is pending (e.g. a double click).
+#[tauri::command]
+fn apply_pending_update(app: tauri::AppHandle, pending: tauri::State<'_, PendingUpdate>) {
+    let taken = {
+        let mut slot = lock_or_recover(&pending.0, "pending_update");
+        slot.take()
+    };
+    let Some((update, bytes)) = taken else {
+        return;
+    };
+    let version = update.version.clone();
+
+    #[cfg(target_os = "windows")]
+    {
+        emit_update_status(&app, UpdateStatus::Installing { version: version.clone() });
+        // install() launches the installer and terminates the process; on
+        // success nothing after this runs. Reaching past it means it failed.
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Update install failed: {}", e);
+            emit_update_status(&app, UpdateStatus::Failed { version });
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Update install failed: {}", e);
+            emit_update_status(&app, UpdateStatus::Failed { version });
+            return;
+        }
+        emit_update_status(&app, UpdateStatus::Restarting { version });
+        app.restart();
+    }
+}
+
+/// "Remind me later": discard the prompt. On macOS/Linux swap the binary on
+/// disk so the next launch is updated; on Windows drop the download (re-checks
+/// next launch). No-op if nothing is pending.
+#[tauri::command]
+fn dismiss_pending_update(pending: tauri::State<'_, PendingUpdate>) {
+    let taken = {
+        let mut slot = lock_or_recover(&pending.0, "pending_update");
+        slot.take()
+    };
+    let Some((update, bytes)) = taken else {
+        return;
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Err(e) = update.install(bytes) {
+            eprintln!("Deferred update disk-swap failed: {}", e);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        drop((update, bytes));
+    }
+}
+```
+
+- [ ] **Step 5: Register the commands in the invoke handler**
+
+In `tauri::generate_handler![ … ]` (`lib.rs:617-624`), add the two names after `update_session_hostname,`:
+
+```rust
+            update_session_hostname,
+            apply_pending_update,
+            dismiss_pending_update,
+```
+
+- [ ] **Step 6: Build + run the Rust tests**
+
+Run: `cd apps/viewer/src-tauri && cargo build && cargo test`
+Expected: builds cleanly; `update_status_serializes_to_expected_shape` and existing tests PASS.
+
+> If `cargo build` complains that `Update` is not `Send + Sync` (managed state requires it), STOP and report — the fallback is to box the install closure differently; do not silently change behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/viewer/src-tauri/src/lib.rs
+git commit -m "feat(viewer): gate update install/restart behind user choice"
+```
+
+---
+
+### Task 3: Add the `ready` phase to the frontend status helper (+ tests)
+
+**Files:**
+- Modify: `apps/viewer/src/lib/updateStatus.ts`
+- Test: `apps/viewer/src/lib/updateStatus.test.ts`
+
+**Interfaces:**
+- Consumes: the `ready` serde shape `{ phase: 'ready', version: string }` (Task 1).
+- Produces: `UpdateStatus` union includes `ready`; `updateStatusMessage` returns `Update {version} downloaded`; `isUpdateActive('ready') === false`; `shouldAutoDismiss('ready') === false`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/viewer/src/lib/updateStatus.test.ts`, add a new block (place near the other `describe`s):
+
+```ts
+describe('ready phase', () => {
+  const ready: UpdateStatus = { phase: 'ready', version: '1.2.3' };
+
+  it('messages as a downloaded-and-waiting prompt', () => {
+    expect(updateStatusMessage(ready)).toBe('Update 1.2.3 downloaded');
+  });
+
+  it('is not "active" (no progress affordance)', () => {
+    expect(isUpdateActive(ready)).toBe(false);
+  });
+
+  it('does not auto-dismiss (stays pinned until the user acts)', () => {
+    expect(shouldAutoDismiss(ready)).toBe(false);
+  });
+
+  it('is accepted by the IPC-boundary guard', () => {
+    expect(isUpdateStatus({ phase: 'ready', version: '1.2.3' })).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — verify they FAIL**
+
+Run: `cd apps/viewer && pnpm install && pnpm exec vitest run src/lib/updateStatus.test.ts`
+Expected: FAIL — `updateStatusMessage` has no `ready` case / type error on the `ready` literal.
+
+- [ ] **Step 3: Implement the `ready` phase**
+
+In `apps/viewer/src/lib/updateStatus.ts`:
+
+a) Add to the union (after the `failed` line, `:21`):
+
+```ts
+  | { phase: 'failed'; version: string }
+  | { phase: 'ready'; version: string };
+```
+
+b) Add to `KNOWN_PHASES` (`:33-40`):
+
+```ts
+  failed: true,
+  ready: true,
+```
+
+c) Add a case in `updateStatusMessage` (before `default:`, `:92`):
+
+```ts
+    case 'ready':
+      return `Update ${status.version} downloaded`;
+```
+
+d) Add a case in `isUpdateActive` — group it with the non-active phases (`:109-111`):
+
+```ts
+    case 'deferred':
+    case 'failed':
+    case 'ready':
+      return false;
+```
+
+> `shouldAutoDismiss` needs no change: it returns true only for `deferred`/`failed`, so `ready` is already false.
+
+- [ ] **Step 4: Run the tests — verify they PASS**
+
+Run: `cd apps/viewer && pnpm exec vitest run src/lib/updateStatus.test.ts`
+Expected: PASS (all cases, including the new block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/viewer/src/lib/updateStatus.ts apps/viewer/src/lib/updateStatus.test.ts
+git commit -m "feat(viewer): add ready phase to update status helper"
+```
+
+---
+
+### Task 4: Add the `updateActions` IPC wrappers (+ tests)
+
+**Files:**
+- Create: `apps/viewer/src/lib/updateActions.ts`
+- Test: `apps/viewer/src/lib/updateActions.test.ts`
+
+**Interfaces:**
+- Consumes: Tauri commands `apply_pending_update` / `dismiss_pending_update` (Task 2); `invoke` from `@tauri-apps/api/core`.
+- Produces: `applyPendingUpdate(): Promise<void>` and `dismissPendingUpdate(): Promise<void>` (used by the component in Task 5).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/viewer/src/lib/updateActions.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { applyPendingUpdate, dismissPendingUpdate } from './updateActions';
+
+beforeEach(() => {
+  invoke.mockReset();
+  invoke.mockResolvedValue(undefined);
+});
+
+describe('updateActions', () => {
+  it('applyPendingUpdate invokes the apply command', async () => {
+    await applyPendingUpdate();
+    expect(invoke).toHaveBeenCalledWith('apply_pending_update');
+  });
+
+  it('dismissPendingUpdate invokes the dismiss command', async () => {
+    await dismissPendingUpdate();
+    expect(invoke).toHaveBeenCalledWith('dismiss_pending_update');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — verify they FAIL**
+
+Run: `cd apps/viewer && pnpm exec vitest run src/lib/updateActions.test.ts`
+Expected: FAIL — `Cannot find module './updateActions'`.
+
+- [ ] **Step 3: Implement the wrappers**
+
+Create `apps/viewer/src/lib/updateActions.ts`:
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * "Restart & update": apply the downloaded update now. On macOS/Linux the
+ * viewer reinstalls and restarts; on Windows the installer launches and the
+ * process exits. Backed by the `apply_pending_update` Tauri command.
+ */
+export function applyPendingUpdate(): Promise<void> {
+  return invoke('apply_pending_update');
+}
+
+/**
+ * "Remind me later": dismiss the update prompt. macOS/Linux swaps the binary
+ * on disk for next launch; Windows re-checks on next launch. Backed by the
+ * `dismiss_pending_update` Tauri command.
+ */
+export function dismissPendingUpdate(): Promise<void> {
+  return invoke('dismiss_pending_update');
+}
+```
+
+- [ ] **Step 4: Run the tests — verify they PASS**
+
+Run: `cd apps/viewer && pnpm exec vitest run src/lib/updateActions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/viewer/src/lib/updateActions.ts apps/viewer/src/lib/updateActions.test.ts
+git commit -m "feat(viewer): add update apply/dismiss IPC wrappers"
+```
+
+---
+
+### Task 5: Render the interactive prompt in `UpdateIndicator`
+
+**Files:**
+- Modify: `apps/viewer/src/components/UpdateIndicator.tsx`
+
+**Interfaces:**
+- Consumes: `applyPendingUpdate` / `dismissPendingUpdate` (Task 4); `ready` phase from `updateStatus.ts` (Task 3).
+
+> No unit test (no testing-library in this app — see Global Constraints). Verified by `tsc` (via `pnpm build`) and the manual checks in the spec.
+
+- [ ] **Step 1: Import the actions and add `useState`**
+
+At the top of `apps/viewer/src/components/UpdateIndicator.tsx`, add the import (after the `updateStatus` import block, `:11`):
+
+```ts
+import { applyPendingUpdate, dismissPendingUpdate } from '../lib/updateActions';
+```
+
+Add an `acting` guard next to the existing `status` state (`:26`):
+
+```ts
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [acting, setActing] = useState(false);
+```
+
+- [ ] **Step 2: Make the banner interactive only for `ready`**
+
+The container's `className` is currently a plain double-quoted string (`:74-77`). Convert it to a template literal so the pointer-events class can be conditional. Replace this exact block:
+
+```tsx
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-50 max-w-[90vw]
+                 flex flex-col gap-1 px-3 py-2 rounded-lg shadow-lg
+                 bg-gray-800/95 border border-gray-700 text-gray-100
+                 backdrop-blur-sm pointer-events-none"
+```
+
+with (note the backticks and `${...}`):
+
+```tsx
+      className={`fixed top-3 left-1/2 -translate-x-1/2 z-50 max-w-[90vw]
+                 flex flex-col gap-1 px-3 py-2 rounded-lg shadow-lg
+                 bg-gray-800/95 border border-gray-700 text-gray-100
+                 backdrop-blur-sm ${status.phase === 'ready' ? 'pointer-events-auto' : 'pointer-events-none'}`}
+```
+
+- [ ] **Step 3: Render the two buttons for the `ready` phase**
+
+Immediately after the closing `</div>` of the message row (the `<div className="flex items-center gap-2 text-xs">…</div>` block ending at `:84`) and before the `{active && (` progress block (`:85`), insert:
+
+```tsx
+      {status.phase === 'ready' && (
+        <div className="flex items-center gap-2 mt-0.5">
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => {
+              setActing(true);
+              applyPendingUpdate().catch((e) => {
+                console.error('Failed to apply update', e);
+                setActing(false);
+              });
+            }}
+            className="px-2 py-0.5 rounded bg-blue-600 hover:bg-blue-500
+                       disabled:opacity-50 text-xs font-medium"
+          >
+            Restart &amp; update
+          </button>
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => {
+              setActing(true);
+              dismissPendingUpdate()
+                .catch((e) => console.error('Failed to dismiss update', e))
+                .finally(() => setStatus(null));
+            }}
+            className="px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600
+                       disabled:opacity-50 text-xs"
+          >
+            Remind me later
+          </button>
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Type-check / build the frontend**
+
+Run: `cd apps/viewer && pnpm build`
+Expected: `tsc` passes (no type errors), Vite build succeeds.
+
+- [ ] **Step 5: Run the full viewer frontend test suite**
+
+Run: `cd apps/viewer && pnpm exec vitest run`
+Expected: all tests PASS (including the new `updateStatus` and `updateActions` suites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/viewer/src/components/UpdateIndicator.tsx
+git commit -m "feat(viewer): show Restart & update / Remind me later prompt"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] **Rust:** `cd apps/viewer/src-tauri && cargo test` — all pass.
+- [ ] **Frontend:** `cd apps/viewer && pnpm exec vitest run` — all pass; `pnpm build` clean.
+- [ ] **Manual (per spec "Manual verification"):** confirm — no-session prompt appears and never closes without a click; "Remind me later" hides the banner and the app keeps running; "Restart & update" relaunches into the new version; active-session shows the deferred notice and is NOT interrupted (especially on Windows).
+- [ ] Spec behavior matrix re-read against the diff; no auto-`restart()`/auto-`install()` remains on the no-session path.

--- a/docs/superpowers/specs/2026-06-25-viewer-update-prompt-design.md
+++ b/docs/superpowers/specs/2026-06-25-viewer-update-prompt-design.md
@@ -1,0 +1,166 @@
+# Viewer interactive update prompt — design
+
+**Date:** 2026-06-25
+**Branch:** `feat/viewer-update-prompt`
+**Area:** `apps/viewer` (Tauri + React remote-desktop viewer)
+
+## Problem
+
+The viewer auto-updates silently. Commit `34ab25adb` (#1450) added an
+`UpdateIndicator` banner so the download/install no longer *looks* like a crash,
+but the viewer still **closes itself without giving the user any choice**:
+
+- **No active session, macOS/Linux:** after `update.install()` swaps the binary,
+  `auto_update` calls `app.restart()` immediately (`lib.rs:604`). The "restarting…"
+  banner flashes but the app relaunches the same instant — no chance to react.
+- **Windows (any case):** `update.install(bytes)` (`lib.rs:573`) launches the
+  MSI/NSIS installer and the process exits. The window just vanishes. This fires
+  even when a remote session is active, interrupting it.
+
+We want the user to **optionally close and re-open** instead of the viewer
+deciding for them.
+
+## Goal
+
+When an update has downloaded and **no remote session is active**, present an
+interactive prompt and never close without an explicit click:
+
+```
+⬆  Update 1.2.3 downloaded
+   [ Restart & update ]   [ Remind me later ]
+```
+
+When a remote session **is** active, keep the existing non-interactive
+"applies when this session ends" deferral — restarting mid-session would kill
+the live session.
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Interaction model | Interactive prompt with **Restart & update** / **Remind me later**. Never closes without a click (no-session case). |
+| Windows "Remind me later" | **Re-prompt next launch** — drop the downloaded bytes, banner dismisses, `auto_update` re-checks and re-prompts on next start. (Windows can't swap in place + keep running.) |
+| Active remote session | **Keep deferring silently** — show the existing "applies when this session ends" notice, no buttons. Prompt only appears with no active session. |
+| Copy | Banner: `Update {version} downloaded`. Buttons: `Restart & update` / `Remind me later`. |
+
+**Rejected:** countdown-with-cancel (still closes on its own if the user steps
+away — doesn't solve "closes without notice").
+
+## Behavior matrix
+
+| Situation | Today | New |
+|---|---|---|
+| No active session | macOS/Linux: silent `app.restart()`. Windows: installer launches, window vanishes | **Interactive `Ready` prompt:** `Update X downloaded — [Restart & update] [Remind me later]` |
+| Active remote session | macOS/Linux: defers (notice, binary already swapped, no restart). Windows: **installer launches and kills the session** | macOS/Linux: defer + swap-on-disk (unchanged). Windows: defer **without installing** — no longer interrupts the session |
+| "Restart & update" clicked | — | macOS/Linux: `install()` → `app.restart()`. Windows: `install()` (process exits, installer runs, relaunches) |
+| "Remind me later" clicked | — | macOS/Linux: `install()` swaps binary silently, banner dismisses, applies next launch. Windows: drop bytes, banner dismisses, re-checks next launch |
+
+## Architecture
+
+### Rust — `apps/viewer/src-tauri/src/lib.rs`
+
+1. **Pending-update state.** Add a Tauri-managed
+   `PendingUpdate(Mutex<Option<PendingUpdateInner>>)` where `PendingUpdateInner`
+   holds the downloaded `tauri_plugin_updater::Update` and its `Vec<u8>` bytes.
+   The `Update` handle is needed because `install()` is a method on it.
+
+2. **Restructure `auto_update`.** After a successful `download(...)`:
+   - Compute `has_active_sessions` (existing logic at `lib.rs:590`).
+   - **Active session** → emit `UpdateStatus::Deferred`. On macOS/Linux call
+     `update.install(bytes)` first so the binary is swapped for next launch
+     (matches today). On Windows do **not** install (don't interrupt the
+     session) — drop the bytes; it re-checks next launch.
+   - **No active session** → store `(update, bytes)` in `PendingUpdate`, emit the
+     new `UpdateStatus::Ready { version }`, and return. Do **not** install or
+     restart. The prompt now drives what happens next.
+
+   The previous unconditional `update.install(bytes)` at `lib.rs:573` and the
+   `app.restart()` at `lib.rs:604` are removed from the auto path; the install /
+   restart now happen only in response to the commands below.
+
+3. **Two new `#[tauri::command]`s** (registered in the `invoke_handler`):
+   - `apply_pending_update(app)`: take the stored `(update, bytes)`.
+     - macOS/Linux: emit `Restarting`, `update.install(bytes)`, then `app.restart()`.
+     - Windows: emit `Installing`, `update.install(bytes)` (process exits).
+     - On install error → emit `Failed`, clear pending state.
+     - If nothing is pending (double-click race) → no-op.
+   - `dismiss_pending_update(app)` ("Remind me later"): take + clear the pending
+     entry.
+     - macOS/Linux: `update.install(bytes)` to swap the binary silently (applies
+       next launch). Errors are logged but non-fatal (next launch re-checks).
+     - Windows: drop the bytes (no install). Next launch re-checks and re-prompts.
+     - Emits nothing — the frontend hides the banner locally on click.
+
+4. **`UpdateStatus` enum:** add the `Ready { version }` variant. Update the
+   `serialize_*` contract test that locks the serde tag names / field shapes so
+   the Rust and TS definitions can't drift.
+
+### Frontend
+
+1. **`apps/viewer/src/lib/updateStatus.ts`**
+   - Add `{ phase: 'ready'; version: string }` to the `UpdateStatus` union and to
+     `KNOWN_PHASES` (the exhaustiveness map — adding to the union without the map
+     is a compile error, so both must change together).
+   - `updateStatusMessage`: `ready` → `Update {version} downloaded`.
+   - `isUpdateActive`: `ready` → `false` (no progress bar / pulse).
+   - `shouldAutoDismiss`: `ready` → `false` (stays pinned until the user acts).
+
+2. **`apps/viewer/src/components/UpdateIndicator.tsx`**
+   - When `status.phase === 'ready'`, render two buttons:
+     - **Restart & update** → `invoke('apply_pending_update')`.
+     - **Remind me later** → `invoke('dismiss_pending_update')` then
+       `setStatus(null)` to hide the banner locally.
+   - Make the banner container `pointer-events-auto` **only** in the `ready`
+     phase (it is `pointer-events-none` today and must stay so for the
+     informational phases, which sit over the remote-desktop canvas).
+   - Use an upload/arrow icon for `ready` (e.g. `ArrowUpCircle`); keep existing
+     icons for the other phases.
+   - Guard against double-invoke: disable the buttons after the first click.
+
+### Tests
+
+- **`apps/viewer/src/lib/updateStatus.test.ts`** — add cases for the `ready`
+  phase: message text, `isUpdateActive === false`, `shouldAutoDismiss === false`,
+  and `isUpdateStatus` acceptance of a well-formed `ready` payload.
+- **`apps/viewer/src/components/UpdateIndicator.test.tsx`** (if present, else add)
+  — `ready` renders both buttons and wires them to the right `invoke` calls;
+  "Remind me later" hides the banner; buttons disable after click. Mock
+  `@tauri-apps/api/core`'s `invoke`.
+- **Rust `serialize_*` contract test** — assert the `ready` tag serializes as
+  `{"phase":"ready","version":"..."}`.
+- Command-level behavior (`apply` / `dismiss` branching by platform) is hard to
+  unit-test without a live updater; cover it with `#[cfg]`-gated logic kept thin
+  and a manual verification note (below).
+
+## Edge cases
+
+- **Double-click / re-entrancy:** commands take-and-clear the `Mutex<Option<…>>`
+  atomically, so a second click finds `None` and no-ops. Frontend also disables
+  buttons after first click.
+- **Install failure on apply:** emit `Failed`, clear pending state so the banner
+  doesn't stay stuck on "Installing…".
+- **Window closed while prompt is up:** existing last-window-close → `exit(0)`
+  path (`lib.rs:756`) is unchanged; the un-applied update is simply re-checked on
+  next launch (macOS already has the binary swapped only if a prior dismiss ran,
+  otherwise it re-downloads — acceptable).
+- **`Deferred` copy:** unchanged ("applies when this session ends") since it now
+  only fires in the active-session branch.
+
+## Out of scope
+
+- No change to the 3-second startup delay or the update-check cadence.
+- No persistence of "remind me later" across launches (Windows re-prompts each
+  launch by design; macOS applies on next launch so there's nothing to nag).
+- No change to the Helper Tauri app — this is the **viewer** only.
+
+## Manual verification
+
+- macOS, no session: trigger an update → prompt appears → "Remind me later"
+  hides it and the app keeps running; relaunch shows the new version. "Restart &
+  update" relaunches into the new version immediately.
+- macOS, active session: update finishes → "applies when this session ends"
+  notice, session uninterrupted.
+- Windows, no session: prompt appears → "Restart & update" runs the installer;
+  "Remind me later" hides it and a fresh launch re-prompts.
+- Windows, active session: update finishes → deferred notice, session **not**
+  interrupted (the key bug fix on Windows).


### PR DESCRIPTION
## Problem

The viewer auto-updates silently. #1450 added the `UpdateIndicator` banner so the download/install no longer *looks* like a crash, but the viewer still **closed itself without giving the user a choice**:

- **No active session, macOS/Linux:** after `update.install()` swaps the binary, `auto_update` called `app.restart()` the same instant — the "restarting…" banner flashed but the app relaunched with no chance to react.
- **Windows (any case):** `update.install(bytes)` launched the MSI/NSIS installer and the process exited — the window just vanished. This fired **even during an active remote session**, interrupting it.

## What this does

After a download finishes and **no remote session is active**, the viewer now stashes the update and shows an interactive prompt instead of closing itself:

```
⬆  Update 1.2.3 downloaded
   [ Restart & update ]   [ Remind me later ]
```

| Action | Behavior |
|---|---|
| **Restart & update** | macOS/Linux: install → `app.restart()`. Windows: install (process exits, installer runs, relaunches). |
| **Remind me later** | macOS/Linux: swap the binary on disk silently, banner dismisses, applies next launch. Windows: drop the bytes, banner dismisses, re-checks next launch. |
| **Active remote session** | Unchanged silent "applies when this session ends" deferral — and on **Windows** the installer no longer launches mid-session, so a live session is no longer interrupted (bug fix). |

The viewer never closes without an explicit click in the no-session case — the original complaint.

## How

- **Rust (`apps/viewer/src-tauri/src/lib.rs`):** new `UpdateStatus::Ready` phase; `PendingUpdate` managed state holding the downloaded `(Update, Vec<u8>)`; `auto_update` restructured to stash + emit `Ready` instead of auto-installing; two new commands `apply_pending_update` / `dismiss_pending_update` (atomic take-and-clear, double-click safe, no lock held across `install()`/`restart()`). The serde tag contract test is extended to lock the new phase.
- **Frontend:** `ready` phase added to `updateStatus.ts` (message `Update {version} downloaded`, not active, stays pinned); new `updateActions.ts` IPC wrappers; `UpdateIndicator.tsx` renders the two buttons, is interactive (`pointer-events-auto`) only in the `ready` phase, disables both buttons after first click, and hides the banner on "Remind me later".

## Testing

- Rust: `cargo test` — 7/7 pass (incl. the `UpdateStatus` serialize contract test).
- Frontend: `pnpm exec vitest run` — full suite green (incl. new `updateStatus` and `updateActions` tests); `pnpm build` (tsc + vite) clean.
- No `@testing-library/react` in this app by design — the component is kept thin and its logic is covered by the pure `updateStatus` / `updateActions` tests. Manual verification steps for each platform/session combination are listed in the design spec.

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
