### PR TITLE
feat: working Network Proxy (HTTP reverse proxy) + discovery asset-modal UX rework

### DIFF
--- a/agent/internal/heartbeat/handlers_httpproxy.go
+++ b/agent/internal/heartbeat/handlers_httpproxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/remote/tools"
@@ -37,6 +38,18 @@ func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
 	}
 	if path == "" {
 		path = "/"
+	}
+
+	// SECURITY: reject any path that is not a plain relative path. A value like
+	// "@evil.com/x" or "//evil.com/x" would otherwise re-parse to a different
+	// host and bypass the IsBlocked/IsAllowed checks below (which validate
+	// targetHost only). Defense-in-depth — tunnel.Fetch enforces this too.
+	if !strings.HasPrefix(path, "/") {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      "path must start with /",
+			DurationMs: time.Since(start).Milliseconds(),
+		}
 	}
 
 	// Decode optional request body (arrives base64-encoded).

--- a/agent/internal/heartbeat/handlers_httpproxy.go
+++ b/agent/internal/heartbeat/handlers_httpproxy.go
@@ -40,6 +40,17 @@ func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
 		path = "/"
 	}
 
+	// SECURITY: restrict the scheme to http(s). An empty scheme is fine —
+	// tunnel.Fetch derives it from the port. Anything else (file://, gopher://,
+	// etc.) is rejected outright.
+	if scheme != "" && scheme != "http" && scheme != "https" {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      "unsupported scheme",
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
 	// SECURITY: reject any path that is not a plain relative path. A value like
 	// "@evil.com/x" or "//evil.com/x" would otherwise re-parse to a different
 	// host and bypass the IsBlocked/IsAllowed checks below (which validate

--- a/agent/internal/heartbeat/handlers_httpproxy.go
+++ b/agent/internal/heartbeat/handlers_httpproxy.go
@@ -1,0 +1,155 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/tunnel"
+)
+
+const (
+	httpProxyTimeout = 20 * time.Second
+	httpProxyMaxBody = 16 << 20 // 16 MiB
+)
+
+func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+
+	targetHost, _ := cmd.Payload["targetHost"].(string)
+	targetPortF, _ := cmd.Payload["targetPort"].(float64)
+	targetPort := int(targetPortF)
+	scheme, _ := cmd.Payload["scheme"].(string)
+	method, _ := cmd.Payload["method"].(string)
+	path, _ := cmd.Payload["path"].(string)
+
+	if targetHost == "" || targetPort == 0 {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      "missing targetHost or targetPort",
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+	if method == "" {
+		method = "GET"
+	}
+	if path == "" {
+		path = "/"
+	}
+
+	// Decode optional request body (arrives base64-encoded).
+	var body []byte
+	if b64, ok := cmd.Payload["bodyB64"].(string); ok && b64 != "" {
+		var err error
+		body, err = base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return tools.CommandResult{
+				Status:     "failed",
+				Error:      "invalid bodyB64: " + err.Error(),
+				DurationMs: time.Since(start).Milliseconds(),
+			}
+		}
+	}
+
+	// Parse forwarded request headers.
+	headers := parseProxyHeaderMap(cmd.Payload["headers"])
+
+	// Defense-in-depth guard 1: hardcoded block list (same as tunnel_open, isVNC=false).
+	if blocked, reason := tunnel.IsBlocked(targetHost, targetPort, false); blocked {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      fmt.Sprintf("target %s:%d is blocked: %s", targetHost, targetPort, reason),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	// Defense-in-depth guard 2: allowlist rules sent by the API.
+	// Empty rules = deny (API must always send rules for http_request).
+	var rules []tunnel.AllowlistRule
+	if rawRules, ok := cmd.Payload["allowlistRules"].([]interface{}); ok {
+		for _, r := range rawRules {
+			if pattern, ok := r.(string); ok {
+				rule, err := tunnel.ParseAllowlistRule(pattern)
+				if err != nil {
+					log.Warn("invalid allowlist rule from API", "pattern", pattern, "error", err.Error())
+					continue
+				}
+				rules = append(rules, rule)
+			}
+		}
+	}
+	if !tunnel.IsAllowed(targetHost, targetPort, rules) {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      fmt.Sprintf("target %s:%d not permitted by allowlist", targetHost, targetPort),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpProxyTimeout)
+	defer cancel()
+
+	return fetchAndEncodeHttp(ctx, tunnel.FetchRequest{
+		Scheme:  scheme,
+		Host:    targetHost,
+		Port:    targetPort,
+		Method:  method,
+		Path:    path,
+		Headers: headers,
+		Body:    body,
+	}, start)
+}
+
+// fetchAndEncodeHttp performs the proxied fetch and builds the command result.
+// It deliberately does NOT run the IsBlocked/IsAllowed guards — callers must
+// apply those first. Kept separate so the fetch→encode path can be tested
+// against a loopback httptest server in any environment (including CI
+// containers with only a loopback interface), without weakening the block guard.
+func fetchAndEncodeHttp(ctx context.Context, req tunnel.FetchRequest, start time.Time) tools.CommandResult {
+	resp, err := tunnel.Fetch(ctx, req, httpProxyTimeout, httpProxyMaxBody)
+	if err != nil {
+		return tools.CommandResult{
+			Status:     "failed",
+			Error:      err.Error(),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	return tools.NewSuccessResult(map[string]any{
+		"status":    resp.Status,
+		"headers":   resp.Headers,
+		"bodyB64":   base64.StdEncoding.EncodeToString(resp.Body),
+		"truncated": resp.Truncated,
+	}, time.Since(start).Milliseconds())
+}
+
+// parseProxyHeaderMap converts the raw payload "headers" value (a
+// map[string]any where values may be []any or string) to the canonical
+// map[string][]string used by tunnel.FetchRequest / net/http.
+func parseProxyHeaderMap(raw any) map[string][]string {
+	if raw == nil {
+		return nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string][]string, len(m))
+	for k, v := range m {
+		switch val := v.(type) {
+		case []any:
+			strs := make([]string, 0, len(val))
+			for _, s := range val {
+				if str, ok := s.(string); ok {
+					strs = append(strs, str)
+				}
+			}
+			out[k] = strs
+		case string:
+			out[k] = []string{val}
+		}
+	}
+	return out
+}

--- a/agent/internal/heartbeat/handlers_httpproxy_test.go
+++ b/agent/internal/heartbeat/handlers_httpproxy_test.go
@@ -1,0 +1,252 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/tunnel"
+)
+
+// TestFetchAndEncodeHttp exercises the post-guard fetch→encode path against a
+// loopback httptest server. This helper does NOT run IsBlocked, so binding to
+// 127.0.0.1 is fine here — the guards are tested separately in
+// TestHandleHttpRequest. This runs deterministically in ANY environment,
+// including CI containers that only have a loopback interface.
+func TestFetchAndEncodeHttp(t *testing.T) {
+	const responseBody = "hello from loopback proxy"
+
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Forwarded-Probe")
+		w.Header().Set("X-Test", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result := fetchAndEncodeHttp(ctx, tunnel.FetchRequest{
+		Scheme:  "http",
+		Host:    u.Hostname(),
+		Port:    port,
+		Method:  "GET",
+		Path:    "/",
+		Headers: map[string][]string{"X-Forwarded-Probe": {"probe-value"}},
+	}, time.Now())
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, error = %q, want completed", result.Status, result.Error)
+	}
+
+	var payload struct {
+		Status    int                 `json:"status"`
+		Headers   map[string][]string `json:"headers"`
+		BodyB64   string              `json:"bodyB64"`
+		Truncated bool                `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout=%s", err, result.Stdout)
+	}
+
+	if payload.Status != http.StatusOK {
+		t.Errorf("payload.status = %d, want 200", payload.Status)
+	}
+	if payload.Truncated {
+		t.Errorf("payload.truncated = true, want false")
+	}
+
+	body, err := base64.StdEncoding.DecodeString(payload.BodyB64)
+	if err != nil {
+		t.Fatalf("decode bodyB64: %v", err)
+	}
+	if string(body) != responseBody {
+		t.Errorf("body = %q, want %q", string(body), responseBody)
+	}
+
+	if vals := payload.Headers["X-Test"]; len(vals) == 0 || vals[0] != "yes" {
+		t.Errorf("X-Test response header = %v, want [yes]", vals)
+	}
+
+	if gotHeader != "probe-value" {
+		t.Errorf("forwarded request header X-Forwarded-Probe = %q, want %q", gotHeader, "probe-value")
+	}
+}
+
+// TestHandleHttpRequest covers the full-handler guard paths and an end-to-end
+// happy path. The blocked/empty-allowlist subtests run everywhere; the
+// end-to-end subtest needs a non-loopback interface (127/8 is block-listed) and
+// skips gracefully where none exists — the fetch→encode path is covered
+// deterministically by TestFetchAndEncodeHttp regardless.
+func TestHandleHttpRequest(t *testing.T) {
+	t.Run("blocked target is rejected", func(t *testing.T) {
+		// 127.0.0.1 is on the hardcoded block list for non-VNC connections.
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost":     "127.0.0.1",
+				"targetPort":     float64(8080),
+				"scheme":         "http",
+				"method":         "GET",
+				"path":           "/",
+				"allowlistRules": []any{"127.0.0.1/32:8080"},
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("status = %q, want failed", result.Status)
+		}
+		if !strings.Contains(result.Error, "blocked") {
+			t.Fatalf("error = %q, want 'blocked' mention", result.Error)
+		}
+	})
+
+	t.Run("empty allowlist is rejected", func(t *testing.T) {
+		// A public-routable IP that is not on the block list but has no allowlist rules.
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost": "203.0.113.1", // TEST-NET-3, not in blockedNetworks
+				"targetPort": float64(80),
+				"scheme":     "http",
+				"method":     "GET",
+				"path":       "/",
+				// allowlistRules absent → empty slice → deny
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("status = %q, want failed", result.Status)
+		}
+		if !strings.Contains(result.Error, "not permitted") {
+			t.Fatalf("error = %q, want 'not permitted' mention", result.Error)
+		}
+	})
+
+	t.Run("allowed target returns completed result with decoded body", func(t *testing.T) {
+		const responseBody = "hello from proxy"
+
+		// 127.0.0.1 is block-listed, so we bind the test server to all
+		// interfaces and connect via the machine's non-loopback IPv4 address so
+		// IsBlocked passes. If no such address exists (e.g. loopback-only CI),
+		// skip — the fetch→encode path is covered by TestFetchAndEncodeHttp.
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("X-Test", "yes")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(responseBody))
+		}))
+
+		ln, err := net.Listen("tcp", "0.0.0.0:0")
+		if err != nil {
+			t.Skipf("cannot bind test server: %v", err)
+		}
+		srv.Listener = ln
+		srv.Start()
+		defer srv.Close()
+
+		port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+		host := nonLoopbackIPv4(t)
+		if host == "" {
+			t.Skip("no non-loopback IPv4 address available; skipping network proxy test")
+		}
+
+		allowlistRule := host + "/32:" + strconv.Itoa(port)
+
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost":     host,
+				"targetPort":     float64(port),
+				"scheme":         "http",
+				"method":         "GET",
+				"path":           "/",
+				"allowlistRules": []any{allowlistRule},
+			},
+		})
+
+		if result.Status != "completed" {
+			t.Fatalf("status = %q, error = %q, want completed", result.Status, result.Error)
+		}
+
+		var payload struct {
+			Status    int                 `json:"status"`
+			Headers   map[string][]string `json:"headers"`
+			BodyB64   string              `json:"bodyB64"`
+			Truncated bool                `json:"truncated"`
+		}
+		if err := json.Unmarshal([]byte(result.Stdout), &payload); err != nil {
+			t.Fatalf("unmarshal stdout: %v\nstdout=%s", err, result.Stdout)
+		}
+
+		if payload.Status != http.StatusOK {
+			t.Errorf("payload.status = %d, want 200", payload.Status)
+		}
+		if payload.Truncated {
+			t.Errorf("payload.truncated = true, want false")
+		}
+
+		body, err := base64.StdEncoding.DecodeString(payload.BodyB64)
+		if err != nil {
+			t.Fatalf("decode bodyB64: %v", err)
+		}
+		if string(body) != responseBody {
+			t.Errorf("body = %q, want %q", string(body), responseBody)
+		}
+
+		if vals := payload.Headers["X-Test"]; len(vals) == 0 || vals[0] != "yes" {
+			t.Errorf("X-Test header = %v, want [yes]", vals)
+		}
+	})
+}
+
+// nonLoopbackIPv4 returns the first non-loopback IPv4 address on the machine,
+// or "" if none is found.
+func nonLoopbackIPv4(t *testing.T) string {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			if v4 := ip.To4(); v4 != nil {
+				return v4.String()
+			}
+		}
+	}
+	return ""
+}

--- a/agent/internal/heartbeat/handlers_httpproxy_test.go
+++ b/agent/internal/heartbeat/handlers_httpproxy_test.go
@@ -140,6 +140,26 @@ func TestHandleHttpRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("unsupported scheme is rejected", func(t *testing.T) {
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost":     "203.0.113.5",
+				"targetPort":     float64(80),
+				"scheme":         "file",
+				"method":         "GET",
+				"path":           "/etc/passwd",
+				"allowlistRules": []any{"203.0.113.5/32:80"},
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("status = %q, want failed", result.Status)
+		}
+		if !strings.Contains(result.Error, "unsupported scheme") {
+			t.Fatalf("error = %q, want 'unsupported scheme' mention", result.Error)
+		}
+	})
+
 	t.Run("host-injection path is rejected", func(t *testing.T) {
 		// A path of "@evil.example/x" would, under naive string concat, re-parse
 		// so the host becomes evil.example — bypassing the allowlist. The handler

--- a/agent/internal/heartbeat/handlers_httpproxy_test.go
+++ b/agent/internal/heartbeat/handlers_httpproxy_test.go
@@ -140,6 +140,29 @@ func TestHandleHttpRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("host-injection path is rejected", func(t *testing.T) {
+		// A path of "@evil.example/x" would, under naive string concat, re-parse
+		// so the host becomes evil.example — bypassing the allowlist. The handler
+		// must reject it before any fetch.
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost":     "203.0.113.5",
+				"targetPort":     float64(80),
+				"scheme":         "http",
+				"method":         "GET",
+				"path":           "@evil.example/x",
+				"allowlistRules": []any{"203.0.113.5/32:80"},
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("status = %q, want failed", result.Status)
+		}
+		if !strings.Contains(result.Error, "path must start with /") {
+			t.Fatalf("error = %q, want 'path must start with /' mention", result.Error)
+		}
+	})
+
 	t.Run("allowed target returns completed result with decoded body", func(t *testing.T) {
 		const responseBody = "hello from proxy"
 

--- a/agent/internal/heartbeat/handlers_test.go
+++ b/agent/internal/heartbeat/handlers_test.go
@@ -117,6 +117,7 @@ var allCommandTypes = []string{
 
 	// handlers_tunnel.go init()
 	tools.CmdTunnelOpen, tools.CmdTunnelData, tools.CmdTunnelClose,
+	tools.CmdHttpRequest,
 
 	// handlers_actuate.go init() — PAM Track 5
 	tools.CmdActuateElevation,

--- a/agent/internal/heartbeat/handlers_tunnel.go
+++ b/agent/internal/heartbeat/handlers_tunnel.go
@@ -20,6 +20,7 @@ func init() {
 	handlerRegistry[tools.CmdTunnelOpen] = handleTunnelOpen
 	handlerRegistry[tools.CmdTunnelData] = handleTunnelData
 	handlerRegistry[tools.CmdTunnelClose] = handleTunnelClose
+	handlerRegistry[tools.CmdHttpRequest] = handleHttpRequest
 }
 
 func handleTunnelOpen(h *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -215,6 +215,9 @@ const (
 	CmdTunnelData  = "tunnel_data"
 	CmdTunnelClose = "tunnel_close"
 
+	// One-shot HTTP proxy request (network proxy)
+	CmdHttpRequest = "http_request"
+
 	// PAM Track 5: actuate an approved UAC elevation by typing the
 	// dormant-admin credentials into consent.exe on the secure desktop.
 	// Server-pushed only; handled by internal/pamactuator on Windows and

--- a/agent/internal/tunnel/httpfetch.go
+++ b/agent/internal/tunnel/httpfetch.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -56,14 +58,39 @@ func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody
 		}
 	}
 
-	rawURL := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(req.Host, fmt.Sprintf("%d", req.Port)), req.Path)
+	// SECURITY: build the URL with net/url and pin the host to req.Host.
+	// A browser-supplied path like "@evil.com/x" or "//evil.com/x" would, if
+	// string-concatenated, re-parse so the host becomes evil.com — bypassing the
+	// IsBlocked/IsAllowed checks (which only validated req.Host). Reject anything
+	// that is not a plain relative path before constructing the request.
+	if !strings.HasPrefix(req.Path, "/") {
+		return nil, fmt.Errorf("path must start with /")
+	}
+	ref, err := url.Parse(req.Path)
+	if err != nil {
+		return nil, err
+	}
+	if ref.IsAbs() || ref.Host != "" || ref.User != nil || ref.Scheme != "" {
+		return nil, fmt.Errorf("path must be a relative path, not a URL")
+	}
+	u := &url.URL{
+		Scheme:   scheme,
+		Host:     net.JoinHostPort(req.Host, strconv.Itoa(req.Port)),
+		Path:     ref.Path,
+		RawQuery: ref.RawQuery,
+	}
+	// Defense-in-depth: the constructed URL must still target exactly req.Host
+	// with no userinfo component.
+	if u.User != nil || !strings.EqualFold(u.Hostname(), req.Host) {
+		return nil, fmt.Errorf("refusing to fetch: host/userinfo mismatch")
+	}
 
 	var bodyReader io.Reader
 	if len(req.Body) > 0 {
 		bodyReader = bytes.NewReader(req.Body)
 	}
 
-	hreq, err := http.NewRequestWithContext(ctx, req.Method, rawURL, bodyReader)
+	hreq, err := http.NewRequestWithContext(ctx, req.Method, u.String(), bodyReader)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/tunnel/httpfetch.go
+++ b/agent/internal/tunnel/httpfetch.go
@@ -77,6 +77,7 @@ func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody
 		Scheme:   scheme,
 		Host:     net.JoinHostPort(req.Host, strconv.Itoa(req.Port)),
 		Path:     ref.Path,
+		RawPath:  ref.RawPath, // preserve %2F etc. — device APIs may distinguish encoded slashes
 		RawQuery: ref.RawQuery,
 	}
 	// Defense-in-depth: the constructed URL must still target exactly req.Host

--- a/agent/internal/tunnel/httpfetch.go
+++ b/agent/internal/tunnel/httpfetch.go
@@ -1,0 +1,126 @@
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FetchRequest is one proxied HTTP request to a LAN target.
+type FetchRequest struct {
+	Scheme  string              // "http" | "https" (derived from target port if empty)
+	Host    string              // target IP/host
+	Port    int                 // target port
+	Method  string              // GET/POST/...
+	Path    string              // path + raw query, e.g. "/admin/index.html?x=1"
+	Headers map[string][]string // forwarded request headers (already filtered by caller)
+	Body    []byte              // request body (may be nil)
+}
+
+// FetchResponse holds the proxied response.
+type FetchResponse struct {
+	Status    int
+	Headers   map[string][]string
+	Body      []byte // capped at maxBody bytes
+	Truncated bool   // true when the response body exceeded maxBody
+}
+
+// hopByHop lists headers that must not be forwarded in either direction.
+var hopByHop = map[string]bool{
+	"connection":          true,
+	"keep-alive":          true,
+	"proxy-authenticate":  true,
+	"proxy-authorization": true,
+	"te":                  true,
+	"trailer":             true,
+	"transfer-encoding":   true,
+	"upgrade":             true,
+}
+
+// Fetch performs the one-shot HTTP/HTTPS request described by req.
+// timeout caps total round-trip time; maxBody caps response bytes read
+// (the response is marked Truncated if the body exceeded the cap).
+func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody int64) (*FetchResponse, error) {
+	scheme := req.Scheme
+	if scheme == "" {
+		if req.Port == 443 {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	rawURL := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(req.Host, fmt.Sprintf("%d", req.Port)), req.Path)
+
+	var bodyReader io.Reader
+	if len(req.Body) > 0 {
+		bodyReader = bytes.NewReader(req.Body)
+	}
+
+	hreq, err := http.NewRequestWithContext(ctx, req.Method, rawURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, vs := range req.Headers {
+		if hopByHop[strings.ToLower(k)] {
+			continue
+		}
+		for _, v := range vs {
+			hreq.Header.Add(k, v)
+		}
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Self-signed printer/device certs are the norm on a LAN. The tunnel
+			// target is already constrained to the tunnel_session's host:port and
+			// re-checked against the org allowlist, so cert pinning adds no security
+			// here while breaking every real device. Skip verification deliberately.
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			DisableKeepAlives: true,
+			Proxy:             nil,
+		},
+		// Do not auto-follow redirects — the API layer rewrites Location headers.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	resp, err := client.Do(hreq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read up to maxBody+1 bytes so we can detect truncation.
+	limited := io.LimitReader(resp.Body, maxBody+1)
+	b, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	truncated := int64(len(b)) > maxBody
+	if truncated {
+		b = b[:maxBody]
+	}
+
+	outHeaders := make(map[string][]string)
+	for k, vs := range resp.Header {
+		if hopByHop[strings.ToLower(k)] {
+			continue
+		}
+		outHeaders[k] = vs
+	}
+
+	return &FetchResponse{
+		Status:    resp.StatusCode,
+		Headers:   outHeaders,
+		Body:      b,
+		Truncated: truncated,
+	}, nil
+}

--- a/agent/internal/tunnel/httpfetch_test.go
+++ b/agent/internal/tunnel/httpfetch_test.go
@@ -1,0 +1,84 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetch(t *testing.T) {
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/echo" && r.Method == http.MethodPost {
+			b, _ := io.ReadAll(r.Body)
+			w.Header().Set("X-Seen", "yes")
+			w.WriteHeader(201)
+			w.Write([]byte("got:" + string(b)))
+			return
+		}
+		w.Write([]byte("hello-plain"))
+	}))
+	defer plain.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello-tls"))
+	}))
+	defer tlsSrv.Close()
+
+	hostPort := func(u string) (string, int) {
+		u = strings.TrimPrefix(strings.TrimPrefix(u, "http://"), "https://")
+		parts := strings.SplitN(u, ":", 2)
+		p, _ := strconv.Atoi(parts[1])
+		return parts[0], p
+	}
+
+	t.Run("plain GET", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 200 || string(resp.Body) != "hello-plain" {
+			t.Fatalf("got %d %q", resp.Status, resp.Body)
+		}
+	})
+
+	t.Run("POST body + headers", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "POST", Path: "/echo", Body: []byte("ping")}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 201 || string(resp.Body) != "got:ping" || resp.Headers["X-Seen"][0] != "yes" {
+			t.Fatalf("got %d %q %v", resp.Status, resp.Body, resp.Headers)
+		}
+	})
+
+	t.Run("self-signed TLS accepted", func(t *testing.T) {
+		h, p := hostPort(tlsSrv.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "https", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(resp.Body) != "hello-tls" {
+			t.Fatalf("got %q", resp.Body)
+		}
+		_ = tls.VersionTLS12
+	})
+
+	t.Run("body cap truncates", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !resp.Truncated || len(resp.Body) != 4 {
+			t.Fatalf("expected truncated 4 bytes, got %d trunc=%v", len(resp.Body), resp.Truncated)
+		}
+	})
+}

--- a/agent/internal/tunnel/httpfetch_test.go
+++ b/agent/internal/tunnel/httpfetch_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -148,6 +149,54 @@ func TestFetch(t *testing.T) {
 		}
 		if !resp.Truncated || len(resp.Body) != 4 {
 			t.Fatalf("expected truncated 4 bytes, got %d trunc=%v", len(resp.Body), resp.Truncated)
+		}
+	})
+
+	// SECURITY: a malicious path must never subvert the pinned host. Each of
+	// these would, under naive string concatenation, re-parse so the host
+	// becomes evil.example (host-injection SSRF / allowlist bypass). Fetch must
+	// reject them with an error and perform NO request against the real target.
+	t.Run("malicious paths are rejected without a request", func(t *testing.T) {
+		var hits int32
+		guard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.Write([]byte("should-not-be-reached"))
+		}))
+		defer guard.Close()
+		h, p := hostPort(guard.URL)
+
+		for _, badPath := range []string{
+			"@evil.example/x",       // userinfo injection → host becomes evil.example
+			"http://evil.example/x", // absolute URL
+			"//evil.example/x",      // scheme-relative URL → host becomes evil.example
+			"x/y",                   // no leading slash
+		} {
+			resp, err := Fetch(context.Background(), FetchRequest{
+				Scheme: "http", Host: h, Port: p, Method: "GET", Path: badPath,
+			}, 5*time.Second, 1<<20)
+			if err == nil {
+				t.Fatalf("path %q: expected error, got nil (resp=%+v)", badPath, resp)
+			}
+			if resp != nil {
+				t.Fatalf("path %q: expected nil response on rejection, got %+v", badPath, resp)
+			}
+		}
+
+		if n := atomic.LoadInt32(&hits); n != 0 {
+			t.Fatalf("expected 0 requests to the target for malicious paths, got %d", n)
+		}
+	})
+
+	t.Run("normal path with query still works", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{
+			Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/?q=1",
+		}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 200 || string(resp.Body) != "hello-plain" {
+			t.Fatalf("got %d %q", resp.Status, resp.Body)
 		}
 	})
 }

--- a/agent/internal/tunnel/httpfetch_test.go
+++ b/agent/internal/tunnel/httpfetch_test.go
@@ -2,7 +2,6 @@ package tunnel
 
 import (
 	"context"
-	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,14 +13,27 @@ import (
 
 func TestFetch(t *testing.T) {
 	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/echo" && r.Method == http.MethodPost {
+		switch {
+		case r.URL.Path == "/echo" && r.Method == http.MethodPost:
 			b, _ := io.ReadAll(r.Body)
 			w.Header().Set("X-Seen", "yes")
+			// Echo back a request header so the test can assert forwarding.
+			w.Header().Set("X-Echoed-Forward", r.Header.Get("X-Forward-Me"))
 			w.WriteHeader(201)
 			w.Write([]byte("got:" + string(b)))
-			return
+		case r.URL.Path == "/hop":
+			// Report whether the target saw the hop-by-hop request header.
+			w.Header().Set("X-Saw-TE", r.Header.Get("Transfer-Encoding"))
+			w.Header().Set("X-Saw-Connection", r.Header.Get("Connection"))
+			// And emit a hop-by-hop response header that must be stripped.
+			w.Header().Set("Connection", "keep-alive")
+			w.Write([]byte("hop-ok"))
+		case r.URL.Path == "/redirect":
+			w.Header().Set("Location", "/other")
+			w.WriteHeader(http.StatusMovedPermanently)
+		default:
+			w.Write([]byte("hello-plain"))
 		}
-		w.Write([]byte("hello-plain"))
 	}))
 	defer plain.Close()
 
@@ -50,12 +62,70 @@ func TestFetch(t *testing.T) {
 
 	t.Run("POST body + headers", func(t *testing.T) {
 		h, p := hostPort(plain.URL)
-		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "POST", Path: "/echo", Body: []byte("ping")}, 5*time.Second, 1<<20)
+		resp, err := Fetch(context.Background(), FetchRequest{
+			Scheme:  "http",
+			Host:    h,
+			Port:    p,
+			Method:  "POST",
+			Path:    "/echo",
+			Headers: map[string][]string{"X-Forward-Me": {"myval"}},
+			Body:    []byte("ping"),
+		}, 5*time.Second, 1<<20)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if resp.Status != 201 || string(resp.Body) != "got:ping" || resp.Headers["X-Seen"][0] != "yes" {
 			t.Fatalf("got %d %q %v", resp.Status, resp.Body, resp.Headers)
+		}
+		// The forwarded request header must have reached the target.
+		if got := resp.Headers["X-Echoed-Forward"]; len(got) == 0 || got[0] != "myval" {
+			t.Fatalf("expected forwarded header X-Forward-Me=myval, target saw %v", got)
+		}
+	})
+
+	t.Run("hop-by-hop headers stripped both directions", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{
+			Scheme: "http",
+			Host:   h,
+			Port:   p,
+			Method: "GET",
+			Path:   "/hop",
+			Headers: map[string][]string{
+				"Transfer-Encoding": {"identity"},
+				"Connection":        {"keep-alive"},
+			},
+		}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// (a) Target must NOT have seen our forwarded hop-by-hop request headers.
+		// Note: the transport sets its own "Connection: close" because
+		// DisableKeepAlives is true, so we assert our forwarded "keep-alive"
+		// value specifically did not pass through (not that it is empty).
+		if got := resp.Headers["X-Saw-Te"]; len(got) > 0 && got[0] != "" {
+			t.Fatalf("target saw forwarded Transfer-Encoding request header: %v", got)
+		}
+		if got := resp.Headers["X-Saw-Connection"]; len(got) > 0 && got[0] == "keep-alive" {
+			t.Fatalf("target saw forwarded Connection: keep-alive request header: %v", got)
+		}
+		// (b) Hop-by-hop response header must be stripped from the result.
+		if _, ok := resp.Headers["Connection"]; ok {
+			t.Fatalf("Connection response header should have been stripped, got %v", resp.Headers["Connection"])
+		}
+	})
+
+	t.Run("redirects are not followed", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/redirect"}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != http.StatusMovedPermanently {
+			t.Fatalf("expected 301 (no redirect follow), got %d", resp.Status)
+		}
+		if got := resp.Headers["Location"]; len(got) == 0 || got[0] != "/other" {
+			t.Fatalf("expected Location: /other preserved, got %v", got)
 		}
 	})
 
@@ -68,7 +138,6 @@ func TestFetch(t *testing.T) {
 		if string(resp.Body) != "hello-tls" {
 			t.Fatalf("got %q", resp.Body)
 		}
-		_ = tls.VersionTLS12
 	})
 
 	t.Run("body cap truncates", func(t *testing.T) {

--- a/agent/internal/tunnel/httpfetch_test.go
+++ b/agent/internal/tunnel/httpfetch_test.go
@@ -32,6 +32,11 @@ func TestFetch(t *testing.T) {
 		case r.URL.Path == "/redirect":
 			w.Header().Set("Location", "/other")
 			w.WriteHeader(http.StatusMovedPermanently)
+		case strings.HasPrefix(r.URL.EscapedPath(), "/foo"):
+			// Report the escaped path so the test can assert %2F survived.
+			w.Header().Set("X-Escaped-Path", r.URL.EscapedPath())
+			w.Header().Set("X-Request-URI", r.RequestURI)
+			w.Write([]byte("escaped-ok"))
 		default:
 			w.Write([]byte("hello-plain"))
 		}
@@ -197,6 +202,27 @@ func TestFetch(t *testing.T) {
 		}
 		if resp.Status != 200 || string(resp.Body) != "hello-plain" {
 			t.Fatalf("got %d %q", resp.Status, resp.Body)
+		}
+	})
+
+	// Device APIs may distinguish an encoded slash (%2F) from a real one, so the
+	// proxy must preserve the encoded form rather than normalizing it away.
+	t.Run("encoded path preserves %2F", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{
+			Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/foo%2Fbar",
+		}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 200 || string(resp.Body) != "escaped-ok" {
+			t.Fatalf("got %d %q", resp.Status, resp.Body)
+		}
+		if got := resp.Headers["X-Escaped-Path"]; len(got) == 0 || !strings.Contains(got[0], "%2F") {
+			t.Fatalf("target saw escaped path %v, want one containing %%2F", got)
+		}
+		if got := resp.Headers["X-Request-Uri"]; len(got) == 0 || !strings.Contains(got[0], "%2F") {
+			t.Fatalf("target saw request URI %v, want one containing %%2F", got)
 		}
 	})
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -112,6 +112,7 @@ import { createAgentWsRoutes } from './routes/agentWs';
 import { createTerminalWsRoutes } from './routes/terminalWs';
 import { createDesktopWsRoutes } from './routes/desktopWs';
 import { createTunnelWsRoutes } from './routes/tunnelWs';
+import { tunnelHttpRoutes } from './routes/tunnelHttp';
 import { createEventWsRoutes, createEventWsTicketRoute } from './routes/eventWs';
 import { tunnelRoutes, vncExchangeRoutes, vncViewerRoutes } from './routes/tunnels';
 import { agentVersionRoutes } from './routes/agentVersions';
@@ -794,6 +795,7 @@ api.route('/logs', logsRoutes);
 api.route('/remote/sessions', createTerminalWsRoutes(upgradeWebSocket)); // WebSocket routes first (no auth middleware)
 api.route('/desktop-ws', createDesktopWsRoutes(upgradeWebSocket)); // Desktop WebSocket routes (outside /remote to avoid auth middleware)
 api.route('/tunnel-ws', createTunnelWsRoutes(upgradeWebSocket)); // Tunnel WebSocket routes (no auth middleware — uses one-time tickets)
+api.route('/tunnel-http', tunnelHttpRoutes); // HTTP reverse-proxy (no auth middleware — ticket→scoped-cookie self-auth)
 api.route('/events', createEventWsRoutes(upgradeWebSocket)); // Event stream WebSocket (no auth middleware — uses one-time tickets)
 api.route('/tunnels', tunnelRoutes);
 api.route('/vnc-exchange', vncExchangeRoutes); // No auth — one-time code is the auth

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1346,11 +1346,15 @@ async function processCommandResult(
   try {
     // Resolve any in-process promise awaiting this command id (e.g. http_request
     // sent via sendCommandToAgentAwaitResult). No-op for all other result types.
-    resolvePendingAgentCommand(result.commandId, {
+    // When consumed, the result has no device_commands row and needs no further
+    // dispatch — short-circuit to avoid 3 needless DB lookups + a console.warn
+    // per result (matters for a proxy issuing many http_request commands).
+    const consumed = resolvePendingAgentCommand(result.commandId, {
       status: result.status,
       result: result.result,
       error: result.error,
     });
+    if (consumed) return;
 
     // Non-UUID command IDs (for example mon-* and snmp-*) are dispatched directly
     // over WebSocket and do not have a device_commands row.

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1352,6 +1352,7 @@ async function processCommandResult(
     const consumed = resolvePendingAgentCommand(result.commandId, {
       status: result.status,
       result: result.result,
+      stdout: result.stdout,
       error: result.error,
     });
     if (consumed) return;

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -37,6 +37,7 @@ import { publishEvent } from '../services/eventBus';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
 import { logSessionAudit, classifyConsentDenyAction, resolveConsentMarkerSessionId } from './remote/helpers';
 import { getActiveTrustKeyset } from '../services/manifestSigning';
+import { resolvePendingAgentCommand } from '../services/agentCommandAwait';
 
 /** Capabilities advertised to agents in the post-connect `connected` message. */
 export const AGENT_WS_CAPABILITIES = ['terminal_output_base64'] as const;
@@ -1343,6 +1344,14 @@ async function processCommandResult(
   deviceId?: string
 ): Promise<void> {
   try {
+    // Resolve any in-process promise awaiting this command id (e.g. http_request
+    // sent via sendCommandToAgentAwaitResult). No-op for all other result types.
+    resolvePendingAgentCommand(result.commandId, {
+      status: result.status,
+      result: result.result,
+      error: result.error,
+    });
+
     // Non-UUID command IDs (for example mon-* and snmp-*) are dispatched directly
     // over WebSocket and do not have a device_commands row.
     if (!UUID_REGEX.test(result.commandId)) {

--- a/apps/api/src/routes/tunnelHttp.test.ts
+++ b/apps/api/src/routes/tunnelHttp.test.ts
@@ -93,7 +93,6 @@ vi.mock('../services/tunnelAllowlist', () => ({
   getActiveAllowlistPatterns: vi.fn(async () => ['192.168.1.0/24']),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 import { tunnelHttpRoutes } from './tunnelHttp';
 
 function makeApp() {

--- a/apps/api/src/routes/tunnelHttp.test.ts
+++ b/apps/api/src/routes/tunnelHttp.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// --- UUID constants ---
+const TUNNEL_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const ORG_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID = 'uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu';
+const AGENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+// --- DB join row (tunnelSessions ⋈ devices), driven by the setter below ---
+let joinRow:
+  | {
+      session: {
+        userId: string;
+        status: string;
+        orgId: string;
+        type: string;
+        targetHost: string;
+        targetPort: number;
+      };
+      device: { id: string; status: string; agentId: string | null };
+    }
+  | undefined;
+
+function setJoinRow(row: typeof joinRow) {
+  joinRow = row;
+}
+
+function defaultJoinRow(over: Partial<{ port: number; deviceStatus: string; ownerId: string; status: string }> = {}) {
+  return {
+    session: {
+      userId: over.ownerId ?? USER_ID,
+      status: over.status ?? 'active',
+      orgId: ORG_ID,
+      type: 'proxy',
+      targetHost: '192.168.1.50',
+      targetPort: over.port ?? 80,
+    },
+    device: { id: DEVICE_ID, status: over.deviceStatus ?? 'online', agentId: AGENT_ID },
+  };
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => (joinRow ? [joinRow] : [])),
+          })),
+        })),
+      })),
+    })),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  tunnelSessions: { id: 'tunnelSessions.id', deviceId: 'tunnelSessions.deviceId' },
+  devices: { id: 'devices.id' },
+}));
+
+const { consumeWsTicketMock } = vi.hoisted(() => ({ consumeWsTicketMock: vi.fn() }));
+vi.mock('../services/remoteSessionAuth', () => ({
+  consumeWsTicket: consumeWsTicketMock,
+}));
+
+const { isAgentConnectedMock } = vi.hoisted(() => ({ isAgentConnectedMock: vi.fn(() => true) }));
+vi.mock('./agentWs', () => ({
+  isAgentConnected: isAgentConnectedMock,
+}));
+
+const { sendCommandMock } = vi.hoisted(() => ({ sendCommandMock: vi.fn() }));
+vi.mock('../services/agentCommandAwait', () => ({
+  sendCommandToAgentAwaitResult: sendCommandMock,
+}));
+
+const { checkRemoteAccessMock } = vi.hoisted(() => ({
+  checkRemoteAccessMock: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('../services/remoteAccessPolicy', () => ({
+  checkRemoteAccess: checkRemoteAccessMock,
+}));
+
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => '203.0.113.7'),
+}));
+
+// getActiveAllowlistPatterns is replicated in-file in the route, which queries
+// the (mocked) db; it resolves to [] given the join-only db mock above.
+vi.mock('../services/tunnelAllowlist', () => ({
+  getActiveAllowlistPatterns: vi.fn(async () => ['192.168.1.0/24']),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { tunnelHttpRoutes } from './tunnelHttp';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/api/v1/tunnel-http', tunnelHttpRoutes);
+  return app;
+}
+
+const BASE = `/api/v1/tunnel-http/${TUNNEL_ID}`;
+
+function okAgentResult(over: Partial<{ status: number; headers: Record<string, string[]>; bodyB64: string }> = {}) {
+  return {
+    status: 'completed',
+    stdout: JSON.stringify({
+      status: over.status ?? 200,
+      headers: over.headers ?? { 'content-type': ['text/plain'] },
+      bodyB64: over.bodyB64 ?? Buffer.from('hello').toString('base64'),
+      truncated: false,
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setJoinRow(defaultJoinRow());
+  isAgentConnectedMock.mockReturnValue(true);
+  checkRemoteAccessMock.mockResolvedValue({ allowed: true });
+  sendCommandMock.mockResolvedValue(okAgentResult());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Helper: run the ticket flow and return the signed auth cookie value.
+async function mintCookie(app: Hono): Promise<string> {
+  consumeWsTicketMock.mockResolvedValueOnce({
+    ok: true,
+    sessionId: TUNNEL_ID,
+    sessionType: 'tunnel-http',
+    userId: USER_ID,
+    expiresAt: Date.now() + 60_000,
+  });
+  const res = await app.request(`${BASE}/?__bzt=goodticket`);
+  expect(res.status).toBe(302);
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const m = setCookie.match(/(bz_tunnel_[^=]+=[^;]+)/);
+  if (!m || !m[1]) throw new Error(`no auth cookie in: ${setCookie}`);
+  return m[1];
+}
+
+describe('tunnelHttp auth: ticket + cookie', () => {
+  it('returns 401 with no ticket and no cookie', async () => {
+    const app = makeApp();
+    const res = await app.request(`${BASE}/`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an invalid/expired ticket', async () => {
+    consumeWsTicketMock.mockResolvedValueOnce({ ok: false, reason: 'not_found' });
+    const app = makeApp();
+    const res = await app.request(`${BASE}/?__bzt=bad`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when ticket sessionType is not tunnel-http', async () => {
+    consumeWsTicketMock.mockResolvedValueOnce({
+      ok: true,
+      sessionId: TUNNEL_ID,
+      sessionType: 'tunnel',
+      userId: USER_ID,
+      expiresAt: Date.now() + 60_000,
+    });
+    const app = makeApp();
+    const res = await app.request(`${BASE}/?__bzt=goodticket`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when ticket sessionId does not match :tunnelId', async () => {
+    consumeWsTicketMock.mockResolvedValueOnce({
+      ok: true,
+      sessionId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      sessionType: 'tunnel-http',
+      userId: USER_ID,
+      expiresAt: Date.now() + 60_000,
+    });
+    const app = makeApp();
+    const res = await app.request(`${BASE}/?__bzt=goodticket`);
+    expect(res.status).toBe(401);
+  });
+
+  it('valid ticket -> 302 setting HttpOnly cookie, Location strips __bzt', async () => {
+    consumeWsTicketMock.mockResolvedValueOnce({
+      ok: true,
+      sessionId: TUNNEL_ID,
+      sessionType: 'tunnel-http',
+      userId: USER_ID,
+      expiresAt: Date.now() + 60_000,
+    });
+    const app = makeApp();
+    const res = await app.request(`${BASE}/status?__bzt=goodticket&foo=bar`);
+    expect(res.status).toBe(302);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain(`bz_tunnel_${TUNNEL_ID}=`);
+    expect(setCookie.toLowerCase()).toContain('httponly');
+    expect(setCookie.toLowerCase()).toContain('samesite=lax');
+    expect(setCookie).toContain(`Path=/api/v1/tunnel-http/${TUNNEL_ID}/`);
+    const loc = res.headers.get('location') ?? '';
+    expect(loc).not.toContain('__bzt');
+    expect(loc).toContain('foo=bar');
+    expect(loc).toContain('/status');
+  });
+});
+
+describe('tunnelHttp dispatch (cookie-authed)', () => {
+  it('dispatches http_request with target from session, scheme http on port 80', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/admin/page?x=1`, {
+      method: 'GET',
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    const [agentId, command] = sendCommandMock.mock.calls[0]!;
+    expect(agentId).toBe(AGENT_ID);
+    expect(command.type).toBe('http_request');
+    expect(command.payload.targetHost).toBe('192.168.1.50');
+    expect(command.payload.targetPort).toBe(80);
+    expect(command.payload.scheme).toBe('http');
+    expect(command.payload.method).toBe('GET');
+    expect(command.payload.path).toBe('/admin/page?x=1');
+    expect(command.payload.tunnelId).toBe(TUNNEL_ID);
+    expect(Array.isArray(command.payload.allowlistRules)).toBe(true);
+    // hop-by-hop + our own auth cookie must not be forwarded
+    expect(JSON.stringify(command.payload.headers).toLowerCase()).not.toContain('bz_tunnel');
+    expect(await res.text()).toBe('hello');
+  });
+
+  it('derives https scheme for port 443', async () => {
+    setJoinRow(defaultJoinRow({ port: 443 }));
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    setJoinRow(defaultJoinRow({ port: 443 }));
+    await app.request(`${BASE}/`, { headers: { cookie } });
+    const [, command] = sendCommandMock.mock.calls.at(-1)!;
+    expect(command.payload.scheme).toBe('https');
+    expect(command.payload.targetPort).toBe(443);
+  });
+
+  it('returns 404 when session is not owned by the cookie user', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    setJoinRow(defaultJoinRow({ ownerId: 'someone-else' }));
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 502 when agent is not connected', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    isAgentConnectedMock.mockReturnValue(false);
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 502 when device is offline', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    setJoinRow(defaultJoinRow({ deviceStatus: 'offline' }));
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 504 when the agent command times out', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    sendCommandMock.mockResolvedValueOnce({ status: 'failed', error: 'timeout waiting for agent command result' });
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(504);
+  });
+
+  it('returns 502 when the agent reports a generic failure', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    sendCommandMock.mockResolvedValueOnce({ status: 'failed', error: 'agent offline' });
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('tunnelHttp response rewriting', () => {
+  it('strips CSP and content-length headers', async () => {
+    sendCommandMock.mockResolvedValue(
+      okAgentResult({
+        headers: {
+          'content-type': ['text/plain'],
+          'content-security-policy': ["default-src 'self'"],
+          'content-length': ['5'],
+        },
+      }),
+    );
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.headers.get('content-security-policy')).toBeNull();
+  });
+
+  it('injects <base> tag into text/html responses', async () => {
+    sendCommandMock.mockResolvedValue(
+      okAgentResult({
+        headers: { 'content-type': ['text/html'] },
+        bodyB64: Buffer.from('<html><head><title>P</title></head><body>x</body></html>').toString('base64'),
+      }),
+    );
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    const body = await res.text();
+    expect(body).toContain(`<base href="/api/v1/tunnel-http/${TUNNEL_ID}/">`);
+  });
+
+  it('rewrites an absolute Location header to the proxy base', async () => {
+    sendCommandMock.mockResolvedValue(
+      okAgentResult({
+        status: 302,
+        headers: { location: ['http://192.168.1.50/foo'] },
+        bodyB64: '',
+      }),
+    );
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/`, { headers: { cookie }, redirect: 'manual' });
+    expect(res.headers.get('location')).toBe(`/api/v1/tunnel-http/${TUNNEL_ID}/foo`);
+  });
+
+  it('rewrites a relative Location header to the proxy base', async () => {
+    sendCommandMock.mockResolvedValue(
+      okAgentResult({
+        status: 302,
+        headers: { location: ['/login'] },
+        bodyB64: '',
+      }),
+    );
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/`, { headers: { cookie }, redirect: 'manual' });
+    expect(res.headers.get('location')).toBe(`/api/v1/tunnel-http/${TUNNEL_ID}/login`);
+  });
+
+  it('rewrites Set-Cookie Path to the proxy base', async () => {
+    sendCommandMock.mockResolvedValue(
+      okAgentResult({
+        headers: { 'content-type': ['text/plain'], 'set-cookie': ['sid=abc; Path=/; HttpOnly'] },
+      }),
+    );
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    const sc = res.headers.get('set-cookie') ?? '';
+    expect(sc).toContain(`Path=/api/v1/tunnel-http/${TUNNEL_ID}/`);
+  });
+});

