### PR TITLE
feat(reliability): cap alarming counts, age-aware windows, offender drill-down (#1907)

### DIFF
--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -12,6 +12,7 @@ vi.mock('../services/reliabilityScoring', () => ({
   listReliabilityDevices: vi.fn(),
   getOrgReliabilitySummary: vi.fn(),
   getDeviceReliabilityHistory: vi.fn(),
+  getDeviceReliabilityOffenders: vi.fn(),
   getDeviceReliability: vi.fn(),
   evaluateReliabilityScores: vi.fn(),
 }));
@@ -30,6 +31,7 @@ import {
   listReliabilityDevices,
   getOrgReliabilitySummary,
   getDeviceReliabilityHistory,
+  getDeviceReliabilityOffenders,
   getDeviceReliability,
   evaluateReliabilityScores,
 } from '../services/reliabilityScoring';
@@ -462,6 +464,70 @@ describe('public reliability routes', () => {
       expect(body.days).toBe(30);
 
       expect(vi.mocked(getDeviceReliabilityHistory)).toHaveBeenCalledWith(DEVICE_ID, 30);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // GET /:deviceId/offenders
+  // ──────────────────────────────────────────────────────────
+  describe('GET /:deviceId/offenders', () => {
+    const offenders = {
+      services: [{ key: 'Spooler', label: 'Spooler', count: 3, lastOccurrence: '2026-06-20T10:00:00.000Z' }],
+      hardware: [],
+      hangs: [],
+    };
+
+    it('returns 404 when device not found', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(null);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders`);
+      expect(res.status).toBe(404);
+      expect(vi.mocked(getDeviceReliabilityOffenders)).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when device site is denied', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SITE_ACCESS_DENIED as never);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders`);
+      expect(res.status).toBe(403);
+      expect(vi.mocked(getDeviceReliabilityOffenders)).not.toHaveBeenCalled();
+    });
+
+    it('returns offenders with default window and limit', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceReliabilityOffenders).mockResolvedValue(offenders as any);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual({ deviceId: DEVICE_ID, days: 30, offenders });
+      expect(vi.mocked(getDeviceReliabilityOffenders)).toHaveBeenCalledWith(DEVICE_ID, 30, 5);
+    });
+
+    it('passes custom days and limit through to the service', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+      vi.mocked(getDeviceReliabilityOffenders).mockResolvedValue(offenders as any);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders?days=7&limit=3`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.days).toBe(7);
+      expect(vi.mocked(getDeviceReliabilityOffenders)).toHaveBeenCalledWith(DEVICE_ID, 7, 3);
+    });
+
+    it('rejects an out-of-range limit through validation', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders?limit=50`);
+      expect(res.status).toBe(400);
+      expect(vi.mocked(getDeviceReliabilityOffenders)).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/reliability.test.ts
+++ b/apps/api/src/routes/reliability.test.ts
@@ -529,5 +529,14 @@ describe('public reliability routes', () => {
       expect(res.status).toBe(400);
       expect(vi.mocked(getDeviceReliabilityOffenders)).not.toHaveBeenCalled();
     });
+
+    it('rejects an out-of-range days through validation', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: ORG_ID } as any);
+
+      const app = buildApp();
+      const res = await app.request(`/reliability/${DEVICE_ID}/offenders?days=400`);
+      expect(res.status).toBe(400);
+      expect(vi.mocked(getDeviceReliabilityOffenders)).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/routes/reliability.ts
+++ b/apps/api/src/routes/reliability.ts
@@ -7,6 +7,7 @@ import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/pe
 import {
   getDeviceReliability,
   getDeviceReliabilityHistory,
+  getDeviceReliabilityOffenders,
   getOrgReliabilitySummary,
   evaluateReliabilityScores,
   listReliabilityDevices,
@@ -37,6 +38,11 @@ const orgIdParamSchema = z.object({
 
 const historyQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(365).default(90),
+});
+
+const offendersQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(365).default(30),
+  limit: z.coerce.number().int().min(1).max(20).default(5),
 });
 
 const evaluationQuerySchema = z.object({
@@ -244,6 +250,37 @@ reliabilityRoutes.get(
       deviceId,
       days,
       points,
+    });
+  }
+);
+
+// Issue #1907: drill-down behind the count tiles — the top offending services,
+// hardware components, and processes (distinct-deduped, consistent with #1905),
+// so a tech can see *which* service is flapping rather than a bare total.
+reliabilityRoutes.get(
+  '/:deviceId/offenders',
+  requireScope('organization', 'partner', 'system'),
+  requireReliabilityRead,
+  zValidator('param', deviceIdParamSchema),
+  zValidator('query', offendersQuerySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceId } = c.req.valid('param');
+    const { days, limit } = c.req.valid('query');
+
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    const offenders = await getDeviceReliabilityOffenders(deviceId, days, limit);
+    return c.json({
+      deviceId,
+      days,
+      offenders,
     });
   }
 );

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -933,4 +933,60 @@ describe('aggregateReliabilityOffenders', () => {
     expect(result.services).toHaveLength(2);
     expect(result.services.map((offender) => offender.label)).not.toContain('');
   });
