### PR TITLE
fix(web): show all services + reliable Close/Back in Remote Tools

### DIFF
--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -297,6 +297,32 @@ describe('system tools routes', () => {
     expect(body.meta.total).toBe(1);
   });
 
+  it('forwards a high services limit and clamps it to the route maximum (500)', async () => {
+    mockDeviceSelect();
+    mockExecuteCommand.mockResolvedValue({
+      status: 'completed',
+      stdout: JSON.stringify({ services: [], total: 0, page: 1, limit: 500, totalPages: 0 })
+    });
+
+    // The web Services tab requests ?limit=500 to fetch the full list in one
+    // request; values above the route cap must clamp to 500, not fall back to 50.
+    await app.request(`/system-tools/devices/${deviceId}/services?limit=500`);
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith(
+      deviceId,
+      'LIST_SERVICES',
+      expect.objectContaining({ limit: 500 }),
+      expect.anything()
+    );
+
+    await app.request(`/system-tools/devices/${deviceId}/services?limit=600`);
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith(
+      deviceId,
+      'LIST_SERVICES',
+      expect.objectContaining({ limit: 500 }),
+      expect.anything()
+    );
+  });
+
   it('gets service details via agent command', async () => {
     mockDeviceSelect();
     mockExecuteCommand.mockResolvedValue({

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -96,7 +96,10 @@ servicesRoutes.get(
     }
 
     const query = c.req.valid('query');
-    const { page, limit } = getPagination(query);
+    // The Services UI paginates client-side, so it fetches the full list in one
+    // request. Allow up to the agent's per-page maximum (500) instead of the
+    // default cap of 100 so all of a device's services are returned.
+    const { page, limit } = getPagination(query, 500);
     const search = query.search || '';
     const status = query.status || '';
 

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -96,9 +96,12 @@ servicesRoutes.get(
     }
 
     const query = c.req.valid('query');
-    // The Services UI paginates client-side, so it fetches the full list in one
-    // request. Allow up to the agent's per-page maximum (500) instead of the
-    // default cap of 100 so all of a device's services are returned.
+    // The Services UI paginates client-side, so it fetches the list in one
+    // request with a high limit. Allow up to 500 (the agent's max accepted page
+    // size, matching the Processes tab) instead of the default cap of 100 — this
+    // covers realistic Windows service counts. The agent hard-caps the full list
+    // at 512 (maxServiceListEntries), so devices with >500 services are not paged
+    // through here; 500 is intentionally the single-request ceiling.
     const { page, limit } = getPagination(query, 500);
     const search = query.search || '';
     const status = query.status || '';

--- a/apps/web/src/components/remote/RemoteFilesPage.tsx
+++ b/apps/web/src/components/remote/RemoteFilesPage.tsx
@@ -49,9 +49,11 @@ export default function RemoteFilesPage({ deviceId }: RemoteFilesPageProps) {
   }, [deviceId]);
 
   const handleBack = () => {
-    // Navigate deterministically to the device's detail page rather than relying
-    // on window.history.back(), which lands on intermediate SPA history entries
-    // (or nowhere, on a direct visit) after the user has navigated around.
+    // Always return to this device's detail page. This page can be opened from
+    // the devices list, the remote launcher, or device detail, so this is an
+    // intentional, fixed destination rather than a true "back": history.back()
+    // was unreliable across those origins (it lands on intermediate SPA history
+    // entries) and dead-ends on a direct visit.
     void navigateTo(`/devices/${deviceId}`);
   };
 

--- a/apps/web/src/components/remote/RemoteFilesPage.tsx
+++ b/apps/web/src/components/remote/RemoteFilesPage.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Monitor, Loader2, AlertCircle } from 'lucide-react';
 import FileManager from './FileManager';
 import { getInitialFilePath, type DeviceOs } from './filePathUtils';
 import { fetchWithAuth } from '@/stores/auth';
+import { navigateTo } from '@/lib/navigation';
 import Breadcrumbs from '../layout/Breadcrumbs';
 
 type Device = {
@@ -48,7 +49,10 @@ export default function RemoteFilesPage({ deviceId }: RemoteFilesPageProps) {
   }, [deviceId]);
 
   const handleBack = () => {
-    window.history.back();
+    // Navigate deterministically to the device's detail page rather than relying
+    // on window.history.back(), which lands on intermediate SPA history entries
+    // (or nowhere, on a direct visit) after the user has navigated around.
+    void navigateTo(`/devices/${deviceId}`);
   };
 
   const handleError = (errorMessage: string) => {

--- a/apps/web/src/components/remote/RemoteTerminalPage.tsx
+++ b/apps/web/src/components/remote/RemoteTerminalPage.tsx
@@ -48,9 +48,11 @@ export default function RemoteTerminalPage({ deviceId }: RemoteTerminalPageProps
   }, [deviceId]);
 
   const handleBack = () => {
-    // Navigate deterministically to the device's detail page rather than relying
-    // on window.history.back(), which lands on intermediate SPA history entries
-    // (or nowhere, on a direct visit) after the user has navigated around.
+    // Always return to this device's detail page. This page can be opened from
+    // the devices list, the remote launcher, or device detail, so this is an
+    // intentional, fixed destination rather than a true "back": history.back()
+    // was unreliable across those origins (it lands on intermediate SPA history
+    // entries) and dead-ends on a direct visit.
     void navigateTo(`/devices/${deviceId}`);
   };
 

--- a/apps/web/src/components/remote/RemoteTerminalPage.tsx
+++ b/apps/web/src/components/remote/RemoteTerminalPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { ArrowLeft, Monitor, Loader2, AlertCircle } from 'lucide-react';
 import RemoteTerminal from './RemoteTerminal';
 import { fetchWithAuth } from '@/stores/auth';
+import { navigateTo } from '@/lib/navigation';
 
 type Device = {
   id: string;
@@ -47,7 +48,10 @@ export default function RemoteTerminalPage({ deviceId }: RemoteTerminalPageProps
   }, [deviceId]);
 
   const handleBack = () => {
-    window.history.back();
+    // Navigate deterministically to the device's detail page rather than relying
+    // on window.history.back(), which lands on intermediate SPA history entries
+    // (or nowhere, on a direct visit) after the user has navigated around.
+    void navigateTo(`/devices/${deviceId}`);
   };
 
   const handleSessionCreated = (newSessionId: string) => {

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -13,6 +13,7 @@ import {
   ShieldOff
 } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
+import { navigateTo } from '@/lib/navigation';
 
 // Import actual components
 import ProcessManager, { type Process, type ProcessStatus } from './ProcessManager';
@@ -428,10 +429,12 @@ export default function RemoteToolsPage({
       onClose();
       return;
     }
-    if (typeof window !== 'undefined') {
-      window.history.back();
-    }
-  }, [onClose]);
+    // Navigate deterministically back to the device's detail page (the only
+    // entry point to this page). Using window.history.back() was unreliable:
+    // after the user clicked around, intermediate SPA history entries meant
+    // "back" landed inside Remote Tools instead of leaving it.
+    void navigateTo(`/devices/${deviceId}`);
+  }, [onClose, deviceId]);
 
   useEffect(() => {
     setResolvedDeviceOs(normalizeDeviceOs(deviceOs));
@@ -516,7 +519,9 @@ export default function RemoteToolsPage({
   const fetchServices = useCallback(async () => {
     setServiceLoading(true);
     try {
-      const res = await fetchWithAuth(`/system-tools/devices/${deviceId}/services`);
+      // Fetch the full list (pagination/filtering happens client-side in ServicesManager).
+      // 500 matches the agent's per-page maximum so all services are returned.
+      const res = await fetchWithAuth(`/system-tools/devices/${deviceId}/services?limit=500`);
       if (!res.ok) throw new Error('Failed to fetch services');
       const json = await res.json();
       const data: ApiService[] = Array.isArray(json.data) ? json.data : [];

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -519,8 +519,9 @@ export default function RemoteToolsPage({
   const fetchServices = useCallback(async () => {
     setServiceLoading(true);
     try {
-      // Fetch the full list (pagination/filtering happens client-side in ServicesManager).
-      // 500 matches the agent's per-page maximum so all services are returned.
+      // Fetch with a high limit; ServicesManager paginates/filters client-side.
+      // 500 is the agent's max accepted page size (same as the Processes tab) and
+      // covers realistic Windows service counts (the agent caps the list at 512).
       const res = await fetchWithAuth(`/system-tools/devices/${deviceId}/services?limit=500`);
       if (!res.ok) throw new Error('Failed to fetch services');
       const json = await res.json();


### PR DESCRIPTION
Fixes two unrelated UX bugs in the device **Remote Tools** experience, both reported by Todd.

## 1. Services list was capped at 50

`ServicesManager` paginates **client-side** and expects to receive the device's full service list. But `RemoteToolsPage.fetchServices` requested `/system-tools/devices/:id/services` with **no `limit`**, so the API's `getPagination` defaulted to `limit=50` (and would have capped at 100 anyway). Result: only the first 50 services ever reached the UI.

**Fix:**
- Web requests `?limit=500`.
- API route raises `getPagination`'s `maxLimit` to `500` for this endpoint. The Go agent already accepts `limit` up to 500; its hard safety cap (`maxServiceListEntries = 512`) is untouched. 500 comfortably covers real devices (a busy Windows server runs ~250–350 services).

## 2. Close / Back buttons did an unreliable browser-back

`RemoteToolsPage` (Close), `RemoteTerminalPage` and `RemoteFilesPage` (Back) all fell back to `window.history.back()`. After the user clicks around, Astro's client-side router accumulates intermediate SPA history entries, so `back()` lands *inside* the tool instead of leaving it — and does nothing at all on a direct visit. This is the "Close doesn't work after clicking around" symptom.

**Fix:** navigate deterministically to the device's detail page (`/devices/:id`) via the existing `navigateTo` helper (same open-redirect-guarded path used elsewhere). The device a tools page operates on is unambiguous, so its detail page is always a correct destination.

`VncViewerPage` was left alone — it has only a `tunnelId` (no deviceId) and already navigates deterministically to `/remote`.

## Testing
- `tsc --noEmit` (API) — clean
- `astro check` (web) — 0 errors
- `vitest run src/lib/navigation.test.ts` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)