### PR TITLE
feat(tunnel-proxy): per-session TLS verification + explicit scheme (#1916)

### DIFF
--- a/agent/internal/heartbeat/handlers_httpproxy.go
+++ b/agent/internal/heartbeat/handlers_httpproxy.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
 	targetPortF, _ := cmd.Payload["targetPort"].(float64)
 	targetPort := int(targetPortF)
 	scheme, _ := cmd.Payload["scheme"].(string)
+	skipTLSVerify, _ := cmd.Payload["skipTlsVerify"].(bool)
 	method, _ := cmd.Payload["method"].(string)
 	path, _ := cmd.Payload["path"].(string)
 
@@ -116,13 +118,14 @@ func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
 	defer cancel()
 
 	return fetchAndEncodeHttp(ctx, tunnel.FetchRequest{
-		Scheme:  scheme,
-		Host:    targetHost,
-		Port:    targetPort,
-		Method:  method,
-		Path:    path,
-		Headers: headers,
-		Body:    body,
+		Scheme:        scheme,
+		Host:          targetHost,
+		Port:          targetPort,
+		Method:        method,
+		Path:          path,
+		Headers:       headers,
+		Body:          body,
+		SkipTLSVerify: skipTLSVerify,
 	}, start)
 }
 
@@ -134,9 +137,15 @@ func handleHttpRequest(_ *Heartbeat, cmd Command) tools.CommandResult {
 func fetchAndEncodeHttp(ctx context.Context, req tunnel.FetchRequest, start time.Time) tools.CommandResult {
 	resp, err := tunnel.Fetch(ctx, req, httpProxyTimeout, httpProxyMaxBody)
 	if err != nil {
+		errStr := err.Error()
+		if errors.Is(err, tunnel.ErrTLSCertUntrusted) {
+			// Stable token the API matches to surface a "recreate with self-signed
+			// allowed" banner. Keep it exactly "tls_cert_untrusted".
+			errStr = "tls_cert_untrusted"
+		}
 		return tools.CommandResult{
 			Status:     "failed",
-			Error:      err.Error(),
+			Error:      errStr,
 			DurationMs: time.Since(start).Milliseconds(),
 		}
 	}

--- a/agent/internal/heartbeat/handlers_httpproxy.go
+++ b/agent/internal/heartbeat/handlers_httpproxy.go
@@ -138,9 +138,13 @@ func fetchAndEncodeHttp(ctx context.Context, req tunnel.FetchRequest, start time
 	resp, err := tunnel.Fetch(ctx, req, httpProxyTimeout, httpProxyMaxBody)
 	if err != nil {
 		errStr := err.Error()
+		// Defensive guard: normalise the error to the stable API token.
+		// Today Fetch returns ErrTLSCertUntrusted unwrapped, so err.Error() already
+		// equals "tls_cert_untrusted" and the branch is belt-and-suspenders; but if
+		// Fetch ever wraps the sentinel with %w, errors.Is still catches it while a
+		// bare string comparison would not, keeping the stable "tls_cert_untrusted"
+		// token intact for the API's string match.
 		if errors.Is(err, tunnel.ErrTLSCertUntrusted) {
-			// Stable token the API matches to surface a "recreate with self-signed
-			// allowed" banner. Keep it exactly "tls_cert_untrusted".
 			errStr = "tls_cert_untrusted"
 		}
 		return tools.CommandResult{

--- a/agent/internal/heartbeat/handlers_httpproxy_test.go
+++ b/agent/internal/heartbeat/handlers_httpproxy_test.go
@@ -259,6 +259,29 @@ func TestHandleHttpRequest(t *testing.T) {
 	})
 }
 
+func TestFetchAndEncodeHttp_TLSCertUntrusted(t *testing.T) {
+	// Self-signed TLS server; SkipTLSVerify=false must yield the typed token.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "https://"))
+	port, _ := strconv.Atoi(portStr)
+
+	res := fetchAndEncodeHttp(context.Background(), tunnel.FetchRequest{
+		Scheme: "https", Host: host, Port: port, Method: "GET", Path: "/",
+		SkipTLSVerify: false,
+	}, time.Now())
+
+	if res.Status != "failed" {
+		t.Fatalf("want failed, got %q", res.Status)
+	}
+	if res.Error != "tls_cert_untrusted" {
+		t.Fatalf("want error token tls_cert_untrusted, got %q", res.Error)
+	}
+}
+
 // nonLoopbackIPv4 returns the first non-loopback IPv4 address on the machine,
 // or "" if none is found.
 func nonLoopbackIPv4(t *testing.T) string {

--- a/agent/internal/heartbeat/handlers_httpproxy_test.go
+++ b/agent/internal/heartbeat/handlers_httpproxy_test.go
@@ -183,6 +183,93 @@ func TestHandleHttpRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("skipTlsVerify=true threads through handler and accepts self-signed HTTPS cert (Leg A)", func(t *testing.T) {
+		// Leg A: proves skipTlsVerify flows from cmd.Payload through handleHttpRequest
+		// into tunnel.FetchRequest.SkipTLSVerify. The self-signed cert used by
+		// httptest.StartTLS() would be rejected by default TLS verification; if the
+		// flag did NOT thread through, this subtest would get "failed"/"tls_cert_untrusted"
+		// instead of "completed". Non-vacuity: flip skipTlsVerify to false (or remove
+		// it) and the test fails — the completed result is only achievable because the
+		// flag disabled cert verification all the way down.
+		host := nonLoopbackIPv4(t)
+		if host == "" {
+			t.Skip("no non-loopback IPv4 address available; skipping TLS threading test")
+		}
+
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		ln, err := net.Listen("tcp", "0.0.0.0:0")
+		if err != nil {
+			t.Skipf("cannot bind TLS test server: %v", err)
+		}
+		srv.Listener = ln
+		srv.StartTLS()
+		defer srv.Close()
+
+		port := srv.Listener.Addr().(*net.TCPAddr).Port
+		allowlistRule := host + "/32:" + strconv.Itoa(port)
+
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost":     host,
+				"targetPort":     float64(port),
+				"scheme":         "https",
+				"skipTlsVerify":  true,
+				"method":         "GET",
+				"path":           "/",
+				"allowlistRules": []any{allowlistRule},
+			},
+		})
+
+		if result.Status != "completed" {
+			t.Fatalf("Leg A: status = %q, error = %q; want completed (skipTlsVerify must reach Fetch to accept the self-signed cert)", result.Status, result.Error)
+		}
+	})
+
+	t.Run("skipTlsVerify=false (default) rejects self-signed HTTPS cert with stable token (Leg B)", func(t *testing.T) {
+		// Leg B: proves the verify-on path through handleHttpRequest yields the stable
+		// "tls_cert_untrusted" error token. Mirrors Leg A's setup but omits
+		// skipTlsVerify so it defaults to false, which should trigger cert rejection.
+		host := nonLoopbackIPv4(t)
+		if host == "" {
+			t.Skip("no non-loopback IPv4 address available; skipping TLS threading test")
+		}
+
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		ln, err := net.Listen("tcp", "0.0.0.0:0")
+		if err != nil {
+			t.Skipf("cannot bind TLS test server: %v", err)
+		}
+		srv.Listener = ln
+		srv.StartTLS()
+		defer srv.Close()
+
+		port := srv.Listener.Addr().(*net.TCPAddr).Port
+		allowlistRule := host + "/32:" + strconv.Itoa(port)
+
+		result := handleHttpRequest(&Heartbeat{}, Command{
+			Payload: map[string]any{
+				"targetHost": host,
+				"targetPort": float64(port),
+				"scheme":     "https",
+				// skipTlsVerify omitted → defaults to false → cert verification ON
+				"method":         "GET",
+				"path":           "/",
+				"allowlistRules": []any{allowlistRule},
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("Leg B: status = %q, want failed (self-signed cert must be rejected when skipTlsVerify=false)", result.Status)
+		}
+		if result.Error != "tls_cert_untrusted" {
+			t.Fatalf("Leg B: error = %q, want tls_cert_untrusted (stable API token must be returned)", result.Error)
+		}
+	})
+
 	t.Run("allowed target returns completed result with decoded body", func(t *testing.T) {
 		const responseBody = "hello from proxy"
 

--- a/agent/internal/tunnel/httpfetch.go
+++ b/agent/internal/tunnel/httpfetch.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -14,6 +16,11 @@ import (
 	"time"
 )
 
+// ErrTLSCertUntrusted is returned by Fetch when the target presents a
+// certificate that fails verification (self-signed / unknown CA / bad host)
+// and the session did not opt into skipping verification.
+var ErrTLSCertUntrusted = errors.New("tls_cert_untrusted")
+
 // FetchRequest is one proxied HTTP request to a LAN target.
 type FetchRequest struct {
 	Scheme  string              // "http" | "https" (derived from target port if empty)
@@ -23,6 +30,9 @@ type FetchRequest struct {
 	Path    string              // path + raw query, e.g. "/admin/index.html?x=1"
 	Headers map[string][]string // forwarded request headers (already filtered by caller)
 	Body    []byte              // request body (may be nil)
+	// SkipTLSVerify disables TLS certificate verification for this request.
+	// Set per-session for known self-signed embedded LAN devices. Default false.
+	SkipTLSVerify bool
 }
 
 // FetchResponse holds the proxied response.
@@ -108,11 +118,10 @@ func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody
 	client := &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			// Self-signed printer/device certs are the norm on a LAN. The tunnel
-			// target is already constrained to the tunnel_session's host:port and
-			// re-checked against the org allowlist, so cert pinning adds no security
-			// here while breaking every real device. Skip verification deliberately.
-			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			// TLS verification is ON by default. It is disabled only when the
+			// owning tunnel session explicitly opted in (req.SkipTLSVerify) for a
+			// known self-signed embedded LAN device — a per-session, audited choice.
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: req.SkipTLSVerify}, //nolint:gosec
 			DisableKeepAlives: true,
 			Proxy:             nil,
 		},
@@ -122,6 +131,12 @@ func Fetch(ctx context.Context, req FetchRequest, timeout time.Duration, maxBody
 
 	resp, err := client.Do(hreq)
 	if err != nil {
+		var unknownAuth x509.UnknownAuthorityError
+		var hostErr x509.HostnameError
+		var certInvalid x509.CertificateInvalidError
+		if errors.As(err, &unknownAuth) || errors.As(err, &hostErr) || errors.As(err, &certInvalid) {
+			return nil, ErrTLSCertUntrusted
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/agent/internal/tunnel/httpfetch_test.go
+++ b/agent/internal/tunnel/httpfetch_test.go
@@ -2,7 +2,9 @@ package tunnel
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -135,9 +137,9 @@ func TestFetch(t *testing.T) {
 		}
 	})
 
-	t.Run("self-signed TLS accepted", func(t *testing.T) {
+	t.Run("self-signed TLS accepted with SkipTLSVerify", func(t *testing.T) {
 		h, p := hostPort(tlsSrv.URL)
-		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "https", Host: h, Port: p, Method: "GET", Path: "/"}, 5*time.Second, 1<<20)
+		resp, err := Fetch(context.Background(), FetchRequest{Scheme: "https", Host: h, Port: p, Method: "GET", Path: "/", SkipTLSVerify: true}, 5*time.Second, 1<<20)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,4 +227,33 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("target saw request URI %v, want one containing %%2F", got)
 		}
 	})
+}
+
+func TestFetch_TLSVerification(t *testing.T) {
+	// httptest TLS server presents a self-signed cert (unknown CA).
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "https://"))
+	port, _ := strconv.Atoi(portStr)
+	base := FetchRequest{Scheme: "https", Host: host, Port: port, Method: "GET", Path: "/"}
+
+	// Verify ON (default): self-signed cert must be rejected as a typed error.
+	if _, err := Fetch(context.Background(), base, 5*time.Second, 1<<20); !errors.Is(err, ErrTLSCertUntrusted) {
+		t.Fatalf("verify-on: want ErrTLSCertUntrusted, got %v", err)
+	}
+
+	// Verify OFF (explicit opt-in): self-signed cert is accepted.
+	skip := base
+	skip.SkipTLSVerify = true
+	resp, err := Fetch(context.Background(), skip, 5*time.Second, 1<<20)
+	if err != nil {
+		t.Fatalf("verify-off: unexpected error %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("verify-off: want 200, got %d", resp.Status)
+	}
 }

--- a/apps/api/migrations/2026-06-25-tunnel-session-tls-verify.sql
+++ b/apps/api/migrations/2026-06-25-tunnel-session-tls-verify.sql
@@ -1,0 +1,22 @@
+-- Per-session TLS verification + explicit scheme for the tunnel http-proxy (#1916).
+-- scheme: 'http' | 'https' for proxy sessions (NULL for VNC / pre-existing rows).
+-- skip_tls_verify: explicit per-session opt-out of cert verification for known
+-- self-signed embedded LAN devices. Default false = verify (secure by default).
+
+ALTER TABLE tunnel_sessions
+  ADD COLUMN IF NOT EXISTS scheme varchar(5);
+
+ALTER TABLE tunnel_sessions
+  ADD COLUMN IF NOT EXISTS skip_tls_verify boolean NOT NULL DEFAULT false;
+
+-- Constrain scheme to the two valid values (defense-in-depth; the app validates too).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tunnel_sessions_scheme_check'
+  ) THEN
+    ALTER TABLE tunnel_sessions
+      ADD CONSTRAINT tunnel_sessions_scheme_check
+      CHECK (scheme IS NULL OR scheme IN ('http', 'https'));
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/tunnels.ts
+++ b/apps/api/src/db/schema/tunnels.ts
@@ -16,6 +16,12 @@ export const tunnelSessions = pgTable('tunnel_sessions', {
   status: tunnelStatusEnum('status').notNull().default('pending'),
   targetHost: varchar('target_host', { length: 255 }).notNull(),
   targetPort: integer('target_port').notNull(),
+  // http/https for proxy sessions; null for VNC and pre-existing rows (callers
+  // fall back to port inference when null).
+  scheme: varchar('scheme', { length: 5 }),
+  // When true, the agent skips TLS cert verification for this session's HTTPS
+  // target (explicit opt-in for known self-signed embedded LAN devices).
+  skipTlsVerify: boolean('skip_tls_verify').notNull().default(false),
   sourceIp: varchar('source_ip', { length: 45 }),
   bytesSent: bigint('bytes_sent', { mode: 'number' }).default(0),
   bytesRecv: bigint('bytes_recv', { mode: 'number' }).default(0),

--- a/apps/api/src/routes/tunnelHttp.test.ts
+++ b/apps/api/src/routes/tunnelHttp.test.ts
@@ -18,6 +18,8 @@ let joinRow:
         type: string;
         targetHost: string;
         targetPort: number;
+        scheme: string | null;
+        skipTlsVerify: boolean;
       };
       device: { id: string; status: string; agentId: string | null };
     }
@@ -27,7 +29,9 @@ function setJoinRow(row: typeof joinRow) {
   joinRow = row;
 }
 
-function defaultJoinRow(over: Partial<{ port: number; deviceStatus: string; ownerId: string; status: string }> = {}) {
+function defaultJoinRow(
+  over: Partial<{ port: number; deviceStatus: string; ownerId: string; status: string; scheme: string | null; skipTlsVerify: boolean }> = {},
+) {
   return {
     session: {
       userId: over.ownerId ?? USER_ID,
@@ -36,10 +40,15 @@ function defaultJoinRow(over: Partial<{ port: number; deviceStatus: string; owne
       type: 'proxy',
       targetHost: '192.168.1.50',
       targetPort: over.port ?? 80,
+      scheme: 'scheme' in over ? (over.scheme ?? null) : null,
+      skipTlsVerify: over.skipTlsVerify ?? false,
     },
     device: { id: DEVICE_ID, status: over.deviceStatus ?? 'online', agentId: AGENT_ID },
   };
 }
+
+// Captures the values passed to db.update(...).set(values) for assertion.
+let capturedSessionUpdate: Record<string, unknown> | null = null;
 
 vi.mock('../db', () => ({
   db: {
@@ -51,6 +60,12 @@ vi.mock('../db', () => ({
           })),
         })),
       })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        capturedSessionUpdate = values;
+        return { where: vi.fn(async () => {}) };
+      }),
     })),
   },
   withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
