### PR TITLE
fix(config-policy): avoid nested monitoring buttons (#1932)

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MonitoringTab from './MonitoringTab';
+import { fetchWithAuth } from '../../../stores/auth';
+
+const saveMock = vi.fn();
+const removeMock = vi.fn();
+const clearErrorMock = vi.fn();
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: undefined,
+    clearError: clearErrorMock,
+  }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+// The disclosure header is a role="button" wrapper around the section title.
+function sectionHeader(title: string): HTMLElement {
+  const header = screen.getByText(title).closest('[role="button"]');
+  if (!header) throw new Error(`No disclosure header found for section "${title}"`);
+  return header as HTMLElement;
+}
+
+function renderTab() {
+  return render(
+    <MonitoringTab
+      policyId="policy-1"
+      existingLink={undefined}
+      linkedPolicyId={null}
+      onLinkChanged={vi.fn()}
+    />,
+  );
+}
+
+describe('MonitoringTab disclosure keyboard toggle (issue #1932)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // known-services autocomplete fetch on mount
+    fetchMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+  });
+
+  it('wires aria-controls to the rendered region id when expanded', () => {
+    renderTab();
+
+    const header = sectionHeader('Service & Process Watches');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.keyDown(header, { key: 'Enter' });
+
+    const panelId = header.getAttribute('aria-controls');
+    expect(panelId).toBeTruthy();
+    // The region the header controls is now rendered with the matching id.
+    expect(document.getElementById(panelId!)).not.toBeNull();
+  });
+
+  it('toggles the section open and closed on Enter', () => {
+    renderTab();
+
+    const header = sectionHeader('Service & Process Watches');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText(/No watches configured yet/i)).toBeNull();
+
+    fireEvent.keyDown(header, { key: 'Enter' });
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText(/No watches configured yet/i)).toBeTruthy();
+
+    fireEvent.keyDown(header, { key: 'Enter' });
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText(/No watches configured yet/i)).toBeNull();
+  });
+
+  it('toggles the section on Space and calls preventDefault to avoid page scroll', () => {
+    renderTab();
+
+    const header = sectionHeader('Service & Process Watches');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+
+    // Dispatch a real, cancelable keydown so we can observe preventDefault.
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    fireEvent(header, event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('does not toggle when the keydown originates from a nested action button', () => {
+    renderTab();
+
+    const header = sectionHeader('Service & Process Watches');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+
+    // The "Add Watch" button lives inside the header; a keydown on it has
+    // event.target !== event.currentTarget and must be ignored by the guard.
+    // Exact name avoids matching the header role="button", whose accessible
+    // name also contains the nested "Add Watch" button text.
+    const addButton = screen.getByRole('button', { name: 'Add Watch' });
+    fireEvent.keyDown(addButton, { key: 'Enter' });
+
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText(/No watches configured yet/i)).toBeNull();
+  });
+
+  it('ignores keys other than Enter and Space', () => {
+    renderTab();
+
+    const header = sectionHeader('Service & Process Watches');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.keyDown(header, { key: 'a' });
+    fireEvent.keyDown(header, { key: 'ArrowDown' });
+
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
@@ -253,6 +253,7 @@ function MonitoringSection({
       <div
         role="button"
         tabIndex={0}
+        aria-expanded={open}
         onClick={() => setOpen(!open)}
         onKeyDown={(event) => handleToggleKeyDown(event, () => setOpen(!open))}
         className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/30 transition"
@@ -701,6 +702,7 @@ function WatchCard({
       <div
         role="button"
         tabIndex={0}
+        aria-expanded={expanded}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
@@ -863,6 +865,7 @@ function EventLogAlertCard({
       <div
         role="button"
         tabIndex={0}
+        aria-expanded={expanded}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
@@ -991,6 +994,7 @@ function AlertRuleCard({
       <div
         role="button"
         tabIndex={0}
+        aria-expanded={expanded}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"

--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
+import { useState, useEffect, useRef, useCallback, type KeyboardEvent, type ReactNode } from 'react';
 import { Activity, Plus, Trash2, Server, Cpu, FileWarning, Bell, ChevronDown, ChevronRight, Settings2 } from 'lucide-react';
 import type { FeatureTabProps } from './types';
 import { FEATURE_META } from './types';
@@ -12,6 +12,13 @@ import { fetchWithAuth } from '../../../stores/auth';
 
 type WatchType = 'service' | 'process';
 type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+function handleToggleKeyDown(event: KeyboardEvent<HTMLElement>, onToggle: () => void) {
+  if (event.target !== event.currentTarget) return;
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.preventDefault();
+  onToggle();
+}
 
 type WatchEntry = {
   watchType: WatchType;
@@ -243,9 +250,11 @@ function MonitoringSection({
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden">
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setOpen(!open)}
+        onKeyDown={(event) => handleToggleKeyDown(event, () => setOpen(!open))}
         className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/30 transition"
       >
         {open ? (
@@ -279,7 +288,7 @@ function MonitoringSection({
           <Plus className="h-3.5 w-3.5" />
           {addLabel}
         </button>
-      </button>
+      </div>
 
       {open && (
         <div className="border-t px-4 py-3">
@@ -689,9 +698,11 @@ function WatchCard({
   return (
     <div className="rounded-md border bg-background">
       {/* Header */}
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onToggle}
+        onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
       >
         {expanded ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
@@ -722,7 +733,7 @@ function WatchCard({
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </button>
+      </div>
 
       {/* Expanded form */}
       {expanded && (
@@ -849,9 +860,11 @@ function EventLogAlertCard({
   return (
     <div className="rounded-md border bg-background">
       {/* Header */}
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onToggle}
+        onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
       >
         {expanded ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
@@ -884,7 +897,7 @@ function EventLogAlertCard({
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </button>
+      </div>
 
       {/* Expanded form */}
       {expanded && (
@@ -975,9 +988,11 @@ function AlertRuleCard({
   return (
     <div className="rounded-md border bg-background">
       {/* Header */}
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onToggle}
+        onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
       >
         {expanded ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
@@ -998,7 +1013,7 @@ function AlertRuleCard({
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>
-      </button>
+      </div>
 
       {/* Expanded form */}
       {expanded && (

--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, type KeyboardEvent, type ReactNode } from 'react';
+import { useState, useEffect, useRef, useCallback, useId, type KeyboardEvent, type ReactNode } from 'react';
 import { Activity, Plus, Trash2, Server, Cpu, FileWarning, Bell, ChevronDown, ChevronRight, Settings2 } from 'lucide-react';
 import type { FeatureTabProps } from './types';
 import { FEATURE_META } from './types';
@@ -247,6 +247,7 @@ function MonitoringSection({
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen ?? count > 0);
+  const panelId = useId();
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden">
@@ -254,6 +255,7 @@ function MonitoringSection({
         role="button"
         tabIndex={0}
         aria-expanded={open}
+        aria-controls={panelId}
         onClick={() => setOpen(!open)}
         onKeyDown={(event) => handleToggleKeyDown(event, () => setOpen(!open))}
         className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/30 transition"
@@ -292,7 +294,7 @@ function MonitoringSection({
       </div>
 
       {open && (
-        <div className="border-t px-4 py-3">
+        <div id={panelId} className="border-t px-4 py-3">
           {children}
         </div>
       )}
@@ -691,6 +693,7 @@ function WatchCard({
   onRemove: () => void;
   nameInputRef?: React.RefObject<HTMLInputElement | null>;
 }) {
+  const panelId = useId();
   const summaryParts: string[] = [];
   if (watch.alertOnStop) summaryParts.push('alert on stop');
   if (watch.autoRestart) summaryParts.push('auto-restart');
@@ -703,6 +706,7 @@ function WatchCard({
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
+        aria-controls={panelId}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
@@ -739,7 +743,7 @@ function WatchCard({
 
       {/* Expanded form */}
       {expanded && (
-        <div className="border-t px-4 py-3 space-y-4">
+        <div id={panelId} className="border-t px-4 py-3 space-y-4">
           <div className="grid gap-4 sm:grid-cols-3">
             <div>
               <label className="text-xs font-medium text-muted-foreground">Type</label>
@@ -859,6 +863,7 @@ function EventLogAlertCard({
   onRemove: () => void;
   nameInputRef?: React.RefObject<HTMLInputElement | null>;
 }) {
+  const panelId = useId();
   return (
     <div className="rounded-md border bg-background">
       {/* Header */}
@@ -866,6 +871,7 @@ function EventLogAlertCard({
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
+        aria-controls={panelId}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
@@ -904,7 +910,7 @@ function EventLogAlertCard({
 
       {/* Expanded form */}
       {expanded && (
-        <div className="border-t px-4 py-3 space-y-4">
+        <div id={panelId} className="border-t px-4 py-3 space-y-4">
           <div className="grid gap-4 sm:grid-cols-3">
             <div>
               <label className="text-xs font-medium text-muted-foreground">Rule Name</label>
@@ -988,6 +994,7 @@ function AlertRuleCard({
   onRemoveCondition: (ci: number) => void;
   nameInputRef?: React.RefObject<HTMLInputElement | null>;
 }) {
+  const panelId = useId();
   return (
     <div className="rounded-md border bg-background">
       {/* Header */}
@@ -995,6 +1002,7 @@ function AlertRuleCard({
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
+        aria-controls={panelId}
         onClick={onToggle}
         onKeyDown={(event) => handleToggleKeyDown(event, onToggle)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
@@ -1021,7 +1029,7 @@ function AlertRuleCard({
 
       {/* Expanded form */}
       {expanded && (
-        <div className="border-t px-4 pb-4 pt-3 space-y-4">
+        <div id={panelId} className="border-t px-4 pb-4 pt-3 space-y-4">
           {/* Name */}
           <div>
             <label className="text-xs font-medium text-muted-foreground">Rule Name</label>


### PR DESCRIPTION
## Summary
- Converts Monitoring tab collapsible row headers from outer `<button>` elements to keyboard-accessible `div role="button"` controls.
- Keeps the nested add/toggle/delete actions as real buttons, removing invalid button-inside-button markup and the React hydration warning.
- Guards the row key handler so keyboard events from nested action buttons do not also toggle the row.

## Validation
- `./node_modules/.bin/eslint apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx`

Closes #1932.
