### PR TITLE
fix(api): phase-split s1Sync + patchScheduler conn-holds (#1896)

### DIFF
--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -331,11 +331,12 @@ async function scanAndCreateJobs(): Promise<{
 }> {
   const now = new Date();
   let created = 0;
-  // Job ids to enqueue to Redis AFTER the system DB access-context transaction
-  // closes. Enqueuing inside it held the pooled connection idle-in-transaction
-  // across BullMQ/Redis round-trips — a contributor to the #1105 pool-poisoning
-  // pattern (txn around slow non-DB work). DB writes stay in the context; the
-  // Redis enqueue happens outside it (see the worker processor).
+  // Job ids to enqueue to Redis AFTER scanAndCreateJobs returns — by then every
+  // short DB context opened below has already committed and closed. Enqueuing
+  // mid-scan held the pooled connection idle-in-transaction across BullMQ/Redis
+  // round-trips, a contributor to the #1105 pool-poisoning pattern (txn around
+  // slow non-DB work). DB writes happen in short contexts; the Redis enqueue
+  // happens outside any context (see the worker processor).
   const enqueueJobIds: string[] = [];
 
   const patchPoliciesWithSchedules = await runWithSystemDbAccess(() =>
@@ -364,8 +365,9 @@ async function scanAndCreateJobs(): Promise<{
       // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
       // The guard is a defensive backstop; it never skips real work.
       if (row.policyOrgId === null) continue;
-      // Capture the narrowed (non-null) value: the `!== null` narrowing above
-      // does not propagate into the nested runWithSystemDbAccess closures below.
+      // Capture the narrowed value: the `=== null` early-continue above narrows
+      // row.policyOrgId to non-null, but that narrowing does not propagate into
+      // the nested runWithSystemDbAccess closure where it's consumed below.
       const policyOrgId = row.policyOrgId;
 
       const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -338,22 +338,24 @@ async function scanAndCreateJobs(): Promise<{
   // Redis enqueue happens outside it (see the worker processor).
   const enqueueJobIds: string[] = [];
 
-  const patchPoliciesWithSchedules = await db
-    .select({
-      configPolicyId: configurationPolicies.id,
-      policyName: configurationPolicies.name,
-      policyOrgId: configurationPolicies.orgId,
-      featureLinkId: configPolicyFeatureLinks.id,
-    })
-    .from(configPolicyFeatureLinks)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active')
+  const patchPoliciesWithSchedules = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        configPolicyId: configurationPolicies.id,
+        policyName: configurationPolicies.name,
+        policyOrgId: configurationPolicies.orgId,
+        featureLinkId: configPolicyFeatureLinks.id,
+      })
+      .from(configPolicyFeatureLinks)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active')
+        )
       )
-    )
-    .where(eq(configPolicyFeatureLinks.featureType, 'patch'));
+      .where(eq(configPolicyFeatureLinks.featureType, 'patch'))
+  );
 
   for (const row of patchPoliciesWithSchedules) {
     try {
@@ -362,8 +364,11 @@ async function scanAndCreateJobs(): Promise<{
       // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
       // The guard is a defensive backstop; it never skips real work.
       if (row.policyOrgId === null) continue;
+      // Capture the narrowed (non-null) value: the `!== null` narrowing above
+      // does not propagate into the nested runWithSystemDbAccess closures below.
+      const policyOrgId = row.policyOrgId;
 
-      const policyLocal = await loadPolicyLocalPatchConfig(row.configPolicyId);
+      const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));
       if (!policyLocal) continue;
 
       if (!policyLocal.ring.valid) {
@@ -373,25 +378,31 @@ async function scanAndCreateJobs(): Promise<{
         continue;
       }
 
-      const assignments = await db
-        .select({
-          level: configPolicyAssignments.level,
-          targetId: configPolicyAssignments.targetId,
-        })
-        .from(configPolicyAssignments)
-        .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId));
+      const assignments = await runWithSystemDbAccess(() =>
+        db
+          .select({
+            level: configPolicyAssignments.level,
+            targetId: configPolicyAssignments.targetId,
+          })
+          .from(configPolicyAssignments)
+          .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId))
+      );
 
       if (assignments.length === 0) continue;
 
       const allDeviceIds = new Set<string>();
       for (const assignment of assignments) {
-        const ids = await resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, row.policyOrgId);
+        const ids = await runWithSystemDbAccess(() =>
+          resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, policyOrgId)
+        );
         for (const id of ids) allDeviceIds.add(id);
       }
 
       if (allDeviceIds.size === 0) continue;
 
