### PR TITLE
fix(jobs): phase-split s1Sync + patchScheduler conn-holds (#1896)

### DIFF
--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -331,14 +331,16 @@ async function scanAndCreateJobs(): Promise<{
 }> {
   const now = new Date();
   let created = 0;
-  // Job ids to enqueue to Redis AFTER the system DB access-context transaction
-  // closes. Enqueuing inside it held the pooled connection idle-in-transaction
-  // across BullMQ/Redis round-trips — a contributor to the #1105 pool-poisoning
-  // pattern (txn around slow non-DB work). DB writes stay in the context; the
-  // Redis enqueue happens outside it (see the worker processor).
+  // #1105/#1896: this scan is NOT wrapped in one held system DB access context.
+  // Each DB touch below (policy/assignment/device reads, maintenance-window
+  // checks, the patch_jobs insert) opens its OWN short context via
+  // runWithSystemDbAccess, so the nested policy→assignment→device loops never pin
+  // a single pooled connection in an open transaction across the whole sweep (the
+  // ~5s held-context warnings #1896 targets). Job ids are still enqueued to Redis
+  // AFTER scanAndCreateJobs returns (see enqueueScanResults in the worker).
   const enqueueJobIds: string[] = [];
 
-  const patchPoliciesWithSchedules = await db
+  const patchPoliciesWithSchedules = await runWithSystemDbAccess(() => db
     .select({
       configPolicyId: configurationPolicies.id,
       policyName: configurationPolicies.name,
@@ -353,7 +355,7 @@ async function scanAndCreateJobs(): Promise<{
         eq(configurationPolicies.status, 'active')
       )
     )
-    .where(eq(configPolicyFeatureLinks.featureType, 'patch'));
+    .where(eq(configPolicyFeatureLinks.featureType, 'patch')));
 
   for (const row of patchPoliciesWithSchedules) {
     try {
@@ -362,8 +364,12 @@ async function scanAndCreateJobs(): Promise<{
       // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
       // The guard is a defensive backstop; it never skips real work.
       if (row.policyOrgId === null) continue;
+      // Capture the non-null narrowing in a const: the property narrowing from the
+      // guard above does not survive into the deferred runWithSystemDbAccess
+      // closures below (#1896 phase-split wraps each DB touch in its own callback).
+      const policyOrgId = row.policyOrgId;
 
-      const policyLocal = await loadPolicyLocalPatchConfig(row.configPolicyId);
+      const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));
       if (!policyLocal) continue;
 
       if (!policyLocal.ring.valid) {
@@ -373,25 +379,25 @@ async function scanAndCreateJobs(): Promise<{
         continue;
       }
 
-      const assignments = await db
+      const assignments = await runWithSystemDbAccess(() => db
         .select({
           level: configPolicyAssignments.level,
           targetId: configPolicyAssignments.targetId,
         })
         .from(configPolicyAssignments)
-        .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId));
+        .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId)));
 
       if (assignments.length === 0) continue;
 
       const allDeviceIds = new Set<string>();
       for (const assignment of assignments) {
-        const ids = await resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, row.policyOrgId);
+        const ids = await runWithSystemDbAccess(() => resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, policyOrgId));
         for (const id of ids) allDeviceIds.add(id);
       }
 
       if (allDeviceIds.size === 0) continue;
 
