### PR TITLE
test(api): fix userDeleteResurrect 403 after #1887 partner-mgmt gate

### DIFF
--- a/apps/api/src/__tests__/integration/userDeleteResurrect.integration.test.ts
+++ b/apps/api/src/__tests__/integration/userDeleteResurrect.integration.test.ts
@@ -32,6 +32,11 @@ type AuthCtx = {
   orgId: string | null;
   accessibleOrgIds: string[] | null;
   accessiblePartnerIds: string[] | null;
+  // The id of the user MAKING the request. The partner-wide user-management
+  // gate in users.ts (#1887) looks the caller up in partnerUsers and 403s
+  // unless they hold an orgAccess='all' membership, so partner-scope cases
+  // must seed a real full-access caller and pass its id here.
+  userId?: string | null;
 };
 
 let activeAuthContext: AuthCtx | null = null;
@@ -49,7 +54,7 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
         partnerId: ctx.partnerId,
         orgId: ctx.orgId,
         accessibleOrgIds: ctx.accessibleOrgIds ?? [],
-        user: { id: null, email: 'integration@test' },
+        user: { id: ctx.userId ?? null, email: 'integration@test' },
       });
       return withDbAccessContext(
         {
@@ -57,7 +62,7 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
           orgId: ctx.orgId,
           accessibleOrgIds: ctx.accessibleOrgIds,
           accessiblePartnerIds: ctx.accessiblePartnerIds,
-          userId: null,
+          userId: ctx.userId ?? null,
         },
         () => next(),
       );
@@ -112,6 +117,14 @@ describe('user delete → neutralize orphan (#1367)', () => {
   it('neutralizes the orphaned users row when the last membership is deleted', async () => {
     const partner = await createPartner();
     const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    // The caller making the DELETE: a full-access (orgAccess='all') partner
+    // admin, as required by the partner-wide user-management gate (#1887).
+    const caller = await createUser({
+      partnerId: partner.id,
+      email: `caller-${Date.now()}@example.com`,
+      status: 'active',
+    });
+    await assignUserToPartner(caller.id, partner.id, role.id, 'all');
     const target = await createUser({
       partnerId: partner.id,
       email: `orphan-${Date.now()}@example.com`,
@@ -125,6 +138,7 @@ describe('user delete → neutralize orphan (#1367)', () => {
       orgId: null,
       accessibleOrgIds: [],
       accessiblePartnerIds: [partner.id],
+      userId: caller.id,
     };
 
     const app = await buildApp();
@@ -194,6 +208,13 @@ describe('user re-invite → resurrect tombstone (#1367)', () => {
   it('resets a neutralized tombstone to a clean invited state on re-invite', async () => {
     const partner = await createPartner();
     const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    // Full-access partner admin issuing the re-invite (gate requirement, #1887).
+    const caller = await createUser({
+      partnerId: partner.id,
+      email: `caller-${Date.now()}@example.com`,
+      status: 'active',
+    });
+    await assignUserToPartner(caller.id, partner.id, role.id, 'all');
     const email = `revive-${Date.now()}@example.com`;
 
     // Seed a tombstone directly: the state a prior delete (or the backfill
@@ -217,6 +238,7 @@ describe('user re-invite → resurrect tombstone (#1367)', () => {
       orgId: null,
       accessibleOrgIds: [],
       accessiblePartnerIds: [partner.id],
+      userId: caller.id,
     };
 
     const app = await buildApp();


### PR DESCRIPTION
## What

`userDeleteResurrect.integration.test.ts` has been red on **main** (not on PRs — integration tests are skipped there), masking CI signal on every PR. Both partner-scope cases returned **403** where 200/201 was expected (lines 132/228).

## Root cause

**#1887** (`fix(api): close cross-org/partner app-layer allowlist gaps`) hardened the partner-wide user-management gate in `users.ts`. The old gate read `organizations` under request RLS and checked `partnerOrgRows.every(o => accessibleOrgIds.includes(o.id))` — which is **vacuously true** for a partner with zero orgs (the very escalation hole #1887 closed). The new gate looks the caller up in `partnerUsers` and requires `orgAccess === 'all'`.

The integration test's synthetic caller had `auth.user.id = null` and no membership, so it had been passing only via that now-closed vacuous-true path. Org-scope test 2 was unaffected (the gate is partner-scope only), which is exactly why only the two partner-scope cases failed.

This is a **test gap exposed by a correct security fix**, not a product regression.

## Fix

Model the caller the way the gate now requires: seed a real full-access (`orgAccess='all'`) partner admin and thread its id through the auth mock. No product code changes.

## Verification

- Reproduced the 403s against the real docker test DB, then confirmed **3/3 pass** after the fix.
- Ran the other #1887-touched route integration suites (config policies, time-entries, pax8, update-rings) — **35/35 green**, confirming `userDeleteResurrect` was the only collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)