### PR TITLE
feat(billing): bulk actions on quotes/invoices/contracts + draft delete on detail

### DIFF
--- a/apps/api/src/__tests__/integration/bulkOpsIsolation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/bulkOpsIsolation.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Real-DB proof that runBulkIsolated runs EACH item in its own transaction.
+ *
+ * The bulk billing endpoints rely on per-item isolation for two guarantees the
+ * unit tests can only assert at the wiring level (they stub `../db`):
+ *   1. A per-item failure must NOT roll back siblings that already succeeded —
+ *      and the returned counts must reflect what actually persisted.
+ *   2. Each item commits independently (no single held request transaction).
+ *
+ * This exercises the REAL `withDbAccessContext` + `runOutsideDbContext`
+ * (AsyncLocalStorage exit + a fresh `breeze_app` transaction per item) against
+ * Postgres, using `quotes` (org-axis RLS) as the tenant table. If runBulkIsolated
+ * regressed to looping on one shared transaction, the post-write throw on item 2
+ * would abort the whole transaction and item 1's delete would roll back too —
+ * making the "item 1 is gone" assertion fail.
+ *
+ * Fixture re-seeded per test (integration/setup.ts TRUNCATEs CASCADE in
+ * beforeEach); matches every sibling *.integration.test.ts. No memoization.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { createOrganization, createPartner } from './db-utils';
+import { createQuote, deleteDraftQuote } from '../../services/quoteService';
+import { runBulkIsolated } from '../../lib/bulkOps';
+import { type QuoteActor } from '../../services/quoteTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Fixture {
+  orgA: { id: string };
+  actorA: QuoteActor;
+  ctxA: DbAccessContext;
+}
+
+async function seedFixture(): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const actorA: QuoteActor = { userId: null, partnerId: partnerA.id, accessibleOrgIds: null };
+    // quotes use org-axis RLS, so the context must list orgA on the accessible
+    // org axis — exactly what dbAccessContextFromAuth would produce for a
+    // partner admin (mirrors the request middleware).
+    const ctxA: DbAccessContext = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [partnerA.id],
+      userId: null,
+    };
+    return { orgA: { id: orgA.id }, actorA, ctxA };
+  });
+}
+
+async function seedDraft(fx: Fixture): Promise<string> {
+  const q = await withDbAccessContext(fx.ctxA, () =>
+    createQuote({ orgId: fx.orgA.id, currencyCode: 'USD' }, fx.actorA)
+  );
+  return q.id;
+}
+
+/** Count surviving quote rows by id, read under system scope (bypasses RLS). */
+async function exists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db.select({ id: quotes.id }).from(quotes).where(eq(quotes.id, id));
+    return rows.length > 0;
+  });
+}
+
+describe('runBulkIsolated per-item transaction isolation (breeze_app, real DB)', () => {
+  runDb('a post-write throw on one item rolls back only that item; siblings persist', async () => {
+    const fx = await seedFixture();
+    const id1 = await seedDraft(fx);
+    const id2 = await seedDraft(fx);
+
+    // perItem deletes the row, then throws for id2 AFTER the write. With per-item
+    // transactions, id2's delete rolls back (row survives) while id1 commits.
+    const result = await runBulkIsolated(fx.ctxA, [id1, id2], async (id) => {
+      await db.delete(quotes).where(eq(quotes.id, id));
+      if (id === id2) throw new Error('simulated post-write failure');
+    });
+
+    expect(result).toMatchObject({ total: 2, succeeded: 1, skipped: 0, failed: 1 });
+    expect(await exists(id1)).toBe(false); // committed independently
+    expect(await exists(id2)).toBe(true); // its transaction rolled back
+  });
+
+  runDb('deletes every draft via the real service when all items succeed', async () => {
+    const fx = await seedFixture();
+    const id1 = await seedDraft(fx);
+    const id2 = await seedDraft(fx);
+
+    const result = await runBulkIsolated(fx.ctxA, [id1, id2], (id) =>
+      deleteDraftQuote(id, fx.actorA)
+    );
+
+    expect(result).toMatchObject({ total: 2, succeeded: 2, skipped: 0, failed: 0 });
+    expect(await exists(id1)).toBe(false);
+    expect(await exists(id2)).toBe(false);
+  });
+});

--- a/apps/api/src/lib/bulkOps.test.ts
+++ b/apps/api/src/lib/bulkOps.test.ts
@@ -1,9 +1,29 @@
-import { describe, it, expect, vi } from 'vitest';
-import { runBulk } from './bulkOps';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// runBulkIsolated wraps each item in withDbAccessContext + runOutsideDbContext.
+// Stub both as passthrough spies so the loop runs without a real DB and we can
+// assert the per-item isolation wiring. Implementations are (re)set per test in
+// beforeEach so the afterEach restoreAllMocks (which clears the console spy in
+// the failure test) can't strip them.
+const withDbAccessContext = vi.fn();
+const runOutsideDbContext = vi.fn();
+vi.mock('../db', () => ({
+  withDbAccessContext: (ctx: unknown, fn: () => unknown) => withDbAccessContext(ctx, fn),
+  runOutsideDbContext: (fn: () => unknown) => runOutsideDbContext(fn),
+}));
+
+import { runBulk, runBulkIsolated } from './bulkOps';
 
 class SvcError extends Error {
   constructor(msg: string, public status: number, public code?: string) { super(msg); }
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  withDbAccessContext.mockImplementation((_ctx: unknown, fn: () => unknown) => fn());
+  runOutsideDbContext.mockImplementation((fn: () => unknown) => fn());
+});
+afterEach(() => vi.restoreAllMocks());
 
 describe('runBulk', () => {
   it('counts successes', async () => {
@@ -28,5 +48,35 @@ describe('runBulk', () => {
     const fn = vi.fn().mockRejectedValue(new Error('boom'));
     const r = await runBulk(['a'], fn);
     expect(r).toMatchObject({ total: 1, succeeded: 0, skipped: 0, failed: 1 });
+  });
+});
+
+describe('runBulkIsolated', () => {
+  const ctx = { scope: 'partner', orgId: null, accessibleOrgIds: ['o1'] } as never;
+
+  it('runs the loop outside the ambient context and each item in its own access context', async () => {
+    const perItem = vi.fn().mockResolvedValue(undefined);
+    const r = await runBulkIsolated(ctx, ['a', 'b', 'c'], perItem);
+
+    expect(r).toMatchObject({ total: 3, succeeded: 3, skipped: 0, failed: 0 });
+    // whole loop wrapped once in runOutsideDbContext (releases the request txn)
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    // each item re-enters the caller's exact context in its own transaction
+    expect(withDbAccessContext).toHaveBeenCalledTimes(3);
+    expect(withDbAccessContext).toHaveBeenCalledWith(ctx, expect.any(Function));
+    expect(perItem).toHaveBeenCalledTimes(3);
+  });
+
+  it('isolates a per-item failure without aborting siblings (accurate counts)', async () => {
+    const perItem = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new SvcError('not a draft', 409, 'NOT_A_DRAFT'))
+      .mockResolvedValueOnce(undefined);
+    const r = await runBulkIsolated(ctx, ['a', 'b', 'c'], perItem);
+
+    // 'b' failing does not prevent 'c' from running and succeeding
+    expect(r).toMatchObject({ total: 3, succeeded: 2, skipped: 1, failed: 0 });
+    expect(r.skippedReasons).toEqual({ NOT_A_DRAFT: 1 });
+    expect(withDbAccessContext).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/api/src/lib/bulkOps.test.ts
+++ b/apps/api/src/lib/bulkOps.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runBulk } from './bulkOps';
+
+class SvcError extends Error {
+  constructor(msg: string, public status: number, public code?: string) { super(msg); }
+}
+
+describe('runBulk', () => {
+  it('counts successes', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const r = await runBulk(['a', 'b', 'c'], fn);
+    expect(r).toMatchObject({ total: 3, succeeded: 3, skipped: 0, failed: 0 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats 4xx service errors as skipped and tallies reasons by code', async () => {
+    const fn = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new SvcError('not a draft', 409, 'NOT_A_DRAFT'))
+      .mockRejectedValueOnce(new SvcError('denied', 403, 'ORG_DENIED'));
+    const r = await runBulk(['a', 'b', 'c'], fn);
+    expect(r).toMatchObject({ total: 3, succeeded: 1, skipped: 2, failed: 0 });
+    expect(r.skippedReasons).toEqual({ NOT_A_DRAFT: 1, ORG_DENIED: 1 });
+  });
+
+  it('treats unexpected errors as failed without throwing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fn = vi.fn().mockRejectedValue(new Error('boom'));
+    const r = await runBulk(['a'], fn);
+    expect(r).toMatchObject({ total: 1, succeeded: 0, skipped: 0, failed: 1 });
+  });
+});

--- a/apps/api/src/lib/bulkOps.ts
+++ b/apps/api/src/lib/bulkOps.ts
@@ -1,0 +1,45 @@
+export interface BulkResult {
+  total: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  skippedReasons: Record<string, number>;
+}
+
+const SKIP_STATUSES = new Set([400, 403, 404, 409]);
+
+function asServiceError(err: unknown): { status: number; code?: string; message?: string } | null {
+  if (err && typeof err === 'object' && 'status' in err && typeof (err as { status: unknown }).status === 'number') {
+    return err as { status: number; code?: string; message?: string };
+  }
+  return null;
+}
+
+/**
+ * Run a per-item async operation over a list of ids, isolating per-item failures.
+ * Expected 4xx service errors (not-a-draft, org-denied, not-found, invalid-state)
+ * count as `skipped` (tallied by `.code`); anything else counts as `failed`.
+ */
+export async function runBulk(
+  ids: string[],
+  perItem: (id: string) => Promise<unknown>
+): Promise<BulkResult> {
+  const result: BulkResult = { total: ids.length, succeeded: 0, skipped: 0, failed: 0, skippedReasons: {} };
+  for (const id of ids) {
+    try {
+      await perItem(id);
+      result.succeeded++;
+    } catch (err) {
+      const svc = asServiceError(err);
+      if (svc && SKIP_STATUSES.has(svc.status)) {
+        result.skipped++;
+        const code = svc.code ?? 'OTHER';
+        result.skippedReasons[code] = (result.skippedReasons[code] ?? 0) + 1;
+      } else {
+        result.failed++;
+        console.error('[runBulk] item failed:', id, err instanceof Error ? err.message : err);
+      }
+    }
+  }
+  return result;
+}

--- a/apps/api/src/lib/bulkOps.ts
+++ b/apps/api/src/lib/bulkOps.ts
@@ -1,3 +1,5 @@
+import { withDbAccessContext, runOutsideDbContext, type DbAccessContext } from '../db';
+
 export interface BulkResult {
   total: number;
   succeeded: number;
@@ -42,4 +44,35 @@ export async function runBulk(
     }
   }
   return result;
+}
+
+/**
+ * Like {@link runBulk}, but runs EACH item in its own short RLS transaction
+ * instead of the caller's ambient request transaction.
+ *
+ * Why this matters (do not collapse back into a plain `runBulk` on the
+ * request transaction):
+ *  - **Correct partial-success counts.** On the shared request transaction a
+ *    Postgres-level error (FK/trigger) aborts the whole transaction, so every
+ *    "succeeded" item silently rolls back at commit while still being counted.
+ *    Per-item transactions make each success durable independent of siblings.
+ *  - **Connection-pool safety (#1105).** The bulk loop can do slow per-item
+ *    work (a quote/invoice email send, a sub-transaction in issue/void). On
+ *    one held request transaction that pins a single pooled connection
+ *    idle-in-transaction for the whole batch; per-item transactions release
+ *    the connection between items.
+ *
+ * `runOutsideDbContext` exits the ambient request context so each
+ * `withDbAccessContext(ctx, …)` opens a fresh transaction; `ctx` re-establishes
+ * the caller's exact RLS scope (build it with `dbAccessContextFromAuth`) so
+ * tenant isolation is identical to the request path.
+ */
+export async function runBulkIsolated(
+  ctx: DbAccessContext,
+  ids: string[],
+  perItem: (id: string) => Promise<unknown>
+): Promise<BulkResult> {
+  return runOutsideDbContext(() =>
+    runBulk(ids, (id) => withDbAccessContext(ctx, () => perItem(id)))
+  );
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import { verifyToken, TokenPayload } from '../services/jwt';
 import { getUserPermissions, hasPermission, canAccessOrg, canAccessSite, UserPermissions } from '../services/permissions';
 import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../services/tokenRevocation';
-import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext, type DbAccessScope } from '../db';
 import { users, partnerUsers, organizationUsers, organizations, roles } from '../db/schema';
 import { and, eq, inArray, isNull, SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -285,6 +285,49 @@ function computeAccessiblePartnerIds(
   return [];
 }
 
+/**
+ * Build the RLS `DbAccessContext` for a request from its already-resolved
+ * scope/org/partner facts. This is the SINGLE source of truth for the
+ * mapping — both `authMiddleware` (the request-wide context) and any code
+ * that needs to re-establish the same context in a fresh transaction (e.g.
+ * the billing bulk handlers, which run each item in its own short
+ * transaction via `runOutsideDbContext` + `withDbAccessContext`) must build
+ * the context through here so the two can never drift. `accessiblePartnerIds`
+ * is derived purely from scope+partnerId, matching the request path exactly.
+ */
+export function buildDbAccessContext(args: {
+  scope: DbAccessScope;
+  orgId: string | null;
+  accessibleOrgIds: string[] | null;
+  partnerId: string | null;
+  userId: string | null;
+}): DbAccessContext {
+  return {
+    scope: args.scope,
+    orgId: args.orgId,
+    accessibleOrgIds: args.accessibleOrgIds,
+    accessiblePartnerIds: computeAccessiblePartnerIds(args.scope, args.partnerId),
+    userId: args.userId,
+    currentPartnerId: args.partnerId ?? null,
+  };
+}
+
+/**
+ * Re-derive the request's RLS `DbAccessContext` from its `AuthContext`. Use
+ * to re-establish the caller's exact tenant scope inside a fresh transaction
+ * (outside the ambient request transaction) — every field comes from `auth`,
+ * so the re-entered context is identical to the one `authMiddleware` opened.
+ */
+export function dbAccessContextFromAuth(auth: AuthContext): DbAccessContext {
+  return buildDbAccessContext({
+    scope: auth.scope,
+    orgId: auth.orgId,
+    accessibleOrgIds: auth.accessibleOrgIds,
+    partnerId: auth.partnerId,
+    userId: auth.user.id,
+  });
+}
+
 export async function authMiddleware(c: Context, next: Next): Promise<void | Response> {
   // Avoid double-verification when authMiddleware is applied both globally and per-route.
   const existing = c.get('auth') as AuthContext | undefined;
@@ -400,11 +443,6 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     payload.orgId,
     user.id
   );
-  const accessiblePartnerIds = computeAccessiblePartnerIds(
-    payload.scope,
-    payload.partnerId
-  );
-
   // Create helper functions
   const orgCondition = (orgIdColumn: PgColumn): SQL | undefined => {
     if (accessibleOrgIds === null) {
@@ -474,19 +512,19 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) {
       return runGuardedHandler();
     }
+    // Built via buildDbAccessContext (the single source of truth) so the
+    // request context can never drift from the one bulk handlers re-enter
+    // per item. `currentPartnerId` (own-partner read visibility) and
+    // `accessiblePartnerIds` (partner-axis access grant) are both derived
+    // there from scope+partnerId.
     return withDbAccessContext(
-      {
+      buildDbAccessContext({
         scope: payload.scope,
         orgId: payload.orgId,
         accessibleOrgIds,
-        accessiblePartnerIds,
-        userId: user.id,
-        // Own partner — enables read-only visibility of the partner's
-        // partner-wide catalog rows for org-scope (and partner-scope) users.
-        // NOT an access grant; partner-axis write access stays governed by
-        // accessiblePartnerIds.
-        currentPartnerId: payload.partnerId ?? null
-      },
+        partnerId: payload.partnerId,
+        userId: user.id
+      }),
       runGuardedHandler
     );
   };

--- a/apps/api/src/routes/contracts/bulk.test.ts
+++ b/apps/api/src/routes/contracts/bulk.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Full contractService mock — lifecycle.ts imports activateContract/pauseContract/resumeContract too
+vi.mock('../../services/contractService', () => ({
+  deleteDraftContract: vi.fn(),
+  cancelContract: vi.fn(),
+  createContract: vi.fn(),
+  getContract: vi.fn(),
+  listContracts: vi.fn(),
+  updateContract: vi.fn(),
+  addContractLineToContract: vi.fn(),
+  removeContractLine: vi.fn(),
+  activateContract: vi.fn(),
+  pauseContract: vi.fn(),
+  resumeContract: vi.fn(),
+  generateDueInvoice: vi.fn(),
+  computeContractEstimate: vi.fn(),
+}));
+
+// generate.ts uses these at module level
+vi.mock('../../services/invoiceService', () => ({ issueInvoice: vi.fn() }));
+vi.mock('../../services/invoicePdf', () => ({ sendInvoiceEmail: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+}));
+vi.mock('../../services/contractTypes', () => ({
+  ContractServiceError: class ContractServiceError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  },
+}));
+
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { contractRoutes } from './index';
+import { deleteDraftContract, cancelContract } from '../../services/contractService';
+
+const A = '11111111-1111-1111-1111-111111111111';
+function post(path: string, body: unknown) {
+  return contractRoutes.request(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+}
+
+describe('contract bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each draft', async () => {
+    (deleteDraftContract as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(deleteDraftContract).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('bulk-cancel cancels each contract', async () => {
+    (cancelContract as any).mockResolvedValue({});
+    const res = await post('/bulk-cancel', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(cancelContract).toHaveBeenCalledWith(A, expect.anything());
+  });
+});

--- a/apps/api/src/routes/contracts/bulk.test.ts
+++ b/apps/api/src/routes/contracts/bulk.test.ts
@@ -24,6 +24,9 @@ vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
   withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+  // runBulkIsolated wraps each item in withDbAccessContext (passthrough here so
+  // the loop runs without a real DB connection).
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
 }));
 vi.mock('../../services/contractTypes', () => ({
   ContractServiceError: class ContractServiceError extends Error {
@@ -39,6 +42,7 @@ vi.mock('../../middleware/auth', () => ({
   },
   requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
   requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+  dbAccessContextFromAuth: () => ({ scope: 'partner', orgId: null, accessibleOrgIds: null }),
 }));
 
 import { contractRoutes } from './index';

--- a/apps/api/src/routes/contracts/bulk.ts
+++ b/apps/api/src/routes/contracts/bulk.ts
@@ -1,0 +1,29 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkContractIdsSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftContract, cancelContract } from '../../services/contractService';
+import { contractActorFrom, handleContractError } from './contracts';
+
+export const contractBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMISSIONS.CONTRACTS_WRITE.action);
+const managePerm = requirePermission(PERMISSIONS.CONTRACTS_MANAGE.resource, PERMISSIONS.CONTRACTS_MANAGE.action);
+
+contractBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
+  try {
+    const actor = contractActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftContract(id, actor)) });
+  } catch (err) { return handleContractError(c, err); }
+});
+
+contractBulkRoutes.post('/bulk-cancel', scopes, managePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
+  try {
+    const actor = contractActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => cancelContract(id, actor)) });
+  } catch (err) { return handleContractError(c, err); }
+});