--- a/apps/api/src/routes/tunnelHttp.test.ts
+++ b/apps/api/src/routes/tunnelHttp.test.ts
@@ -286,20 +286,49 @@ describe('tunnelHttp dispatch (cookie-authed)', () => {
 });
 
 describe('tunnelHttp response rewriting', () => {
-  it('strips CSP and content-length headers', async () => {
+  it('replaces the device CSP with a restrictive sandbox CSP and drops content-length', async () => {
     sendCommandMock.mockResolvedValue(
       okAgentResult({
         headers: {
           'content-type': ['text/plain'],
           'content-security-policy': ["default-src 'self'"],
           'content-length': ['5'],
+          'x-frame-options': ['SAMEORIGIN'],
         },
       }),
     );
     const app = makeApp();
     const cookie = await mintCookie(app);
     const res = await app.request(`${BASE}/`, { headers: { cookie } });
-    expect(res.headers.get('content-security-policy')).toBeNull();
+    // The device's own CSP must not survive; we impose our own sandbox policy.
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).not.toContain("default-src 'self'");
+    expect(csp).toContain('sandbox');
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(res.headers.get('x-frame-options')).toBeNull();
+  });
+
+  it('does not forward the user app cookies/authorization to the device, only device-prefixed cookies', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    // Browser sends: the proxy auth cookie, a leaked app cookie, and a device cookie.
+    const res = await app.request(`${BASE}/`, {
+      headers: {
+        cookie: `${cookie}; breeze_refresh=SECRET; bzdev_session=devsid`,
+        authorization: 'Bearer USER-API-TOKEN',
+      },
+    });
+    expect(res.status).toBe(200);
+    const [, command] = sendCommandMock.mock.calls.at(-1)!;
+    const fwd = JSON.stringify(command.payload.headers);
+    // App credentials must NOT reach the device.
+    expect(fwd).not.toContain('breeze_refresh');
+    expect(fwd).not.toContain('SECRET');
+    expect(fwd.toLowerCase()).not.toContain('authorization');
+    expect(fwd).not.toContain('USER-API-TOKEN');
+    expect(fwd).not.toContain('bz_tunnel');
+    // The device's own cookie round-trips, de-prefixed.
+    expect(command.payload.headers.cookie?.[0]).toBe('session=devsid');
   });
 
   it('injects <base> tag into text/html responses', async () => {
@@ -344,7 +373,7 @@ describe('tunnelHttp response rewriting', () => {
     expect(res.headers.get('location')).toBe(`/api/v1/tunnel-http/${TUNNEL_ID}/login`);
   });
 
-  it('rewrites Set-Cookie Path to the proxy base', async () => {
+  it('namespaces + path-scopes the device Set-Cookie so it round-trips without colliding with app cookies', async () => {
     sendCommandMock.mockResolvedValue(
       okAgentResult({
         headers: { 'content-type': ['text/plain'], 'set-cookie': ['sid=abc; Path=/; HttpOnly'] },
@@ -354,6 +383,7 @@ describe('tunnelHttp response rewriting', () => {
     const cookie = await mintCookie(app);
     const res = await app.request(`${BASE}/`, { headers: { cookie } });
     const sc = res.headers.get('set-cookie') ?? '';
+    expect(sc).toContain('bzdev_sid=abc');
     expect(sc).toContain(`Path=/api/v1/tunnel-http/${TUNNEL_ID}/`);
   });
 });

--- a/apps/api/src/routes/tunnelHttp.ts
+++ b/apps/api/src/routes/tunnelHttp.ts
@@ -58,6 +58,43 @@ const HOP_BY_HOP = new Set([
   'host',
 ]);
 
+// Request headers we forward to the LAN device. ALLOWLIST, not denylist — the
+// device is untrusted and must never receive the user's Breeze credentials
+// (`cookie`, `authorization`). Device session cookies are handled separately via
+// the prefixed jar below so they round-trip without leaking app cookies.
+const FORWARDABLE_REQUEST_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'accept-encoding',
+  'user-agent',
+  'content-type',
+  'content-length',
+  'range',
+  'if-modified-since',
+  'if-none-match',
+  'cache-control',
+]);
+
+// The device's own cookies are stored in the browser under this prefix so they
+// are namespaced away from (and never confused with) Breeze app cookies. We
+// de-prefix on the way to the device and re-prefix on the way back.
+const DEVICE_COOKIE_PREFIX = 'bzdev_';
+
+// Restrictive CSP applied to every proxied response: sandbox the device content
+// (null origin — can't read app cookies/storage or reach the parent) while still
+// letting the device's own scripts/forms run, and forbid third-party framing.
+const PROXY_RESPONSE_CSP = "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox; frame-ancestors 'self'";
+
+/** Rebuild a Cookie header containing only the device's own (prefixed) cookies, de-prefixed. */
+function extractDeviceCookies(cookieHeader: string): string {
+  return cookieHeader
+    .split(';')
+    .map((s) => s.trim())
+    .filter((c) => c.startsWith(DEVICE_COOKIE_PREFIX))
+    .map((c) => c.slice(DEVICE_COOKIE_PREFIX.length))
+    .join('; ');
+}
+
 // ---------------------------------------------------------------------------
 // Cookie signing (reuses the JWT keyring from services/jwt.ts — no bespoke
 // crypto). Distinct audience so a tunnel cookie can never be replayed as an API
@@ -155,12 +192,23 @@ function rewriteLocation(loc: string, basePath: string): string {
   }
 }
 
-/** Force an upstream Set-Cookie's Path onto the proxy base so it scopes here. */
-function scopeCookiePath(value: string, basePath: string): string {
-  if (/;\s*path=/i.test(value)) {
-    return value.replace(/;\s*path=[^;]*/i, `; Path=${basePath}`);
+/**
+ * Rewrite an upstream Set-Cookie so it (a) is namespaced under the device-cookie
+ * prefix and (b) scopes to the proxy base path. Namespacing keeps device cookies
+ * from colliding with — or being mistaken for — Breeze app cookies, and lets the
+ * forward path send ONLY device cookies to the device.
+ */
+function prefixAndScopeDeviceCookie(value: string, basePath: string): string {
+  // Prefix the cookie name (everything before the first '=').
+  const eq = value.indexOf('=');
+  let out = eq > 0 ? `${DEVICE_COOKIE_PREFIX}${value}` : value;
+  // Force Path onto the proxy base.
+  if (/;\s*path=/i.test(out)) {
+    out = out.replace(/;\s*path=[^;]*/i, `; Path=${basePath}`);
+  } else {
+    out = `${out}; Path=${basePath}`;
   }
-  return `${value}; Path=${basePath}`;
+  return out;
 }
 
 /** Inject `<base href>` so relative URLs in the framed page resolve via proxy. */
@@ -172,15 +220,6 @@ function injectBaseTag(html: string, basePath: string): string {
     return html.slice(0, idx) + tag + html.slice(idx);
   }
   return tag + html;
-}
-
-/** Drop our own auth cookie from a forwarded Cookie header; keep the rest. */
-function stripAuthCookie(cookieHeader: string, authCookieName: string): string {
-  return cookieHeader
-    .split(';')
-    .map((s) => s.trim())
-    .filter((c) => c.length > 0 && !c.startsWith(`${authCookieName}=`))
-    .join('; ');
 }
 
 // ---------------------------------------------------------------------------
@@ -250,16 +289,19 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
   const qs = new URL(c.req.url).search;
   const path = '/' + wildcard + qs;
 
+  // Forward ONLY allowlisted content-negotiation headers — never the user's
+  // `cookie`/`authorization` (which would leak Breeze session credentials to the
+  // untrusted device). The device's own cookies are reconstructed from the
+  // prefixed jar so its session round-trips without exposing app cookies.
   const headers: Record<string, string[]> = {};
   for (const [k, v] of Object.entries(c.req.header())) {
-    const lk = k.toLowerCase();
-    if (HOP_BY_HOP.has(lk)) continue;
-    if (lk === 'cookie') {
-      const stripped = stripAuthCookie(v, authCookieName);
-      if (stripped.length > 0) headers[k] = [stripped];
-      continue;
+    if (FORWARDABLE_REQUEST_HEADERS.has(k.toLowerCase())) {
+      headers[k] = [v];
     }
-    headers[k] = [v];
+  }
+  const deviceCookies = extractDeviceCookies(c.req.header('cookie') ?? '');
+  if (deviceCookies) {
+    headers['cookie'] = [deviceCookies];
   }
 
   const method = c.req.method.toUpperCase();
@@ -315,9 +357,15 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
   for (const [k, values] of Object.entries(upstream.headers ?? {})) {
     const lk = k.toLowerCase();
     if (HOP_BY_HOP.has(lk)) continue;
-    // content-length is recomputed by the runtime; CSP would block the framed
-    // page from rendering, so both are stripped.
-    if (lk === 'content-length' || lk === 'content-security-policy' || lk === 'content-security-policy-report-only') {
+    // content-length is recomputed by the runtime. We drop the device's CSP and
+    // x-frame-options and impose our own restrictive sandbox CSP below — the
+    // device's policy must not govern content rendered on our origin.
+    if (
+      lk === 'content-length' ||
+      lk === 'content-security-policy' ||
+      lk === 'content-security-policy-report-only' ||
+      lk === 'x-frame-options'
+    ) {
       continue;
     }
     if (lk === 'content-type') {
@@ -330,11 +378,15 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
       continue;
     }
     if (lk === 'set-cookie') {
-      for (const v of values) respHeaders.append('set-cookie', scopeCookiePath(v, basePath));
+      for (const v of values) respHeaders.append('set-cookie', prefixAndScopeDeviceCookie(v, basePath));
       continue;
     }
     for (const v of values) respHeaders.append(k, v);
   }
+
+  // Sandbox the proxied (untrusted) device content so its scripts run in a null
+  // origin and cannot read app cookies/storage or reach the parent frame.
+  respHeaders.set('content-security-policy', PROXY_RESPONSE_CSP);
 
   if (contentType.toLowerCase().includes('text/html')) {
     body = injectBaseTag(body.toString('utf8'), basePath);

--- a/apps/api/src/routes/tunnelHttp.ts
+++ b/apps/api/src/routes/tunnelHttp.ts
@@ -1,0 +1,347 @@
+import { Hono } from 'hono';
+import { getCookie, setCookie } from 'hono/cookie';
+import { SignJWT, jwtVerify } from 'jose';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { tunnelSessions, devices } from '../db/schema';
+import { consumeWsTicket } from '../services/remoteSessionAuth';
+import { sendCommandToAgentAwaitResult } from '../services/agentCommandAwait';
+import { getActiveAllowlistPatterns } from '../services/tunnelAllowlist';
+import { isAgentConnected } from './agentWs';
+import { checkRemoteAccess } from '../services/remoteAccessPolicy';
+import { getTrustedClientIp } from '../services/clientIp';
+import { getSignKey, getVerifyKey, buildHeader } from '../services/jwt';
+
+/**
+ * HTTP reverse-proxy route for the Network Proxy feature.
+ *
+ * Proxies a discovered LAN device's web UI (e.g. a printer/switch admin page)
+ * to the browser by issuing `http_request` commands to the bridging agent.
+ * The proxy target is ALWAYS taken from the owning `tunnel_sessions` row —
+ * NEVER from the request — so the browser can only control method/path/headers/
+ * body, never which internal host is reached (SSRF guard, defense-in-depth with
+ * the agent's own blocked-CIDR + allowlist re-validation).
+ *
+ * Auth model (mirrors tunnel-ws — NOT behind the global Bearer authMiddleware):
+ *   1. First navigation carries `?__bzt=<ticket>` (minted by POST
+ *      /tunnels/:id/http-ticket). We consume the one-time ticket, own-check the
+ *      session, set a short-lived signed HttpOnly cookie scoped to this
+ *      tunnel's proxy base, and 302-redirect to the same URL without `__bzt`
+ *      (so the ticket isn't re-used or leaked via Referer).
+ *   2. Sub-resource requests authenticate via that cookie.
+ *   EVERY request re-checks owner + device-online + agent-connected + policy.
+ *
+ * Known gaps (documented, not bugs): `<base href>` injection fixes relative
+ * URLs in most printer UIs, but absolute-URL or JS-constructed URLs that point
+ * straight at the LAN host won't be rewritten and will 404 through the proxy.
+ * Per-user rate limiting is intentionally deferred to the Task 8 security pass.
+ */
+export const tunnelHttpRoutes = new Hono();
+
+const HTTP_REQUEST_TIMEOUT_MS = 25_000;
+const COOKIE_TTL_SECONDS = 300; // ~5 min
+const COOKIE_AUDIENCE = 'breeze-tunnel-http';
+const CONNECTABLE_TUNNEL_STATUSES = ['pending', 'connecting', 'active'];
+
+// Hop-by-hop headers (RFC 7230 §6.1) plus `host` — never forwarded in either
+// direction. Lowercased for case-insensitive matching.
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+// ---------------------------------------------------------------------------
+// Cookie signing (reuses the JWT keyring from services/jwt.ts — no bespoke
+// crypto). Distinct audience so a tunnel cookie can never be replayed as an API
+// access/viewer token, and vice-versa.
+// ---------------------------------------------------------------------------
+
+async function signTunnelCookie(userId: string, tunnelId: string): Promise<string> {
+  const { key, kid } = getSignKey();
+  return new SignJWT({ tunnelId })
+    .setProtectedHeader(buildHeader(kid))
+    .setSubject(userId)
+    .setIssuedAt()
+    .setExpirationTime(`${COOKIE_TTL_SECONDS}s`)
+    .setIssuer('breeze')
+    .setAudience(COOKIE_AUDIENCE)
+    .sign(key);
+}
+
+async function verifyTunnelCookie(token: string | undefined, tunnelId: string): Promise<string | null> {
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, getVerifyKey, {
+      issuer: 'breeze',
+      audience: COOKIE_AUDIENCE,
+      algorithms: ['HS256'],
+    });
+    if (payload.tunnelId !== tunnelId) return null;
+    if (typeof payload.sub !== 'string' || payload.sub.length === 0) return null;
+    return payload.sub;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session ownership + reachability lookup (fail-closed).
+// ---------------------------------------------------------------------------
+
+interface UsableTunnel {
+  agentId: string | null;
+  deviceId: string;
+  deviceStatus: string;
+  targetHost: string;
+  targetPort: number;
+  orgId: string;
+  type: string;
+}
+
+/**
+ * Load a tunnel session and confirm the cookie/ticket user owns it and it's in
+ * a connectable state. Runs in system DB context because this route mounts
+ * before auth middleware (no request-scoped RLS context); ownership is enforced
+ * in app code by the `session.userId === userId` check. Returns null (→ 404)
+ * when the session is missing, owned by someone else, or in a terminal state.
+ */
+async function loadOwnedTunnelSession(tunnelId: string, userId: string): Promise<UsableTunnel | null> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ session: tunnelSessions, device: devices })
+      .from(tunnelSessions)
+      .innerJoin(devices, eq(tunnelSessions.deviceId, devices.id))
+      .where(eq(tunnelSessions.id, tunnelId))
+      .limit(1);
+
+    if (!row) return null;
+    const { session, device } = row;
+    if (session.userId !== userId) return null;
+    if (!CONNECTABLE_TUNNEL_STATUSES.includes(session.status)) return null;
+
+    return {
+      agentId: device.agentId ?? null,
+      deviceId: device.id,
+      deviceStatus: device.status,
+      targetHost: session.targetHost,
+      targetPort: session.targetPort,
+      orgId: session.orgId,
+      type: session.type,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Response-rewriting helpers.
+// ---------------------------------------------------------------------------
+
+/** Rewrite an upstream Location (3xx) so the browser stays inside the proxy. */
+function rewriteLocation(loc: string, basePath: string): string {
+  try {
+    const u = new URL(loc); // absolute URL → keep only path-and-after
+    return basePath + u.pathname.replace(/^\//, '') + u.search + u.hash;
+  } catch {
+    // Relative URL.
+    if (loc.startsWith('/')) return basePath + loc.replace(/^\//, '');
+    return basePath + loc;
+  }
+}
+
+/** Force an upstream Set-Cookie's Path onto the proxy base so it scopes here. */
+function scopeCookiePath(value: string, basePath: string): string {
+  if (/;\s*path=/i.test(value)) {
+    return value.replace(/;\s*path=[^;]*/i, `; Path=${basePath}`);
+  }
+  return `${value}; Path=${basePath}`;
+}
+
+/** Inject `<base href>` so relative URLs in the framed page resolve via proxy. */
+function injectBaseTag(html: string, basePath: string): string {
+  const tag = `<base href="${basePath}">`;
+  const headMatch = html.match(/<head[^>]*>/i);
+  if (headMatch && headMatch.index !== undefined) {
+    const idx = headMatch.index + headMatch[0].length;
+    return html.slice(0, idx) + tag + html.slice(idx);
+  }
+  return tag + html;
+}
+
+/** Drop our own auth cookie from a forwarded Cookie header; keep the rest. */
+function stripAuthCookie(cookieHeader: string, authCookieName: string): string {
+  return cookieHeader
+    .split(';')
+    .map((s) => s.trim())
+    .filter((c) => c.length > 0 && !c.startsWith(`${authCookieName}=`))
+    .join('; ');
+}
+
+// ---------------------------------------------------------------------------
+// The proxy route.
+// ---------------------------------------------------------------------------
+
+tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
+  const tunnelId = c.req.param('tunnelId');
+  const basePath = `/api/v1/tunnel-http/${tunnelId}/`;
+  const authCookieName = `bz_tunnel_${tunnelId}`;
+
+  // 1. Authn: cookie first; else one-time ticket → set cookie → redirect.
+  let userId = await verifyTunnelCookie(getCookie(c, authCookieName), tunnelId);
+  if (!userId) {
+    const ticket = c.req.query('__bzt');
+    if (!ticket) {
+      return c.text('Unauthorized', 401);
+    }
+    const consumed = await consumeWsTicket(ticket, {
+      ip: getTrustedClientIp(c),
+      userAgent: c.req.header('user-agent') ?? '',
+    });
+    if (
+      !consumed.ok ||
+      consumed.sessionId !== tunnelId ||
+      consumed.sessionType !== 'tunnel-http'
+    ) {
+      return c.text('Unauthorized', 401);
+    }
+
+    // Confirm the ticket-bearer actually owns a usable session before minting
+    // the cookie (fail-closed — don't hand out a 5-min cookie for a dead/
+    // foreign session).
+    const ownedAtMint = await loadOwnedTunnelSession(tunnelId, consumed.userId);
+    if (!ownedAtMint) {
+      return c.text('Not found', 404);
+    }
+
+    setCookie(c, authCookieName, await signTunnelCookie(consumed.userId, tunnelId), {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+      path: basePath,
+      maxAge: COOKIE_TTL_SECONDS,
+    });
+
+    const url = new URL(c.req.url);
+    url.searchParams.delete('__bzt');
+    return c.redirect(url.pathname + url.search, 302);
+  }
+
+  // 2. Authz: owner + device online + agent connected + policy (fail-closed).
+  const session = await loadOwnedTunnelSession(tunnelId, userId);
+  if (!session) {
+    return c.text('Not found', 404);
+  }
+  if (session.deviceStatus !== 'online' || !session.agentId || !isAgentConnected(session.agentId)) {
+    return c.text('Bridge agent offline', 502);
+  }
+  const policy = await checkRemoteAccess(session.deviceId, 'proxy');
+  if (!policy.allowed) {
+    return c.text(policy.reason ?? 'Proxy access disabled by policy', 403);
+  }
+
+  // 3. Build + dispatch the http_request command.
+  const wildcard = c.req.path.startsWith(basePath) ? c.req.path.slice(basePath.length) : '';
+  const qs = new URL(c.req.url).search;
+  const path = '/' + wildcard + qs;
+
+  const headers: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(c.req.header())) {
+    const lk = k.toLowerCase();
+    if (HOP_BY_HOP.has(lk)) continue;
+    if (lk === 'cookie') {
+      const stripped = stripAuthCookie(v, authCookieName);
+      if (stripped.length > 0) headers[k] = [stripped];
+      continue;
+    }
+    headers[k] = [v];
+  }
+
+  const method = c.req.method.toUpperCase();
+  let bodyB64 = '';
+  if (method !== 'GET' && method !== 'HEAD') {
+    const buf = Buffer.from(await c.req.arrayBuffer());
+    bodyB64 = buf.toString('base64');
+  }
+
+  const scheme: 'http' | 'https' = session.targetPort === 443 ? 'https' : 'http';
+
+  const awaitResult = await sendCommandToAgentAwaitResult(
+    session.agentId,
+    {
+      id: `http-req-${tunnelId}-${randomUUID()}`,
+      type: 'http_request',
+      payload: {
+        tunnelId,
+        targetHost: session.targetHost,
+        targetPort: session.targetPort,
+        scheme,
+        method,
+        path,
+        headers,
+        bodyB64,
+        allowlistRules: await getActiveAllowlistPatterns(session.orgId),
+      },
+    },
+    HTTP_REQUEST_TIMEOUT_MS,
+  );
+
+  if (awaitResult.status !== 'completed') {
+    const err = awaitResult.error ?? '';
+    if (/timeout/i.test(err)) {
+      return c.text('Upstream timeout', 504);
+    }
+    return c.text('Bridge agent error', 502);
+  }
+
+  // 4. Parse the agent's structured HTTP response (carried in stdout).
+  let upstream: { status: number; headers: Record<string, string[]>; bodyB64: string; truncated?: boolean };
+  try {
+    upstream = JSON.parse(awaitResult.stdout ?? '');
+  } catch {
+    return c.text('Malformed upstream response', 502);
+  }
+
+  // 5. Rewrite headers + body, then return.
+  let body: Buffer | string = Buffer.from(upstream.bodyB64 ?? '', 'base64');
+  const respHeaders = new Headers();
+  let contentType = '';
+
+  for (const [k, values] of Object.entries(upstream.headers ?? {})) {
+    const lk = k.toLowerCase();
+    if (HOP_BY_HOP.has(lk)) continue;
+    // content-length is recomputed by the runtime; CSP would block the framed
+    // page from rendering, so both are stripped.
+    if (lk === 'content-length' || lk === 'content-security-policy' || lk === 'content-security-policy-report-only') {
+      continue;
+    }
+    if (lk === 'content-type') {
+      contentType = values[0] ?? '';
+      respHeaders.set('content-type', contentType);
+      continue;
+    }
+    if (lk === 'location') {
+      if (values[0]) respHeaders.set('location', rewriteLocation(values[0], basePath));
+      continue;
+    }
+    if (lk === 'set-cookie') {
+      for (const v of values) respHeaders.append('set-cookie', scopeCookiePath(v, basePath));
+      continue;
+    }
+    for (const v of values) respHeaders.append(k, v);
+  }
+
+  if (contentType.toLowerCase().includes('text/html')) {
+    body = injectBaseTag(body.toString('utf8'), basePath);
+  }
+
+  // Buffer isn't a DOM `BodyInit`; hand the runtime a Uint8Array for binary
+  // responses and the string as-is for rewritten HTML.
+  const responseBody: BodyInit = typeof body === 'string' ? body : new Uint8Array(body);
+  return new Response(responseBody, { status: upstream.status, headers: respHeaders });
+});

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -120,6 +120,7 @@ vi.mock('../services/remoteSessionAuth', () => ({
   createVncConnectCode: vi.fn(async () => ({ code: 'test-connect-code-32bytes', expiresInSeconds: 60 })),
   consumeVncConnectCode: vi.fn(),
   getViewerAccessTokenExpirySeconds: vi.fn(() => 900),
+  HTTP_TICKET_TTL_MS: 300_000,
 }));
 
 // --- JWT service ---
@@ -154,7 +155,7 @@ vi.mock('../services/viewerTokenRevocation', () => ({
 
 import { db } from '../db';
 import { sendCommandToAgent } from './agentWs';
-import { createVncConnectCode, consumeVncConnectCode } from '../services/remoteSessionAuth';
+import { createWsTicket, createVncConnectCode, consumeVncConnectCode } from '../services/remoteSessionAuth';
 import { createViewerAccessToken, verifyViewerAccessToken } from '../services/jwt';
 import { captureException } from '../services/sentry';
 
@@ -1509,5 +1510,90 @@ describe('Audit logging — credential-minting tunnel endpoints', () => {
       result: 'success',
     }));
     expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID, type: 'vnc', via: 'downgrade_vnc' }));
+  });
+});
+
+// ─── POST /tunnels/:id/http-ticket ───────────────────────────────────────────
+
+describe('POST /tunnels/:id/http-ticket', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.insert).mockReset();
+    rateLimiterMock.mockResolvedValue({
+      allowed: true,
+      remaining: 19,
+      resetAt: new Date(Date.now() + 60_000),
+    });
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+  });
+
+  it('returns { ticket } for a session owner with a connectable tunnel', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([sessionRecord]) as any);
+    vi.mocked(db.insert).mockReturnValue(makeAuditAwareInsertChain([]) as any);
+
+    const res = await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('ticket');
+  });
+
+  it('returns 404 when the tunnel is not found', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([]) as any);
+
+    const res = await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when the caller is not the session owner', async () => {
+    const otherUserSession = { ...sessionRecord, userId: 'other-user-id' };
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([otherUserSession]) as any);
+
+    const res = await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when the tunnel is in a non-connectable state', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([{ ...sessionRecord, status: 'disconnected' }]) as any);
+
+    const res = await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+    expect(res.status).toBe(400);
+  });
+
+  it('mints with sessionType tunnel-http and passes the 5-min TTL', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([sessionRecord]) as any);
+    vi.mocked(db.insert).mockReturnValue(makeAuditAwareInsertChain([]) as any);
+
+    await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+
+    expect(createWsTicket).toHaveBeenCalledWith(expect.objectContaining({
+      sessionType: 'tunnel-http',
+      ttlMs: 300_000,
+    }));
+  });
+
+  it('writes a tunnel.http_ticket.mint audit row', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([sessionRecord]) as any);
+    const insertMock = vi.fn().mockReturnValue(makeAuditAwareInsertChain([]));
+    vi.mocked(db.insert).mockImplementation(insertMock as any);
+
+    const res = await app.request(`/tunnels/${SESSION_ID}/http-ticket`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    const audits = auditCalls(insertMock);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toEqual(expect.objectContaining({
+      action: 'tunnel.http_ticket.mint',
+      resourceType: 'tunnel_session',
+      resourceId: SESSION_ID,
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      result: 'success',
+    }));
+    expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID }));
   });
 });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -11,6 +11,7 @@ import { checkRemoteAccess } from '../services/remoteAccessPolicy';
 import { createWsTicket, createVncConnectCode, consumeVncConnectCode, getViewerAccessTokenExpirySeconds, HTTP_TICKET_TTL_MS } from '../services/remoteSessionAuth';
 import { createViewerAccessToken, verifyViewerAccessToken } from '../services/jwt';
 import { getTrustedClientIp } from '../services/clientIp';