@@ -117,6 +132,7 @@ function okAgentResult(over: Partial<{ status: number; headers: Record<string, s
 
 beforeEach(() => {
   vi.clearAllMocks();
+  capturedSessionUpdate = null;
   setJoinRow(defaultJoinRow());
   isAgentConnectedMock.mockReturnValue(true);
   checkRemoteAccessMock.mockResolvedValue({ allowed: true });
@@ -384,5 +400,44 @@ describe('tunnelHttp response rewriting', () => {
     const sc = res.headers.get('set-cookie') ?? '';
     expect(sc).toContain('bzdev_sid=abc');
     expect(sc).toContain(`Path=/api/v1/tunnel-http/${TUNNEL_ID}/`);
+  });
+});
+
+describe('tunnelHttp TLS + skipTlsVerify (#1916)', () => {
+  it('maps a tls_cert_untrusted agent result to session-failed + 502', async () => {
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    sendCommandMock.mockResolvedValueOnce({ status: 'failed', error: 'tls_cert_untrusted' });
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('Untrusted');
+    expect(capturedSessionUpdate).toMatchObject({
+      status: 'failed',
+      errorMessage: 'tls_cert_untrusted',
+    });
+    // endedAt must be a Date (not null/undefined)
+    expect(capturedSessionUpdate?.endedAt).toBeInstanceOf(Date);
+  });
+
+  it('forwards session.scheme and skipTlsVerify in the http_request payload', async () => {
+    setJoinRow(defaultJoinRow({ scheme: 'https', skipTlsVerify: true }));
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    setJoinRow(defaultJoinRow({ scheme: 'https', skipTlsVerify: true }));
+    const res = await app.request(`${BASE}/`, { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const [, command] = sendCommandMock.mock.calls.at(-1)!;
+    expect(command.payload.scheme).toBe('https');
+    expect(command.payload.skipTlsVerify).toBe(true);
+  });
+
+  it('falls back to port-based scheme when session.scheme is null', async () => {
+    setJoinRow(defaultJoinRow({ port: 443, scheme: null }));
+    const app = makeApp();
+    const cookie = await mintCookie(app);
+    setJoinRow(defaultJoinRow({ port: 443, scheme: null }));
+    await app.request(`${BASE}/`, { headers: { cookie } });
+    const [, command] = sendCommandMock.mock.calls.at(-1)!;
+    expect(command.payload.scheme).toBe('https');
   });
 });

--- a/apps/api/src/routes/tunnelHttp.ts
+++ b/apps/api/src/routes/tunnelHttp.ts
@@ -347,9 +347,16 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
       // Surface via the session row so ProxyTunnelPage's existing poll renders
       // the "recreate with self-signed allowed" banner. A cert failure on load
       // is terminal for the session — the cert won't become trusted on retry.
-      await db.update(tunnelSessions)
-        .set({ status: 'failed', errorMessage: 'tls_cert_untrusted', endedAt: new Date() })
-        .where(eq(tunnelSessions.id, tunnelId));
+      //
+      // Must run under system DB context: this route mounts before auth
+      // middleware so there is no request-scoped RLS context. Without system
+      // context this becomes a silent 0-row write once tunnel_sessions gains
+      // RLS, causing the recreate banner to never appear (#1916 follow-up).
+      await withSystemDbAccessContext(async () => {
+        await db.update(tunnelSessions)
+          .set({ status: 'failed', errorMessage: 'tls_cert_untrusted', endedAt: new Date() })
+          .where(eq(tunnelSessions.id, tunnelId));
+      });
       return c.text('Untrusted upstream certificate', 502);
     }
     return c.text('Bridge agent error', 502);

--- a/apps/api/src/routes/tunnelHttp.ts
+++ b/apps/api/src/routes/tunnelHttp.ts
@@ -139,6 +139,8 @@ interface UsableTunnel {
   deviceStatus: string;
   targetHost: string;
   targetPort: number;
+  scheme: string | null;
+  skipTlsVerify: boolean;
   orgId: string;
   type: string;
 }
@@ -170,6 +172,8 @@ async function loadOwnedTunnelSession(tunnelId: string, userId: string): Promise
       deviceStatus: device.status,
       targetHost: session.targetHost,
       targetPort: session.targetPort,
+      scheme: session.scheme ?? null,
+      skipTlsVerify: session.skipTlsVerify ?? false,
       orgId: session.orgId,
       type: session.type,
     };
@@ -311,7 +315,7 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
     bodyB64 = buf.toString('base64');
   }
 
-  const scheme: 'http' | 'https' = session.targetPort === 443 ? 'https' : 'http';
+  const scheme: 'http' | 'https' = (session.scheme as 'http' | 'https' | null) ?? (session.targetPort === 443 ? 'https' : 'http');
 
   const awaitResult = await sendCommandToAgentAwaitResult(
     session.agentId,
@@ -327,6 +331,7 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
         path,
         headers,
         bodyB64,
+        skipTlsVerify: session.skipTlsVerify,
         allowlistRules: await getActiveAllowlistPatterns(session.orgId),
       },
     },
