### PR TITLE
fix(software): support catalog all-orgs scope (#1933)

### DIFF
--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -8,8 +8,9 @@
  * the user-supplied orgId, validate it against `accessibleOrgIds`, and forward
  * it through. Foreign orgIds must 403; missing orgId must still 400 with the
  * existing "orgId is required..." message — EXCEPT the software-inventory READ
- * endpoints, which now aggregate across all accessible orgs ("All Orgs") on a
- * missing orgId instead of 400ing (see the software-inventory describe block).
+ * endpoints AND the software catalog LIST endpoint (#1933), which aggregate
+ * across all accessible orgs ("All Orgs") on a missing orgId instead of 400ing
+ * (see the software-inventory and software-catalog describe blocks).
  *
  * #723: GET /orgs/sites must scope by the explicit `organizationId`, not the
  * ambient `orgId` the web client auto-injects (see the #723 describe block).
@@ -254,7 +255,12 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
       await expectNotOrgIdRequired400(res);
     });
 
-    it('GET /software/catalog 400s when orgId is missing', async () => {
+    it('GET /software/catalog aggregates across accessible orgs when orgId is missing (#1933)', async () => {
+      // #1933 supersedes the prior #620 "orgId is required" 400 here: the catalog
+      // LIST endpoint now aggregates across the partner's accessibleOrgIds ("All
+      // Orgs") when no orgId is supplied, instead of 400ing. (Explicit foreign
+      // orgIds still 403 — see the test below — and single-org catalog detail /
+      // write paths are unchanged.)
       const { softwareRoutes } = await import('./software');
       const app = new Hono().route('/software', softwareRoutes);
 
@@ -263,9 +269,10 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
         headers: { Authorization: 'Bearer t' },
       });
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
       const body = await res.json();
-      expect(String(body.error)).toMatch(/orgId is required/i);
+      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty('pagination');
     });
 
     it('GET /software/catalog 403s when ?orgId= points outside accessibleOrgIds', async () => {
@@ -321,8 +328,9 @@ describe('issue #620: partner-multi-org orgId pass-through', () => {
 
     // Exception to the #620 "missing orgId => 400" rule: the software-inventory
     // READ endpoints now aggregate across all accessible orgs ("All Orgs") when
-    // no orgId is supplied, rather than 400ing. (The catalog and discovery
-    // routes below still require an explicit orgId.)
+    // no orgId is supplied, rather than 400ing. (The catalog LIST endpoint does
+    // the same as of #1933; the discovery routes below still require an explicit
+    // orgId.)
     it('GET /software-inventory aggregates across all orgs when orgId is missing', async () => {
       const { softwareInventoryRoutes } = await import('./softwareInventory');
       const app = new Hono().route('/software-inventory', softwareInventoryRoutes);

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -7,8 +7,17 @@ import { captureException } from '../services/sentry';
 import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 import { authMiddleware } from '../middleware/auth';
+import { inArray, eq } from 'drizzle-orm';
 
 vi.mock('../services', () => ({}));
+
+// Wrap drizzle's condition builders in spies (behavior preserved) so tests can
+// assert the actual org-scoping WHERE condition, not just that a query ran.
+// `vi.clearAllMocks()` clears call records but keeps these implementations.
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return { ...actual, inArray: vi.fn(actual.inArray), eq: vi.fn(actual.eq) };
+});
 
 // Chain-friendly mock builder for Drizzle query builder patterns
 function chainMock(terminalValue: any) {
@@ -153,6 +162,11 @@ describe('software routes', () => {
       expect(body).toHaveProperty('data');
       expect(body).toHaveProperty('pagination');
       expect(db.select).toHaveBeenCalledTimes(2);
+      // The catalog query must be org-scoped to the partner's accessible orgs via
+      // `inArray(softwareCatalog.orgId, accessibleOrgIds)`. (Schema is mocked so
+      // `softwareCatalog.orgId` is the literal column name 'org_id'.) A refactor
+      // that drops the inArray scoping — leaking every org's catalog — fails here.
+      expect(inArray).toHaveBeenCalledWith('org_id', ['org-a', 'org-b']);
     });
 
     it('denies explicit orgId outside partner accessible orgs', async () => {
@@ -265,6 +279,48 @@ describe('software routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toHaveProperty('data');
+    });
+
+    it('lets system scope pass an explicit orgId and scopes inventory to it', async () => {
+      // Regression for the resolveScopedOrgId change: system scope used to 403 when
+      // passing an explicit orgId; it must now succeed and scope to that org.
+      const requestedOrgId = '33333333-3333-4333-8333-333333333333';
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'system',
+          orgId: null,
+          partnerId: null,
+          accessibleOrgIds: null
+        });
+        return next();
+      });
+
+      const res = await app.request(`/software/inventory?orgId=${requestedOrgId}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      // Must NOT 403 — and the device lookup must be scoped to the requested org
+      // (`eq(devices.orgId, requestedOrgId)`; devices.orgId mocks to 'org_id').
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('data');
+      expect(eq).toHaveBeenCalledWith('org_id', requestedOrgId);
+    });
+
+    it('denies an org-scoped token requesting a different orgId', async () => {
+      // Negative analog: the default mock auth is org scope on org-123. Passing an
+      // arbitrary other orgId must 403 before any DB query runs.
+      const res = await app.request('/software/inventory?orgId=44444444-4444-4444-8444-444444444444', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Access to this organization denied' });
+      expect(db.select).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -6,6 +6,7 @@ import { uploadBinary, isS3Configured } from '../services/s3Storage';
 import { captureException } from '../services/sentry';
 import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
+import { authMiddleware } from '../middleware/auth';
 
 vi.mock('../services', () => ({}));
 
@@ -127,6 +128,57 @@ describe('software routes', () => {
       const body = await res.json();
       expect(body).toHaveProperty('data');
       expect(body).toHaveProperty('pagination');
+    });
+
+    it('lists catalog items across accessible orgs in partner All-Orgs scope', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['org-a', 'org-b']
+        });
+        return next();
+      });
+
+      const res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty('pagination');
+      expect(db.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns an empty page without querying when partner All-Orgs has no accessible orgs', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: []
+        });
+        return next();
+      });
+
+      const res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        data: [],
+        pagination: { page: 1, limit: 50, total: 0 }
+      });
+      expect(db.select).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -155,6 +155,79 @@ describe('software routes', () => {
       expect(db.select).toHaveBeenCalledTimes(2);
     });
 
+    it('denies explicit orgId outside partner accessible orgs', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['11111111-1111-4111-8111-111111111111']
+        });
+        return next();
+      });
+
+      const res = await app.request('/software/catalog?orgId=22222222-2222-4222-8222-222222222222', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Access to this organization denied' });
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('allows system scope to list a requested orgId', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'system',
+          orgId: null,
+          partnerId: null,
+          accessibleOrgIds: null
+        });
+        return next();
+      });
+
+      const res = await app.request('/software/catalog?orgId=22222222-2222-4222-8222-222222222222', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty('pagination');
+      expect(db.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows system scope to list the all-org catalog without orgId', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'system',
+          orgId: null,
+          partnerId: null,
+          accessibleOrgIds: null
+        });
+        return next();
+      });
+
+      const res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty('pagination');
+      expect(db.select).toHaveBeenCalledTimes(2);
+    });
+
     it('returns an empty page without querying when partner All-Orgs has no accessible orgs', async () => {
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
         c.set('auth', {

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, eq, sql, desc, like, or, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, like, or, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   softwareCatalog,
@@ -41,12 +41,14 @@ type ResolveScopedOrgIdResult =
   | { orgId: string }
   | { error: string; status: 400 | 403 };
 
+type AuthScopeContext = {
+  scope: 'system' | 'partner' | 'organization';
+  orgId?: string | null;
+  accessibleOrgIds?: string[] | null;
+};
+
 function resolveScopedOrgId(
-  auth: {
-    scope: 'system' | 'partner' | 'organization';
-    orgId?: string | null;
-    accessibleOrgIds?: string[] | null;
-  },
+  auth: AuthScopeContext,
   requestedOrgId?: string,
 ): ResolveScopedOrgIdResult {
   if (requestedOrgId) {
@@ -69,6 +71,35 @@ function resolveScopedOrgId(
     if (single) return { orgId: single };
   }
   return { error: 'orgId is required for this scope', status: 400 };
+}
+
+type ResolveCatalogListScopeResult =
+  | { orgCondition?: SQL }
+  | { empty: true }
+  | { error: string; status: 400 | 403 };
+
+function resolveCatalogListScope(
+  auth: AuthScopeContext,
+  requestedOrgId?: string,
+): ResolveCatalogListScopeResult {
+  const scopedOrg = resolveScopedOrgId(auth, requestedOrgId);
+  if ('orgId' in scopedOrg) {
+    return { orgCondition: eq(softwareCatalog.orgId, scopedOrg.orgId) };
+  }
+
+  if (requestedOrgId || scopedOrg.status !== 400) return scopedOrg;
+
+  if (auth.scope === 'partner') {
+    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
+    if (accessibleOrgIds.length === 0) return { empty: true };
+    return { orgCondition: inArray(softwareCatalog.orgId, accessibleOrgIds) };
+  }
+
+  if (auth.scope === 'system') {
+    return {};
+  }
+
+  return scopedOrg;
 }
 
 function getPagination(query: { page?: string; limit?: string }) {
@@ -375,15 +406,19 @@ softwareRoutes.get(
   zValidator('query', listCatalogSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
+    const scopeResult = resolveCatalogListScope(auth, c.req.query('orgId'));
+    if ('error' in scopeResult) return c.json({ error: scopeResult.error }, scopeResult.status);
 
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
     const searchTerm = query.search ?? query.q;
 
-    const conditions = [eq(softwareCatalog.orgId, orgId)];
+    if ('empty' in scopeResult) {
+      return c.json({ data: [], pagination: { page, limit, total: 0 } });
+    }
+
+    const conditions: SQL[] = [];
+    if (scopeResult.orgCondition) conditions.push(scopeResult.orgCondition);
     if (searchTerm) {
       const term = `%${searchTerm}%`;
       conditions.push(
@@ -397,15 +432,16 @@ softwareRoutes.get(
     if (query.category) {
       conditions.push(eq(softwareCatalog.category, query.category));
     }
+    const whereClause = conditions.length > 0 ? and(...conditions)! : sql`true`;
 
     const [items, countResult] = await Promise.all([
       db.select().from(softwareCatalog)
-        .where(and(...conditions))
+        .where(whereClause)
         .orderBy(softwareCatalog.name)
         .limit(limit)
         .offset(offset),
       db.select({ count: sql<number>`count(*)` }).from(softwareCatalog)
-        .where(and(...conditions))
+        .where(whereClause)
     ]);
 
     return c.json({

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -52,13 +52,16 @@ function resolveScopedOrgId(
   requestedOrgId?: string,
 ): ResolveScopedOrgIdResult {
   if (requestedOrgId) {
-    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
+    if (auth.scope === 'system') {
+      return { orgId: requestedOrgId };
+    }
     if (auth.scope === 'organization') {
-      if (auth.orgId && requestedOrgId !== auth.orgId) {
+      if (!auth.orgId || requestedOrgId !== auth.orgId) {
         return { error: 'Access to this organization denied', status: 403 };
       }
       return { orgId: requestedOrgId };
     }
+    const accessibleOrgIds = auth.accessibleOrgIds ?? [];
     if (!accessibleOrgIds.includes(requestedOrgId)) {
       return { error: 'Access to this organization denied', status: 403 };
     }


### PR DESCRIPTION
## Summary
- Adds a catalog-list scope resolver so `GET /software/catalog` can aggregate across partner All-Orgs scope instead of returning `orgId is required`.
- Keeps explicit `orgId` access checks and single-org behavior unchanged for catalog writes/details.
- Returns an empty paginated response without querying when a partner has no accessible orgs.

## Validation
- `/Users/toddhebebrand/breeze-worktrees/1933-software-catalog-all-orgs/apps/api/node_modules/.bin/vitest run src/routes/software.test.ts`

Closes #1933.

**Note:** The `resolveScopedOrgId` change also affects `/inventory`, catalog-detail, and catalog write paths (not just the catalog list): system scope can now pass an explicit `orgId`, and an org-scoped token with no `orgId` is now correctly rejected (403) instead of trusted.