+import { getActiveAllowlistPatterns } from '../services/tunnelAllowlist';
 import { getRedis } from '../services/redis';
 import { rateLimiter } from '../services/rate-limit';
 import { isViewerJtiRevoked, isViewerSessionRevoked, revokeViewerSession } from '../services/viewerTokenRevocation';
@@ -281,18 +282,6 @@ async function logTunnelAudit(
     console.error('Failed to log tunnel audit:', error);
     captureException(error);
   }
-}
-
-async function getActiveAllowlistPatterns(orgId: string): Promise<string[]> {
-  const rules = await db
-    .select({ pattern: tunnelAllowlists.pattern })
-    .from(tunnelAllowlists)
-    .where(and(
-      eq(tunnelAllowlists.orgId, orgId),
-      eq(tunnelAllowlists.direction, 'destination'),
-      eq(tunnelAllowlists.enabled, true),
-    ));
-  return rules.map(r => r.pattern);
 }
 
 // --- Routes ---

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -8,7 +8,7 @@ import { captureException } from '../services/sentry';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
 import { checkRemoteAccess } from '../services/remoteAccessPolicy';
-import { createWsTicket, createVncConnectCode, consumeVncConnectCode, getViewerAccessTokenExpirySeconds } from '../services/remoteSessionAuth';
+import { createWsTicket, createVncConnectCode, consumeVncConnectCode, getViewerAccessTokenExpirySeconds, HTTP_TICKET_TTL_MS } from '../services/remoteSessionAuth';
 import { createViewerAccessToken, verifyViewerAccessToken } from '../services/jwt';
 import { getTrustedClientIp } from '../services/clientIp';
 import { getRedis } from '../services/redis';
