### PR TITLE
fix(db): guard partner-scope migration reruns (#1936)

### DIFF
--- a/apps/api/migrations/2026-06-27-a-update-rings-partner-scope.sql
+++ b/apps/api/migrations/2026-06-27-a-update-rings-partner-scope.sql
@@ -9,13 +9,20 @@ ALTER TABLE patch_policies ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES p
 DO $$
 DECLARE n bigint;
 BEGIN
-  UPDATE patch_policies p
-     SET partner_id = o.partner_id
-    FROM organizations o
-   WHERE p.org_id = o.id
-     AND p.partner_id IS NULL;
-  GET DIAGNOSTICS n = ROW_COUNT;
-  IF n > 0 THEN RAISE WARNING 'patch_policies partner backfill: % rows', n; END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = 'patch_policies'
+       AND column_name = 'org_id'
+  ) THEN
+    UPDATE patch_policies p
+       SET partner_id = o.partner_id
+      FROM organizations o
+     WHERE p.org_id = o.id
+       AND p.partner_id IS NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN RAISE WARNING 'patch_policies partner backfill: % rows', n; END IF;
+  END IF;
 END $$;
 
 -- 3. Enforce NOT NULL once backfilled.

--- a/apps/api/migrations/2026-06-27-b-patch-approvals-partner-scope.sql
+++ b/apps/api/migrations/2026-06-27-b-patch-approvals-partner-scope.sql
@@ -9,13 +9,20 @@ ALTER TABLE patch_approvals ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES 
 DO $$
 DECLARE n bigint;
 BEGIN
-  UPDATE patch_approvals a
-     SET partner_id = o.partner_id
-    FROM organizations o
-   WHERE a.org_id = o.id
-     AND a.partner_id IS NULL;
-  GET DIAGNOSTICS n = ROW_COUNT;
-  IF n > 0 THEN RAISE WARNING 'patch_approvals partner backfill: % rows', n; END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = 'patch_approvals'
+       AND column_name = 'org_id'
+  ) THEN
+    UPDATE patch_approvals a
+       SET partner_id = o.partner_id
+      FROM organizations o
+     WHERE a.org_id = o.id
+       AND a.partner_id IS NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN RAISE WARNING 'patch_approvals partner backfill: % rows', n; END IF;
+  END IF;
 END $$;
 
 -- 3. Dedup collisions BEFORE the new unique index. Two orgs under one partner can

--- a/apps/api/migrations/2026-06-27-b-patch-approvals-partner-scope.sql
+++ b/apps/api/migrations/2026-06-27-b-patch-approvals-partner-scope.sql
@@ -30,6 +30,11 @@ END $$;
 -- Keep one deterministic winner per (partner_id, patch_id, COALESCE(ring_id,NIL)):
 -- status precedence approved>deferred>rejected>pending, then latest updated_at,
 -- then latest id. Delete the losers and report the count (forensic trail).
+-- No org_id guard needed (unlike step 2): this block reads only
+-- partner_id/patch_id/ring_id/status/updated_at/id, never org_id, so it runs
+-- safely even after org_id has been dropped. On a re-apply of the partner
+-- end-state it's a harmless no-op — the unique index already prevents
+-- duplicate (partner, patch, ring) approvals, so there are no losers to delete.
 DO $$
 DECLARE n bigint;
 BEGIN

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -53,6 +53,16 @@ export const CHECKSUM_RECONCILIATIONS: Record<
     to: '214ebca196629d81d54610bad9ff79fef8b2b5bfb19c0b024a4cf2a6b230f693',
     reason: '#994: canonical audit-chain fix (companion to 2026-05-25-b)',
   },
+  '2026-06-27-a-update-rings-partner-scope.sql': {
+    from: '116206c6dca9085c7b539ce9a0adc00ca686a290ccf103c77476198d2d8ea73d',
+    to: '343795b2cdc3ab7ac938d0b0ad71360b69f32e1a6219cd7e4c591842f14e9dd0',
+    reason: '#1936: guard patch_policies org_id backfill for already partner-scoped reruns',
+  },
+  '2026-06-27-b-patch-approvals-partner-scope.sql': {
+    from: 'e7047df7bf793525af48e8bd0f6ce9eadee38b8fdb10227bf7b387595fb44384',
+    to: '857bb9005dbdbda33f55295db45a685d7003442414386d94d9cb32e7ceb9f1a0',
+    reason: '#1936: guard patch_approvals org_id backfill for already partner-scoped reruns',
+  },
 };
 
 /**

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -60,8 +60,8 @@ export const CHECKSUM_RECONCILIATIONS: Record<
   },
   '2026-06-27-b-patch-approvals-partner-scope.sql': {
     from: 'e7047df7bf793525af48e8bd0f6ce9eadee38b8fdb10227bf7b387595fb44384',
-    to: '857bb9005dbdbda33f55295db45a685d7003442414386d94d9cb32e7ceb9f1a0',
-    reason: '#1936: guard patch_approvals org_id backfill for already partner-scoped reruns',
+    to: '83cf9d01bf2030bb1cf063c4624c3847d9eac71ce90ae4d511228a98d14eaca6',
+    reason: '#1936: guard patch_approvals org_id backfill for already partner-scoped reruns; note why step-3 dedup needs no org_id guard',
   },
 };
 


### PR DESCRIPTION
## Summary
- Guards the `patch_policies` and `patch_approvals` partner-scope backfills so they no-op after `org_id` has already been dropped.
- Adds exact checksum reconciliation entries for these reviewed in-place migration fixes so already-applied databases heal the recorded checksum instead of crash-looping.
- Leaves all other checksum mismatches fail-closed.

## Validation
- `./node_modules/.bin/tsx apps/api/scripts/check-migrations.ts` reconciled both old checksums and confirmed all migrations were already applied; final command then failed at the existing local superuser/BYPASSRLS guard because `DATABASE_URL_APP` / app role credentials are not configured in this environment.

Closes #1936.
