### PR TITLE
fix(api): phase-split s1Sync + patchScheduler conn-holds (#1896)

### DIFF
--- a/apps/api/src/jobs/patchSchedulerWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.dbcontext.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// #1896 — patchSchedulerWorker.scanAndCreateJobs must NOT run the whole scan
+// (policies → assignments → devices → maintenance checks → insert) inside ONE
+// held system DB context. That single open transaction pinned a pooled
+// connection for the entire multi-policy/device scan (#1105 conn-hold pattern).
+// The fix gives each DB touch its OWN short context. We track context depth and
+// assert: every DB op (and the per-device checkDeviceMaintenanceWindow) runs at
+// depth 1, depth never nests beyond 1, and many separate contexts are opened —
+// i.e. no single context spans the scan.
+// ---------------------------------------------------------------------------
+
+let contextDepth = 0;
+const dbCallDepths: number[] = [];
+const maintenanceDepths: number[] = [];
+let contextOpenCount = 0;
+let maxDepth = 0;
+let selectResults: unknown[][] = [];
+
+function chain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'from', 'where', 'limit', 'values', 'returning',
+    'set', 'onConflictDoNothing', 'onConflictDoUpdate', 'innerJoin', 'leftJoin',
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return c;
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(selectResults.shift() ?? []);
+    }),
+    insert: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain([{ id: 'job-1' }]);
+    }),
+    update: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+    delete: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    contextOpenCount += 1;
+    contextDepth += 1;
+    maxDepth = Math.max(maxDepth, contextDepth);
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  }),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  configurationPolicies: { id: 'cp.id', name: 'cp.name', orgId: 'cp.orgId', status: 'cp.status' },
+  configPolicyFeatureLinks: { id: 'fl.id', configPolicyId: 'fl.cpId', featureType: 'fl.type' },
+  configPolicyAssignments: { configPolicyId: 'a.cpId', level: 'a.level', targetId: 'a.targetId' },
+  patchJobs: { id: 'pj.id', configPolicyId: 'pj.cpId', orgId: 'pj.orgId', createdAt: 'pj.createdAt' },
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  deviceGroupMemberships: { deviceId: 'dgm.deviceId', groupId: 'dgm.groupId', orgId: 'dgm.orgId' },
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId', settings: 'organizations.settings' },
+  partners: { id: 'partners.id', timezone: 'partners.timezone', settings: 'partners.settings' },
+  sites: { id: 'sites.id', timezone: 'sites.timezone' },
+}));
+
+const checkDeviceMaintenanceWindow = vi.fn(async () => {
+  maintenanceDepths.push(contextDepth);
+  return { active: false, suppressAlerts: false, suppressPatching: false, suppressAutomations: false, suppressScripts: false };
+});
+vi.mock('../services/featureConfigResolver', () => ({ checkDeviceMaintenanceWindow }));
+
+const loadPolicyLocalPatchConfig = vi.fn(async () => ({
+  ring: { valid: true, ringId: 'ring-1', classification: 'ok' },
+  settings: { scheduleFrequency: 'daily', scheduleTime: '02:00' },
+}));
+vi.mock('../services/configPolicyPatching', () => ({
+  backfillMissingPatchSettings: vi.fn(),
+  listAllPatchInventory: vi.fn(),
+  loadPolicyLocalPatchConfig,
+  summarizePatchInventory: vi.fn(),
+}));
+
+const selectStaleScheduledJobIds = vi.fn(async () => {
+  dbCallDepths.push(contextDepth);
+  return [];
+});
+vi.mock('./patchJobExecutor', () => ({
+  enqueuePatchJob: vi.fn(),
+  selectStaleScheduledJobIds,
+  filterOrphanedJobIds: vi.fn(async () => []),
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/patchJobSnapshot', () => ({ buildPatchesSnapshot: vi.fn(() => ({})) }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
+
+const { __testOnly } = await import('./patchSchedulerWorker');
+
+const { scanAndCreateJobs } = __testOnly;
+
+describe('patchSchedulerWorker.scanAndCreateJobs — DB context boundaries (#1896)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // 02:00 UTC so a daily/02:00 schedule for a UTC device is due now.
+    vi.setSystemTime(new Date('2026-06-25T02:00:00.000Z'));
+    contextDepth = 0;
+    contextOpenCount = 0;
+    maxDepth = 0;
+    dbCallDepths.length = 0;
+    maintenanceDepths.length = 0;
+    selectResults = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs each DB op (incl. per-device maintenance check) in its own short context — no single context spans the scan', async () => {
+    selectResults = [
+      // 1. patchPoliciesWithSchedules
+      [{ configPolicyId: 'cp-1', policyName: 'Daily Patch', policyOrgId: 'org-1', featureLinkId: 'fl-1' }],
+      // 2. assignments
+      [{ level: 'device', targetId: 'dev-1' }],
+      // 3. resolveDeviceIdsForAssignment (device case)
+      [{ id: 'dev-1' }],
+      // 4. loadDeviceSchedulingContexts (join) — UTC device so 02:00 schedule is due
+      [{ deviceId: 'dev-1', orgId: 'org-1', siteTimezone: 'UTC', orgSettings: null, partnerTimezone: null, partnerSettings: null }],
+      // 5. hasExistingOccurrenceJob — none exists yet
+      [],
+    ];
+
+    const result = await scanAndCreateJobs();
+
+    // The due path completed end-to-end (proves we exercised maintenance + insert).
+    expect(result.created).toBe(1);
+    expect(checkDeviceMaintenanceWindow).toHaveBeenCalledWith('dev-1');
+
+    // Every DB read/write ran inside a context...
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) expect(depth).toBe(1);
+    // ...including the per-device maintenance lookup.
+    expect(maintenanceDepths).toEqual([1]);
+    // No nesting: depth never exceeded 1 (i.e. no big outer wrapper around the scan).
+    expect(maxDepth).toBe(1);
+    // Many SEPARATE short contexts were opened — not one spanning the whole scan.
+    expect(contextOpenCount).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -338,7 +338,8 @@ async function scanAndCreateJobs(): Promise<{
   // Redis enqueue happens outside it (see the worker processor).
   const enqueueJobIds: string[] = [];
 
-  const patchPoliciesWithSchedules = await db
+  const patchPoliciesWithSchedules = await runWithSystemDbAccess(() =>
+    db
     .select({
       configPolicyId: configurationPolicies.id,
       policyName: configurationPolicies.name,
@@ -353,7 +354,8 @@ async function scanAndCreateJobs(): Promise<{
         eq(configurationPolicies.status, 'active')
       )
     )
-    .where(eq(configPolicyFeatureLinks.featureType, 'patch'));
+    .where(eq(configPolicyFeatureLinks.featureType, 'patch'))
+  );
 
   for (const row of patchPoliciesWithSchedules) {
     try {
@@ -362,8 +364,11 @@ async function scanAndCreateJobs(): Promise<{
       // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
       // The guard is a defensive backstop; it never skips real work.
       if (row.policyOrgId === null) continue;
+      // Bind the non-null org id locally: the post-guard narrowing of
+      // `row.policyOrgId` does not survive into the closures below.
+      const policyOrgId = row.policyOrgId;
 
-      const policyLocal = await loadPolicyLocalPatchConfig(row.configPolicyId);
+      const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));
       if (!policyLocal) continue;
 
       if (!policyLocal.ring.valid) {
@@ -373,25 +378,31 @@ async function scanAndCreateJobs(): Promise<{
         continue;
       }
 
-      const assignments = await db
+      const assignments = await runWithSystemDbAccess(() =>
+        db
         .select({
           level: configPolicyAssignments.level,
           targetId: configPolicyAssignments.targetId,
         })
         .from(configPolicyAssignments)
-        .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId));
+        .where(eq(configPolicyAssignments.configPolicyId, row.configPolicyId))
+      );
 
       if (assignments.length === 0) continue;
 
       const allDeviceIds = new Set<string>();
       for (const assignment of assignments) {
-        const ids = await resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, row.policyOrgId);
+        const ids = await runWithSystemDbAccess(() =>
+          resolveDeviceIdsForAssignment(assignment.level, assignment.targetId, policyOrgId)
+        );
         for (const id of ids) allDeviceIds.add(id);
       }
 
       if (allDeviceIds.size === 0) continue;
 
-      const schedulingContexts = await loadDeviceSchedulingContexts(Array.from(allDeviceIds));
+      const schedulingContexts = await runWithSystemDbAccess(() =>
+        loadDeviceSchedulingContexts(Array.from(allDeviceIds))
+      );
       const groupedContexts = new Map<string, { orgId: string; timezone: string; deviceIds: string[] }>();
 
       for (const context of schedulingContexts) {
@@ -418,13 +429,19 @@ async function scanAndCreateJobs(): Promise<{
       }
 
       for (const group of dueGroups) {
-        if (await hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now)) {
+        const occurrenceExists = await runWithSystemDbAccess(() =>
+          hasExistingOccurrenceJob(row.configPolicyId, group.orgId, group.timezone, group.occurrenceKey, now)
+        );
+        if (occurrenceExists) {
           continue;
         }
 
+        // Per-device maintenance check: each lookup is its OWN short context so
+        // this loop never holds one pooled connection across the whole device
+        // set (#1105/#1896 conn-hold). checkDeviceMaintenanceWindow is DB-backed.
         const eligibleDeviceIds: string[] = [];
         for (const deviceId of group.deviceIds) {
-          const maintenance = await checkDeviceMaintenanceWindow(deviceId);
+          const maintenance = await runWithSystemDbAccess(() => checkDeviceMaintenanceWindow(deviceId));
           if (!maintenance.active || !maintenance.suppressPatching) {
             eligibleDeviceIds.push(deviceId);
           }
@@ -434,7 +451,8 @@ async function scanAndCreateJobs(): Promise<{
           continue;
         }
 
-        const [job] = await db
+        const [job] = await runWithSystemDbAccess(() =>
+          db
           .insert(patchJobs)
           .values({
             orgId: group.orgId,
@@ -455,7 +473,8 @@ async function scanAndCreateJobs(): Promise<{
             devicesTotal: eligibleDeviceIds.length,
             devicesPending: eligibleDeviceIds.length,
           })
-          .returning();
+          .returning()
+        );
 
         if (job) {
           enqueueJobIds.push(job.id);
@@ -481,7 +500,7 @@ async function scanAndCreateJobs(): Promise<{
   // it to Sentry, not just the console (#1379 worker-observability convention).
   let staleScheduledJobs: StaleScheduledJob[] = [];
   try {
-    staleScheduledJobs = await selectStaleScheduledJobIds(now);
+    staleScheduledJobs = await runWithSystemDbAccess(() => selectStaleScheduledJobIds(now));
   } catch (err) {
     const message = '[PatchScheduler] Failed to read stale scheduled jobs for reconcile';
     console.error(`${message}:`, err instanceof Error ? err.message : err);
@@ -580,20 +599,23 @@ function createSchedulerWorker(): Worker {
   return new Worker(
     QUEUE_NAME,
     async (_job: Job) => {
-      const result = await runWithSystemDbAccess(async () => {
-        try {
-          return await scanAndCreateJobs();
-        } catch (error: unknown) {
-          if (isRelationNotFoundError(error)) {
-            if (!_configPolicyTableWarningLogged) {
-              _configPolicyTableWarningLogged = true;
-              console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
-            }
-            return { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+      // scanAndCreateJobs manages its OWN short system contexts per DB op so no
+      // single transaction spans the full multi-policy/device scan (#1105/#1896
+      // conn-hold). The relation-not-found guard now wraps the call itself.
+      let result: Awaited<ReturnType<typeof scanAndCreateJobs>>;
+      try {
+        result = await scanAndCreateJobs();
+      } catch (error: unknown) {
+        if (isRelationNotFoundError(error)) {
+          if (!_configPolicyTableWarningLogged) {
+            _configPolicyTableWarningLogged = true;
+            console.warn('[PatchScheduler] Config policy tables not found — run "pnpm db:migrate" to create them. Skipping patch schedule scan.');
           }
+          result = { created: 0, scanned: 0, enqueueJobIds: [], staleScheduledJobs: [] };
+        } else {
           throw error;
         }
-      });
+      }
 
       const { recovered } = await enqueueScanResults(result);
 
@@ -674,4 +696,5 @@ export async function shutdownPatchSchedulerWorker(): Promise<void> {
 export const __testOnly = {
   loadDeviceSchedulingContexts,
   enqueueScanResults,
+  scanAndCreateJobs,
 };

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -331,11 +331,12 @@ async function scanAndCreateJobs(): Promise<{
 }> {
   const now = new Date();
   let created = 0;
-  // Job ids to enqueue to Redis AFTER the system DB access-context transaction
-  // closes. Enqueuing inside it held the pooled connection idle-in-transaction
-  // across BullMQ/Redis round-trips — a contributor to the #1105 pool-poisoning
-  // pattern (txn around slow non-DB work). DB writes stay in the context; the
-  // Redis enqueue happens outside it (see the worker processor).
+  // Job ids to enqueue to Redis AFTER the scan completes. Each DB op below runs
+  // in its OWN short system context (#1896) so no single transaction spans the
+  // scan; the BullMQ/Redis enqueue then happens entirely outside any context
+  // (see enqueueScanResults in the worker processor) — enqueuing inside a held
+  // context pinned the pooled connection idle-in-transaction across Redis
+  // round-trips, a contributor to the #1105 pool-poisoning pattern.
   const enqueueJobIds: string[] = [];
 
   const patchPoliciesWithSchedules = await runWithSystemDbAccess(() =>

--- a/apps/api/src/jobs/s1Sync.dbcontext.test.ts
+++ b/apps/api/src/jobs/s1Sync.dbcontext.test.ts
@@ -10,6 +10,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 let contextDepth = 0;
+// Peak nesting observed across the run. The conn-hold regression this guards
+// against is an OUTER context wrapping the whole job while the inner
+// runOutsideDbContext calls remain — that nets depth 2 on the inner DB ops.
+// `runOutsideDbContext` only swaps the `db` handle (ALS exit); it does NOT
+// release an outer transaction, so a depth-0 HTTP assertion alone can pass
+// vacuously. Asserting maxDepth === 1 is what actually catches the re-wrap.
+let maxDepth = 0;
 const httpDepths: number[] = [];
 const publishDepths: number[] = [];
 const dbCallDepths: number[] = [];
@@ -54,6 +61,7 @@ vi.mock('../db', () => ({
   },
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
     contextDepth += 1;
+    maxDepth = Math.max(maxDepth, contextDepth);
     try {
       return await fn();
     } finally {
@@ -81,7 +89,7 @@ const listAgentsMock = vi.fn(async () => {
 });
 const listThreatsMock = vi.fn(async () => {
   httpDepths.push(contextDepth);
-  return { results: [], truncated: false };
+  return { results: [] as unknown[], truncated: false };
 });
 const getActivityStatusMock = vi.fn(async () => {
   httpDepths.push(contextDepth);
@@ -118,6 +126,7 @@ describe('s1Sync — DB context boundaries (#1896)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     contextDepth = 0;
+    maxDepth = 0;
     httpDepths.length = 0;
     publishDepths.length = 0;
     dbCallDepths.length = 0;
@@ -154,6 +163,9 @@ describe('s1Sync — DB context boundaries (#1896)', () => {
     for (const depth of dbCallDepths) {
       expect(depth).toBeGreaterThan(0);
     }
+    // No outer wrapper around the whole job: depth never nested (catches a
+    // regression that re-wraps processSyncIntegration in one context).
+    expect(maxDepth).toBe(1);
     // The final status write committed inside a (short) context.
     const statusWrite = updatePayloads.find((u) => u.payload.lastSyncStatus !== undefined);
     expect(statusWrite).toBeDefined();
@@ -182,6 +194,67 @@ describe('s1Sync — DB context boundaries (#1896)', () => {
     const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
     expect(errorWrite).toBeDefined();
     expect(errorWrite!.depth).toBeGreaterThan(0);
+    // The error write's runOutsideDbContext(runWithSystemDbAccess(...)) nets a
+    // single fresh context — never a nested one.
+    expect(maxDepth).toBe(1);
+  });
+
+  it('processSyncIntegration: emits threat-detected events OUTSIDE the DB context, upserts inside it', async () => {
+    selectResults = [
+      // 1. integration read
+      [{
+        id: 'int-1',
+        partnerId: 'partner-1',
+        managementUrl: 'https://s1.example.com',
+        apiTokenEncrypted: 'enc',
+        isActive: true,
+        lastSyncAt: null,
+      }],
+      // 2. agentRows (s1_agents) — provides the org/device context for the threat
+      [{ s1AgentId: 'agent-1', orgId: 'org-1', deviceId: 'device-1' }],
+    ];
+    // One active, recently-detected threat for agent-1 → a detection is emitted.
+    // Use mockImplementationOnce (not mockResolvedValueOnce) so the depth-recording
+    // body still runs for this call.
+    listThreatsMock.mockImplementationOnce(async () => {
+      httpDepths.push(contextDepth);
+      return {
+        results: [{
+          id: 'threat-1',
+          agentId: 'agent-1',
+          mitigationStatus: 'active',
+          threatSeverity: 'high',
+          detectedAt: new Date().toISOString(),
+          resolvedAt: null,
+          threatName: 'EICAR',
+          processName: null,
+          filePath: null,
+          classification: 'Malware',
+          mitreTechniques: null,
+        }] as unknown[],
+        truncated: false,
+      };
+    });
+
+    const result = await processSyncIntegration({
+      type: 'sync-integration',
+      integrationId: 'int-1',
+      syncAgents: false,
+      syncThreats: true,
+    });
+
+    expect(listThreatsMock).toHaveBeenCalledTimes(1);
+    expect(httpDepths).toEqual([0]);             // listThreats ran with no txn held
+    // The threat upsert ran inside a context...
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+    // ...and the event-bus publish ran OUTSIDE it (a regression that emits
+    // inside the Phase-2 context would hold a connection over the Redis call).
+    expect(publishDepths).toEqual([0]);
+    expect(maxDepth).toBe(1);
+    expect(result.fetchedThreats).toBe(1);
   });
 
   it('processPollActions: polls the provider with no DB context held, writes status inside one', async () => {
@@ -211,6 +284,7 @@ describe('s1Sync — DB context boundaries (#1896)', () => {
     }
     // The completed-action event published OUTSIDE any held transaction.
     expect(publishDepths).toEqual([0]);
+    expect(maxDepth).toBe(1);
     expect(result.polled).toBe(1);
     expect(result.updated).toBe(1);
   });

--- a/apps/api/src/jobs/s1Sync.dbcontext.test.ts
+++ b/apps/api/src/jobs/s1Sync.dbcontext.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// #1896 — the SentinelOne sync worker must NOT hold a pooled DB connection in an
+// open transaction across its external HTTP calls (agent/threat fetch, per-action
+// status poll) or its event-bus publishes. Same depth-tracking model as the
+// DNS/Huntress sync tests: withSystemDbAccessContext increments depth,
+// runOutsideDbContext zeroes it; assert the S1 HTTP + Redis publishes run at
+// depth 0 while DB reads/writes run at depth > 0.
+// ---------------------------------------------------------------------------
+
+let contextDepth = 0;
+const httpDepths: number[] = [];
+const publishDepths: number[] = [];
+const dbCallDepths: number[] = [];
+let selectResults: unknown[][] = [];
+const updatePayloads: Array<{ depth: number; payload: Record<string, unknown> }> = [];
+
+function chain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'from', 'where', 'limit', 'values', 'returning',
+    'onConflictDoNothing', 'onConflictDoUpdate', 'innerJoin', 'leftJoin',
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.set = vi.fn((payload: Record<string, unknown>) => {
+    updatePayloads.push({ depth: contextDepth, payload });
+    return c;
+  });
+  (c as { then: unknown }).then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return c;
+}
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(selectResults.shift() ?? []);
+    }),
+    insert: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain([{ id: 'row-1' }]);
+    }),
+    update: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+    delete: vi.fn(() => {
+      dbCallDepths.push(contextDepth);
+      return chain(undefined);
+    }),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    contextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      contextDepth -= 1;
+    }
+  }),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => {
+    const saved = contextDepth;
+    contextDepth = 0;
+    try {
+      return fn();
+    } finally {
+      contextDepth = saved;
+    }
+  }),
+}));
+
+vi.mock('../services/secretCrypto', () => ({
+  decryptForColumn: (_t: string, _c: string, value: unknown) => value ?? 'decrypted',
+}));
+
+const listAgentsMock = vi.fn(async () => {
+  httpDepths.push(contextDepth);
+  return { results: [], truncated: false };
+});
+const listThreatsMock = vi.fn(async () => {
+  httpDepths.push(contextDepth);
+  return { results: [], truncated: false };
+});
+const getActivityStatusMock = vi.fn(async () => {
+  httpDepths.push(contextDepth);
+  return { status: 'completed', details: null };
+});
+
+vi.mock('../services/sentinelOne/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/sentinelOne/client')>();
+  class MockSentinelOneClient {
+    listAgents = listAgentsMock;
+    listThreats = listThreatsMock;
+    getActivityStatus = getActivityStatusMock;
+  }
+  return { ...actual, SentinelOneClient: MockSentinelOneClient };
+});
+
+vi.mock('../services/sentinelOne/metrics', () => ({
+  recordS1ActionDispatch: vi.fn(),
+  recordS1ActionPollTransition: vi.fn(),
+  recordS1SyncRun: vi.fn(),
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/eventBus', () => ({
+  publishEvent: vi.fn(async () => {
+    publishDepths.push(contextDepth);
+  }),
+}));
+
+const { processSyncIntegration, processPollActions } = await import('./s1Sync');
+
+describe('s1Sync — DB context boundaries (#1896)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextDepth = 0;
+    httpDepths.length = 0;
+    publishDepths.length = 0;
+    dbCallDepths.length = 0;
+    selectResults = [];
+    updatePayloads.length = 0;
+  });
+
+  it('processSyncIntegration: fetches agents + threats with no DB context held, persists inside one', async () => {
+    // Phase 1 integration read.
+    selectResults = [
+      [{
+        id: 'int-1',
+        partnerId: 'partner-1',
+        managementUrl: 'https://s1.example.com',
+        apiTokenEncrypted: 'enc',
+        isActive: true,
+        lastSyncAt: null,
+      }],
+    ];
+
+    const result = await processSyncIntegration({
+      type: 'sync-integration',
+      integrationId: 'int-1',
+      syncAgents: true,
+      syncThreats: true,
+    });
+
+    expect(listAgentsMock).toHaveBeenCalledTimes(1);
+    expect(listThreatsMock).toHaveBeenCalledTimes(1);
+    // Both provider fetches ran with NO transaction held.
+    expect(httpDepths).toEqual([0, 0]);
+    // Every DB read/write ran inside a context.
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);
+    }
+    // The final status write committed inside a (short) context.
+    const statusWrite = updatePayloads.find((u) => u.payload.lastSyncStatus !== undefined);
+    expect(statusWrite).toBeDefined();
+    expect(statusWrite!.depth).toBeGreaterThan(0);
+    expect(result.integrationId).toBe('int-1');
+  });
+
+  it('processSyncIntegration: on fetch failure records error status on a fresh context and re-throws the ORIGINAL error', async () => {
+    selectResults = [
+      [{
+        id: 'int-1',
+        partnerId: 'partner-1',
+        managementUrl: 'https://s1.example.com',
+        apiTokenEncrypted: 'enc',
+        isActive: true,
+        lastSyncAt: null,
+      }],
+    ];
+    const boom = new Error('s1 agents fetch exploded');
+    listAgentsMock.mockRejectedValueOnce(boom);
+
+    await expect(
+      processSyncIntegration({ type: 'sync-integration', integrationId: 'int-1', syncAgents: true, syncThreats: false }),
+    ).rejects.toBe(boom);
+
+    const errorWrite = updatePayloads.find((u) => u.payload.lastSyncStatus === 'error');
+    expect(errorWrite).toBeDefined();
+    expect(errorWrite!.depth).toBeGreaterThan(0);
+  });
+
+  it('processPollActions: polls the provider with no DB context held, writes status inside one', async () => {
+    selectResults = [
+      // 1. pending actions
+      [{
+        id: 'action-1',
+        orgId: 'org-1',
+        deviceId: 'device-1',
+        action: 'quarantine',
+        payload: {},
+        providerActionId: 'provider-act-1',
+      }],
+      // 2. organizations → partner
+      [{ id: 'org-1', partnerId: 'partner-A' }],
+      // 3. s1_integrations for partner-A
+      [{ partnerId: 'partner-A', managementUrl: 'https://s1.example.com', apiTokenEncrypted: 'enc' }],
+    ];
+
+    const result = await processPollActions();
+
+    expect(getActivityStatusMock).toHaveBeenCalledTimes(1);
+    expect(httpDepths).toEqual([0]);             // provider poll ran with no txn held
+    expect(dbCallDepths.length).toBeGreaterThan(0);
+    for (const depth of dbCallDepths) {
+      expect(depth).toBeGreaterThan(0);          // reads + status write inside a context
+    }
+    // The completed-action event published OUTSIDE any held transaction.
+    expect(publishDepths).toEqual([0]);
+    expect(result.polled).toBe(1);
+    expect(result.updated).toBe(1);
+  });
+});

--- a/apps/api/src/jobs/s1Sync.ts
+++ b/apps/api/src/jobs/s1Sync.ts
@@ -500,9 +500,15 @@ async function syncAgentsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
 ): Promise<{ fetched: number; upserted: number; skipped: number; truncated: boolean }> {
-  const agentResult = await client.listAgents(integration.lastSyncAt ?? undefined);
+  // Phase 1 — fetch agents from SentinelOne with NO DB context held (#1896).
+  // The HTTP round-trip must not pin a pooled connection in an open transaction.
+  const agentResult = await dbModule.runOutsideDbContext(() =>
+    client.listAgents(integration.lastSyncAt ?? undefined)
+  );
   const fetchedAgents = agentResult.results;
 
+  // Phase 2 — all reconcile/mapping/upsert DB work runs in ONE short context.
+  return runWithSystemDbAccess(async () => {
   // Derive distinct sites from the fetched agent list (skip agents with no siteId).
   const siteCountMap = new Map<string, { siteName: string | null; count: number }>();
   for (const agent of fetchedAgents) {
@@ -615,21 +621,28 @@ async function syncAgentsForIntegration(
     upserted += inserted.length;
   }
 
-  return {
-    fetched: fetchedAgents.length,
-    upserted,
-    skipped,
-    truncated: agentResult.truncated
-  };
+    return {
+      fetched: fetchedAgents.length,
+      upserted,
+      skipped,
+      truncated: agentResult.truncated
+    };
+  });
 }
 
 async function syncThreatsForIntegration(
   integration: IntegrationForSync,
   client: SentinelOneClient
 ): Promise<{ fetched: number; upserted: number; skipped: number; emitted: number; emitFailures: number; truncated: boolean }> {
-  const threatResult = await client.listThreats(integration.lastSyncAt ?? undefined);
+  // Phase 1 — fetch threats from SentinelOne with NO DB context held (#1896).
+  const threatResult = await dbModule.runOutsideDbContext(() =>
+    client.listThreats(integration.lastSyncAt ?? undefined)
+  );
   const fetchedThreats = threatResult.results;
 
+  // Phase 2 — load contexts + upsert threats in ONE short context; collect the
+  // detections to emit so the event-bus publishes (Phase 3) run OUTSIDE it.
+  const { upserted, skipped, threatsToEmit } = await runWithSystemDbAccess(async () => {
   // Load agent contexts from already-synced s1_agents rows.
   // If an agent was skipped during agent sync (unmapped site), it won't appear here
   // and its threats will be skipped too — consistent with the partner-wide model.
@@ -745,6 +758,11 @@ async function syncThreatsForIntegration(
     upserted += inserted.length;
   }
 
+    return { upserted, skipped, threatsToEmit };
+  });
+
+  // Phase 3 — publish threat-detected events OUTSIDE any DB context (#1896): the
+  // event-bus (Redis) round-trips must not hold a pooled connection.
   let emitted = 0;
   let emitFailures = 0;
   for (const threat of dedupeThreatDetections(threatsToEmit)) {
@@ -787,18 +805,22 @@ async function syncThreatsForIntegration(
 // back to `redactLogMessage(error.responseBody)` would otherwise pass every
 // existing helper-level test.
 export async function processSyncIntegration(data: SyncIntegrationJobData) {
-  const [integration] = await db
-    .select({
-      id: s1Integrations.id,
-      partnerId: s1Integrations.partnerId,
-      managementUrl: s1Integrations.managementUrl,
-      apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
-      isActive: s1Integrations.isActive,
-      lastSyncAt: s1Integrations.lastSyncAt
-    })
-    .from(s1Integrations)
-    .where(eq(s1Integrations.id, data.integrationId))
-    .limit(1);
+  // Phase 1 — read the integration row in its own SHORT context so the provider
+  // fetches (inside syncAgents/syncThreats) hold no open transaction (#1896).
+  const [integration] = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: s1Integrations.id,
+        partnerId: s1Integrations.partnerId,
+        managementUrl: s1Integrations.managementUrl,
+        apiTokenEncrypted: s1Integrations.apiTokenEncrypted,
+        isActive: s1Integrations.isActive,
+        lastSyncAt: s1Integrations.lastSyncAt
+      })
+      .from(s1Integrations)
+      .where(eq(s1Integrations.id, data.integrationId))
+      .limit(1)
+  );
 
   if (!integration || !integration.isActive) {
     console.warn(`[S1SyncJob] Integration ${data.integrationId} not found or inactive; skipping sync`);
@@ -832,15 +854,18 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
       : { fetched: 0, upserted: 0, emitted: 0, emitFailures: 0, truncated: false };
 
     const wasTruncated = agentResult.truncated || threatResult.truncated;
-    await db
-      .update(s1Integrations)
-      .set({
-        lastSyncAt: new Date(),
-        lastSyncStatus: wasTruncated ? 'partial' : 'success',
-        lastSyncError: wasTruncated ? 'Results were truncated due to pagination limits' : null,
-        updatedAt: new Date()
-      })
-      .where(eq(s1Integrations.id, integration.id));
+    // Final status write in its own SHORT context (#1896).
+    await runWithSystemDbAccess(() =>
+      db
+        .update(s1Integrations)
+        .set({
+          lastSyncAt: new Date(),
+          lastSyncStatus: wasTruncated ? 'partial' : 'success',
+          lastSyncError: wasTruncated ? 'Results were truncated due to pagination limits' : null,
+          updatedAt: new Date()
+        })
+        .where(eq(s1Integrations.id, integration.id))
+    );
 
     return {
       integrationId: integration.id,
@@ -857,14 +882,20 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
     // via truncateError — a SentinelOneHttpError's `.message` carries no body.
     logSyncFailureServerSide({ integrationId: integration.id, partnerId: integration.partnerId }, error);
     try {
-      await db
-        .update(s1Integrations)
-        .set({
-          lastSyncStatus: 'error',
-          lastSyncError: truncateError(error),
-          updatedAt: new Date()
-        })
-        .where(eq(s1Integrations.id, integration.id));
+      // Record on a FRESH short context (escape any held/poisoned context first)
+      // so the error status survives and holds no connection over slow work (#1896).
+      await dbModule.runOutsideDbContext(() =>
+        runWithSystemDbAccess(() =>
+          db
+            .update(s1Integrations)
+            .set({
+              lastSyncStatus: 'error',
+              lastSyncError: truncateError(error),
+              updatedAt: new Date()
+            })
+            .where(eq(s1Integrations.id, integration.id))
+        )
+      );
     } catch (dbError) {
       console.error('[S1SyncJob] Failed to persist sync error status:', dbError);
       captureException(dbError);
@@ -875,7 +906,8 @@ export async function processSyncIntegration(data: SyncIntegrationJobData) {
 
 async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
   const queue = getS1SyncQueue();
-  const integrations = await listActiveIntegrations();
+  // Read in a SHORT context; the BullMQ/Redis enqueue below runs outside it (#1896).
+  const integrations = await runWithSystemDbAccess(() => listActiveIntegrations());
 
   await Promise.all(
     integrations.map((integration) => addUniqueJob(
@@ -896,6 +928,10 @@ async function processSyncAll(syncAgents: boolean, syncThreats: boolean) {
 }
 
 export async function processPollActions() {
+  // Phase 1 — read pending actions + resolve per-org SentinelOne clients in ONE
+  // SHORT context (#1896). The per-action provider polls (Phase 2) then run with
+  // no held transaction so a slow/unresponsive S1 API can't pin the connection.
+  const { pendingActions, clientByOrg, clientErrorByOrg } = await runWithSystemDbAccess(async () => {
   const pendingActions = await db
     .select({
       id: s1Actions.id,
@@ -915,7 +951,11 @@ export async function processPollActions() {
     .limit(200);
 
   if (pendingActions.length === 0) {
-    return { polled: 0, updated: 0 };
+    return {
+      pendingActions,
+      clientByOrg: new Map<string, SentinelOneClient | null>(),
+      clientErrorByOrg: new Map<string, string>(),
+    };
   }
 
   // Resolve each action's org → partner → active integration.
@@ -990,6 +1030,13 @@ export async function processPollActions() {
     // → will hit the "No integration found" branch below
   }
 
+    return { pendingActions, clientByOrg, clientErrorByOrg };
+  });
+
+  if (pendingActions.length === 0) {
+    return { polled: 0, updated: 0 };
+  }
+
   let updated = 0;
   for (const action of pendingActions) {
     if (!action.providerActionId) continue;
@@ -998,14 +1045,16 @@ export async function processPollActions() {
 
     if (client === undefined) {
       // No integration found for this org
-      await db
+      await runWithSystemDbAccess(() =>
+        db
         .update(s1Actions)
         .set({
           status: 'failed',
           error: 'Action status polling failed: no active SentinelOne integration is available for this organization',
           completedAt: new Date()
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id))
+      );
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
@@ -1013,21 +1062,27 @@ export async function processPollActions() {
 
     if (!client) {
       // Client construction failed (bad token)
-      await db
+      await runWithSystemDbAccess(() =>
+        db
         .update(s1Actions)
         .set({
           status: 'failed',
           error: `Action status polling failed: ${clientError ?? 'unknown client error'}`,
           completedAt: new Date()
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id))
+      );
       recordS1ActionPollTransition('failed');
       updated += 1;
       continue;
     }
 
     try {
-      const activity = await client.getActivityStatus(action.providerActionId);
+      // Provider status poll OUTSIDE any DB context (#1896): the S1 HTTP must not
+      // pin a pooled connection in an open transaction.
+      const activity = await dbModule.runOutsideDbContext(() =>
+        client.getActivityStatus(action.providerActionId!)
+      );
       const nextStatus = activity.status;
       const isDone = nextStatus === 'completed' || nextStatus === 'failed';
       const nextPayload = toObject(action.payload);
@@ -1035,7 +1090,8 @@ export async function processPollActions() {
       nextPayload.lastPollAt = new Date().toISOString();
 
       try {
-        await db
+        await runWithSystemDbAccess(() =>
+          db
           .update(s1Actions)
           .set({
             status: nextStatus,
@@ -1043,7 +1099,8 @@ export async function processPollActions() {
             error: nextStatus === 'failed' ? truncateError(activity.details) : null,
             payload: nextPayload
           })
-          .where(eq(s1Actions.id, action.id));
+          .where(eq(s1Actions.id, action.id))
+        );
       } catch (dbError) {
         console.error(`[S1SyncJob] Failed to persist poll result for action ${action.id}:`, dbError);
         captureException(dbError);
@@ -1096,7 +1153,8 @@ export async function processPollActions() {
       const failure = applyPollFailure(action.payload, error);
       const nextStatus: S1ActionStatus = failure.shouldFail ? 'failed' : 'in_progress';
 
-      await db
+      await runWithSystemDbAccess(() =>
+        db
         .update(s1Actions)
         .set({
           status: nextStatus,
@@ -1106,7 +1164,8 @@ export async function processPollActions() {
             : null,
           completedAt: failure.shouldFail ? new Date() : null
         })
-        .where(eq(s1Actions.id, action.id));
+        .where(eq(s1Actions.id, action.id))
+      );
 
       recordS1ActionPollTransition(nextStatus);
       updated += 1;
@@ -1123,56 +1182,58 @@ function createS1SyncWorker(): Worker<S1SyncJobData> {
   return new Worker<S1SyncJobData>(
     S1_SYNC_QUEUE,
     async (job: Job<S1SyncJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        const start = Date.now();
-        const syncType = job.data.type;
-        switch (job.data.type) {
-          case 'sync-integration': {
-            try {
-              const result = await processSyncIntegration(job.data);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-agents': {
-            try {
-              const result = await processSyncAll(true, false);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'sync-all-threats': {
-            try {
-              const result = await processSyncAll(false, true);
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          case 'poll-actions': {
-            try {
-              const result = await processPollActions();
-              recordS1SyncRun(syncType, 'success', Date.now() - start);
-              return result;
-            } catch (error) {
-              recordS1SyncRun(syncType, 'failure', Date.now() - start);
-              throw error;
-            }
-          }
-          default: {
+      // NOT wrapped in one runWithSystemDbAccess: each processor manages its own
+      // SHORT system contexts so the SentinelOne HTTP calls (agent/threat fetch,
+      // per-action status poll) never pin a pooled connection in an open
+      // transaction (#1105/#1896 conn-hold → "held a pooled connection" warnings).
+      const start = Date.now();
+      const syncType = job.data.type;
+      switch (job.data.type) {
+        case 'sync-integration': {
+          try {
+            const result = await processSyncIntegration(job.data);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
             recordS1SyncRun(syncType, 'failure', Date.now() - start);
-            throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+            throw error;
           }
         }
-      });
+        case 'sync-all-agents': {
+          try {
+            const result = await processSyncAll(true, false);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'sync-all-threats': {
+          try {
+            const result = await processSyncAll(false, true);
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        case 'poll-actions': {
+          try {
+            const result = await processPollActions();
+            recordS1SyncRun(syncType, 'success', Date.now() - start);
+            return result;
+          } catch (error) {
+            recordS1SyncRun(syncType, 'failure', Date.now() - start);
+            throw error;
+          }
+        }
+        default: {
+          recordS1SyncRun(syncType, 'failure', Date.now() - start);
+          throw new Error(`Unknown S1 sync job type: ${(job.data as { type?: string }).type ?? 'unknown'}`);
+        }
+      }
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/s1Sync_sites.test.ts
+++ b/apps/api/src/jobs/s1Sync_sites.test.ts
@@ -80,7 +80,7 @@ const mockDb = {
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
+  withSystemDbAccessContext: <T>(fn: () => Promise<T> | T): Promise<T> | T => fn(),
   runOutsideDbContext: <T>(fn: () => T): T => fn(),
 }));
 

--- a/apps/api/src/jobs/s1Sync_syncError.test.ts
+++ b/apps/api/src/jobs/s1Sync_syncError.test.ts
@@ -37,7 +37,7 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   db: mockDb,
-  withSystemDbAccessContext: undefined,
+  withSystemDbAccessContext: <T>(fn: () => Promise<T> | T): Promise<T> | T => fn(),
   runOutsideDbContext: <T>(fn: () => T): T => fn(),
   assertOutsideHeldDbContext: vi.fn(),
 }));


### PR DESCRIPTION
**Follow-up to #1894.** Two background workers still ran slow non-DB work inside a single held `withSystemDbAccessContext`, pinning a pooled connection in an open transaction — the residual #1105 conn-hold pattern (the ~5s `held a pooled connection in an open transaction` warnings still seen on prod after 0.83.3, plus the Sentry pressure those warnings cause).

The fix mirrors #1894 and the canonical `dnsSyncJob` pattern: read in a short context, do HTTP/loops OUTSIDE any context, write back in short contexts. Because `withDbAccessContext` is a no-op when already inside a context, the key change is removing each worker's top-level wrapper and giving each DB touch its own short context.

### `s1Sync.ts`
- **`processSyncIntegration`** — integration read, final status write, and the catch-block error write each run in their own short context. The error write escapes any held/poisoned context first (`runOutsideDbContext`) so it records on a fresh connection.
- **`syncAgentsForIntegration` / `syncThreatsForIntegration`** — the SentinelOne `listAgents`/`listThreats` HTTP runs OUTSIDE any context; DB upserts run in one short context; the `s1.threat_detected` event-bus publishes moved outside it.
- **`processPollActions`** — pending-actions read + per-org client resolution run in one short context; each action's `getActivityStatus` HTTP runs outside any context; each status write is its own short context; completion events publish outside.
- **`processSyncAll`** — integrations read in a short context, BullMQ enqueue outside.
- Worker no longer wraps the whole job; metrics + per-case try/catch unchanged.

### `patchSchedulerWorker.ts`
- **`scanAndCreateJobs`** — no longer runs the entire policy → assignment → device scan in one transaction. Each DB touch gets its own short context: the top policies query, `loadPolicyLocalPatchConfig`, the assignments query, `resolveDeviceIdsForAssignment`, `loadDeviceSchedulingContexts`, `hasExistingOccurrenceJob`, the **per-device `checkDeviceMaintenanceWindow` loop**, the `patch_jobs` insert, and the stale-job read. The relation-not-found guard now wraps the call itself. (The post-scan Redis enqueue was already outside the context.)

### Tests
- `s1Sync.dbcontext.test.ts` — depth-tracking: S1 HTTP (`listAgents`/`listThreats`/`getActivityStatus`) and event-bus publishes run at depth 0; all DB reads/writes at depth > 0; fetch-failure path records error status on a fresh context and re-throws the original error.
- `patchSchedulerWorker.dbcontext.test.ts` — every DB op and the per-device maintenance check run at depth 1, depth never nests beyond 1, and many separate short contexts are opened (no single context spans the scan).
- Updated the two existing s1Sync test `db` mocks (`s1Sync_sites`, `s1Sync_syncError`) to provide a working `withSystemDbAccessContext` passthrough, since the functions now use it internally.

### Verification
- `apps/api` affected suite green: `vitest run` over the 6 files (48 passed).
- `tsc --noEmit` clean.
- Business logic (claim/resolve/poll/result mapping, idempotency, orphan recovery, SSRF body-free error redaction) unchanged — only transaction boundaries moved.

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)