--- a/apps/api/src/routes/contracts/bulk.ts
+++ b/apps/api/src/routes/contracts/bulk.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { requireScope, requirePermission } from '../../middleware/auth';
+import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkContractIdsSchema } from '@breeze/shared';
-import { runBulk } from '../../lib/bulkOps';
+import { runBulkIsolated } from '../../lib/bulkOps';
 import { deleteDraftContract, cancelContract } from '../../services/contractService';
 import { contractActorFrom, handleContractError } from './contracts';
 
@@ -14,16 +14,18 @@ const managePerm = requirePermission(PERMISSIONS.CONTRACTS_MANAGE.resource, PERM
 
 contractBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = contractActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => deleteDraftContract(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => deleteDraftContract(id, actor)) });
   } catch (err) { return handleContractError(c, err); }
 });
 
 contractBulkRoutes.post('/bulk-cancel', scopes, managePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = contractActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => cancelContract(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => cancelContract(id, actor)) });
   } catch (err) { return handleContractError(c, err); }
 });

--- a/apps/api/src/routes/contracts/index.ts
+++ b/apps/api/src/routes/contracts/index.ts
@@ -4,9 +4,11 @@ import { contractCrudRoutes } from './contracts';
 import { contractLifecycleRoutes } from './lifecycle';
 import { contractGenerateRoutes } from './generate';
 import { contractLineRoutes } from './lines';
+import { contractBulkRoutes } from './bulk';
 
 export const contractRoutes = new Hono();
 contractRoutes.use('*', authMiddleware);
+contractRoutes.route('/', contractBulkRoutes);       // bulk-* before /:id
 contractRoutes.route('/', contractLifecycleRoutes); // /:id/activate, /:id/pause, /:id/resume, /:id/cancel
 contractRoutes.route('/', contractGenerateRoutes);  // /:id/generate
 contractRoutes.route('/', contractLineRoutes);       // /:id/lines, /:id/lines/:lineId

--- a/apps/api/src/routes/invoices/bulk.test.ts
+++ b/apps/api/src/routes/invoices/bulk.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/invoiceService', () => ({
+  deleteDraftInvoice: vi.fn(), issueInvoice: vi.fn(), voidInvoice: vi.fn(),
+}));
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { invoiceRoutes } from './index';
+import { deleteDraftInvoice, issueInvoice, voidInvoice } from '../../services/invoiceService';
+
+const A = '11111111-1111-1111-1111-111111111111';
+const B = '22222222-2222-2222-2222-222222222222';
+function post(path: string, body: unknown) {
+  return invoiceRoutes.request(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+}
+
+describe('invoice bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each draft', async () => {
+    (deleteDraftInvoice as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 2 });
+    expect(deleteDraftInvoice).toHaveBeenCalledTimes(2);
+  });
+
+  it('bulk-issue issues each invoice', async () => {
+    (issueInvoice as any).mockResolvedValue({});
+    const res = await post('/bulk-issue', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(issueInvoice).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('bulk-void requires a reason and passes reissue:false', async () => {
+    (voidInvoice as any).mockResolvedValue({});
+    const noReason = await post('/bulk-void', { ids: [A] });
+    expect(noReason.status).toBe(400);
+
+    const ok = await post('/bulk-void', { ids: [A], reason: 'duplicate' });
+    expect(ok.status).toBe(200);
+    expect(voidInvoice).toHaveBeenCalledWith(A, 'duplicate', { reissue: false }, expect.anything());
+  });
+});

--- a/apps/api/src/routes/invoices/bulk.test.ts
+++ b/apps/api/src/routes/invoices/bulk.test.ts
@@ -11,6 +11,13 @@ vi.mock('../../middleware/auth', () => ({
   },
   requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
   requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+  dbAccessContextFromAuth: () => ({ scope: 'partner', orgId: null, accessibleOrgIds: null }),
+}));
+// runBulkIsolated wraps each item in withDbAccessContext + runOutsideDbContext;
+// stub both as passthroughs so the loop logic runs without a real DB connection.
+vi.mock('../../db', () => ({
+  withDbAccessContext: (_ctx: any, fn: any) => fn(),
+  runOutsideDbContext: (fn: any) => fn(),
 }));
 
 import { invoiceRoutes } from './index';

--- a/apps/api/src/routes/invoices/bulk.ts
+++ b/apps/api/src/routes/invoices/bulk.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkInvoiceIdsSchema, bulkVoidInvoicesSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftInvoice, issueInvoice, voidInvoice } from '../../services/invoiceService';
+import { invoiceActorFrom, handleServiceError } from './invoices';
+
+export const invoiceBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.INVOICES_SEND.resource, PERMISSIONS.INVOICES_SEND.action);
+
+invoiceBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftInvoice(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+invoiceBulkRoutes.post('/bulk-issue', scopes, sendPerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => issueInvoice(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+invoiceBulkRoutes.post('/bulk-void', scopes, sendPerm, zValidator('json', bulkVoidInvoicesSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids, reason } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => voidInvoice(id, reason, { reissue: false }, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});

--- a/apps/api/src/routes/invoices/bulk.ts
+++ b/apps/api/src/routes/invoices/bulk.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { requireScope, requirePermission } from '../../middleware/auth';
+import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkInvoiceIdsSchema, bulkVoidInvoicesSchema } from '@breeze/shared';
-import { runBulk } from '../../lib/bulkOps';
+import { runBulkIsolated } from '../../lib/bulkOps';
 import { deleteDraftInvoice, issueInvoice, voidInvoice } from '../../services/invoiceService';
 import { invoiceActorFrom, handleServiceError } from './invoices';
 
@@ -14,24 +14,27 @@ const sendPerm = requirePermission(PERMISSIONS.INVOICES_SEND.resource, PERMISSIO
 
 invoiceBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = invoiceActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => deleteDraftInvoice(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => deleteDraftInvoice(id, actor)) });
   } catch (err) { return handleServiceError(c, err); }
 });
 
 invoiceBulkRoutes.post('/bulk-issue', scopes, sendPerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = invoiceActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => issueInvoice(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => issueInvoice(id, actor)) });
   } catch (err) { return handleServiceError(c, err); }
 });
 
 invoiceBulkRoutes.post('/bulk-void', scopes, sendPerm, zValidator('json', bulkVoidInvoicesSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = invoiceActorFrom(c);
     const { ids, reason } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => voidInvoice(id, reason, { reissue: false }, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => voidInvoice(id, reason, { reissue: false }, actor)) });
   } catch (err) { return handleServiceError(c, err); }
 });

--- a/apps/api/src/routes/invoices/index.ts
+++ b/apps/api/src/routes/invoices/index.ts
@@ -5,9 +5,11 @@ import { invoiceLifecycleRoutes } from './lifecycle';
 import { invoicePaymentRoutes } from './payments';
 import { invoicePdfRoutes } from './pdf'; // added in Phase 5
 import { invoiceStripeRoutes } from './stripe';
+import { invoiceBulkRoutes } from './bulk';
 
 export const invoiceRoutes = new Hono();
 invoiceRoutes.use('*', authMiddleware);
+invoiceRoutes.route('/', invoiceBulkRoutes);       // bulk-* before /:id
 invoiceRoutes.route('/', invoiceLifecycleRoutes);  // /:id/issue, /:id/send, /:id/void
 invoiceRoutes.route('/', invoicePaymentRoutes);    // /:id/payments...
 invoiceRoutes.route('/', invoiceStripeRoutes);     // /:id/pay-link

--- a/apps/api/src/routes/quotes/bulk.test.ts
+++ b/apps/api/src/routes/quotes/bulk.test.ts
@@ -15,6 +15,13 @@ vi.mock('../../middleware/auth', () => ({
   },
   requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
   requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+  dbAccessContextFromAuth: () => ({ scope: 'partner', orgId: null, accessibleOrgIds: null }),
+}));
+// runBulkIsolated wraps each item in withDbAccessContext + runOutsideDbContext;
+// stub both as passthroughs so the loop logic runs without a real DB connection.
+vi.mock('../../db', () => ({
+  withDbAccessContext: (_ctx: any, fn: any) => fn(),
+  runOutsideDbContext: (fn: any) => fn(),
 }));
 
 import { quoteRoutes } from './index';

--- a/apps/api/src/routes/quotes/bulk.test.ts
+++ b/apps/api/src/routes/quotes/bulk.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/quoteService', () => ({ deleteDraftQuote: vi.fn() }));
+vi.mock('../../services/quoteLifecycle', () => ({ sendQuote: vi.fn() }));
+vi.mock('../../services/quoteTypes', () => ({
+  QuoteServiceError: class QuoteServiceError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  },
+}));
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { quoteRoutes } from './index';
+import { deleteDraftQuote } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { QuoteServiceError } from '../../services/quoteTypes';
+
+const A = '11111111-1111-1111-1111-111111111111';
+const B = '22222222-2222-2222-2222-222222222222';
+
+function post(path: string, body: unknown) {
+  return quoteRoutes.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('quote bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each id and reports counts', async () => {
+    (deleteDraftQuote as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ total: 2, succeeded: 2, skipped: 0, failed: 0 });
+    expect(deleteDraftQuote).toHaveBeenCalledTimes(2);
+  });
+
+  it('bulk-delete tallies non-draft skips without failing the request', async () => {
+    (deleteDraftQuote as any)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new QuoteServiceError('Quote is not a draft', 409, 'NOT_A_DRAFT'));
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect(res.status).toBe(200);
+    const data = (await res.json()).data;
+    expect(data).toMatchObject({ succeeded: 1, skipped: 1 });
+    expect(data.skippedReasons).toEqual({ NOT_A_DRAFT: 1 });
+  });
+
+  it('bulk-send sends each draft', async () => {
+    (sendQuote as any).mockResolvedValue({});
+    const res = await post('/bulk-send', { ids: [A] });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(sendQuote).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('rejects an empty id list with 400', async () => {
+    const res = await post('/bulk-delete', { ids: [] });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/quotes/bulk.ts
+++ b/apps/api/src/routes/quotes/bulk.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { requireScope, requirePermission } from '../../middleware/auth';
+import { requireScope, requirePermission, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { bulkQuoteIdsSchema } from '@breeze/shared';
-import { runBulk } from '../../lib/bulkOps';
+import { runBulkIsolated } from '../../lib/bulkOps';
 import { deleteDraftQuote } from '../../services/quoteService';
 import { sendQuote } from '../../services/quoteLifecycle';
 import { quoteActorFrom, handleServiceError } from './quotes';
@@ -15,16 +15,18 @@ const sendPerm = requirePermission(PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS
 
 quoteBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = quoteActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => deleteDraftQuote(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => deleteDraftQuote(id, actor)) });
   } catch (err) { return handleServiceError(c, err); }
 });
 
 quoteBulkRoutes.post('/bulk-send', scopes, sendPerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
   try {
+    const ctx = dbAccessContextFromAuth(c.get('auth') as AuthContext);
     const actor = quoteActorFrom(c);
     const { ids } = c.req.valid('json');
-    return c.json({ data: await runBulk(ids, (id) => sendQuote(id, actor)) });
+    return c.json({ data: await runBulkIsolated(ctx, ids, (id) => sendQuote(id, actor)) });
   } catch (err) { return handleServiceError(c, err); }
 });

