### PR TITLE
fix(discovery): clarify network changes empty state (#1935)

### DIFF
--- a/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
@@ -84,6 +84,7 @@ async function selectSite(siteId: string) {
 describe('NetworkChangesPanel empty state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.location.hash = '';
   });
 
   it('shows the prerequisite hint when no loaded profile records changes', async () => {
@@ -233,16 +234,21 @@ describe('NetworkChangesPanel empty state', () => {
     });
   });
 
-  it('shows no hint when profiles fail to load (empty list)', async () => {
+  it('shows a setup prompt when no discovery profiles exist', async () => {
     mockEndpoints({ profiles: [], changes: [] });
 
     render(<NetworkChangesPanel {...baseProps} />);
 
     await waitFor(() => {
       expect(
-        desktop().getByText('No change events match the selected filters.')
+        desktop().getByTestId('changes-no-profiles-hint')
       ).toBeInTheDocument();
     });
+    expect(desktop().getByText('Set up a network discovery profile to start tracking changes.')).toBeInTheDocument();
+    expect(desktop().queryByText('No change events match the selected filters.')).not.toBeInTheDocument();
     expect(desktop().queryByTestId('changes-alerting-hint')).not.toBeInTheDocument();
+
+    fireEvent.click(desktop().getByTestId('changes-create-profile'));
+    expect(window.location.hash).toBe('#profiles');
   });
 });

--- a/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
@@ -22,6 +22,14 @@ function jsonResponse(body: unknown): Response {
   } as unknown as Response;
 }
 