+
+  it('keeps the worst hardware severity even when a lower one is reported later', () => {
+    const rows = [
+      makeHistoryRow({
+        hardwareErrors: [
+          { type: 'disk', severity: 'critical', source: 'disk0', timestamp: '2026-02-20T10:00:00.000Z' },
+          { type: 'disk', severity: 'warning', source: 'disk0', timestamp: '2026-02-20T11:00:00.000Z' },
+          { type: 'disk', severity: 'bogus' as never, source: 'disk0', timestamp: '2026-02-20T12:00:00.000Z' },
+        ],
+      }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows);
+
+    // critical reported first must not be downgraded by a later warning / unknown severity.
+    expect(result.hardware[0]).toMatchObject({ key: 'disk0', count: 3, detail: 'critical' });
+  });
+
+  it('breaks count ties by most-recent occurrence', () => {
+    const rows = [
+      makeHistoryRow({
+        serviceFailures: [
+          { serviceName: 'Older', timestamp: '2026-02-20T08:00:00.000Z', recovered: false },
+          { serviceName: 'Newer', timestamp: '2026-02-20T20:00:00.000Z', recovered: false },
+        ],
+      }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows, 1);
+
+    // Equal counts (1 each) → the more recent offender ranks first and survives the top-1 slice.
+    expect(result.services).toEqual([
+      { key: 'Newer', label: 'Newer', count: 1, lastOccurrence: '2026-02-20T20:00:00.000Z' },
+    ]);
+  });
+
+  it('excludes events whose day falls outside the supplied window', () => {
+    const rows = [
+      makeHistoryRow({
+        collectedAt: new Date('2026-02-20T10:00:00.000Z'),
+        serviceFailures: [
+          { serviceName: 'InWindow', timestamp: '2026-02-19T10:00:00.000Z', recovered: false },
+          // Re-reported in a recent row but its own day is well before the window start.
+          { serviceName: 'OldReReport', timestamp: '2026-01-01T10:00:00.000Z', recovered: false },
+        ],
+      }),
+    ];
+    const window = { sinceKey: '2026-02-13', todayKey: '2026-02-20' };
+
+    const filtered = aggregateReliabilityOffenders(rows, 5, window);
+    expect(filtered.services.map((offender) => offender.label)).toEqual(['InWindow']);
+
+    // Without a window the old re-report is still counted (pure aggregation).
+    const unfiltered = aggregateReliabilityOffenders(rows);
+    expect(unfiltered.services.map((offender) => offender.label).sort()).toEqual(['InWindow', 'OldReReport']);
+  });
 });

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -866,3 +866,71 @@ describe('computeReliabilityEvaluationSummary', () => {
     expect(summary.precision).toBe(1);
   });
 });
+
+describe('aggregateReliabilityOffenders', () => {
+  const { aggregateReliabilityOffenders } = reliabilityScoringInternals;
+
+  it('groups distinct events by offender and ranks by count', () => {
+    const rows = [
+      makeHistoryRow({
+        serviceFailures: [
+          { serviceName: 'Spooler', timestamp: '2026-02-20T10:01:00.000Z', recovered: true },
+          { serviceName: 'Spooler', timestamp: '2026-02-20T11:01:00.000Z', recovered: false },
+          { serviceName: 'WinDefend', timestamp: '2026-02-20T12:01:00.000Z', recovered: false },
+        ],
+        hardwareErrors: [
+          { type: 'disk', severity: 'warning', source: 'disk0', timestamp: '2026-02-20T10:05:00.000Z' },
+          { type: 'disk', severity: 'critical', source: 'disk0', timestamp: '2026-02-20T13:05:00.000Z' },
+        ],
+        appHangs: [
+          { processName: 'chrome.exe', timestamp: '2026-02-20T10:09:00.000Z', duration: 5, resolved: false },
+        ],
+      }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows);
+
+    expect(result.services).toEqual([
+      { key: 'Spooler', label: 'Spooler', count: 2, lastOccurrence: '2026-02-20T11:01:00.000Z', detail: '1/2 recovered' },
+      { key: 'WinDefend', label: 'WinDefend', count: 1, lastOccurrence: '2026-02-20T12:01:00.000Z' },
+    ]);
+    // Worst severity wins for the detail; the latest timestamp is retained.
+    expect(result.hardware).toEqual([
+      { key: 'disk0', label: 'disk0', count: 2, lastOccurrence: '2026-02-20T13:05:00.000Z', detail: 'critical' },
+    ]);
+    expect(result.hangs).toEqual([
+      { key: 'chrome.exe', label: 'chrome.exe', count: 1, lastOccurrence: '2026-02-20T10:09:00.000Z', detail: '1 unresolved' },
+    ]);
+  });
+
+  it('de-duplicates the same event re-reported across overlapping rows (issue #1905 parity)', () => {
+    const dup = { serviceName: 'Spooler', timestamp: '2026-02-20T10:01:00.000Z', errorCode: '7', recovered: false };
+    const rows = [
+      makeHistoryRow({ serviceFailures: [dup] }),
+      makeHistoryRow({ collectedAt: new Date('2026-02-20T12:00:00.000Z'), serviceFailures: [dup, { ...dup }] }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows);
+
+    expect(result.services).toEqual([
+      { key: 'Spooler', label: 'Spooler', count: 1, lastOccurrence: '2026-02-20T10:01:00.000Z' },
+    ]);
+  });
+
+  it('honors the top-N limit and labels nameless offenders with a placeholder', () => {
+    const rows = [
+      makeHistoryRow({
+        serviceFailures: [
+          { serviceName: 'A', timestamp: '2026-02-20T10:01:00.000Z', recovered: false },
+          { serviceName: 'B', timestamp: '2026-02-20T10:02:00.000Z', recovered: false },
+          { serviceName: '', timestamp: '2026-02-20T10:03:00.000Z', recovered: false },
+        ],
+      }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows, 2);
+
+    expect(result.services).toHaveLength(2);
+    expect(result.services.map((offender) => offender.label)).not.toContain('');
+  });
+});

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -159,6 +159,9 @@ export interface ReliabilityListItem {
   topIssues: ReliabilityTopIssue[];
   computedAt: string;
   drivers?: ReliabilityFactorDriver[];
+  // Device enrollment time (ISO). Lets the UI relabel fixed windows ("30d") to
+  // the actually-observed age on young devices ("since enroll · 13d"). Issue #1907.
+  enrolledAt?: string | null;
 }
 
 export interface DeviceReliabilityHistoryPoint {
@@ -170,6 +173,30 @@ export interface DeviceReliabilityHistoryPoint {
   serviceFailureCount: number;
   hardwareErrorCount: number;
   reliabilityEstimate: number;
+}
+
+// Issue #1907: per-device drill-down. A count tile ("service failure count 30d:
+// 900") tells a tech nothing actionable; the offender breakdown answers *which*
+// service is flapping / *which* component is throwing errors. Counts here are
+// DISTINCT across the window (same dedup keys as #1905) so they line up with the
+// headline tiles instead of re-inflating.
+export interface ReliabilityOffender {
+  /** Stable identity used for de-duplication and as the React key. */
+  key: string;
+  /** Human label (service name, hardware source, or process name). */
+  label: string;
+  /** Distinct event count attributed to this offender within the window. */
+  count: number;
+  /** ISO timestamp of the most recent attributed event, when known. */
+  lastOccurrence: string | null;
+  /** Optional qualifier (worst hardware severity, recovered/unresolved counts). */
+  detail?: string;
+}
+
+export interface DeviceReliabilityOffenders {
+  services: ReliabilityOffender[];
+  hardware: ReliabilityOffender[];
+  hangs: ReliabilityOffender[];
 }
 
 export type ReliabilityFactorName = 'uptime' | 'crashes' | 'hangs' | 'serviceFailures' | 'hardwareErrors';
@@ -1388,6 +1415,7 @@ export async function getDeviceReliability(deviceId: string): Promise<Reliabilit
       topIssues: deviceReliability.topIssues,
       details: deviceReliability.details,
       computedAt: deviceReliability.computedAt,
+      enrolledAt: devices.enrolledAt,
     })
     .from(deviceReliability)
     .innerJoin(devices, eq(deviceReliability.deviceId, devices.id))
@@ -1414,6 +1442,7 @@ export async function getDeviceReliability(deviceId: string): Promise<Reliabilit
     topIssues: Array.isArray(row.topIssues) ? row.topIssues : [],
     computedAt: row.computedAt.toISOString(),
     drivers: buildReliabilityDrivers(row.details),
+    enrolledAt: row.enrolledAt ? row.enrolledAt.toISOString() : null,
   };
 }
 
