### PR TITLE
chore(ci): enable DB_CONTEXTLESS_WRITE_STRICT suite-wide (#1828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,6 +865,13 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
+          # #1828 — fail the build on any contextless db write (the #1375 silent
+          # 0-row class). The opt-in gate (#1379 A1) is flipped on suite-wide now
+          # that the RLS negative-control tests route their deliberate contextless
+          # writes through a raw breeze_app client (getAppDb) instead of the
+          # guarded `db` proxy. Production code must always carry an access
+          # context, so a genuine offender here is a real bug, not test noise.
+          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:integration
 
       # The rls-coverage contract test inspects pg_catalog to verify every
@@ -884,6 +891,10 @@ jobs:
           APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
           MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
           NODE_ENV: test
+          # #1828 — strict gate on here too. The rls-coverage forge writes all
+          # carry a context (withDbAccessContext / withSystemDbAccessContext);
+          # the catalog-inspection statements are reads, which the guard ignores.
+          DB_CONTEXTLESS_WRITE_STRICT: 'true'
         run: pnpm --filter=@breeze/api test:rls-coverage
 
       - name: Show container logs on failure

--- a/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-checksum.integration.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { createHash } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import { db, withSystemDbAccessContext, withDbAccessContext, runOutsideDbContext } from '../../db';
-import { getTestDb } from './setup';
+import { getTestDb, getAppDb } from './setup';
 import { createPartner, createOrganization } from './db-utils';
 
 describe('audit_logs checksum chain', () => {
@@ -367,11 +367,17 @@ describe('audit_logs checksum chain', () => {
   });
 
   // breeze_app cannot mutate the chain at all (append-only + REVOKE).
-  // Implementation note: we run the mutation attempts OUTSIDE withSystemDbAccessContext
-  // so they hit the breeze_app pool directly (no transaction wrapper). Inside a
-  // withSystemDbAccessContext transaction, a PostgresError aborts the whole transaction
-  // and the outer begin() also rejects, making it impossible to catch just the inner
-  // error cleanly. Running outside the context keeps each rejection self-contained.
+  // Implementation note: we issue the mutation attempts through getAppDb() — a
+  // raw breeze_app client with no transaction wrapper and, crucially, no
+  // contextless-write proxy guard. Under DB_CONTEXTLESS_WRITE_STRICT the
+  // production `db` proxy would THROW on a contextless write (#1379 A1 /
+  // #1828) before the statement reached Postgres, pre-empting the DB-layer
+  // "permission denied"/"append-only" rejection this control asserts. The raw
+  // client still connects as breeze_app, so the REVOKE + append-only trigger
+  // are genuinely exercised. Hitting the pool directly (no withSystemDbAccessContext
+  // transaction) also keeps each rejection self-contained: inside a context
+  // transaction a PostgresError aborts the whole tx and the outer begin() also
+  // rejects, making it impossible to catch just the inner error cleanly.
   // The underlying PostgresError message is "permission denied for table audit_log_chain";
   // Drizzle wraps it in DrizzleQueryError (message: "Failed query: …") with the original
   // in .cause — we walk the cause chain to match "permission denied" precisely.
@@ -399,17 +405,16 @@ describe('audit_logs checksum chain', () => {
       }
     };
 
-    // runOutsideDbContext so db resolves to the bare breeze_app pool (no
-    // transaction wrapper). This keeps each rejection self-contained.
-    await runOutsideDbContext(() =>
-      expectPermissionDenied(
-        db.execute(sql`UPDATE audit_log_chain SET chain_checksum = 'forged' WHERE org_id = ${orgId}::uuid`),
-      )
+    // getAppDb() is a raw breeze_app client (no transaction wrapper, no
+    // contextless-write proxy guard), so each rejection is self-contained and
+    // the contextless write reaches Postgres to surface the real REVOKE /
+    // append-only rejection rather than the strict guard's throw.
+    const appDb = getAppDb();
+    await expectPermissionDenied(
+      appDb.execute(sql`UPDATE audit_log_chain SET chain_checksum = 'forged' WHERE org_id = ${orgId}::uuid`),
     );
-    await runOutsideDbContext(() =>
-      expectPermissionDenied(
-        db.execute(sql`DELETE FROM audit_log_chain WHERE org_id = ${orgId}::uuid`),
-      )
+    await expectPermissionDenied(
+      appDb.execute(sql`DELETE FROM audit_log_chain WHERE org_id = ${orgId}::uuid`),
     );
   });
 

--- a/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-logs-rls.integration.test.ts
@@ -51,17 +51,24 @@ import { db, withDbAccessContext } from '../../db';
 import { auditLogs } from '../../db/schema';
 import { logSessionAudit } from '../../routes/remote/helpers';
 import { createPartner, createOrganization } from './db-utils';
-import { getTestDb } from './setup';
+import { getTestDb, getAppDb } from './setup';
 
 describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
   it('reproduces the pre-fix bug: raw insert with no access context is rejected by RLS (harness smoke test)', async () => {
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
 
-    // Simulate the pre-fix behavior: call the production db pool directly,
-    // without any access context. As `breeze_app` the session has scope
-    // defaulting to 'none' / accessible_org_ids='', so breeze_has_org_access
-    // returns false and the WITH CHECK clause rejects the row.
+    // Simulate the pre-fix behavior: issue a contextless write as `breeze_app`.
+    // As `breeze_app` the session has scope defaulting to 'none' /
+    // accessible_org_ids='', so breeze_has_org_access returns false and the
+    // WITH CHECK clause rejects the row.
+    //
+    // We route this through getAppDb() (a raw breeze_app client) rather than
+    // the production `db` proxy: under DB_CONTEXTLESS_WRITE_STRICT the proxy
+    // guard would throw before the statement reaches Postgres (#1379 A1 /
+    // #1828), pre-empting the DB-layer RLS rejection this control asserts.
+    // The raw client still connects as breeze_app with no GUCs, so forced RLS
+    // is genuinely enforced.
     //
     // Note: this test reproduces the bug regardless of whether the fix is
     // applied — its role is to anchor the RLS contract and prove the
@@ -69,7 +76,7 @@ describe('audit_logs RLS — logSessionAudit (issue #437)', () => {
     // below is the actual regression guard for the fix.
     let caught: unknown;
     try {
-      await db.insert(auditLogs).values({
+      await getAppDb().insert(auditLogs).values({
         orgId: org.id,
         actorType: 'user',
         actorId: '00000000-0000-0000-0000-000000000001',

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -113,6 +113,8 @@ export type TestDatabase = PostgresJsDatabase<typeof schema>;
 
 let testClient: Sql;
 let testDb: TestDatabase;
+let appClient: Sql;
+let appDb: TestDatabase;
 let testRedis: Redis;
 
 export function getTestDb(): TestDatabase {
@@ -120,6 +122,36 @@ export function getTestDb(): TestDatabase {
     throw new Error('Test database not initialized. Make sure integration test setup ran.');
   }
   return testDb;
+}
+
+/**
+ * A drizzle instance connected as the unprivileged `breeze_app` role, the
+ * SAME role the production `db` pool uses — but WITHOUT the RLS-access-context
+ * proxy guard (`apps/api/src/db/index.ts`).
+ *
+ * Use this for the handful of RLS negative-control assertions that must issue
+ * a *genuinely contextless* write to prove the DB layer itself rejects it
+ * (e.g. `new row violates row-level security policy`). The production `db`
+ * proxy now throws on a contextless write when `DB_CONTEXTLESS_WRITE_STRICT`
+ * is set (#1379 A1 / #1828) — which would pre-empt the DB-layer rejection
+ * these tests assert. Routing the deliberate contextless write through this
+ * raw client keeps the negative control meaningful under the strict gate.
+ *
+ * It connects with NO `breeze.*` GUCs set, so RLS sees the default
+ * scope='none' / accessible_org_ids='' — exactly the state a contextless
+ * production write would land in. Drizzle wraps the underlying postgres.js
+ * error in `.cause`, so callers read `err.cause.message` just as they did
+ * against the proxied `db`.
+ *
+ * Do NOT use this to bypass RLS for convenience seeding — that's what
+ * `getTestDb()` (the superuser client) is for. This is strictly for
+ * negative-control writes that must hit `breeze_app`'s forced RLS.
+ */
+export function getAppDb(): TestDatabase {
+  if (!appDb) {
+    throw new Error('App (breeze_app) test database not initialized. Make sure integration test setup ran.');
+  }
+  return appDb;
 }
 
 export function getTestRedis() {
@@ -155,6 +187,19 @@ export async function setupIntegrationTests() {
   });
 
   testDb = drizzle(testClient, { schema });
+
+  // Raw `breeze_app` client (no proxy guard) for RLS negative-control writes.
+  // Connects as the same unprivileged role as production code-under-test, so
+  // forced RLS is enforced, but bypasses the contextless-write proxy guard
+  // (#1379 A1 / #1828) so a deliberate contextless write reaches the DB layer
+  // and surfaces the real RLS rejection instead of the guard's throw.
+  appClient = postgres(DATABASE_URL_APP, {
+    max: 5,
+    idle_timeout: 20,
+    connect_timeout: 10,
+    onnotice: () => {}
+  });
+  appDb = drizzle(appClient, { schema });
 
   // Create Redis connection
   testRedis = new Redis(REDIS_URL, {
@@ -192,6 +237,9 @@ export async function setupIntegrationTests() {
 export async function teardownIntegrationTests() {
   if (testRedis) {
     await testRedis.quit();
+  }
+  if (appClient) {
+    await appClient.end();
   }
   if (testClient) {
     await testClient.end();

--- a/apps/api/src/db/contextlessWriteGuard.test.ts
+++ b/apps/api/src/db/contextlessWriteGuard.test.ts
@@ -117,6 +117,54 @@ describe('contextless-write guard on proxiedDb (#1375/#1379)', () => {
       expect(classifyContextlessExecuteVerb(sql`SELECT ${'delete'} AS action`)).toBeNull();
     });
 
+    it('does not false-positive on write verbs in a string-literal array (catalog reads, #1828)', () => {
+      // The rls-coverage contract queries are pure catalog reads that contain
+      // ARRAY['SELECT','INSERT','UPDATE','DELETE']. The old greedy regex skipped
+      // past the leading CTE and matched DELETE inside that literal, throwing
+      // under DB_CONTEXTLESS_WRITE_STRICT. The verbs are quoted and not anchored
+      // to a target, so the classifier must treat the whole thing as a read.
+      expect(
+        classifyContextlessExecuteVerb(sql`
+          WITH t AS (
+            SELECT c.relname FROM pg_class c WHERE c.relname = ANY(${'x'})
+          ),
+          cov AS (
+            SELECT p.tablename FROM pg_policies p
+            CROSS JOIN UNNEST(ARRAY['SELECT','INSERT','UPDATE','DELETE']) AS cmd
+          )
+          SELECT t.relname FROM t
+        `),
+      ).toBeNull();
+    });
+
+    it('does not false-positive on a verb appearing only inside a string literal', () => {
+      expect(classifyContextlessExecuteVerb(sql`SELECT 'DELETE FROM x' AS literal`)).toBeNull();
+    });
+
+    it('classifies an aliased / ONLY update target', () => {
+      expect(classifyContextlessExecuteVerb(sql`UPDATE foo AS f SET x = ${1} WHERE f.id = ${2}`)).toBe('update');
+      expect(classifyContextlessExecuteVerb(sql`UPDATE ONLY foo SET x = ${1}`)).toBe('update');
+    });
+
+    it('does not false-positive on identifiers that merely contain update/set substrings', () => {
+      // `updated_at` is not the UPDATE verb (no word boundary); `OFFSET`
+      // contains "set" but not as a standalone token.
+      expect(
+        classifyContextlessExecuteVerb(sql`SELECT updated_at FROM foo ORDER BY id OFFSET ${10}`),
+      ).toBeNull();
+    });
+
+    it('still classifies a data-modifying CTE statement that trails a long CTE block', () => {
+      // A genuine WITH ... DELETE FROM cascade write must still be caught even
+      // when the DELETE trails a sizeable CTE prefix.
+      const longCte = 'a'.repeat(400);
+      expect(
+        classifyContextlessExecuteVerb(
+          sql`WITH t AS (SELECT 1 AS x /* ${sql.raw(longCte)} */) DELETE FROM foo WHERE id IN (SELECT x FROM t)`,
+        ),
+      ).toBe('delete');
+    });
+
     it('returns null defensively for non-sql shapes', () => {
       expect(classifyContextlessExecuteVerb(undefined)).toBeNull();
       expect(classifyContextlessExecuteVerb({})).toBeNull();

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -262,10 +262,28 @@ const CONTEXTLESS_WRITE_GUARD_METHODS = new Set<PropertyKey>(['insert', 'update'
 // Raw SQL writes go through `db.execute(sql`...`)`, which the builder-method set
 // above cannot see — so a contextless raw DELETE/UPDATE/INSERT would slip the
 // guard entirely (the exact style cascadeDeletePartner uses). This classifies
-// the leading verb of an execute() statement. A leading CTE (`WITH ...`) is
-// skipped so `WITH ... DELETE` still classifies as a write. SELECT and catalog
-// reads never match, so they're left alone.
-const RAW_WRITE_RE = /^\s*(?:with\b[\s\S]*)?\b(insert|update|delete)\b/i;
+// the leading verb of an execute() statement.
+//
+// A non-CTE write starts directly with the verb. A CTE-prefixed write
+// (`WITH ... DELETE FROM t`) carries the data-modifying statement after the
+// CTE block, so we also match a write verb anchored to its target keyword:
+// `INSERT INTO`, `UPDATE <ident> SET`, `DELETE FROM`. Anchoring to the target
+// is what keeps a *read* like `WITH cte AS (SELECT ...) SELECT ...` from being
+// misclassified when the query merely MENTIONS those verbs — e.g. a catalog
+// inspection containing `UNNEST(ARRAY['SELECT','INSERT','UPDATE','DELETE'])`.
+// String literals are stripped first (in classifyContextlessExecuteVerb) so a
+// quoted `'DELETE'` can never match, and the bare verbs in such a list aren't
+// followed by INTO/FROM/an UPDATE target+SET, so they don't match the anchored
+// form either. SELECT/WITH reads never match; genuine raw writes still do.
+const RAW_WRITE_LEADING_RE = /^\s*(insert|update|delete)\b/i;
+// `UPDATE <target> ... SET` allows an optional ONLY and a table alias between
+// the target and SET (`UPDATE foo AS f SET`), bounded so it can't run away into
+// an unrelated later `set`. Literals are already stripped, so a bare `update`
+// keyword here is a real statement, not a quoted word.
+const RAW_WRITE_STMT_RE = /\b(?:(insert)\s+into|(update)\s+(?:only\s+)?[a-z_"][a-z0-9_."]*\b[\s\S]{0,80}?\bset\b|(delete)\s+from)\b/i;
+// Single-quoted SQL string literals (with '' escape) — removed before
+// classification so verbs appearing inside a literal cannot trip the match.
+const SQL_STRING_LITERAL_RE = /'(?:[^']|'')*'/g;
 
 // Dedup so a hot contextless path can't flood Sentry and bury the signal.
 // Keyed by the originating stack → each distinct call site reports once.
@@ -305,7 +323,9 @@ function reportContextlessWrite(label: string): void {
 // Best-effort extraction of the leading SQL text from a drizzle `sql` object so
 // execute() can be classified read-vs-write. Defensive: any shape surprise just
 // yields '' (treated as a non-write — fail open, since this is observability,
-// not a security control).
+// not a security control). The window is generous (not just a short prefix) so
+// a data-modifying statement that trails a long CTE block — `WITH big AS (...)
+// DELETE FROM t` — is still reached by the anchored classifier below.
 function rawSqlLeadingText(arg: unknown): string {
   try {
     const chunks = (arg as { queryChunks?: unknown[] })?.queryChunks;
@@ -315,7 +335,7 @@ function rawSqlLeadingText(arg: unknown): string {
       const v = (ch as { value?: unknown })?.value;
       if (typeof v === 'string') text += v;
       else if (Array.isArray(v)) text += (v as unknown[]).join('');
-      if (text.length >= 256) break; // enough to clear a short leading CTE
+      if (text.length >= 4096) break; // enough to clear a long leading CTE
     }
     return text;
   } catch {
@@ -326,9 +346,27 @@ function rawSqlLeadingText(arg: unknown): string {
 // Returns the leading write verb ('insert'|'update'|'delete') of a raw `sql`
 // statement, or null for reads. Exported so the guard's classification can be
 // unit-tested without opening a DB connection.
+//
+// Strips single-quoted string literals first so a verb inside a literal (e.g.
+// a catalog query's `ARRAY['SELECT','INSERT','UPDATE','DELETE']`) never trips
+// the match. A statement is a write when it either *starts* with a write verb
+// (plain INSERT/UPDATE/DELETE) or contains the verb anchored to its target
+// (`INSERT INTO`, `UPDATE <ident> SET`, `DELETE FROM`) — the latter catches a
+// data-modifying CTE statement that trails a `WITH ...` prefix while ignoring
+// reads that merely mention the verbs.
 export function classifyContextlessExecuteVerb(arg: unknown): string | null {
-  const m = rawSqlLeadingText(arg).match(RAW_WRITE_RE);
-  return m && m[1] ? m[1].toLowerCase() : null;
+  const text = rawSqlLeadingText(arg).replace(SQL_STRING_LITERAL_RE, "''");
+
+  const leading = text.match(RAW_WRITE_LEADING_RE);
+  if (leading && leading[1]) return leading[1].toLowerCase();
+
+  const stmt = text.match(RAW_WRITE_STMT_RE);
+  if (stmt) {
+    const verb = stmt[1] ?? stmt[2] ?? stmt[3];
+    if (verb) return verb.toLowerCase();
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
**Closes #1828.** Flips the #1379 A1 contextless-write gate from opt-in to **enforced** in CI, so a contextless `db` write (the #1375 silent-0-row-under-RLS class) fails the build at the call site instead of only warning.

## What changed

**1. New raw `breeze_app` test client — `getAppDb()`** (`apps/api/src/__tests__/integration/setup.ts`)
The two RLS negative-control tests that *deliberately* issue a contextless write to assert a DB-layer rejection are migrated off the guarded `db` proxy onto this client. It connects as the same unprivileged `breeze_app` role with no GUCs (so forced RLS is genuinely exercised) but bypasses the contextless-write proxy guard — so the deliberate contextless write reaches Postgres and surfaces the real `row-level security` / `permission denied` rejection rather than the strict guard's throw.
- `audit-logs-rls.integration.test.ts` — the pre-fix-reproducer `insert(auditLogs)` now goes through `getAppDb()`.
- `audit-checksum.integration.test.ts` — the `UPDATE/DELETE audit_log_chain` REVOKE/append-only control now goes through `getAppDb()`.

Every other integration test already wraps its writes in a context, so **no further test migration was needed** — the full suite passes under strict.

**2. Classifier false-positive fix** (`apps/api/src/db/index.ts`)
Enabling strict exposed a latent bug in `classifyContextlessExecuteVerb`: the old regex `^\s*(?:with\b[\s\S]*)?\b(insert|update|delete)\b` greedily skipped a leading `WITH` and matched a write verb **anywhere**, including inside a string literal. The rls-coverage contract queries are pure catalog reads containing `UNNEST(ARRAY['SELECT','INSERT','UPDATE','DELETE'])`, so they were misclassified as `delete` writes and threw under strict. The classifier now:
- strips single-quoted string literals first, and
- only matches a write verb that is the **leading statement keyword** or **anchored to its target** (`INSERT INTO` / `UPDATE <target> … SET` / `DELETE FROM`).

Genuine raw writes — including `WITH … DELETE FROM` cascades that trail a long CTE — are still caught (the leading-text window was widened from 256→4096 chars to reach a trailing DML statement). New unit cases in `contextlessWriteGuard.test.ts` lock this in.

**3. CI** (`.github/workflows/ci.yml`)
`DB_CONTEXTLESS_WRITE_STRICT: 'true'` added to the `Run integration tests` and `Run RLS coverage contract test` job envs.

## Verification (local, `:5433` test stack, all under `DB_CONTEXTLESS_WRITE_STRICT=true`)
- Integration suite: **134 files / 674 tests passed**, 3 skipped, **0 contextless-write throws**.
- RLS coverage: **45 passed**.
- Classifier unit tests: **16 passed** (incl. the new false-positive + aliased-update coverage).
- `tsc --noEmit` clean; `eslint` clean on changed files.

No production behavior change beyond strictly **fewer** false-positive warn-mode reports (the classifier no longer flags catalog reads that merely mention write verbs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)