### PR TITLE
docs(issue-to-pr): prevent duplicate PRs when fanning out issue-fixers

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -9,8 +9,15 @@ Interpret `$ARGUMENTS`:
 
 - **One issue number** (e.g. `1234` or `#1234`) → dispatch a single `issue-fixer` on that issue.
 - **Several issue numbers** → dispatch one `issue-fixer` per number **in a single message so they run in parallel**, each in its own worktree.
-- **Blank** → dispatch one `issue-fixer` and tell it to do the skill's step-0 selection: scan the backlog, rank candidates, run the eligibility guard on its top pick (next pick if it aborts) until one passes, then work it.
-- **A description** (e.g. "find a small frontend bug") → dispatch one `issue-fixer` with that as the selection filter for step-0.
+- **Blank** → dispatch **one** `issue-fixer` and tell it to do the skill's step-0 selection: scan the backlog, rank candidates, run the eligibility guard on its top pick (next pick if it aborts) until one passes, then work it.
+- **A description** (e.g. "find a small frontend bug") → dispatch **one** `issue-fixer` with that as the selection filter for step-0.
+- **Fan out *several* without explicit numbers** (e.g. "find a few to work on", "pick up a couple more", a description + "do N of them") → **YOU select and claim the distinct issues first, then dispatch one agent per chosen number.** Do NOT spawn multiple selection-free agents — they self-select in parallel, all rank the same top issue, and can't see each other's claim yet, so they collide on one issue and open duplicate PRs (this happened: 3 agents → 3 PRs on #1896). Procedure:
+  1. Scan the backlog once yourself (`gh issue list --repo LanternOps/breeze --state open --limit 60 --json number,title,assignees,labels,createdAt,comments`) and rank using the skill's step-0 criteria.
+  2. Walk the ranked list and pick **N distinct** eligible candidates, running the step-1 guard on each (skip closed / assigned-to-others / already-referenced-by-a-PR). State the cap and which you skipped.
+  3. **Claim each up front** so the set is reserved and visible: `gh issue edit <N> --repo LanternOps/breeze --add-assignee @me`.
+  4. Dispatch one `issue-fixer` per **already-chosen number** (a normal "several issue numbers" fan-out), each in its own worktree. The agents no longer self-select, so they can't collide.
+
+**Never rely on claim-comment de-dup to separate parallel self-selecting agents** — selection happens before any claim is visible, so the guard can't see a sibling's pick. Distinctness must be decided by the orchestrator before dispatch.
 
 **Worktree isolation (tell every dispatched agent):** each `issue-fixer` is spawned with its CWD inside *your* (the orchestrator's) worktree — which belongs to a different task. It must NOT work there, and must NOT reach into the shared `/Users/toddhebebrand/breeze` checkout (possibly stale). Each agent runs `git fetch origin main`, creates its **own** new worktree off `origin/main`, and verifies `git rev-parse HEAD == origin/main` before branching. (Reusing the spawn worktree or editing the shared checkout has silently reverted other in-flight PRs' files.) The `issue-to-pr` skill §3 documents this in full.
 

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -233,18 +233,39 @@ are the user's judgment calls — see the merge/hold rules. The issue stays
 
 To work several issues at once, the in-session agent acts as orchestrator:
 
-1. Take the **explicit list** of issue numbers (or a label filter the user named).
+1. **Decide the issue numbers BEFORE dispatch — never let multiple workers
+   self-select in parallel.** Each worker's step-0 selection ranks the backlog
+   the same way and claims aren't visible at selection time, so parallel
+   self-selecting agents converge on the *same* top issue and open duplicate PRs
+   (observed: 3 agents → PRs #1917/#1918/#1919, all on #1896). Get a distinct set
+   one of two ways:
+   - The user **named explicit numbers / a label filter** → use that list.
+   - The user asked you to **"find a few" with no numbers** → *you* (the
+     orchestrator) do the selection: scan the backlog once, rank with the step-0
+     criteria, pick **N distinct** eligible candidates, run the step-1 guard on
+     each, and **claim each up front** (`gh issue edit <N> --add-assignee @me`)
+     so the set is reserved. Only then dispatch.
+
    Any orchestrator-level eligibility pre-check has the same blind spot as the
    worker's: `gh pr list --state open` won't reveal an already-merged fix, so
    don't pre-declare an issue "eligible" on that basis — the worker's full guard
    (comments + `--state all` + `origin/main`) is the real gate.
 2. **REQUIRED SUB-SKILL:** `superpowers:dispatching-parallel-agents` — spawn one
-   `issue-fixer` agent per number, each in its **own worktree** (isolation
-   prevents branch/DB collisions; see the worktree skill).
+   `issue-fixer` agent **per already-chosen number**, each in its **own worktree**
+   (isolation prevents branch/DB collisions; see the worktree skill). Every agent
+   gets a concrete number — none self-selects.
 3. Each agent runs this runbook independently and returns its PR number (or its
-   abort reason).
+   abort reason). A worker that finds its handed number already assigned to `@me`
+   (because the orchestrator pre-claimed it) treats that as eligible — that's the
+   reservation working, not a poach.
 4. Collect the results into one summary table for the user. The orchestrator
    does **not** merge or close either — same boundary applies.
 
 Do not auto-expand the list beyond what the user named. If you self-selected
 from a label, `log`/state the cap and which issues were dropped.
+
+> **Anti-pattern (do not do this):** dispatching 2+ `issue-fixer` agents that
+> each run step-0 selection, trusting a "skip already-claimed issues" instruction
+> to keep them apart. Selection precedes any visible claim, so the guard can't
+> see a sibling's pick — they collide. Distinctness is the orchestrator's job,
+> settled before dispatch.


### PR DESCRIPTION
## Why

When `/issue` is asked to fan out several `issue-fixer` agents **without explicit issue numbers** (e.g. "find a few to work on", "pick up a couple more"), the old contract let the orchestrator spawn multiple *selection-free* agents. Each ran the skill's step-0 selection independently, ranked the backlog identically, and converged on the same top issue — claims aren't visible at selection time, so the "skip already-claimed issues" guard can't break the tie.

**Observed:** 3 agents → 3 duplicate PRs (#1917 / #1918 / #1919), all on issue #1896. Two had to be closed by hand.

## Fix

Encode the missing contract in both the command and the skill:

- **`.claude/commands/issue.md`** — new rule for "fan out several without explicit numbers": the **orchestrator** scans + ranks + guards + **claims N distinct issues up front** (`gh issue edit <N> --add-assignee @me`), then dispatches one agent per already-chosen number. Plus the invariant: never rely on claim-comment de-dup to separate parallel self-selecting agents.
- **`.claude/skills/issue-to-pr/SKILL.md`** — the "Orchestrating multiple issues" section now requires numbers to be decided before dispatch, explains the pre-claim reservation (a worker seeing its handed issue assigned to `@me` treats it as eligible, not a poach), and adds an explicit anti-pattern callout citing this exact incident.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)