@@ -337,6 +342,15 @@ tunnelHttpRoutes.all('/:tunnelId/*', async (c) => {
     const err = awaitResult.error ?? '';
     if (/timeout/i.test(err)) {
       return c.text('Upstream timeout', 504);
+    }
+    if (err === 'tls_cert_untrusted') {
+      // Surface via the session row so ProxyTunnelPage's existing poll renders
+      // the "recreate with self-signed allowed" banner. A cert failure on load
+      // is terminal for the session — the cert won't become trusted on retry.
+      await db.update(tunnelSessions)
+        .set({ status: 'failed', errorMessage: 'tls_cert_untrusted', endedAt: new Date() })
+        .where(eq(tunnelSessions.id, tunnelId));
+      return c.text('Untrusted upstream certificate', 502);
     }
     return c.text('Bridge agent error', 502);
   }

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1597,3 +1597,101 @@ describe('POST /tunnels/:id/http-ticket', () => {
     expect(audits[0].details).toEqual(expect.objectContaining({ deviceId: DEVICE_ID }));
   });
 });
+
+// ─── POST /tunnels — proxy scheme/skipTlsVerify persistence (#1916) ──────────
+
+describe('POST /tunnels — proxy scheme/skipTlsVerify persistence', () => {
+  let app: Hono;
+
+  // Allowlist rule that permits any port on 10.0.0.0/8
+  const destAllowlistRule = {
+    id: 'r1r1r1r1-r1r1-4r1r-8r1r-r1r1r1r1r1r1',
+    orgId: ORG_ID,
+    direction: 'destination',
+    enabled: true,
+    pattern: '10.0.0.0/8:*',
+  };
+
+  // Return the non-audit values payload from the session insert call.
+  // Mirrors auditCalls() but selects rows WITHOUT an `action` field.
+  function sessionInsertValues(insertMock: any): any[] {
+    const calls: any[] = [];
+    const seen = new Set<any>();
+    for (const result of insertMock.mock.results) {
+      const chain = result.value;
+      if (!chain?.values?.mock || seen.has(chain)) continue;
+      seen.add(chain);
+      for (const call of chain.values.mock.calls) {
+        const arg = call[0];
+        if (arg && typeof arg === 'object' && !('action' in arg)) calls.push(arg);
+      }
+    }
+    return calls;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.insert).mockReset();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+  });
+
+  it('persists resolved scheme + skipTlsVerify for an https proxy session', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([onlineDevice]) as any)       // device lookup
+      .mockReturnValueOnce(makeSelectChain([]) as any)                   // source-IP allowlist (no rules = allowed)
+      .mockReturnValueOnce(makeSelectChain([destAllowlistRule]) as any)  // destination allowlist
+      .mockReturnValueOnce(makeSelectChain([]) as any);                  // getActiveAllowlistPatterns
+    const proxySession = { ...sessionRecord, type: 'proxy', targetHost: '10.0.0.5', targetPort: 8443, scheme: 'https', skipTlsVerify: true };
+    const insertMock = vi.fn().mockReturnValue(makeAuditAwareInsertChain([proxySession]));
+    vi.mocked(db.insert).mockImplementation(insertMock as any);
+
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        deviceId: DEVICE_ID,
+        type: 'proxy',
+        targetHost: '10.0.0.5',
+        targetPort: 8443,
+        scheme: 'https',
+        skipTlsVerify: true,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const sessionVals = sessionInsertValues(insertMock);
+    expect(sessionVals).toHaveLength(1);
+    expect(sessionVals[0]).toMatchObject({ scheme: 'https', skipTlsVerify: true });
+  });
+
+  it('forces skipTlsVerify false when scheme is http', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([onlineDevice]) as any)       // device lookup
+      .mockReturnValueOnce(makeSelectChain([]) as any)                   // source-IP allowlist
+      .mockReturnValueOnce(makeSelectChain([destAllowlistRule]) as any)  // destination allowlist
+      .mockReturnValueOnce(makeSelectChain([]) as any);                  // getActiveAllowlistPatterns
+    const proxySession = { ...sessionRecord, type: 'proxy', targetHost: '10.0.0.5', targetPort: 80, scheme: 'http', skipTlsVerify: false };
+    const insertMock = vi.fn().mockReturnValue(makeAuditAwareInsertChain([proxySession]));
+    vi.mocked(db.insert).mockImplementation(insertMock as any);
+
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        deviceId: DEVICE_ID,
+        type: 'proxy',
+        targetHost: '10.0.0.5',
+        targetPort: 80,
+        scheme: 'http',
+        skipTlsVerify: true, // should be normalized away
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const sessionVals = sessionInsertValues(insertMock);
+    expect(sessionVals).toHaveLength(1);
+    expect(sessionVals[0]).toMatchObject({ scheme: 'http', skipTlsVerify: false });
+  });
+});

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1664,6 +1664,9 @@ describe('POST /tunnels — proxy scheme/skipTlsVerify persistence', () => {
     const sessionVals = sessionInsertValues(insertMock);
     expect(sessionVals).toHaveLength(1);
     expect(sessionVals[0]).toMatchObject({ scheme: 'https', skipTlsVerify: true });
+    const audits = auditCalls(insertMock);
+    expect(audits).toHaveLength(1);
+    expect(audits[0].details).toEqual(expect.objectContaining({ scheme: 'https', skipTlsVerify: true }));
   });
 
   it('forces skipTlsVerify false when scheme is http', async () => {
@@ -1693,5 +1696,8 @@ describe('POST /tunnels — proxy scheme/skipTlsVerify persistence', () => {
     const sessionVals = sessionInsertValues(insertMock);
     expect(sessionVals).toHaveLength(1);
     expect(sessionVals[0]).toMatchObject({ scheme: 'http', skipTlsVerify: false });
+    const audits = auditCalls(insertMock);
+    expect(audits).toHaveLength(1);
+    expect(audits[0].details).toEqual(expect.objectContaining({ scheme: 'http', skipTlsVerify: false }));
   });
 });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -39,6 +39,8 @@ const createTunnelSchema = z.discriminatedUnion('type', [
     type: z.literal('proxy'),
     targetHost: z.string().max(255),
     targetPort: z.number().int().min(1).max(65535),
+    scheme: z.enum(['http', 'https']).optional(),
+    skipTlsVerify: z.boolean().optional(),
   }),
 ]);
 
