### PR TITLE
fix(agent): persist reliability send cadence across restarts (#1906)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -854,12 +854,24 @@ func (h *Heartbeat) Start() {
 
 	// Send initial inventory in background
 	go h.sendInventory()
-	go h.sendReliabilityMetrics()
 	go h.runProcessSampler()
+
+	// Reliability cadence persists across restarts (#1906). Seed the in-memory
+	// timer from the last persisted post instead of "now", and only post on
+	// startup if at least 24h have actually elapsed since then. Without this, a
+	// restart-prone device (POS/checkout box, crash, auto-update) re-posted an
+	// overlapping event-log window on every boot → duplicate reliability rows.
+	// A zero persisted time (first-ever run / unreadable state) is older than
+	// any threshold, so the very first post still goes out.
+	persistedReliability := h.loadLastReliabilityUpdate()
 	h.mu.Lock()
 	h.lastPostureUpdate = time.Now()
-	h.lastReliabilityUpdate = time.Now()
+	h.lastReliabilityUpdate = persistedReliability
 	h.mu.Unlock()
+	if time.Since(persistedReliability) > 24*time.Hour {
+		h.markReliabilitySent(time.Now())
+		go h.sendReliabilityMetrics()
+	}
 
 	for {
 		select {
@@ -898,7 +910,7 @@ func (h *Heartbeat) Start() {
 			}
 			shouldSendReliability := time.Since(h.lastReliabilityUpdate) > 24*time.Hour
 			if shouldSendReliability {
-				h.lastReliabilityUpdate = time.Now()
+				h.lastReliabilityUpdate = now
 			}
 			h.mu.Unlock()
 
@@ -961,6 +973,11 @@ func (h *Heartbeat) Start() {
 				go h.sendManagementPosture()
 			}
 			if shouldSendReliability {
+				// Persist the new send time (captured as `now` under the lock
+				// above) so the 24h gate survives the next restart (#1906).
+				if err := h.saveLastReliabilityUpdate(now); err != nil {
+					log.Warn("failed to persist reliability send timestamp", "error", err.Error())
+				}
 				go h.sendReliabilityMetrics()
 			}
 		case <-h.stopChan:

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -862,15 +862,22 @@ func (h *Heartbeat) Start() {
 	// restart-prone device (POS/checkout box, crash, auto-update) re-posted an
 	// overlapping event-log window on every boot → duplicate reliability rows.
 	// A zero persisted time (first-ever run / unreadable state) is older than
-	// any threshold, so the very first post still goes out.
+	// any threshold, so the very first post still goes out. The persisted
+	// timestamp is advanced only on a confirmed send (see sendReliabilityMetrics),
+	// so a failed startup post still retries after the next restart.
+	startupNow := time.Now()
 	persistedReliability := h.loadLastReliabilityUpdate()
+	postReliability := reliabilityPostDue(persistedReliability, startupNow)
 	h.mu.Lock()
-	h.lastPostureUpdate = time.Now()
-	h.lastReliabilityUpdate = persistedReliability
+	h.lastPostureUpdate = startupNow
+	if postReliability {
+		h.lastReliabilityUpdate = startupNow
+	} else {
+		h.lastReliabilityUpdate = persistedReliability
+	}
 	h.mu.Unlock()
-	if time.Since(persistedReliability) > 24*time.Hour {
-		h.markReliabilitySent(time.Now())
-		go h.sendReliabilityMetrics()
+	if postReliability {
+		go h.sendReliabilityMetrics(startupNow)
 	}
 
 	for {
@@ -908,7 +915,7 @@ func (h *Heartbeat) Start() {
 			if shouldSendPosture {
 				h.lastPostureUpdate = now
 			}
-			shouldSendReliability := time.Since(h.lastReliabilityUpdate) > 24*time.Hour
+			shouldSendReliability := reliabilityPostDue(h.lastReliabilityUpdate, now)
 			if shouldSendReliability {
 				h.lastReliabilityUpdate = now
 			}
@@ -973,12 +980,9 @@ func (h *Heartbeat) Start() {
 				go h.sendManagementPosture()
 			}
 			if shouldSendReliability {
-				// Persist the new send time (captured as `now` under the lock
-				// above) so the 24h gate survives the next restart (#1906).
-				if err := h.saveLastReliabilityUpdate(now); err != nil {
-					log.Warn("failed to persist reliability send timestamp", "error", err.Error())
-				}
-				go h.sendReliabilityMetrics()
+				// `now` was captured under the lock above; the persisted gate is
+				// advanced to it only on a confirmed send (#1906).
+				go h.sendReliabilityMetrics(now)
 			}
 		case <-h.stopChan:
 			return
@@ -2169,7 +2173,11 @@ func (h *Heartbeat) sendBootPerformance(metrics *collectors.BootPerformanceMetri
 	}
 }
 
-func (h *Heartbeat) sendReliabilityMetrics() {
+// sendReliabilityMetrics collects and uploads reliability metrics. On a
+// confirmed 2xx it persists sentAt as the last-send time so the 24h cadence
+// survives restarts (#1906); on any failure the persisted gate is left stale
+// so the next restart retries.
+func (h *Heartbeat) sendReliabilityMetrics(sentAt time.Time) {
 	if h.reliabilityCol == nil {
 		return
 	}
@@ -2209,6 +2217,9 @@ func (h *Heartbeat) sendReliabilityMetrics() {
 			"body", string(errBody))
 		return
 	}
+
+	// Confirmed success — advance the persisted 24h gate (#1906).
+	h.persistReliabilitySent(sentAt)
 
 	log.Info("reliability metrics uploaded successfully",
 		"crashes", len(metrics.CrashEvents),

--- a/agent/internal/heartbeat/reliability_state.go
+++ b/agent/internal/heartbeat/reliability_state.go
@@ -1,0 +1,100 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+const reliabilityStateFileName = "reliability_state.json"
+
+// reliabilityState persists the last time reliability metrics were posted so
+// the 24h send cadence survives agent restarts. Without it, every restart
+// (crash, auto-update, machine reboot — frequent on POS/checkout boxes) reset
+// the in-memory timer to its zero value and immediately re-posted an
+// overlapping event-log window, creating duplicate device_reliability_history
+// rows and inflating failure counts (issue #1906).
+type reliabilityState struct {
+	LastUpdate time.Time `json:"lastUpdate"`
+}
+
+// reliabilityStatePath mirrors ipStatePath: prefer the per-user ~/.breeze dir,
+// fall back to the configured data dir, then a temp dir as a last resort.
+func (h *Heartbeat) reliabilityStatePath() string {
+	if homeDir, err := os.UserHomeDir(); err == nil && strings.TrimSpace(homeDir) != "" {
+		return filepath.Join(homeDir, ".breeze", reliabilityStateFileName)
+	}
+
+	dataDir := strings.TrimSpace(config.GetDataDir())
+	if dataDir == "" {
+		tmpPath := filepath.Join(os.TempDir(), "breeze", reliabilityStateFileName)
+		log.Warn("reliability state directory unavailable, falling back to temp dir", "path", tmpPath)
+		return tmpPath
+	}
+	return filepath.Join(dataDir, reliabilityStateFileName)
+}
+
+// loadLastReliabilityUpdate returns the persisted last-send timestamp, or the
+// zero time when no state exists yet or it can't be read/decoded. A zero time
+// is treated as "never sent" by the caller, so a fresh or unreadable state
+// lets the first post go out (fail-open — at worst one extra post, which
+// #1905's aggregation dedup absorbs).
+func (h *Heartbeat) loadLastReliabilityUpdate() time.Time {
+	path := h.reliabilityStatePath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("failed to read reliability state", "path", path, "error", err.Error())
+		}
+		return time.Time{}
+	}
+
+	var st reliabilityState
+	if err := json.Unmarshal(raw, &st); err != nil {
+		log.Warn("failed to decode reliability state", "path", path, "error", err.Error())
+		return time.Time{}
+	}
+	return st.LastUpdate
+}
+
+// saveLastReliabilityUpdate atomically persists the last-send timestamp.
+func (h *Heartbeat) saveLastReliabilityUpdate(t time.Time) error {
+	path := h.reliabilityStatePath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create reliability state directory %s: %w", dir, err)
+	}
+
+	payload, err := json.Marshal(reliabilityState{LastUpdate: t})
+	if err != nil {
+		return fmt.Errorf("failed to encode reliability state: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0600); err != nil {
+		return fmt.Errorf("failed to write reliability state temp file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to persist reliability state %s: %w", path, err)
+	}
+	return nil
+}
+
+// markReliabilitySent records, in memory and on disk, that a reliability post
+// was just initiated so the 24h cadence survives restarts (#1906). A persist
+// failure is logged but non-fatal — the in-memory timer still gates the rest
+// of this process's lifetime.
+func (h *Heartbeat) markReliabilitySent(t time.Time) {
+	h.mu.Lock()
+	h.lastReliabilityUpdate = t
+	h.mu.Unlock()
+	if err := h.saveLastReliabilityUpdate(t); err != nil {
+		log.Warn("failed to persist reliability send timestamp", "error", err.Error())
+	}
+}

--- a/agent/internal/heartbeat/reliability_state.go
+++ b/agent/internal/heartbeat/reliability_state.go
@@ -13,6 +13,19 @@ import (
 
 const reliabilityStateFileName = "reliability_state.json"
 
+// reliabilityPostInterval is the minimum spacing between reliability posts —
+// metrics are meant to go out at most once per this window.
+const reliabilityPostInterval = 24 * time.Hour
+
+// reliabilityPostDue reports whether a reliability post is due given the last
+// time one was sent and the current time. A zero `last` (never sent, or an
+// unreadable/corrupt persisted state) is always due, so the first post fails
+// open. Extracted as a pure function so the gate — the heart of #1906 — is
+// unit-testable without driving the long-running heartbeat loop.
+func reliabilityPostDue(last, now time.Time) bool {
+	return now.Sub(last) > reliabilityPostInterval
+}
+
 // reliabilityState persists the last time reliability metrics were posted so
 // the 24h send cadence survives agent restarts. Without it, every restart
 // (crash, auto-update, machine reboot — frequent on POS/checkout boxes) reset
@@ -86,14 +99,13 @@ func (h *Heartbeat) saveLastReliabilityUpdate(t time.Time) error {
 	return nil
 }
 
-// markReliabilitySent records, in memory and on disk, that a reliability post
-// was just initiated so the 24h cadence survives restarts (#1906). A persist
-// failure is logged but non-fatal — the in-memory timer still gates the rest
-// of this process's lifetime.
-func (h *Heartbeat) markReliabilitySent(t time.Time) {
-	h.mu.Lock()
-	h.lastReliabilityUpdate = t
-	h.mu.Unlock()
+// persistReliabilitySent records on disk that a reliability post succeeded at
+// time t, so the 24h cadence survives restarts (#1906). Called only from the
+// success path of sendReliabilityMetrics: a failed upload leaves the persisted
+// timestamp stale so a restart retries, while the in-memory timer (advanced at
+// dispatch under h.mu) still prevents duplicate sends within this process. A
+// persist failure is logged but non-fatal.
+func (h *Heartbeat) persistReliabilitySent(t time.Time) {
 	if err := h.saveLastReliabilityUpdate(t); err != nil {
 		log.Warn("failed to persist reliability send timestamp", "error", err.Error())
 	}

--- a/agent/internal/heartbeat/reliability_state_test.go
+++ b/agent/internal/heartbeat/reliability_state_test.go
@@ -59,30 +59,50 @@ func TestLoadLastReliabilityUpdateCorruptIsZero(t *testing.T) {
 	}
 }
 
-// markReliabilitySent must update both the in-memory timer and the persisted
-// file, so a restart that reads the file gets the same gate value.
-func TestMarkReliabilitySentPersistsAndSeeds(t *testing.T) {
+// reliabilityPostDue is the gate that defines #1906's fix: a recently-sent
+// (persisted) timestamp must suppress the next post, while a stale/zero one
+// must let it through. Table-tested directly so a flipped comparison or lost
+// seed is caught without driving the heartbeat loop.
+func TestReliabilityPostDue(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		last time.Time
+		want bool
+	}{
+		{"never sent (zero) → due", time.Time{}, true},
+		{"sent 25h ago → due", now.Add(-25 * time.Hour), true},
+		{"sent just over 24h ago → due", now.Add(-24*time.Hour - time.Second), true},
+		{"sent exactly 24h ago → not due", now.Add(-24 * time.Hour), false},
+		{"sent 1h ago → not due", now.Add(-time.Hour), false},
+		{"sent in the future (clock skew) → not due", now.Add(time.Hour), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reliabilityPostDue(tc.last, now); got != tc.want {
+				t.Fatalf("reliabilityPostDue(%v, now) = %v, want %v", tc.last, got, tc.want)
+			}
+		})
+	}
+}
+
+// persistReliabilitySent must write a timestamp a restart can read back, and
+// that timestamp must gate the next post (reliabilityPostDue == false).
+func TestPersistReliabilitySentSurvivesRestart(t *testing.T) {
 	useTempHome(t)
 	h := &Heartbeat{}
 
 	sentAt := time.Now().UTC().Truncate(time.Second)
-	h.markReliabilitySent(sentAt)
-
-	h.mu.Lock()
-	inMem := h.lastReliabilityUpdate
-	h.mu.Unlock()
-	if !inMem.Equal(sentAt) {
-		t.Fatalf("in-memory timer not updated: want %v, got %v", sentAt, inMem)
-	}
+	h.persistReliabilitySent(sentAt)
 
 	// Simulate a restart: a fresh Heartbeat reading the same file must see it,
-	// and the 24h gate must NOT have elapsed (so no immediate re-post).
+	// and the gate must NOT be due (so no immediate re-post on boot).
 	restarted := &Heartbeat{}
 	persisted := restarted.loadLastReliabilityUpdate()
 	if !persisted.Equal(sentAt) {
 		t.Fatalf("persisted timer not readable after restart: want %v, got %v", sentAt, persisted)
 	}
-	if time.Since(persisted) > 24*time.Hour {
-		t.Fatalf("recently-sent timer should gate the next post, but 24h already elapsed: %v", persisted)
+	if reliabilityPostDue(persisted, time.Now()) {
+		t.Fatalf("recently-sent timer should gate the next post, but it reported due: %v", persisted)
 	}
 }

--- a/agent/internal/heartbeat/reliability_state_test.go
+++ b/agent/internal/heartbeat/reliability_state_test.go
@@ -1,0 +1,88 @@
+package heartbeat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// useTempHome points os.UserHomeDir at a throwaway dir so the reliability state
+// file lands under <tmp>/.breeze instead of the real home directory.
+func useTempHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)        // unix
+	t.Setenv("USERPROFILE", tmp) // windows
+	return tmp
+}
+
+func TestReliabilityStateRoundTrip(t *testing.T) {
+	tmp := useTempHome(t)
+	h := &Heartbeat{}
+
+	// No state yet → zero time, so the caller treats it as "never sent".
+	if got := h.loadLastReliabilityUpdate(); !got.IsZero() {
+		t.Fatalf("expected zero time for missing state, got %v", got)
+	}
+
+	want := time.Now().UTC().Truncate(time.Second)
+	if err := h.saveLastReliabilityUpdate(want); err != nil {
+		t.Fatalf("saveLastReliabilityUpdate: %v", err)
+	}
+
+	if got := h.loadLastReliabilityUpdate(); !got.Equal(want) {
+		t.Fatalf("round-trip mismatch: want %v, got %v", want, got)
+	}
+
+	// File persisted under <home>/.breeze/.
+	if _, err := os.Stat(filepath.Join(tmp, ".breeze", reliabilityStateFileName)); err != nil {
+		t.Fatalf("reliability state file not at expected path: %v", err)
+	}
+}
+
+func TestLoadLastReliabilityUpdateCorruptIsZero(t *testing.T) {
+	tmp := useTempHome(t)
+	h := &Heartbeat{}
+
+	dir := filepath.Join(tmp, ".breeze")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, reliabilityStateFileName), []byte("{not valid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt state must fail open to "never sent", not crash or block sends.
+	if got := h.loadLastReliabilityUpdate(); !got.IsZero() {
+		t.Fatalf("expected zero time for corrupt state, got %v", got)
+	}
+}
+
+// markReliabilitySent must update both the in-memory timer and the persisted
+// file, so a restart that reads the file gets the same gate value.
+func TestMarkReliabilitySentPersistsAndSeeds(t *testing.T) {
+	useTempHome(t)
+	h := &Heartbeat{}
+
+	sentAt := time.Now().UTC().Truncate(time.Second)
+	h.markReliabilitySent(sentAt)
+
+	h.mu.Lock()
+	inMem := h.lastReliabilityUpdate
+	h.mu.Unlock()
+	if !inMem.Equal(sentAt) {
+		t.Fatalf("in-memory timer not updated: want %v, got %v", sentAt, inMem)
+	}
+
+	// Simulate a restart: a fresh Heartbeat reading the same file must see it,
+	// and the 24h gate must NOT have elapsed (so no immediate re-post).
+	restarted := &Heartbeat{}
+	persisted := restarted.loadLastReliabilityUpdate()
+	if !persisted.Equal(sentAt) {
+		t.Fatalf("persisted timer not readable after restart: want %v, got %v", sentAt, persisted)
+	}
+	if time.Since(persisted) > 24*time.Hour {
+		t.Fatalf("recently-sent timer should gate the next post, but 24h already elapsed: %v", persisted)
+	}
+}


### PR DESCRIPTION
## Summary

Reliability metrics are supposed to POST **once per 24h**, but the 24h gate lived only in the process-local in-memory `lastReliabilityUpdate` timer, and `Start()` fired an **unconditional** reliability post at startup. So every agent restart (crash, auto-update, machine reboot — frequent on POS/checkout boxes) reset the timer to its zero value and immediately re-posted an overlapping last-50-events window → multiple `device_reliability_history` rows per day with re-ingested events (the source of the duplicate rows in #1906; #1905 only made the *aggregation* dedup-safe).

## Fix (issue option 1 — persist `lastReliabilityUpdate`)

- New `agent/internal/heartbeat/reliability_state.go` persists the last-send timestamp to `<home>/.breeze/reliability_state.json` (atomic temp-file rename, mirroring the existing `ip_state.json` pattern in `ip_tracking.go`).
- `Start()` now seeds the in-memory timer from the persisted value instead of `now`, and only posts on startup when **≥24h have actually elapsed** since the last persisted post. The periodic 24h path persists each new send time.
- **Fail-open:** a missing/unreadable/corrupt state file yields the zero time → treated as "never sent" → the first post still goes out. The rare extra post is absorbed by #1905's aggregation dedup.

## Acceptance

- A restarting agent no longer emits a fresh reliability row on every boot — it posts at most ~1 row/24h, gated by the persisted timestamp. ✅

## Scope note

Issue option 2 (server-side per-event ingest dedup in `routes/agents/reliability.ts`) is intentionally **not** included — it's a larger API+DB change and #1905 already makes ingest aggregation dedup-safe. Option 1 is the root-cause fix and directly satisfies the acceptance criterion; option 2 can follow as defense-in-depth if desired.

## Tests

`agent/internal/heartbeat/reliability_state_test.go`: round-trip persist/load, corrupt-state fails open to zero, and a restart simulation proving a recently-sent timer gates the next post. Full `internal/heartbeat` package green under `go test -race`; `go vet` clean.

Closes #1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)