--- a/apps/api/src/routes/quotes/bulk.ts
+++ b/apps/api/src/routes/quotes/bulk.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkQuoteIdsSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftQuote } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { quoteActorFrom, handleServiceError } from './quotes';
+
+export const quoteBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIONS.QUOTES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action);
+
+quoteBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
+  try {
+    const actor = quoteActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftQuote(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+quoteBulkRoutes.post('/bulk-send', scopes, sendPerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
+  try {
+    const actor = quoteActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => sendQuote(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});

--- a/apps/api/src/routes/quotes/index.ts
+++ b/apps/api/src/routes/quotes/index.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono';
 import { authMiddleware } from '../../middleware/auth';
+import { quoteBulkRoutes } from './bulk';
 import { quoteCrudRoutes } from './quotes';
 import { quoteLifecycleRoutes } from './lifecycle';
 
 export const quoteRoutes = new Hono();
 quoteRoutes.use('*', authMiddleware);
+quoteRoutes.route('/', quoteBulkRoutes);      // bulk-* before /:id
 quoteRoutes.route('/', quoteCrudRoutes); // /, /:id, /:id/lines, /:id/blocks...
 quoteRoutes.route('/', quoteLifecycleRoutes); // /:id/send, /:id/images, /:id/images/:imageId

--- a/apps/web/src/components/billing/InvoiceDetail.delete.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.delete.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceDetail from './InvoiceDetail';
+import { fetchWithAuth } from '../../stores/auth';
+import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+
+// Full set of auth mock (same pattern as InvoiceDetail.permissions.test.tsx)
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const draftDetail: InvoiceDetailData = {
+  invoice: {
+    id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null,
+    subtotal: '0.00', taxRate: null, taxTotal: '0.00', total: '0.00',
+    amountPaid: '0.00', balance: '0.00', billToName: 'Acme',
+    notes: null, termsAndConditions: null, sellerSnapshot: null,
+    createdAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [],
+};
+
+const sentDetail: InvoiceDetailData = {
+  ...draftDetail,
+  invoice: { ...draftDetail.invoice, status: 'sent', sentAt: '2026-06-02T00:00:00Z' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'invoices', action: 'write' }];
+  // Default: payments endpoint returns empty list; other calls succeed.
+  fetchMock.mockImplementation(async (input: string) => {
+    if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+    return resp({ data: null });
+  });
+});
+
+describe('InvoiceDetail — delete action', () => {
+  it('shows the Delete draft button for a draft invoice when the user has invoices:write', async () => {
+    render(<InvoiceDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-delete-open')).toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button on a non-draft invoice', async () => {
+    render(<InvoiceDetail detail={sentDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button when the user lacks invoices:write', async () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('deletes a draft invoice and navigates to the invoices list', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    const navigateMock = vi.mocked(navigateTo);
+
+    render(<InvoiceDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-delete-open'));
+    await waitFor(() => expect(screen.getByTestId('invoice-delete-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-delete-confirm'));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1', { method: 'DELETE' });
+      expect(navigateMock).toHaveBeenCalledWith('/billing/invoices');
+    });
+  });
+});

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -5,6 +5,7 @@ import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { Dialog } from '../shared/Dialog';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import {
   type InvoiceDetail as InvoiceDetailData,
   type InvoiceLine,
@@ -44,6 +45,8 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
 
   // Void dialog
   const [voidOpen, setVoidOpen] = useState(false);
+  // Delete dialog
+  const [delOpen, setDelOpen] = useState(false);
   const [voidReason, setVoidReason] = useState('');
   const [voidReissue, setVoidReissue] = useState(false);
 
@@ -208,6 +211,25 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     }
   }, [busy, voidReason, voidReissue, invoice.id, refresh]);
 
+  const remove = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}`, { method: 'DELETE' }),
+        errorFallback: 'Could not delete the draft.',
+        successMessage: 'Draft deleted',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDelOpen(false);
+      void navigateTo('/billing/invoices');
+    } catch (err) {
+      handleActionError(err, 'Could not delete the draft.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, invoice.id]);
+
   return (
     <div className="space-y-6" data-testid="invoice-detail">
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
@@ -337,6 +359,16 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                 Void invoice
               </button>
             )}
+            {invoice.status === 'draft' && can('invoices', 'write') && (
+              <button
+                type="button"
+                onClick={() => setDelOpen(true)}
+                data-testid="invoice-delete-open"
+                className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+              >
+                Delete draft
+              </button>
+            )}
           </div>
 
           {/* Payments */}
@@ -440,6 +472,18 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Delete draft dialog */}
+      <ConfirmDialog
+        open={delOpen}
+        onClose={() => setDelOpen(false)}
+        onConfirm={() => void remove()}
+        isLoading={busy}
+        title="Delete draft invoice"
+        message="This permanently deletes the draft invoice. This cannot be undone."
+        confirmLabel="Delete draft"
+        confirmTestId="invoice-delete-confirm"
+      />
 
       {/* Void dialog */}
       <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoice" maxWidth="md" className="p-6">

--- a/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
@@ -67,6 +67,10 @@ describe('InvoicesPage bulk actions', () => {
 
     fireEvent.click(screen.getByTestId('invoices-bulk-action-delete'));
 
+    // Confirm dialog must appear before the request is sent.
+    const confirmBtn = await screen.findByTestId('invoices-bulk-delete-confirm');
+    fireEvent.click(confirmBtn);
+
     await waitFor(() => {
       const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/invoices/bulk-delete'));
       expect(call).toBeTruthy();

--- a/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
@@ -112,4 +112,39 @@ describe('InvoicesPage bulk actions', () => {
       expect(body.reason).toBe('duplicate');
     });
   });
+
+  it('keeps void dialog open and preserves reason when bulk-void fails', async () => {
+    render(<InvoicesPage />);
+    await screen.findByTestId(`invoices-row-${I1}`);
+
+    fireEvent.click(screen.getByTestId(`invoices-select-${I1}`));
+    fireEvent.click(screen.getByTestId('invoices-bulk-action-void'));
+
+    await screen.findByTestId('invoices-bulk-void-dialog');
+
+    const textarea = screen.getByTestId('invoices-bulk-void-reason');
+    fireEvent.change(textarea, { target: { value: 'client requested' } });
+    expect(screen.getByTestId('invoices-bulk-void-submit')).not.toBeDisabled();
+
+    // Wire bulk-void to return HTTP 500 so runAction throws.
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (String(url).includes('/bulk-void'))
+        return Promise.resolve(json({ error: 'Internal server error' }, 500));
+      if (String(url).includes('/orgs/organizations')) return Promise.resolve(json({ data: [] }));
+      if (String(url).startsWith('/invoices')) return Promise.resolve(json({ data: INVOICES }));
+      return Promise.resolve(json({}, 404));
+    });
+
+    fireEvent.click(screen.getByTestId('invoices-bulk-void-submit'));
+
+    // Dialog must remain open and reason must be preserved.
+    await waitFor(() => {
+      expect(screen.getByTestId('invoices-bulk-void-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('invoices-bulk-void-reason')).toHaveValue('client requested');
+    });
+
+    // Clearing the reason re-disables the submit button.
+    fireEvent.change(screen.getByTestId('invoices-bulk-void-reason'), { target: { value: '' } });
+    expect(screen.getByTestId('invoices-bulk-void-submit')).toBeDisabled();
+  });
 });

--- a/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Mock fetchWithAuth — InvoicesPage calls it directly (no listInvoices wrapper).
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+
+// Mock showToast to suppress UI side-effects.
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// Mock navigateTo to prevent navigation side-effects.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// Grant all permissions so all bulk actions appear.
+vi.mock('../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+import { InvoicesPage } from './InvoicesPage';
+
+const json = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const I1 = '11111111-1111-1111-1111-111111111111';
+const I2 = '22222222-2222-2222-2222-222222222222';
+
+const INVOICES = [
+  { id: I1, orgId: 'o1', status: 'draft', total: '10.00', balance: '10.00', currencyCode: 'USD', issueDate: null, dueDate: null },
+  { id: I2, orgId: 'o1', status: 'draft', total: '20.00', balance: '20.00', currencyCode: 'USD', issueDate: null, dueDate: null },
+];
+
+function wireDefault() {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (String(url).includes('/orgs/organizations')) return Promise.resolve(json({ data: [] }));
+    if (String(url).startsWith('/invoices')) return Promise.resolve(json({ data: INVOICES }));
+    return Promise.resolve(json({}, 404));
+  });
+}
+
+describe('InvoicesPage bulk actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefault();
+  });
+
+  it('selects rows and posts ids to /invoices/bulk-delete', async () => {
+    render(<InvoicesPage />);
+    await screen.findByTestId(`invoices-row-${I1}`);
+
+    fireEvent.click(screen.getByTestId(`invoices-select-${I1}`));
+    fireEvent.click(screen.getByTestId(`invoices-select-${I2}`));
+
+    // Wire bulk-delete response and subsequent refetch.
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (String(url).includes('/bulk-delete'))
+        return Promise.resolve(json({ data: { total: 2, succeeded: 2, skipped: 0, failed: 0, skippedReasons: {} } }));
+      if (String(url).includes('/orgs/organizations')) return Promise.resolve(json({ data: [] }));
+      if (String(url).startsWith('/invoices')) return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({}, 404));
+    });
+
+    fireEvent.click(screen.getByTestId('invoices-bulk-action-delete'));
+
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/invoices/bulk-delete'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string).ids).toEqual([I1, I2]);
+    });
+  });
+
+  it('opens void dialog, fills reason, and posts to /invoices/bulk-void', async () => {
+    render(<InvoicesPage />);
+    await screen.findByTestId(`invoices-row-${I1}`);
+
+    fireEvent.click(screen.getByTestId(`invoices-select-${I1}`));
+
+    fireEvent.click(screen.getByTestId('invoices-bulk-action-void'));
+
+    // Void dialog should appear.
+    await screen.findByTestId('invoices-bulk-void-dialog');
+
+    // Submit is disabled while reason is empty.
+    expect(screen.getByTestId('invoices-bulk-void-submit')).toBeDisabled();
+
+    // Fill in reason.
+    fireEvent.change(screen.getByTestId('invoices-bulk-void-reason'), {
+      target: { value: 'duplicate' },
+    });
+
+    // Wire bulk-void response and subsequent refetch.
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (String(url).includes('/bulk-void'))
+        return Promise.resolve(json({ data: { total: 1, succeeded: 1, skipped: 0, failed: 0, skippedReasons: {} } }));
+      if (String(url).includes('/orgs/organizations')) return Promise.resolve(json({ data: [] }));
+      if (String(url).startsWith('/invoices')) return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({}, 404));
+    });
+
+    fireEvent.click(screen.getByTestId('invoices-bulk-void-submit'));
+
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/invoices/bulk-void'));
+      expect(call).toBeTruthy();
+      const body = JSON.parse((call![1] as RequestInit).body as string);
+      expect(body.ids).toEqual([I1]);
+      expect(body.reason).toBe('duplicate');
+    });
+  });
+});

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -18,7 +18,7 @@ import {
   formatDate,
   formatMoney,
 } from './invoiceTypes';
-import { INVOICE_STATUSES } from '@breeze/shared';
+import { INVOICE_STATUSES, BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
   id: string;
@@ -231,6 +231,10 @@ export function InvoicesPage() {
     async (path: string, verb: string, extraBody?: Record<string, unknown>): Promise<boolean> => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return false;
+      if (ids.length > BULK_ID_LIMIT) {
+        showToast({ type: 'warning', message: `Select up to ${BULK_ID_LIMIT} at a time.` });
+        return false;
+      }
       setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number } }>({
@@ -576,7 +580,7 @@ export function InvoicesPage() {
             <button
               type="button"
               onClick={async () => { const ok = await runBulkInvoices('/invoices/bulk-void', 'voided', { reason: voidReason.trim() }); if (ok) setVoidOpen(false); }}
-              disabled={!voidReason.trim()}
+              disabled={!voidReason.trim() || bulkBusy}
               data-testid="invoices-bulk-void-submit"
               className="inline-flex items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
             >

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -4,6 +4,7 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { Dialog } from '../shared/Dialog';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from './bulk/useBulkSelection';
 import { BulkActionBar } from './bulk/BulkActionBar';
@@ -85,6 +86,9 @@ export function InvoicesPage() {
   const [filters, setFilters] = useState<Filters>(() => readFilters());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   // Bulk void dialog state
   const [voidOpen, setVoidOpen] = useState(false);
@@ -221,6 +225,7 @@ export function InvoicesPage() {
     async (path: string, verb: string, extraBody?: Record<string, unknown>): Promise<boolean> => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return false;
+      setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number } }>({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids, ...extraBody }) }),
@@ -239,6 +244,8 @@ export function InvoicesPage() {
       } catch (err) {
         handleActionError(err, `Bulk ${verb} failed. Retry.`);
         return false;
+      } finally {
+        setBulkBusy(false);
       }
     },
     [bulk, loadInvoices, filters],
@@ -524,9 +531,9 @@ export function InvoicesPage() {
               onClear={bulk.clear}
               testIdPrefix="invoices"
               actions={[
-                ...(can('invoices', 'send') ? [{ key: 'issue', label: 'Issue', onClick: () => void runBulkInvoices('/invoices/bulk-issue', 'issued') }] : []),
-                ...(can('invoices', 'send') ? [{ key: 'void', label: 'Void', variant: 'destructive' as const, onClick: () => { setVoidReason(''); setVoidOpen(true); } }] : []),
-                ...(can('invoices', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkInvoices('/invoices/bulk-delete', 'deleted') }] : []),
+                ...(can('invoices', 'send') ? [{ key: 'issue', label: 'Issue', disabled: bulkBusy, onClick: () => void runBulkInvoices('/invoices/bulk-issue', 'issued') }] : []),
+                ...(can('invoices', 'send') ? [{ key: 'void', label: 'Void', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => { setVoidReason(''); setVoidOpen(true); } }] : []),
+                ...(can('invoices', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setDeleteOpen(true) }] : []),
               ]}
             />
           </div>
@@ -572,6 +579,16 @@ export function InvoicesPage() {
           </div>
         </div>
       </Dialog>
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => { setDeleteOpen(false); void runBulkInvoices('/invoices/bulk-delete', 'deleted'); }}
+        title="Delete draft invoices"
+        message={`Delete ${bulk.size} selected invoice(s)? Only DRAFT invoices will be deleted; this cannot be undone.`}
+        confirmLabel="Delete drafts"
+        confirmTestId="invoices-bulk-delete-confirm"
+      />
 
       {/* New-invoice dialog (assemble | blank) */}
       <Dialog

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -218,9 +218,9 @@ export function InvoicesPage() {
     setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' }));
 
   const runBulkInvoices = useCallback(
-    async (path: string, verb: string, extraBody?: Record<string, unknown>) => {
+    async (path: string, verb: string, extraBody?: Record<string, unknown>): Promise<boolean> => {
       const ids = Array.from(bulk.selectedIds);
-      if (ids.length === 0) return;
+      if (ids.length === 0) return false;
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number } }>({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids, ...extraBody }) }),
@@ -235,8 +235,10 @@ export function InvoicesPage() {
         );
         bulk.clear();
         void loadInvoices(filters);
+        return true;
       } catch (err) {
         handleActionError(err, `Bulk ${verb} failed. Retry.`);
+        return false;
       }
     },
     [bulk, loadInvoices, filters],
@@ -560,7 +562,7 @@ export function InvoicesPage() {
             </button>
             <button
               type="button"
-              onClick={async () => { await runBulkInvoices('/invoices/bulk-void', 'voided', { reason: voidReason.trim() }); setVoidOpen(false); }}
+              onClick={async () => { const ok = await runBulkInvoices('/invoices/bulk-void', 'voided', { reason: voidReason.trim() }); if (ok) setVoidOpen(false); }}
               disabled={!voidReason.trim()}
               data-testid="invoices-bulk-void-submit"
               className="inline-flex items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -151,6 +151,12 @@ export function InvoicesPage() {
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
 
+  // Clear bulk selection whenever the server-side filters or client-side search
+  // change so stale invisible rows are never acted on.
+  useEffect(() => {
+    bulk.clear();
+  }, [filters.orgId, filters.status, filters.from, filters.to, search, bulk.clear]);
+
   const applyFilter = useCallback((patch: Partial<Filters>) => {
     setFilters((prev) => {
       const next = { ...prev, ...patch };

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -4,6 +4,9 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { Dialog } from '../shared/Dialog';
+import { showToast } from '../shared/Toast';
+import { useBulkSelection } from './bulk/useBulkSelection';
+import { BulkActionBar } from './bulk/BulkActionBar';
 import AccessDenied from '../shared/AccessDenied';
 import {
   type InvoiceStatus,
@@ -69,8 +72,9 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
 const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
 
-export default function InvoicesPage() {
+export function InvoicesPage() {
   const { can } = usePermissions();
+  const bulk = useBulkSelection();
   const [invoices, setInvoices] = useState<InvoiceSummary[]>([]);
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
@@ -81,6 +85,10 @@ export default function InvoicesPage() {
   const [filters, setFilters] = useState<Filters>(() => readFilters());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+
+  // Bulk void dialog state
+  const [voidOpen, setVoidOpen] = useState(false);
+  const [voidReason, setVoidReason] = useState('');
 
   // New-invoice dialog state
   const [assembleOpen, setAssembleOpen] = useState(false);
@@ -208,6 +216,31 @@ export default function InvoicesPage() {
 
   const toggleSort = (key: SortKey) =>
     setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' }));
+
+  const runBulkInvoices = useCallback(
+    async (path: string, verb: string, extraBody?: Record<string, unknown>) => {
+      const ids = Array.from(bulk.selectedIds);
+      if (ids.length === 0) return;
+      try {
+        const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number } }>({
+          request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids, ...extraBody }) }),
+          errorFallback: `Bulk ${verb} failed. Retry.`,
+          onUnauthorized: UNAUTHORIZED,
+        });
+        const { succeeded, skipped, failed } = result.data;
+        showToast(
+          skipped + failed > 0
+            ? { type: 'warning', message: `${succeeded} ${verb}, ${skipped} skipped${failed ? `, ${failed} failed` : ''}` }
+            : { type: 'success', message: `${succeeded} ${verb}` },
+        );
+        bulk.clear();
+        void loadInvoices(filters);
+      } catch (err) {
+        handleActionError(err, `Bulk ${verb} failed. Retry.`);
+      }
+    },
+    [bulk, loadInvoices, filters],
+  );
 
   // ---- derived rows: search filter (client) then optional sort ------------
   const rows = useMemo(() => {
@@ -408,65 +441,135 @@ export default function InvoicesPage() {
             No invoices match these filters.
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm" data-testid="invoices-table">
-              <thead>
-                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-3 py-3 font-medium">Number</th>
-                  <th className="px-3 py-3 font-medium">Organization</th>
-                  <SortHeaderLeft label="Issued" sortKey="issued" sort={sort} onSort={toggleSort} />
-                  <SortHeaderLeft label="Due" sortKey="due" sort={sort} onSort={toggleSort} />
-                  <SortHeader label="Total" sortKey="total" />
-                  <SortHeader label="Balance" sortKey="balance" />
-                  <th className="px-3 py-3 font-medium">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((inv) => {
-                  const overdue = inv.status === 'overdue';
-                  const hasBalance = num(inv.balance) > 0 && inv.status !== 'void';
-                  return (
-                    <tr
-                      key={inv.id}
-                      onClick={() => void navigateTo(`/billing/invoices/${inv.id}`)}
-                      data-testid={`invoices-row-${inv.id}`}
-                      className="cursor-pointer border-t transition hover:bg-muted/40"
-                    >
-                      <td className="px-3 py-3 font-medium">
-                        <span className="flex items-center gap-2">
-                          <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-red-500' : 'bg-transparent'}`} aria-hidden="true" />
-                          {inv.invoiceNumber ?? (
-                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                              Draft
-                            </span>
-                          )}
-                        </span>
-                      </td>
-                      <td className="px-3 py-3">{orgName(inv.orgId)}</td>
-                      <td className="px-3 py-3 text-muted-foreground">{formatDate(inv.issueDate)}</td>
-                      <td className={`px-3 py-3 ${overdue ? 'font-medium text-red-700 dark:text-red-400' : 'text-muted-foreground'}`}>
-                        {formatDate(inv.dueDate)}
-                      </td>
-                      <td className="px-3 py-3 text-right tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</td>
-                      <td className={`px-3 py-3 text-right tabular-nums ${hasBalance ? 'font-medium' : 'text-muted-foreground'}`}>
-                        {formatMoney(inv.balance, inv.currencyCode)}
-                      </td>
-                      <td className="px-3 py-3">
-                        <span
-                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
-                          data-testid={`invoices-status-${inv.id}`}
-                        >
-                          {statusLabel(inv)}
-                        </span>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+          <div className="relative">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="invoices-table">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="w-8 px-3 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all invoices"
+                        data-testid="invoices-select-all"
+                        checked={rows.length > 0 && rows.every((r) => bulk.has(r.id))}
+                        onChange={(e) => (e.target.checked ? bulk.selectAll(rows.map((r) => r.id)) : bulk.clear())}
+                      />
+                    </th>
+                    <th className="px-3 py-3 font-medium">Number</th>
+                    <th className="px-3 py-3 font-medium">Organization</th>
+                    <SortHeaderLeft label="Issued" sortKey="issued" sort={sort} onSort={toggleSort} />
+                    <SortHeaderLeft label="Due" sortKey="due" sort={sort} onSort={toggleSort} />
+                    <SortHeader label="Total" sortKey="total" />
+                    <SortHeader label="Balance" sortKey="balance" />
+                    <th className="px-3 py-3 font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((inv) => {
+                    const overdue = inv.status === 'overdue';
+                    const hasBalance = num(inv.balance) > 0 && inv.status !== 'void';
+                    return (
+                      <tr
+                        key={inv.id}
+                        onClick={() => void navigateTo(`/billing/invoices/${inv.id}`)}
+                        data-testid={`invoices-row-${inv.id}`}
+                        className="cursor-pointer border-t transition hover:bg-muted/40"
+                      >
+                        <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            aria-label={`Select invoice ${inv.invoiceNumber ?? inv.id}`}
+                            data-testid={`invoices-select-${inv.id}`}
+                            checked={bulk.has(inv.id)}
+                            onChange={() => bulk.toggle(inv.id)}
+                          />
+                        </td>
+                        <td className="px-3 py-3 font-medium">
+                          <span className="flex items-center gap-2">
+                            <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-red-500' : 'bg-transparent'}`} aria-hidden="true" />
+                            {inv.invoiceNumber ?? (
+                              <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                                Draft
+                              </span>
+                            )}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3">{orgName(inv.orgId)}</td>
+                        <td className="px-3 py-3 text-muted-foreground">{formatDate(inv.issueDate)}</td>
+                        <td className={`px-3 py-3 ${overdue ? 'font-medium text-red-700 dark:text-red-400' : 'text-muted-foreground'}`}>
+                          {formatDate(inv.dueDate)}
+                        </td>
+                        <td className="px-3 py-3 text-right tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</td>
+                        <td className={`px-3 py-3 text-right tabular-nums ${hasBalance ? 'font-medium' : 'text-muted-foreground'}`}>
+                          {formatMoney(inv.balance, inv.currencyCode)}
+                        </td>
+                        <td className="px-3 py-3">
+                          <span
+                            className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
+                            data-testid={`invoices-status-${inv.id}`}
+                          >
+                            {statusLabel(inv)}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <BulkActionBar
+              count={bulk.size}
+              onClear={bulk.clear}
+              testIdPrefix="invoices"
+              actions={[
+                ...(can('invoices', 'send') ? [{ key: 'issue', label: 'Issue', onClick: () => void runBulkInvoices('/invoices/bulk-issue', 'issued') }] : []),
+                ...(can('invoices', 'send') ? [{ key: 'void', label: 'Void', variant: 'destructive' as const, onClick: () => { setVoidReason(''); setVoidOpen(true); } }] : []),
+                ...(can('invoices', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkInvoices('/invoices/bulk-delete', 'deleted') }] : []),
+              ]}
+            />
           </div>
         )}
       </div>
+
+      {/* Bulk void dialog */}
+      <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoices" maxWidth="md" className="p-6">
+        <div className="space-y-4" data-testid="invoices-bulk-void-dialog">
+          <div>
+            <h2 className="text-lg font-semibold">Void invoices</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Voiding releases billed work so it can be re-invoiced. This cannot be undone.
+            </p>
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            Reason
+            <textarea
+              value={voidReason}
+              onChange={(e) => setVoidReason(e.target.value)}
+              rows={3}
+              data-testid="invoices-bulk-void-reason"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setVoidOpen(false)}
+              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={async () => { await runBulkInvoices('/invoices/bulk-void', 'voided', { reason: voidReason.trim() }); setVoidOpen(false); }}
+              disabled={!voidReason.trim()}
+              data-testid="invoices-bulk-void-submit"
+              className="inline-flex items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+            >
+              Void invoices
+            </button>
+          </div>
+        </div>
+      </Dialog>
 
       {/* New-invoice dialog (assemble | blank) */}
       <Dialog