-      const schedulingContexts = await loadDeviceSchedulingContexts(Array.from(allDeviceIds));
+      const schedulingContexts = await runWithSystemDbAccess(() => loadDeviceSchedulingContexts(Array.from(allDeviceIds)));
       const groupedContexts = new Map<string, { orgId: string; timezone: string; deviceIds: string[] }>();
 
       for (const context of schedulingContexts) {
@@ -418,13 +424,13 @@ async function scanAndCreateJobs(): Promise<{
       }
 
       for (const group of dueGroups) {
-        if (await hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now)) {
+        if (await runWithSystemDbAccess(() => hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now))) {
           continue;
         }
 
         const eligibleDeviceIds: string[] = [];
         for (const deviceId of group.deviceIds) {
-          const maintenance = await checkDeviceMaintenanceWindow(deviceId);
+          const maintenance = await runWithSystemDbAccess(() => checkDeviceMaintenanceWindow(deviceId));
           if (!maintenance.active || !maintenance.suppressPatching) {
             eligibleDeviceIds.push(deviceId);
           }
@@ -434,7 +440,7 @@ async function scanAndCreateJobs(): Promise<{
           continue;
         }
 
-        const [job] = await db
+        const [job] = await runWithSystemDbAccess(() => db
           .insert(patchJobs)
           .values({
             orgId: group.orgId,
@@ -455,7 +461,7 @@ async function scanAndCreateJobs(): Promise<{
             devicesTotal: eligibleDeviceIds.length,
             devicesPending: eligibleDeviceIds.length,
           })
-          .returning();
+          .returning());
 
         if (job) {
           enqueueJobIds.push(job.id);
@@ -481,7 +487,7 @@ async function scanAndCreateJobs(): Promise<{
   // it to Sentry, not just the console (#1379 worker-observability convention).
   let staleScheduledJobs: StaleScheduledJob[] = [];
   try {
-    staleScheduledJobs = await selectStaleScheduledJobIds(now);
+    staleScheduledJobs = await runWithSystemDbAccess(() => selectStaleScheduledJobIds(now));
   } catch (err) {
     const message = '[PatchScheduler] Failed to read stale scheduled jobs for reconcile';
     console.error(`${message}:`, err instanceof Error ? err.message : err);
@@ -580,20 +586,25 @@ function createSchedulerWorker(): Worker {
   return new Worker(
     QUEUE_NAME,
     async (_job: Job) => {
-      const result = await runWithSystemDbAccess(async () => {
-        try {
-          return await scanAndCreateJobs();
-        } catch (error: unknown) {
-          if (isRelationNotFoundError(error)) {
-            if (!_configPolicyTableWarningLogged) {
-              _configPolicyTableWarningLogged = true;
-              console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
-            }
-            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+      // #1105/#1896: scanAndCreateJobs is NOT wrapped in a single
+      // runWithSystemDbAccess — it opens a SHORT system context per DB touch so the
+      // nested policy/assignment/device sweep never holds one pooled connection in
+      // an open transaction. enqueueScanResults still runs outside any context (the
+      // Redis round-trips happen after the DB writes have committed).
+      let result: Awaited<ReturnType<typeof scanAndCreateJobs>>;
+      try {
+        result = await scanAndCreateJobs();
+      } catch (error: unknown) {
+        if (isRelationNotFoundError(error)) {
+          if (!_configPolicyTableWarningLogged) {
+            _configPolicyTableWarningLogged = true;
+            console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
           }
+          result = { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+        } else {
           throw error;
         }
-      });
+      }
 
       const { recovered } = await enqueueScanResults(result);
 

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -41,8 +41,14 @@ import {
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  // Fail loud if the context helper is missing rather than silently running the
+  // query contextless under the forced-RLS breeze_app role — that is the #1375
+  // silent-0-row vector this worker now relies on NOT hitting (each DB touch is
+  // wrapped per #1896). Mirrors the s1Sync.ts shim; tests pass a passthrough mock.
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[PatchScheduler] withSystemDbAccessContext is unavailable');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
 };
 
 function isRelationNotFoundError(error: unknown): boolean {

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -500,6 +500,9 @@ async function syncAgentsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
 ): Promise<{ fetched: number; upserted: number; skipped: number; truncated: boolean }> {
+  // #1105/#1896: the SentinelOne fetch runs OUTSIDE any DB context. Each DB touch
+  // below opens its own short system context, so the pooled connection is never
+  // held idle-in-transaction across this (potentially slow) upstream HTTP call.
   const agentResult = await client.listAgents(integration.lastSyncAt ?? undefined);
   const fetchedAgents = agentResult.results;
 
@@ -524,23 +527,23 @@ async function syncAgentsForIntegration(
   // Skip sites with no siteName — a null siteName can never match a provisional row
   // (which is keyed as 'name:<siteName>'), so attempting reconciliation would silently
   // miss and build a 'name:<siteId>' key that matches nothing.
-  await reconcileProvisionalSiteMappings(
+  await runWithSystemDbAccess(() => reconcileProvisionalSiteMappings(
     integration.id,
     discoveredSites
       .filter((s): s is { siteId: string; siteName: string; count: number } => typeof s.siteName === 'string' && s.siteName.length > 0)
       .map((s) => ({ siteId: s.siteId, siteName: s.siteName }))
-  );
+  ));
 
   // Step 2: Upsert discovered sites (sets agents_count, last_seen_at; preserves org_id).
-  await upsertDiscoveredSites({
+  await runWithSystemDbAccess(() => upsertDiscoveredSites({
     integrationId: integration.id,
     partnerId: integration.partnerId,
     sites: discoveredSites,
-  });
+  }));
 
   // Step 3: Load the org mapping keyed by s1_site_id (only rows with mapped org_id).
-  const siteOrgIds = await mapSiteOrgIds(integration.id);
-  const candidatesByOrg = await mapDeviceCandidatesByOrg([...siteOrgIds.values()]);
+  const siteOrgIds = await runWithSystemDbAccess(() => mapSiteOrgIds(integration.id));
+  const candidatesByOrg = await runWithSystemDbAccess(() => mapDeviceCandidatesByOrg([...siteOrgIds.values()]));
 
   let upserted = 0;
   let skipped = 0;
@@ -592,7 +595,7 @@ async function syncAgentsForIntegration(
 
     if (values.length === 0) continue;
 
-    const inserted = await db
+    const inserted = await runWithSystemDbAccess(() => db
       .insert(s1Agents)
       .values(values)
       .onConflictDoUpdate({
@@ -610,7 +613,7 @@ async function syncAgentsForIntegration(
           updatedAt: sql`excluded.updated_at`
         }
       })
-      .returning({ id: s1Agents.id });
+      .returning({ id: s1Agents.id }));
 
     upserted += inserted.length;
   }
@@ -627,20 +630,22 @@ async function syncThreatsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
 ): Promise<{ fetched: number; upserted: number; skipped: number; emitted: number; emitFailures: number; truncated: boolean }> {
+  // #1105/#1896: the SentinelOne fetch and the post-upsert publishEvent loop both
+  // run OUTSIDE any DB context; only the reads/upserts below open short contexts.
   const threatResult = await client.listThreats(integration.lastSyncAt ?? undefined);
   const fetchedThreats = threatResult.results;
 
   // Load agent contexts from already-synced s1_agents rows.
   // If an agent was skipped during agent sync (unmapped site), it won't appear here
   // and its threats will be skipped too — consistent with the partner-wide model.
-  const agentRows = await db
+  const agentRows = await runWithSystemDbAccess(() => db
     .select({
       s1AgentId: s1Agents.s1AgentId,
       orgId: s1Agents.orgId,
       deviceId: s1Agents.deviceId
     })
     .from(s1Agents)
-    .where(eq(s1Agents.integrationId, integration.id));
+    .where(eq(s1Agents.integrationId, integration.id)));
 
   const agentContextByAgentId = new Map<string, AgentContext>();
   for (const row of agentRows) {
@@ -718,7 +723,7 @@ async function syncThreatsForIntegration(
 
     if (values.length === 0) continue;
 
-    const inserted = await db
+    const inserted = await runWithSystemDbAccess(() => db
       .insert(s1Threats)
       .values(values)
       .onConflictDoUpdate({
@@ -740,7 +745,7 @@ async function syncThreatsForIntegration(
           updatedAt: sql`excluded.updated_at`
         }
       })
-      .returning({ id: s1Threats.id });
+      .returning({ id: s1Threats.id }));
 
     upserted += inserted.length;
   }
@@ -787,7 +792,10 @@ async function syncThreatsForIntegration(
 // back to `redactLogMessage(error.responseBody)` would otherwise pass every
 // existing helper-level test.
 export async function processSyncIntegration(data: SyncIntegrationJobData) {
-  const [integration] = await db
+  // #1105/#1896: read in a short context; the SentinelOne HTTP work inside
+  // syncAgents/syncThreats runs OUTSIDE any context (those functions phase-split
+  // internally), and the status write-backs below are their own short contexts.
+  const [integration] = await runWithSystemDbAccess(() => db
     .select({
       id: s1Integrations.id,
       partnerId: s1Integrations.partnerId,
@@ -798,7 +806,7 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
     })
     .from(s1Integrations)
     .where(eq(s1Integrations.id, data.integrationId))
-    .limit(1);
+    .limit(1));
 
   if (!integration || !integration.isActive) {
     console.warn(`[S1SyncJob] Integration ${data.integrationId} not found or inactive; skipping sync`);
@@ -832,7 +840,7 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
       : { fetched: 0, upserted: 0, emitted: 0, emitFailures: 0, truncated: false };
 
     const wasTruncated = agentResult.truncated || threatResult.truncated;
-    await db
+    await runWithSystemDbAccess(() => db
       .update(s1Integrations)
       .set({
         lastSyncAt: new Date(),
@@ -840,7 +848,7 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
         lastSyncError: wasTruncated ? 'Results were truncated due to pagination limits' : null,
         updatedAt: new Date()
       })
-      .where(eq(s1Integrations.id, integration.id));
+      .where(eq(s1Integrations.id, integration.id)));
 
     return {
       integrationId: integration.id,
@@ -857,14 +865,14 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
     // via truncateError — a SentinelOneHttpError's `.message` carries no body.
     logSyncFailureServerSide({ integrationId: integration.id, partnerId: integration.partnerId }, error);
     try {
-      await db
+      await runWithSystemDbAccess(() => db
         .update(s1Integrations)
         .set({
           lastSyncStatus: 'error',
           lastSyncError: truncateError(error),
           updatedAt: new Date()
         })
-        .where(eq(s1Integrations.id, integration.id));
+        .where(eq(s1Integrations.id, integration.id)));
     } catch (dbError) {
       console.error('[S1SyncJob] Failed to persist sync error status:', dbError);
       captureException(dbError);
@@ -875,7 +883,8 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
 
 async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
   const queue = getS1SyncQueue();
-  const integrations = await listActiveIntegrations();
+  // #1105/#1896: read in a short context; the Redis enqueues below run OUTSIDE it.
+  const integrations = await runWithSystemDbAccess(() => listActiveIntegrations());
 
   await Promise.all(
     integrations.map((integration) => addUniqueJob(
@@ -896,7 +905,12 @@ async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
 }
 
 export async function processPollActions() {
-  const pendingActions = await db
+  // #1105/#1896: all reads here use short contexts, and per-action the SentinelOne
+  // getActivityStatus HTTP call + publishEvent run OUTSIDE any context. Each
+  // s1_actions write inside the loop opens its own short context, so a pooled
+  // connection is never held idle-in-transaction across the upstream poll latency
+  // (previously up to 200 sequential HTTP calls ran inside ONE open transaction).
+  const pendingActions = await runWithSystemDbAccess(() => db
     .select({
       id: s1Actions.id,
       orgId: s1Actions.orgId,
@@ -912,7 +926,7 @@ export async function processPollActions() {
         isNotNull(s1Actions.providerActionId)
       )
     )
-    .limit(200);
+    .limit(200));
 
   if (pendingActions.length === 0) {
     return { polled: 0, updated: 0 };
@@ -926,13 +940,13 @@ export async function processPollActions() {
   const orgIds = Array.from(new Set(pendingActions.map((row) => row.orgId)));
 
   // Step 1: Resolve org_id → partner_id
-  const orgRows = await db
+  const orgRows = await runWithSystemDbAccess(() => db
     .select({
       id: organizations.id,
       partnerId: organizations.partnerId,
     })
     .from(organizations)
-    .where(inArray(organizations.id, orgIds));
+    .where(inArray(organizations.id, orgIds)));
 
   const partnerIdByOrg = new Map<string, string>();
   for (const row of orgRows) {
@@ -942,14 +956,14 @@ export async function processPollActions() {
   // Step 2: Fetch the active integration for each distinct partner (deduplicated)
   const distinctPartnerIds = Array.from(new Set([...partnerIdByOrg.values()]));
   const partnerIntegrations = distinctPartnerIds.length > 0
-    ? await db
+    ? await runWithSystemDbAccess(() => db
         .select({
           partnerId: s1Integrations.partnerId,
           managementUrl: s1Integrations.managementUrl,
           apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
         })
         .from(s1Integrations)
-        .where(and(inArray(s1Integrations.partnerId, distinctPartnerIds), eq(s1Integrations.isActive, true)))
+        .where(and(inArray(s1Integrations.partnerId, distinctPartnerIds), eq(s1Integrations.isActive, true))))
     : [];
 
   // Step 3: Build a reusable client per partner to avoid redundant decrypt + instantiation
@@ -998,14 +1012,14 @@ export async function processPollActions() {
 
     if (client === undefined) {
       // No integration found for this org
-      await db
+      await runWithSystemDbAccess(() => db
         .update(s1Actions)
         .set({
           status: 'failed',
           error: 'Action status polling failed: no active SentinelOne integration is available for this organization',
           completedAt: new Date()
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id)));
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
@@ -1013,14 +1027,14 @@ export async function processPollActions() {
 
     if (!client) {
       // Client construction failed (bad token)
-      await db
+      await runWithSystemDbAccess(() => db
         .update(s1Actions)
         .set({
           status: 'failed',
           error: `Action status polling failed: ${clientError ?? 'unknown client error'}`,
           completedAt: new Date()
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id)));
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
@@ -1035,7 +1049,7 @@ export async function processPollActions() {
       nextPayload.lastPollAt = new Date().toISOString();
 
       try {
-        await db
+        await runWithSystemDbAccess(() => db
           .update(s1Actions)
           .set({
             status: nextStatus,
@@ -1043,7 +1057,7 @@ export async function processPollActions() {
             error: nextStatus === 'failed' ? truncateError(activity.details) : null,
             payload: nextPayload
           })
-          .where(eq(s1Actions.id, action.id));
+          .where(eq(s1Actions.id, action.id)));
       } catch (dbError) {
         console.error(`[S1SyncJob] Failed to persist poll result for action ${action.id}:`, dbError);
         captureException(dbError);
@@ -1096,7 +1110,7 @@ export async function processPollActions() {
       const failure = applyPollFailure(action.payload, error);
       const nextStatus: S1ActionStatus = failure.shouldFail ? 'failed' : 'in_progress';
 
-      await db
+      await runWithSystemDbAccess(() => db
         .update(s1Actions)
         .set({
           status: nextStatus,
@@ -1106,7 +1120,7 @@ export async function processPollActions() {
             : null,
           completedAt: failure.shouldFail ? new Date() : null
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id)));
 
       recordS1ActionPollTransition(nextStatus);
       updated += 1;
@@ -1123,56 +1137,59 @@ function createS1SyncWorker(): Worker<S1SyncJobData> {
   return new Worker<S1SyncJobData>(
     S1_SYNC_QUEUE,
     async (job: Job<S1SyncJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        const start = Date.now();
-        const syncType = job.data.type;
-        switch (job.data.type) {
-          case 'sync-integration': {
-            try {
-              const result = await processSyncIntegration(job.data);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-agents': {
-            try {
-              const result = await processSyncAll(true, false);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-threats': {
-            try {
-              const result = await processSyncAll(false, true);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'poll-actions': {
-            try {
-              const result = await processPollActions();
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          default: {
+      // #1105/#1896: the job is NOT wrapped in a single runWithSystemDbAccess.
+      // Each process function below opens its own SHORT system context around DB
+      // work and runs SentinelOne HTTP calls OUTSIDE any context, so a pooled
+      // connection is never held idle-in-transaction across the upstream latency
+      // (the conn-hold that contributed to the US pool-starvation pressure).
+      const start = Date.now();
+      const syncType = job.data.type;
+      switch (job.data.type) {
+        case 'sync-integration': {
+          try {
+            const result = await processSyncIntegration(job.data);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
             recordS1SyncRun(syncType, 'failure', Date.now() - start);
-            throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+            throw error;
           }
         }
-      });
+        case 'sync-all-agents': {
+          try {
+            const result = await processSyncAll(true, false);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'sync-all-threats': {
+          try {
+            const result = await processSyncAll(false, true);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'poll-actions': {
+          try {
+            const result = await processPollActions();
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        default: {
+          recordS1SyncRun(syncType, 'failure', Date.now() - start);
+          throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+        }
+      }
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/s1Sync_connHold.test.ts
+++ b/apps/api/src/jobs/s1Sync_connHold.test.ts
@@ -81,18 +81,20 @@ vi.mock('../services/sentinelOne/metrics', () => ({
 }));
 
 const getActivityStatusMock = vi.fn();
+const listAgentsMock = vi.fn();
+const listThreatsMock = vi.fn();
 
 vi.mock('../services/sentinelOne/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
   class MockSentinelOneClient {
-    listAgents = vi.fn().mockResolvedValue({ results: [], truncated: false });
-    listThreats = vi.fn().mockResolvedValue({ results: [], truncated: false });
+    listAgents = listAgentsMock;
+    listThreats = listThreatsMock;
     getActivityStatus = getActivityStatusMock;
   }
   return { ...actual, SentinelOneClient: MockSentinelOneClient };
 });
 
-const { processPollActions } = await import('./s1Sync');
+const { processPollActions, processSyncIntegration } = await import('./s1Sync');
 
 describe('processPollActions conn-hold phase-split (#1105/#1896)', () => {
   beforeEach(() => {
@@ -144,5 +146,45 @@ describe('processPollActions conn-hold phase-split (#1105/#1896)', () => {
 
     expect(selectContexts.length).toBe(3);
     expect(selectContexts.every((v) => v === true)).toBe(true);
+  });
+});
+
+describe('processSyncIntegration conn-hold phase-split (#1105/#1896)', () => {
+  beforeEach(() => {
+    contextDepth = 0;
+    selectContexts.length = 0;
+    updateContexts.length = 0;
+    httpContexts.length = 0;
+    // Only the initial integration read returns a row; the agent/threat upserts
+    // are skipped (empty results), so remaining selects (mapSiteOrgIds, agentRows)
+    // default to [] and the only write is the final s1_integrations status update.
+    selectRowsQueue = [
+      [{
+        id: 'integration-1',
+        partnerId: 'partner-1',
+        managementUrl: 'https://example.sentinelone.net',
+        apiTokenEncrypted: 'enc',
+        isActive: true,
+        lastSyncAt: null,
+      }],
+    ];
+    for (const mock of [listAgentsMock, listThreatsMock]) {
+      mock.mockReset();
+      mock.mockImplementation(() => {
+        httpContexts.push(inContext());
+        return Promise.resolve({ results: [], truncated: false });
+      });
+    }
+  });
+
+  it('runs listAgents and listThreats OUTSIDE any held DB context, writes status INSIDE one', async () => {
+    await processSyncIntegration({ type: 'sync-integration', integrationId: 'integration-1', syncAgents: true, syncThreats: true });
+
+    // Both SentinelOne fetches ran, and neither was inside a held transaction.
+    expect(httpContexts).toEqual([false, false]);
+    // The integration read + the lastSyncAt/status write each ran inside a context.
+    expect(selectContexts[0]).toBe(true);
+    expect(updateContexts.length).toBeGreaterThan(0);
+    expect(updateContexts.every((v) => v === true)).toBe(true);
   });
 });

--- a/apps/api/src/jobs/s1Sync_connHold.test.ts
+++ b/apps/api/src/jobs/s1Sync_connHold.test.ts
@@ -1,0 +1,148 @@
+/**
+ * #1105 / #1896 conn-hold regression: the S1 sync worker must NOT hold a single
+ * DB access context (open transaction) across SentinelOne HTTP calls.
+ *
+ * These tests instrument the DB-context boundary: `withSystemDbAccessContext`
+ * increments a depth counter for the duration of its callback, and every mocked
+ * primitive records whether it ran while that depth was > 0. The phase-split
+ * contract is then asserted directly:
+ *
+ *   - DB reads/writes run INSIDE a (short) context  → depth > 0
+ *   - the SentinelOne HTTP call runs OUTSIDE any context → depth === 0
+ *
+ * A regression that re-wraps the whole job/loop in one held context (the
+ * pre-#1896 shape) makes the HTTP call observe depth > 0 and fails here.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Tracks the active withSystemDbAccessContext nesting depth so each mocked
+// primitive can record whether it ran inside a held context.
+let contextDepth = 0;
+const inContext = () => contextDepth > 0;
+
+const selectContexts: boolean[] = [];
+const updateContexts: boolean[] = [];
+const httpContexts: boolean[] = [];
+
+// SELECT chain: awaitable at `.where()` (via .then) and at `.limit()`.
+function selectReturning(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'leftJoin']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.limit = vi.fn().mockResolvedValue(rows);
+  chain.then = (resolve: (value: unknown[]) => unknown) => resolve(rows);
+  return chain;
+}
+
+// Rows handed back by successive db.select() calls in processPollActions:
+//   1) pending s1_actions, 2) organizations (org→partner), 3) active integrations.
+let selectRowsQueue: unknown[][] = [];
+
+const mockDb = {
+  select: vi.fn().mockImplementation(() => {
+    selectContexts.push(inContext());
+    const rows = selectRowsQueue.shift() ?? [];
+    return selectReturning(rows);
+  }),
+  update: vi.fn().mockImplementation(() => {
+    updateContexts.push(inContext());
+    return { set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) };
+  }),
+  insert: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => {
+    contextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  },
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  hasDbAccessContext: () => contextDepth > 0,
+}));
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: () => 'decrypted-token',
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../services/sentinelOne/metrics', () => ({
+  recordS1ActionDispatch: vi.fn(),
+  recordS1ActionPollTransition: vi.fn(),
+  recordS1SyncRun: vi.fn(),
+}));
+
+const getActivityStatusMock = vi.fn();
+
+vi.mock('../services/sentinelOne/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
+  class MockSentinelOneClient {
+    listAgents = vi.fn().mockResolvedValue({ results: [], truncated: false });
+    listThreats = vi.fn().mockResolvedValue({ results: [], truncated: false });
+    getActivityStatus = getActivityStatusMock;
+  }
+  return { ...actual, SentinelOneClient: MockSentinelOneClient };
+});
+
+const { processPollActions } = await import('./s1Sync');
+
+describe('processPollActions conn-hold phase-split (#1105/#1896)', () => {
+  beforeEach(() => {
+    contextDepth = 0;
+    selectContexts.length = 0;
+    updateContexts.length = 0;
+    httpContexts.length = 0;
+    selectRowsQueue = [
+      // 1) pending actions
+      [{
+        id: 'action-1',
+        orgId: 'org-1',
+        deviceId: 'device-1',
+        action: 'isolate',
+        payload: {},
+        providerActionId: 'provider-1',
+      }],
+      // 2) organizations → partner resolution
+      [{ id: 'org-1', partnerId: 'partner-1' }],
+      // 3) active integration for the partner
+      [{ partnerId: 'partner-1', managementUrl: 'https://example.sentinelone.net', apiTokenEncrypted: 'enc' }],
+    ];
+    getActivityStatusMock.mockReset();
+    getActivityStatusMock.mockImplementation(() => {
+      // Record the context depth observed at the moment the HTTP call fires.
+      httpContexts.push(inContext());
+      return Promise.resolve({ status: 'completed', details: null });
+    });
+  });
+
+  it('runs the SentinelOne getActivityStatus HTTP call OUTSIDE any held DB context', async () => {
+    const result = await processPollActions();
+
+    expect(result).toEqual({ polled: 1, updated: 1 });
+    // The HTTP poll ran exactly once, and NOT inside a held transaction.
+    expect(httpContexts).toEqual([false]);
+  });
+
+  it('still performs the status write INSIDE a short DB context', async () => {
+    await processPollActions();
+
+    // The s1_actions status update ran, and every such write was wrapped in a context.
+    expect(updateContexts.length).toBeGreaterThan(0);
+    expect(updateContexts.every((v) => v === true)).toBe(true);
+  });
+
+  it('reads the action/org/integration rows INSIDE a DB context', async () => {
+    await processPollActions();
+
+    expect(selectContexts.length).toBe(3);
+    expect(selectContexts.every((v) => v === true)).toBe(true);
+  });
+});

--- a/apps/api/src/jobs/s1Sync_sites.test.ts
+++ b/apps/api/src/jobs/s1Sync_sites.test.ts
@@ -80,7 +80,9 @@ const mockDb = {
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
+  // #1896: the sync functions now open a short system context per DB touch, so
+  // the mock must provide a passthrough (run fn against the mocked db immediately).
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>): Promise<T> => fn(),
   runOutsideDbContext: <T>(fn: () => T): T => fn(),
 }));
 

--- a/apps/api/src/jobs/s1Sync_syncError.test.ts
+++ b/apps/api/src/jobs/s1Sync_syncError.test.ts
@@ -37,7 +37,9 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
+  // #1896: the sync functions now open a short system context per DB touch, so
+  // the mock must provide a passthrough (run fn against the mocked db immediately).
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>): Promise<T> => fn(),
   runOutsideDbContext: <T>(fn: () => T): T => fn(),
   assertOutsideHeldDbContext: vi.fn(),
 }));


### PR DESCRIPTION
## Summary

Follow-up to #1894. Closes #1896. Two more workers still ran slow non-DB work inside a single held `runWithSystemDbAccess` transaction — the #1105 anti-pattern that pins a pooled connection idle-in-transaction. These produce the residual ~5s `held a pooled connection in an open transaction` warnings seen on prod after 0.83.3; they are shorter than the patch/deploy 30-min polls #1894 fixed, but the same bug and the same fix.

## What changed

**`apps/api/src/jobs/s1Sync.ts`** — the entire job was wrapped in one context (`createS1SyncWorker`, ~L1126), so every SentinelOne HTTP call ran inside an open transaction:
- `processSyncIntegration` → `syncAgentsForIntegration` / `syncThreatsForIntegration` held the txn across `client.listAgents` / `client.listThreats`.
- `processPollActions` looped over up to 200 actions calling `client.getActivityStatus()` (HTTP) **per action** inside one transaction.

The job is no longer wrapped. Each process function now opens a **short** system context per DB touch and runs the SentinelOne HTTP calls + `publishEvent` (pure Redis pub/sub) **outside** any context. This matches the `pollForPatchCommandResult` / `pollDeploymentCommandResult` reference pattern from #1894.

**`apps/api/src/jobs/patchSchedulerWorker.ts`** — `scanAndCreateJobs` (~L583) ran its nested policy→assignment→device loops (incl. per-device `checkDeviceMaintenanceWindow`) inside one held context. There is no HTTP here, but the cumulative nested-loop queries held a single transaction across the whole sweep. Each DB touch now opens its own short context, so no single transaction spans the scan. The Redis enqueue (`enqueueScanResults`) already ran outside the context and is unchanged.

## Behavior / atomicity note

Splitting the single transaction into per-touch short contexts means sync upserts now commit independently rather than as one atomic unit. This is safe and intended for these idempotent `onConflictDoUpdate` sync jobs (and matches #1894's accepted tradeoff): partial progress is re-converged on the next run, and read-after-write across functions (threats reading just-upserted agents) now sees committed rows rather than relying on same-txn visibility.

## Tests

- **New** `s1Sync_connHold.test.ts` — regression guard: instruments the DB-context depth and asserts `getActivityStatus` (HTTP) runs with **no** held context (`depth === 0`) while the action reads/writes run **inside** a short context. Re-wrapping the loop in one context (the pre-fix shape) fails this test.
- Updated the two s1Sync mocks that pinned `withSystemDbAccessContext: undefined` (harmless before — the directly-tested functions used bare `db`; now they open short contexts) to a passthrough, mirroring `patchSchedulerWorker.test.ts`.
- `apps/api` affected suite green: `vitest run s1Sync*.test.ts patchSchedulerWorker.test.ts` → 47 passed. `tsc --noEmit` clean.

## Verification (prod, post-deploy)

Watch `breeze-api` logs for `held a pooled connection in an open transaction (scope=...)` — should drop to near-zero. `pg_stat_activity` should show no `breeze_app` txn with `xact_start` older than a few seconds under normal load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)