@@ -1560,6 +1589,123 @@ export async function getDeviceReliabilityHistory(deviceId: string, days: number
     });
 }
 
+const DEFAULT_OFFENDER_LIMIT = 5;
+
+const HARDWARE_SEVERITY_RANK: Record<string, number> = { critical: 3, error: 2, warning: 1 };
+
+interface OffenderAccumulator {
+  key: string;
+  label: string;
+  count: number;
+  lastOccurrence: string | undefined;
+  worstSeverity?: string;
+  recovered: number;
+  unresolved: number;
+}
+
+function upsertOffender(map: Map<string, OffenderAccumulator>, id: string): OffenderAccumulator {
+  let entry = map.get(id);
+  if (!entry) {
+    entry = { key: id, label: id, count: 0, lastOccurrence: undefined, recovered: 0, unresolved: 0 };
+    map.set(id, entry);
+  }
+  return entry;
+}
+
+function offenderTimestampMs(value: string | null): number {
+  if (!value) return 0;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+function finalizeOffenders(
+  map: Map<string, OffenderAccumulator>,
+  limit: number,
+  toDetail: (entry: OffenderAccumulator) => string | undefined
+): ReliabilityOffender[] {
+  return Array.from(map.values())
+    .sort((left, right) => (
+      right.count - left.count
+      || offenderTimestampMs(right.lastOccurrence ?? null) - offenderTimestampMs(left.lastOccurrence ?? null)
+      || left.label.localeCompare(right.label)
+    ))
+    .slice(0, Math.max(1, limit))
+    .map((entry) => {
+      const detail = toDetail(entry);
+      return {
+        key: entry.key,
+        label: entry.label,
+        count: entry.count,
+        lastOccurrence: entry.lastOccurrence ?? null,
+        ...(detail ? { detail } : {}),
+      };
+    });
+}
+
+// Pure: aggregate the top offending services / hardware components / processes
+// from raw history rows. Events are de-duplicated across the WHOLE row set with
+// the same keys the score aggregation uses (#1905), so an event re-reported in
+// overlapping windows is attributed to its offender exactly once.
+function aggregateReliabilityOffenders(rows: HistoryRow[], limit = DEFAULT_OFFENDER_LIMIT): DeviceReliabilityOffenders {
+  const seen = new Set<string>();
+  const services = new Map<string, OffenderAccumulator>();
+  const hardware = new Map<string, OffenderAccumulator>();
+  const hangs = new Map<string, OffenderAccumulator>();
+
+  const isNewEvent = (key: string): boolean => {
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  };
+
+  for (const row of rows) {
+    for (const event of row.serviceFailures) {
+      if (!isNewEvent(serviceFailureKey(event))) continue;
+      const entry = upsertOffender(services, event.serviceName?.trim() || 'Unknown service');
+      entry.count += 1;
+      if (event.recovered) entry.recovered += 1;
+      entry.lastOccurrence = maxTimestamp([entry.lastOccurrence, event.timestamp]);
+    }
+
+    for (const event of row.hardwareErrors) {
+      if (!isNewEvent(hardwareErrorKey(event))) continue;
+      const entry = upsertOffender(hardware, event.source?.trim() || 'Unknown component');
+      entry.count += 1;
+      entry.lastOccurrence = maxTimestamp([entry.lastOccurrence, event.timestamp]);
+      const rank = HARDWARE_SEVERITY_RANK[event.severity] ?? 0;
+      const currentRank = entry.worstSeverity ? (HARDWARE_SEVERITY_RANK[entry.worstSeverity] ?? 0) : 0;
+      if (rank > currentRank) entry.worstSeverity = event.severity;
+    }
+
+    for (const event of row.appHangs) {
+      if (!isNewEvent(appHangKey(event))) continue;
+      const entry = upsertOffender(hangs, event.processName?.trim() || 'Unknown process');
+      entry.count += 1;
+      if (!event.resolved) entry.unresolved += 1;
+      entry.lastOccurrence = maxTimestamp([entry.lastOccurrence, event.timestamp]);
+    }
+  }
+
+  return {
+    services: finalizeOffenders(services, limit, (entry) => (
+      entry.recovered > 0 ? `${entry.recovered}/${entry.count} recovered` : undefined
+    )),
+    hardware: finalizeOffenders(hardware, limit, (entry) => entry.worstSeverity),
+    hangs: finalizeOffenders(hangs, limit, (entry) => (
+      entry.unresolved > 0 ? `${entry.unresolved} unresolved` : undefined
+    )),
+  };
+}
+
+export async function getDeviceReliabilityOffenders(
+  deviceId: string,
+  days: number,
+  limit: number = DEFAULT_OFFENDER_LIMIT
+): Promise<DeviceReliabilityOffenders> {
+  const rows = await getHistoryForDevice(deviceId, days);
+  return aggregateReliabilityOffenders(rows, limit);
+}
+
 export async function getOrgReliabilitySummary(orgId: string, options: { siteIds?: string[] } = {}): Promise<{
   orgId: string;
   devices: number;
@@ -1651,6 +1797,7 @@ export const reliabilityScoringInternals = {
   scoreBand,
   computeTopIssues,
   buildReliabilityDrivers,
+  aggregateReliabilityOffenders,
   computeReliabilityEvaluationSummary,
   resolveWeightProfile,
   isWorkstationRole,

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -1642,11 +1642,27 @@ function finalizeOffenders(
     });
 }
 
+// Optional event-day window for the offender aggregation. When supplied, an
+// event is only counted if its own day (event timestamp, falling back to the
+// row's collectedAt — the same `eventDayKey` rule the score buckets use) lies
+// within [sinceKey, todayKey]. This makes the drill-down counts reconcile with
+// the headline tiles, which window by event day via `bucketsInWindow`, rather
+// than counting every event a recent row happens to re-report from deeper
+// history (a row's collectedAt is always >= its events' timestamps).
+interface OffenderWindow {
+  sinceKey: string;
+  todayKey: string;
+}
+
 // Pure: aggregate the top offending services / hardware components / processes
 // from raw history rows. Events are de-duplicated across the WHOLE row set with
 // the same keys the score aggregation uses (#1905), so an event re-reported in
 // overlapping windows is attributed to its offender exactly once.
-function aggregateReliabilityOffenders(rows: HistoryRow[], limit = DEFAULT_OFFENDER_LIMIT): DeviceReliabilityOffenders {
+function aggregateReliabilityOffenders(
+  rows: HistoryRow[],
+  limit = DEFAULT_OFFENDER_LIMIT,
+  window?: OffenderWindow
+): DeviceReliabilityOffenders {
   const seen = new Set<string>();
   const services = new Map<string, OffenderAccumulator>();
   const hardware = new Map<string, OffenderAccumulator>();
@@ -1658,8 +1674,15 @@ function aggregateReliabilityOffenders(rows: HistoryRow[], limit = DEFAULT_OFFEN
     return true;
   };
 
+  const inWindow = (eventTimestamp: string | undefined, collectedAt: Date): boolean => {
+    if (!window) return true;
+    const dayKey = eventDayKey(eventTimestamp, collectedAt);
+    return dayKey >= window.sinceKey && dayKey <= window.todayKey;
+  };
+
   for (const row of rows) {
     for (const event of row.serviceFailures) {
+      if (!inWindow(event.timestamp, row.collectedAt)) continue;
       if (!isNewEvent(serviceFailureKey(event))) continue;
       const entry = upsertOffender(services, event.serviceName?.trim() || 'Unknown service');
       entry.count += 1;
@@ -1668,6 +1691,7 @@ function aggregateReliabilityOffenders(rows: HistoryRow[], limit = DEFAULT_OFFEN
     }
 
     for (const event of row.hardwareErrors) {
+      if (!inWindow(event.timestamp, row.collectedAt)) continue;
       if (!isNewEvent(hardwareErrorKey(event))) continue;
       const entry = upsertOffender(hardware, event.source?.trim() || 'Unknown component');
       entry.count += 1;
@@ -1678,6 +1702,7 @@ function aggregateReliabilityOffenders(rows: HistoryRow[], limit = DEFAULT_OFFEN
     }
 
     for (const event of row.appHangs) {
+      if (!inWindow(event.timestamp, row.collectedAt)) continue;
       if (!isNewEvent(appHangKey(event))) continue;
       const entry = upsertOffender(hangs, event.processName?.trim() || 'Unknown process');
       entry.count += 1;
@@ -1702,8 +1727,15 @@ export async function getDeviceReliabilityOffenders(
   days: number,
   limit: number = DEFAULT_OFFENDER_LIMIT
 ): Promise<DeviceReliabilityOffenders> {
+  const now = new Date();
   const rows = await getHistoryForDevice(deviceId, days);
-  return aggregateReliabilityOffenders(rows, limit);
+  // Mirror the headline tiles' event-day window (bucketsInWindow) so the
+  // drill-down counts reconcile with the tile they sit under.
+  const window: OffenderWindow = {
+    sinceKey: toDayKey(new Date(now.getTime() - days * DAY_MS)),
+    todayKey: toDayKey(now),
+  };
+  return aggregateReliabilityOffenders(rows, limit, window);
 }
 
 export async function getOrgReliabilitySummary(orgId: string, options: { siteIds?: string[] } = {}): Promise<{

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -495,5 +495,72 @@ describe('DeviceReliabilityPanel', () => {
     expect(await screen.findByText('Spooler')).toBeInTheDocument();
     expect(screen.getByText('1/3 recovered')).toBeInTheDocument();
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/reliability/dev-1/offenders');
+
+    // Caching contract: collapsing and re-expanding must NOT refetch.
+    fireEvent.click(screen.getByTestId('reliability-offenders-toggle'));
+    fireEvent.click(screen.getByTestId('reliability-offenders-toggle'));
+    expect(await screen.findByText('Spooler')).toBeInTheDocument();
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2); // snapshot + one offenders fetch
+  });
+
+  it('surfaces an offenders load failure with a working Retry (issue #1907)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({ snapshot: baseSnapshot({ serviceFailureCount30d: 3 }), history: [] }),
+      )
+      .mockResolvedValueOnce(makeJsonResponse({ error: 'boom' }, false, 500))
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          deviceId: 'dev-1',
+          days: 30,
+          offenders: {
+            services: [{ key: 'Spooler', label: 'Spooler', count: 3, lastOccurrence: '2026-06-17T10:00:00.000Z' }],
+            hardware: [],
+            hangs: [],
+          },
+        }),
+      );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-offenders-toggle'));
+
+    // Failure is surfaced, not swallowed into a blank panel.
+    expect(await screen.findByText('Failed to load reliability detail')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    // Retry refetches (the fetched-once guard was reset) and renders the data.
+    expect(await screen.findByText('Spooler')).toBeInTheDocument();
+  });
+
+  it('treats a 200 with a malformed offenders body as a failure, not a blank panel (issue #1907)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({ snapshot: baseSnapshot({ serviceFailureCount30d: 3 }), history: [] }),
+      )
+      .mockResolvedValueOnce(makeJsonResponse({ deviceId: 'dev-1', days: 30 })); // no `offenders` field
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-offenders-toggle'));
+
+    expect(await screen.findByText('Reliability detail response was malformed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when the drill-down returns no offenders (issue #1907)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({ snapshot: baseSnapshot({ serviceFailureCount30d: 3 }), history: [] }),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({ deviceId: 'dev-1', days: 30, offenders: { services: [], hardware: [], hangs: [] } }),
+      );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    fireEvent.click(await screen.findByTestId('reliability-offenders-toggle'));
+
+    expect(await screen.findByText(/No offending services or components recorded/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -384,4 +384,116 @@ describe('DeviceReliabilityPanel', () => {
     fireEvent.click(atRiskHelp.querySelector('button')!);
     expect(await screen.findByText(/Biggest drag: Crashes/)).toBeInTheDocument();
   });
+
+  const baseSnapshot = (overrides: Record<string, unknown> = {}) => ({
+    deviceId: 'dev-1',
+    reliabilityScore: 30,
+    trendDirection: 'degrading',
+    trendConfidence: 0.8,
+    uptime30d: 94.2,
+    crashCount30d: 0,
+    hangCount30d: 0,
+    serviceFailureCount30d: 0,
+    hardwareErrorCount30d: 0,
+    mtbfHours: 72,
+    topIssues: [],
+    drivers: [],
+    computedAt: '2026-06-18T12:00:00.000Z',
+    ...overrides,
+  });
+
+  it('caps alarming counts in the summary tiles (issue #1907)', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: baseSnapshot({
+          serviceFailureCount30d: 1228,
+          drivers: [
+            {
+              factor: 'serviceFailures',
+              label: 'Service failures',
+              score: 0,
+              weight: 25,
+              lostPoints: 25,
+              evidence: { serviceFailure30d: 1228 },
+            },
+          ],
+        }),
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    await screen.findByText('Service failures');
+    // The raw 1,228 is capped to 999+ in the tile; the exact value moves to the title attr.
+    expect(screen.getByText('999+')).toBeInTheDocument();
+    expect(screen.queryByText('1,228')).toBeNull();
+  });
+
+  it('relabels fixed windows to observed age on a young device (issue #1907)', async () => {
+    const enrolledAt = new Date(Date.now() - 13 * 24 * 60 * 60 * 1000).toISOString();
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ snapshot: baseSnapshot({ enrolledAt }), history: [] }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    const windowLabel = await screen.findByTestId('reliability-uptime-window');
+    expect(windowLabel.textContent).toContain('since enroll · 13d');
+  });
+
+  it('keeps the full window label when the device is older than the window', async () => {
+    const enrolledAt = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ snapshot: baseSnapshot({ enrolledAt }), history: [] }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    const windowLabel = await screen.findByTestId('reliability-uptime-window');
+    expect(windowLabel.textContent).toBe('30d uptime');
+  });
+
+  it('does not show the offenders drill-down when there are no offending events', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ snapshot: baseSnapshot(), history: [] }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    await screen.findByText('Reliability');
+    expect(screen.queryByTestId('reliability-offenders-toggle')).toBeNull();
+  });
+
+  it('lazily loads and renders top offenders when the drill-down is expanded (issue #1907)', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(
+        makeJsonResponse({ snapshot: baseSnapshot({ serviceFailureCount30d: 3 }), history: [] }),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          deviceId: 'dev-1',
+          days: 30,
+          offenders: {
+            services: [
+              { key: 'Spooler', label: 'Spooler', count: 3, lastOccurrence: '2026-06-17T10:00:00.000Z', detail: '1/3 recovered' },
+            ],
+            hardware: [],
+            hangs: [],
+          },
+        }),
+      );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    // Offenders are NOT fetched on mount — only the snapshot request fires.
+    await screen.findByText('Reliability');
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(await screen.findByTestId('reliability-offenders-toggle'));
+
+    expect(await screen.findByText('Spooler')).toBeInTheDocument();
+    expect(screen.getByText('1/3 recovered')).toBeInTheDocument();
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/reliability/dev-1/offenders');
+  });
 });

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AlertTriangle, ChevronDown, RefreshCw, ShieldCheck, Sparkles, Wrench, XCircle } from 'lucide-react';
+import { Activity, AlertTriangle, ChevronDown, Cpu, RefreshCw, Settings, ShieldCheck, Sparkles, Wrench, XCircle } from 'lucide-react';
 
 import type { AiPageContext } from '@breeze/shared';
 import { runAction, handleActionError } from '../../lib/runAction';