@@ -330,6 +332,14 @@ tunnelRoutes.post(
     const targetHost = isVNC ? '127.0.0.1' : body.targetHost;
     const targetPort = isVNC ? 5900 : body.targetPort;
 
+    // Resolve scheme (explicit, else infer from port) and normalize the skip
+    // flag: it is only meaningful for https — forced false otherwise.
+    const scheme = isVNC
+      ? null
+      : (body.scheme ?? (targetPort === 443 ? 'https' : 'http'));
+    const skipTlsVerify =
+      !isVNC && scheme === 'https' ? (body.skipTlsVerify ?? false) : false;
+
     // Source IP check
     if (!(await isSourceIpAllowed(sourceIp, device.orgId))) {
       return c.json({ error: 'Source IP not permitted' }, 403);
@@ -358,6 +368,8 @@ tunnelRoutes.post(
         status: 'pending',
         targetHost,
         targetPort,
+        scheme,
+        skipTlsVerify,
         sourceIp: sourceIp,
       })
       .returning();
@@ -388,7 +400,7 @@ tunnelRoutes.post(
       session!.id,
       auth.user.id,
       device.orgId,
-      { deviceId: device.id, type: body.type, targetHost, targetPort },
+      { deviceId: device.id, type: body.type, targetHost, targetPort, scheme, skipTlsVerify },
       sourceIp,
     );
 

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -176,6 +176,79 @@ describe('AssetDetailModal — proxy bridge agent (decoupled from link)', () => 
   });
 });
 