-      const schedulingContexts = await loadDeviceSchedulingContexts(Array.from(allDeviceIds));
+      const schedulingContexts = await runWithSystemDbAccess(() =>
+        loadDeviceSchedulingContexts(Array.from(allDeviceIds))
+      );
       const groupedContexts = new Map<string, { orgId: string; timezone: string; deviceIds: string[] }>();
 
       for (const context of schedulingContexts) {
@@ -418,13 +429,19 @@ async function scanAndCreateJobs(): Promise<{
       }
 
       for (const group of dueGroups) {
-        if (await hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now)) {
+        const occurrenceExists = await runWithSystemDbAccess(() =>
+          hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now)
+        );
+        if (occurrenceExists) {
           continue;
         }
 
+        // Each per-device maintenance check is its own short context (#1896): the
+        // group can hold many devices, and running them all inside one held
+        // transaction was the residual ~5s conn-hold this issue targets.
         const eligibleDeviceIds: string[] = [];
         for (const deviceId of group.deviceIds) {
-          const maintenance = await checkDeviceMaintenanceWindow(deviceId);
+          const maintenance = await runWithSystemDbAccess(() => checkDeviceMaintenanceWindow(deviceId));
           if (!maintenance.active || !maintenance.suppressPatching) {
             eligibleDeviceIds.push(deviceId);
           }
@@ -434,28 +451,30 @@ async function scanAndCreateJobs(): Promise<{
           continue;
         }
 
-        const [job] = await db
-          .insert(patchJobs)
-          .values({
-            orgId: group.orgId,
-            configPolicyId: row.configPolicyId,
-            ringId: policyLocal.ring.ringId,
-            name: `Scheduled Patch Job - ${row.policyName}`,
-            patches: buildPatchesSnapshot(policyLocal),
-            targets: {
-              deviceIds: eligibleDeviceIds,
+        const [job] = await runWithSystemDbAccess(() =>
+          db
+            .insert(patchJobs)
+            .values({
+              orgId: group.orgId,
               configPolicyId: row.configPolicyId,
-              configPolicyName: row.policyName,
-              deployment: policyLocal.settings,
-              resolvedTimezone: group.timezone,
-              scheduleOccurrenceKey: group.occurrenceKey,
-            },
-            status: 'scheduled',
-            scheduledAt: now,
-            devicesTotal: eligibleDeviceIds.length,
-            devicesPending: eligibleDeviceIds.length,
-          })
-          .returning();
+              ringId: policyLocal.ring.ringId,
+              name: `Scheduled Patch Job - ${row.policyName}`,
+              patches: buildPatchesSnapshot(policyLocal),
+              targets: {
+                deviceIds: eligibleDeviceIds,
+                configPolicyId: row.configPolicyId,
+                configPolicyName: row.policyName,
+                deployment: policyLocal.settings,
+                resolvedTimezone: group.timezone,
+                scheduleOccurrenceKey: group.occurrenceKey,
+              },
+              status: 'scheduled',
+              scheduledAt: now,
+              devicesTotal: eligibleDeviceIds.length,
+              devicesPending: eligibleDeviceIds.length,
+            })
+            .returning()
+        );
 
         if (job) {
           enqueueJobIds.push(job.id);
@@ -475,13 +494,14 @@ async function scanAndCreateJobs(): Promise<{
 
   // Orphan-recovery read (#1733): collect `scheduled` patch_jobs rows whose
   // intended run time has passed (plus grace) so the worker can re-enqueue any
-  // whose Redis job was lost in the create->enqueue gap. This is a DB-only read;
-  // the queue-state check + re-enqueue happen outside this DB access context
-  // (see the worker). A failure here silently disables the backstop, so surface
-  // it to Sentry, not just the console (#1379 worker-observability convention).
+  // whose Redis job was lost in the create->enqueue gap. This is a DB-only read
+  // in its own short context (#1896); the queue-state check + re-enqueue happen
+  // outside any DB access context (see the worker). A failure here silently
+  // disables the backstop, so surface it to Sentry, not just the console
+  // (#1379 worker-observability convention).
   let staleScheduledJobs: StaleScheduledJob[] = [];
   try {
-    staleScheduledJobs = await selectStaleScheduledJobIds(now);
+    staleScheduledJobs = await runWithSystemDbAccess(() => selectStaleScheduledJobIds(now));
   } catch (err) {
     const message = '[PatchScheduler] Failed to read stale scheduled jobs for reconcile';
     console.error(`${message}:`, err instanceof Error ? err.message : err);
@@ -580,20 +600,24 @@ function createSchedulerWorker(): Worker {
   return new Worker(
     QUEUE_NAME,
     async (_job: Job) => {
-      const result = await runWithSystemDbAccess(async () => {
-        try {
-          return await scanAndCreateJobs();
-        } catch (error: unknown) {
-          if (isRelationNotFoundError(error)) {
-            if (!_configPolicyTableWarningLogged) {
-              _configPolicyTableWarningLogged = true;
-              console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
-            }
-            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+      // #1896: scanAndCreateJobs no longer runs inside one big system context.
+      // It opens a SHORT context per DB touch (per-policy reads, per-device
+      // maintenance checks, per-job insert) so the scan never pins a pooled
+      // connection idle-in-transaction across the nested loops (#1105).
+      let result: Awaited<ReturnType<typeof scanAndCreateJobs>>;
+      try {
+        result = await scanAndCreateJobs();
+      } catch (error: unknown) {
+        if (isRelationNotFoundError(error)) {
+          if (!_configPolicyTableWarningLogged) {
+            _configPolicyTableWarningLogged = true;
+            console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
           }
+          result = { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+        } else {
           throw error;
         }
-      });
+      }
 
       const { recovered } = await enqueueScanResults(result);
 

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -27,10 +27,12 @@ import {
 const { db } = dbModule;
 // Opens a SHORT system DB access context for one read/write group (#1896,
 // mirrors #1894). The worker no longer wraps a whole job in one context — each
-// DB touch gets its own short context so SentinelOne HTTP calls and per-action
-// loops run OUTSIDE any open transaction and never pin a pooled connection
-// idle-in-transaction (#1105). Falls back to `fn()` when the context helper is
-// unavailable (unit tests mock `../db` with `withSystemDbAccessContext: undefined`).
+// processor opens short contexts around its DB touches (a few related touches
+// may share one) so SentinelOne HTTP calls and per-action loops run OUTSIDE any
+// open transaction and never pin a pooled connection idle-in-transaction
+// (#1105). The load-bearing invariant: HTTP/Redis work is never inside a
+// context. Falls back to `fn()` when the context helper is unavailable (unit
+// tests mock `../db` with `withSystemDbAccessContext: undefined`).
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
   return typeof withSystem === 'function' ? withSystem(fn) : fn();

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -25,11 +25,15 @@ import {
 } from '../services/sentinelOne/metrics';
 
 const { db } = dbModule;
+// Opens a SHORT system DB access context for one read/write group (#1896,
+// mirrors #1894). The worker no longer wraps a whole job in one context — each
+// DB touch gets its own short context so SentinelOne HTTP calls and per-action
+// loops run OUTSIDE any open transaction and never pin a pooled connection
+// idle-in-transaction (#1105). Falls back to `fn()` when the context helper is
+// unavailable (unit tests mock `../db` with `withSystemDbAccessContext: undefined`).
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
-  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
-    throw new Error('[S1SyncJob] withSystemDbAccessContext is unavailable');
-  }
-  return dbModule.withSystemDbAccessContext(fn);
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
 };
 
 const S1_SYNC_QUEUE = 's1-sync';
@@ -520,100 +524,108 @@ async function syncAgentsForIntegration(
     count: info.count,
   }));
 
-  // Step 1: Reconcile provisional mappings BEFORE upsert so carried org_id survives.
-  // Skip sites with no siteName — a null siteName can never match a provisional row
-  // (which is keyed as 'name:<siteName>'), so attempting reconciliation would silently
-  // miss and build a 'name:<siteId>' key that matches nothing.
-  await reconcileProvisionalSiteMappings(
-    integration.id,
-    discoveredSites
-      .filter((s): s is { siteId: string; siteName: string; count: number } => typeof s.siteName === 'string' && s.siteName.length > 0)
-      .map((s) => ({ siteId: s.siteId, siteName: s.siteName }))
-  );
+  // All writes/reads below run in ONE short system context (#1896): the
+  // SentinelOne fetch above already ran OUTSIDE any context, so no transaction
+  // spans the HTTP call. This is pure DB work (reconcile, upsert, lookups, batch
+  // upserts), which is fine to group inside a single short-lived transaction.
+  const { upserted, skipped } = await runWithSystemDbAccess(async () => {
+    // Step 1: Reconcile provisional mappings BEFORE upsert so carried org_id survives.
+    // Skip sites with no siteName — a null siteName can never match a provisional row
+    // (which is keyed as 'name:<siteName>'), so attempting reconciliation would silently
+    // miss and build a 'name:<siteId>' key that matches nothing.
+    await reconcileProvisionalSiteMappings(
+      integration.id,
+      discoveredSites
+        .filter((s): s is { siteId: string; siteName: string; count: number } => typeof s.siteName === 'string' && s.siteName.length > 0)
+        .map((s) => ({ siteId: s.siteId, siteName: s.siteName }))
+    );
 
-  // Step 2: Upsert discovered sites (sets agents_count, last_seen_at; preserves org_id).
-  await upsertDiscoveredSites({
-    integrationId: integration.id,
-    partnerId: integration.partnerId,
-    sites: discoveredSites,
-  });
+    // Step 2: Upsert discovered sites (sets agents_count, last_seen_at; preserves org_id).
+    await upsertDiscoveredSites({
+      integrationId: integration.id,
+      partnerId: integration.partnerId,
+      sites: discoveredSites,
+    });
 
-  // Step 3: Load the org mapping keyed by s1_site_id (only rows with mapped org_id).
-  const siteOrgIds = await mapSiteOrgIds(integration.id);
-  const candidatesByOrg = await mapDeviceCandidatesByOrg([...siteOrgIds.values()]);
+    // Step 3: Load the org mapping keyed by s1_site_id (only rows with mapped org_id).
+    const siteOrgIds = await mapSiteOrgIds(integration.id);
+    const candidatesByOrg = await mapDeviceCandidatesByOrg([...siteOrgIds.values()]);
 
-  let upserted = 0;
-  let skipped = 0;
-  for (let i = 0; i < fetchedAgents.length; i += 300) {
-    const batch = fetchedAgents.slice(i, i + 300);
+    let upserted = 0;
+    let skipped = 0;
+    for (let i = 0; i < fetchedAgents.length; i += 300) {
+      const batch = fetchedAgents.slice(i, i + 300);
 
-    const values: Array<{
-      orgId: string;
-      integrationId: string;
-      s1AgentId: string;
-      deviceId: string | null;
-      status: string;
-      infected: boolean;
-      threatCount: number;
-      policyName: string | null;
-      lastSeenAt: Date | null;
-      metadata: Record<string, unknown>;
-      updatedAt: Date;
-    }> = [];
+      const values: Array<{
+        orgId: string;
+        integrationId: string;
+        s1AgentId: string;
+        deviceId: string | null;
+        status: string;
+        infected: boolean;
+        threatCount: number;
+        policyName: string | null;
+        lastSeenAt: Date | null;
+        metadata: Record<string, unknown>;
+        updatedAt: Date;
+      }> = [];
 
-    for (const agent of batch) {
-      // Resolve the agent to an org via its stable siteId (no fallback default org).
-      const target = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
-      if (!target) {
-        skipped += 1;
-        continue;
+      for (const agent of batch) {
+        // Resolve the agent to an org via its stable siteId (no fallback default org).
+        const target = resolveAgentSyncTargetById(agent, siteOrgIds, candidatesByOrg);
+        if (!target) {
+          skipped += 1;
+          continue;
+        }
+        const threatCount = Number(agent.activeThreats ?? 0);
+        values.push({
+          orgId: target.orgId,
+          integrationId: integration.id,
+          s1AgentId: agent.id,
+          deviceId: target.deviceId,
+          status: agent.isActive === false ? 'offline' : 'online',
+          infected: agent.infected === true,
+          threatCount: Number.isFinite(threatCount) ? Math.max(0, Math.round(threatCount)) : 0,
+          policyName: agent.policyName ?? null,
+          lastSeenAt: toDateOrNull(agent.lastSeen),
+          metadata: {
+            uuid: agent.uuid ?? null,
+            computerName: agent.computerName ?? null,
+            osName: agent.osName ?? null,
+            siteName: agent.siteName ?? null,
+            siteId: agent.siteId ?? null,
+          },
+          updatedAt: new Date()
+        });
       }
-      const threatCount = Number(agent.activeThreats ?? 0);
-      values.push({
-        orgId: target.orgId,
-        integrationId: integration.id,
-        s1AgentId: agent.id,
-        deviceId: target.deviceId,
-        status: agent.isActive === false ? 'offline' : 'online',
-        infected: agent.infected === true,
-        threatCount: Number.isFinite(threatCount) ? Math.max(0, Math.round(threatCount)) : 0,
-        policyName: agent.policyName ?? null,
-        lastSeenAt: toDateOrNull(agent.lastSeen),
-        metadata: {
-          uuid: agent.uuid ?? null,
-          computerName: agent.computerName ?? null,
-          osName: agent.osName ?? null,
-          siteName: agent.siteName ?? null,
-          siteId: agent.siteId ?? null,
-        },
-        updatedAt: new Date()
-      });
+
+      if (values.length === 0) continue;
+
+      const inserted = await db
+        .insert(s1Agents)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [s1Agents.integrationId, s1Agents.s1AgentId],
+          set: {
+            orgId: sql`excluded.org_id`,
+            integrationId: sql`excluded.integration_id`,
+            deviceId: sql`excluded.device_id`,
+            status: sql`excluded.status`,
+            infected: sql`excluded.infected`,
+            threatCount: sql`excluded.threat_count`,
+            policyName: sql`excluded.policy_name`,
+            lastSeenAt: sql`excluded.last_seen_at`,
+            metadata: sql`excluded.metadata`,
+            updatedAt: sql`excluded.updated_at`
+          }
+        })
+        .returning({ id: s1Agents.id });
+
+      upserted += inserted.length;
     }
 
-    if (values.length === 0) continue;
-
-    const inserted = await db
-      .insert(s1Agents)
-      .values(values)
-      .onConflictDoUpdate({
-        target: [s1Agents.integrationId, s1Agents.s1AgentId],
-        set: {
-          orgId: sql`excluded.org_id`,
-          integrationId: sql`excluded.integration_id`,
-          deviceId: sql`excluded.device_id`,
-          status: sql`excluded.status`,
-          infected: sql`excluded.infected`,
-          threatCount: sql`excluded.threat_count`,
-          policyName: sql`excluded.policy_name`,
-          lastSeenAt: sql`excluded.last_seen_at`,
-          metadata: sql`excluded.metadata`,
-          updatedAt: sql`excluded.updated_at`
-        }
-      })
-      .returning({ id: s1Agents.id });
-
-    upserted += inserted.length;
-  }
+    return { upserted, skipped };
+  });
 
   return {
     fetched: fetchedAgents.length,
@@ -630,120 +642,130 @@ async function syncThreatsForIntegration(
   const threatResult = await client.listThreats(integration.lastSyncAt ?? undefined);
   const fetchedThreats = threatResult.results;
 
-  // Load agent contexts from already-synced s1_agents rows.
-  // If an agent was skipped during agent sync (unmapped site), it won't appear here
-  // and its threats will be skipped too — consistent with the partner-wide model.
-  const agentRows = await db
-    .select({
-      s1AgentId: s1Agents.s1AgentId,
-      orgId: s1Agents.orgId,
-      deviceId: s1Agents.deviceId
-    })
-    .from(s1Agents)
-    .where(eq(s1Agents.integrationId, integration.id));
-
-  const agentContextByAgentId = new Map<string, AgentContext>();
-  for (const row of agentRows) {
-    agentContextByAgentId.set(row.s1AgentId, { orgId: row.orgId, deviceId: row.deviceId });
-  }
-
-  const emitSince = integration.lastSyncAt ?? new Date(Date.now() - (24 * 60 * 60 * 1000));
+  // Populated inside the DB context below, consumed by the publishEvent loop
+  // (which runs OUTSIDE any context — Redis work must not hold a transaction).
   const threatsToEmit: Array<{ s1ThreatId: string; orgId: string; severity: string; deviceId: string | null; detectedAt: Date | null }> = [];
 
-  let upserted = 0;
-  let skipped = 0;
-  for (let i = 0; i < fetchedThreats.length; i += 300) {
-    const batch = fetchedThreats.slice(i, i + 300);
-    const values: Array<{
-      orgId: string;
-      integrationId: string;
-      deviceId: string | null;
-      s1ThreatId: string;
-      classification: string | null;
-      severity: string;
-      threatName: string | null;
-      processName: string | null;
-      filePath: string | null;
-      mitreTactics: unknown;
-      status: string;
-      detectedAt: Date | null;
-      resolvedAt: Date | null;
-      details: unknown;
-      updatedAt: Date;
-    }> = [];
+  // One short system context (#1896): the listThreats HTTP fetch above ran
+  // OUTSIDE any context, so no transaction spans it. Group the agent-context
+  // read + threat batch upserts into a single short-lived transaction.
+  const { upserted, skipped } = await runWithSystemDbAccess(async () => {
+    // Load agent contexts from already-synced s1_agents rows.
+    // If an agent was skipped during agent sync (unmapped site), it won't appear here
+    // and its threats will be skipped too — consistent with the partner-wide model.
+    const agentRows = await db
+      .select({
+        s1AgentId: s1Agents.s1AgentId,
+        orgId: s1Agents.orgId,
+        deviceId: s1Agents.deviceId
+      })
+      .from(s1Agents)
+      .where(eq(s1Agents.integrationId, integration.id));
 
-    for (const threat of batch) {
-      const detectedAt = toDateOrNull(threat.detectedAt);
-      const resolvedAt = toDateOrNull(threat.resolvedAt);
-      const status = normalizeThreatStatus(threat.mitigationStatus);
-      const severity = normalizeSeverity(threat.threatSeverity);
+    const agentContextByAgentId = new Map<string, AgentContext>();
+    for (const row of agentRows) {
+      agentContextByAgentId.set(row.s1AgentId, { orgId: row.orgId, deviceId: row.deviceId });
+    }
 
-      // Resolve the threat's org via its parent agent's already-written context.
-      // If the agent has no context (was skipped because its site is unmapped),
-      // skip this threat too — there is no fallback "default org" in the partner-wide model.
-      const agentContext = agentContextByAgentId.get(threat.agentId ?? '');
-      if (!agentContext) {
-        skipped += 1;
-        continue;
-      }
+    const emitSince = integration.lastSyncAt ?? new Date(Date.now() - (24 * 60 * 60 * 1000));
 
-      if (status === 'active' && detectedAt && detectedAt >= emitSince) {
-        threatsToEmit.push({
-          s1ThreatId: threat.id,
+    let upserted = 0;
+    let skipped = 0;
+    for (let i = 0; i < fetchedThreats.length; i += 300) {
+      const batch = fetchedThreats.slice(i, i + 300);
+      const values: Array<{
+        orgId: string;
+        integrationId: string;
+        deviceId: string | null;
+        s1ThreatId: string;
+        classification: string | null;
+        severity: string;
+        threatName: string | null;
+        processName: string | null;
+        filePath: string | null;
+        mitreTactics: unknown;
+        status: string;
+        detectedAt: Date | null;
+        resolvedAt: Date | null;
+        details: unknown;
+        updatedAt: Date;
+      }> = [];
+
+      for (const threat of batch) {
+        const detectedAt = toDateOrNull(threat.detectedAt);
+        const resolvedAt = toDateOrNull(threat.resolvedAt);
+        const status = normalizeThreatStatus(threat.mitigationStatus);
+        const severity = normalizeSeverity(threat.threatSeverity);
+
+        // Resolve the threat's org via its parent agent's already-written context.
+        // If the agent has no context (was skipped because its site is unmapped),
+        // skip this threat too — there is no fallback "default org" in the partner-wide model.
+        const agentContext = agentContextByAgentId.get(threat.agentId ?? '');
+        if (!agentContext) {
+          skipped += 1;
+          continue;
+        }
+
+        if (status === 'active' && detectedAt && detectedAt >= emitSince) {
+          threatsToEmit.push({
+            s1ThreatId: threat.id,
+            orgId: agentContext.orgId,
+            severity,
+            deviceId: agentContext.deviceId,
+            detectedAt
+          });
+        }
+
+        values.push({
           orgId: agentContext.orgId,
-          severity,
+          integrationId: integration.id,
           deviceId: agentContext.deviceId,
-          detectedAt
+          s1ThreatId: threat.id,
+          classification: threat.classification ?? null,
+          severity,
+          threatName: threat.threatName ?? null,
+          processName: threat.processName ?? null,
+          filePath: threat.filePath ?? null,
+          mitreTactics: threat.mitreTechniques ?? null,
+          status,
+          detectedAt,
+          resolvedAt,
+          details: threat,
+          updatedAt: new Date()
         });
       }
 
-      values.push({
-        orgId: agentContext.orgId,
-        integrationId: integration.id,
-        deviceId: agentContext.deviceId,
-        s1ThreatId: threat.id,
-        classification: threat.classification ?? null,
-        severity,
-        threatName: threat.threatName ?? null,
-        processName: threat.processName ?? null,
-        filePath: threat.filePath ?? null,
-        mitreTactics: threat.mitreTechniques ?? null,
-        status,
-        detectedAt,
-        resolvedAt,
-        details: threat,
-        updatedAt: new Date()
-      });
+      if (values.length === 0) continue;
+
+      const inserted = await db
+        .insert(s1Threats)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [s1Threats.integrationId, s1Threats.s1ThreatId],
+          set: {
+            orgId: sql`excluded.org_id`,
+            integrationId: sql`excluded.integration_id`,
+            deviceId: sql`excluded.device_id`,
+            classification: sql`excluded.classification`,
+            severity: sql`excluded.severity`,
+            threatName: sql`excluded.threat_name`,
+            processName: sql`excluded.process_name`,
+            filePath: sql`excluded.file_path`,
+            mitreTactics: sql`excluded.mitre_tactics`,
+            status: sql`excluded.status`,
+            detectedAt: sql`excluded.detected_at`,
+            resolvedAt: sql`excluded.resolved_at`,
+            details: sql`excluded.details`,
+            updatedAt: sql`excluded.updated_at`
+          }
+        })
+        .returning({ id: s1Threats.id });
+
+      upserted += inserted.length;
     }
 
-    if (values.length === 0) continue;
-
-    const inserted = await db
-      .insert(s1Threats)
-      .values(values)
-      .onConflictDoUpdate({
-        target: [s1Threats.integrationId, s1Threats.s1ThreatId],
-        set: {
-          orgId: sql`excluded.org_id`,
-          integrationId: sql`excluded.integration_id`,
-          deviceId: sql`excluded.device_id`,
-          classification: sql`excluded.classification`,
-          severity: sql`excluded.severity`,
-          threatName: sql`excluded.threat_name`,
-          processName: sql`excluded.process_name`,
-          filePath: sql`excluded.file_path`,
-          mitreTactics: sql`excluded.mitre_tactics`,
-          status: sql`excluded.status`,
-          detectedAt: sql`excluded.detected_at`,
-          resolvedAt: sql`excluded.resolved_at`,
-          details: sql`excluded.details`,
-          updatedAt: sql`excluded.updated_at`
-        }
-      })
-      .returning({ id: s1Threats.id });
-
-    upserted += inserted.length;
-  }
+    return { upserted, skipped };
+  });
 
   let emitted = 0;
   let emitFailures = 0;
@@ -787,18 +809,20 @@ async function syncThreatsForIntegration(
 // back to `redactLogMessage(error.responseBody)` would otherwise pass every
 // existing helper-level test.
 export async function processSyncIntegration(data: SyncIntegrationJobData) {
-  const [integration] = await db
-    .select({
-      id: s1Integrations.id,
-      partnerId: s1Integrations.partnerId,
-      managementUrl: s1Integrations.managementUrl,
-      apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
-      isActive: s1Integrations.isActive,
-      lastSyncAt: s1Integrations.lastSyncAt
-    })
-    .from(s1Integrations)
-    .where(eq(s1Integrations.id, data.integrationId))
-    .limit(1);
+  const [integration] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: s1Integrations.id,
+        partnerId: s1Integrations.partnerId,
+        managementUrl: s1Integrations.managementUrl,
+        apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
+        isActive: s1Integrations.isActive,
+        lastSyncAt: s1Integrations.lastSyncAt
+      })
+      .from(s1Integrations)
+      .where(eq(s1Integrations.id, data.integrationId))
+      .limit(1)
+  );
 
   if (!integration || !integration.isActive) {
     console.warn(`[S1SyncJob] Integration ${data.integrationId} not found or inactive; skipping sync`);
@@ -824,6 +848,8 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
   });
 
   try {
+    // syncAgents/syncThreats make SentinelOne HTTP calls — run them OUTSIDE any
+    // DB access context (#1896); each opens its own short context for its writes.
     const agentResult = data.syncAgents
       ? await syncAgentsForIntegration(integration, client)
       : { fetched: 0, upserted: 0, truncated: false };
@@ -832,15 +858,17 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
       : { fetched: 0, upserted: 0, emitted: 0, emitFailures: 0, truncated: false };
 
     const wasTruncated = agentResult.truncated || threatResult.truncated;
-    await db
-      .update(s1Integrations)
-      .set({
-        lastSyncAt: new Date(),
-        lastSyncStatus: wasTruncated ? 'partial' : 'success',
-        lastSyncError: wasTruncated ? 'Results were truncated due to pagination limits' : null,
-        updatedAt: new Date()
-      })
-      .where(eq(s1Integrations.id, integration.id));
+    await runWithSystemDbAccess(() =>
+      db
+        .update(s1Integrations)
+        .set({
+          lastSyncAt: new Date(),
+          lastSyncStatus: wasTruncated ? 'partial' : 'success',
+          lastSyncError: wasTruncated ? 'Results were truncated due to pagination limits' : null,
+          updatedAt: new Date()
+        })
+        .where(eq(s1Integrations.id, integration.id))
+    );
 
     return {
       integrationId: integration.id,
@@ -857,14 +885,16 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
     // via truncateError — a SentinelOneHttpError's `.message` carries no body.
     logSyncFailureServerSide({ integrationId: integration.id, partnerId: integration.partnerId }, error);
     try {
-      await db
-        .update(s1Integrations)
-        .set({
-          lastSyncStatus: 'error',
-          lastSyncError: truncateError(error),
-          updatedAt: new Date()
-        })
-        .where(eq(s1Integrations.id, integration.id));
+      await runWithSystemDbAccess(() =>
+        db
+          .update(s1Integrations)
+          .set({
+            lastSyncStatus: 'error',
+            lastSyncError: truncateError(error),
+            updatedAt: new Date()
+          })
+          .where(eq(s1Integrations.id, integration.id))
+      );
     } catch (dbError) {
       console.error('[S1SyncJob] Failed to persist sync error status:', dbError);
       captureException(dbError);
@@ -875,7 +905,9 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
 
 async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
   const queue = getS1SyncQueue();
-  const integrations = await listActiveIntegrations();
+  // Read in a short context (#1896); the BullMQ enqueues below are Redis work
+  // and run OUTSIDE any DB transaction.
+  const integrations = await runWithSystemDbAccess(() => listActiveIntegrations());
 
   await Promise.all(
     integrations.map((integration) => addUniqueJob(
@@ -896,23 +928,28 @@ async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
 }
 
 export async function processPollActions() {
-  const pendingActions = await db
-    .select({
-      id: s1Actions.id,
-      orgId: s1Actions.orgId,
-      deviceId: s1Actions.deviceId,
-      action: s1Actions.action,
-      payload: s1Actions.payload,
-      providerActionId: s1Actions.providerActionId
-    })
-    .from(s1Actions)
-    .where(
-      and(
-        inArray(s1Actions.status, ['queued', 'in_progress']),
-        isNotNull(s1Actions.providerActionId)
+  // Read pending actions in a short context (#1896). The per-action
+  // getActivityStatus HTTP calls + writes happen later, each OUTSIDE / in its
+  // own short context, so no transaction spans the up-to-200-action poll loop.
+  const pendingActions = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: s1Actions.id,
+        orgId: s1Actions.orgId,
+        deviceId: s1Actions.deviceId,
+        action: s1Actions.action,
+        payload: s1Actions.payload,
+        providerActionId: s1Actions.providerActionId
+      })
+      .from(s1Actions)
+      .where(
+        and(
+          inArray(s1Actions.status, ['queued', 'in_progress']),
+          isNotNull(s1Actions.providerActionId)
+        )
       )
-    )
-    .limit(200);
+      .limit(200)
+  );
 
   if (pendingActions.length === 0) {
     return { polled: 0, updated: 0 };
@@ -925,32 +962,37 @@ export async function processPollActions() {
   // legacyOrgId is NULL (they would never be found by a legacyOrgId lookup).
   const orgIds = Array.from(new Set(pendingActions.map((row) => row.orgId)));
 
-  // Step 1: Resolve org_id → partner_id
-  const orgRows = await db
-    .select({
-      id: organizations.id,
-      partnerId: organizations.partnerId,
-    })
-    .from(organizations)
-    .where(inArray(organizations.id, orgIds));
+  // Steps 1-2 (one short context): resolve org_id → partner_id, then fetch the
+  // active integration per distinct partner. Pure DB reads — grouping them in a
+  // single short transaction is fine; the slow HTTP work is the per-action loop.
+  const { partnerIdByOrg, partnerIntegrations } = await runWithSystemDbAccess(async () => {
+    const orgRows = await db
+      .select({
+        id: organizations.id,
+        partnerId: organizations.partnerId,
+      })
+      .from(organizations)
+      .where(inArray(organizations.id, orgIds));
 
-  const partnerIdByOrg = new Map<string, string>();
-  for (const row of orgRows) {
-    partnerIdByOrg.set(row.id, row.partnerId);
-  }
+    const partnerIdByOrg = new Map<string, string>();
+    for (const row of orgRows) {
+      partnerIdByOrg.set(row.id, row.partnerId);
+    }
 
-  // Step 2: Fetch the active integration for each distinct partner (deduplicated)
-  const distinctPartnerIds = Array.from(new Set([...partnerIdByOrg.values()]));
-  const partnerIntegrations = distinctPartnerIds.length > 0
-    ? await db
-        .select({
-          partnerId: s1Integrations.partnerId,
-          managementUrl: s1Integrations.managementUrl,
-          apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
-        })
-        .from(s1Integrations)
-        .where(and(inArray(s1Integrations.partnerId, distinctPartnerIds), eq(s1Integrations.isActive, true)))
-    : [];
+    const distinctPartnerIds = Array.from(new Set([...partnerIdByOrg.values()]));
+    const partnerIntegrations = distinctPartnerIds.length > 0
+      ? await db
+          .select({
+            partnerId: s1Integrations.partnerId,
+            managementUrl: s1Integrations.managementUrl,
+            apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
+          })
+          .from(s1Integrations)
+          .where(and(inArray(s1Integrations.partnerId, distinctPartnerIds), eq(s1Integrations.isActive, true)))
+      : [];
+
+    return { partnerIdByOrg, partnerIntegrations };
+  });
 
   // Step 3: Build a reusable client per partner to avoid redundant decrypt + instantiation
   const clientByPartner = new Map<string, SentinelOneClient | null>();
@@ -998,14 +1040,16 @@ export async function processPollActions() {
 
     if (client === undefined) {
       // No integration found for this org
-      await db
-        .update(s1Actions)
-        .set({
-          status: 'failed',
-          error: 'Action status polling failed: no active SentinelOne integration is available for this organization',
-          completedAt: new Date()
-        })
-        .where(eq(s1Actions.id, action.id));
+      await runWithSystemDbAccess(() =>
+        db
+          .update(s1Actions)
+          .set({
+            status: 'failed',
+            error: 'Action status polling failed: no active SentinelOne integration is available for this organization',
+            completedAt: new Date()
+          })
+          .where(eq(s1Actions.id, action.id))
+      );
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
@@ -1013,14 +1057,16 @@ export async function processPollActions() {
 
     if (!client) {
       // Client construction failed (bad token)
-      await db
-        .update(s1Actions)
-        .set({
-          status: 'failed',
-          error: `Action status polling failed: ${clientError ?? 'unknown client error'}`,
-          completedAt: new Date()
-        })
-        .where(eq(s1Actions.id, action.id));
+      await runWithSystemDbAccess(() =>
+        db
+          .update(s1Actions)
+          .set({
+            status: 'failed',
+            error: `Action status polling failed: ${clientError ?? 'unknown client error'}`,
+            completedAt: new Date()
+          })
+          .where(eq(s1Actions.id, action.id))
+      );
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
@@ -1035,15 +1081,17 @@ export async function processPollActions() {
       nextPayload.lastPollAt = new Date().toISOString();
 
       try {
-        await db
-          .update(s1Actions)
-          .set({
-            status: nextStatus,
-            completedAt: isDone ? new Date() : null,
-            error: nextStatus === 'failed' ? truncateError(activity.details) : null,
-            payload: nextPayload
-          })
-          .where(eq(s1Actions.id, action.id));
+        await runWithSystemDbAccess(() =>
+          db
+            .update(s1Actions)
+            .set({
+              status: nextStatus,
+              completedAt: isDone ? new Date() : null,
+              error: nextStatus === 'failed' ? truncateError(activity.details) : null,
+              payload: nextPayload
+            })
+            .where(eq(s1Actions.id, action.id))
+        );
       } catch (dbError) {
         console.error(`[S1SyncJob] Failed to persist poll result for action ${action.id}:`, dbError);
         captureException(dbError);
@@ -1096,17 +1144,19 @@ export async function processPollActions() {
       const failure = applyPollFailure(action.payload, error);
       const nextStatus: S1ActionStatus = failure.shouldFail ? 'failed' : 'in_progress';
 
-      await db
-        .update(s1Actions)
-        .set({
-          status: nextStatus,
-          payload: failure.payload,
-          error: failure.shouldFail
-            ? `Action status polling failed ${failure.failureCount} times: ${failure.error}`
-            : null,
-          completedAt: failure.shouldFail ? new Date() : null
-        })
-        .where(eq(s1Actions.id, action.id));
+      await runWithSystemDbAccess(() =>
+        db
+          .update(s1Actions)
+          .set({
+            status: nextStatus,
+            payload: failure.payload,
+            error: failure.shouldFail
+              ? `Action status polling failed ${failure.failureCount} times: ${failure.error}`
+              : null,
+            completedAt: failure.shouldFail ? new Date() : null
+          })
+          .where(eq(s1Actions.id, action.id))
+      );
 
       recordS1ActionPollTransition(nextStatus);
       updated += 1;
@@ -1123,56 +1173,59 @@ function createS1SyncWorker(): Worker<S1SyncJobData> {
   return new Worker<S1SyncJobData>(
     S1_SYNC_QUEUE,
     async (job: Job<S1SyncJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        const start = Date.now();
-        const syncType = job.data.type;
-        switch (job.data.type) {
-          case 'sync-integration': {
-            try {
-              const result = await processSyncIntegration(job.data);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-agents': {
-            try {
-              const result = await processSyncAll(true, false);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-threats': {
-            try {
-              const result = await processSyncAll(false, true);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'poll-actions': {
-            try {
-              const result = await processPollActions();
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          default: {
+      // #1896: do NOT wrap the whole job in one withSystemDbAccessContext. The
+      // processors below make SentinelOne HTTP calls and loop over up to 200
+      // actions; holding a single transaction across that work pinned a pooled
+      // connection idle-in-transaction (#1105). Each processor opens its own
+      // short context around its DB touches, with HTTP/Redis run outside.
+      const start = Date.now();
+      const syncType = job.data.type;
+      switch (job.data.type) {
+        case 'sync-integration': {
+          try {
+            const result = await processSyncIntegration(job.data);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
             recordS1SyncRun(syncType, 'failure', Date.now() - start);
-            throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+            throw error;
           }
         }
-      });
+        case 'sync-all-agents': {
+          try {
+            const result = await processSyncAll(true, false);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'sync-all-threats': {
+          try {
+            const result = await processSyncAll(false, true);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'poll-actions': {
+          try {
+            const result = await processPollActions();
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        default: {
+          recordS1SyncRun(syncType, 'failure', Date.now() - start);
+          throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+        }
+      }
     },
     {
       connection: getBullMQConnection(),


### PR DESCRIPTION
## What

Follow-up to #1894. Two background workers still ran their **whole job inside a single `withSystemDbAccessContext`**, pinning a pooled Postgres connection in an open transaction across slow non-DB work — the residual #1105 conn-hold (the ~5s `held a pooled connection in an open transaction` warnings still seen after the 0.83.3 deploy). This phase-splits both so a transaction never spans HTTP / Redis / per-item loops.

## s1Sync.ts

The worker no longer wraps the job in one context. Each processor opens **short** contexts around its DB touches while SentinelOne HTTP calls (`listAgents` / `listThreats` / `getActivityStatus`) and Redis publishes run **outside** any transaction:

- **`processSyncIntegration`** — integration read + status writes each in a short ctx; `syncAgents`/`syncThreats` called outside any ctx.
- **`syncAgentsForIntegration` / `syncThreatsForIntegration`** — HTTP fetch outside; the reconcile/upsert/lookup/batch-upsert DB tail grouped in one short ctx; the threat `publishEvent` loop outside.
- **`processPollActions`** — reads in a short ctx; the up-to-200-action loop does each `getActivityStatus` HTTP call outside, each per-action write in its own short ctx.
- **`processSyncAll`** — integrations read in a short ctx; BullMQ enqueues outside.

The local `runWithSystemDbAccess` helper now **falls back to `fn()`** when the context helper is absent (matching `patchJobExecutor`), so the unit tests that mock `../db` with `withSystemDbAccessContext: undefined` keep exercising the real paths.

## patchSchedulerWorker.ts

`scanAndCreateJobs` no longer runs in one big context. Each DB touch — per-policy reads, per-assignment device resolution, the per-device `checkDeviceMaintenanceWindow` loop the issue specifically flags, the patch-job insert, and the orphan-recovery read — is its **own short context**, so the nested scan loops never hold one connection idle-in-transaction.

Business logic is unchanged — **only transaction boundaries moved** (mirrors #1894). Worker `concurrency` is 1 (scheduler) / 4 (s1Sync); partial-progress on a mid-scan crash is already handled by the #1733 orphan-recovery backstop.

## Testing

- `vitest run` (single-fork) — affected suites green: `s1Sync.test.ts`, `s1Sync_sites.test.ts`, `s1Sync_syncError.test.ts`, `patchSchedulerWorker.test.ts`, plus dependent `sentinelOne.test.ts` / `aiToolsSentinelOne.siteScope.test.ts` / `sentinelOne/actions.test.ts` / `actions_dispatchError.test.ts` — **103 passed**.
- `npx tsc --noEmit` — clean.

Verification of the conn-hold elimination itself is post-deploy (prod `breeze-api` logs / `pg_stat_activity`), per the issue's detection notes.

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)