@@ -43,7 +43,52 @@ type ReliabilitySnapshot = {
   topIssues: ReliabilityTopIssue[];
   drivers?: ReliabilityDriver[];
   computedAt: string;
+  enrolledAt?: string | null;
 };
+
+type ReliabilityOffender = {
+  key: string;
+  label: string;
+  count: number;
+  lastOccurrence: string | null;
+  detail?: string;
+};
+
+type ReliabilityOffenders = {
+  services: ReliabilityOffender[];
+  hardware: ReliabilityOffender[];
+  hangs: ReliabilityOffender[];
+};
+
+// The window the panel summarizes events over (matches the API offenders default).
+const OFFENDER_WINDOW_DAYS = 30;
+// Counts at or above this read as "machine on fire / number is broken" noise in a
+// summary tile (issue #1907); cap the tile and keep the exact figure in the
+// title + the per-offender drill-down.
+const COUNT_CAP = 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Cap large summary counts so a tile shows "999+" instead of a 4-digit wall.
+function formatCount(value: number): string {
+  if (!Number.isFinite(value)) return '—';
+  if (value >= COUNT_CAP) return `${COUNT_CAP - 1}+`;
+  return value.toLocaleString();
+}
+
+// Observed device age in whole days, or null when enrollment time is unknown.
+function deviceAgeDays(enrolledAt?: string | null): number | null {
+  if (!enrolledAt) return null;
+  const ms = Date.parse(enrolledAt);
+  if (Number.isNaN(ms)) return null;
+  return Math.max(0, Math.floor((Date.now() - ms) / DAY_MS));
+}
+
+// Relabel a fixed window ("30d") to the actually-observed age on a device younger
+// than the window ("since enroll · 13d"), so counts aren't read as a full month.
+function windowLabel(windowDays: number, ageDays: number | null): string {
+  if (ageDays !== null && ageDays < windowDays) return `since enroll · ${ageDays}d`;
+  return `${windowDays}d`;
+}
 
 type DeviceReliabilityPanelProps = {
   deviceId: string;
@@ -128,7 +173,60 @@ function formatEvidenceKey(value: string): string {
 
 function formatEvidenceValue(key: string, value: number): string {
   if (key.toLowerCase().includes('uptime')) return `${value.toFixed(1)}%`;
-  return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1);
+  return Number.isInteger(value) ? formatCount(value) : value.toFixed(1);
+}
+
+function formatOffenderWhen(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return formatDateTime(date, { month: 'short', day: 'numeric' });
+}
+
+function OffenderGroup({
+  title,
+  Icon,
+  offenders,
+  testId,
+}: {
+  title: string;
+  Icon: typeof Wrench;
+  offenders: ReliabilityOffender[];
+  testId: string;
+}) {
+  if (offenders.length === 0) return null;
+  return (
+    <div data-testid={testId}>
+      <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        {title}
+      </div>
+      <ul className="mt-2 space-y-1.5">
+        {offenders.map((offender) => {
+          const when = formatOffenderWhen(offender.lastOccurrence);
+          return (
+            <li key={offender.key} className="flex items-center justify-between gap-3 text-sm">
+              <span className="min-w-0 truncate">
+                <span className="font-medium">{offender.label}</span>
+                {offender.detail && (
+                  <span className="ml-2 text-xs text-muted-foreground">{offender.detail}</span>
+                )}
+              </span>
+              <span className="flex shrink-0 items-center gap-2 text-xs tabular-nums text-muted-foreground">
+                {when && <span>{when}</span>}
+                <span
+                  className="rounded bg-muted px-1.5 py-0.5 font-semibold text-foreground"
+                  title={offender.count.toLocaleString()}
+                >
+                  {formatCount(offender.count)}×
+                </span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
 }
 
 export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPanelProps) {
@@ -188,6 +286,37 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
   const [outcomeMenuOpen, setOutcomeMenuOpen] = useState(false);
   const outcomeMenuRef = useRef<HTMLDivElement>(null);
   useClickOutside(outcomeMenuOpen, outcomeMenuRef, () => setOutcomeMenuOpen(false));
+
+  // Offenders drill-down (issue #1907): lazily fetched on first expand so the
+  // initial panel render stays a single request and healthy devices pay nothing.
+  const [offendersOpen, setOffendersOpen] = useState(false);
+  const [offenders, setOffenders] = useState<ReliabilityOffenders | null>(null);
+  const [offendersLoading, setOffendersLoading] = useState(false);
+  const [offendersError, setOffendersError] = useState<string>();
+  const offendersFetchedRef = useRef(false);
+
+  const loadOffenders = useCallback(async () => {
+    offendersFetchedRef.current = true;
+    setOffendersLoading(true);
+    setOffendersError(undefined);
+    try {
+      const response = await fetchWithAuth(`/reliability/${deviceId}/offenders`);
+      if (!response.ok) throw new Error('Failed to load reliability detail');
+      const json = await response.json();
+      setOffenders((json?.offenders as ReliabilityOffenders | undefined) ?? null);
+    } catch (err) {
+      offendersFetchedRef.current = false; // allow a retry on next expand
+      setOffendersError(err instanceof Error ? err.message : 'Failed to load reliability detail');
+    } finally {
+      setOffendersLoading(false);
+    }
+  }, [deviceId]);
+
+  const toggleOffenders = useCallback(() => {
+    const next = !offendersOpen;
+    setOffendersOpen(next);
+    if (next && !offendersFetchedRef.current) void loadOffenders();
+  }, [offendersOpen, loadOffenders]);
 
   function handleOutcome(outcome: 'failure_confirmed' | 'replaced' | 'false_alarm') {
     setOutcomeMenuOpen(false);
@@ -273,6 +402,11 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
     );
   }
 
+  const ageDays = deviceAgeDays(snapshot.enrolledAt);
+  const uptimeWindow = windowLabel(OFFENDER_WINDOW_DAYS, ageDays);
+  const offenderEventTotal =
+    snapshot.serviceFailureCount30d + snapshot.hardwareErrorCount30d + snapshot.hangCount30d;
+
   return (
     <div className="rounded-lg border bg-card p-5 shadow-sm">
       <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
@@ -313,7 +447,14 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
               <div className="text-sm font-medium capitalize">{snapshot.trendDirection}</div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground">30d uptime</div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <span data-testid="reliability-uptime-window">{uptimeWindow} uptime</span>
+                {ageDays !== null && ageDays < OFFENDER_WINDOW_DAYS && (
+                  <HelpTooltip
+                    text={`This device enrolled ${ageDays} day${ageDays === 1 ? '' : 's'} ago, so the ${OFFENDER_WINDOW_DAYS}-day windows only span its lifetime so far.`}
+                  />
+                )}
+              </div>
               <div className="text-sm font-medium tabular-nums">{snapshot.uptime30d.toFixed(1)}%</div>
             </div>
             <div>
@@ -419,10 +560,82 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
           <div key={issue.type} className="rounded-md border p-3">
             <p className="text-sm font-medium">{issueLabels[issue.type]}</p>
             <p className="mt-1 text-xs capitalize text-muted-foreground">{issue.severity}</p>
-            <p className="mt-3 text-lg font-semibold tabular-nums">{issue.count}</p>
+            <p className="mt-3 text-lg font-semibold tabular-nums" title={issue.count.toLocaleString()}>
+              {formatCount(issue.count)}
+            </p>
           </div>
         ))}
       </div>
+
+      {offenderEventTotal > 0 && (
+        <div className="mt-4 border-t pt-3">
+          <button
+            type="button"
+            data-testid="reliability-offenders-toggle"
+            aria-expanded={offendersOpen}
+            onClick={toggleOffenders}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            <ChevronDown className={`h-4 w-4 transition-transform ${offendersOpen ? 'rotate-180' : ''}`} />
+            {offendersOpen ? 'Hide' : 'Show'} offending services &amp; components
+          </button>
+
+          {offendersOpen && (
+            <div data-testid="reliability-offenders" className="mt-3 space-y-4">
+              {offendersLoading && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  Loading detail…
+                </div>
+              )}
+              {offendersError && (
+                <div className="flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
+                  <span className="text-destructive">{offendersError}</span>
+                  <button
+                    type="button"
+                    onClick={() => void loadOffenders()}
+                    className="inline-flex items-center gap-1.5 self-start rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-muted"
+                  >
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    Retry
+                  </button>
+                </div>
+              )}
+              {!offendersLoading && !offendersError && offenders && (
+                offenders.services.length + offenders.hardware.length + offenders.hangs.length > 0 ? (
+                  <>
+                    <OffenderGroup
+                      testId="reliability-offenders-services"
+                      title="Top services"
+                      Icon={Settings}
+                      offenders={offenders.services}
+                    />
+                    <OffenderGroup
+                      testId="reliability-offenders-hardware"
+                      title="Top hardware components"
+                      Icon={Cpu}
+                      offenders={offenders.hardware}
+                    />
+                    <OffenderGroup
+                      testId="reliability-offenders-hangs"
+                      title="Top processes"
+                      Icon={Activity}
+                      offenders={offenders.hangs}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Distinct events over the last {OFFENDER_WINDOW_DAYS} days.
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No offending services or components recorded in the last {OFFENDER_WINDOW_DAYS} days.
+                  </p>
+                )
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -303,13 +303,33 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
       const response = await fetchWithAuth(`/reliability/${deviceId}/offenders`);
       if (!response.ok) throw new Error('Failed to load reliability detail');
       const json = await response.json();
-      setOffenders((json?.offenders as ReliabilityOffenders | undefined) ?? null);
+      // A 200 with a missing/malformed body must not render a blank, retry-less
+      // panel — treat it as a failure so the existing error+retry path handles it.
+      const data = json?.offenders;
+      if (!data || typeof data !== 'object') {
+        throw new Error('Reliability detail response was malformed');
+      }
+      setOffenders({
+        services: Array.isArray(data.services) ? data.services : [],
+        hardware: Array.isArray(data.hardware) ? data.hardware : [],
+        hangs: Array.isArray(data.hangs) ? data.hangs : [],
+      });
     } catch (err) {
       offendersFetchedRef.current = false; // allow a retry on next expand
       setOffendersError(err instanceof Error ? err.message : 'Failed to load reliability detail');
     } finally {
       setOffendersLoading(false);
     }
+  }, [deviceId]);
+
+  // Reset the drill-down when the panel is pointed at a different device, so a
+  // stale offender list (and the fetched-once guard) can't bleed across devices.
+  useEffect(() => {
+    setOffendersOpen(false);
+    setOffenders(null);
+    setOffendersError(undefined);
+    setOffendersLoading(false);
+    offendersFetchedRef.current = false;
   }, [deviceId]);
 
   const toggleOffenders = useCallback(() => {
@@ -404,6 +424,12 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
 
   const ageDays = deviceAgeDays(snapshot.enrolledAt);
   const uptimeWindow = windowLabel(OFFENDER_WINDOW_DAYS, ageDays);
+  // Phrase the drill-down window the same way as the tiles: observed age on a
+  // young device, otherwise the fixed window.
+  const offenderWindowText =
+    ageDays !== null && ageDays < OFFENDER_WINDOW_DAYS
+      ? `since enroll (${ageDays}d)`
+      : `last ${OFFENDER_WINDOW_DAYS} days`;
   const offenderEventTotal =
     snapshot.serviceFailureCount30d + snapshot.hardwareErrorCount30d + snapshot.hangCount30d;
 
@@ -623,12 +649,12 @@ export default function DeviceReliabilityPanel({ deviceId }: DeviceReliabilityPa
                       offenders={offenders.hangs}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Distinct events over the last {OFFENDER_WINDOW_DAYS} days.
+                      Distinct events from the {offenderWindowText}.
                     </p>
                   </>
                 ) : (
                   <p className="text-sm text-muted-foreground">
-                    No offending services or components recorded in the last {OFFENDER_WINDOW_DAYS} days.
+                    No offending services or components recorded in the {offenderWindowText}.
                   </p>
                 )
               )}


### PR DESCRIPTION
## What

Fast-follow to #1904 / #1905 addressing the "users will see a scary, unactionable number" concern on the device Reliability panel (issue #1907).

**1. Cap alarming counts in the summary tiles.** A raw `service failure count: 1,228` reads as either "machine on fire" or "this number is broken." Counts ≥ 1000 now render as `999+` in the tiles, with the exact figure preserved in the `title` attribute and the new drill-down.

**2. Age-aware window labels.** On a device younger than the window, the fixed `30d` label is relabeled to the observed age (e.g. `since enroll · 13d`) so counts on a 13-day-old box aren't read as a full month. Driven by the device's `enrolledAt`, now surfaced on the reliability snapshot.

**3. Offender drill-down (the actual path to the problem).** New `GET /reliability/:deviceId/offenders` returns the **top offending services, hardware components, and processes**, distinct-deduped with the *same* event keys as #1905 so the per-offender counts line up with the headline tiles. The panel lazily loads this on expand (no extra request on mount / for healthy devices) and shows *which* service is flapping / *which* component is erroring, with last-seen and a recovered/unresolved qualifier.

## Files

- `apps/api/src/services/reliabilityScoring.ts` — `aggregateReliabilityOffenders` (pure, distinct-deduped) + `getDeviceReliabilityOffenders`; `enrolledAt` added to the snapshot.
- `apps/api/src/routes/reliability.ts` — `GET /:deviceId/offenders` (same auth/site-access guard + Zod-validated `days`/`limit`).
- `apps/web/src/components/devices/DeviceReliabilityPanel.tsx` — count capping, age-aware labels, lazy offender drill-down.
- Tests added in all three co-located test files.

## Verification

- `apps/api`: `reliabilityScoring.test.ts` + `reliability.test.ts` — 107 passed (offender aggregation, #1905 dedup parity, route auth/validation/passthrough).
- `apps/web`: `DeviceReliabilityPanel.test.tsx` — 16 passed (capping, age labels, lazy offenders fetch + render, no-fetch-on-mount).
- `tsc --noEmit` clean for both apps; ESLint clean on all touched files.

No schema/migration or agent changes. The "+ sparkline" mentioned in the issue is intentionally deferred — the offender list with distinct counts + last-seen already answers "which service / which component"; a per-offender trend sparkline can be a follow-up.

## Note

UI change — recommend a quick visual pass on the device Reliability panel before merge (capping, the `since enroll · Nd` label, and the expand/collapse drill-down). Logic is unit-covered; the rendering itself was not browser-verified.

Closes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)