+function errorResponse(body: unknown, status = 500): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => body
+  } as unknown as Response;
+}
+
 type AlertSettingsSeed = {
   enabled?: boolean;
   alertOnNew?: boolean;
@@ -39,9 +47,12 @@ type ProfileSeed = {
 // A profile that actually records changes: master switch on + a recording toggle.
 const RECORDING: AlertSettingsSeed = { enabled: true, alertOnNew: true };
 
-function mockEndpoints(options: { profiles: ProfileSeed[]; changes?: unknown[] }) {
+function mockEndpoints(options: { profiles?: ProfileSeed[]; changes?: unknown[]; profilesError?: boolean }) {
   fetchWithAuthMock.mockImplementation((url: string) => {
     if (url.startsWith('/discovery/profiles')) {
+      if (options.profilesError) {
+        return Promise.resolve(errorResponse({ error: 'Profile metadata unavailable' }));
+      }
       return Promise.resolve(jsonResponse({ data: options.profiles }));
     }
     if (url.startsWith('/devices')) {
@@ -232,6 +243,19 @@ describe('NetworkChangesPanel empty state', () => {
     await waitFor(() => {
       expect(desktop().getByTestId('changes-alerting-hint')).toBeInTheDocument();
     });
+  });
+
+  it('does not show the setup prompt when profile metadata fails to load', async () => {
+    mockEndpoints({ profilesError: true, changes: [] });
+
+    render(<NetworkChangesPanel {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Profile metadata unavailable')).toBeInTheDocument();
+    });
+    expect(desktop().getByText('No change events match the selected filters.')).toBeInTheDocument();
+    expect(desktop().queryByTestId('changes-no-profiles-hint')).not.toBeInTheDocument();
+    expect(desktop().queryByTestId('changes-alerting-hint')).not.toBeInTheDocument();
   });
 
   it('shows a setup prompt when no discovery profiles exist', async () => {

--- a/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import NetworkChangesPanel from './NetworkChangesPanel';
@@ -256,6 +256,54 @@ describe('NetworkChangesPanel empty state', () => {
     expect(desktop().getByText('No change events match the selected filters.')).toBeInTheDocument();
     expect(desktop().queryByTestId('changes-no-profiles-hint')).not.toBeInTheDocument();
     expect(desktop().queryByTestId('changes-alerting-hint')).not.toBeInTheDocument();
+  });
+
+  it('does not flash the generic empty state before the profiles fetch settles', async () => {
+    // Profiles are deferred so the changes fetch resolves (empty) first — the
+    // race that previously flashed the generic message before the setup CTA.
+    let resolveProfiles!: (response: Response) => void;
+    const profilesPromise = new Promise<Response>((resolve) => {
+      resolveProfiles = resolve;
+    });
+
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      if (url.startsWith('/discovery/profiles')) {
+        return profilesPromise;
+      }
+      if (url.startsWith('/devices')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+      if (url.startsWith('/network/changes')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+      return Promise.resolve(jsonResponse({ data: [] }));
+    });
+
+    render(<NetworkChangesPanel {...baseProps} />);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(expect.stringContaining('/network/changes'));
+    });
+    // Flush the changes-fetch resolution microtasks; profiles stay pending.
+    await act(async () => {});
+
+    // Changes settled empty + profiles still in flight → keep the loading row,
+    // never the generic message and never the setup CTA.
+    expect(desktop().getByText('Loading network changes...')).toBeInTheDocument();
+    expect(
+      desktop().queryByText('No change events match the selected filters.')
+    ).not.toBeInTheDocument();
+    expect(desktop().queryByTestId('changes-no-profiles-hint')).not.toBeInTheDocument();
+
+    // Profiles resolve empty → the setup CTA replaces the loading row.
+    await act(async () => {
+      resolveProfiles(jsonResponse({ data: [] }));
+    });
+
+    await waitFor(() => {
+      expect(desktop().getByTestId('changes-no-profiles-hint')).toBeInTheDocument();
+    });
+    expect(desktop().queryByText('Loading network changes...')).not.toBeInTheDocument();
   });
 
   it('shows a setup prompt when no discovery profiles exist', async () => {

--- a/apps/web/src/components/discovery/NetworkChangesPanel.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.tsx
@@ -91,6 +91,7 @@ export default function NetworkChangesPanel({
   const [changes, setChanges] = useState<NetworkChangeEvent[]>([]);
   const [profiles, setProfiles] = useState<ProfileOption[]>([]);
   const [profilesLoaded, setProfilesLoaded] = useState(false);
+  const [profilesError, setProfilesError] = useState(false);
   const [devices, setDevices] = useState<DeviceOption[]>([]);
   const [filters, setFilters] = useState<FilterState>(() => createDefaultFilters(currentSiteId));
   const [loading, setLoading] = useState(true);
@@ -109,46 +110,55 @@ export default function NetworkChangesPanel({
 
   const fetchProfiles = useCallback(async () => {
     setProfilesLoaded(false);
+    setProfilesError(false);
     const params = new URLSearchParams();
     if (currentOrgId) params.set('orgId', currentOrgId);
     const query = params.toString();
 
-    const response = await fetchWithAuth(`/discovery/profiles${query ? `?${query}` : ''}`);
-    if (!response.ok) {
-      throw new Error(await extractError(response, 'Failed to load profile filters'));
+    try {
+      const response = await fetchWithAuth(`/discovery/profiles${query ? `?${query}` : ''}`);
+      if (!response.ok) {
+        throw new Error(await extractError(response, 'Failed to load profile filters'));
+      }
+
+      const payload = await response.json();
+      const items = Array.isArray(payload?.data)
+        ? payload.data
+        : Array.isArray(payload)
+          ? payload
+          : [];
+
+      const mapped: ProfileOption[] = items
+        .map((row: Record<string, unknown>) => {
+          const id = typeof row.id === 'string' ? row.id : null;
+          const name = typeof row.name === 'string' ? row.name : null;
+          if (!id || !name) return null;
+          // A profile records discovery-scan change events only when the master
+          // Alerting switch is on AND at least one recording sub-toggle is set —
+          // the worker gates each insert on `enabled && alertOn{New,Changed,...}`
+          // (assetApproval.ts), so `enabled: true` with every sub-toggle off
+          // still records nothing. Mirror that here so the hint stays accurate.
+          const alert = (row.alertSettings && typeof row.alertSettings === 'object')
+            ? row.alertSettings as Record<string, unknown>
+            : null;
+          const recordsChanges = !!(alert
+            && alert.enabled === true
+            && [alert.alertOnNew, alert.alertOnChanged, alert.alertOnDisappeared]
+              .some((flag) => flag === true));
+          const siteId = typeof row.siteId === 'string' ? row.siteId : null;
+          return { id, name, siteId, recordsChanges };
+        })
+        .filter((row: ProfileOption | null): row is ProfileOption => row !== null);
+
+      setProfiles(mapped);
+      setProfilesLoaded(true);
+    } catch (profilesFetchError) {
+      // Mark the profiles fetch as settled-with-error so the empty state
+      // resolves to the generic message (not a perpetual spinner, not the
+      // setup CTA). Re-throw so the Promise.all catch still surfaces the banner.
+      setProfilesError(true);
+      throw profilesFetchError;
     }
-
-    const payload = await response.json();
-    const items = Array.isArray(payload?.data)
-      ? payload.data
-      : Array.isArray(payload)
-        ? payload
-        : [];
-
-    const mapped: ProfileOption[] = items
-      .map((row: Record<string, unknown>) => {
-        const id = typeof row.id === 'string' ? row.id : null;
-        const name = typeof row.name === 'string' ? row.name : null;
-        if (!id || !name) return null;
-        // A profile records discovery-scan change events only when the master
-        // Alerting switch is on AND at least one recording sub-toggle is set —
-        // the worker gates each insert on `enabled && alertOn{New,Changed,...}`
-        // (assetApproval.ts), so `enabled: true` with every sub-toggle off
-        // still records nothing. Mirror that here so the hint stays accurate.
-        const alert = (row.alertSettings && typeof row.alertSettings === 'object')
-          ? row.alertSettings as Record<string, unknown>
-          : null;
-        const recordsChanges = !!(alert
-          && alert.enabled === true
-          && [alert.alertOnNew, alert.alertOnChanged, alert.alertOnDisappeared]
-            .some((flag) => flag === true));
-        const siteId = typeof row.siteId === 'string' ? row.siteId : null;
-        return { id, name, siteId, recordsChanges };
-      })
-      .filter((row: ProfileOption | null): row is ProfileOption => row !== null);
-
-    setProfiles(mapped);
-    setProfilesLoaded(true);
   }, [currentOrgId]);
 
   const fetchDevices = useCallback(async () => {
@@ -475,6 +485,19 @@ export default function NetworkChangesPanel({
     <span className="text-sm text-muted-foreground">No change events match the selected filters.</span>
   );
 
+  // Don't render the *terminal* empty state until BOTH fetches have settled.
+  // The changes fetch (`loading`) and the profiles fetch (`profilesLoaded` /
+  // `profilesError`) run as independent effects; without this gate a genuine
+  // no-profiles org briefly flashes the generic "no events" copy before the
+  // setup CTA appears once profiles resolve. While profiles are still in
+  // flight (neither loaded nor errored) we keep showing the loading row.
+  const profilesSettled = profilesLoaded || profilesError;
+  const emptyStateResolving = changes.length === 0 && (loading || !profilesSettled);
+
+  // Reached only once profiles have settled (the gate above intercepts the
+  // still-loading case). When `profilesLoaded` is false here, it means the
+  // profiles fetch errored — fall through to the generic message rather than
+  // the setup CTA.
   const renderEmptyState = () =>
     !profilesLoaded ? genericEmptyState : profiles.length === 0 ? (
       <div className="mx-auto max-w-xl space-y-3 text-sm text-muted-foreground" data-testid="changes-no-profiles-hint">
@@ -681,7 +704,7 @@ export default function NetworkChangesPanel({
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {loading && changes.length === 0 ? (
+                {emptyStateResolving ? (
                   <tr>
                     <td colSpan={7} className="px-4 py-6 text-center text-sm text-muted-foreground">
                       Loading network changes...
@@ -717,7 +740,7 @@ export default function NetworkChangesPanel({
             </table>
           }
           cards={
-            loading && changes.length === 0 ? (
+            emptyStateResolving ? (
               <DataCard>
                 <p className="py-2 text-center text-sm text-muted-foreground">Loading network changes...</p>
               </DataCard>

--- a/apps/web/src/components/discovery/NetworkChangesPanel.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.tsx
@@ -90,6 +90,7 @@ export default function NetworkChangesPanel({
 }: NetworkChangesPanelProps) {
   const [changes, setChanges] = useState<NetworkChangeEvent[]>([]);
   const [profiles, setProfiles] = useState<ProfileOption[]>([]);
+  const [profilesLoaded, setProfilesLoaded] = useState(false);
   const [devices, setDevices] = useState<DeviceOption[]>([]);
   const [filters, setFilters] = useState<FilterState>(() => createDefaultFilters(currentSiteId));
   const [loading, setLoading] = useState(true);
@@ -107,6 +108,7 @@ export default function NetworkChangesPanel({
   }, [currentSiteId]);
 
   const fetchProfiles = useCallback(async () => {
+    setProfilesLoaded(false);
     const params = new URLSearchParams();
     if (currentOrgId) params.set('orgId', currentOrgId);
     const query = params.toString();
@@ -146,6 +148,7 @@ export default function NetworkChangesPanel({
       .filter((row: ProfileOption | null): row is ProfileOption => row !== null);
 
     setProfiles(mapped);
+    setProfilesLoaded(true);
   }, [currentOrgId]);
 
   const fetchDevices = useCallback(async () => {
@@ -468,8 +471,12 @@ export default function NetworkChangesPanel({
     </div>
   );
 
+  const genericEmptyState = (
+    <span className="text-sm text-muted-foreground">No change events match the selected filters.</span>
+  );
+
   const renderEmptyState = () =>
-    profiles.length === 0 ? (
+    !profilesLoaded ? genericEmptyState : profiles.length === 0 ? (
       <div className="mx-auto max-w-xl space-y-3 text-sm text-muted-foreground" data-testid="changes-no-profiles-hint">
         <div className="space-y-1">
           <p className="font-medium text-foreground">Set up a network discovery profile to start tracking changes.</p>
@@ -500,9 +507,7 @@ export default function NetworkChangesPanel({
           settings (Profiles tab) to start tracking network changes.
         </p>
       </div>
-    ) : (
-      <span className="text-sm text-muted-foreground">No change events match the selected filters.</span>
-    );
+    ) : genericEmptyState;
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/components/discovery/NetworkChangesPanel.tsx
+++ b/apps/web/src/components/discovery/NetworkChangesPanel.tsx
@@ -469,7 +469,27 @@ export default function NetworkChangesPanel({
   );
 
   const renderEmptyState = () =>
-    alertingPrerequisite ? (
+    profiles.length === 0 ? (
+      <div className="mx-auto max-w-xl space-y-3 text-sm text-muted-foreground" data-testid="changes-no-profiles-hint">
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">Set up a network discovery profile to start tracking changes.</p>
+          <p>
+            Network change events are created by discovery profiles. Create a profile and enable Alerting
+            to record new, changed, or disappeared devices.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            if (typeof window !== 'undefined') window.location.hash = 'profiles';
+          }}
+          className="inline-flex items-center rounded-md border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+          data-testid="changes-create-profile"
+        >
+          Go to Profiles
+        </button>
+      </div>
+    ) : alertingPrerequisite ? (
       <div className="mx-auto max-w-xl space-y-1 text-sm text-muted-foreground" data-testid="changes-alerting-hint">
         <p className="font-medium text-foreground">No change events recorded yet.</p>
         <p>


### PR DESCRIPTION
## Summary
- Adds a distinct Network Changes empty state for orgs with no discovery profiles.
- Points users to the Profiles tab with a CTA instead of saying no events match filters.
- Keeps the existing alerting-disabled and no-match states for orgs that do have profiles.

## Validation
- `/Users/toddhebebrand/breeze-worktrees/1935-network-changes-empty-state/apps/web/node_modules/.bin/vitest run src/components/discovery/NetworkChangesPanel.test.tsx`

Closes #1935.