@@ -804,6 +804,64 @@ tunnelRoutes.post(
 
     await logTunnelAudit(
       'tunnel.ws_ticket.mint',
+      'tunnel_session',
+      id,
+      auth.user.id,
+      session.orgId,
+      { deviceId: session.deviceId, type: session.type },
+      getClientIp(c),
+    );
+
+    return c.json({ ticket });
+  }
+);
+
+// POST /tunnels/:id/http-ticket — Issue a one-time HTTP proxy ticket (5-min TTL for proxy page load)
+tunnelRoutes.post(
+  '/:id/http-ticket',
+  requireScope('organization', 'partner', 'system'),
+  zValidator('param', idParamSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { id } = c.req.valid('param');
+
+    const conditions = [eq(tunnelSessions.id, id)];
+    if (auth.orgId) {
+      conditions.push(eq(tunnelSessions.orgId, auth.orgId));
+    }
+
+    const [session] = await db
+      .select()
+      .from(tunnelSessions)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!session) {
+      return c.json({ error: 'Tunnel session not found' }, 404);
+    }
+
+    if (session.userId !== auth.user.id) {
+      return c.json({ error: 'Not the session owner' }, 403);
+    }
+
+    if (!CONNECTABLE_TUNNEL_STATUSES.includes(session.status as (typeof CONNECTABLE_TUNNEL_STATUSES)[number])) {
+      return c.json({
+        error: 'Cannot mint HTTP ticket for tunnel in current state',
+        status: session.status,
+      }, 400);
+    }
+
+    const ticket = await createWsTicket({
+      sessionId: id,
+      sessionType: 'tunnel-http',
+      userId: auth.user.id,
+      ip: getTrustedClientIp(c),
+      userAgent: c.req.header('user-agent') ?? '',
+      ttlMs: HTTP_TICKET_TTL_MS,
+    });
+
+    await logTunnelAudit(
+      'tunnel.http_ticket.mint',
       'tunnel_session',
       id,
       auth.user.id,

--- a/apps/api/src/services/agentCommandAwait.test.ts
+++ b/apps/api/src/services/agentCommandAwait.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock sendCommandToAgent before importing the module under test
+vi.mock('../routes/agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+}));
+
+import { sendCommandToAgentAwaitResult, resolvePendingAgentCommand } from './agentCommandAwait';
+import { sendCommandToAgent } from '../routes/agentWs';
+
+const mockSendCommandToAgent = vi.mocked(sendCommandToAgent);
+
+const testCommand = { id: 'test-cmd-id-001', type: 'http_request', payload: { url: 'http://example.com' } };
+
+describe('agentCommandAwait', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves with result when resolvePendingAgentCommand is called with matching id', async () => {
+    mockSendCommandToAgent.mockReturnValue(true);
+
+    const promise = sendCommandToAgentAwaitResult('agent-001', testCommand, 5000);
+
+    const expectedResult = { status: 'completed', result: { statusCode: 200, body: 'ok' } };
+    resolvePendingAgentCommand(testCommand.id, expectedResult);
+
+    await expect(promise).resolves.toEqual(expectedResult);
+  });
+
+  it('returns {status:"failed"} on timeout without actually sleeping', async () => {
+    mockSendCommandToAgent.mockReturnValue(true);
+
+    const promise = sendCommandToAgentAwaitResult('agent-001', testCommand, 3000);
+
+    vi.advanceTimersByTime(3000);
+
+    const result = await promise;
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/timeout/i);
+  });
+
+  it('returns {status:"failed", error:"agent offline"} immediately when sendCommandToAgent returns false', async () => {
+    mockSendCommandToAgent.mockReturnValue(false);
+
+    const result = await sendCommandToAgentAwaitResult('agent-001', testCommand, 5000);
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/offline/i);
+  });
+
+  it('resolvePendingAgentCommand for unknown id is a no-op and does not throw', () => {
+    expect(() => {
+      resolvePendingAgentCommand('no-such-id', { status: 'completed' });
+    }).not.toThrow();
+  });
+
+  it('does not leak timers — calling resolve before timeout clears the timer', async () => {
+    mockSendCommandToAgent.mockReturnValue(true);
+
+    const cmd = { id: 'cmd-timer-leak', type: 'http_request', payload: {} };
+    const promise = sendCommandToAgentAwaitResult('agent-001', cmd, 10000);
+
+    resolvePendingAgentCommand(cmd.id, { status: 'completed' });
+    await promise;
+
+    // Advance past the timeout — should not resolve again or throw
+    vi.advanceTimersByTime(15000);
+    // No assertions needed: test passes if no unhandled rejection or double-resolve
+  });
+
+  it('passes the agentId and command through to sendCommandToAgent', async () => {
+    mockSendCommandToAgent.mockReturnValue(true);
+
+    const cmd = { id: 'cmd-passthrough', type: 'http_request', payload: { url: 'http://test' } };
+    const p = sendCommandToAgentAwaitResult('my-agent-id', cmd, 1000);
+
+    resolvePendingAgentCommand(cmd.id, { status: 'completed' });
+    await p;
+
+    expect(mockSendCommandToAgent).toHaveBeenCalledWith('my-agent-id', cmd);
+  });
+});