@@ -605,3 +708,5 @@ function SortHeaderLeft({
 
 // re-exported for tests that need the error type
 export { ActionError };
+
+export default InvoicesPage;

--- a/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BulkActionBar } from './BulkActionBar';
+
+describe('BulkActionBar', () => {
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<BulkActionBar count={0} actions={[]} onClear={() => {}} testIdPrefix="quotes" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the count and fires action + clear handlers', () => {
+    const onClick = vi.fn();
+    const onClear = vi.fn();
+    render(
+      <BulkActionBar
+        count={2}
+        actions={[{ key: 'delete', label: 'Delete', variant: 'destructive', onClick }]}
+        onClear={onClear}
+        testIdPrefix="quotes"
+      />
+    );
+    expect(screen.getByTestId('quotes-bulk-bar')).toHaveTextContent('2 selected');
+    fireEvent.click(screen.getByTestId('quotes-bulk-action-delete'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('quotes-bulk-clear'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/billing/bulk/BulkActionBar.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.tsx
@@ -1,0 +1,54 @@
+export interface BulkAction {
+  key: string;
+  label: string;
+  variant?: 'default' | 'destructive';
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export interface BulkActionBarProps {
+  count: number;
+  actions: BulkAction[];
+  onClear: () => void;
+  testIdPrefix: string;
+}
+
+export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkActionBarProps) {
+  if (count === 0) return null;
+  return (
+    <div
+      className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
+      data-testid={`${testIdPrefix}-bulk-bar`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium tabular-nums">{count} selected</span>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          {actions.map((a) => (
+            <button
+              key={a.key}
+              type="button"
+              onClick={a.onClick}
+              disabled={a.disabled}
+              data-testid={`${testIdPrefix}-bulk-action-${a.key}`}
+              className={`inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-50 ${
+                a.variant === 'destructive'
+                  ? 'border border-destructive/40 text-destructive hover:bg-destructive/10'
+                  : 'border hover:bg-muted'
+              }`}
+            >
+              {a.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={onClear}
+            data-testid={`${testIdPrefix}-bulk-clear`}
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/bulk/useBulkSelection.test.ts
+++ b/apps/web/src/components/billing/bulk/useBulkSelection.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBulkSelection } from './useBulkSelection';
+
+describe('useBulkSelection', () => {
+  it('toggles ids on and off', () => {
+    const { result } = renderHook(() => useBulkSelection());
+    act(() => result.current.toggle('a'));
+    expect(result.current.has('a')).toBe(true);
+    expect(result.current.size).toBe(1);
+    act(() => result.current.toggle('a'));
+    expect(result.current.has('a')).toBe(false);
+    expect(result.current.size).toBe(0);
+  });
+
+  it('selectAll adds all ids and clear empties', () => {
+    const { result } = renderHook(() => useBulkSelection());
+    act(() => result.current.selectAll(['a', 'b', 'c']));
+    expect(result.current.size).toBe(3);
+    act(() => result.current.clear());
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/apps/web/src/components/billing/bulk/useBulkSelection.ts
+++ b/apps/web/src/components/billing/bulk/useBulkSelection.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+
+export interface BulkSelection {
+  selectedIds: Set<string>;
+  size: number;
+  has: (id: string) => boolean;
+  toggle: (id: string) => void;
+  selectAll: (ids: string[]) => void;
+  clear: () => void;
+}
+
+export function useBulkSelection(): BulkSelection {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelectedIds((prev) => new Set([...prev, ...ids]));
+  }, []);
+
+  const clear = useCallback(() => setSelectedIds(new Set()), []);
+  const has = useCallback((id: string) => selectedIds.has(id), [selectedIds]);
+
+  return { selectedIds, size: selectedIds.size, has, toggle, selectAll, clear };
+}

--- a/apps/web/src/components/billing/quotes/QuoteDetail.delete.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.delete.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// Full set of auth mock (same pattern as QuoteDetail.permissions.test.tsx)
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/quotes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/api/quotes')>();
+  return { ...actual, deleteQuote: vi.fn() };
+});
+
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const draftDetail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const sentDetail: QuoteDetailData = {
+  ...draftDetail,
+  quote: { ...draftDetail.quote, status: 'sent', sentAt: '2026-06-02T00:00:00Z' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'write' }];
+});
+
+describe('QuoteDetail — delete action', () => {
+  it('shows the Delete draft button for a draft quote when the user has quotes:write', async () => {
+    render(<QuoteDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-delete-open')).toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button on a non-draft quote', async () => {
+    render(<QuoteDetail detail={sentDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button when the user lacks quotes:write', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    render(<QuoteDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('deletes a draft quote and navigates to the list', async () => {
+    const deleteQuote = vi.mocked(quotesApi.deleteQuote);
+    deleteQuote.mockResolvedValue(resp({ data: null }));
+
+    const { navigateTo } = await import('@/lib/navigation');
+    const navigateMock = vi.mocked(navigateTo);
+
+    render(<QuoteDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-delete-open'));
+    // ConfirmDialog should now be open
+    await waitFor(() => expect(screen.getByTestId('quote-delete-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-delete-confirm'));
+    await waitFor(() => {
+      expect(deleteQuote).toHaveBeenCalledWith('q-1');
+      expect(navigateMock).toHaveBeenCalledWith('/billing/quotes');
+    });
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -4,7 +4,8 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
-import { quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
+import { deleteQuote, quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
+import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -35,6 +36,8 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
 
   const [busy, setBusy] = useState(false);
   const [sending, setSending] = useState(false);
+  const [delOpen, setDelOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
 
   const send = useCallback(async () => {
@@ -54,6 +57,25 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
       setSending(false);
     }
   }, [sending, quote.id, refresh]);
+
+  const remove = useCallback(async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await runAction({
+        request: () => deleteQuote(quote.id),
+        errorFallback: 'Could not delete the draft.',
+        successMessage: 'Draft deleted',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDelOpen(false);
+      void navigateTo('/billing/quotes');
+    } catch (err) {
+      handleActionError(err, 'Could not delete the draft.');
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleting, quote.id]);
 
   const sortedBlocks = useMemo(
     () => [...blocks].sort((a, b) => a.sortOrder - b.sortOrder),
@@ -251,9 +273,29 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 {sending ? 'Sending…' : 'Send proposal'}
               </button>
             )}
+            {can('quotes', 'write') && quote.status === 'draft' && (
+              <button
+                type="button"
+                onClick={() => setDelOpen(true)}
+                data-testid="quote-delete-open"
+                className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+              >
+                Delete draft
+              </button>
+            )}
           </div>
         </div>
       </div>
+      <ConfirmDialog
+        open={delOpen}
+        onClose={() => setDelOpen(false)}
+        onConfirm={() => void remove()}
+        isLoading={deleting}
+        title="Delete draft quote"
+        message="This permanently deletes the draft quote. This cannot be undone."
+        confirmLabel="Delete draft"
+        confirmTestId="quote-delete-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Mock fetchWithAuth for loadOrgs (called directly) and bulk action calls.
+const fetchWithAuth = vi.fn();
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+// Mock showToast to suppress UI side-effects.
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// Mock navigateTo to prevent navigation side-effects.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// Grant all permissions so both bulk actions appear.
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+// Mock listQuotes (used by loadQuotes inside QuotesPage) and createQuote.
+const listQuotes = vi.fn();
+vi.mock('../../../lib/api/quotes', () => ({
+  listQuotes: (...a: unknown[]) => listQuotes(...a),
+  createQuote: vi.fn(),
+}));
+
+import { QuotesPage } from './QuotesPage';
+
+const json = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const Q1 = '11111111-1111-1111-1111-111111111111';
+const Q2 = '22222222-2222-2222-2222-222222222222';
+
+describe('QuotesPage bulk delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // loadOrgs calls fetchWithAuth directly.
+    fetchWithAuth.mockResolvedValueOnce(json({ data: [] }));
+    // loadQuotes calls listQuotes which wraps fetchWithAuth.
+    listQuotes.mockResolvedValueOnce(
+      json({
+        data: [
+          { id: Q1, orgId: 'o1', status: 'draft', total: '10', currencyCode: 'USD', createdAt: '2026-06-01' },
+          { id: Q2, orgId: 'o1', status: 'draft', total: '20', currencyCode: 'USD', createdAt: '2026-06-02' },
+        ],
+      }),
+    );
+  });
+
+  it('selects rows and posts ids to /quotes/bulk-delete', async () => {
+    render(<QuotesPage />);
+    await screen.findByTestId(`quotes-row-${Q1}`);
+
+    fireEvent.click(screen.getByTestId(`quotes-select-${Q1}`));
+    fireEvent.click(screen.getByTestId(`quotes-select-${Q2}`));
+
+    // bulk-delete response + refetch response
+    fetchWithAuth.mockResolvedValueOnce(
+      json({ data: { total: 2, succeeded: 2, skipped: 0, failed: 0, skippedReasons: {} } }),
+    );
+    listQuotes.mockResolvedValueOnce(json({ data: [] }));
+
+    fireEvent.click(screen.getByTestId('quotes-bulk-action-delete'));
+
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/quotes/bulk-delete'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string).ids).toEqual([Q1, Q2]);
+    });
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx
@@ -61,6 +61,10 @@ describe('QuotesPage bulk delete', () => {
 
     fireEvent.click(screen.getByTestId('quotes-bulk-action-delete'));
 
+    // Confirm dialog must appear before the request is sent.
+    const confirmBtn = await screen.findByTestId('quotes-bulk-delete-confirm');
+    fireEvent.click(confirmBtn);
+
     await waitFor(() => {
       const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/quotes/bulk-delete'));
       expect(call).toBeTruthy();

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -17,6 +17,7 @@ import {
   formatDate,
   formatMoney,
 } from './quoteTypes';
+import { BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
   id: string;
@@ -216,6 +217,10 @@ export function QuotesPage() {
     async (path: string, verb: string) => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return;
+      if (ids.length > BULK_ID_LIMIT) {
+        showToast({ type: 'warning', message: `Select up to ${BULK_ID_LIMIT} at a time.` });
+        return;
+      }
       setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -5,6 +5,9 @@ import { runAction, handleActionError, ActionError } from '../../../lib/runActio
 import { usePermissions } from '../../../lib/permissions';
 import { Dialog } from '../../shared/Dialog';
 import { listQuotes, createQuote } from '../../../lib/api/quotes';
+import { showToast } from '../../shared/Toast';
+import { useBulkSelection } from '../bulk/useBulkSelection';
+import { BulkActionBar } from '../bulk/BulkActionBar';
 import {
   type Quote,
   type QuoteStatus,
@@ -67,9 +70,10 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
 const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
 
-export default function QuotesPage() {
+export function QuotesPage() {
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
+  const bulk = useBulkSelection();
   const [quotes, setQuotes] = useState<Quote[]>([]);
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
@@ -198,6 +202,31 @@ export default function QuotesPage() {
     return out;
   }, [quotes, search, sort, orgName]);
 
+  const runBulkQuotes = useCallback(
+    async (path: string, verb: string) => {
+      const ids = Array.from(bulk.selectedIds);
+      if (ids.length === 0) return;
+      try {
+        const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({
+          request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids }) }),
+          errorFallback: `Bulk ${verb} failed. Retry.`,
+          onUnauthorized: UNAUTHORIZED,
+        });
+        const { succeeded, skipped, failed } = result.data;
+        showToast(
+          skipped + failed > 0
+            ? { type: 'warning', message: `${succeeded} ${verb}, ${skipped} skipped${failed ? `, ${failed} failed` : ''}` }
+            : { type: 'success', message: `${succeeded} ${verb}` }
+        );
+        bulk.clear();
+        void loadQuotes(filters);
+      } catch (err) {
+        handleActionError(err, `Bulk ${verb} failed. Retry.`);
+      }
+    },
+    [bulk, loadQuotes, filters],
+  );
+
   const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
     <th className="px-3 py-3 text-right font-medium">
       <button
@@ -316,47 +345,76 @@ export default function QuotesPage() {
             No quotes match these filters.
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm" data-testid="quotes-table">
-              <thead>
-                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-3 py-3 font-medium">Number</th>
-                  <th className="px-3 py-3 font-medium">Organization</th>
-                  <th className="px-3 py-3 font-medium">Status</th>
-                  <SortHeader label="Total" sortKey="total" />
-                  <SortHeaderLeft label="Created" sortKey="created" sort={sort} onSort={toggleSort} />
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((qt) => (
-                  <tr
-                    key={qt.id}
-                    onClick={() => void navigateTo(`/billing/quotes/${qt.id}`)}
-                    data-testid={`quotes-row-${qt.id}`}
-                    className="cursor-pointer border-t transition hover:bg-muted/40"
-                  >
-                    <td className="px-3 py-3 font-medium">
-                      {qt.quoteNumber ?? (
-                        <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                          Draft
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-3 py-3">{orgName(qt.orgId)}</td>
-                    <td className="px-3 py-3">
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[qt.status]}`}
-                        data-testid={`quotes-status-${qt.id}`}
-                      >
-                        {statusLabel(qt)}
-                      </span>
-                    </td>
-                    <td className="px-3 py-3 text-right tabular-nums">{formatMoney(qt.total, qt.currencyCode)}</td>
-                    <td className="px-3 py-3 text-muted-foreground">{formatDate(qt.createdAt)}</td>
+          <div className="relative">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="quotes-table">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="w-8 px-3 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all quotes"
+                        data-testid="quotes-select-all"
+                        checked={rows.length > 0 && rows.every((r) => bulk.has(r.id))}
+                        onChange={(e) => (e.target.checked ? bulk.selectAll(rows.map((r) => r.id)) : bulk.clear())}
+                      />
+                    </th>
+                    <th className="px-3 py-3 font-medium">Number</th>
+                    <th className="px-3 py-3 font-medium">Organization</th>
+                    <th className="px-3 py-3 font-medium">Status</th>
+                    <SortHeader label="Total" sortKey="total" />
+                    <SortHeaderLeft label="Created" sortKey="created" sort={sort} onSort={toggleSort} />
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {rows.map((qt) => (
+                    <tr
+                      key={qt.id}
+                      onClick={() => void navigateTo(`/billing/quotes/${qt.id}`)}
+                      data-testid={`quotes-row-${qt.id}`}
+                      className="cursor-pointer border-t transition hover:bg-muted/40"
+                    >
+                      <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select quote ${qt.quoteNumber ?? qt.id}`}
+                          data-testid={`quotes-select-${qt.id}`}
+                          checked={bulk.has(qt.id)}
+                          onChange={() => bulk.toggle(qt.id)}
+                        />
+                      </td>
+                      <td className="px-3 py-3 font-medium">
+                        {qt.quoteNumber ?? (
+                          <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                            Draft
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-3">{orgName(qt.orgId)}</td>
+                      <td className="px-3 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[qt.status]}`}
+                          data-testid={`quotes-status-${qt.id}`}
+                        >
+                          {statusLabel(qt)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums">{formatMoney(qt.total, qt.currencyCode)}</td>
+                      <td className="px-3 py-3 text-muted-foreground">{formatDate(qt.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <BulkActionBar
+              count={bulk.size}
+              onClear={bulk.clear}
+              testIdPrefix="quotes"
+              actions={[
+                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
+                ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkQuotes('/quotes/bulk-delete', 'deleted') }] : []),
+              ]}
+            />
           </div>
         )}
       </div>
@@ -453,3 +511,5 @@ function SortHeaderLeft({
 
 // re-exported for tests that need the error type
 export { ActionError };
+
+export default QuotesPage;

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -4,6 +4,7 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
 import { Dialog } from '../../shared/Dialog';
+import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { listQuotes, createQuote } from '../../../lib/api/quotes';
 import { showToast } from '../../shared/Toast';
 import { useBulkSelection } from '../bulk/useBulkSelection';
@@ -81,6 +82,9 @@ export function QuotesPage() {
   const [filters, setFilters] = useState<Filters>(() => readFilters());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   // New-quote dialog state
   const [createOpen, setCreateOpen] = useState(false);
@@ -206,6 +210,7 @@ export function QuotesPage() {
     async (path: string, verb: string) => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return;
+      setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids }) }),
@@ -222,6 +227,8 @@ export function QuotesPage() {
         void loadQuotes(filters);
       } catch (err) {
         handleActionError(err, `Bulk ${verb} failed. Retry.`);
+      } finally {
+        setBulkBusy(false);
       }
     },
     [bulk, loadQuotes, filters],
@@ -411,13 +418,23 @@ export function QuotesPage() {
               onClear={bulk.clear}
               testIdPrefix="quotes"
               actions={[
-                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
-                ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkQuotes('/quotes/bulk-delete', 'deleted') }] : []),
+                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', disabled: bulkBusy, onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
+                ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setDeleteOpen(true) }] : []),
               ]}
             />
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => { setDeleteOpen(false); void runBulkQuotes('/quotes/bulk-delete', 'deleted'); }}
+        title="Delete draft quotes"
+        message={`Delete ${bulk.size} selected quote(s)? Only DRAFT quotes will be deleted; this cannot be undone.`}
+        confirmLabel="Delete drafts"
+        confirmTestId="quotes-bulk-delete-confirm"
+      />
 
       {/* New-quote dialog */}
       <Dialog

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -132,6 +132,12 @@ export function QuotesPage() {
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
 
+  // Clear bulk selection whenever the server-side filters or client-side search
+  // change so stale invisible rows are never acted on.
+  useEffect(() => {
+    bulk.clear();
+  }, [filters.orgId, filters.status, search, bulk.clear]);
+
   const applyFilter = useCallback((patch: Partial<Filters>) => {
     setFilters((prev) => {
       const next = { ...prev, ...patch };

--- a/apps/web/src/components/contracts/ContractDetail.delete.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.delete.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractDetail from './ContractDetail';
+import * as contractsApi from '../../lib/api/contracts';
+import type { ContractDetail as ContractDetailData } from '../../lib/api/contracts';
+
+// Auth mock (same pattern as ContractDetail.permissions.test.tsx)
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    contractTransition: vi.fn(),
+    generateContractInvoice: vi.fn(),
+    getContractEstimate: vi.fn(),
+    deleteContract: vi.fn(),
+  };
+});
+
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const draftDetail: ContractDetailData = {
+  contract: {
+    id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'draft',
+    billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
+    nextBillingAt: null, autoIssue: false, autoRenew: false, renewalTermMonths: null, renewalNoticeDays: null,
+    currencyCode: 'USD', notes: null, terms: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [],
+  periods: [],
+};
+
+const activeDetail: ContractDetailData = {
+  ...draftDetail,
+  contract: { ...draftDetail.contract, status: 'active' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'contracts', action: 'write' }];
+  (contractsApi.getContractEstimate as ReturnType<typeof vi.fn>).mockResolvedValue(
+    resp({ data: { currencyCode: 'USD', periodTotal: '0.00', lines: [] } }),
+  );
+});
+
+describe('ContractDetail — delete action', () => {
+  it('shows the Delete draft button for a draft contract when the user has contracts:write', async () => {
+    render(<ContractDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('contract-delete-open')).toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button on a non-draft contract', async () => {
+    render(<ContractDetail detail={activeDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('contract-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('hides the Delete draft button when the user lacks contracts:write', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'read' }];
+    render(<ContractDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('contract-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('deletes a draft contract and navigates to the contracts list', async () => {
+    const deleteContract = vi.mocked(contractsApi.deleteContract);
+    deleteContract.mockResolvedValue(resp({ data: null }));
+
+    const { navigateTo } = await import('@/lib/navigation');
+    const navigateMock = vi.mocked(navigateTo);
+
+    render(<ContractDetail detail={draftDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('contract-delete-open'));
+    await waitFor(() => expect(screen.getByTestId('contract-delete-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('contract-delete-confirm'));
+    await waitFor(() => {
+      expect(deleteContract).toHaveBeenCalledWith('ct-1');
+      expect(navigateMock).toHaveBeenCalledWith('/contracts');
+    });
+  });
+});

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -129,6 +129,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
         successMessage: 'Draft deleted',
         onUnauthorized: UNAUTHORIZED,
       });
+      setDelOpen(false);
       void navigateTo('/contracts');
     } catch (err) {
       handleActionError(err, 'Could not delete the draft.');

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import {
   contractTransition,
+  deleteContract,
   generateContractInvoice,
   getContractEstimate,
   formatCadence,
@@ -61,6 +63,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
   const currency = contract.currencyCode;
 
   const [busy, setBusy] = useState(false);
+  const [delOpen, setDelOpen] = useState(false);
   const [estimate, setEstimate] = useState<ContractEstimate | null>(null);
 
   useEffect(() => {
@@ -115,6 +118,24 @@ export default function ContractDetail({ detail, onChanged }: Props) {
       setBusy(false);
     }
   }, [busy, contract.id, refresh]);
+
+  const remove = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => deleteContract(contract.id),
+        errorFallback: 'Could not delete the draft.',
+        successMessage: 'Draft deleted',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      void navigateTo('/contracts');
+    } catch (err) {
+      handleActionError(err, 'Could not delete the draft.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, contract.id]);
 
   const availableTransitions = TRANSITIONS_FOR_STATUS[contract.status] ?? [];
   const canGenerate = contract.status === 'active';
@@ -323,8 +344,31 @@ export default function ContractDetail({ detail, onChanged }: Props) {
               Generate invoice now
             </button>
           )}
+
+          {/* Delete draft (write-gated, draft-only) */}
+          {can('contracts', 'write') && contract.status === 'draft' && (
+            <button
+              type="button"
+              onClick={() => setDelOpen(true)}
+              data-testid="contract-delete-open"
+              className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+            >
+              Delete draft
+            </button>
+          )}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={delOpen}
+        onClose={() => setDelOpen(false)}
+        onConfirm={() => void remove()}
+        isLoading={busy}
+        title="Delete draft contract"
+        message="This permanently deletes the draft contract. This cannot be undone."
+        confirmLabel="Delete draft"
+        confirmTestId="contract-delete-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/contracts/ContractsList.bulk.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.bulk.test.tsx
@@ -102,6 +102,10 @@ describe('ContractsList bulk actions', () => {
 
     fireEvent.click(screen.getByTestId('contracts-bulk-action-delete'));
 
+    // Confirm dialog must appear before the request is sent.
+    const confirmBtn = await screen.findByTestId('contracts-bulk-delete-confirm');
+    fireEvent.click(confirmBtn);
+
     await waitFor(() => {
       const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/contracts/bulk-delete'));
       expect(call).toBeTruthy();

--- a/apps/web/src/components/contracts/ContractsList.bulk.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.bulk.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Mock fetchWithAuth — called directly for loadOrgs and bulk action POSTs.
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+// Mock showToast to suppress UI side-effects.
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// Mock navigateTo to prevent navigation side-effects.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// Grant all permissions so both bulk actions appear.
+vi.mock('../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+// Mock listContracts (used by loadContracts inside ContractsList).
+const listContracts = vi.fn();
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return { ...orig, listContracts: (...a: unknown[]) => listContracts(...a) };
+});
+
+import { ContractsList } from './ContractsList';
+
+const json = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const C1 = '11111111-1111-1111-1111-111111111111';
+const C2 = '22222222-2222-2222-2222-222222222222';
+
+const CONTRACTS = [
+  {
+    id: C1,
+    orgId: 'o1',
+    partnerId: 'p1',
+    name: 'Contract A',
+    status: 'draft',
+    intervalMonths: 1,
+    currencyCode: 'USD',
+    nextBillingAt: null,
+    estimatedPeriodValue: '100.00',
+    billingTiming: 'advance',
+    startDate: '2026-01-01',
+    endDate: null,
+    autoIssue: false,
+    autoRenew: false,
+    renewalTermMonths: null,
+    renewalNoticeDays: null,
+    notes: null,
+    terms: null,
+    createdBy: null,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+  },
+  {
+    id: C2,
+    orgId: 'o1',
+    partnerId: 'p1',
+    name: 'Contract B',
+    status: 'draft',
+    intervalMonths: 1,
+    currencyCode: 'USD',
+    nextBillingAt: null,
+    estimatedPeriodValue: '200.00',
+    billingTiming: 'advance',
+    startDate: '2026-01-01',
+    endDate: null,
+    autoIssue: false,
+    autoRenew: false,
+    renewalTermMonths: null,
+    renewalNoticeDays: null,
+    notes: null,
+    terms: null,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+  },
+];
+
+describe('ContractsList bulk actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // loadOrgs calls fetchWithAuth directly.
+    fetchWithAuth.mockResolvedValue(json({ data: [] }));
+    // loadContracts calls listContracts.
+    listContracts.mockResolvedValueOnce(json({ data: CONTRACTS }));
+  });
+
+  it('selects rows and posts ids to /contracts/bulk-delete', async () => {
+    render(<ContractsList />);
+    await screen.findByTestId(`contract-row-${C1}`);
+
+    fireEvent.click(screen.getByTestId(`contract-select-${C1}`));
+    fireEvent.click(screen.getByTestId(`contract-select-${C2}`));
+
+    // Wire bulk-delete response and subsequent refetch.
+    fetchWithAuth.mockResolvedValueOnce(
+      json({ data: { total: 2, succeeded: 2, skipped: 0, failed: 0, skippedReasons: {} } }),
+    );
+    listContracts.mockResolvedValueOnce(json({ data: [] }));
+
+    fireEvent.click(screen.getByTestId('contracts-bulk-action-delete'));
+
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/contracts/bulk-delete'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string).ids).toEqual([C1, C2]);
+    });
+  });
+
+  it('opens cancel confirm dialog and posts ids to /contracts/bulk-cancel', async () => {
+    render(<ContractsList />);
+    await screen.findByTestId(`contract-row-${C1}`);
+
+    fireEvent.click(screen.getByTestId(`contract-select-${C1}`));
+
+    // Click the Cancel bulk action to open the ConfirmDialog.
+    fireEvent.click(screen.getByTestId('contracts-bulk-action-cancel'));
+
+    // The confirm button should appear in the dialog.
+    const confirmBtn = await screen.findByTestId('contracts-bulk-cancel-confirm');
+    expect(confirmBtn).toBeInTheDocument();
+
+    // Wire bulk-cancel response and subsequent refetch.
+    fetchWithAuth.mockResolvedValueOnce(
+      json({ data: { total: 1, succeeded: 1, skipped: 0, failed: 0, skippedReasons: {} } }),
+    );
+    listContracts.mockResolvedValueOnce(json({ data: [] }));
+
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/contracts/bulk-cancel'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string).ids).toEqual([C1]);
+    });
+  });
+});

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { handleActionError } from '../../lib/runAction';
+import { runAction, handleActionError } from '../../lib/runAction';
 import {
   listContracts,
   formatCadence,
@@ -13,6 +13,10 @@ import {
 } from '../../lib/api/contracts';
 import { formatMoney } from '../billing/invoiceTypes';
 import { usePermissions } from '../../lib/permissions';
+import { showToast } from '../shared/Toast';
+import { useBulkSelection } from '../billing/bulk/useBulkSelection';
+import { BulkActionBar } from '../billing/bulk/BulkActionBar';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 
 interface Organization {
   id: string;
@@ -71,8 +75,9 @@ interface Props {
   lockedOrgId?: string;
 }
 
-export default function ContractsList({ lockedOrgId }: Props = {}) {
+export function ContractsList({ lockedOrgId }: Props = {}) {
   const { can } = usePermissions();
+  const bulk = useBulkSelection();
   const [contracts, setContracts] = useState<ContractSummary[]>([]);
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,6 +85,7 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
   const [filters, setFilters] = useState<Filters>(() =>
     lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : readFilters(),
   );
+  const [cancelOpen, setCancelOpen] = useState(false);
 
   const orgName = useCallback(
     (id: string) => orgs.find((o) => o.id === id)?.name ?? id.slice(0, 8),
@@ -142,6 +148,31 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
     const total = active.reduce((sum, c) => sum + monthlyValue(c.estimatedPeriodValue, c.intervalMonths), 0);
     return { total, count: active.length, ccy: contracts[0]?.currencyCode || 'USD' };
   }, [contracts]);
+
+  const runBulkContracts = useCallback(
+    async (path: string, verb: string) => {
+      const ids = Array.from(bulk.selectedIds);
+      if (ids.length === 0) return;
+      try {
+        const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({
+          request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids }) }),
+          errorFallback: `Bulk ${verb} failed. Retry.`,
+          onUnauthorized: UNAUTHORIZED,
+        });
+        const { succeeded, skipped, failed } = result.data;
+        showToast(
+          skipped + failed > 0
+            ? { type: 'warning', message: `${succeeded} ${verb}, ${skipped} skipped${failed ? `, ${failed} failed` : ''}` }
+            : { type: 'success', message: `${succeeded} ${verb}` }
+        );
+        bulk.clear();
+        void loadContracts(filters);
+      } catch (err) {
+        handleActionError(err, `Bulk ${verb} failed. Retry.`);
+      }
+    },
+    [bulk, loadContracts, filters],
+  );
 
   return (
     <div className="space-y-6" data-testid="contracts-page">
@@ -233,48 +264,89 @@ export default function ContractsList({ lockedOrgId }: Props = {}) {
             No contracts match these filters.
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm" data-testid="contracts-list">
-              <thead>
-                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="px-3 py-3 font-medium">Name</th>
-                  <th className="px-3 py-3 font-medium">Organization</th>
-                  <th className="px-3 py-3 font-medium">Status</th>
-                  <th className="px-3 py-3 font-medium">Cadence</th>
-                  <th className="px-3 py-3 font-medium">Next bill</th>
-                  <th className="px-3 py-3 text-right font-medium">Est. / period</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((ctr) => (
-                  <tr
-                    key={ctr.id}
-                    onClick={() => void navigateTo(`/contracts/${ctr.id}`)}
-                    data-testid={`contract-row-${ctr.id}`}
-                    className="cursor-pointer border-t transition hover:bg-muted/40"
-                  >
-                    <td className="px-3 py-3 font-medium">{ctr.name}</td>
-                    <td className="px-3 py-3">{orgName(ctr.orgId)}</td>
-                    <td className="px-3 py-3">
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${CONTRACT_STATUS_COLORS[ctr.status]}`}
-                        data-testid={`contract-status-${ctr.id}`}
-                      >
-                        {CONTRACT_STATUS_LABELS[ctr.status]}
-                      </span>
-                    </td>
-                    <td className="px-3 py-3">{formatCadence(ctr.intervalMonths)}</td>
-                    <td className="px-3 py-3">{formatDate(ctr.nextBillingAt)}</td>
-                    <td className="px-3 py-3 text-right tabular-nums" data-testid={`contract-estimate-${ctr.id}`}>
-                      {ctr.estimatedPeriodValue != null ? formatMoney(ctr.estimatedPeriodValue, ctr.currencyCode) : '—'}
-                    </td>
+          <div className="relative">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="contracts-list">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="w-8 px-3 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all contracts"
+                        data-testid="contracts-select-all"
+                        checked={rows.length > 0 && rows.every((r) => bulk.has(r.id))}
+                        onChange={(e) => (e.target.checked ? bulk.selectAll(rows.map((r) => r.id)) : bulk.clear())}
+                      />
+                    </th>
+                    <th className="px-3 py-3 font-medium">Name</th>
+                    <th className="px-3 py-3 font-medium">Organization</th>
+                    <th className="px-3 py-3 font-medium">Status</th>
+                    <th className="px-3 py-3 font-medium">Cadence</th>
+                    <th className="px-3 py-3 font-medium">Next bill</th>
+                    <th className="px-3 py-3 text-right font-medium">Est. / period</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {rows.map((ctr) => (
+                    <tr
+                      key={ctr.id}
+                      onClick={() => void navigateTo(`/contracts/${ctr.id}`)}
+                      data-testid={`contract-row-${ctr.id}`}
+                      className="cursor-pointer border-t transition hover:bg-muted/40"
+                    >
+                      <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select contract ${ctr.name}`}
+                          data-testid={`contract-select-${ctr.id}`}
+                          checked={bulk.has(ctr.id)}
+                          onChange={() => bulk.toggle(ctr.id)}
+                        />
+                      </td>
+                      <td className="px-3 py-3 font-medium">{ctr.name}</td>
+                      <td className="px-3 py-3">{orgName(ctr.orgId)}</td>
+                      <td className="px-3 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${CONTRACT_STATUS_COLORS[ctr.status]}`}
+                          data-testid={`contract-status-${ctr.id}`}
+                        >
+                          {CONTRACT_STATUS_LABELS[ctr.status]}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3">{formatCadence(ctr.intervalMonths)}</td>
+                      <td className="px-3 py-3">{formatDate(ctr.nextBillingAt)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums" data-testid={`contract-estimate-${ctr.id}`}>
+                        {ctr.estimatedPeriodValue != null ? formatMoney(ctr.estimatedPeriodValue, ctr.currencyCode) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <BulkActionBar
+              count={bulk.size}
+              onClear={bulk.clear}
+              testIdPrefix="contracts"
+              actions={[
+                ...(can('contracts', 'manage') ? [{ key: 'cancel', label: 'Cancel', variant: 'destructive' as const, onClick: () => setCancelOpen(true) }] : []),
+                ...(can('contracts', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkContracts('/contracts/bulk-delete', 'deleted') }] : []),
+              ]}
+            />
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={cancelOpen}
+        onClose={() => setCancelOpen(false)}
+        onConfirm={() => { setCancelOpen(false); void runBulkContracts('/contracts/bulk-cancel', 'cancelled'); }}
+        title="Cancel contracts"
+        message={`Cancel ${bulk.size} selected contract(s)? Active and paused contracts will be cancelled; this cannot be undone.`}
+        confirmLabel="Cancel contracts"
+        confirmTestId="contracts-bulk-cancel-confirm"
+      />
     </div>
   );
 }
+
+export default ContractsList;

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -132,6 +132,12 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     return () => window.removeEventListener('hashchange', onHash);
   }, [lockedOrgId]);
 
+  // Clear bulk selection whenever the server-side filters change so stale
+  // invisible rows are never acted on. No client-side search in this component.
+  useEffect(() => {
+    bulk.clear();
+  }, [filters.orgId, filters.status, bulk.clear]);
+
   const applyFilter = useCallback((patch: Partial<Filters>) => {
     setFilters((prev) => {
       const next = { ...prev, ...patch };

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -86,6 +86,8 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : readFilters(),
   );
   const [cancelOpen, setCancelOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   const orgName = useCallback(
     (id: string) => orgs.find((o) => o.id === id)?.name ?? id.slice(0, 8),
@@ -153,6 +155,7 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     async (path: string, verb: string) => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return;
+      setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids }) }),
@@ -169,6 +172,8 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
         void loadContracts(filters);
       } catch (err) {
         handleActionError(err, `Bulk ${verb} failed. Retry.`);
+      } finally {
+        setBulkBusy(false);
       }
     },
     [bulk, loadContracts, filters],
@@ -328,8 +333,8 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
               onClear={bulk.clear}
               testIdPrefix="contracts"
               actions={[
-                ...(can('contracts', 'manage') ? [{ key: 'cancel', label: 'Cancel', variant: 'destructive' as const, onClick: () => setCancelOpen(true) }] : []),
-                ...(can('contracts', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkContracts('/contracts/bulk-delete', 'deleted') }] : []),
+                ...(can('contracts', 'manage') ? [{ key: 'cancel', label: 'Cancel', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setCancelOpen(true) }] : []),
+                ...(can('contracts', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setDeleteOpen(true) }] : []),
               ]}
             />
           </div>
@@ -344,6 +349,16 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
         message={`Cancel ${bulk.size} selected contract(s)? Active and paused contracts will be cancelled; this cannot be undone.`}
         confirmLabel="Cancel contracts"
         confirmTestId="contracts-bulk-cancel-confirm"
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => { setDeleteOpen(false); void runBulkContracts('/contracts/bulk-delete', 'deleted'); }}
+        title="Delete draft contracts"
+        message={`Delete ${bulk.size} selected contract(s)? Only DRAFT contracts will be deleted; this cannot be undone.`}
+        confirmLabel="Delete drafts"
+        confirmTestId="contracts-bulk-delete-confirm"
       />
     </div>
   );

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BULK_ID_LIMIT } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
@@ -161,6 +162,10 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     async (path: string, verb: string) => {
       const ids = Array.from(bulk.selectedIds);
       if (ids.length === 0) return;
+      if (ids.length > BULK_ID_LIMIT) {
+        showToast({ type: 'warning', message: `Select up to ${BULK_ID_LIMIT} at a time.` });
+        return;
+      }
       setBulkBusy(true);
       try {
         const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({

--- a/docs/superpowers/plans/2026-06-25-billing-bulk-and-detail-actions.md
+++ b/docs/superpowers/plans/2026-06-25-billing-bulk-and-detail-actions.md
@@ -1,0 +1,1373 @@
+# Billing Bulk Actions + Detail Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add row-selection + bulk actions to the Quotes, Invoices, and Contracts list tables, and a draft-only Delete button to each of their detail screens.
+
+**Architecture:** New per-action **bulk API endpoints** (one Hono route per entity file) loop over an id list and call the *existing* per-item service functions (`deleteDraftQuote`, `sendQuote`, `deleteDraftInvoice`, `issueInvoice`, `voidInvoice`, `deleteDraftContract`, `cancelContract`), collecting `{succeeded, skipped, failed, skippedReasons}` via a shared `runBulk` helper — mirroring the existing `POST /tickets/bulk` pattern. On the web, a reusable `useBulkSelection` hook + `BulkActionBar` component drive checkbox selection on all three tables. Detail-screen Delete reuses the **already-existing** `DELETE /:id` endpoints (draft-only) — no new API for that part. No new DB tables, no schema migration, no RLS changes: every bulk operation runs inside the request's existing `withDbAccessContext` and each reused service already enforces org access.
+
+**Tech Stack:** Hono + Zod + Drizzle (API), React + Tailwind (web), Vitest (both).
+
+## Global Constraints
+
+- **No new tables / migrations / RLS work.** Bulk endpoints only reuse existing org-scoped service functions; detail-delete reuses existing routes. (Verified: `deleteDraftQuote`/`deleteDraftInvoice`/`deleteDraftContract` and lifecycle fns all call `assertOrg`/`requireOrgAccess` and run under the request's RLS context.)
+- **All web mutations go through `runAction`** (`apps/web/src/lib/runAction.ts`) per CLAUDE.md. Catch with `handleActionError(err, fallback)`.
+- **Do NOT modify `TARGET_GLOBS`** in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (avoids the count-drift squash hazard). Adding `runAction`-wrapped handlers inside already-listed files is fine.
+- **Permission constants** (`packages/shared/src/constants/permissions.ts`, imported in routes as `PERMISSIONS` from `../../services/permissions`):
+  - `QUOTES_WRITE` = quotes:write, `QUOTES_SEND` = quotes:send
+  - `INVOICES_WRITE` = invoices:write, `INVOICES_SEND` = invoices:send
+  - `CONTRACTS_WRITE` = contracts:write, `CONTRACTS_MANAGE` = contracts:manage
+- **Bulk action → permission mapping:** delete → `*_WRITE`; quote send / invoice issue / invoice void → `*_SEND`; contract cancel → `CONTRACTS_MANAGE`. (One endpoint per action so the existing `requirePermission` middleware gates each correctly.)
+- **Route ordering:** register bulk routes **before** the `/:id` CRUD routes in each entity's `index.ts` (matches the tickets precedent — `/bulk` before `/:id`).
+- **Bulk id cap:** `z.array(z.string().guid()).min(1).max(200)`.
+- **Web import paths:** `runAction, handleActionError` from `lib/runAction`; `fetchWithAuth` from `stores/auth`; `navigateTo` from `@/lib/navigation`; `showToast` from `components/shared/Toast`; `usePermissions` (→ `can`) from `lib/permissions`; `ConfirmDialog` from `components/shared/ConfirmDialog`.
+- Run API tests with: `pnpm --filter @breeze/api exec vitest run <path>` (per memory: `db:migrate`/bare vitest gotchas). Run web tests with `pnpm --filter @breeze/web exec vitest run <path>`.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/src/lib/bulkOps.ts` — `runBulk()` helper + `BulkResult` type (shared by all bulk routes).
+- `apps/api/src/routes/quotes/bulk.ts` — `quoteBulkRoutes` (`/bulk-delete`, `/bulk-send`).
+- `apps/api/src/routes/quotes/bulk.test.ts`
+- `apps/api/src/routes/invoices/bulk.ts` — `invoiceBulkRoutes` (`/bulk-delete`, `/bulk-issue`, `/bulk-void`).
+- `apps/api/src/routes/invoices/bulk.test.ts`
+- `apps/api/src/routes/contracts/bulk.ts` — `contractBulkRoutes` (`/bulk-delete`, `/bulk-cancel`).
+- `apps/api/src/routes/contracts/bulk.test.ts`
+- `apps/web/src/components/billing/bulk/useBulkSelection.ts` — selection hook.
+- `apps/web/src/components/billing/bulk/useBulkSelection.test.ts`
+- `apps/web/src/components/billing/bulk/BulkActionBar.tsx` — slide-up action bar.
+- `apps/web/src/components/billing/bulk/BulkActionBar.test.tsx`
+
+**Modify:**
+- `packages/shared/src/validators/quotes.ts` — add `bulkQuoteIdsSchema`.
+- `packages/shared/src/validators/invoices.ts` — add `bulkInvoiceIdsSchema`, `bulkVoidInvoicesSchema`.
+- `packages/shared/src/validators/contracts.ts` — add `bulkContractIdsSchema`.
+- `apps/api/src/routes/quotes/index.ts`, `invoices/index.ts`, `contracts/index.ts` — mount bulk routes before CRUD.
+- `apps/web/src/components/billing/quotes/QuotesPage.tsx` — selection column + bar.
+- `apps/web/src/components/billing/InvoicesPage.tsx` — selection column + bar.
+- `apps/web/src/components/contracts/ContractsList.tsx` — selection column + bar.
+- `apps/web/src/components/billing/quotes/QuoteDetail.tsx` — Delete (draft) button.
+- `apps/web/src/components/billing/InvoiceDetail.tsx` — Delete (draft) button.
+- `apps/web/src/components/contracts/ContractDetail.tsx` — Delete (draft) button.
+- `apps/web/src/lib/api/quotes.ts` — add `deleteQuote(id)`.
+- `apps/web/src/lib/api/contracts.ts` — add `deleteContract(id)`.
+
+---
+
+## Task 1: Shared bulk Zod schemas + `runBulk` helper
+
+**Files:**
+- Modify: `packages/shared/src/validators/quotes.ts`
+- Modify: `packages/shared/src/validators/invoices.ts`
+- Modify: `packages/shared/src/validators/contracts.ts`
+- Create: `apps/api/src/lib/bulkOps.ts`
+- Test: `apps/api/src/lib/bulkOps.test.ts`
+
+**Interfaces:**
+- Produces: `bulkQuoteIdsSchema`, `bulkInvoiceIdsSchema`, `bulkVoidInvoicesSchema`, `bulkContractIdsSchema` (all from `@breeze/shared`); `runBulk(ids, perItem)` → `Promise<BulkResult>`; `BulkResult = { total; succeeded; skipped; failed; skippedReasons: Record<string,number> }`.
+- `runBulk` classifies a thrown error as **skipped** when it is an object with a numeric `status` in {400,403,404,409} (reads optional `.code`); anything else is **failed** (logged via `console.error`).
+
+- [ ] **Step 1: Write the failing test for `runBulk`**
+
+Create `apps/api/src/lib/bulkOps.test.ts`:
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { runBulk } from './bulkOps';
+
+class SvcError extends Error {
+  constructor(msg: string, public status: number, public code?: string) { super(msg); }
+}
+
+describe('runBulk', () => {
+  it('counts successes', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const r = await runBulk(['a', 'b', 'c'], fn);
+    expect(r).toMatchObject({ total: 3, succeeded: 3, skipped: 0, failed: 0 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats 4xx service errors as skipped and tallies reasons by code', async () => {
+    const fn = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new SvcError('not a draft', 409, 'NOT_A_DRAFT'))
+      .mockRejectedValueOnce(new SvcError('denied', 403, 'ORG_DENIED'));
+    const r = await runBulk(['a', 'b', 'c'], fn);
+    expect(r).toMatchObject({ total: 3, succeeded: 1, skipped: 2, failed: 0 });
+    expect(r.skippedReasons).toEqual({ NOT_A_DRAFT: 1, ORG_DENIED: 1 });
+  });
+
+  it('treats unexpected errors as failed without throwing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fn = vi.fn().mockRejectedValue(new Error('boom'));
+    const r = await runBulk(['a'], fn);
+    expect(r).toMatchObject({ total: 1, succeeded: 0, skipped: 0, failed: 1 });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/lib/bulkOps.test.ts`
+Expected: FAIL — `Cannot find module './bulkOps'`.
+
+- [ ] **Step 3: Implement `runBulk`**
+
+Create `apps/api/src/lib/bulkOps.ts`:
+```typescript
+export interface BulkResult {
+  total: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  skippedReasons: Record<string, number>;
+}
+
+const SKIP_STATUSES = new Set([400, 403, 404, 409]);
+
+function asServiceError(err: unknown): { status: number; code?: string; message?: string } | null {
+  if (err && typeof err === 'object' && 'status' in err && typeof (err as { status: unknown }).status === 'number') {
+    return err as { status: number; code?: string; message?: string };
+  }
+  return null;
+}
+
+/**
+ * Run a per-item async operation over a list of ids, isolating per-item failures.
+ * Expected 4xx service errors (not-a-draft, org-denied, not-found, invalid-state)
+ * count as `skipped` (tallied by `.code`); anything else counts as `failed`.
+ */
+export async function runBulk(
+  ids: string[],
+  perItem: (id: string) => Promise<unknown>
+): Promise<BulkResult> {
+  const result: BulkResult = { total: ids.length, succeeded: 0, skipped: 0, failed: 0, skippedReasons: {} };
+  for (const id of ids) {
+    try {
+      await perItem(id);
+      result.succeeded++;
+    } catch (err) {
+      const svc = asServiceError(err);
+      if (svc && SKIP_STATUSES.has(svc.status)) {
+        result.skipped++;
+        const code = svc.code ?? 'OTHER';
+        result.skippedReasons[code] = (result.skippedReasons[code] ?? 0) + 1;
+      } else {
+        result.failed++;
+        console.error('[runBulk] item failed:', id, err instanceof Error ? err.message : err);
+      }
+    }
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/lib/bulkOps.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add the shared Zod schemas**
+
+In `packages/shared/src/validators/quotes.ts`, add (top-level export; `z` is already imported there):
+```typescript
+export const bulkQuoteIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+```
+
+In `packages/shared/src/validators/invoices.ts`, add:
+```typescript
+export const bulkInvoiceIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+export const bulkVoidInvoicesSchema = bulkInvoiceIdsSchema.extend({
+  reason: z.string().trim().min(1).max(500),
+});
+```
+
+In `packages/shared/src/validators/contracts.ts`, add:
+```typescript
+export const bulkContractIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+```
+
+- [ ] **Step 6: Verify the barrel re-exports them**
+
+Run: `pnpm --filter @breeze/shared exec tsc --noEmit`
+Expected: PASS. (These validator files are already re-exported via `@breeze/shared` — `createQuoteSchema` etc. import from there — so no index edit is needed. If tsc complains the new symbol is missing from `@breeze/shared`, add the export to the validators barrel/index and re-run.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/lib/bulkOps.ts apps/api/src/lib/bulkOps.test.ts packages/shared/src/validators/quotes.ts packages/shared/src/validators/invoices.ts packages/shared/src/validators/contracts.ts
+git commit -m "feat(billing): add runBulk helper + bulk request schemas"
+```
+
+---
+
+## Task 2: Quotes bulk API endpoints
+
+**Files:**
+- Create: `apps/api/src/routes/quotes/bulk.ts`
+- Test: `apps/api/src/routes/quotes/bulk.test.ts`
+- Modify: `apps/api/src/routes/quotes/index.ts`
+
+**Interfaces:**
+- Consumes: `runBulk` (Task 1); `bulkQuoteIdsSchema` (Task 1); existing `deleteDraftQuote`, `sendQuote`, `quoteActorFrom`, `handleServiceError`.
+- Produces: `quoteBulkRoutes`; `POST /quotes/bulk-delete` (write), `POST /quotes/bulk-send` (send) → `{ data: BulkResult }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/quotes/bulk.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/quoteService', () => ({ deleteDraftQuote: vi.fn() }));
+vi.mock('../../services/quoteLifecycle', () => ({ sendQuote: vi.fn() }));
+vi.mock('../../services/quoteTypes', () => ({
+  QuoteServiceError: class QuoteServiceError extends Error {
+    constructor(msg: string, public status = 400, public code?: string) { super(msg); }
+  },
+}));
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { quoteRoutes } from './index';
+import { deleteDraftQuote } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { QuoteServiceError } from '../../services/quoteTypes';
+
+const A = '11111111-1111-1111-1111-111111111111';
+const B = '22222222-2222-2222-2222-222222222222';
+
+function post(path: string, body: unknown) {
+  return quoteRoutes.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('quote bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each id and reports counts', async () => {
+    (deleteDraftQuote as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ total: 2, succeeded: 2, skipped: 0, failed: 0 });
+    expect(deleteDraftQuote).toHaveBeenCalledTimes(2);
+  });
+
+  it('bulk-delete tallies non-draft skips without failing the request', async () => {
+    (deleteDraftQuote as any)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new QuoteServiceError('Quote is not a draft', 409, 'NOT_A_DRAFT'));
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect(res.status).toBe(200);
+    const data = (await res.json()).data;
+    expect(data).toMatchObject({ succeeded: 1, skipped: 1 });
+    expect(data.skippedReasons).toEqual({ NOT_A_DRAFT: 1 });
+  });
+
+  it('bulk-send sends each draft', async () => {
+    (sendQuote as any).mockResolvedValue({});
+    const res = await post('/bulk-send', { ids: [A] });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(sendQuote).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('rejects an empty id list with 400', async () => {
+    const res = await post('/bulk-delete', { ids: [] });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/quotes/bulk.test.ts`
+Expected: FAIL — route not found (404) / module not yet exported.
+
+- [ ] **Step 3: Implement the bulk routes**
+
+Create `apps/api/src/routes/quotes/bulk.ts`:
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkQuoteIdsSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftQuote } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { quoteActorFrom, handleServiceError } from './quotes';
+
+export const quoteBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIONS.QUOTES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.QUOTES_SEND.resource, PERMISSIONS.QUOTES_SEND.action);
+
+quoteBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
+  try {
+    const actor = quoteActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftQuote(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+quoteBulkRoutes.post('/bulk-send', scopes, sendPerm, zValidator('json', bulkQuoteIdsSchema), async (c) => {
+  try {
+    const actor = quoteActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => sendQuote(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+```
+
+- [ ] **Step 4: Mount the routes before CRUD**
+
+In `apps/api/src/routes/quotes/index.ts`, add the import and register **before** `quoteCrudRoutes`:
+```typescript
+import { quoteBulkRoutes } from './bulk';
+// ...
+quoteRoutes.use('*', authMiddleware);
+quoteRoutes.route('/', quoteBulkRoutes);      // bulk-* before /:id
+quoteRoutes.route('/', quoteCrudRoutes);
+quoteRoutes.route('/', quoteLifecycleRoutes);
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/quotes/bulk.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/quotes/bulk.ts apps/api/src/routes/quotes/bulk.test.ts apps/api/src/routes/quotes/index.ts
+git commit -m "feat(api): quotes bulk-delete + bulk-send endpoints"
+```
+
+---
+
+## Task 3: Invoices bulk API endpoints
+
+**Files:**
+- Create: `apps/api/src/routes/invoices/bulk.ts`
+- Test: `apps/api/src/routes/invoices/bulk.test.ts`
+- Modify: `apps/api/src/routes/invoices/index.ts`
+
+**Interfaces:**
+- Consumes: `runBulk`; `bulkInvoiceIdsSchema`, `bulkVoidInvoicesSchema`; existing `deleteDraftInvoice`, `issueInvoice`, `voidInvoice(id, reason, {reissue}, actor)`, `invoiceActorFrom`, `handleServiceError`.
+- Produces: `invoiceBulkRoutes`; `POST /invoices/bulk-delete` (write), `POST /invoices/bulk-issue` (send), `POST /invoices/bulk-void` (send; body `{ ids, reason }`, `reissue` forced false in bulk) → `{ data: BulkResult }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/invoices/bulk.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/invoiceService', () => ({
+  deleteDraftInvoice: vi.fn(), issueInvoice: vi.fn(), voidInvoice: vi.fn(),
+}));
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { invoiceRoutes } from './index';
+import { deleteDraftInvoice, issueInvoice, voidInvoice } from '../../services/invoiceService';
+
+const A = '11111111-1111-1111-1111-111111111111';
+const B = '22222222-2222-2222-2222-222222222222';
+function post(path: string, body: unknown) {
+  return invoiceRoutes.request(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+}
+
+describe('invoice bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each draft', async () => {
+    (deleteDraftInvoice as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A, B] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 2 });
+    expect(deleteDraftInvoice).toHaveBeenCalledTimes(2);
+  });
+
+  it('bulk-issue issues each invoice', async () => {
+    (issueInvoice as any).mockResolvedValue({});
+    const res = await post('/bulk-issue', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(issueInvoice).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('bulk-void requires a reason and passes reissue:false', async () => {
+    (voidInvoice as any).mockResolvedValue({});
+    const noReason = await post('/bulk-void', { ids: [A] });
+    expect(noReason.status).toBe(400);
+
+    const ok = await post('/bulk-void', { ids: [A], reason: 'duplicate' });
+    expect(ok.status).toBe(200);
+    expect(voidInvoice).toHaveBeenCalledWith(A, 'duplicate', { reissue: false }, expect.anything());
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/invoices/bulk.test.ts`
+Expected: FAIL — routes not mounted.
+
+- [ ] **Step 3: Implement the bulk routes**
+
+Create `apps/api/src/routes/invoices/bulk.ts`:
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkInvoiceIdsSchema, bulkVoidInvoicesSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftInvoice, issueInvoice, voidInvoice } from '../../services/invoiceService';
+import { invoiceActorFrom, handleServiceError } from './invoices';
+
+export const invoiceBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
+const sendPerm = requirePermission(PERMISSIONS.INVOICES_SEND.resource, PERMISSIONS.INVOICES_SEND.action);
+
+invoiceBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftInvoice(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+invoiceBulkRoutes.post('/bulk-issue', scopes, sendPerm, zValidator('json', bulkInvoiceIdsSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => issueInvoice(id, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+invoiceBulkRoutes.post('/bulk-void', scopes, sendPerm, zValidator('json', bulkVoidInvoicesSchema), async (c) => {
+  try {
+    const actor = invoiceActorFrom(c);
+    const { ids, reason } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => voidInvoice(id, reason, { reissue: false }, actor)) });
+  } catch (err) { return handleServiceError(c, err); }
+});
+```
+
+- [ ] **Step 4: Mount before CRUD**
+
+In `apps/api/src/routes/invoices/index.ts`, import and register `invoiceBulkRoutes` **before** `invoiceCrudRoutes` (right after `authMiddleware`):
+```typescript
+import { invoiceBulkRoutes } from './bulk';
+// ...
+invoiceRoutes.use('*', authMiddleware);
+invoiceRoutes.route('/', invoiceBulkRoutes);     // bulk-* before /:id
+invoiceRoutes.route('/', invoiceLifecycleRoutes);
+// ...existing routes unchanged...
+invoiceRoutes.route('/', invoiceCrudRoutes);
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/invoices/bulk.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/invoices/bulk.ts apps/api/src/routes/invoices/bulk.test.ts apps/api/src/routes/invoices/index.ts
+git commit -m "feat(api): invoices bulk-delete + bulk-issue + bulk-void endpoints"
+```
+
+---
+
+## Task 4: Contracts bulk API endpoints
+
+**Files:**
+- Create: `apps/api/src/routes/contracts/bulk.ts`
+- Test: `apps/api/src/routes/contracts/bulk.test.ts`
+- Modify: `apps/api/src/routes/contracts/index.ts`
+
+**Interfaces:**
+- Consumes: `runBulk`; `bulkContractIdsSchema`; existing `deleteDraftContract`, `cancelContract`, `contractActorFrom`, `handleContractError`.
+- Produces: `contractBulkRoutes`; `POST /contracts/bulk-delete` (write), `POST /contracts/bulk-cancel` (manage) → `{ data: BulkResult }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/contracts/bulk.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/contractService', () => ({ deleteDraftContract: vi.fn(), cancelContract: vi.fn() }));
+const gate = vi.hoisted(() => ({ permGate: async (_c: any, next: any) => next() }));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner', accessibleOrgIds: null });
+    await next();
+  },
+  requireScope: () => async (c: any, next: any) => gate.permGate(c, next),
+  requirePermission: () => async (c: any, next: any) => gate.permGate(c, next),
+}));
+
+import { contractRoutes } from './index';
+import { deleteDraftContract, cancelContract } from '../../services/contractService';
+
+const A = '11111111-1111-1111-1111-111111111111';
+function post(path: string, body: unknown) {
+  return contractRoutes.request(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+}
+
+describe('contract bulk routes', () => {
+  beforeEach(() => { vi.clearAllMocks(); gate.permGate = async (_c: any, next: any) => next(); });
+
+  it('bulk-delete deletes each draft', async () => {
+    (deleteDraftContract as any).mockResolvedValue(undefined);
+    const res = await post('/bulk-delete', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(deleteDraftContract).toHaveBeenCalledWith(A, expect.anything());
+  });
+
+  it('bulk-cancel cancels each contract', async () => {
+    (cancelContract as any).mockResolvedValue({});
+    const res = await post('/bulk-cancel', { ids: [A] });
+    expect((await res.json()).data).toMatchObject({ succeeded: 1 });
+    expect(cancelContract).toHaveBeenCalledWith(A, expect.anything());
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/contracts/bulk.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the bulk routes**
+
+Create `apps/api/src/routes/contracts/bulk.ts`:
+```typescript
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { requireScope, requirePermission } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { bulkContractIdsSchema } from '@breeze/shared';
+import { runBulk } from '../../lib/bulkOps';
+import { deleteDraftContract, cancelContract } from '../../services/contractService';
+import { contractActorFrom, handleContractError } from './contracts';
+
+export const contractBulkRoutes = new Hono();
+const scopes = requireScope('partner', 'system');
+const writePerm = requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMISSIONS.CONTRACTS_WRITE.action);
+const managePerm = requirePermission(PERMISSIONS.CONTRACTS_MANAGE.resource, PERMISSIONS.CONTRACTS_MANAGE.action);
+
+contractBulkRoutes.post('/bulk-delete', scopes, writePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
+  try {
+    const actor = contractActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => deleteDraftContract(id, actor)) });
+  } catch (err) { return handleContractError(c, err); }
+});
+
+contractBulkRoutes.post('/bulk-cancel', scopes, managePerm, zValidator('json', bulkContractIdsSchema), async (c) => {
+  try {
+    const actor = contractActorFrom(c);
+    const { ids } = c.req.valid('json');
+    return c.json({ data: await runBulk(ids, (id) => cancelContract(id, actor)) });
+  } catch (err) { return handleContractError(c, err); }
+});
+```
+
+- [ ] **Step 4: Mount before CRUD**
+
+In `apps/api/src/routes/contracts/index.ts`, import and register `contractBulkRoutes` **before** `contractCrudRoutes` (right after `authMiddleware`):
+```typescript
+import { contractBulkRoutes } from './bulk';
+// ...
+contractRoutes.use('*', authMiddleware);
+contractRoutes.route('/', contractBulkRoutes);   // bulk-* before /:id
+contractRoutes.route('/', contractLifecycleRoutes);
+// ...existing routes unchanged...
+contractRoutes.route('/', contractCrudRoutes);
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/contracts/bulk.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/contracts/bulk.ts apps/api/src/routes/contracts/bulk.test.ts apps/api/src/routes/contracts/index.ts
+git commit -m "feat(api): contracts bulk-delete + bulk-cancel endpoints"
+```
+
+---
+
+## Task 5: Web bulk-selection hook + action bar
+
+**Files:**
+- Create: `apps/web/src/components/billing/bulk/useBulkSelection.ts`
+- Test: `apps/web/src/components/billing/bulk/useBulkSelection.test.ts`
+- Create: `apps/web/src/components/billing/bulk/BulkActionBar.tsx`
+- Test: `apps/web/src/components/billing/bulk/BulkActionBar.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `useBulkSelection()` → `{ selectedIds: Set<string>; size: number; has(id): boolean; toggle(id): void; selectAll(ids: string[]): void; clear(): void }`.
+  - `BulkActionBar({ count, actions, onClear, testIdPrefix })` where `actions: Array<{ key: string; label: string; variant?: 'default' | 'destructive'; disabled?: boolean; onClick: () => void }>`. Renders nothing when `count === 0`.
+
+- [ ] **Step 1: Write the failing hook test**
+
+Create `apps/web/src/components/billing/bulk/useBulkSelection.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBulkSelection } from './useBulkSelection';
+
+describe('useBulkSelection', () => {
+  it('toggles ids on and off', () => {
+    const { result } = renderHook(() => useBulkSelection());
+    act(() => result.current.toggle('a'));
+    expect(result.current.has('a')).toBe(true);
+    expect(result.current.size).toBe(1);
+    act(() => result.current.toggle('a'));
+    expect(result.current.has('a')).toBe(false);
+    expect(result.current.size).toBe(0);
+  });
+
+  it('selectAll adds all ids and clear empties', () => {
+    const { result } = renderHook(() => useBulkSelection());
+    act(() => result.current.selectAll(['a', 'b', 'c']));
+    expect(result.current.size).toBe(3);
+    act(() => result.current.clear());
+    expect(result.current.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/bulk/useBulkSelection.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/web/src/components/billing/bulk/useBulkSelection.ts`:
+```typescript
+import { useCallback, useState } from 'react';
+
+export interface BulkSelection {
+  selectedIds: Set<string>;
+  size: number;
+  has: (id: string) => boolean;
+  toggle: (id: string) => void;
+  selectAll: (ids: string[]) => void;
+  clear: () => void;
+}
+
+export function useBulkSelection(): BulkSelection {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelectedIds((prev) => new Set([...prev, ...ids]));
+  }, []);
+
+  const clear = useCallback(() => setSelectedIds(new Set()), []);
+  const has = useCallback((id: string) => selectedIds.has(id), [selectedIds]);
+
+  return { selectedIds, size: selectedIds.size, has, toggle, selectAll, clear };
+}
+```
+
+- [ ] **Step 4: Run the hook test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/bulk/useBulkSelection.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing action-bar test**
+
+Create `apps/web/src/components/billing/bulk/BulkActionBar.test.tsx`:
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BulkActionBar } from './BulkActionBar';
+
+describe('BulkActionBar', () => {
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<BulkActionBar count={0} actions={[]} onClear={() => {}} testIdPrefix="quotes" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the count and fires action + clear handlers', () => {
+    const onClick = vi.fn();
+    const onClear = vi.fn();
+    render(
+      <BulkActionBar
+        count={2}
+        actions={[{ key: 'delete', label: 'Delete', variant: 'destructive', onClick }]}
+        onClear={onClear}
+        testIdPrefix="quotes"
+      />
+    );
+    expect(screen.getByTestId('quotes-bulk-bar')).toHaveTextContent('2 selected');
+    fireEvent.click(screen.getByTestId('quotes-bulk-action-delete'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('quotes-bulk-clear'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 6: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/bulk/BulkActionBar.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 7: Implement the action bar**
+
+Create `apps/web/src/components/billing/bulk/BulkActionBar.tsx`:
+```typescript
+export interface BulkAction {
+  key: string;
+  label: string;
+  variant?: 'default' | 'destructive';
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export interface BulkActionBarProps {
+  count: number;
+  actions: BulkAction[];
+  onClear: () => void;
+  testIdPrefix: string;
+}
+
+export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkActionBarProps) {
+  if (count === 0) return null;
+  return (
+    <div
+      className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
+      data-testid={`${testIdPrefix}-bulk-bar`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium tabular-nums">{count} selected</span>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          {actions.map((a) => (
+            <button
+              key={a.key}
+              type="button"
+              onClick={a.onClick}
+              disabled={a.disabled}
+              data-testid={`${testIdPrefix}-bulk-action-${a.key}`}
+              className={`inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-50 ${
+                a.variant === 'destructive'
+                  ? 'border border-destructive/40 text-destructive hover:bg-destructive/10'
+                  : 'border hover:bg-muted'
+              }`}
+            >
+              {a.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={onClear}
+            data-testid={`${testIdPrefix}-bulk-clear`}
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Run the action-bar test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/bulk/BulkActionBar.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/components/billing/bulk/
+git commit -m "feat(web): reusable useBulkSelection hook + BulkActionBar"
+```
+
+---
+
+## Task 6: Quotes list — selection column + bulk bar
+
+**Files:**
+- Modify: `apps/web/src/components/billing/quotes/QuotesPage.tsx`
+- Test: `apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `useBulkSelection`, `BulkActionBar` (Task 5); `runAction`, `handleActionError`, `fetchWithAuth`, `showToast`, `usePermissions`, `BulkResult` shape `{ total, succeeded, skipped, failed, skippedReasons }`.
+- Quote rows expose `qt.id` and `qt.status`. The table's wrapper must be `relative` so the absolutely-positioned bar anchors to it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx`. Mock `fetchWithAuth`, `showToast`, `navigateTo`, and the quotes list fetch the page uses; render, select two rows, click bulk delete, assert `POST /quotes/bulk-delete` body contains both ids. Skeleton:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+import { QuotesPage } from './QuotesPage';
+
+const json = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+const Q1 = '11111111-1111-1111-1111-111111111111';
+const Q2 = '22222222-2222-2222-2222-222222222222';
+
+describe('QuotesPage bulk delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // initial list load
+    fetchWithAuth.mockResolvedValueOnce(json({ data: [
+      { id: Q1, orgId: 'o1', status: 'draft', total: '10', currencyCode: 'USD', createdAt: '2026-06-01' },
+      { id: Q2, orgId: 'o1', status: 'draft', total: '20', currencyCode: 'USD', createdAt: '2026-06-02' },
+    ] }));
+  });
+
+  it('selects rows and posts ids to /quotes/bulk-delete', async () => {
+    render(<QuotesPage />);
+    await screen.findByTestId(`quotes-row-${Q1}`);
+    fireEvent.click(screen.getByTestId(`quotes-select-${Q1}`));
+    fireEvent.click(screen.getByTestId(`quotes-select-${Q2}`));
+    // bulk endpoint + refetch
+    fetchWithAuth.mockResolvedValueOnce(json({ data: { total: 2, succeeded: 2, skipped: 0, failed: 0, skippedReasons: {} } }));
+    fetchWithAuth.mockResolvedValueOnce(json({ data: [] }));
+    fireEvent.click(screen.getByTestId('quotes-bulk-action-delete'));
+    await waitFor(() => {
+      const call = fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/quotes/bulk-delete'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string).ids).toEqual([Q1, Q2]);
+    });
+  });
+});
+```
+> Note: adjust the initial-load mock + the page's named/default export to match the actual `QuotesPage` data-fetching shape when you open the file. The selection `data-testid`s (`quotes-select-<id>`) are added in Step 3.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/quotes/QuotesPage.bulk.test.tsx`
+Expected: FAIL — `quotes-select-*` checkboxes don't exist yet.
+
+- [ ] **Step 3: Add selection state, checkbox column, and bulk bar**
+
+In `QuotesPage.tsx`:
+
+1. Add imports:
+```typescript
+import { useBulkSelection } from '../bulk/useBulkSelection';
+import { BulkActionBar } from '../bulk/BulkActionBar';
+import { runAction, handleActionError } from '../../../lib/runAction';
+import { fetchWithAuth } from '../../../stores/auth';
+import { showToast } from '../../shared/Toast';
+import { usePermissions } from '../../../lib/permissions';
+```
+(Several of these may already be imported — de-dupe.)
+
+2. Inside the component, near other hooks:
+```typescript
+const bulk = useBulkSelection();
+const { can } = usePermissions();
+```
+
+3. Add the bulk runner (place after the `rows` memo; `rows` is the rendered quote array, `refresh`/`load` is the page's existing list-refetch fn — use whatever it's named):
+```typescript
+const runBulkQuotes = useCallback(
+  async (path: string, verb: string) => {
+    const ids = Array.from(bulk.selectedIds);
+    if (ids.length === 0) return;
+    try {
+      const result = await runAction<{ data: { succeeded: number; skipped: number; failed: number; skippedReasons?: Record<string, number> } }>({
+        request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify({ ids }) }),
+        errorFallback: `Bulk ${verb} failed. Retry.`,
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true }),
+      });
+      const { succeeded, skipped, failed } = result.data;
+      showToast(
+        skipped + failed > 0
+          ? { type: 'warning', message: `${succeeded} ${verb}, ${skipped} skipped${failed ? `, ${failed} failed` : ''}` }
+          : { type: 'success', message: `${succeeded} ${verb}` }
+      );
+      bulk.clear();
+      void refresh(); // <-- the page's existing list-refetch function
+    } catch (err) {
+      handleActionError(err, `Bulk ${verb} failed. Retry.`);
+    }
+  },
+  [bulk, refresh]
+);
+```
+> If the page already imports `navigateTo`/`loginPathWithNext`, reuse them; otherwise simplify `onUnauthorized` to the page's existing redirect pattern.
+
+4. Wrap the table container so the bar anchors. The existing `<div className="overflow-x-auto">` becomes:
+```tsx
+<div className="relative">
+  <div className="overflow-x-auto">
+    <table className="w-full text-sm" data-testid="quotes-table">
+      <thead>
+        <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="w-8 px-3 py-3">
+            <input
+              type="checkbox"
+              aria-label="Select all quotes"
+              data-testid="quotes-select-all"
+              checked={rows.length > 0 && rows.every((r) => bulk.has(r.id))}
+              onChange={(e) => (e.target.checked ? bulk.selectAll(rows.map((r) => r.id)) : bulk.clear())}
+            />
+          </th>
+          <th className="px-3 py-3 font-medium">Number</th>
+          {/* ...existing headers unchanged... */}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((qt) => (
+          <tr key={qt.id} onClick={() => void navigateTo(`/billing/quotes/${qt.id}`)} data-testid={`quotes-row-${qt.id}`} className="cursor-pointer border-t transition hover:bg-muted/40">
+            <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+              <input
+                type="checkbox"
+                aria-label={`Select quote ${qt.quoteNumber ?? qt.id}`}
+                data-testid={`quotes-select-${qt.id}`}
+                checked={bulk.has(qt.id)}
+                onChange={() => bulk.toggle(qt.id)}
+              />
+            </td>
+            {/* ...existing cells unchanged... */}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+  <BulkActionBar
+    count={bulk.size}
+    onClear={bulk.clear}
+    testIdPrefix="quotes"
+    actions={[
+      ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
+      ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkQuotes('/quotes/bulk-delete', 'deleted') }] : []),
+    ]}
+  />
+</div>
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/quotes/QuotesPage.bulk.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Guard against silent mutations + typecheck**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts && pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS (QuotesPage.tsx is already in `TARGET_GLOBS`; the new handler uses `runAction`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/billing/quotes/QuotesPage.tsx apps/web/src/components/billing/quotes/QuotesPage.bulk.test.tsx
+git commit -m "feat(web): bulk select + send/delete on quotes list"
+```
+
+---
+
+## Task 7: Invoices list — selection column + bulk bar
+
+**Files:**
+- Modify: `apps/web/src/components/billing/InvoicesPage.tsx`
+- Test: `apps/web/src/components/billing/InvoicesPage.bulk.test.tsx` (create)
+
+**Interfaces:** Same hook/bar/runner pattern as Task 6. Invoice bulk void needs a **reason**, so the void action opens a small reason dialog before posting (reuse the inline `Dialog` pattern already in `InvoiceDetail.tsx`, or `ConfirmDialog` is not enough since it has no text field). Invoice rows expose `inv.id`, `inv.status`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/billing/InvoicesPage.bulk.test.tsx` mirroring Task 6's test, but: data-testids are `invoices-select-<id>` / `invoices-bulk-action-delete`; the initial list mock uses invoice fields (`id, orgId, status, total, balance, currencyCode, issueDate, dueDate`); assert `POST /invoices/bulk-delete` carries both ids. Add a second test that clicking the void action opens `invoices-bulk-void-dialog`, typing a reason and submitting posts `/invoices/bulk-void` with `{ ids, reason }`.
+```typescript
+// ...same mock scaffold as Task 6 (fetchWithAuth, showToast, navigateTo, permissions=can()=>true)...
+import { InvoicesPage } from './InvoicesPage';
+// initial load: two draft invoices I1, I2
+// test 1 (delete): select both → click invoices-bulk-action-delete → expect /invoices/bulk-delete body.ids == [I1, I2]
+// test 2 (void):  select an issued invoice → click invoices-bulk-action-void → fill invoices-bulk-void-reason → click invoices-bulk-void-submit
+//                 → expect /invoices/bulk-void body == { ids:[...], reason:'duplicate' }
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/InvoicesPage.bulk.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Apply the same edits as Task 6 §3 with `testIdPrefix="invoices"`, `data-testid={`invoices-select-${inv.id}`}`, container made `relative`, and a `runBulkInvoices(path, verb, extraBody?)` runner identical to `runBulkQuotes` but merging `extraBody` into the JSON (for the void reason). Add bulk void reason dialog state:
+```typescript
+const [voidOpen, setVoidOpen] = useState(false);
+const [voidReason, setVoidReason] = useState('');
+```
+Bar actions:
+```tsx
+actions={[
+  ...(can('invoices', 'send') ? [{ key: 'issue', label: 'Issue', onClick: () => void runBulkInvoices('/invoices/bulk-issue', 'issued') }] : []),
+  ...(can('invoices', 'send') ? [{ key: 'void', label: 'Void', variant: 'destructive' as const, onClick: () => { setVoidReason(''); setVoidOpen(true); } }] : []),
+  ...(can('invoices', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkInvoices('/invoices/bulk-delete', 'deleted') }] : []),
+]}
+```
+Add a `Dialog` (mirroring `InvoiceDetail.tsx` lines 444–478) with `data-testid="invoices-bulk-void-dialog"`, a `data-testid="invoices-bulk-void-reason"` textarea bound to `voidReason`, and a submit button `data-testid="invoices-bulk-void-submit"` that calls `await runBulkInvoices('/invoices/bulk-void', 'voided', { reason: voidReason.trim() })` then `setVoidOpen(false)`, disabled while `!voidReason.trim()`.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/InvoicesPage.bulk.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Guard + typecheck**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts && pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS (InvoicesPage.tsx already in `TARGET_GLOBS`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/billing/InvoicesPage.tsx apps/web/src/components/billing/InvoicesPage.bulk.test.tsx
+git commit -m "feat(web): bulk select + issue/void/delete on invoices list"
+```
+
+---
+
+## Task 8: Contracts list — selection column + bulk bar
+
+**Files:**
+- Modify: `apps/web/src/components/contracts/ContractsList.tsx`
+- Test: `apps/web/src/components/contracts/ContractsList.bulk.test.tsx` (create)
+
+**Interfaces:** Same pattern as Task 6. Contract rows expose `ctr.id`, `ctr.status`. Bulk cancel is destructive → wrap it in a `ConfirmDialog` (no free text needed). Note: `ContractsList.tsx` is **not** in `no-silent-mutations` `TARGET_GLOBS` — do not add it; just ensure the handler uses `runAction` anyway for consistency.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/contracts/ContractsList.bulk.test.tsx` mirroring Task 6 with prefix `contracts`, testids `contract-select-<id>` (match existing `contract-row-<id>` convention), initial load of two draft contracts, select both, click `contracts-bulk-action-delete`, assert `POST /contracts/bulk-delete` body carries both ids.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/contracts/ContractsList.bulk.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Apply the Task 6 §3 edits to `ContractsList.tsx`: `relative` container, header checkbox `data-testid="contracts-select-all"`, per-row `data-testid={`contract-select-${ctr.id}`}` (cell wrapped with `onClick={(e) => e.stopPropagation()}`), a `runBulkContracts(path, verb)` runner identical to `runBulkQuotes`, and:
+```tsx
+const [cancelOpen, setCancelOpen] = useState(false);
+// ...
+<BulkActionBar
+  count={bulk.size}
+  onClear={bulk.clear}
+  testIdPrefix="contracts"
+  actions={[
+    ...(can('contracts', 'manage') ? [{ key: 'cancel', label: 'Cancel', variant: 'destructive' as const, onClick: () => setCancelOpen(true) }] : []),
+    ...(can('contracts', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, onClick: () => void runBulkContracts('/contracts/bulk-delete', 'deleted') }] : []),
+  ]}
+/>
+<ConfirmDialog
+  open={cancelOpen}
+  onClose={() => setCancelOpen(false)}
+  onConfirm={() => { setCancelOpen(false); void runBulkContracts('/contracts/bulk-cancel', 'cancelled'); }}
+  title="Cancel contracts"
+  message={`Cancel ${bulk.size} selected contract(s)? Active and paused contracts will be cancelled; this cannot be undone.`}
+  confirmLabel="Cancel contracts"
+  confirmTestId="contracts-bulk-cancel-confirm"
+/>
+```
+Add `import { ConfirmDialog } from '../shared/ConfirmDialog';` plus the bulk/runAction imports.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/contracts/ContractsList.bulk.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/contracts/ContractsList.tsx apps/web/src/components/contracts/ContractsList.bulk.test.tsx
+git commit -m "feat(web): bulk select + cancel/delete on contracts list"
+```
+
+---
+
+## Task 9: Detail-screen draft Delete buttons (quote, invoice, contract)
+
+**Files:**
+- Modify: `apps/web/src/lib/api/quotes.ts` — add `deleteQuote`.
+- Modify: `apps/web/src/lib/api/contracts.ts` — add `deleteContract`.
+- Modify: `apps/web/src/components/billing/quotes/QuoteDetail.tsx`
+- Modify: `apps/web/src/components/billing/InvoiceDetail.tsx`
+- Modify: `apps/web/src/components/contracts/ContractDetail.tsx`
+- Test: `apps/web/src/components/billing/quotes/QuoteDetail.delete.test.tsx` (create)
+- Test: `apps/web/src/components/contracts/ContractDetail.delete.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: existing `DELETE /:id` endpoints (quotes/invoices/contracts — all draft-only, already implemented); `ConfirmDialog`; `runAction`/`handleActionError`; `usePermissions`.
+- Produces: `deleteQuote(id) => Promise<Response>` (api/quotes.ts), `deleteContract(id) => Promise<Response>` (api/contracts.ts). Delete buttons render only when `status === 'draft'` and the user has write permission; on success they toast and `navigateTo` the list.
+
+- [ ] **Step 1: Add the api wrappers**
+
+In `apps/web/src/lib/api/quotes.ts` (mirror `sendQuote`'s `fetchWithAuth` style already in that file):
+```typescript
+export function deleteQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}`, { method: 'DELETE' });
+}
+```
+In `apps/web/src/lib/api/contracts.ts` (mirror `contractTransition`):
+```typescript
+export function deleteContract(id: string): Promise<Response> {
+  return fetchWithAuth(`/contracts/${id}`, { method: 'DELETE' });
+}
+```
+
+- [ ] **Step 2: Write the failing QuoteDetail delete test**
+
+Create `apps/web/src/components/billing/quotes/QuoteDetail.delete.test.tsx`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const deleteQuote = vi.fn();
+vi.mock('../../../lib/api/quotes', async (orig) => ({ ...(await orig<any>()), deleteQuote: (...a: unknown[]) => deleteQuote(...a) }));
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+import { QuoteDetail } from './QuoteDetail';
+
+const draftQuote = { id: 'q1', status: 'draft', /* ...minimal fields QuoteDetail needs... */ } as any;
+const json = (p: unknown, status = 200) => ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(p) }) as unknown as Response;
+
+describe('QuoteDetail delete', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes a draft quote and navigates to the list', async () => {
+    deleteQuote.mockResolvedValue(json({ data: { ok: true } }));
+    render(<QuoteDetail quote={draftQuote} refresh={vi.fn()} />); // match actual props
+    fireEvent.click(screen.getByTestId('quote-delete-open'));
+    fireEvent.click(screen.getByTestId('quote-delete-confirm'));
+    await waitFor(() => {
+      expect(deleteQuote).toHaveBeenCalledWith('q1');
+      expect(navigateTo).toHaveBeenCalledWith('/billing/quotes');
+    });
+  });
+});
+```
+> Adjust `draftQuote` fields and `QuoteDetail` props to the real component signature when you open the file.
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/quotes/QuoteDetail.delete.test.tsx`
+Expected: FAIL — no `quote-delete-open`.
+
+- [ ] **Step 4: Implement the QuoteDetail delete button**
+
+In `QuoteDetail.tsx` add `import { ConfirmDialog } from '../../shared/ConfirmDialog';`, `deleteQuote` to the existing `lib/api/quotes` import, and `useState` for `delOpen`/`deleting`. Add a handler mirroring `send`:
+```typescript
+const [delOpen, setDelOpen] = useState(false);
+const [deleting, setDeleting] = useState(false);
+const remove = useCallback(async () => {
+  if (deleting) return;
+  setDeleting(true);
+  try {
+    await runAction({
+      request: () => deleteQuote(quote.id),
+      errorFallback: 'Could not delete the draft.',
+      successMessage: 'Draft deleted',
+      onUnauthorized: UNAUTHORIZED,
+    });
+    setDelOpen(false);
+    void navigateTo('/billing/quotes');
+  } catch (err) {
+    handleActionError(err, 'Could not delete the draft.');
+  } finally {
+    setDeleting(false);
+  }
+}, [deleting, quote.id]);
+```
+Render the trigger next to the existing Send button, draft-only + write-gated:
+```tsx
+{can('quotes', 'write') && quote.status === 'draft' && (
+  <button
+    type="button"
+    onClick={() => setDelOpen(true)}
+    data-testid="quote-delete-open"
+    className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+  >
+    Delete draft
+  </button>
+)}
+<ConfirmDialog
+  open={delOpen}
+  onClose={() => setDelOpen(false)}
+  onConfirm={() => void remove()}
+  isLoading={deleting}
+  title="Delete draft quote"
+  message="This permanently deletes the draft quote. This cannot be undone."
+  confirmLabel="Delete draft"
+  confirmTestId="quote-delete-confirm"
+/>
+```
+> `UNAUTHORIZED` / `can` already exist in this file (used by the Send action). Reuse them.
+
+- [ ] **Step 5: Run the QuoteDetail test to confirm it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/billing/quotes/QuoteDetail.delete.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Add the InvoiceDetail delete button**
+
+`InvoiceDetail.tsx` uses raw `fetchWithAuth`. Add (draft-only, write-gated), mirroring its `submitVoid` handler:
+```tsx
+{invoice.status === 'draft' && can('invoices', 'write') && (
+  <button
+    type="button"
+    onClick={() => setDelOpen(true)}
+    data-testid="invoice-delete-open"
+    className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+  >
+    Delete draft
+  </button>
+)}
+```
+Handler:
+```typescript
+const [delOpen, setDelOpen] = useState(false);
+const [deleting, setDeleting] = useState(false);
+const remove = useCallback(async () => {
+  if (deleting) return;
+  setDeleting(true);
+  try {
+    await runAction({
+      request: () => fetchWithAuth(`/invoices/${invoice.id}`, { method: 'DELETE' }),
+      errorFallback: 'Could not delete the draft.',
+      successMessage: 'Draft deleted',
+      onUnauthorized: UNAUTHORIZED,
+    });
+    setDelOpen(false);
+    void navigateTo('/billing/invoices');
+  } catch (err) {
+    handleActionError(err, 'Could not delete the draft.');
+  } finally {
+    setDeleting(false);
+  }
+}, [deleting, invoice.id]);
+```
+Plus a `ConfirmDialog` with `confirmTestId="invoice-delete-confirm"` (import `ConfirmDialog` if not present).
+
+- [ ] **Step 7: Write + run the ContractDetail delete test, then implement**
+
+Create `apps/web/src/components/contracts/ContractDetail.delete.test.tsx` mirroring Step 2 (mock `../../lib/api/contracts` `deleteContract`, assert navigate to `/contracts`). Then in `ContractDetail.tsx` add `deleteContract` to the `lib/api/contracts` import and a draft-only, write-gated delete button + `ConfirmDialog`, mirroring the `transition` handler:
+```typescript
+const remove = useCallback(async () => {
+  if (busy) return;
+  setBusy(true);
+  try {
+    await runAction({
+      request: () => deleteContract(contract.id),
+      errorFallback: 'Could not delete the draft.',
+      successMessage: 'Draft deleted',
+      onUnauthorized: UNAUTHORIZED,
+    });
+    void navigateTo('/contracts');
+  } catch (err) {
+    handleActionError(err, 'Could not delete the draft.');
+  } finally {
+    setBusy(false);
+  }
+}, [busy, contract.id]);
+```
+Button (draft-only):
+```tsx
+{can('contracts', 'write') && contract.status === 'draft' && (
+  <button type="button" onClick={() => setDelOpen(true)} data-testid="contract-delete-open"
+    className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10">
+    Delete draft
+  </button>
+)}
+```
++ `ConfirmDialog` with `confirmTestId="contract-delete-confirm"`.
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/contracts/ContractDetail.delete.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 8: Guard + typecheck**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts && pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: PASS. (InvoiceDetail.tsx + ContractDetail.tsx are already in `TARGET_GLOBS`; QuoteDetail.tsx is not — both fine, handlers use `runAction`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/lib/api/quotes.ts apps/web/src/lib/api/contracts.ts \
+  apps/web/src/components/billing/quotes/QuoteDetail.tsx apps/web/src/components/billing/quotes/QuoteDetail.delete.test.tsx \
+  apps/web/src/components/billing/InvoiceDetail.tsx \
+  apps/web/src/components/contracts/ContractDetail.tsx apps/web/src/components/contracts/ContractDetail.delete.test.tsx
+git commit -m "feat(web): draft Delete action on quote/invoice/contract detail"
+```
+
+---
+
+## Final verification
+
+- [ ] **API suite (changed files):** `pnpm --filter @breeze/api exec vitest run src/lib/bulkOps.test.ts src/routes/quotes/bulk.test.ts src/routes/invoices/bulk.test.ts src/routes/contracts/bulk.test.ts` → all PASS.
+- [ ] **Web suite (changed files):** `pnpm --filter @breeze/web exec vitest run src/components/billing/bulk src/components/billing/quotes src/components/billing/InvoicesPage.bulk.test.tsx src/components/contracts` → all PASS.
+- [ ] **Lint + typecheck:** `pnpm --filter @breeze/api exec tsc --noEmit && pnpm --filter @breeze/web exec tsc --noEmit && pnpm lint` → clean.
+- [ ] **Manual smoke (worktree-stack skill):** bring up the stack, select multiple draft quotes/invoices/contracts → bulk delete; bulk send quotes; bulk issue + bulk void invoices; bulk cancel contracts; on each detail screen delete a draft. Confirm toasts report succeeded/skipped counts and non-draft rows are skipped, not errored.
+
+## Self-Review notes
+
+- **Spec coverage:** bulk on all three tables (Tasks 6–8) with the user-selected action set — delete + send (quotes), delete + issue + void (invoices), delete + cancel (contracts) via API Tasks 2–4; draft Delete on all three detail screens (Task 9). ✔
+- **No new RLS/migration** — reuses org-scoped services and existing `DELETE /:id`. ✔
+- **Type consistency:** `BulkResult` fields (`total/succeeded/skipped/failed/skippedReasons`) are identical across API helper, routes, and web runners; `useBulkSelection` / `BulkActionBar` signatures match their consumers. ✔
+- **Permission gating** matches the action→permission table for both API middleware and web `can()` button gating. ✔
+- **Known follow-up (out of scope):** API `bulk.test.ts` files mock the service layer (route-level coverage). If you want end-to-end org-isolation coverage for the bulk paths, add an integration test under `apps/api/src/__tests__/integration/` — not required since the reused services already have isolation coverage.

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -105,6 +105,13 @@ export const DEFAULT_POLICY_CHECK_INTERVAL = 60;
 export const DEFAULT_PAGE_SIZE = 50;
 export const MAX_PAGE_SIZE = 100;
 
+// Max ids accepted by a single bulk billing action (quotes/invoices/contracts).
+// Each id runs sequentially in its own short transaction, so this bounds both
+// request latency and connection-pool pressure. Shared by the Zod request
+// schemas (server enforcement) and the web bulk runners (client-side guard +
+// friendly message) so the two can never drift.
+export const BULK_ID_LIMIT = 50;
+
 // Session timeouts
 export const ACCESS_TOKEN_EXPIRY = '15m';
 export const REFRESH_TOKEN_EXPIRY = '7d';

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -65,6 +65,10 @@ export const listContractsQuerySchema = z.object({
   cursor: z.string().guid().optional()
 });
 
+export const bulkContractIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+
 export type ContractLineInput = z.infer<typeof contractLineInputSchema>;
 export type CreateContractInput = z.infer<typeof createContractSchema>;
 export type UpdateContractInput = z.infer<typeof updateContractSchema>;

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BULK_ID_LIMIT } from '../constants';
 
 const money = z.string().regex(/^\d+(\.\d{1,2})?$/, 'must be a 2-decimal money string');
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
@@ -66,8 +67,8 @@ export const listContractsQuerySchema = z.object({
 });
 
 export const bulkContractIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
-  ids: z.array(z.string().guid()).min(1).max(50),
+  // capped at BULK_ID_LIMIT: each item runs sequentially in its own short transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(BULK_ID_LIMIT),
 });
 
 export type ContractLineInput = z.infer<typeof contractLineInputSchema>;

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -66,7 +66,7 @@ export const listContractsQuerySchema = z.object({
 });
 
 export const bulkContractIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
   ids: z.array(z.string().guid()).min(1).max(50),
 });
 

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -66,7 +66,8 @@ export const listContractsQuerySchema = z.object({
 });
 
 export const bulkContractIdsSchema = z.object({
-  ids: z.array(z.string().guid()).min(1).max(200),
+  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(50),
 });
 
 export type ContractLineInput = z.infer<typeof contractLineInputSchema>;

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 // Spread the readonly SSOT tuples into z.enum (keep it a direct spread of the
 // const — a `string[]` intermediate would widen the schema to z.enum(string)).
 import { INVOICE_STATUSES, PAYMENT_METHODS } from '../types/billing-enums';
+import { BULK_ID_LIMIT } from '../constants';
 
 const money = z.number().nonnegative().multipleOf(0.01);
 const positiveQty = z.number().positive().multipleOf(0.01);
@@ -109,8 +110,8 @@ export const orgBillingSettingsSchema = z.object({
 });
 
 export const bulkInvoiceIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
-  ids: z.array(z.string().guid()).min(1).max(50),
+  // capped at BULK_ID_LIMIT: each item runs sequentially in its own short transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(BULK_ID_LIMIT),
 });
 export const bulkVoidInvoicesSchema = bulkInvoiceIdsSchema.extend({
   reason: z.string().trim().min(1).max(500),

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -108,6 +108,13 @@ export const orgBillingSettingsSchema = z.object({
   billingAddressCountry: z.string().length(2).nullable().optional()
 });
 
+export const bulkInvoiceIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+export const bulkVoidInvoicesSchema = bulkInvoiceIdsSchema.extend({
+  reason: z.string().trim().min(1).max(500),
+});
+
 export type AssembleFromOrgInput = z.infer<typeof assembleFromOrgSchema>;
 export type ManualLineInput = z.infer<typeof manualLineSchema>;
 export type RecordPaymentInput = z.infer<typeof recordPaymentSchema>;

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -109,7 +109,7 @@ export const orgBillingSettingsSchema = z.object({
 });
 
 export const bulkInvoiceIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
   ids: z.array(z.string().guid()).min(1).max(50),
 });
 export const bulkVoidInvoicesSchema = bulkInvoiceIdsSchema.extend({

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -109,7 +109,8 @@ export const orgBillingSettingsSchema = z.object({
 });
 
 export const bulkInvoiceIdsSchema = z.object({
-  ids: z.array(z.string().guid()).min(1).max(200),
+  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(50),
 });
 export const bulkVoidInvoicesSchema = bulkInvoiceIdsSchema.extend({
   reason: z.string().trim().min(1).max(500),

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -94,6 +94,10 @@ export const listQuotesQuerySchema = z.object({
   cursor: z.string().guid().optional(),
 });
 
+export const bulkQuoteIdsSchema = z.object({
+  ids: z.array(z.string().guid()).min(1).max(200),
+});
+
 export type QuoteLineInput = z.infer<typeof quoteLineInputSchema>;
 export type QuoteBlockInput = z.infer<typeof quoteBlockInputSchema>;
 export type CreateQuoteInput = z.infer<typeof createQuoteSchema>;

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -95,7 +95,7 @@ export const listQuotesQuerySchema = z.object({
 });
 
 export const bulkQuoteIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
   ids: z.array(z.string().guid()).min(1).max(50),
 });
 

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BULK_ID_LIMIT } from '../constants';
 
 // Bounded to numeric(12,2) (max 9,999,999,999.99) so out-of-range inputs fail
 // fast with a 400 rather than overflowing at insert (DB-layer 500). Mirrors the
@@ -95,8 +96,8 @@ export const listQuotesQuerySchema = z.object({
 });
 
 export const bulkQuoteIdsSchema = z.object({
-  // capped at 50: each item runs sequentially in its own short transaction (conn-pool safety)
-  ids: z.array(z.string().guid()).min(1).max(50),
+  // capped at BULK_ID_LIMIT: each item runs sequentially in its own short transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(BULK_ID_LIMIT),
 });
 
 export type QuoteLineInput = z.infer<typeof quoteLineInputSchema>;

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -95,7 +95,8 @@ export const listQuotesQuerySchema = z.object({
 });
 
 export const bulkQuoteIdsSchema = z.object({
-  ids: z.array(z.string().guid()).min(1).max(200),
+  // capped at 50: each item runs sequentially in the request transaction (conn-pool safety)
+  ids: z.array(z.string().guid()).min(1).max(50),
 });
 
 export type QuoteLineInput = z.infer<typeof quoteLineInputSchema>;


### PR DESCRIPTION
## Summary

Adds **bulk actions** to the Quotes, Invoices, and Contracts list tables, and a draft-only **Delete** button to each of their detail screens.

- **Quotes:** bulk Send + Delete drafts
- **Invoices:** bulk Issue + Void (with reason dialog) + Delete drafts
- **Contracts:** bulk Cancel + Delete drafts
- **Detail screens:** draft-only Delete on quote / invoice / contract detail

No new tables, migrations, or RLS policies — bulk endpoints loop the *existing* org-scoped service functions, and detail-Delete reuses the existing draft-only `DELETE /:id` routes.

## How it works

- **API:** per-action bulk endpoints (`/bulk-delete`, `/bulk-send`, `/bulk-issue`, `/bulk-void`, `/bulk-cancel`) registered before `/:id`, gated by the correct permission per action (delete → `*_WRITE`; quote-send / invoice issue+void → `*_SEND`; contract cancel → `CONTRACTS_MANAGE`). A shared `runBulkIsolated` helper runs **each item in its own short transaction** (`runOutsideDbContext` + per-item `withDbAccessContext`) so a per-item failure can't roll back its siblings and no single pooled connection is held across the batch (#1105 class). Per-item RLS context is rebuilt through a single source of truth (`buildDbAccessContext` / `dbAccessContextFromAuth`) shared with the auth middleware, so the bulk path and request path can't drift. Partial-success results report `{ total, succeeded, skipped, failed, skippedReasons }`.
- **Web:** reusable `useBulkSelection` hook + `BulkActionBar`, wired into all three tables (header select-all + per-row checkboxes with `stopPropagation`). Every mutation goes through `runAction`. Every destructive action confirms first (bulk delete + cancel via `ConfirmDialog`; void via a reason dialog). Bulk buttons disable while in flight; selection clears when filters/search change; a friendly client-side guard blocks >50 selections before the request.
- The bulk id cap is a single shared `BULK_ID_LIMIT` (= 50) used by both the Zod schemas and the web guard.

## Testing

- **API:** unit tests for `runBulk` / `runBulkIsolated`, each bulk route, and the auth context helper.
- **API integration (real Postgres):** `bulkOpsIsolation.integration.test.ts` proves per-item isolation — a post-write throw on one item rolls back only that item while siblings commit, and counts reflect what persisted.
- **Web:** hook + action-bar unit tests, per-page bulk tests (asserting the POST payloads), and detail-Delete tests (gating + delete-then-navigate).
- All suites green; `@breeze/shared`, `@breeze/api`, `@breeze/web` typecheck clean; `no-silent-mutations` guard passes.

## Notes for review

- Tenant isolation was the key risk and was reviewed field-by-field: `dbAccessContextFromAuth` reproduces the middleware's request context exactly, and per-item `withDbAccessContext` opens one transaction per item.
- `bulk-send` (quotes) and `bulk-issue`/`bulk-void` (invoices) do per-item email/sub-transaction work — now bounded to one connection at a time and capped at 50 ids; moving email fully onto a queue remains a possible future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