+describe('AssetDetailModal — proxy scheme + self-signed certificate (#1916)', () => {
+  const onlineDevices = [{ id: 'dev-online', name: 'FC-ESME', online: true }];
+
+  const assetWithHttpsPort: AssetDetail = {
+    id: 'asset-https',
+    ip: '192.168.1.100',
+    mac: '—',
+    hostname: 'printer-ilo',
+    type: 'unknown',
+    approvalStatus: 'pending',
+    isOnline: true,
+    manufacturer: '—',
+    linkedDeviceId: null,
+    openPorts: [{ port: 443, service: 'https' }],
+    ...({ proxyEnabled: true } as Record<string, unknown>),
+  };
+
+  it('posts scheme + skipTlsVerify when self-signed allowed', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ id: 'tun-1' }));
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<AssetDetailModal open asset={assetWithHttpsPort} devices={onlineDevices} onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId('proxy-scheme-select'), { target: { value: 'https' } });
+    fireEvent.click(screen.getByTestId('proxy-allow-self-signed'));
+    fireEvent.click(screen.getByTestId('proxy-connect-btn'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tunnels', expect.any(Object)));
+    const call = fetchMock.mock.calls.find(c => c[0] === '/tunnels');
+    expect(call).toBeDefined();
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body).toMatchObject({ type: 'proxy', scheme: 'https', skipTlsVerify: true });
+    openSpy.mockRestore();
+  });
+
+  it('does not send skipTlsVerify:true when scheme is http', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ id: 'tun-2' }));
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<AssetDetailModal open asset={assetWithHttpsPort} devices={onlineDevices} onClose={() => {}} />);
+
+    // Select http explicitly
+    fireEvent.change(screen.getByTestId('proxy-scheme-select'), { target: { value: 'http' } });
+    fireEvent.click(screen.getByTestId('proxy-connect-btn'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tunnels', expect.any(Object)));
+    const call = fetchMock.mock.calls.find(c => c[0] === '/tunnels');
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body.scheme).toBe('http');
+    expect(body.skipTlsVerify).toBe(false);
+    openSpy.mockRestore();
+  });
+
+  it('shows self-signed checkbox only when scheme is https', async () => {
+    render(<AssetDetailModal open asset={assetWithHttpsPort} devices={onlineDevices} onClose={() => {}} />);
+
+    // Default is http (or derived from port), checkbox not visible
+    const schemeSelect = screen.getByTestId('proxy-scheme-select');
+
+    // Switch to https → checkbox appears
+    fireEvent.change(schemeSelect, { target: { value: 'https' } });
+    expect(screen.getByTestId('proxy-allow-self-signed')).toBeInTheDocument();
+
+    // Switch back to http → checkbox hidden
+    fireEvent.change(schemeSelect, { target: { value: 'http' } });
+    expect(screen.queryByTestId('proxy-allow-self-signed')).not.toBeInTheDocument();
+  });
+
+  it('defaults scheme to https when the selected port is 443', () => {
+    render(<AssetDetailModal open asset={assetWithHttpsPort} devices={onlineDevices} onClose={() => {}} />);
+    const schemeSelect = screen.getByTestId('proxy-scheme-select') as HTMLSelectElement;
+    expect(schemeSelect.value).toBe('https');
+  });
+});
+
 describe('AssetDetailModal — SNMP data card', () => {
   it('renders collected SNMP fields with friendly labels (#1731)', () => {
     const snmpAsset: AssetDetail = {

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -230,14 +230,15 @@ describe('AssetDetailModal — proxy scheme + self-signed certificate (#1916)', 
   it('shows self-signed checkbox only when scheme is https', async () => {
     render(<AssetDetailModal open asset={assetWithHttpsPort} devices={onlineDevices} onClose={() => {}} />);
 
-    // Default is http (or derived from port), checkbox not visible
+    // Port 443 → default scheme is https → checkbox IS visible initially.
     const schemeSelect = screen.getByTestId('proxy-scheme-select');
 
-    // Switch to https → checkbox appears
+    // Already on https; confirm checkbox visible, then switch to https explicitly
+    // (no-op) to keep the assertion ordering consistent with the toggle test.
     fireEvent.change(schemeSelect, { target: { value: 'https' } });
     expect(screen.getByTestId('proxy-allow-self-signed')).toBeInTheDocument();
 
-    // Switch back to http → checkbox hidden
+    // Switch to http → checkbox hidden
     fireEvent.change(schemeSelect, { target: { value: 'http' } });
     expect(screen.queryByTestId('proxy-allow-self-signed')).not.toBeInTheDocument();
   });

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -68,6 +68,8 @@ export default function AssetDetailModal({
   const [proxyError, setProxyError] = useState<string>();
   const [connectingProxy, setConnectingProxy] = useState(false);
   const [selectedProxyPort, setSelectedProxyPort] = useState<number>(0);
+  const [selectedScheme, setSelectedScheme] = useState<'http' | 'https'>('http');
+  const [allowSelfSigned, setAllowSelfSigned] = useState(false);
   // The bridge agent = which managed device's agent dials the target. This is
   // independent of the identity link below — the right bridge is an online agent
   // that can reach this device on the LAN, which may differ from the device you
@@ -90,7 +92,11 @@ export default function AssetDetailModal({
     setSaveSuccess(false);
     setProxyEnabled((asset as any)?.proxyEnabled ?? false);
     setProxyError(undefined);
-    setSelectedProxyPort(asset?.openPorts?.[0]?.port ?? 80);
+    const initialPort = asset?.openPorts?.[0]?.port ?? 80;
+    setSelectedProxyPort(initialPort);
+    const initialScheme = initialPort === 443 ? 'https' : 'http';
+    setSelectedScheme(initialScheme);
+    setAllowSelfSigned(false);
   }, [asset]);
 
   // Default the proxy bridge agent: prefer the linked device when it's online,
@@ -241,6 +247,8 @@ export default function AssetDetailModal({
           type: 'proxy',
           targetHost: asset.ip,
           targetPort: port,
+          scheme: selectedScheme,
+          skipTlsVerify: selectedScheme === 'https' ? allowSelfSigned : false,
         }),
       });
       if (!response.ok) {
@@ -256,7 +264,7 @@ export default function AssetDetailModal({
     } finally {
       setConnectingProxy(false);
     }
-  }, [asset, selectedProxyPort, selectedBridgeDeviceId]);
+  }, [asset, selectedProxyPort, selectedScheme, allowSelfSigned, selectedBridgeDeviceId]);
 
   // No asset record yet: never render nothing while open, or a node click looks
   // like it did nothing. Show a loading state, then a graceful not-found state
@@ -550,7 +558,13 @@ export default function AssetDetailModal({
                       <div className="flex items-center gap-2">
                         <select
                           value={selectedProxyPort}
-                          onChange={e => setSelectedProxyPort(Number(e.target.value))}
+                          onChange={e => {
+                            const port = Number(e.target.value);
+                            setSelectedProxyPort(port);
+                            const newScheme = port === 443 ? 'https' : 'http';
+                            setSelectedScheme(newScheme);
+                            if (newScheme !== 'https') setAllowSelfSigned(false);
+                          }}
                           className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
                         >
                           {openPorts.length > 0 ? (
@@ -566,16 +580,41 @@ export default function AssetDetailModal({
                             </>
                           )}
                         </select>
+                        <select
+                          value={selectedScheme}
+                          onChange={e => {
+                            const scheme = e.target.value as 'http' | 'https';
+                            setSelectedScheme(scheme);
+                            if (scheme !== 'https') setAllowSelfSigned(false);
+                          }}
+                          data-testid="proxy-scheme-select"
+                          className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          <option value="http">HTTP</option>
+                          <option value="https">HTTPS</option>
+                        </select>
                         <button
                           type="button"
                           onClick={handleConnectProxy}
                           disabled={connectingProxy || !selectedBridgeDeviceId}
+                          data-testid="proxy-connect-btn"
                           className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-600 px-3 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-70"
                         >
                           <ExternalLink className="h-3 w-3" />
                           {connectingProxy ? 'Connecting...' : 'Connect'}
                         </button>
                       </div>
+                      {selectedScheme === 'https' && (
+                        <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                          <input
+                            type="checkbox"
+                            checked={allowSelfSigned}
+                            onChange={e => setAllowSelfSigned(e.target.checked)}
+                            data-testid="proxy-allow-self-signed"
+                          />
+                          Allow self-signed certificate (common for printers, iLO/IPMI, switches)
+                        </label>
+                      )}
                     </>
                   ) : (
                     <p className="text-xs text-amber-600 dark:text-amber-400">

--- a/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.test.tsx
@@ -89,4 +89,21 @@ describe('ProxyTunnelPage', () => {
       expect(screen.getByText('Tunnel open failed on agent')).toBeInTheDocument();
     });
   });
+
+  it('shows the recreate-with-self-signed banner on tls_cert_untrusted', async () => {
+    fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (url === `/tunnels/${TUNNEL_ID}/http-ticket` && opts?.method === 'POST') {
+        return makeResponse({ ticket: { ticket: 'TKT-abc', expiresInSeconds: 300 } });
+      }
+      if (url === `/tunnels/${TUNNEL_ID}`) {
+        return makeResponse({ status: 'failed', errorMessage: 'tls_cert_untrusted' });
+      }
+      return makeResponse({});
+    });
+
+    render(<ProxyTunnelPage tunnelId={TUNNEL_ID} target="10.1.2.209:8443" />);
+
+    await screen.findByText(/self-signed certificate/i);
+    expect(screen.getByText(/recreate the proxy session/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/remote/ProxyTunnelPage.tsx
+++ b/apps/web/src/components/remote/ProxyTunnelPage.tsx
@@ -8,6 +8,9 @@ interface Props {
   target: string;
 }
 
+const TLS_UNTRUSTED_MSG =
+  'This device presented an untrusted or self-signed certificate. Recreate the proxy session with "Allow self-signed certificate" enabled to proceed.';
+
 /**
  * Network Proxy page. Renders the proxied device's web UI in an iframe served
  * through the API HTTP reverse proxy (`/api/v1/tunnel-http/:id/*`). A one-time
@@ -39,7 +42,13 @@ export default function ProxyTunnelPage({ tunnelId, target }: Props) {
         const data = await res.json();
         if (data.status === 'failed' || data.status === 'disconnected') {
           setStatus(data.status);
-          if (data.status === 'failed') setError(extractApiError(data, 'Tunnel failed'));
+          if (data.status === 'failed') {
+            setError(
+              data.errorMessage === 'tls_cert_untrusted'
+                ? TLS_UNTRUSTED_MSG
+                : extractApiError(data, 'Tunnel failed'),
+            );
+          }
         }
       }
     } catch { /* ignore */ }


### PR DESCRIPTION
Builds on the network HTTP reverse-proxy feature already on `main` (#1913). Hardens its TLS posture from **blanket insecure to verify-by-default**.

## Why
`agent/internal/tunnel/httpfetch.go` disabled TLS verification unconditionally (`InsecureSkipVerify: true`) for every HTTPS target. Self-signed certs are normal for the embedded LAN devices this proxy reaches (printers, iLO/IPMI, switches), so *some* skip is legitimate — but a blanket skip also covers any routable target, allowing on-path MITM with no signal.

## What
Verification is now **on by default**, with an explicit, audited, per-session opt-out:

- **Schema:** `tunnel_sessions` gains `scheme` (http/https) + `skip_tls_verify` (default `false`). Idempotent migration; secure default at DB + ORM.
- **Agent:** `Fetch()` honors `req.SkipTLSVerify` (default false); cert failures (`x509` unknown-authority/hostname/invalid) are classified into a typed `ErrTLSCertUntrusted` → stable `tls_cert_untrusted` token.
- **API create:** `POST /tunnels` accepts `scheme` + `skipTlsVerify`, **normalizes server-side** (the skip flag can never persist `true` for an http or VNC session), persists, and audit-logs both.
- **API proxy:** forwards `skipTlsVerify`, resolves the session's scheme (back-compat for null rows), and maps the `tls_cert_untrusted` token → session marked failed (under system DB context) + HTTP 502.
- **Web picker:** scheme select + an "Allow self-signed certificate" checkbox (HTTPS-only) right in the connect modal, so the common embedded-device case is one click — no failed round-trip.
- **Web proxy page:** a clear recreate banner when verification fails, surfaced via the existing session-status poll.

Also adds **explicit http/https scheme selection** so HTTPS on non-standard ports (8443/4443) is actually reachable — previously scheme was inferred purely from port (443→https), so those were hit as plaintext.

## Security posture
- Default flips from **insecure (skip-all) → secure (verify)**. The insecure path is now an explicit, per-session, audited choice scoped to a single locked target.
- The skip-flag normalization is **server-authoritative** (the web guard is defense-in-depth).
- SSRF guard unchanged — the proxied target still comes only from the `tunnel_sessions` row.

## Notes
- A tracking issue questioning `tunnel_sessions` RLS (#1923) was investigated and **closed as invalid** — RLS is already enabled+forced with Shape-1 `breeze_has_org_access(org_id)` policies (migration `2026-04-11`, verified live + by the auto-discovering contract test). No RLS work needed.
- Built and reviewed via TDD across agent/API/web with per-task + whole-branch review; the one review finding (system DB context on the cert-fail update) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)