--- a/apps/api/src/services/agentCommandAwait.test.ts
+++ b/apps/api/src/services/agentCommandAwait.test.ts
@@ -27,11 +27,19 @@ describe('agentCommandAwait', () => {
 
     const promise = sendCommandToAgentAwaitResult('agent-001', testCommand, 5000);
 
-    const expectedResult = { status: 'completed', result: { statusCode: 200, body: 'ok' } };
+    // Agents put structured output as a JSON string in `stdout` — assert it
+    // survives the round-trip so awaited callers can read the response body.
+    const expectedResult = {
+      status: 'completed',
+      result: { statusCode: 200 },
+      stdout: JSON.stringify({ status: 200, headers: {}, bodyB64: 'b2s=', truncated: false }),
+    };
     const consumed = resolvePendingAgentCommand(testCommand.id, expectedResult);
     expect(consumed).toBe(true);
 
-    await expect(promise).resolves.toEqual(expectedResult);
+    const resolved = await promise;
+    expect(resolved).toEqual(expectedResult);
+    expect(resolved.stdout).toBe(expectedResult.stdout);
   });
 
   it('returns {status:"failed"} on timeout without actually sleeping', async () => {

--- a/apps/api/src/services/agentCommandAwait.test.ts
+++ b/apps/api/src/services/agentCommandAwait.test.ts
@@ -28,7 +28,8 @@ describe('agentCommandAwait', () => {
     const promise = sendCommandToAgentAwaitResult('agent-001', testCommand, 5000);
 
     const expectedResult = { status: 'completed', result: { statusCode: 200, body: 'ok' } };
-    resolvePendingAgentCommand(testCommand.id, expectedResult);
+    const consumed = resolvePendingAgentCommand(testCommand.id, expectedResult);
+    expect(consumed).toBe(true);
 
     await expect(promise).resolves.toEqual(expectedResult);
   });
@@ -54,10 +55,12 @@ describe('agentCommandAwait', () => {
     expect(result.error).toMatch(/offline/i);
   });
 
-  it('resolvePendingAgentCommand for unknown id is a no-op and does not throw', () => {
+  it('resolvePendingAgentCommand for unknown id is a no-op, returns false, and does not throw', () => {
+    let returned: boolean | undefined;
     expect(() => {
-      resolvePendingAgentCommand('no-such-id', { status: 'completed' });
+      returned = resolvePendingAgentCommand('no-such-id', { status: 'completed' });
     }).not.toThrow();
+    expect(returned).toBe(false);
   });
 
   it('does not leak timers — calling resolve before timeout clears the timer', async () => {
@@ -67,11 +70,12 @@ describe('agentCommandAwait', () => {
     const promise = sendCommandToAgentAwaitResult('agent-001', cmd, 10000);
 
     resolvePendingAgentCommand(cmd.id, { status: 'completed' });
-    await promise;
+    // Positive assertion: it resolves with the supplied result (not the timeout value)
+    await expect(promise).resolves.toEqual({ status: 'completed' });
 
     // Advance past the timeout — should not resolve again or throw
     vi.advanceTimersByTime(15000);
-    // No assertions needed: test passes if no unhandled rejection or double-resolve
+    // The timer was cleared on resolve, so advancing does nothing (no double-resolve).
   });
 
   it('passes the agentId and command through to sendCommandToAgent', async () => {

--- a/apps/api/src/services/agentCommandAwait.ts
+++ b/apps/api/src/services/agentCommandAwait.ts
@@ -1,0 +1,75 @@
+/**
+ * Promise-correlated agent command await helper.
+ *
+ * Sends a command to a connected agent and awaits its result over the
+ * WebSocket command-result channel, correlating by command id. The caller
+ * gets back a typed Promise instead of having to wire up a callback manually.
+ *
+ * Usage:
+ *   const result = await sendCommandToAgentAwaitResult(agentId, command, 30_000);
+ *
+ * The companion `resolvePendingAgentCommand` is called from the agentWs
+ * processCommandResult dispatcher whenever a command_result message arrives,
+ * so any in-flight awaited command resolves automatically.
+ */
+
+import { sendCommandToAgent } from '../routes/agentWs';
+
+export type AgentCommandAwaitResult = {
+  status: string;
+  result?: unknown;
+  error?: string;
+};
+
+type PendingEntry = {
+  resolve: (value: AgentCommandAwaitResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+const pending = new Map<string, PendingEntry>();
+
+/**
+ * Send a command to an agent and await its result.
+ *
+ * Resolves with the result payload when `resolvePendingAgentCommand` is called
+ * for the same command id. Resolves with `{status:'failed'}` if the agent is
+ * offline (sendCommandToAgent returns false) or if timeoutMs elapses.
+ */
+export function sendCommandToAgentAwaitResult(
+  agentId: string,
+  command: { id: string; type: string; payload: Record<string, unknown> },
+  timeoutMs: number,
+): Promise<AgentCommandAwaitResult> {
+  const sent = sendCommandToAgent(agentId, command);
+  if (!sent) {
+    return Promise.resolve({ status: 'failed', error: 'agent offline' });
+  }
+
+  return new Promise<AgentCommandAwaitResult>((resolve) => {
+    const timer = setTimeout(() => {
+      if (pending.delete(command.id)) {
+        resolve({ status: 'failed', error: 'timeout waiting for agent command result' });
+      }
+    }, timeoutMs);
+
+    pending.set(command.id, { resolve, timer });
+  });
+}
+
+/**
+ * Resolve a pending awaited command by id.
+ *
+ * Called from agentWs.processCommandResult for every incoming command_result
+ * message. Is a no-op when nobody is awaiting that id (the common case for
+ * non-awaited fire-and-forget commands).
+ */
+export function resolvePendingAgentCommand(
+  commandId: string,
+  result: AgentCommandAwaitResult,
+): void {
+  const entry = pending.get(commandId);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  pending.delete(commandId);
+  entry.resolve(result);
+}

--- a/apps/api/src/services/agentCommandAwait.ts
+++ b/apps/api/src/services/agentCommandAwait.ts
@@ -18,6 +18,10 @@ import { sendCommandToAgent } from '../routes/agentWs';
 export type AgentCommandAwaitResult = {
   status: string;
   result?: unknown;
+  // Agents put structured command output as a JSON string in `stdout`
+  // (Go CommandResult.Stdout via NewSuccessResult) — e.g. http_request returns
+  // {status,headers,bodyB64,truncated}. Forwarded so awaited callers can read it.
+  stdout?: string;
   error?: string;
 };
 

--- a/apps/api/src/services/agentCommandAwait.ts
+++ b/apps/api/src/services/agentCommandAwait.ts
@@ -62,14 +62,21 @@ export function sendCommandToAgentAwaitResult(
  * Called from agentWs.processCommandResult for every incoming command_result
  * message. Is a no-op when nobody is awaiting that id (the common case for
  * non-awaited fire-and-forget commands).
+ *
+ * Returns true if a pending entry was found and resolved, false otherwise.
+ * Callers use this to short-circuit further dispatch when the result has been
+ * fully consumed by an awaiting promise (e.g. http_request proxy commands that
+ * have no device_commands row and would otherwise trigger needless DB lookups
+ * plus a console.warn per result).
  */
 export function resolvePendingAgentCommand(
   commandId: string,
   result: AgentCommandAwaitResult,
-): void {
+): boolean {
   const entry = pending.get(commandId);
-  if (!entry) return;
+  if (!entry) return false;
   clearTimeout(entry.timer);
   pending.delete(commandId);
   entry.resolve(result);
+  return true;
 }

--- a/apps/api/src/services/remoteSessionAuth.test.ts
+++ b/apps/api/src/services/remoteSessionAuth.test.ts
@@ -259,3 +259,48 @@ describe('WS ticket caller binding (IP + UA)', () => {
     expect(consumed.ok === false && consumed.reason).toBe('not_found');
   });
 });
+
+describe('tunnel-http ticket TTL', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.NODE_ENV = 'test';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('tunnel-http tickets remain valid at 61s while tunnel tickets are expired', async () => {
+    const { createWsTicket, consumeWsTicket } = await import('./remoteSessionAuth');
+
+    const tunnelIssued = await createWsTicket({
+      sessionId: 's-tunnel',
+      sessionType: 'tunnel',
+      userId: 'u1',
+      ip: '1.2.3.4',
+      userAgent: 'ua',
+    });
+    const httpIssued = await createWsTicket({
+      sessionId: 's-http',
+      sessionType: 'tunnel-http',
+      userId: 'u1',
+      ip: '1.2.3.4',
+      userAgent: 'ua',
+      ttlMs: 5 * 60 * 1000, // 5 minutes
+    });
+
+    // Advance time past the 60s tunnel TTL but well within the 5-min http TTL.
+    vi.advanceTimersByTime(61_000);
+
+    const tunnelResult = await consumeWsTicket(tunnelIssued.ticket, { ip: '1.2.3.4', userAgent: 'ua' });
+    expect(tunnelResult.ok).toBe(false);
+    expect(tunnelResult.ok === false && tunnelResult.reason).toBe('expired');
+
+    const httpResult = await consumeWsTicket(httpIssued.ticket, { ip: '1.2.3.4', userAgent: 'ua' });
+    expect(httpResult.ok).toBe(true);
+    if (httpResult.ok) {
+      expect(httpResult.sessionType).toBe('tunnel-http');
+    }
+  });
+});

--- a/apps/api/src/services/remoteSessionAuth.ts
+++ b/apps/api/src/services/remoteSessionAuth.ts
@@ -2,9 +2,10 @@ import { createHash, randomBytes } from 'crypto';
 import { getRedis } from './redis';
 import { VIEWER_ACCESS_TOKEN_EXPIRY_SECONDS } from './jwt';
 
-type SessionType = 'terminal' | 'desktop' | 'tunnel';
+type SessionType = 'terminal' | 'desktop' | 'tunnel' | 'tunnel-http';
 
 const WS_TICKET_TTL_MS = 60 * 1000; // 60 seconds
+export const HTTP_TICKET_TTL_MS = 5 * 60 * 1000; // 5 minutes (interactive proxy page load window)
 const DESKTOP_CONNECT_CODE_TTL_MS = 2 * 60 * 1000; // 2 minutes
 const VNC_CONNECT_CODE_TTL_MS = 60 * 1000; // 60 seconds
 // Viewer-token advertised expiry derives from the real signed TTL
@@ -179,21 +180,24 @@ export async function createWsTicket(input: {
   ip?: string;
   /** User-Agent of the issuer; stored as sha256(ua)[:16]. */
   userAgent?: string;
+  /** Override TTL in milliseconds. Defaults to WS_TICKET_TTL_MS (60s). Use HTTP_TICKET_TTL_MS for tunnel-http tickets. */
+  ttlMs?: number;
 }): Promise<{ ticket: string; expiresInSeconds: number }> {
   purgeExpiredRecords(wsTickets);
   const ticket = generateSecret(32);
+  const effectiveTtlMs = input.ttlMs ?? WS_TICKET_TTL_MS;
   const record: WsTicketRecord = {
     sessionId: input.sessionId,
     sessionType: input.sessionType,
     userId: input.userId,
-    expiresAt: Date.now() + WS_TICKET_TTL_MS,
+    expiresAt: Date.now() + effectiveTtlMs,
     // Only persist caller binding when the issuer provided it. Callsites
     // that pre-date Task 16 keep working but lose the IP/UA binding.
     ...(input.ip ? { ip: input.ip } : {}),
     ...(input.userAgent ? { uaHash: hashUa(input.userAgent) } : {}),
   };
 
-  const ttlSeconds = Math.floor(WS_TICKET_TTL_MS / 1000);
+  const ttlSeconds = Math.floor(effectiveTtlMs / 1000);
   if (shouldUseRedis()) {
     const redis = getRedis();
     if (!redis) {

--- a/apps/api/src/services/tunnelAllowlist.ts
+++ b/apps/api/src/services/tunnelAllowlist.ts
@@ -1,0 +1,25 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { tunnelAllowlists } from '../db/schema';
+
+/**
+ * Active destination allowlist patterns for an org.
+ *
+ * Returned to the bridging agent so it can re-validate the proxy target
+ * (defense-in-depth — the agent is the final authority on which LAN hosts a
+ * tunnel may reach). Shared by the tunnel-create path (`tunnels.ts`) and the
+ * HTTP reverse-proxy route (`tunnelHttp.ts`).
+ */
+export async function getActiveAllowlistPatterns(orgId: string): Promise<string[]> {
+  const rules = await db
+    .select({ pattern: tunnelAllowlists.pattern })
+    .from(tunnelAllowlists)
+    .where(
+      and(
+        eq(tunnelAllowlists.orgId, orgId),
+        eq(tunnelAllowlists.direction, 'destination'),
+        eq(tunnelAllowlists.enabled, true),
+      ),
+    );
+  return rules.map((r) => r.pattern);
+}

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -71,7 +71,7 @@ describe('AssetDetailModal — link to managed device', () => {
         screen.getByText('Asset linked to WS-FRONTDESK. It is now marked approved.')
       ).toBeInTheDocument();
     });
-    expect(onLinked).toHaveBeenCalledWith('asset-1');
+    expect(onLinked).toHaveBeenCalledWith('asset-1', 'dev-1');
     expect(fetchMock).toHaveBeenCalledWith(
       '/discovery/assets/asset-1/link',
       expect.objectContaining({ method: 'POST' })

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AssetDetailModal, { type AssetDetail } from './AssetDetailModal';
@@ -118,6 +118,61 @@ describe('AssetDetailModal — link to managed device', () => {
     await waitFor(() => {
       expect(screen.getByText('Select a device to link.')).toBeInTheDocument();
     });
+  });
+});
+
+describe('AssetDetailModal — proxy bridge agent (decoupled from link)', () => {
+  const proxyAsset: AssetDetail = {
+    ...asset,
+    id: 'asset-1',
+    ip: '10.1.2.209',
+    linkedDeviceId: null,
+    // proxyEnabled drives the enabled branch directly.
+    ...( { proxyEnabled: true } as Record<string, unknown> ),
+  };
+
+  it('lists only ONLINE devices in the bridge picker and connects through the chosen one', async () => {
+    const mixed = [
+      { id: 'dev-online', name: 'FC-ESME', online: true },
+      { id: 'dev-offline', name: 'DRJJ-CHECKOUT', online: false },
+    ];
+    render(<AssetDetailModal open asset={proxyAsset} devices={mixed} onClose={() => {}} />);
+
+    // Bridge picker is present; it lists ONLY the online device (offline hidden).
+    // Scope to the bridge select — the identity Link dropdown lists all devices.
+    expect(screen.getByText('Proxy through agent')).toBeInTheDocument();
+    const bridge = screen.getByTestId('proxy-bridge-select');
+    expect(within(bridge).getByRole('option', { name: 'FC-ESME' })).toBeInTheDocument();
+    expect(within(bridge).queryByRole('option', { name: 'DRJJ-CHECKOUT' })).not.toBeInTheDocument();
+
+    // Connect uses the selected (online) bridge device, NOT the (null) linked device.
+    fetchMock.mockResolvedValueOnce(makeResponse({ id: 'tunnel-xyz' }));
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    fireEvent.click(screen.getByRole('button', { name: /Connect/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tunnels',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"deviceId":"dev-online"'),
+        }),
+      );
+    });
+    openSpy.mockRestore();
+  });
+
+  it('shows a no-online-agent message when no device can bridge', () => {
+    const offlineOnly = [{ id: 'dev-offline', name: 'DRJJ-CHECKOUT', online: false }];
+    render(<AssetDetailModal open asset={proxyAsset} devices={offlineOnly} onClose={() => {}} />);
+
+    expect(screen.getByText(/No online agent available to proxy to this device/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Connect/i })).not.toBeInTheDocument();
+  });
+
+  it('clarifies that linking is identity-only and does not control proxy', () => {
+    render(<AssetDetailModal open asset={asset} devices={devices} onClose={() => {}} />);
+    expect(screen.getByText(/control proxy access/i)).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -34,7 +34,7 @@ type AssetDetailModalProps = {
   asset?: AssetDetail | null;
   /** While the detail is being fetched (topology click / deep link). */
   loading?: boolean;
-  devices?: { id: string; name: string }[];
+  devices?: { id: string; name: string; online?: boolean }[];
   onClose: () => void;
   onLinked?: (assetId: string, deviceId: string) => void;
   onDeleted?: (assetId: string) => void;
@@ -68,6 +68,11 @@ export default function AssetDetailModal({
   const [proxyError, setProxyError] = useState<string>();
   const [connectingProxy, setConnectingProxy] = useState(false);
   const [selectedProxyPort, setSelectedProxyPort] = useState<number>(0);
+  // The bridge agent = which managed device's agent dials the target. This is
+  // independent of the identity link below — the right bridge is an online agent
+  // that can reach this device on the LAN, which may differ from the device you
+  // link for asset-tracking.
+  const [selectedBridgeDeviceId, setSelectedBridgeDeviceId] = useState('');
 
   useEffect(() => {
     if (asset?.linkedDeviceId) {
@@ -87,6 +92,18 @@ export default function AssetDetailModal({
     setProxyError(undefined);
     setSelectedProxyPort(asset?.openPorts?.[0]?.port ?? 80);
   }, [asset]);
+
+  // Default the proxy bridge agent: prefer the linked device when it's online,
+  // otherwise the first online device. Kept separate from the reset effect above
+  // so a device-list refresh doesn't clobber in-progress edits.
+  useEffect(() => {
+    const onlineIds = new Set((devices ?? []).filter(d => d.online).map(d => d.id));
+    if (asset?.linkedDeviceId && onlineIds.has(asset.linkedDeviceId)) {
+      setSelectedBridgeDeviceId(asset.linkedDeviceId);
+      return;
+    }
+    setSelectedBridgeDeviceId((devices ?? []).find(d => d.online)?.id ?? '');
+  }, [asset, devices]);
 
   const handleLink = async () => {
     if (!asset) return;
@@ -212,7 +229,7 @@ export default function AssetDetailModal({
   }, [asset, onUpdated]);
 
   const handleConnectProxy = useCallback(async () => {
-    if (!asset || !asset.linkedDeviceId) return;
+    if (!asset || !selectedBridgeDeviceId) return;
     try {
       setConnectingProxy(true);
       setProxyError(undefined);
@@ -220,7 +237,7 @@ export default function AssetDetailModal({
       const response = await fetchWithAuth('/tunnels', {
         method: 'POST',
         body: JSON.stringify({
-          deviceId: asset.linkedDeviceId,
+          deviceId: selectedBridgeDeviceId,
           type: 'proxy',
           targetHost: asset.ip,
           targetPort: port,
@@ -239,7 +256,7 @@ export default function AssetDetailModal({
     } finally {
       setConnectingProxy(false);
     }
-  }, [asset, selectedProxyPort]);
+  }, [asset, selectedProxyPort, selectedBridgeDeviceId]);
 
   // No asset record yet: never render nothing while open, or a node click looks
   // like it did nothing. Show a loading state, then a graceful not-found state
@@ -281,6 +298,8 @@ export default function AssetDetailModal({
   const openPorts = asset.openPorts ?? [];
   const osFingerprint = asset.osFingerprint ?? '—';
   const snmpData = asset.snmpData ?? {};
+  // Only online agents can bridge a proxy, so the bridge picker hides offline ones.
+  const onlineDevices = devices.filter(d => d.online);
 
   return (
     <Dialog open={open} onClose={onClose} title={asset.label || asset.hostname || asset.ip} maxWidth="5xl" alignTop className="flex flex-col max-h-[calc(100vh-4rem)]">
@@ -439,6 +458,10 @@ export default function AssetDetailModal({
                 treats them as the same machine. This does not install an agent or create a new
                 device. The asset will be marked as approved.
               </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Identity / asset-tracking only — this does <strong>not</strong> control proxy access
+                or choose the proxy agent (set those under Proxy Access below).
+              </p>
               <div className="mt-3 flex items-center gap-3">
                 <select
                   value={selectedDevice}
@@ -481,7 +504,9 @@ export default function AssetDetailModal({
               {!proxyEnabled ? (
                 <div className="mt-3">
                   <p className="text-xs text-muted-foreground">
-                    Enable proxy access to reach this device's web interface through a managed agent.
+                    Reach this device's web interface in your browser, tunnelled through an
+                    online agent on its network. Enabling whitelists this device's IP so an
+                    agent is permitted to proxy to it.
                   </p>
                   <button
                     type="button"
@@ -499,39 +524,63 @@ export default function AssetDetailModal({
                       Proxy enabled
                     </span>
                   </div>
-                  {asset.linkedDeviceId ? (
-                    <div className="flex items-center gap-2">
-                      <select
-                        value={selectedProxyPort}
-                        onChange={e => setSelectedProxyPort(Number(e.target.value))}
-                        className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        {openPorts.length > 0 ? (
-                          openPorts.map(p => (
-                            <option key={p.port} value={p.port}>
-                              Port {p.port}{p.service ? ` (${p.service})` : ''}
+                  {onlineDevices.length > 0 ? (
+                    <>
+                      <div>
+                        <label className="text-xs font-medium text-muted-foreground">
+                          Proxy through agent
+                        </label>
+                        <p className="mt-0.5 text-[11px] text-muted-foreground">
+                          Pick an online agent that can reach {asset.ip} on its network (usually the
+                          one that discovered it). This is separate from the identity link above.
+                        </p>
+                        <select
+                          value={selectedBridgeDeviceId}
+                          onChange={e => setSelectedBridgeDeviceId(e.target.value)}
+                          data-testid="proxy-bridge-select"
+                          className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          {onlineDevices.map(d => (
+                            <option key={d.id} value={d.id}>
+                              {d.name}
                             </option>
-                          ))
-                        ) : (
-                          <>
-                            <option value={80}>Port 80 (HTTP)</option>
-                            <option value={443}>Port 443 (HTTPS)</option>
-                          </>
-                        )}
-                      </select>
-                      <button
-                        type="button"
-                        onClick={handleConnectProxy}
-                        disabled={connectingProxy}
-                        className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-600 px-3 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-70"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        {connectingProxy ? 'Connecting...' : 'Connect'}
-                      </button>
-                    </div>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <select
+                          value={selectedProxyPort}
+                          onChange={e => setSelectedProxyPort(Number(e.target.value))}
+                          className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          {openPorts.length > 0 ? (
+                            openPorts.map(p => (
+                              <option key={p.port} value={p.port}>
+                                Port {p.port}{p.service ? ` (${p.service})` : ''}
+                              </option>
+                            ))
+                          ) : (
+                            <>
+                              <option value={80}>Port 80 (HTTP)</option>
+                              <option value={443}>Port 443 (HTTPS)</option>
+                            </>
+                          )}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={handleConnectProxy}
+                          disabled={connectingProxy || !selectedBridgeDeviceId}
+                          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-600 px-3 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-70"
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                          {connectingProxy ? 'Connecting...' : 'Connect'}
+                        </button>
+                      </div>
+                    </>
                   ) : (
                     <p className="text-xs text-amber-600 dark:text-amber-400">
-                      Link this asset to a managed device first to use as the proxy agent.
+                      No online agent available to proxy to this device. An agent must be online and
+                      on the same network as {asset.ip} to bridge the connection.
                     </p>
                   )}
                 </div>

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -36,7 +36,7 @@ type AssetDetailModalProps = {
   loading?: boolean;
   devices?: { id: string; name: string }[];
   onClose: () => void;
-  onLinked?: (assetId: string) => void;
+  onLinked?: (assetId: string, deviceId: string) => void;
   onDeleted?: (assetId: string) => void;
   onUpdated?: (assetId: string) => void;
 };
@@ -115,7 +115,7 @@ export default function AssetDetailModal({
           ? `Asset linked to ${deviceName}. It is now marked approved.`
           : 'Asset linked. It is now marked approved.'
       );
-      onLinked?.(asset.id);
+      onLinked?.(asset.id, selectedDevice);
     } catch (err) {
       setLinkError(err instanceof Error ? err.message : 'An error occurred');
     } finally {

--- a/apps/web/src/components/discovery/DiscoveredAssetList.tsx
+++ b/apps/web/src/components/discovery/DiscoveredAssetList.tsx
@@ -76,7 +76,7 @@ export type ApiDiscoveryAsset = {
   updatedAt?: string;
 };
 
-type DeviceOption = { id: string; name: string };
+type DeviceOption = { id: string; name: string; online?: boolean };
 
 export const typeConfig: Record<DiscoveredAssetType, { label: string; color: string }> = {
   workstation: { label: 'Workstation', color: 'bg-indigo-500/20 text-indigo-700 border-indigo-500/40' },
@@ -316,7 +316,7 @@ export default function DiscoveredAssetList({ timezone }: DiscoveredAssetListPro
       }
       const data = await response.json();
       const raw: any[] = data.devices ?? data.data ?? data ?? [];
-      setDevices(raw.map((d: any) => ({ id: d.id, name: d.displayName || d.hostname || d.id })));
+      setDevices(raw.map((d: any) => ({ id: d.id, name: d.displayName || d.hostname || d.id, online: d.status === 'online' })));
     } catch (err) {
       console.warn('[DiscoveredAssetList] Failed to fetch devices:', err);
     }

--- a/apps/web/src/components/discovery/DiscoveredAssetList.tsx
+++ b/apps/web/src/components/discovery/DiscoveredAssetList.tsx
@@ -778,8 +778,11 @@ export default function DiscoveredAssetList({ timezone }: DiscoveredAssetListPro
         asset={selectedAsset}
         devices={devices}
         onClose={() => setSelectedAsset(null)}
-        onLinked={async () => {
-          setSelectedAsset(null);
+        onLinked={async (_assetId, deviceId) => {
+          // Keep the modal open — linking is usually a prerequisite for the
+          // next action in this same modal (e.g. Proxy Access). Reflect the new
+          // link in place so the Proxy section unlocks without a reopen.
+          setSelectedAsset(prev => (prev ? { ...prev, linkedDeviceId: deviceId } : prev));
           await fetchAssets();
         }}
         onDeleted={async () => {

--- a/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
@@ -42,6 +42,10 @@ describe('ProxyTunnelPage', () => {
     expect(frame.getAttribute('src')).toContain(
       `/api/v1/tunnel-http/${TUNNEL_ID}/?__bzt=TKT-abc`,
     );
+    // Untrusted device content must be sandboxed without allow-same-origin.
+    const sandbox = frame.getAttribute('sandbox') ?? '';
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).not.toContain('allow-same-origin');
 
     // The mint call was actually made with POST.
     expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ProxyTunnelPage from './ProxyTunnelPage';
+import { fetchWithAuth } from '@/stores/auth';
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeResponse = (payload: unknown = {}, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+
+const TUNNEL_ID = 'tunnel-123';
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('ProxyTunnelPage', () => {
+  it('mints an http-ticket and renders the proxied service in an iframe', async () => {
+    fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (url === `/tunnels/${TUNNEL_ID}/http-ticket` && opts?.method === 'POST') {
+        // The mint endpoint wraps the ticket.
+        return makeResponse({ ticket: { ticket: 'TKT-abc', expiresInSeconds: 300 } });
+      }
+      if (url === `/tunnels/${TUNNEL_ID}`) {
+        return makeResponse({ status: 'connecting' });
+      }
+      return makeResponse({});
+    });
+
+    render(<ProxyTunnelPage tunnelId={TUNNEL_ID} target="10.1.2.209:80" />);
+
+    const frame = await screen.findByTestId('network-proxy-frame');
+    expect(frame.getAttribute('src')).toContain(
+      `/api/v1/tunnel-http/${TUNNEL_ID}/?__bzt=TKT-abc`,
+    );
+
+    // The mint call was actually made with POST.
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/tunnels/${TUNNEL_ID}/http-ticket`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+
+    // "Open in new tab" points at the same proxy URL.
+    const openLink = screen.getByRole('link', { name: /open in new tab/i });
+    expect(openLink.getAttribute('href')).toContain(`/api/v1/tunnel-http/${TUNNEL_ID}/?__bzt=TKT-abc`);
+  });
+
+  it('shows an error when the ticket cannot be minted', async () => {
+    fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (url === `/tunnels/${TUNNEL_ID}/http-ticket` && opts?.method === 'POST') {
+        return makeResponse({ error: 'No proxy access' }, false);
+      }
+      return makeResponse({ status: 'connecting' });
+    });
+
+    render(<ProxyTunnelPage tunnelId={TUNNEL_ID} target="10.1.2.209:80" />);
+
+    expect(await screen.findByText('No proxy access')).toBeInTheDocument();
+    expect(screen.queryByTestId('network-proxy-frame')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a server-side tunnel failure from the status poll', async () => {
+    fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (url === `/tunnels/${TUNNEL_ID}/http-ticket` && opts?.method === 'POST') {
+        return makeResponse({ ticket: { ticket: 'TKT-abc', expiresInSeconds: 300 } });
+      }
+      if (url === `/tunnels/${TUNNEL_ID}`) {
+        return makeResponse({ status: 'failed', error: 'Tunnel open failed on agent' });
+      }
+      return makeResponse({});
+    });
+
+    render(<ProxyTunnelPage tunnelId={TUNNEL_ID} target="10.1.2.209:80" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tunnel open failed on agent')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/remote/ProxyTunnelPage.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.tsx
@@ -171,6 +171,12 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
           src={proxyUrl}
           title="Proxied service"
           data-testid="network-proxy-frame"
+          // The proxied device is untrusted. Omitting `allow-same-origin` forces
+          // the framed content into a null origin so its scripts cannot read this
+          // app's cookies/storage or reach the parent frame (defense-in-depth with
+          // the server-set sandbox CSP). The proxy auth cookie is HttpOnly and
+          // attaches by site, so auth still works.
+          sandbox="allow-scripts allow-forms allow-popups"
           className="w-full flex-1 border-0"
           onLoad={() => setStatus((s) => (s === 'failed' || s === 'disconnected' ? s : 'active'))}
         />

--- a/apps/web/src/components/remote/ProxyTunnelPage.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { ArrowLeft, Copy, Check, X, Globe, Network } from 'lucide-react';
+import { ArrowLeft, X, Globe, Network, ExternalLink } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
 import { extractApiError } from '@/lib/apiError';
 
@@ -9,30 +9,37 @@ interface Props {
 }
 
 /**
- * Proxy tunnel info page. Shows the tunnel status, target, and connection URLs
- * for accessing the proxied service.
+ * Network Proxy page. Renders the proxied device's web UI in an iframe served
+ * through the API HTTP reverse proxy (`/api/v1/tunnel-http/:id/*`). A one-time
+ * http-ticket authorizes the first navigation, which the proxy exchanges for a
+ * short-lived, path-scoped cookie used by all sub-resource requests.
+ *
+ * Note: unlike VNC/terminal there is no long-lived relay WebSocket, so the
+ * `tunnel_sessions` status never flips to "active". The displayed status is
+ * driven by the iframe load; the background poll only surfaces a server-side
+ * failure/teardown.
  */
-function buildTunnelWsUrl(tunnelId: string, ticket: string): string {
+function buildProxyUrl(tunnelId: string, ticket: string): string {
   const apiUrl = import.meta.env.PUBLIC_API_URL || window.location.origin;
-  const wsProtocol = apiUrl.startsWith('https') ? 'wss' : 'ws';
-  const wsHost = apiUrl.replace(/^https?:\/\//, '');
-  return `${wsProtocol}://${wsHost}/api/v1/tunnel-ws/${tunnelId}/ws?ticket=${encodeURIComponent(ticket)}`;
+  return `${apiUrl}/api/v1/tunnel-http/${tunnelId}/?__bzt=${encodeURIComponent(ticket)}`;
 }
 
 export default function ProxyTunnelPage({ tunnelId, target }: Props) {
   const [status, setStatus] = useState<'connecting' | 'active' | 'disconnected' | 'failed'>('connecting');
-  const [wsUrl, setWsUrl] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [proxyUrl, setProxyUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Poll only to surface a server-side failure/teardown. The proxied service's
+  // liveness is reflected by the iframe load below — the HTTP proxy issues
+  // per-request fetches, so no relay ever flips the session to "active".
   const pollStatus = useCallback(async () => {
     try {
       const res = await fetchWithAuth(`/tunnels/${tunnelId}`);
       if (res.ok) {
         const data = await res.json();
-        setStatus(data.status);
-        if (data.status === 'failed') {
-          setError(extractApiError(data, 'Tunnel failed'));
+        if (data.status === 'failed' || data.status === 'disconnected') {
+          setStatus(data.status);
+          if (data.status === 'failed') setError(extractApiError(data, 'Tunnel failed'));
         }
       }
     } catch { /* ignore */ }
@@ -49,22 +56,23 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
 
     const mintTicket = async () => {
       try {
-        const res = await fetchWithAuth(`/tunnels/${tunnelId}/ws-ticket`, { method: 'POST' });
+        const res = await fetchWithAuth(`/tunnels/${tunnelId}/http-ticket`, { method: 'POST' });
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
           throw new Error(body.error || 'Failed to obtain tunnel ticket');
         }
         const body = await res.json();
+        // The mint endpoint wraps the ticket: `{ ticket: { ticket, expiresInSeconds } }`.
         const ticket = typeof body.ticket === 'string' ? body.ticket : body.ticket?.ticket;
         if (!ticket) {
           throw new Error('Invalid tunnel ticket response');
         }
         if (!cancelled) {
-          setWsUrl(buildTunnelWsUrl(tunnelId, ticket));
+          setProxyUrl(buildProxyUrl(tunnelId, ticket));
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to prepare tunnel relay URL');
+          setError(err instanceof Error ? err.message : 'Failed to prepare the proxy connection');
         }
       }
     };
@@ -80,14 +88,6 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
     setStatus('disconnected');
   }, [tunnelId]);
 
-  const handleCopyWsUrl = useCallback(() => {
-    if (!wsUrl) return;
-    navigator.clipboard.writeText(wsUrl).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }, [wsUrl]);
-
   const statusColor = {
     connecting: 'text-amber-500',
     active: 'text-green-500',
@@ -96,16 +96,16 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
   }[status];
 
   const statusLabel = {
-    connecting: 'Connecting...',
-    active: 'Active',
+    connecting: 'Connecting…',
+    active: 'Connected',
     disconnected: 'Disconnected',
     failed: 'Failed',
   }[status];
 
   return (
     <div className="flex h-full flex-col bg-background">
-      <div className="flex items-center justify-between border-b px-6 py-3">
-        <div className="flex items-center gap-3">
+      <div className="flex items-center justify-between gap-4 border-b px-6 py-3">
+        <div className="flex items-center gap-3 min-w-0">
           <a
             href="/remote"
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition"
@@ -114,33 +114,44 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
             Back
           </a>
           <span className="text-muted-foreground">|</span>
-          <Globe className="h-4 w-4 text-muted-foreground" />
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-sm font-medium">Network Proxy</span>
+          <span className="text-muted-foreground">·</span>
+          <span className="truncate font-mono text-xs text-muted-foreground">{target || '—'}</span>
+          <span className={`shrink-0 text-xs font-medium ${statusColor}`}>{statusLabel}</span>
         </div>
-        <button
-          type="button"
-          onClick={handleClose}
-          disabled={status === 'disconnected' || status === 'failed'}
-          className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition disabled:opacity-50"
-        >
-          <X className="h-4 w-4" />
-          Close Tunnel
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          {proxyUrl && (
+            <a
+              href={proxyUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            >
+              <ExternalLink className="h-4 w-4" />
+              Open in new tab
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={status === 'disconnected' || status === 'failed'}
+            className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+            Close
+          </button>
+        </div>
       </div>
 
-      <div className="flex-1 flex items-start justify-center p-8">
-        <div className="w-full max-w-lg space-y-6">
-          <div className="rounded-lg border bg-card p-6 shadow-sm">
-            <h2 className="text-lg font-semibold flex items-center gap-2">
+      {error ? (
+        <div className="flex flex-1 items-start justify-center p-8">
+          <div className="w-full max-w-lg rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="flex items-center gap-2 text-lg font-semibold">
               <Network className="h-5 w-5" />
               Tunnel Details
             </h2>
-
             <dl className="mt-4 space-y-3 text-sm">
-              <div className="flex justify-between">
-                <dt className="text-muted-foreground">Status</dt>
-                <dd className={`font-medium ${statusColor}`}>{statusLabel}</dd>
-              </div>
               <div className="flex justify-between">
                 <dt className="text-muted-foreground">Target</dt>
                 <dd className="font-mono font-medium">{target || '—'}</dd>
@@ -150,37 +161,24 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
                 <dd className="font-mono text-xs text-muted-foreground">{tunnelId}</dd>
               </div>
             </dl>
-
-            {error && (
-              <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400">
-                {error}
-              </div>
-            )}
-          </div>
-
-          {wsUrl && status !== 'failed' && (
-            <div className="rounded-lg border bg-card p-6 shadow-sm">
-              <h3 className="text-sm font-semibold">WebSocket Relay URL</h3>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Use this URL to connect to the proxied service via WebSocket relay.
-              </p>
-              <div className="mt-3 flex items-center gap-2">
-                <code className="flex-1 rounded-md border bg-muted px-3 py-2 text-xs font-mono break-all">
-                  {wsUrl}
-                </code>
-                <button
-                  type="button"
-                  onClick={handleCopyWsUrl}
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition"
-                  title="Copy URL"
-                >
-                  {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-                </button>
-              </div>
+            <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400">
+              {error}
             </div>
-          )}
+          </div>
         </div>
-      </div>
+      ) : proxyUrl ? (
+        <iframe
+          src={proxyUrl}
+          title="Proxied service"
+          data-testid="network-proxy-frame"
+          className="w-full flex-1 border-0"
+          onLoad={() => setStatus((s) => (s === 'failed' || s === 'disconnected' ? s : 'active'))}
+        />
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
+          Preparing proxy connection…
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-06-25-network-proxy-http-reverse-proxy.md
+++ b/docs/superpowers/plans/2026-06-25-network-proxy-http-reverse-proxy.md
@@ -1,0 +1,606 @@
+# Network Proxy — Agent HTTP-Fetch Reverse Proxy + Asset-Modal UX Rework
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Network Proxy feature actually connect — let an operator view a discovered device's HTTP/HTTPS web UI (e.g. a printer admin page) in the browser through a managed agent — and clean up the confusing discovery asset-modal UX around linking vs. proxying.
+
+**Architecture:** The current `ProxyTunnelPage` never opens the relay WebSocket, so tunnels never activate (confirmed: 0 of 7 US tunnels ever reached `active`, fleet-wide, all-time). Rather than bludgeon the single-consumer raw-TCP relay into an HTTP proxy, add a new agent capability: an `http_request` command where the **agent performs the HTTP/HTTPS fetch to the target locally** (Go handles self-signed TLS and concurrency cleanly) and returns the response. The API exposes an authenticated reverse-proxy route (`/api/v1/tunnel-http/:tunnelId/*`) that issues `http_request` commands and streams responses into an iframe. This reuses the existing tunnel-session record, allowlist/SSRF guards, and remote-access policy.
+
+**Tech Stack:** Go (agent: `net/http`, `crypto/tls`), Hono + TypeScript (API), Drizzle ORM, Astro + React (web), Vitest (API/web), Go `testing` (agent).
+
+## Global Constraints
+
+- **Agent version:** new capability requires an agent release. Bump per repo convention; bare semver (no `v` prefix) in code/config; `v` prefix only on git tags. After release, promote on US per region (platformAdmin + MFA; `AGENT_AUTO_PROMOTE=false`).
+- **Tenant isolation:** every new DB access on the request path uses `withDbAccessContext`; background/await-result paths use `withSystemDbAccessContext` (RLS forced; bare pool forbidden in request code).
+- **SSRF / target safety:** the proxy target is fixed by the `tunnel_sessions` row (`targetHost`/`targetPort`) — never attacker-supplied per request. Reuse existing blocked-CIDR (`127.0.0.0/8` except `127.0.0.1:5900` VNC; `169.254.0.0/16`) and the org destination allowlist (`tunnelAllowlists`). Agent re-validates (defense-in-depth) exactly like `tunnel_open`.
+- **Auth:** API auth middleware is **Bearer-token only** (`apps/api/src/middleware/auth.ts:296`). Browser iframe navigations carry no Authorization header, so use a one-time ticket in the iframe URL that the route exchanges for a short-lived **HttpOnly cookie scoped to `/api/v1/tunnel-http/<tunnelId>/`** for sub-resource requests.
+- **Frequent commits, TDD, DRY, YAGNI.** UI work stays in-session on Opus (per team convention), backend may be delegated.
+- **Security review (`security-review` skill) is mandatory before merge** — this is an authenticated proxy to internal IPs.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `agent/internal/tunnel/httpfetch.go` (create) | One-shot HTTP/HTTPS fetch to a target with self-signed support, size/time caps, header filtering. |
+| `agent/internal/tunnel/httpfetch_test.go` (create) | Table-driven tests against `httptest` (HTTP + TLS) servers. |
+| `agent/internal/heartbeat/handlers_httpproxy.go` (create) | `CmdHttpRequest` handler: blocked/allowlist re-check → call `httpfetch` → return result. |
+| `agent/internal/heartbeat/handlers_httpproxy_test.go` (create) | Handler tests (blocked target, allowlist deny, success). |
+| `agent/internal/heartbeat/handlers_tunnel.go:19-23` (modify) | Register `CmdHttpRequest` in the handler registry. |
+| `apps/api/src/routes/agentWs.ts` (modify) | Add `http_request` to result dispatch; add pending-promise map + `sendCommandToAgentAwaitResult`. |
+| `apps/api/src/services/agentCommandAwait.ts` (create) | Promise-correlated send-and-await-result helper + result resolver. |
+| `apps/api/src/routes/tunnelHttp.ts` (create) | `ALL /:tunnelId/*` reverse-proxy route: ticket↔cookie auth, ownership/policy/online checks, build `http_request`, rewrite + stream response. |
+| `apps/api/src/routes/tunnelHttp.test.ts` (create) | Route tests: auth, ownership, rewrite, error mapping. |
+| `apps/api/src/routes/tunnels.ts` (modify) | Add `POST /tunnels/:id/http-ticket` (mint ticket for the http proxy). |
+| `apps/api/src/index.ts:796` (modify) | Mount `api.route('/tunnel-http', tunnelHttpRoutes)`. |
+| `apps/web/src/components/remote/ProxyTunnelPage.tsx` (modify) | Replace the dead "relay URL" box with an iframe to `/api/v1/tunnel-http/:id/` (+ "Open in new tab"); drive status from tunnel + iframe load. |
+| `apps/web/src/components/discovery/AssetDetailModal.tsx` (modify) | UX rework: separate "Link (asset tracking)" from a "Remote Proxy" group with its own **bridge-agent picker** (online-only, defaults to discovering agent), clearer copy. |
+| `apps/web/src/components/discovery/DiscoveredAssetList.tsx` (modify) | Include device `status` in the `devices` list; pass discovering-device hint to the modal. (modal-close fix already applied.) |
+
+---
+
+## Task 1: Agent — one-shot HTTP/HTTPS fetch (`httpfetch.go`)
+
+**Files:**
+- Create: `agent/internal/tunnel/httpfetch.go`
+- Test: `agent/internal/tunnel/httpfetch_test.go`
+
+**Interfaces:**
+- Produces:
+  ```go
+  // FetchRequest is one proxied HTTP request to a LAN target.
+  type FetchRequest struct {
+      Scheme  string              // "http" | "https" (derived from target port / explicit)
+      Host    string              // target IP/host
+      Port    int                 // target port
+      Method  string              // GET/POST/...
+      Path    string              // path + raw query, e.g. "/admin/index.html?x=1"
+      Headers map[string][]string // forwarded request headers (already filtered by caller)
+      Body    []byte              // request body (may be nil)
+  }
+  type FetchResponse struct {
+      Status  int
+      Headers map[string][]string
+      Body    []byte              // capped; truncated flag set if exceeded
+      Truncated bool
+  }
+  // Fetch performs the request. timeout caps total time; maxBody caps response bytes.
+  func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody int64) (*FetchResponse, error)
+  ```
+- Consumes: nothing from prior tasks.
+
+- [ ] **Step 1: Write the failing test** (`httpfetch_test.go`)
+
+```go
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetch(t *testing.T) {
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/echo" && r.Method == http.MethodPost {
+			b, _ := io.ReadAll(r.Body)
+			w.Header().Set("X-Seen", "yes")
+			w.WriteHeader(201)
+			w.Write([]byte("got:" + string(b)))
+			return
+		}
+		w.Write([]byte("hello-plain"))
+	}))
+	defer plain.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello-tls"))
+	}))
+	defer tlsSrv.Close()
+
+	hostPort := func(u string) (string, int) {
+		u = strings.TrimPrefix(strings.TrimPrefix(u, "http://"), "https://")
+		parts := strings.SplitN(u, ":", 2)
+		var p int
+		_, _ = fmtSscan(parts[1], &p)
+		return parts[0], p
+	}
+
+	t.Run("plain GET", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 200 || string(resp.Body) != "hello-plain" {
+			t.Fatalf("got %d %q", resp.Status, resp.Body)
+		}
+	})
+
+	t.Run("POST body + headers", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "POST", Path: "/echo", Body: []byte("ping")}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != 201 || string(resp.Body) != "got:ping" || resp.Headers["X-Seen"][0] != "yes" {
+			t.Fatalf("got %d %q %v", resp.Status, resp.Body, resp.Headers)
+		}
+	})
+
+	t.Run("self-signed TLS accepted", func(t *testing.T) {
+		h, p := hostPort(tlsSrv.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "https", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(resp.Body) != "hello-tls" {
+			t.Fatalf("got %q", resp.Body)
+		}
+		_ = tls.VersionTLS12
+	})
+
+	t.Run("body cap truncates", func(t *testing.T) {
+		h, p := hostPort(plain.URL)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "http", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !resp.Truncated || len(resp.Body) != 4 {
+			t.Fatalf("expected truncated 4 bytes, got %d trunc=%v", len(resp.Body), resp.Truncated)
+		}
+	})
+}
+```
+
+> Note: add a tiny `fmtSscan` shim or replace with `strconv.Atoi`/`fmt.Sscan` directly — the helper above is illustrative; use `strconv.Atoi(parts[1])` in the real test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && go test ./internal/tunnel/ -run TestFetch -v`
+Expected: FAIL (`undefined: Fetch`).
+
+- [ ] **Step 3: Write minimal implementation** (`httpfetch.go`)
+
+```go
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+type FetchRequest struct {
+	Scheme  string
+	Host    string
+	Port    int
+	Method  string
+	Path    string
+	Headers map[string][]string
+	Body    []byte
+}
+
+type FetchResponse struct {
+	Status    int
+	Headers   map[string][]string
+	Body      []byte
+	Truncated bool
+}
+
+// hop-by-hop headers we never forward in either direction.
+var hopByHop = map[string]bool{
+	"connection": true, "keep-alive": true, "proxy-authenticate": true,
+	"proxy-authorization": true, "te": true, "trailer": true,
+	"transfer-encoding": true, "upgrade": true,
+}
+
+func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody int64) (*FetchResponse, error) {
+	scheme := req.Scheme
+	if scheme == "" {
+		if req.Port == 443 {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	url := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(req.Host, fmt.Sprintf("%d", req.Port)), req.Path)
+
+	var bodyReader io.Reader
+	if len(req.Body) > 0 {
+		bodyReader = newByteReader(req.Body)
+	}
+	hreq, err := http.NewRequestWithContext(ctx, req.Method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	for k, vs := range req.Headers {
+		if hopByHop[lower(k)] {
+			continue
+		}
+		for _, v := range vs {
+			hreq.Header.Add(k, v)
+		}
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Self-signed printer/device certs are the norm on a LAN. The tunnel
+			// target is already constrained to the tunnel_session's host:port and
+			// re-checked against the org allowlist, so cert pinning adds no security
+			// here while breaking every real device. Skip verification deliberately.
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			DisableKeepAlives: true,
+			Proxy:             nil,
+		},
+		// Do not auto-follow redirects — the API layer rewrites Location.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	resp, err := client.Do(hreq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxBody+1)
+	b, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	truncated := int64(len(b)) > maxBody
+	if truncated {
+		b = b[:maxBody]
+	}
+
+	outHeaders := map[string][]string{}
+	for k, vs := range resp.Header {
+		if hopByHop[lower(k)] {
+			continue
+		}
+		outHeaders[k] = vs
+	}
+	return &FetchResponse{Status: resp.StatusCode, Headers: outHeaders, Body: b, Truncated: truncated}, nil
+}
+
+func lower(s string) string { return string([]byte(toLowerASCII(s))) }
+```
+
+> Add small helpers `toLowerASCII`, `newByteReader` (wrap `bytes.NewReader`). Prefer `bytes.NewReader`/`strings.ToLower` directly — the named helpers above are only to keep the snippet self-contained; use stdlib in the real implementation.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd agent && go test -race ./internal/tunnel/ -run TestFetch -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/tunnel/httpfetch.go agent/internal/tunnel/httpfetch_test.go
+git commit -m "feat(agent): one-shot HTTP/HTTPS fetch for tunnel http-proxy"
+```
+
+---
+
+## Task 2: Agent — `http_request` command handler
+
+**Files:**
+- Create: `agent/internal/heartbeat/handlers_httpproxy.go`
+- Test: `agent/internal/heartbeat/handlers_httpproxy_test.go`
+- Modify: `agent/internal/heartbeat/handlers_tunnel.go:19-23` (registry)
+
+**Interfaces:**
+- Consumes: `tunnel.Fetch` (Task 1); existing `tunnel.IsBlocked(host, port, isVNC)` (`agent/internal/tunnel/allowlist.go:114`), `tunnel.IsAllowed(host, port, rules)` (`allowlist.go:145`).
+- Produces: handler registered under command type `"http_request"` returning a result payload:
+  ```jsonc
+  // command result payload (status:"completed")
+  { "status": 200, "headers": {"Content-Type":["text/html"]}, "bodyB64": "...", "truncated": false }
+  // on rejection: Status "failed", error "blocked target" | "not allowed" | dial/timeout message
+  ```
+
+- [ ] **Step 1: Write the failing test** — assert (a) blocked target → failed, (b) empty allowlist → failed, (c) allowed → completed with decoded body. Mirror the structure of the existing `handlers_tunnel.go` tests; use an `httptest` server as the target and pass its host/port + an allowlist rule covering it.
+
+- [ ] **Step 2: Run** `cd agent && go test ./internal/heartbeat/ -run TestHandleHttpRequest -v` → FAIL.
+
+- [ ] **Step 3: Implement** `handleHttpRequest`:
+
+```go
+package heartbeat
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+
+	"github.com/<org>/breeze/agent/internal/tunnel" // match existing import path
+)
+
+const CmdHttpRequest = "http_request"
+
+const (
+	httpProxyTimeout = 20 * time.Second
+	httpProxyMaxBody = 16 << 20 // 16 MiB
+)
+
+func (h *Handler) handleHttpRequest(cmd Command) CommandResult {
+	host, _ := cmd.Payload["targetHost"].(string)
+	port := toInt(cmd.Payload["targetPort"])
+	scheme, _ := cmd.Payload["scheme"].(string)
+	method, _ := cmd.Payload["method"].(string)
+	path, _ := cmd.Payload["path"].(string)
+	headers := toHeaderMap(cmd.Payload["headers"])
+	var body []byte
+	if b64, ok := cmd.Payload["bodyB64"].(string); ok && b64 != "" {
+		body, _ = base64.StdEncoding.DecodeString(b64)
+	}
+
+	// Defense-in-depth: re-apply the same guards as tunnel_open.
+	if tunnel.IsBlocked(host, port, false) {
+		return failed(cmd, "blocked target")
+	}
+	rules := parseAllowlistRules(cmd.Payload["allowlistRules"]) // reuse helper from handlers_tunnel.go
+	if !tunnel.IsAllowed(host, port, rules) {
+		return failed(cmd, "target not allowed")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpProxyTimeout)
+	defer cancel()
+	resp, err := tunnel.Fetch(ctx, tunnel.FetchRequest{
+		Scheme: scheme, Host: host, Port: port, Method: method, Path: path, Headers: headers, Body: body,
+	}, httpProxyTimeout, httpProxyMaxBody)
+	if err != nil {
+		return failed(cmd, err.Error())
+	}
+	return completed(cmd, map[string]any{
+		"status":    resp.Status,
+		"headers":   resp.Headers,
+		"bodyB64":   base64.StdEncoding.EncodeToString(resp.Body),
+		"truncated": resp.Truncated,
+	})
+}
+```
+
+> `failed`/`completed`/`toInt`/`toHeaderMap`/`parseAllowlistRules` — reuse or mirror the helpers already in `handlers_tunnel.go`. Register in the registry map (`handlers_tunnel.go:19-23`): `CmdHttpRequest: h.handleHttpRequest`.
+
+- [ ] **Step 4: Run** `cd agent && go test -race ./internal/heartbeat/ -run TestHandleHttpRequest -v` → PASS.
+
+- [ ] **Step 5: Commit** `feat(agent): http_request command handler for network proxy`.
+
+---
+
+## Task 3: API — send-command-and-await-result helper
+
+**Files:**
+- Create: `apps/api/src/services/agentCommandAwait.ts`
+- Test: `apps/api/src/services/agentCommandAwait.test.ts`
+- Modify: `apps/api/src/routes/agentWs.ts` (call the resolver from result dispatch)
+
+**Interfaces:**
+- Consumes: `sendCommandToAgent(agentId, command)` (`agentWs.ts:2500`), the `commandResultSchema` shape (`agentWs.ts:571`).
+- Produces:
+  ```ts
+  export function sendCommandToAgentAwaitResult(
+    agentId: string,
+    command: { id: string; type: string; payload: Record<string, unknown> },
+    timeoutMs: number,
+  ): Promise<{ status: string; result?: unknown; error?: string }>;
+  export function resolvePendingAgentCommand(commandId: string, result: { status: string; result?: unknown; error?: string }): void;
+  ```
+
+- [ ] **Step 1: Write the failing test** — `sendCommandToAgentAwaitResult` rejects on timeout; resolves when `resolvePendingAgentCommand(id, …)` is called with the matching id; returns `{status:'failed'}` if `sendCommandToAgent` returns false (agent offline). Mock `sendCommandToAgent`.
+
+- [ ] **Step 2: Run** `cd apps/api && pnpm exec vitest run src/services/agentCommandAwait.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement** a `Map<string, {resolve, reject, timer}>` keyed by `command.id`; `sendCommandToAgentAwaitResult` registers the entry, calls `sendCommandToAgent` (resolve `{status:'failed', error:'agent offline'}` if false), arms a timeout that rejects/cleans up; `resolvePendingAgentCommand` looks up the id, clears the timer, resolves, deletes.
+
+- [ ] **Step 4:** Wire into `agentWs.ts`: in `processCommandResult`, before/after the existing dispatch, call `resolvePendingAgentCommand(result.commandId, { status: result.status, result: result.result, error: result.error })` so awaited commands resolve. (Add `http_request` is fire-via-await, so it does **not** need a persist handler in `commandResultHandlers` — the resolver path is enough; ensure unknown types still hit the resolver.)
+
+- [ ] **Step 5:** Run tests → PASS. Commit `feat(api): promise-correlated agent command await helper`.
+
+---
+
+## Task 4: API — `POST /tunnels/:id/http-ticket`
+
+**Files:**
+- Modify: `apps/api/src/routes/tunnels.ts` (new route near `ws-ticket`, lines ~762-817)
+- Modify: `apps/api/src/services/remoteSessionAuth.ts` (allow a longer TTL for http tickets; see below)
+- Test: extend `apps/api/src/routes/tunnels.test.ts`
+
+**Interfaces:**
+- Consumes: `createWsTicket({sessionId, sessionType, userId, ip, userAgent})` (`remoteSessionAuth.ts`), `WS_TICKET_TTL_MS` (`remoteSessionAuth.ts:7`).
+- Produces: `POST /tunnels/:id/http-ticket` → `{ ticket: string }`. Mint with `sessionType: 'tunnel-http'`.
+
+- [ ] **Step 1: Write the failing test** — authed owner gets `{ ticket }`; non-owner gets 404/403; mint uses `sessionType:'tunnel-http'`.
+- [ ] **Step 2:** Run the test → FAIL.
+- [ ] **Step 3:** Implement: copy the `ws-ticket` handler, change `sessionType` to `'tunnel-http'`. **TTL:** the existing 60s is too tight for an interactive page (the agent also idle-closed at ~60s, but that idle reaper does not apply here — there's no long-lived tunnel; each request is a fresh `http_request`). Add a separate constant `HTTP_TICKET_TTL_MS = 5 * 60 * 1000` and thread a per-type TTL into `createWsTicket` (default keeps 60s for `tunnel`/`vnc`). Update `consumeWsTicket`/`createWsTicket` to accept/apply per-type TTL.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Commit `feat(api): http-ticket minting for network proxy`.
+
+---
+
+## Task 5: API — reverse-proxy route `tunnelHttp.ts`
+
+**Files:**
+- Create: `apps/api/src/routes/tunnelHttp.ts`
+- Test: `apps/api/src/routes/tunnelHttp.test.ts`
+- Modify: `apps/api/src/index.ts:796` (mount), near the other tunnel routes.
+
+**Interfaces:**
+- Consumes: `validateTunnelAccess`-style checks (reuse the ownership/online/policy logic — extract a shared `assertTunnelUsable(tunnelId, userId)` if convenient, or replicate the session+device+policy lookups from `tunnelWs.ts:159-243`), `consumeWsTicket` (one-time, sessionType `'tunnel-http'`), `sendCommandToAgentAwaitResult` (Task 3), `getActiveAllowlistPatterns(orgId)` (`tunnels.ts:286`), `isAgentConnected` (`agentWs.ts:2546`).
+- Produces: `tunnelHttpRoutes` (Hono). Routes:
+  - `GET|POST|PUT|... /:tunnelId/*` — the proxy.
+  - Mounted at `/api/v1/tunnel-http`.
+
+**Auth model (no Bearer on iframe navigations):**
+1. First request carries `?__bzt=<ticket>`. Route consumes the one-time ticket, verifies it matches `:tunnelId` + sessionType `tunnel-http`, loads the session, checks owner + device online + remote-access policy.
+2. Route mints a short-lived signed cookie `bz_tunnel_<tunnelId>` (HttpOnly, Secure, SameSite=Lax, `Path=/api/v1/tunnel-http/<tunnelId>/`, ~5 min) carrying `{userId, tunnelId, exp}` (sign with the existing JWT/secret util). Redirect (302) to the same URL **without** the `__bzt` query so the ticket isn't re-used/leaked in referrers.
+3. Subsequent sub-resource requests authenticate via the cookie. Each request re-checks owner+online+policy (cheap) before dispatching.
+
+> This route is **NOT** behind the global Bearer `authMiddleware` — like `tunnel-ws`, it self-authenticates (ticket then cookie). Mount it the same way (`// no auth middleware — ticket/cookie self-auth`).
+
+- [ ] **Step 1: Write the failing tests** (`tunnelHttp.test.ts`):
+  - missing/invalid ticket and no cookie → 401.
+  - valid ticket → 302 setting `bz_tunnel_<id>` cookie, Location strips `__bzt`.
+  - with valid cookie: dispatches `http_request` with the right `targetHost`/`targetPort`/`scheme` (from session; scheme `https` when port 443 else `http`), method, path (`/*` + query), filtered headers; returns agent status/body; sets response content-type from agent headers.
+  - agent offline → 502; agent timeout → 504; session not owned → 404.
+  - HTML rewriting: a `<head>` response gets a `<base href="/api/v1/tunnel-http/<id>/">` injected; a 3xx `Location: http://<target>/foo` is rewritten to `/api/v1/tunnel-http/<id>/foo`.
+
+- [ ] **Step 2:** Run `cd apps/api && pnpm exec vitest run src/routes/tunnelHttp.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement** the route. Sketch:
+
+```ts
+import { Hono } from 'hono';
+import { getCookie, setCookie } from 'hono/cookie';
+// reuse: consumeWsTicket, session/device/policy lookups, sendCommandToAgentAwaitResult,
+// getActiveAllowlistPatterns, isAgentConnected, getTrustedClientIp, signTunnelCookie/verifyTunnelCookie
+
+export const tunnelHttpRoutes = new Hono();
+
+const HTTP_REQUEST_TIMEOUT_MS = 25_000;
+const HOP_BY_HOP = new Set(['connection','keep-alive','proxy-authenticate','proxy-authorization','te','trailer','transfer-encoding','upgrade','host']);
+
+tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
+  const tunnelId = c.req.param('tunnelId');
+  const basePath = `/api/v1/tunnel-http/${tunnelId}/`;
+
+  // 1. Authn: cookie first, else one-time ticket → set cookie → redirect.
+  let userId = await verifyTunnelCookie(getCookie(c, `bz_tunnel_${tunnelId}`), tunnelId);
+  if (!userId) {
+    const ticket = c.req.query('__bzt');
+    const consumed = ticket ? await consumeWsTicket(ticket) : null;
+    if (!consumed || consumed.sessionId !== tunnelId || consumed.sessionType !== 'tunnel-http') {
+      return c.text('Unauthorized', 401);
+    }
+    userId = consumed.userId;
+    setCookie(c, `bz_tunnel_${tunnelId}`, await signTunnelCookie(userId, tunnelId), {
+      httpOnly: true, secure: true, sameSite: 'Lax', path: basePath, maxAge: 300,
+    });
+    const url = new URL(c.req.url);
+    url.searchParams.delete('__bzt');
+    return c.redirect(url.pathname + url.search, 302);
+  }
+
+  // 2. Authz: owner + device online + policy (fail-closed). Reuse the tunnelWs checks.
+  const session = await loadOwnedTunnelSession(tunnelId, userId); // {agentId, targetHost, targetPort, type, orgId, deviceStatus}
+  if (!session) return c.text('Not found', 404);
+  if (session.deviceStatus !== 'online' || !isAgentConnected(session.agentId)) return c.text('Bridge agent offline', 502);
+  // (remote-access policy re-check here)
+
+  // 3. Build + dispatch http_request.
+  const wildcard = c.req.path.slice(basePath.length); // path after base
+  const qs = new URL(c.req.url).search;
+  const headers: Record<string,string[]> = {};
+  for (const [k,v] of Object.entries(c.req.header())) if (!HOP_BY_HOP.has(k.toLowerCase())) headers[k] = [v as string];
+  const bodyBuf = ['GET','HEAD'].includes(c.req.method) ? undefined : Buffer.from(await c.req.arrayBuffer());
+  const scheme = session.targetPort === 443 ? 'https' : 'http';
+
+  const res = await sendCommandToAgentAwaitResult(session.agentId, {
+    id: `http-req-${tunnelId}-${cryptoRandomId()}`,
+    type: 'http_request',
+    payload: {
+      tunnelId, targetHost: session.targetHost, targetPort: session.targetPort, scheme,
+      method: c.req.method, path: '/' + wildcard + qs,
+      headers, bodyB64: bodyBuf ? bodyBuf.toString('base64') : '',
+      allowlistRules: await getActiveAllowlistPatterns(session.orgId),
+    },
+  }, HTTP_REQUEST_TIMEOUT_MS).catch(() => null);
+
+  if (!res) return c.text('Upstream timeout', 504);
+  if (res.status === 'failed') return c.text(`Proxy error: ${res.error ?? 'unknown'}`, 502);
+
+  // 4. Rewrite + return.
+  const r = res.result as { status: number; headers: Record<string,string[]>; bodyB64: string };
+  let body: Buffer | string = Buffer.from(r.bodyB64, 'base64');
+  const ctype = (r.headers['Content-Type']?.[0] ?? r.headers['content-type']?.[0] ?? '').toLowerCase();
+  const respHeaders = new Headers();
+  for (const [k,vs] of Object.entries(r.headers)) {
+    const lk = k.toLowerCase();
+    if (HOP_BY_HOP.has(lk) || lk === 'content-length' || lk === 'content-security-policy') continue;
+    if (lk === 'location') { respHeaders.set(k, rewriteLocation(vs[0], session, basePath)); continue; }
+    if (lk === 'set-cookie') { for (const v of vs) respHeaders.append('set-cookie', scopeCookiePath(v, basePath)); continue; }
+    for (const v of vs) respHeaders.append(k, v);
+  }
+  if (ctype.includes('text/html')) {
+    body = injectBaseTag(body.toString('utf8'), basePath); // insert <base href="basePath"> after <head>
+    respHeaders.set('content-type', ctype || 'text/html');
+  }
+  return new Response(body, { status: r.status, headers: respHeaders });
+});
+```
+
+> Helpers to implement in-file: `loadOwnedTunnelSession`, `signTunnelCookie`/`verifyTunnelCookie` (HMAC with existing secret), `rewriteLocation`, `scopeCookiePath`, `injectBaseTag`, `cryptoRandomId`. Strip upstream CSP so the framed page renders. `<base>` injection handles most relative-URL printer UIs; document absolute-URL/JS-built-URL limitations as known gaps.
+
+- [ ] **Step 4:** Run tests → PASS.
+- [ ] **Step 5:** Mount in `index.ts:796`: `api.route('/tunnel-http', tunnelHttpRoutes); // ticket/cookie self-auth`. Commit `feat(api): http reverse-proxy route for network proxy`.
+
+---
+
+## Task 6: Web — `ProxyTunnelPage` renders the service in an iframe
+
+**Files:**
+- Modify: `apps/web/src/components/remote/ProxyTunnelPage.tsx`
+- Test: `apps/web/src/components/remote/ProxyTunnelPage.test.tsx` (create if absent)
+
+- [ ] **Step 1: Write failing test** — on mount, the page POSTs `/tunnels/:id/http-ticket`, then renders an `<iframe>` whose `src` is `/api/v1/tunnel-http/:id/?__bzt=<ticket>`; shows a "Open in new tab" link to the same; status badge reads `active` once the iframe `onLoad` fires (or tunnel status poll returns non-pending). Failure (ticket error) shows the error box.
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement** — replace the "WebSocket Relay URL" block (lines 161-181) with:
+  - Mint an http-ticket (reuse the existing mint effect, change endpoint to `/tunnels/:id/http-ticket`).
+  - `const proxyUrl = `/api/v1/tunnel-http/${tunnelId}/?__bzt=${encodeURIComponent(ticket)}``.
+  - Render `<iframe src={proxyUrl} className="h-[70vh] w-full rounded-md border" title="Proxied service" onLoad={() => setStatus('active')} />` plus an "Open in new tab" anchor (`target="_blank" rel="noreferrer"`).
+  - Keep the status poll for `failed`/`disconnected`. Remove the copy-URL affordance.
+
+- [ ] **Step 4:** Run web tests → PASS.
+- [ ] **Step 5:** Commit `feat(web): render network proxy target in iframe`.
+
+---
+
+## Task 7: Web — Asset modal UX rework (decouple link vs. proxy; online-only bridge picker)
+
+**Files:**
+- Modify: `apps/web/src/components/discovery/AssetDetailModal.tsx`
+- Modify: `apps/web/src/components/discovery/DiscoveredAssetList.tsx` (devices need `status`; pass discovering-device hint)
+- Test: extend `apps/web/src/components/discovery/AssetDetailModal.test.tsx`
+
+**Design (approved):**
+- "Link to managed device" stays = **asset tracking / identity only**. Copy clarified: "Identity only — links this asset to a managed device for inventory/asset tracking. Does not affect proxy access."
+- New **"Remote Proxy"** group combines: Enable Proxy Access (the allowlist whitelist — clarify copy: "Whitelists this device's IP so an agent may tunnel to it") **and** a **bridge-agent picker** (which agent does the dialing) that is **independent of the identity link**.
+- Bridge-agent picker: lists **online devices only**, defaults to the discovering agent (asset's `lastJobId.agentId` → device), else the linked device, else first online. `Connect` uses the picker's deviceId (not `asset.linkedDeviceId`).
+- If no online device can bridge: show "No online agent available to proxy to this device" instead of a dead Connect.
+
+- [ ] **Step 1:** In `DiscoveredAssetList.tsx:319`, include status: `setDevices(raw.map(d => ({ id: d.id, name: d.displayName||d.hostname||d.id, online: d.status === 'online' })))`. Update the `devices` prop type in `AssetDetailModal` to `{id; name; online?: boolean}[]`. Pass a `discoveringDeviceId?` hint if available from the asset payload (map from `lastJobId`/scan agent → device; if not exposed, default to linked/first-online and note as a follow-up).
+- [ ] **Step 2: Write failing test** — bridge picker shows only `online` devices; defaults appropriately; `Connect` POSTs `/tunnels` with the picker's deviceId; offline-only fleet shows the "no online agent" message; Link copy no longer implies proxy.
+- [ ] **Step 3:** Run → FAIL.
+- [ ] **Step 4: Implement** the restructured right column: separate `<Link>` card (identity copy) and `<RemoteProxy>` card (enable + bridge-agent `<select>` filtered to `devices.filter(d=>d.online)` + Connect using `selectedBridgeDeviceId`). Update `handleConnectProxy` to use `selectedBridgeDeviceId`.
+- [ ] **Step 5:** Run all discovery web tests → PASS. Commit `feat(web): decouple asset linking from proxy bridge; online-only bridge picker`.
+
+---
+
+## Task 8: Security review, integration verification, release
+
+- [ ] **Step 1: Security review** — run the `security-review` skill against the branch. Focus: ticket→cookie auth can't be forged/replayed; cookie is path-scoped + HMAC-signed + short TTL; proxy can only ever reach the session's fixed `targetHost:targetPort` (no per-request host override); allowlist + blocked-CIDR enforced on **both** API and agent; per-request authz re-check is fail-closed; tenant isolation on all session lookups (`withDbAccessContext`); rate-limit the proxy route per user.
+- [ ] **Step 2: Integration test** — add an API integration test (`__tests__/integration/*.integration.test.ts`) exercising mint-ticket → proxy GET through a stubbed agent (assert the `http_request` command shape + response relay). Run with `--config vitest.integration.config.ts`.
+- [ ] **Step 3: Agent race + full suites** — `cd agent && go test -race ./...`; `pnpm test --filter=@breeze/api`; web discovery + remote tests.
+- [ ] **Step 4: Release** — bump agent version, build, tag off `main` (full release), register on US, **promote per region** (platformAdmin + MFA). Deploy API + web. Upgrade (or wait for) the bridge endpoint(s) to the new agent.
+- [ ] **Step 5: Verify on US** — with the printer `10.1.2.209` linked/whitelisted and a healthy online bridge agent on its subnet, click Connect → the printer's web UI renders in the iframe; `tunnel_sessions` shows the request path working. (Separately: DRJJ-CHECKOUT + FC-ESME are in watchdog failover — restart those agents out-of-band; unrelated to this fix.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** root-cause (no WS consumer) → Tasks 5-6 (real consumer via iframe/proxy). "Connecting forever" → status now driven by iframe load + the proxy actually returning bytes. UX confusion (link vs whitelist vs bridge) → Task 7 separates all three. Modal-close bug → already fixed on `fix/discovery-proxy-link-ux`. Offline-device hiding → Task 7 bridge picker. 60s ticket race → Task 4 (5-min http-ticket).
+- **Known gaps (documented, not silently dropped):** `<base>`-tag rewriting won't fix absolute-URL or JS-constructed-URL printer UIs (follow-up: fuller HTML/redirect rewriting or per-asset "open in new tab" only); large responses capped at 16 MiB (Task 2) — streaming/chunked transfer is a follow-up; WebSocket-based device UIs aren't supported by one-shot `http_request` (follow-up if needed).
+- **Type consistency:** `http_request` payload (`targetHost/targetPort/scheme/method/path/headers/bodyB64/allowlistRules`) is identical in Task 2 (agent), Task 5 (API dispatch). Result shape (`status/headers/bodyB64/truncated`) identical Task 2 → Task 5. `sendCommandToAgentAwaitResult` signature identical Task 3 → Task 5.


### PR DESCRIPTION
## Why

The **Network Proxy** feature never connected. From Network Discovery you could "Connect" to a discovered device's web UI, but it sat on **Connecting…** forever. Root cause: `ProxyTunnelPage` only ever *displayed* a `wss://` relay URL — it never opened a WebSocket, so the tunnel never activated. Confirmed against US prod: **0 of 7 tunnels ever reached `active`, on every agent, all-time** (no `GET /tunnel-ws` ever fired). The wedged DRJJ-CHECKOUT/FC-ESME agents were a red herring.

This PR makes the proxy actually work, and reworks the confusing discovery-asset UX around linking vs. proxying.

## What

**Agent (Go)**
- New `http_request` command: the agent performs the HTTP/HTTPS fetch to the LAN device locally (Go handles self-signed device certs cleanly), with the same blocked-CIDR + allowlist guards as tunnels.
- SSRF-hardened: URL built via `net/url` with the host pinned to the tunnel target; rejects path-based host/userinfo injection; scheme restricted to http(s); encoded paths preserved.

**API (Hono)**
- `agentCommandAwait`: promise-correlated send-and-await for agent command results (forwards the agent's `stdout` payload).
- `POST /tunnels/:id/http-ticket`: one-time ticket (5-min TTL; ws-ticket stays 60s).
- `tunnelHttp.ts`: authenticated reverse proxy `GET|POST|… /api/v1/tunnel-http/:id/*`. Target is **always** taken from the `tunnel_sessions` row (never the request). Ticket→scoped-cookie self-auth (jose-signed, path-scoped, HttpOnly), per-request owner + device-online + agent-connected + policy re-check, hop-by-hop stripping, `Location`/`Set-Cookie`/`<base>` rewriting.

**Web (Astro/React)**
- `ProxyTunnelPage` now renders the device UI in an **iframe** (+ "Open in new tab"); status driven by the iframe load.
- Asset modal reworked: **Link** is now identity/asset-tracking only (clarified copy); **Proxy Access** gets its own **bridge-agent picker that lists only online devices** (defaults to linked-if-online, else first online) and connects through the chosen agent — directly addressing the "hide offline devices / unclear linking" feedback.
- Bug fix: **Link no longer closes the modal** (it unlocks the proxy section in place).

## Security

Three findings from review, all fixed in-PR:

1. **SSRF allowlist bypass via path** (agent) — host now pinned via `net/url`; non-`/` and host-injecting paths rejected; zero-request regression test.
2. **Credential leak to the untrusted device** (API) — the forwarded `Cookie` header previously leaked the user's *other* same-origin cookies (HttpOnly refresh token, CSRF) to the LAN device. Now forwards a strict **allowlist** of safe headers only (never `cookie`/`authorization`); the device's own session cookies round-trip via a namespaced `bzdev_` jar.
3. **iframe XSS / origin isolation** (web+API) — proxied device HTML rendered same-origin with CSP stripped. Now sets a restrictive **`sandbox` CSP** on every proxied response **and** sandboxes the iframe (no `allow-same-origin` → null origin); device `x-frame-options` dropped.

`InsecureSkipVerify` in the agent fetch is **intentional** (LAN devices ship self-signed certs; target is constrained by the session + org allowlist).

## Tests

Agent (`go test -race`: tunnel + heartbeat), API (`tunnelHttp` 18, `tunnels`, `agentCommandAwait`, `remoteSessionAuth` — 108 total across the touched files), web (discovery + remote, incl. new `ProxyTunnelPage` tests). All green; clean typecheck on changed files.

## Before this ships / follow-ups

- **Release to US is an ops gate**: needs an agent release + per-region MFA promote + API/web deploy before it works on the fleet.
- **GA hardening recommendation**: serve `/tunnel-http` on a **separate, cookie-isolated origin** (e.g. `tunnel-proxy.2breeze.app`) for full isolation from untrusted device content. The in-PR sandbox is the secure default; the separate origin is also the fix if a device UI that relies on JS cookie access breaks under sandbox.
- **Deferred (non-blocking)**: per-user rate-limit on the proxy route; an API integration test (stubbed agent end-to-end); auto-defaulting the bridge picker to the *discovering* agent (needs a small backend field — currently defaults to linked/first-online; users can pick the on-subnet agent manually).

Plan: `docs/superpowers/plans/2026-06-25-network-proxy-http-reverse-proxy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
