### PR TITLE
perf(agent): cut redundant Windows collection — batch hardware WMI, daily hardware/patch scans

### DIFF
--- a/agent/internal/collectors/hardware_test.go
+++ b/agent/internal/collectors/hardware_test.go
@@ -1,6 +1,8 @@
 package collectors
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestNormalizeOSVersionBuild(t *testing.T) {
 	tests := []struct {
@@ -171,6 +173,113 @@ func TestFirstCleanHardwareIdentityValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := firstCleanHardwareIdentityValue(tt.values...); got != tt.want {
 				t.Errorf("firstCleanHardwareIdentityValue(%q) = %q, want %q", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseHardwareJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    windowsHardwareJSON
+		wantErr bool
+	}{
+		{
+			name:  "full valid response with two GPUs",
+			input: `{"BiosSerial":"SN123","BiosVersion":"1.2.3","BoardSerial":"BS456","BoardManufacturer":"ASUS","BoardProduct":"Z790","BoardVersion":"Rev 1.0","SysManufacturer":"Dell","SysModel":"XPS 15","GPUNames":["NVIDIA RTX 4090","Intel UHD 770"]}`,
+			want: windowsHardwareJSON{
+				BiosSerial:        "SN123",
+				BiosVersion:       "1.2.3",
+				BoardSerial:       "BS456",
+				BoardManufacturer: "ASUS",
+				BoardProduct:      "Z790",
+				BoardVersion:      "Rev 1.0",
+				SysManufacturer:   "Dell",
+				SysModel:          "XPS 15",
+				GPUNames:          []string{"NVIDIA RTX 4090", "Intel UHD 770"},
+			},
+		},
+		{
+			name:  "single GPU as array",
+			input: `{"BiosSerial":"","BiosVersion":"","BoardSerial":"","BoardManufacturer":"","BoardProduct":"","BoardVersion":"","SysManufacturer":"","SysModel":"","GPUNames":["AMD Radeon RX 7900"]}`,
+			want: windowsHardwareJSON{
+				GPUNames: []string{"AMD Radeon RX 7900"},
+			},
+		},
+		{
+			name:  "empty GPU array",
+			input: `{"BiosSerial":"SN1","BiosVersion":"1.0","BoardSerial":"","BoardManufacturer":"","BoardProduct":"","BoardVersion":"","SysManufacturer":"","SysModel":"","GPUNames":[]}`,
+			want: windowsHardwareJSON{
+				BiosSerial:  "SN1",
+				BiosVersion: "1.0",
+				GPUNames:    []string{},
+			},
+		},
+		{
+			// PowerShell 5.1 serializes an empty @() as JSON null, not []. Go
+			// decodes null into a nil slice, which the caller treats the same as
+			// an empty list (no GPU model recorded).
+			name:  "null GPU list (PS 5.1 serializes empty @() as null)",
+			input: `{"BiosSerial":"SN1","BiosVersion":"1.0","BoardSerial":"","BoardManufacturer":"","BoardProduct":"","BoardVersion":"","SysManufacturer":"","SysModel":"","GPUNames":null}`,
+			want: windowsHardwareJSON{
+				BiosSerial:  "SN1",
+				BiosVersion: "1.0",
+				GPUNames:    nil,
+			},
+		},
+		{
+			name:  "trailing newline in output is tolerated",
+			input: `{"BiosSerial":"X","BiosVersion":"","BoardSerial":"","BoardManufacturer":"","BoardProduct":"","BoardVersion":"","SysManufacturer":"","SysModel":"","GPUNames":["GPU1"]}` + "\n",
+			want: windowsHardwareJSON{
+				BiosSerial: "X",
+				GPUNames:   []string{"GPU1"},
+			},
+		},
+		{
+			name:    "invalid JSON returns error",
+			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "empty input returns error",
+			input:   ``,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseHardwareJSON([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseHardwareJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			checkStr := func(field, got, want string) {
+				t.Helper()
+				if got != want {
+					t.Errorf("%s = %q, want %q", field, got, want)
+				}
+			}
+			checkStr("BiosSerial", got.BiosSerial, tt.want.BiosSerial)
+			checkStr("BiosVersion", got.BiosVersion, tt.want.BiosVersion)
+			checkStr("BoardSerial", got.BoardSerial, tt.want.BoardSerial)
+			checkStr("BoardManufacturer", got.BoardManufacturer, tt.want.BoardManufacturer)
+			checkStr("BoardProduct", got.BoardProduct, tt.want.BoardProduct)
+			checkStr("BoardVersion", got.BoardVersion, tt.want.BoardVersion)
+			checkStr("SysManufacturer", got.SysManufacturer, tt.want.SysManufacturer)
+			checkStr("SysModel", got.SysModel, tt.want.SysModel)
+			if len(got.GPUNames) != len(tt.want.GPUNames) {
+				t.Errorf("GPUNames len = %d, want %d: got %v, want %v",
+					len(got.GPUNames), len(tt.want.GPUNames), got.GPUNames, tt.want.GPUNames)
+				return
+			}
+			for i, name := range got.GPUNames {
+				if name != tt.want.GPUNames[i] {
+					t.Errorf("GPUNames[%d] = %q, want %q", i, name, tt.want.GPUNames[i])
+				}
 			}
 		})
 	}

--- a/agent/internal/collectors/hardware_test.go
+++ b/agent/internal/collectors/hardware_test.go
@@ -217,6 +217,19 @@ func TestParseHardwareJSON(t *testing.T) {
 			},
 		},
 		{
+			// PowerShell 5.1 collapses a single-element array to a bare scalar in
+			// ConvertTo-Json, so a one-GPU host (the common case) emits a string,
+			// not an array. The custom unmarshaler must normalize it to a slice —
+			// otherwise the whole hardware record would be dropped on most hosts.
+			name:  "single GPU collapsed to scalar (PS 5.1 ConvertTo-Json)",
+			input: `{"BiosSerial":"SN1","BiosVersion":"1.0","BoardSerial":"","BoardManufacturer":"","BoardProduct":"","BoardVersion":"","SysManufacturer":"","SysModel":"","GPUNames":"Intel(R) UHD Graphics"}`,
+			want: windowsHardwareJSON{
+				BiosSerial:  "SN1",
+				BiosVersion: "1.0",
+				GPUNames:    gpuNameList{"Intel(R) UHD Graphics"},
+			},
+		},
+		{
 			// PowerShell 5.1 serializes an empty @() as JSON null, not []. Go
 			// decodes null into a nil slice, which the caller treats the same as
 			// an empty list (no GPU model recorded).

--- a/agent/internal/collectors/hardware_windows.go
+++ b/agent/internal/collectors/hardware_windows.go
@@ -31,68 +31,6 @@ func wmicGet(args []string, property string) string {
 	return ""
 }
 
-func powershellWmiPropertyValues(className, property string) []string {
-	script := fmt.Sprintf(`
-$ErrorActionPreference = 'Stop'
-$items = $null
-if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
-  try {
-    $items = Get-CimInstance -ClassName '%s' -ErrorAction Stop
-  } catch {
-    $items = $null
-  }
-}
-if ($null -eq $items -and (Get-Command Get-WmiObject -ErrorAction SilentlyContinue)) {
-  $items = Get-WmiObject -Class '%s' -ErrorAction Stop
-}
-$values = $items |
-  Where-Object { $_.%s } |
-  Select-Object -ExpandProperty '%s'
-foreach ($entry in $values) {
-  if ($null -ne $entry) {
-    [Console]::WriteLine(([string]$entry).Trim())
-  }
-}
-`, className, className, property, property)
-
-	out, err := runCollectorOutput(wmicTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))
-	if err != nil {
-		slog.Debug("powershell WMI query failed", "class", className, "property", property, "error", err.Error())
-		return nil
-	}
-
-	seen := make(map[string]struct{})
-	values := make([]string, 0)
-	for _, line := range strings.Split(string(out), "\n") {
-		value := strings.TrimSpace(line)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		values = append(values, value)
-	}
-	return values
-}
-
-func powershellWmiFirstProperty(className, property string) string {
-	values := powershellWmiPropertyValues(className, property)
-	if len(values) == 0 {
-		return ""
-	}
-	return truncateCollectorString(values[0])
-}
-
-func powershellWmiJoinedProperties(className, property string) string {
-	values := powershellWmiPropertyValues(className, property)
-	if len(values) == 0 {
-		return ""
-	}
-	return truncateCollectorString(strings.Join(values, "; "))
-}
-
 // enrichOSInfo refines the OS version/build on Windows using the authoritative
 // registry source (HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion):
 //
@@ -136,16 +74,80 @@ func enrichOSInfo(info *SystemInfo) {
 	}
 }
 
+// collectPlatformHardware queries Win32_BIOS, Win32_BaseBoard,
+// Win32_ComputerSystem, and Win32_VideoController in a single PowerShell
+// invocation (one process spawn instead of ~9) and populates hw with the
+// results. Graceful degradation: a failed or unparseable response leaves the
+// affected fields empty.
 func collectPlatformHardware(hw *HardwareInfo) {
-	hw.SerialNumber = firstCleanHardwareIdentityValue(
-		powershellWmiFirstProperty("Win32_BIOS", "SerialNumber"),
-		powershellWmiFirstProperty("Win32_BaseBoard", "SerialNumber"),
-	)
-	hw.Manufacturer = cleanHardwareIdentityValue(powershellWmiFirstProperty("Win32_ComputerSystem", "Manufacturer"))
-	hw.Model = cleanHardwareIdentityValue(powershellWmiFirstProperty("Win32_ComputerSystem", "Model"))
-	hw.MotherboardManufacturer = cleanHardwareIdentityValue(powershellWmiFirstProperty("Win32_BaseBoard", "Manufacturer"))
-	hw.MotherboardProduct = cleanHardwareIdentityValue(powershellWmiFirstProperty("Win32_BaseBoard", "Product"))
-	hw.MotherboardVersion = cleanHardwareIdentityValue(powershellWmiFirstProperty("Win32_BaseBoard", "Version"))
-	hw.BIOSVersion = powershellWmiFirstProperty("Win32_BIOS", "SMBIOSBIOSVersion")
-	hw.GPUModel = powershellWmiJoinedProperties("Win32_VideoController", "Name")
+	// One batched PowerShell invocation fetches all WMI properties at once,
+	// cutting ~9 cold-start process spawns per collection cycle down to one.
+	// Each WMI class tries Get-CimInstance first (preferred, modern) and falls
+	// back to Get-WmiObject for older hosts where CIM is unavailable.
+	script := `
+$ErrorActionPreference = 'SilentlyContinue'
+function Get-WmiSafe($ClassName) {
+  $r = $null
+  if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
+    try { $r = Get-CimInstance -ClassName $ClassName -ErrorAction Stop } catch {}
+  }
+  if ($null -eq $r -and (Get-Command Get-WmiObject -ErrorAction SilentlyContinue)) {
+    try { $r = Get-WmiObject -Class $ClassName -ErrorAction Stop } catch {}
+  }
+  $r
+}
+$bios  = @(Get-WmiSafe 'Win32_BIOS')          | Select-Object -First 1
+$board = @(Get-WmiSafe 'Win32_BaseBoard')      | Select-Object -First 1
+$sys   = @(Get-WmiSafe 'Win32_ComputerSystem') | Select-Object -First 1
+$gpus  = @(@(Get-WmiSafe 'Win32_VideoController') |
+  Where-Object { $_ -and $_.Name } |
+  Select-Object -ExpandProperty Name |
+  ForEach-Object { ([string]$_).Trim() } |
+  Where-Object { $_ -ne '' } |
+  Select-Object -Unique)
+[PSCustomObject]@{
+  BiosSerial        = if ($bios)  { ([string]$bios.SerialNumber).Trim() }      else { '' }
+  BiosVersion       = if ($bios)  { ([string]$bios.SMBIOSBIOSVersion).Trim() } else { '' }
+  BoardSerial       = if ($board) { ([string]$board.SerialNumber).Trim() }     else { '' }
+  BoardManufacturer = if ($board) { ([string]$board.Manufacturer).Trim() }     else { '' }
+  BoardProduct      = if ($board) { ([string]$board.Product).Trim() }          else { '' }
+  BoardVersion      = if ($board) { ([string]$board.Version).Trim() }          else { '' }
+  SysManufacturer   = if ($sys)   { ([string]$sys.Manufacturer).Trim() }       else { '' }
+  SysModel          = if ($sys)   { ([string]$sys.Model).Trim() }              else { '' }
+  GPUNames          = $gpus
+} | ConvertTo-Json -Compress
+`
+
+	out, err := runCollectorOutput(wmicTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))
+	if err != nil {
+		slog.Debug("hardware WMI batch query failed", "error", err.Error())
+		return
+	}
+
+	parsed, err := parseHardwareJSON(out)
+	if err != nil {
+		slog.Debug("hardware WMI batch query JSON parse failed", "error", err.Error())
+		return
+	}
+
+	hw.SerialNumber = firstCleanHardwareIdentityValue(parsed.BiosSerial, parsed.BoardSerial)
+	hw.Manufacturer = cleanHardwareIdentityValue(parsed.SysManufacturer)
+	hw.Model = cleanHardwareIdentityValue(parsed.SysModel)
+	hw.MotherboardManufacturer = cleanHardwareIdentityValue(parsed.BoardManufacturer)
+	hw.MotherboardProduct = cleanHardwareIdentityValue(parsed.BoardProduct)
+	hw.MotherboardVersion = cleanHardwareIdentityValue(parsed.BoardVersion)
+	hw.BIOSVersion = truncateCollectorString(strings.TrimSpace(parsed.BiosVersion))
+
+	// Join GPU names exactly as before: unique, non-empty, separated by "; ".
+	// De-duplication was handled in PowerShell (Select-Object -Unique); trim
+	// any stray whitespace that slipped through and drop empty strings.
+	gpuParts := make([]string, 0, len(parsed.GPUNames))
+	for _, name := range parsed.GPUNames {
+		if name = strings.TrimSpace(name); name != "" {
+			gpuParts = append(gpuParts, name)
+		}
+	}
+	if len(gpuParts) > 0 {
+		hw.GPUModel = truncateCollectorString(strings.Join(gpuParts, "; "))
+	}
 }

--- a/agent/internal/collectors/hardware_windows.go
+++ b/agent/internal/collectors/hardware_windows.go
@@ -120,13 +120,16 @@ $gpus  = @(@(Get-WmiSafe 'Win32_VideoController') |
 
 	out, err := runCollectorOutput(wmicTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", utf8PowerShellCommand(script))
 	if err != nil {
-		slog.Debug("hardware WMI batch query failed", "error", err.Error())
+		// Whole-scan failure (powershell blocked by WDAC/AppLocker, WMI repository
+		// corruption, timeout, …) leaves every WMI-derived field empty this cycle,
+		// so log at Warn — Debug is suppressed at the default "info" level.
+		slog.Warn("hardware WMI batch query failed; WMI-derived hardware fields empty this cycle", "error", err.Error())
 		return
 	}
 
 	parsed, err := parseHardwareJSON(out)
 	if err != nil {
-		slog.Debug("hardware WMI batch query JSON parse failed", "error", err.Error())
+		slog.Warn("hardware WMI batch query JSON parse failed; WMI-derived hardware fields empty this cycle", "error", err.Error(), "bytes", len(out))
 		return
 	}
 
@@ -138,9 +141,9 @@ $gpus  = @(@(Get-WmiSafe 'Win32_VideoController') |
 	hw.MotherboardVersion = cleanHardwareIdentityValue(parsed.BoardVersion)
 	hw.BIOSVersion = truncateCollectorString(strings.TrimSpace(parsed.BiosVersion))
 
-	// Join GPU names exactly as before: unique, non-empty, separated by "; ".
-	// De-duplication was handled in PowerShell (Select-Object -Unique); trim
-	// any stray whitespace that slipped through and drop empty strings.
+	// Join GPU names in the same shape as before: unique, non-empty, "; "-joined.
+	// De-duplication is handled in PowerShell (Select-Object -Unique, which is
+	// case-insensitive); here we just trim stray whitespace and drop empties.
 	gpuParts := make([]string, 0, len(parsed.GPUNames))
 	for _, name := range parsed.GPUNames {
 		if name = strings.TrimSpace(name); name != "" {

--- a/agent/internal/collectors/hardware_wmi_parse.go
+++ b/agent/internal/collectors/hardware_wmi_parse.go
@@ -1,0 +1,28 @@
+package collectors
+
+import "encoding/json"
+
+// windowsHardwareJSON is the shape emitted by the batched WMI PowerShell query
+// in collectPlatformHardware. It lives in a build-tag-free file so the parser
+// and its tests can run cross-platform (darwin/linux CI).
+type windowsHardwareJSON struct {
+	BiosSerial        string   `json:"BiosSerial"`
+	BiosVersion       string   `json:"BiosVersion"`
+	BoardSerial       string   `json:"BoardSerial"`
+	BoardManufacturer string   `json:"BoardManufacturer"`
+	BoardProduct      string   `json:"BoardProduct"`
+	BoardVersion      string   `json:"BoardVersion"`
+	SysManufacturer   string   `json:"SysManufacturer"`
+	SysModel          string   `json:"SysModel"`
+	GPUNames          []string `json:"GPUNames"`
+}
+
+// parseHardwareJSON decodes the JSON output from the batched WMI query.
+// Unknown fields are ignored; missing or null fields leave the zero value.
+func parseHardwareJSON(data []byte) (windowsHardwareJSON, error) {
+	var result windowsHardwareJSON
+	if err := json.Unmarshal(data, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}

--- a/agent/internal/collectors/hardware_wmi_parse.go
+++ b/agent/internal/collectors/hardware_wmi_parse.go
@@ -1,20 +1,56 @@
 package collectors
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// gpuNameList is the GPU-name field of the batched WMI query. It exists to
+// tolerate both shapes Windows can emit: a JSON array ("GPUNames":["a","b"])
+// and — critically — a bare scalar string. Windows PowerShell 5.1 (the default
+// shell on essentially every managed endpoint) collapses a single-element array
+// to a scalar during ConvertTo-Json, so a one-GPU host (the common case) emits
+// "GPUNames":"Intel UHD" rather than ["Intel UHD"]. Decoding straight into a
+// []string would fail on those hosts and, because the caller treats any parse
+// error as fatal, would drop the entire hardware record (serial, model, …).
+type gpuNameList []string
+
+// UnmarshalJSON accepts a JSON array, a bare string, or null/empty.
+func (g *gpuNameList) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*g = nil
+		return nil
+	}
+	if trimmed[0] == '[' {
+		var many []string
+		if err := json.Unmarshal(trimmed, &many); err != nil {
+			return err
+		}
+		*g = many
+		return nil
+	}
+	var one string
+	if err := json.Unmarshal(trimmed, &one); err != nil {
+		return err
+	}
+	*g = []string{one}
+	return nil
+}
 
 // windowsHardwareJSON is the shape emitted by the batched WMI PowerShell query
 // in collectPlatformHardware. It lives in a build-tag-free file so the parser
 // and its tests can run cross-platform (darwin/linux CI).
 type windowsHardwareJSON struct {
-	BiosSerial        string   `json:"BiosSerial"`
-	BiosVersion       string   `json:"BiosVersion"`
-	BoardSerial       string   `json:"BoardSerial"`
-	BoardManufacturer string   `json:"BoardManufacturer"`
-	BoardProduct      string   `json:"BoardProduct"`
-	BoardVersion      string   `json:"BoardVersion"`
-	SysManufacturer   string   `json:"SysManufacturer"`
-	SysModel          string   `json:"SysModel"`
-	GPUNames          []string `json:"GPUNames"`
+	BiosSerial        string      `json:"BiosSerial"`
+	BiosVersion       string      `json:"BiosVersion"`
+	BoardSerial       string      `json:"BoardSerial"`
+	BoardManufacturer string      `json:"BoardManufacturer"`
+	BoardProduct      string      `json:"BoardProduct"`
+	BoardVersion      string      `json:"BoardVersion"`
+	SysManufacturer   string      `json:"SysManufacturer"`
+	SysModel          string      `json:"SysModel"`
+	GPUNames          gpuNameList `json:"GPUNames"`
 }
 
 // parseHardwareJSON decodes the JSON output from the batched WMI query.

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -51,7 +51,9 @@ type Config struct {
 	HeartbeatIntervalSeconds     int      `mapstructure:"heartbeat_interval_seconds"`
 	MetricsIntervalSeconds       int      `mapstructure:"metrics_interval_seconds"`
 	ProcessSampleIntervalSeconds int      `mapstructure:"process_sample_interval_seconds"`
-	PatchScanIntervalHours       int      `mapstructure:"patch_scan_interval_hours"`
+	// PatchScanIntervalHours is the cadence of the (expensive) patch scan, in
+	// hours. Clamped to [1, 168] at the use site; defaults to DefaultPatchScanIntervalHours.
+	PatchScanIntervalHours int `mapstructure:"patch_scan_interval_hours"`
 	EnabledCollectors            []string `mapstructure:"enabled_collectors"`
 	BackupEnabled                bool     `mapstructure:"backup_enabled"`
 	BackupPaths                  []string `mapstructure:"backup_paths"`
@@ -190,12 +192,16 @@ func ConfigDir() string {
 	return configDir()
 }
 
+// DefaultPatchScanIntervalHours is the default patch-scan cadence. Shared so the
+// config default and the heartbeat clamp don't drift apart.
+const DefaultPatchScanIntervalHours = 24
+
 func Default() *Config {
 	return &Config{
 		HeartbeatIntervalSeconds:     60,
 		MetricsIntervalSeconds:       30,
 		ProcessSampleIntervalSeconds: 180,
-		PatchScanIntervalHours:       24,
+		PatchScanIntervalHours:       DefaultPatchScanIntervalHours,
 		EnabledCollectors:            []string{"hardware", "software", "metrics", "network"},
 		LogLevel:                     "info",
 		LogFormat:                    "text",

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	HeartbeatIntervalSeconds     int      `mapstructure:"heartbeat_interval_seconds"`
 	MetricsIntervalSeconds       int      `mapstructure:"metrics_interval_seconds"`
 	ProcessSampleIntervalSeconds int      `mapstructure:"process_sample_interval_seconds"`
+	PatchScanIntervalHours       int      `mapstructure:"patch_scan_interval_hours"`
 	EnabledCollectors            []string `mapstructure:"enabled_collectors"`
 	BackupEnabled                bool     `mapstructure:"backup_enabled"`
 	BackupPaths                  []string `mapstructure:"backup_paths"`
@@ -194,6 +195,7 @@ func Default() *Config {
 		HeartbeatIntervalSeconds:     60,
 		MetricsIntervalSeconds:       30,
 		ProcessSampleIntervalSeconds: 180,
+		PatchScanIntervalHours:       24,
 		EnabledCollectors:            []string{"hardware", "software", "metrics", "network"},
 		LogLevel:                     "info",
 		LogFormat:                    "text",

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -246,6 +246,20 @@ func handleRefreshInventory(h *Heartbeat, _ Command) tools.CommandResult {
 		h.sendInventoryFn()
 	} else {
 		h.sendInventory()
+		// Hardware, patch, security, and session inventory run on their own
+		// cadences (daily / 5-min) and are no longer part of the sendInventory
+		// fan-out, so dispatch them explicitly here to keep "Refresh Inventory" a
+		// full refresh of everything in the dispatched list below.
+		go h.sendHardwareInventory()
+		go h.sendPatchInventory()
+		go h.sendSecurityStatus()
+		go h.sendSessionInventory()
+		// Reset the daily gates so the scheduler doesn't immediately re-run the
+		// hardware/patch scans right after this manual refresh.
+		h.mu.Lock()
+		h.lastHardwareUpdate = time.Now()
+		h.lastPatchUpdate = time.Now()
+		h.mu.Unlock()
 	}
 	return tools.NewSuccessResult(map[string]any{
 		"dispatched": []string{

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -236,10 +236,12 @@ func handleWakeOnLan(_ *Heartbeat, cmd Command) tools.CommandResult {
 
 // handleRefreshInventory triggers an immediate run of the full inventory cycle
 // (hardware, software, disk, network, configuration changes, sessions,
-// connections, patches, policy state, security status, Apple warranty). Each
-// collector is dispatched to its own goroutine via h.sendInventory(); the
-// returned result acknowledges the dispatch synchronously while data flows in
-// over the next 30s–2min as each collector completes.
+// connections, patches, policy state, security status, Apple warranty). Most
+// collectors are dispatched via h.sendInventory(); hardware, patch, security,
+// and session inventory are dispatched separately here because they run on
+// their own cadences (daily / 5-min) and are no longer in the sendInventory
+// fan-out. Each runs in its own goroutine; the returned result acknowledges the
+// dispatch synchronously while data flows in over the next 30s–2min.
 func handleRefreshInventory(h *Heartbeat, _ Command) tools.CommandResult {
 	start := time.Now()
 	if h.sendInventoryFn != nil {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -162,6 +162,8 @@ type Heartbeat struct {
 	lastSessionUpdate     time.Time
 	lastPostureUpdate     time.Time
 	lastReliabilityUpdate time.Time
+	lastHardwareUpdate    time.Time // zero-value fires on first tick, then every 24 h
+	lastPatchUpdate       time.Time // zero-value fires on first tick, then per PatchScanIntervalHours
 
 	// User session helper (IPC)
 	helperToken      string // retained copy of the helper-scoped token for connect-time pushes
@@ -852,8 +854,13 @@ func (h *Heartbeat) Start() {
 	// Send initial heartbeat after jitter
 	h.sendHeartbeatWithWatchdog()
 
-	// Send initial inventory in background
+	// Send initial inventory in background. Hardware and patch inventory are not
+	// part of the sendInventory fan-out (they run on a daily cadence), so kick
+	// them off here too — a freshly started/enrolled agent should report hardware
+	// and pending patches promptly rather than waiting for the first daily tick.
 	go h.sendInventory()
+	go h.sendHardwareInventory()
+	go h.sendPatchInventory()
 	go h.runProcessSampler()
 
 	// Reliability cadence persists across restarts (#1906). Seed the in-memory
@@ -875,6 +882,8 @@ func (h *Heartbeat) Start() {
 	} else {
 		h.lastReliabilityUpdate = persistedReliability
 	}
+	h.lastHardwareUpdate = startupNow
+	h.lastPatchUpdate = startupNow
 	h.mu.Unlock()
 	if postReliability {
 		go h.sendReliabilityMetrics(startupNow)
@@ -918,6 +927,20 @@ func (h *Heartbeat) Start() {
 			shouldSendReliability := reliabilityPostDue(h.lastReliabilityUpdate, now)
 			if shouldSendReliability {
 				h.lastReliabilityUpdate = now
+			}
+			// Hardware identity rarely changes; collect once per day.
+			// Zero-value lastHardwareUpdate fires immediately on the first tick after
+			// startup so the server always gets fresh hardware data on reconnect.
+			shouldSendHardware := now.Sub(h.lastHardwareUpdate) > 24*time.Hour
+			if shouldSendHardware {
+				h.lastHardwareUpdate = now
+			}
+			// Patch scan cadence is configurable (PatchScanIntervalHours, default 24 h).
+			// Zero-value lastPatchUpdate fires on first tick after startup.
+			patchIntervalHours := clampPatchScanIntervalHours(h.config.PatchScanIntervalHours)
+			shouldSendPatch := now.Sub(h.lastPatchUpdate) > time.Duration(patchIntervalHours)*time.Hour
+			if shouldSendPatch {
+				h.lastPatchUpdate = now
 			}
 			h.mu.Unlock()
 
@@ -983,6 +1006,12 @@ func (h *Heartbeat) Start() {
 				// `now` was captured under the lock above; the persisted gate is
 				// advanced to it only on a confirmed send (#1906).
 				go h.sendReliabilityMetrics(now)
+			}
+			if shouldSendHardware {
+				go h.sendHardwareInventory()
+			}
+			if shouldSendPatch {
+				go h.sendPatchInventory()
 			}
 		case <-h.stopChan:
 			return
@@ -1082,21 +1111,23 @@ func (h *Heartbeat) sendMonitoringResults(results []monitoring.CheckResult) {
 	}
 }
 
-// sendInventory collects and sends hardware, software, disk, network, connections, and patch inventory.
-// All goroutines are tracked via inventoryWg for graceful shutdown.
+// sendInventory collects and sends the 15-minute inventory set: software, disk,
+// network, configuration changes, connections, policy registry/config state, and
+// Apple warranty info. All goroutines are tracked via inventoryWg for graceful shutdown.
+//
+// Note: hardware inventory, patch inventory, security status, and session inventory
+// are intentionally absent here — each runs on its own independent cadence:
+//   - hardware / patch:   daily (or configured), dispatched from the tick gate
+//   - security / sessions: every 5 minutes, dispatched from their own tick gates
 func (h *Heartbeat) sendInventory() {
 	fns := []func(){
-		h.sendHardwareInventory,
 		h.sendSoftwareInventory,
 		h.sendDiskInventory,
 		h.sendNetworkInventory,
 		h.sendConfigurationChanges,
-		h.sendSessionInventory,
 		h.sendConnectionsInventory,
-		h.sendPatchInventory,
 		h.sendPolicyRegistryState,
 		h.sendPolicyConfigState,
-		h.sendSecurityStatus,
 		h.sendAppleWarrantyInfo,
 	}
 	for _, fn := range fns {
@@ -1170,6 +1201,19 @@ func clampProcessSampleInterval(secs int) int {
 		return 3600
 	}
 	return secs
+}
+
+// clampPatchScanIntervalHours bounds the configured patch scan interval to
+// [1, 168] hours (1 hour to 7 days). Pure (no side effects) so it can be
+// unit-tested independently. A value ≤0 (unset/zero) returns the default 24 h.
+func clampPatchScanIntervalHours(hours int) int {
+	if hours <= 0 {
+		return 24
+	}
+	if hours > 168 {
+		return 168
+	}
+	return hours
 }
 
 // runProcessSampler periodically captures a top-N process snapshot and POSTs it,
@@ -3271,6 +3315,10 @@ func (h *Heartbeat) executePatchInstallCommand(payload map[string]any, rollback 
 			case <-time.After(60 * time.Second):
 				log.Info("post-install patch rescan triggered", "successCount", successCount)
 				h.sendPatchInventory()
+				// Reset the daily gate so the scheduler doesn't re-scan immediately.
+				h.mu.Lock()
+				h.lastPatchUpdate = time.Now()
+				h.mu.Unlock()
 			case <-h.stopChan:
 				log.Info("post-install patch rescan cancelled — agent shutting down")
 			}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -162,8 +162,8 @@ type Heartbeat struct {
 	lastSessionUpdate     time.Time
 	lastPostureUpdate     time.Time
 	lastReliabilityUpdate time.Time
-	lastHardwareUpdate    time.Time // zero-value fires on first tick, then every 24 h
-	lastPatchUpdate       time.Time // zero-value fires on first tick, then per PatchScanIntervalHours
+	lastHardwareUpdate    time.Time // stamped at startup; gate then re-runs every 24 h
+	lastPatchUpdate       time.Time // stamped at startup; gate then re-runs every PatchScanIntervalHours
 
 	// User session helper (IPC)
 	helperToken      string // retained copy of the helper-scoped token for connect-time pushes
@@ -928,17 +928,17 @@ func (h *Heartbeat) Start() {
 			if shouldSendReliability {
 				h.lastReliabilityUpdate = now
 			}
-			// Hardware identity rarely changes; collect once per day.
-			// Zero-value lastHardwareUpdate fires immediately on the first tick after
-			// startup so the server always gets fresh hardware data on reconnect.
-			shouldSendHardware := now.Sub(h.lastHardwareUpdate) > 24*time.Hour
+			// Hardware identity rarely changes; collect once per day. The initial
+			// send happens via the explicit startup dispatch (see Start), which
+			// stamps lastHardwareUpdate; this gate handles every subsequent day.
+			shouldSendHardware := dueForRun(now, h.lastHardwareUpdate, 24*time.Hour)
 			if shouldSendHardware {
 				h.lastHardwareUpdate = now
 			}
 			// Patch scan cadence is configurable (PatchScanIntervalHours, default 24 h).
-			// Zero-value lastPatchUpdate fires on first tick after startup.
+			// Initial send is the explicit startup dispatch; this gate handles the rest.
 			patchIntervalHours := clampPatchScanIntervalHours(h.config.PatchScanIntervalHours)
-			shouldSendPatch := now.Sub(h.lastPatchUpdate) > time.Duration(patchIntervalHours)*time.Hour
+			shouldSendPatch := dueForRun(now, h.lastPatchUpdate, time.Duration(patchIntervalHours)*time.Hour)
 			if shouldSendPatch {
 				h.lastPatchUpdate = now
 			}
@@ -1205,15 +1205,22 @@ func clampProcessSampleInterval(secs int) int {
 
 // clampPatchScanIntervalHours bounds the configured patch scan interval to
 // [1, 168] hours (1 hour to 7 days). Pure (no side effects) so it can be
-// unit-tested independently. A value ≤0 (unset/zero) returns the default 24 h.
+// unit-tested independently. A value ≤0 (unset/zero) returns the default.
 func clampPatchScanIntervalHours(hours int) int {
 	if hours <= 0 {
-		return 24
+		return config.DefaultPatchScanIntervalHours
 	}
 	if hours > 168 {
 		return 168
 	}
 	return hours
+}
+
+// dueForRun reports whether a periodic task is due — true once at least interval
+// has elapsed since its last run. A zero-value last (never run) is always due.
+// Pure, so the cadence math can be unit-tested independently of the tick loop.
+func dueForRun(now, last time.Time, interval time.Duration) bool {
+	return now.Sub(last) > interval
 }
 
 // runProcessSampler periodically captures a top-N process snapshot and POSTs it,

--- a/agent/internal/heartbeat/heartbeat_processsampler_test.go
+++ b/agent/internal/heartbeat/heartbeat_processsampler_test.go
@@ -1,6 +1,9 @@
 package heartbeat
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestClampProcessSampleInterval(t *testing.T) {
 	cases := []struct {
@@ -38,6 +41,28 @@ func TestClampPatchScanIntervalHours(t *testing.T) {
 	for _, c := range cases {
 		if got := clampPatchScanIntervalHours(c.in); got != c.want {
 			t.Errorf("clampPatchScanIntervalHours(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDueForRun(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	day := 24 * time.Hour
+	cases := []struct {
+		name     string
+		last     time.Time
+		interval time.Duration
+		want     bool
+	}{
+		{name: "never run (zero value) is always due", last: time.Time{}, interval: day, want: true},
+		{name: "interval fully elapsed", last: now.Add(-25 * time.Hour), interval: day, want: true},
+		{name: "interval not yet elapsed", last: now.Add(-1 * time.Hour), interval: day, want: false},
+		{name: "exactly at boundary is not due", last: now.Add(-day), interval: day, want: false},
+		{name: "just past boundary is due", last: now.Add(-day - time.Second), interval: day, want: true},
+	}
+	for _, c := range cases {
+		if got := dueForRun(now, c.last, c.interval); got != c.want {
+			t.Errorf("%s: dueForRun = %v, want %v", c.name, got, c.want)
 		}
 	}
 }

--- a/agent/internal/heartbeat/heartbeat_processsampler_test.go
+++ b/agent/internal/heartbeat/heartbeat_processsampler_test.go
@@ -21,3 +21,23 @@ func TestClampProcessSampleInterval(t *testing.T) {
 		}
 	}
 }
+
+func TestClampPatchScanIntervalHours(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{in: 0, want: 24},    // unset/zero → default 24 h
+		{in: -1, want: 24},   // negative → default 24 h
+		{in: 1, want: 1},     // min boundary
+		{in: 24, want: 24},   // default, in range
+		{in: 48, want: 48},   // arbitrary in-range value
+		{in: 168, want: 168}, // max boundary (7 days)
+		{in: 500, want: 168}, // above max → ceiling
+	}
+	for _, c := range cases {
+		if got := clampPatchScanIntervalHours(c.in); got != c.want {
+			t.Errorf("clampPatchScanIntervalHours(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Triggered by continuous `powershell.exe` observed on a managed Windows endpoint. An audit confirmed the agent was spawning a burst of fresh PowerShell processes on a tight cadence: ~7 spawns every 5 min plus a ~20-process burst every 15 min, including one genuinely slow op (the Windows Update online scan) each cycle. Upstream data *volume* was fine — the cost was local CPU churn from process spawning.

## What changed (agent only)

- **Batched the hardware collector** (`hardware_windows.go`): replaced ~9 per-property `Get-CimInstance` PowerShell spawns with **one** invocation returning all BIOS/baseboard/system/GPU properties as JSON, parsed in Go (CIM with `Get-WmiObject` fallback preserved). JSON parsing extracted to a build-tag-free, unit-tested helper.
- **Hardware → daily** (24h) instead of every 15 min; still sent promptly at startup/enrollment. Hardware identity rarely changes.
- **Patch scan → daily**, configurable via `patch_scan_interval_hours` (default 24, clamped 1h–7d). The uncached `Microsoft.Update.Session` online search went from ~96×/day to 1×/day. On-demand `patch_scan` / `refresh_inventory` commands and the post-install rescan still force an immediate scan.
- **De-duped scheduling**: `sendSecurityStatus` + `sendSessionInventory` were in both their own 5-min timers *and* the 15-min inventory fan-out (firing twice per 15-min window). Removed from the fan-out — now once per 5 min.

Net steady-state effect on Windows: the recurring PowerShell spawn rate drops sharply and the expensive WU scan runs once a day, with no loss of on-demand freshness.

## Review fixes folded in

A full PR review (code/tests/errors/comments/types) ran on the change. Notable:

- **Merge-blocker fixed:** Windows PowerShell 5.1's `ConvertTo-Json` collapses a single-element array to a scalar, so a one-GPU host (the common case) emitted `"GPUNames":"…"` not `["…"]` — which failed the `[]string` decode and, since parse errors were fatal, dropped the **entire** hardware record. Added a `gpuNameList` type tolerant of scalar/array/null + regression tests.
- Total WMI-scan failure now logs at **Warn** (was `Debug`, suppressed at the default level — blank hardware was invisible).
- Cadence decision extracted to a pure, table-tested `dueForRun()` helper; comment accuracy fixes.

## Deferred follow-ups (noted, not in this PR)

- **Success-gated retry** — a failed *startup* scan currently waits the full interval before retrying (matches the existing advance-on-dispatch convention for every sibling collector; patch scan is expensive so naive retry has a perf cost).
- **Patch-policy-aligned scan timing** — the server has `config_policy_patch_settings.scheduleTime/Frequency`, but it's an *install* cadence (not scan) and isn't pushed to the agent today; wiring it spans three layers.

## Testing

- Native build + Windows/macOS cross-compile + `go vet` clean.
- `go test ./internal/heartbeat/... ./internal/config/... ./internal/collectors/...` green, including new tests for the JSON parser (array/scalar/null/empty), the interval clamp, and `dueForRun`.
- ⚠️ The GPU-scalar path only manifests on real PowerShell 5.1 — recommend a quick validation on the Windows test VM via `make dev-push` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)