### PR TITLE
fix(pam): default UAC interception to opt-in; grandfather active orgs

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -220,11 +220,12 @@ type Heartbeat struct {
 	helperEnabled atomic.Bool
 	helperMgr     *helper.Manager
 
-	// uacInterceptionDisabled is set when the server's 'pam' config policy
-	// turns UAC capture off for this device. Inverted so the zero value
-	// (enabled) matches the default-ON contract before the first heartbeat
-	// and against older servers that never send the field.
-	uacInterceptionDisabled atomic.Bool
+	// uacInterceptionEnabled is set when the server's resolved 'pam' config
+	// policy turns UAC capture ON for this device. Opt-in: the zero value
+	// (disabled) means no capture until the server explicitly enables it, so a
+	// device with no PAM policy — or one talking to a server that never sends
+	// the field — never prompts the user before the first heartbeat says so.
+	uacInterceptionEnabled atomic.Bool
 
 	// Service & process monitoring
 	monitor *monitoring.Monitor
@@ -2644,23 +2645,24 @@ func (h *Heartbeat) handleHelperEnabled(enabled bool) {
 }
 
 // IsUACInterceptionEnabled reports whether etwlua should post UAC elevation
-// events. Default true; only an explicit uacInterceptionEnabled=false from
-// the server's resolved 'pam' config policy disables it.
+// events. Default false (opt-in); only an explicit uacInterceptionEnabled=true
+// from the server's resolved 'pam' config policy enables it.
 func (h *Heartbeat) IsUACInterceptionEnabled() bool {
-	return !h.uacInterceptionDisabled.Load()
+	return h.uacInterceptionEnabled.Load()
 }
 
 // handleUACInterception updates the UAC interception flag from the heartbeat
-// response and logs state transitions. nil (field absent — older server)
-// means enabled.
+// response and logs state transitions. nil (field absent — older server) means
+// disabled: capture is opt-in and stays off until the server sends an explicit
+// true.
 func (h *Heartbeat) handleUACInterception(enabled *bool) {
-	disabled := enabled != nil && !*enabled
-	prev := h.uacInterceptionDisabled.Swap(disabled)
-	if prev != disabled {
-		if disabled {
-			log.Info("UAC interception disabled by configuration policy")
-		} else {
+	on := enabled != nil && *enabled
+	prev := h.uacInterceptionEnabled.Swap(on)
+	if prev != on {
+		if on {
 			log.Info("UAC interception enabled by configuration policy")
+		} else {
+			log.Info("UAC interception disabled by configuration policy")
 		}
 	}
 }

--- a/agent/internal/heartbeat/uac_interception_test.go
+++ b/agent/internal/heartbeat/uac_interception_test.go
@@ -10,12 +10,12 @@ func TestUACInterceptionFlag(t *testing.T) {
 		sequence    []*bool // values passed to handleUACInterception in order
 		wantEnabled bool
 	}{
-		{"default before any heartbeat", nil, true},
-		{"nil from old server keeps default on", []*bool{nil}, true},
-		{"explicit true stays on", []*bool{boolPtr(true)}, true},
-		{"explicit false disables", []*bool{boolPtr(false)}, false},
-		{"false then true re-enables", []*bool{boolPtr(false), boolPtr(true)}, true},
-		{"false then nil re-enables (policy unassigned on old server)", []*bool{boolPtr(false), nil}, true},
+		{"default before any heartbeat is off (opt-in)", nil, false},
+		{"nil from old server stays off (opt-in)", []*bool{nil}, false},
+		{"explicit true enables", []*bool{boolPtr(true)}, true},
+		{"explicit false stays off", []*bool{boolPtr(false)}, false},
+		{"true then false disables", []*bool{boolPtr(true), boolPtr(false)}, false},
+		{"true then nil disables (policy unassigned or old server)", []*bool{boolPtr(true), nil}, false},
 	}
 
 	for _, tt := range tests {

--- a/apps/api/migrations/2026-07-01-pam-uac-opt-in-grandfathering.sql
+++ b/apps/api/migrations/2026-07-01-pam-uac-opt-in-grandfathering.sql
@@ -39,7 +39,11 @@ BEGIN
   ON CONFLICT (org_id) DO UPDATE
     SET uac_interception_enabled = true,
         updated_at = now()
-  WHERE pam_org_config.uac_interception_enabled IS DISTINCT FROM true;
+  -- Only fill in where the org has no opinion yet (NULL). This keeps the
+  -- migration idempotent on re-apply AND never clobbers an explicit value an
+  -- admin set later (true OR false) — a manual replay must not flip a
+  -- deliberate opt-out back on.
+  WHERE pam_org_config.uac_interception_enabled IS NULL;
   GET DIAGNOSTICS n = ROW_COUNT;
   IF n > 0 THEN
     RAISE WARNING 'pam opt-in grandfathering: enabled UAC capture for % org(s) with deliberate PAM config', n;

--- a/apps/api/migrations/2026-07-01-pam-uac-opt-in-grandfathering.sql
+++ b/apps/api/migrations/2026-07-01-pam-uac-opt-in-grandfathering.sql
@@ -1,0 +1,47 @@
+-- PAM UAC interception: switch from opt-out (default ON) to opt-in (default OFF).
+--
+-- Previously a Windows device with no 'pam' config-policy feature link still
+-- captured UAC elevation events and prompted the end user — capture was ON by
+-- default. The product default is now opt-in: no capture, no prompt, until an
+-- admin enables it via a config policy.
+--
+-- To avoid silently disabling PAM for orgs that had DELIBERATELY configured it
+-- before this switch, grandfather them to ON via a new org-level fallback flag.
+-- "Deliberate configuration" = authored approval rules (pam_rules), signer
+-- groups (pam_signer_groups), or a changed unmatched-verdict default
+-- (pam_org_config.default_unmatched_verdict <> 'require_approval').
+--
+-- elevation_requests history is EXCLUDED on purpose: those rows are the symptom
+-- of the old default-ON behavior (a user clicked through a prompt), not evidence
+-- that the admin wanted PAM. Grandfathering on them would re-enable capture for
+-- exactly the orgs the opt-in switch is meant to spare.
+--
+-- Resolution order (see resolveDevicePamSettings): a 'pam' config-policy feature
+-- link always wins; this column is the org-level fallback; NULL means "no
+-- opinion" → the global opt-in default (off).
+
+ALTER TABLE pam_org_config
+  ADD COLUMN IF NOT EXISTS uac_interception_enabled boolean;
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  WITH active_pam_orgs AS (
+    SELECT org_id FROM pam_rules
+    UNION
+    SELECT org_id FROM pam_signer_groups
+    UNION
+    SELECT org_id FROM pam_org_config WHERE default_unmatched_verdict <> 'require_approval'
+  )
+  INSERT INTO pam_org_config (org_id, uac_interception_enabled)
+  SELECT org_id, true FROM active_pam_orgs
+  ON CONFLICT (org_id) DO UPDATE
+    SET uac_interception_enabled = true,
+        updated_at = now()
+  WHERE pam_org_config.uac_interception_enabled IS DISTINCT FROM true;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'pam opt-in grandfathering: enabled UAC capture for % org(s) with deliberate PAM config', n;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/pamUacGrandfather.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pamUacGrandfather.integration.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+// The data backfill from migration 2026-07-01-pam-uac-opt-in-grandfathering.sql,
+// inlined verbatim so this test guards the real grandfather criteria. The
+// migration's `ALTER TABLE ... ADD COLUMN` is omitted — the column already
+// exists once migrations have run against the test DB.
+//
+// The load-bearing invariant: grandfather orgs with DELIBERATE PAM config
+// (pam_rules / pam_signer_groups / changed default_unmatched_verdict), and
+// EXCLUDE orgs whose only PAM footprint is elevation_requests history. A
+// regression that lets elevation_requests grandfather an org would silently
+// re-enable UAC prompts for exactly the population the opt-in switch protects.
+const BACKFILL = sql`
+  WITH active_pam_orgs AS (
+    SELECT org_id FROM pam_rules
+    UNION SELECT org_id FROM pam_signer_groups
+    UNION SELECT org_id FROM pam_org_config WHERE default_unmatched_verdict <> 'require_approval'
+  )
+  INSERT INTO pam_org_config (org_id, uac_interception_enabled)
+  SELECT org_id, true FROM active_pam_orgs
+  ON CONFLICT (org_id) DO UPDATE
+    SET uac_interception_enabled = true, updated_at = now()
+  WHERE pam_org_config.uac_interception_enabled IS NULL;
+`;
+
+/** Returns the org's flag, or `undefined` when no pam_org_config row exists. */
+async function uacFlag(
+  db: ReturnType<typeof getTestDb>,
+  orgId: string,
+): Promise<boolean | null | undefined> {
+  const rows = await db.execute(sql`
+    SELECT uac_interception_enabled AS f FROM pam_org_config WHERE org_id = ${orgId} LIMIT 1;
+  `);
+  const typed = rows as unknown as Array<{ f: boolean | null }>;
+  const row = typed[0];
+  return row ? row.f : undefined;
+}
+
+describe('PAM UAC opt-in grandfathering migration', () => {
+  it('grandfathers deliberate-config orgs and spares elevation-history-only / pristine orgs', async () => {
+    const db = getTestDb();
+    const partner = await createPartner({});
+
+    // Deliberate config → should be grandfathered to true.
+    const rulesOrg = await createOrganization({ partnerId: partner.id });
+    await db.execute(
+      sql`INSERT INTO pam_rules (org_id, name, verdict) VALUES (${rulesOrg.id}, 'r', 'require_approval')`,
+    );
+
+    const signerOrg = await createOrganization({ partnerId: partner.id });
+    await db.execute(
+      sql`INSERT INTO pam_signer_groups (org_id, name) VALUES (${signerOrg.id}, 'g')`,
+    );
+
+    const verdictOrg = await createOrganization({ partnerId: partner.id });
+    await db.execute(
+      sql`INSERT INTO pam_org_config (org_id, default_unmatched_verdict) VALUES (${verdictOrg.id}, 'auto_deny')`,
+    );
+
+    // ONLY elevation_requests history (the symptom of the old default-ON
+    // behavior) → must NOT be grandfathered. Requires a real device (FK).
+    const elevOrg = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: elevOrg.id });
+    const deviceRows = (await db.execute(sql`
+      INSERT INTO devices (org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+      VALUES (${elevOrg.id}, ${site.id}, ${`agent-${elevOrg.id}`}, 'host', 'windows', '11', 'amd64', '0.65.0')
+      RETURNING id;
+    `)) as unknown as Array<{ id: string }>;
+    const device = deviceRows[0];
+    if (!device) throw new Error('device seed returned no row');
+    // uac_intercept rows must carry target_executable_path (flow_shape_chk).
+    await db.execute(sql`
+      INSERT INTO elevation_requests (org_id, device_id, flow_type, subject_username, reason, target_executable_path)
+      VALUES (${elevOrg.id}, ${device.id}, 'uac_intercept', 'someuser', 'test', 'C:\\Windows\\System32\\cmd.exe');
+    `);
+
+    // No PAM footprint at all → untouched (opt-in default off).
+    const pristineOrg = await createOrganization({ partnerId: partner.id });
+
+    await db.execute(BACKFILL);
+
+    expect(await uacFlag(db, rulesOrg.id)).toBe(true);
+    expect(await uacFlag(db, signerOrg.id)).toBe(true);
+    expect(await uacFlag(db, verdictOrg.id)).toBe(true);
+    // The whole point of the change: elevation-history-only org is spared.
+    expect(await uacFlag(db, elevOrg.id)).toBeUndefined();
+    expect(await uacFlag(db, pristineOrg.id)).toBeUndefined();
+  });
+
+  it('is idempotent on re-run (no duplicate rows, value stays true)', async () => {
+    const db = getTestDb();
+    const partner = await createPartner({});
+    const org = await createOrganization({ partnerId: partner.id });
+    await db.execute(
+      sql`INSERT INTO pam_rules (org_id, name, verdict) VALUES (${org.id}, 'r', 'require_approval')`,
+    );
+
+    await db.execute(BACKFILL);
+    await db.execute(BACKFILL);
+
+    const rows = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM pam_org_config WHERE org_id = ${org.id};
+    `)) as unknown as Array<{ n: number }>;
+    expect(rows[0]?.n).toBe(1);
+    expect(await uacFlag(db, org.id)).toBe(true);
+  });
+
+  it('never clobbers an explicit admin opt-out (IS NULL guard)', async () => {
+    // Org has deliberate config (so it is in active_pam_orgs) AND an admin has
+    // already set uac_interception_enabled=false. A re-run must leave it false.
+    const db = getTestDb();
+    const partner = await createPartner({});
+    const org = await createOrganization({ partnerId: partner.id });
+    await db.execute(
+      sql`INSERT INTO pam_rules (org_id, name, verdict) VALUES (${org.id}, 'r', 'require_approval')`,
+    );
+    await db.execute(
+      sql`INSERT INTO pam_org_config (org_id, uac_interception_enabled) VALUES (${org.id}, false)`,
+    );
+
+    await db.execute(BACKFILL);
+
+    expect(await uacFlag(db, org.id)).toBe(false);
+  });
+});

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -193,6 +193,12 @@ export type NewPamRule = typeof pamRules.$inferInsert;
  * and no PAM rule. The historical behavior is `require_approval` (the request
  * waits for a human); an org can opt into `auto_deny` (block-by-default).
  *
+ * `uacInterceptionEnabled` is the org-level fallback for whether the agent
+ * captures UAC events at all, consulted only when no 'pam' config-policy
+ * feature link resolves for the device. NULL means "no opinion" → the global
+ * opt-in default (off). It is set to true by the 2026-07-01 grandfathering
+ * migration for orgs that had deliberately configured PAM before the switch.
+ *
  * Tenancy: Shape 1 (direct org_id) — RLS policies in the migration use
  * breeze_has_org_access(org_id), mirroring pam_rules. One row per org
  * (unique org_id); absence of a row means the `require_approval` default.
@@ -207,6 +213,7 @@ export const pamOrgConfig = pgTable(
     defaultUnmatchedVerdict: pamUnmatchedVerdictEnum('default_unmatched_verdict')
       .notNull()
       .default('require_approval'),
+    uacInterceptionEnabled: boolean('uac_interception_enabled'),
     updatedByUserId: uuid('updated_by_user_id').references(() => users.id, {
       onDelete: 'set null',
     }),

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1021,7 +1021,7 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     expect(body.uacInterceptionEnabled).toBe(false);
   });
 
-  it('fails open to uacInterceptionEnabled=true when the pam resolver throws', async () => {
+  it('fails closed to uacInterceptionEnabled=false when the pam resolver throws (opt-in)', async () => {
     const { buildPamConfigUpdate } = await import('./helpers');
     vi.mocked(buildPamConfigUpdate).mockRejectedValueOnce(new Error('boom'));
 
@@ -1033,7 +1033,7 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
 
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
-    expect(body.uacInterceptionEnabled).toBe(true);
+    expect(body.uacInterceptionEnabled).toBe(false);
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -693,7 +693,16 @@ if (latestHelper) {
   try {
     pamSettings = await buildPamConfigUpdate(device.id);
   } catch (err) {
-    console.error(`[agents] failed to build pam config update for ${agentId}:`, err);
+    // Opt-in default means a resolver failure leaves pamSettings null and we
+    // send uacInterceptionEnabled:false below. For an org that *enforces* PAM
+    // (grandfather flag or an explicit enabling policy) this momentarily drops
+    // elevation gating until the next successful heartbeat — call it out so the
+    // Sentry event isn't mistaken for a benign config-build hiccup. Not cached,
+    // so it self-heals on the next heartbeat.
+    console.error(
+      `[agents] failed to build pam config update for ${agentId} — sending uacInterceptionEnabled:false this heartbeat:`,
+      err,
+    );
     captureException(err);
   }
 
@@ -749,9 +758,8 @@ if (latestHelper) {
       rotateToken: rotateToken || undefined,
       helperEnabled: helperSettings?.enabled ?? false,
       helperSettings: helperSettings ?? undefined,
-      // Opt-in: if the resolver errored and left pamSettings undefined, fail
-      // closed (no capture) rather than interrupting users with elevation
-      // prompts they never opted into.
+      // Opt-in default: a null pamSettings (resolver error, logged above) sends
+      // false so we never prompt users on a device that opted into nothing.
       uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? false,
       manageRemoteManagement: manageRemoteManagement || undefined,
     },

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -749,7 +749,10 @@ if (latestHelper) {
       rotateToken: rotateToken || undefined,
       helperEnabled: helperSettings?.enabled ?? false,
       helperSettings: helperSettings ?? undefined,
-      uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? true,
+      // Opt-in: if the resolver errored and left pamSettings undefined, fail
+      // closed (no capture) rather than interrupting users with elevation
+      // prompts they never opted into.
+      uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? false,
       manageRemoteManagement: manageRemoteManagement || undefined,
     },
   };

--- a/apps/api/src/routes/agents/helpers.pam.test.ts
+++ b/apps/api/src/routes/agents/helpers.pam.test.ts
@@ -104,6 +104,10 @@ vi.mock('../../db/schema', () => ({
     featureType: 'cpfl.featureType',
     inlineSettings: 'cpfl.inlineSettings',
   },
+  pamOrgConfig: {
+    orgId: 'poc.orgId',
+    uacInterceptionEnabled: 'poc.uacInterceptionEnabled',
+  },
   // Stub out everything else helpers.ts references so the module loads
   softwarePolicies: {},
   softwareComplianceStatus: {},
@@ -171,14 +175,20 @@ const SITE_ID = '00000000-0000-4000-8000-000000000003';
 const PARTNER_ID = '00000000-0000-4000-8000-000000000004';
 const GROUP_ID = '00000000-0000-4000-8000-000000000005';
 
-/** Queue the 4 db.select calls: [deviceRow[], orgRow[], groupRows[], policyRows[]] */
+/**
+ * Queue the db.select calls in order:
+ *   [deviceRow[], orgRow[], groupRows[], policyRows[], orgConfigRows[]]
+ * The 5th (pam_org_config) is only consumed when the device has no resolving
+ * 'pam' feature link, i.e. the org-level grandfather fallback path.
+ */
 function setDbQueue(
   deviceRows: unknown[],
   orgRows: unknown[],
   groupRows: unknown[],
   policyRows: unknown[],
+  orgConfigRows: unknown[] = [],
 ) {
-  dbMock._resetQueue([deviceRows, orgRows, groupRows, policyRows]);
+  dbMock._resetQueue([deviceRows, orgRows, groupRows, policyRows, orgConfigRows]);
 }
 
 // ---------------------------------------------------------------------------
@@ -262,17 +272,74 @@ describe('resolveDevicePamSettings (via buildPamConfigUpdate, cache miss)', () =
     expect(result.uacInterceptionEnabled).toBe(false);
   });
 
-  it('case 4: zero policy rows → returns PAM_DEFAULTS (uacInterceptionEnabled: true)', async () => {
+  it('case 4: zero policy rows + no grandfather row → returns PAM_DEFAULTS (uacInterceptionEnabled: false)', async () => {
     setDbQueue(
       [{ orgId: ORG_ID, siteId: SITE_ID }],
       [{ partnerId: PARTNER_ID }],
       [],
       [], // no policy rows
+      [], // no pam_org_config row → opt-in default
     );
 
     const result = await buildPamConfigUpdate(DEVICE_ID);
     expect(result).toEqual(PAM_DEFAULTS);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('grandfathered org: zero policy rows + pam_org_config.uacInterceptionEnabled=true → enabled', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [], // no policy rows → org-level fallback
+      [{ enabled: true }], // grandfather flag set by migration
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
     expect(result.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('org fallback: pam_org_config.uacInterceptionEnabled=false → disabled', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [],
+      [{ enabled: false }],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('org fallback: pam_org_config row with null flag → PAM_DEFAULTS (opt-in off)', async () => {
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [],
+      [{ enabled: null }],
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result).toEqual(PAM_DEFAULTS);
+    expect(result.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('explicit policy feature link wins over the org grandfather flag', async () => {
+    // A device-level policy explicitly disables capture; the org carries a
+    // grandfather flag that would enable it. The explicit policy must win and
+    // the org fallback must never be consulted.
+    setDbQueue(
+      [{ orgId: ORG_ID, siteId: SITE_ID }],
+      [{ partnerId: PARTNER_ID }],
+      [],
+      [{ level: 'device', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: false } }],
+      [{ enabled: true }], // present but should be ignored
+    );
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+    expect(result.uacInterceptionEnabled).toBe(false);
   });
 
   it('case 5: device not found (first query returns []) → returns PAM_DEFAULTS', async () => {
@@ -287,8 +354,9 @@ describe('resolveDevicePamSettings (via buildPamConfigUpdate, cache miss)', () =
     expect(result).toEqual(PAM_DEFAULTS);
   });
 
-  it('case 6: winner has malformed inlineSettings (uacInterceptionEnabled as string "false") → parses to default true', async () => {
-    // parsePamSettings treats non-boolean as default → true
+  it('case 6: winner has malformed inlineSettings (uacInterceptionEnabled as string "false") → parses to default false', async () => {
+    // parsePamSettings treats non-boolean as the (opt-in) default → false.
+    // The winner has (truthy) inlineSettings, so the org fallback is NOT used.
     setDbQueue(
       [{ orgId: ORG_ID, siteId: SITE_ID }],
       [{ partnerId: PARTNER_ID }],
@@ -299,8 +367,8 @@ describe('resolveDevicePamSettings (via buildPamConfigUpdate, cache miss)', () =
     );
 
     const result = await buildPamConfigUpdate(DEVICE_ID);
-    // 'false' (string) is not a boolean, so parsePamSettings falls back to default (true)
-    expect(result.uacInterceptionEnabled).toBe(true);
+    // 'false' (string) is not a boolean, so parsePamSettings falls back to default (false)
+    expect(result.uacInterceptionEnabled).toBe(false);
   });
 
   it('winner with null inlineSettings → returns PAM_DEFAULTS', async () => {

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -29,6 +29,7 @@ import {
   configPolicyMonitoringWatches,
   configPolicyOnedriveSettings,
   configPolicyOnedriveLibraries,
+  pamOrgConfig,
 } from '../../db/schema';
 import { getRedis } from '../../services/redis';
 import { publishEvent } from '../../services/eventBus';
@@ -2236,6 +2237,25 @@ export async function buildHelperConfigUpdate(deviceId: string, orgId: string): 
 // PAM Settings (policy-driven)
 // ============================================
 
+/**
+ * Org-level fallback when no 'pam' config-policy feature link resolves for the
+ * device. Orgs that had deliberately configured PAM before the opt-in switch
+ * carry an explicit uac_interception_enabled=true on their pam_org_config row
+ * (grandfathered by migration 2026-07-01); everyone else falls to PAM_DEFAULTS
+ * (opt-in: off). An explicit config-policy feature link always wins over this.
+ */
+async function resolveOrgPamFallback(orgId: string): Promise<PamSettings> {
+  const [cfg] = await db
+    .select({ enabled: pamOrgConfig.uacInterceptionEnabled })
+    .from(pamOrgConfig)
+    .where(eq(pamOrgConfig.orgId, orgId))
+    .limit(1);
+  if (cfg && typeof cfg.enabled === 'boolean') {
+    return { uacInterceptionEnabled: cfg.enabled };
+  }
+  return PAM_DEFAULTS;
+}
+
 async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> {
   // 1. Load device
   const [device] = await db
@@ -2296,7 +2316,7 @@ async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> 
       or(...targetConditions),
     ));
 
-  if (rows.length === 0) return PAM_DEFAULTS;
+  if (rows.length === 0) return resolveOrgPamFallback(device.orgId);
 
   // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
   rows.sort((a, b) => {
@@ -2306,7 +2326,7 @@ async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> 
   });
 
   const winner = rows[0];
-  if (!winner?.inlineSettings) return PAM_DEFAULTS;
+  if (!winner?.inlineSettings) return resolveOrgPamFallback(device.orgId);
 
   return parsePamSettings(winner.inlineSettings);
 }
@@ -2315,8 +2335,8 @@ const PAM_CACHE_TTL_SECONDS = 120;
 
 /**
  * Build PAM config update payload for heartbeat response.
- * Resolves pam policy settings via the config policy hierarchy.
- * Falls back to PAM_DEFAULTS (uacInterceptionEnabled: true) if no policy found.
+ * Resolves pam policy settings via the config policy hierarchy, then the
+ * org-level grandfather flag, then PAM_DEFAULTS (uacInterceptionEnabled: false).
  * Cached per-device in Redis for 120s — policy changes propagate within ~2min + heartbeat interval.
  */
 export async function buildPamConfigUpdate(deviceId: string): Promise<PamSettings> {

--- a/apps/api/src/routes/agents/pamSettings.test.ts
+++ b/apps/api/src/routes/agents/pamSettings.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { PAM_DEFAULTS, parsePamSettings } from './pamSettings';
 
 describe('parsePamSettings', () => {
-  it('defaults to interception enabled', () => {
-    expect(PAM_DEFAULTS.uacInterceptionEnabled).toBe(true);
+  it('defaults to interception disabled (opt-in)', () => {
+    expect(PAM_DEFAULTS.uacInterceptionEnabled).toBe(false);
   });
 
   it('returns defaults for null/undefined/non-object input', () => {

--- a/apps/api/src/routes/agents/pamSettings.ts
+++ b/apps/api/src/routes/agents/pamSettings.ts
@@ -10,12 +10,16 @@ export interface PamSettings {
 }
 
 /**
- * Default ON: UAC capture has always been unconditional on Windows agents.
- * A device with no 'pam' feature link anywhere in its hierarchy must keep
- * capturing, so upgrades are behavior-preserving. Admins opt OUT via policy.
+ * Default OFF (opt-in). UAC capture interrupts end users with an elevation-
+ * approval dialog, so a device with no 'pam' feature link anywhere in its
+ * hierarchy must NOT capture. Admins opt IN via a config policy.
+ *
+ * Orgs that had deliberately configured PAM before the opt-in switch are
+ * grandfathered back to ON via pam_org_config.uac_interception_enabled — see
+ * resolveDevicePamSettings and migration 2026-07-01-pam-uac-opt-in-grandfathering.
  */
 export const PAM_DEFAULTS: PamSettings = {
-  uacInterceptionEnabled: true,
+  uacInterceptionEnabled: false,
 };
 
 export function parsePamSettings(inlineSettings: unknown): PamSettings {

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -549,7 +549,7 @@ Inline settings shapes by feature type:
 - sensitive_data: { detectionClasses: ["credential","pci","phi","pii","financial"], includePaths: [], excludePaths: [], fileTypes: [], maxFileSizeBytes: 104857600, workers: 4, timeoutSeconds: 300, scheduleType: "manual"|"interval"|"cron", intervalMinutes?: 60, cron?: "...", timezone: "UTC" }
 - warranty: { enabled: true, warnDays: 90, criticalDays: 30 }
 - helper: { enabled: true, showOpenPortal: true, showDeviceInfo: true, showRequestSupport: true, portalUrl?: "" }
-- pam: inlineSettings {uacInterceptionEnabled: boolean} — Windows UAC elevation prompt capture (default true when no policy assigns it). PAM rules/approvals are managed separately in the /pam console, not via config policies.
+- pam: inlineSettings {uacInterceptionEnabled: boolean} — Windows UAC elevation prompt capture (default false / opt-in: capture is OFF when no policy assigns this feature). PAM rules/approvals are managed separately in the /pam console, not via config policies.
 
 For link-only types, set featurePolicyId instead of inlineSettings:
 - software_policy: featurePolicyId → existing software policy UUID

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -52,9 +52,10 @@ export const remoteAccessInlineSettingsSchema = z.object({
 }).strict();
 
 // Exported so the route can import the same schema (single source of truth).
-// uacInterceptionEnabled defaults to true on the read side (parsePamSettings),
-// so {} is well-formed. Non-boolean values are rejected to prevent the silent-
-// inversion bug where "false" (string) is coerced back to true on read-back.
+// uacInterceptionEnabled defaults to false on the read side (parsePamSettings)
+// — capture is opt-in, so {} is well-formed and means "no capture". Non-boolean
+// values are rejected to prevent a silent-inversion bug where "false" (string)
+// is coerced back to the default on read-back.
 // .strict() matches the posture of patch/backup: unknown keys are rejected.
 export const pamInlineSettingsSchema = z
   .object({

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.test.tsx
@@ -41,9 +41,22 @@ describe('PamTab', () => {
     removeMock.mockClear();
   });
 
-  it('renders the UAC interception toggle, defaulted ON', () => {
+  it('renders the UAC interception toggle, defaulted OFF (opt-in)', () => {
     render(<PamTab {...baseProps} />);
     expect(screen.getByText('Capture Windows UAC elevation prompts')).toBeTruthy();
+  });
+
+  it('saves uacInterceptionEnabled=false by default (opt-in) without toggling', async () => {
+    render(<PamTab {...baseProps} />);
+
+    const saveButton = screen
+      .getAllByRole('button')
+      .find((b) => /save/i.test(b.textContent ?? '')) as HTMLButtonElement;
+    fireEvent.click(saveButton);
+
+    expect(saveMock).toHaveBeenCalled();
+    const settings = inlineSettingsFromCall(saveMock.mock.calls[0]);
+    expect(settings).toEqual({ uacInterceptionEnabled: false });
   });
 
   it('links rule management out to the /pam console', () => {
@@ -52,7 +65,7 @@ describe('PamTab', () => {
     expect(link.getAttribute('href')).toBe('/pam');
   });
 
-  it('saves uacInterceptionEnabled=false after toggling off', async () => {
+  it('saves uacInterceptionEnabled=true after toggling on', async () => {
     render(<PamTab {...baseProps} />);
 
     const toggleButton = screen.getByTestId('pam-tab-capture-toggle') as HTMLButtonElement;
@@ -66,6 +79,6 @@ describe('PamTab', () => {
 
     expect(saveMock).toHaveBeenCalled();
     const settings = inlineSettingsFromCall(saveMock.mock.calls[0]);
-    expect(settings).toEqual({ uacInterceptionEnabled: false });
+    expect(settings).toEqual({ uacInterceptionEnabled: true });
   });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PamTab.tsx
@@ -9,9 +9,10 @@ type PamSettings = {
   uacInterceptionEnabled: boolean;
 };
 
-// Default ON — matches agent behavior when no policy assigns this feature.
+// Default OFF (opt-in) — matches agent behavior when no policy assigns this
+// feature: a device with no 'pam' policy does not capture UAC prompts.
 const defaults: PamSettings = {
-  uacInterceptionEnabled: true,
+  uacInterceptionEnabled: false,
 };
 
 export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
@@ -84,7 +85,7 @@ export default function PamTab({ policyId, existingLink, onLinkChanged, linkedPo
           <div>
             <p className="text-sm font-medium">Capture Windows UAC elevation prompts</p>
             <p className="text-xs text-muted-foreground">
-              The agent observes UAC consent prompts and records them as elevation requests for PAM review. Capture is on by default when no policy sets this.
+              The agent observes UAC consent prompts and records them as elevation requests for PAM review. Capture is off by default — enable it here to opt a device's scope into PAM.
             </p>
           </div>
           <button


### PR DESCRIPTION
## Problem

End users were getting **"Breeze — Elevation Request"** approval pop-ups on Windows devices even though **no PAM config policy had been applied**. This is the real PAM end-user approval dialog (`showPamDialog`), not a diagnostic prompt.

Root cause is a default-on / fail-to-prompt design at two layers, neither gated by a config policy:

1. **Capture defaulted ON** — with no `pam` feature link anywhere in the hierarchy, the heartbeat still sent `uacInterceptionEnabled: true` (`PAM_DEFAULTS` + `?? true` fallback). The agent captured every UAC event.
2. **Unmatched elevations defaulted to "prompt"** — with no software policy, no PAM rule, and no `auto_deny` org default, the server's decision stays `pending`, which the agent routes to the end-user dialog (`pam_flow.go` `ElevationPending`).

Net: a completely unconfigured org prompted users on **every** UAC elevation.

## Fix — switch opt-out → opt-in

- `pamSettings.ts`: `PAM_DEFAULTS.uacInterceptionEnabled` → `false`.
- `heartbeat.ts`: resolver-error fallback `?? true` → `?? false` (fail **closed** — don't prompt users we can't resolve).
- `helpers.ts`: `resolveDevicePamSettings` consults an org-level grandfather flag (`pam_org_config.uac_interception_enabled`) when no `pam` config-policy feature link resolves. An explicit feature link in the hierarchy still wins.
- Go agent `heartbeat.go`: rename the inverted `uacInterceptionDisabled` atomic to `uacInterceptionEnabled` so the zero value (and `nil`/old-server) means **OFF** (opt-in).
- Web `PamTab.tsx`: toggle defaults **OFF**, copy updated.

## Grandfathering (migration `2026-07-01-pam-uac-opt-in-grandfathering.sql`)

Adds nullable `pam_org_config.uac_interception_enabled`; sets `true` only for orgs with **deliberate** PAM config:
- has `pam_rules`, **or**
- has `pam_signer_groups`, **or**
- has a `pam_org_config` row with `default_unmatched_verdict <> 'require_approval'`

`elevation_requests` history is **excluded on purpose** — those rows are the *symptom* of the old default-ON behavior (a user clicked through a prompt), not evidence the admin wanted PAM. Grandfathering on them would re-enable capture for exactly the orgs this change is meant to spare.

Resolution order: config-policy feature link (closest wins) → org grandfather flag → global opt-in default (off).

## Verification

- **Go**: `heartbeat` + `etwlua` tests pass (default-off cases updated).
- **API**: 66 tests across `pamSettings` / `helpers.pam` / `heartbeat` pass; added grandfather + "explicit policy beats grandfather" cases. `tsc --noEmit` clean. `autoMigrate` ordering regression passes.
- **Web**: `PamTab` 4 tests pass.
- **Migration**: run against real Postgres (rolled back) — grandfathers exactly the deliberate orgs, idempotent (0 rows on re-run), elevation-history-only org gets no row → opt-in. Also applies cleanly against the fully-migrated integration DB (ordering confirmed).

## Rollout note

Takes effect per device on its **next heartbeat** (PAM settings Redis-cached ~120s) — pop-ups stop fleet-wide within ~2 min of deploy, **no agent update required** (server drives the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)