### PR TITLE
feat(web): EDR operations surfacing (SentinelOne + Huntress) — Pillars 1–4a

### DIFF
--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -10,7 +10,7 @@ const { permissionGate, mfaGate, permsState, authState } = vi.hoisted(() => ({
     orgId: '11111111-1111-4111-8111-111111111111' as string | undefined,
     partnerId: 'a0000000-0000-4000-8000-000000000001' as string | undefined,
     accessibleOrgIds: ['11111111-1111-4111-8111-111111111111'] as string[],
-    canAccessOrg: (orgId: string) => orgId === '11111111-1111-4111-8111-111111111111',
+    canAccessOrg: ((orgId: string) => orgId === '11111111-1111-4111-8111-111111111111') as (orgId: string) => boolean,
     orgCondition: () => undefined as any,
   }
 }));
@@ -162,7 +162,9 @@ import { encryptSecret } from '../services/secretCrypto';
 const PARTNER_ID = 'a0000000-0000-4000-8000-000000000001';
 const OTHER_PARTNER_ID = 'a0000000-0000-4000-8000-000000000002';
 const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const ORG_ID_B = '22222222-2222-4222-8222-222222222222';
 const INTEGRATION_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const INTEGRATION_ID_B = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const S1_SITE_ID = 's1-site-abc123';
 
 describe('sentinel one routes', () => {
@@ -1212,6 +1214,63 @@ describe('sentinel one routes', () => {
       });
 
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ───────────────────── GET /threats — partner scope ─────────────────────
+  describe('GET /threats — partner scope', () => {
+    function mockActiveIntegrations(rows: Array<{ id: string }>) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      } as any);
+    }
+
+    function mockThreatsQueries(rows: any[], count: number) {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue(rows)
+                  })
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count }])
+          })
+        } as any);
+    }
+
+    it('GET /threats lists across all partner orgs for a partner-scoped caller without orgId', async () => {
+      authState.scope = 'partner';
+      authState.orgId = undefined;
+      authState.partnerId = PARTNER_ID;
+      authState.accessibleOrgIds = [ORG_ID, ORG_ID_B];
+      authState.canAccessOrg = (orgId: string) => [ORG_ID, ORG_ID_B].includes(orgId);
+      authState.orgCondition = () => undefined as any;
+
+      mockActiveIntegrations([{ id: INTEGRATION_ID }, { id: INTEGRATION_ID_B }]);
+      mockThreatsQueries(
+        [
+          { id: 'threat-a', orgId: ORG_ID, integrationId: INTEGRATION_ID },
+          { id: 'threat-b', orgId: ORG_ID_B, integrationId: INTEGRATION_ID_B }
+        ],
+        2
+      );
+
+      const res = await app.request('/s1/threats');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.map((t: any) => t.orgId).sort()).toEqual([ORG_ID, ORG_ID_B].sort());
+      expect(body.pagination.total).toBe(2);
     });
   });
 

--- a/apps/api/src/routes/sentinelOne.test.ts
+++ b/apps/api/src/routes/sentinelOne.test.ts
@@ -1249,6 +1249,18 @@ describe('sentinel one routes', () => {
         } as any);
     }
 
+    it('GET /threats rejects system scope without explicit partnerId', async () => {
+      authState.scope = 'system';
+      authState.orgId = undefined;
+      authState.partnerId = undefined;
+      authState.accessibleOrgIds = [];
+      authState.canAccessOrg = () => false;
+      authState.orgCondition = () => undefined as any;
+
+      const res = await app.request('/s1/threats');
+      expect(res.status).toBe(400);
+    });
+
     it('GET /threats lists across all partner orgs for a partner-scoped caller without orgId', async () => {
       authState.scope = 'partner';
       authState.orgId = undefined;

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -608,10 +608,13 @@ sentinelOneRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-    const orgResult = resolveOrgId(auth, query.orgId);
-    if ('error' in orgResult) {
+    const requestedOrg = query.orgId;
+    const wantsOrgScope = requestedOrg || auth.scope === 'organization';
+    const orgResult = wantsOrgScope ? resolveOrgId(auth, requestedOrg) : null;
+    if (orgResult && 'error' in orgResult) {
       return c.json({ error: orgResult.error }, orgResult.status);
     }
+    const scopedOrgId = orgResult && 'orgId' in orgResult ? orgResult.orgId : null;
 
     const start = query.start ? new Date(query.start) : null;
     const end = query.end ? new Date(query.end) : null;
@@ -622,15 +625,32 @@ sentinelOneRoutes.get(
       return c.json({ error: 'start must be before or equal to end' }, 400);
     }
 
-    const conditions: SQL[] = [eq(s1Threats.orgId, orgResult.orgId)];
+    const conditions: SQL[] = [];
+    if (scopedOrgId) {
+      conditions.push(eq(s1Threats.orgId, scopedOrgId));
+    }
     withOrgCondition(conditions, auth.orgCondition(s1Threats.orgId));
+
+    if (!scopedOrgId) {
+      const partnerResult = resolvePartnerId(auth, query.partnerId);
+      if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
+      const integrations = await db
+        .select({ id: s1Integrations.id })
+        .from(s1Integrations)
+        .where(and(eq(s1Integrations.partnerId, partnerResult.partnerId), eq(s1Integrations.isActive, true)));
+      const integrationIds = integrations.map((i) => i.id);
+      if (integrationIds.length === 0) {
+        return c.json({ data: [], pagination: { total: 0, limit: query.limit ?? 100, offset: query.offset ?? 0 } });
+      }
+      conditions.push(inArray(s1Threats.integrationId, integrationIds));
+    }
 
     // Site-scope: site is an app-layer authz axis (RLS does not defend it).
     // When the caller is site-restricted, deny an explicit out-of-scope
     // deviceId and narrow the broad list to the caller's accessible devices.
     const perms = c.get('permissions') as UserPermissions | undefined;
-    if (perms?.allowedSiteIds) {
-      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgResult.orgId, perms);
+    if (perms?.allowedSiteIds && scopedOrgId) {
+      const allowedDeviceIds = await resolveSiteAllowedDeviceIds(scopedOrgId, perms);
       if (query.deviceId && !allowedDeviceIds!.includes(query.deviceId)) {
         return c.json({ error: 'Device not found or access denied' }, 403);
       }

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -631,6 +631,7 @@ sentinelOneRoutes.get(
     }
     withOrgCondition(conditions, auth.orgCondition(s1Threats.orgId));
 
+    // System scope without an explicit partnerId is rejected by resolvePartnerId below (mirrors huntress.ts). Partner scope is fenced by orgCondition + the partner's integrationId set.
     if (!scopedOrgId) {
       const partnerResult = resolvePartnerId(auth, query.partnerId);
       if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -359,7 +359,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
       )}
 
       {activeTab === 'security' && (
-        <DeviceSecurityTab deviceId={device.id} timezone={effectiveTimezone} />
+        <DeviceSecurityTab deviceId={device.id} orgId={device.orgId} timezone={effectiveTimezone} />
       )}
 
       {activeTab === 'peripherals' && (

--- a/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
@@ -59,3 +59,18 @@ describe('DeviceEdrPanel isolate', () => {
     await waitFor(() => expect(isolateBody).toEqual({ orgId: 'org-1', deviceIds: ['dev-1'], isolate: true }));
   });
 });
+
+describe('DeviceEdrPanel threat actions', () => {
+  it('POSTs /s1/threat-action with the threat row id', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', threatName: 'Emotet', severity: 'high', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/s1/threat-action') { body = JSON.parse(String(init?.body)); return Promise.resolve(ok({ data: {} })); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-threat-quarantine-t1'));
+    await waitFor(() => expect(body).toEqual({ orgId: 'org-1', action: 'quarantine', threatIds: ['t1'] }));
+  });
+});

--- a/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
+const navigateTo = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 
 import DeviceEdrPanel from './DeviceEdrPanel';
@@ -22,6 +24,7 @@ function routeFetch(map: { s1?: unknown; huntress?: unknown }) {
 
 beforeEach(() => {
   fetchWithAuth.mockReset();
+  navigateTo.mockReset();
 });
 
 describe('DeviceEdrPanel', () => {
@@ -72,6 +75,22 @@ describe('DeviceEdrPanel threat actions', () => {
     render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
     fireEvent.click(await screen.findByTestId('edr-threat-quarantine-t1'));
     await waitFor(() => expect(body).toEqual({ orgId: 'org-1', action: 'quarantine', threatIds: ['t1'] }));
+  });
+});
+
+describe('DeviceEdrPanel promote to incident', () => {
+  it('promotes an S1 threat then navigates to the new incident', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', orgId: 'org-1', deviceId: 'dev-1', threatName: 'Emotet', severity: 'critical', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/incidents') { body = JSON.parse(String(init?.body)); return Promise.resolve({ ok: true, status: 201, json: async () => ({ id: 'inc-9' }) } as Response); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-s1-promote-t1'));
+    await waitFor(() => expect((body as any).classification).toBe('sentinelone-threat'));
+    expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-9');
   });
 });
 

--- a/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+import DeviceEdrPanel from './DeviceEdrPanel';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+// Route by URL + method — never positional (effect-load vs click race).
+function routeFetch(map: { s1?: unknown; huntress?: unknown }) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: map.s1 ?? [], pagination: { total: 0, limit: 50, offset: 0 } }));
+    if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: map.huntress ?? [], total: 0, limit: 50, offset: 0 }));
+    return Promise.resolve(ok({ data: [] }));
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('DeviceEdrPanel', () => {
+  it('renders S1 threats and Huntress incidents for the device', async () => {
+    routeFetch({
+      s1: [{ id: 't1', threatName: 'Emotet', severity: 'high', status: 'active', filePath: 'C:/x.exe', detectedAt: '2026-06-20T00:00:00Z' }],
+      huntress: [{ id: 'i1', title: 'Suspicious persistence', severity: 'critical', status: 'open', category: 'malware', reportedAt: '2026-06-21T00:00:00Z' }],
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    expect(await screen.findByText('Emotet')).toBeInTheDocument();
+    expect(await screen.findByText('Suspicious persistence')).toBeInTheDocument();
+  });
+
+  it('shows empty states when there is no EDR data', async () => {
+    routeFetch({ s1: [], huntress: [] });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    await waitFor(() => expect(screen.getByTestId('edr-s1-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('edr-huntress-empty')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
@@ -74,3 +74,23 @@ describe('DeviceEdrPanel threat actions', () => {
     await waitFor(() => expect(body).toEqual({ orgId: 'org-1', action: 'quarantine', threatIds: ['t1'] }));
   });
 });
+
+describe('DeviceEdrPanel error + status gating', () => {
+  it('shows the error banner when a read fails', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve({ ok: false, status: 500, statusText: 'Server Error', json: async () => ({}) } as Response);
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    expect(await screen.findByTestId('edr-error')).toBeInTheDocument();
+  });
+
+  it('renders no action buttons for non-active threats', async () => {
+    routeFetch({ s1: [{ id: 't9', threatName: 'Quarantined item', severity: 'low', status: 'quarantined', detectedAt: '2026-06-20T00:00:00Z' }], huntress: [] });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    await screen.findByText('Quarantined item');
+    expect(screen.queryByTestId('edr-threat-kill-t9')).toBeNull();
+    expect(screen.queryByTestId('edr-threat-quarantine-t9')).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
@@ -40,5 +40,22 @@ describe('DeviceEdrPanel', () => {
     render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
     await waitFor(() => expect(screen.getByTestId('edr-s1-empty')).toBeInTheDocument());
     expect(screen.getByTestId('edr-huntress-empty')).toBeInTheDocument();
+  });
+});
+
+describe('DeviceEdrPanel isolate', () => {
+  it('confirms then POSTs /s1/isolate with the device id', async () => {
+    let isolateBody: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [], pagination: { total: 0, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/s1/isolate') { isolateBody = JSON.parse(String(init?.body)); return Promise.resolve(ok({ data: {} })); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-isolate-btn'));
+    // confirm modal
+    fireEvent.click(await screen.findByTestId('edr-isolate-confirm'));
+    await waitFor(() => expect(isolateBody).toEqual({ orgId: 'org-1', deviceIds: ['dev-1'], isolate: true }));
   });
 });

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -5,9 +5,11 @@ import { friendlyFetchError } from '../../lib/utils';
 import {
   fetchS1Threats,
   fetchHuntressIncidents,
+  isolateDevice,
   type S1Threat,
   type HuntressIncident,
 } from '../../lib/edr';
+import { ActionError } from '../../lib/runAction';
 
 const severityBadge: Record<string, string> = {
   low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
@@ -33,6 +35,8 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
   const [incidents, setIncidents] = useState<HuntressIncident[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [confirmIsolate, setConfirmIsolate] = useState(false);
+  const [isolating, setIsolating] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -51,6 +55,20 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
     }
   }, [orgId, deviceId]);
 
+  const doIsolate = async () => {
+    setIsolating(true);
+    try {
+      await isolateDevice(orgId, deviceId, true);
+      setConfirmIsolate(false);
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return; // auth redirect handles it
+      // non-401 ActionError already toasted by runAction
+    } finally {
+      setIsolating(false);
+    }
+  };
+
   useEffect(() => { void load(); }, [load]);
 
   return (
@@ -58,6 +76,14 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       <div className="mb-4 flex items-center gap-2">
         <ShieldAlert className="h-4 w-4 text-primary" />
         <h3 className="text-lg font-semibold">Endpoint Protection (EDR)</h3>
+        <button
+          type="button"
+          data-testid="edr-isolate-btn"
+          onClick={() => setConfirmIsolate(true)}
+          className="ml-auto inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+        >
+          Isolate device
+        </button>
       </div>
 
       {error && (
@@ -117,6 +143,29 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
           )}
         </div>
       </div>
+
+      {confirmIsolate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+            <h4 className="text-base font-semibold">Isolate this device?</h4>
+            <p className="mt-2 text-sm text-muted-foreground">
+              SentinelOne will cut the device off the network until you remove isolation. Active sessions will drop.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button type="button" onClick={() => setConfirmIsolate(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
+              <button
+                type="button"
+                data-testid="edr-isolate-confirm"
+                onClick={doIsolate}
+                disabled={isolating}
+                className="inline-flex items-center gap-2 rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:opacity-90 disabled:opacity-60"
+              >
+                {isolating && <Loader2 className="h-4 w-4 animate-spin" />}Isolate
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, ShieldAlert, Activity } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
+import { friendlyFetchError } from '../../lib/utils';
+import {
+  fetchS1Threats,
+  fetchHuntressIncidents,
+  type S1Threat,
+  type HuntressIncident,
+} from '../../lib/edr';
+
+const severityBadge: Record<string, string> = {
+  low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
+  medium: 'bg-yellow-500/20 text-yellow-800 border-yellow-500/40',
+  high: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
+  critical: 'bg-red-500/20 text-red-700 border-red-500/40',
+};
+
+function sevClass(sev: string | null): string {
+  return severityBadge[(sev ?? '').toLowerCase()] ?? 'bg-muted text-muted-foreground border-border';
+}
+
+function fmt(value: string | null, timezone?: string): string {
+  if (!value) return '-';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '-' : formatUserDateTime(d, timezone ? { timeZone: timezone } : undefined);
+}
+
+type Props = { deviceId: string; orgId: string; timezone?: string };
+
+export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
+  const [threats, setThreats] = useState<S1Threat[]>([]);
+  const [incidents, setIncidents] = useState<HuntressIncident[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const [s1, hi] = await Promise.all([
+        fetchS1Threats(orgId, deviceId),
+        fetchHuntressIncidents(orgId, deviceId),
+      ]);
+      setThreats(s1);
+      setIncidents(hi);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, deviceId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="device-edr-panel">
+      <div className="mb-4 flex items-center gap-2">
+        <ShieldAlert className="h-4 w-4 text-primary" />
+        <h3 className="text-lg font-semibold">Endpoint Protection (EDR)</h3>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* SentinelOne threats */}
+        <div>
+          <h4 className="mb-3 text-sm font-semibold">SentinelOne Threats</h4>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading…</div>
+          ) : threats.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="edr-s1-empty">No SentinelOne threats for this device.</p>
+          ) : (
+            <div className="space-y-3">
+              {threats.map((t) => (
+                <div key={t.id} className="rounded-md border bg-background p-3" data-testid="edr-s1-row">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium">{t.threatName}</p>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(t.severity)}`}>{t.severity ?? 'unknown'}</span>
+                      <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{t.status}</span>
+                    </div>
+                  </div>
+                  {t.filePath && <p className="mt-1 text-xs text-muted-foreground" title={t.filePath}>{t.filePath}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground">Detected: {fmt(t.detectedAt, timezone)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Huntress incidents (read-only this pillar) */}
+        <div>
+          <h4 className="mb-3 flex items-center gap-2 text-sm font-semibold"><Activity className="h-4 w-4" />Huntress Incidents</h4>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading…</div>
+          ) : incidents.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="edr-huntress-empty">No Huntress incidents for this device.</p>
+          ) : (
+            <div className="space-y-3">
+              {incidents.map((i) => (
+                <div key={i.id} className="rounded-md border bg-background p-3" data-testid="edr-huntress-row">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium">{i.title}</p>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(i.severity)}`}>{i.severity}</span>
+                      <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{i.status}</span>
+                    </div>
+                  </div>
+                  {i.recommendation && <p className="mt-1 text-xs text-muted-foreground">{i.recommendation}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground">Reported: {fmt(i.reportedAt, timezone)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -176,9 +176,14 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       </div>
 
       {confirmIsolate && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edr-isolate-dialog-title"
+        >
           <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
-            <h4 className="text-base font-semibold">Isolate this device?</h4>
+            <h4 id="edr-isolate-dialog-title" className="text-base font-semibold">Isolate this device?</h4>
             <p className="mt-2 text-sm text-muted-foreground">
               SentinelOne will cut the device off the network until you remove isolation. Active sessions will drop.
             </p>

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -109,7 +109,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive" data-testid="edr-error">{error}</div>
       )}
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -172,6 +172,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                       disabled={promotingId === t.id}
                       className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
                     >
+                      {promotingId === t.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                       Promote to Incident
                     </button>
                   </div>
@@ -209,6 +210,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                       disabled={promotingId === i.id}
                       className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
                     >
+                      {promotingId === i.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                       Promote to Incident
                     </button>
                   </div>

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -6,8 +6,10 @@ import {
   fetchS1Threats,
   fetchHuntressIncidents,
   isolateDevice,
+  runS1ThreatAction,
   type S1Threat,
   type HuntressIncident,
+  type S1ThreatActionType,
 } from '../../lib/edr';
 import { ActionError } from '../../lib/runAction';
 
@@ -37,6 +39,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
   const [error, setError] = useState<string>();
   const [confirmIsolate, setConfirmIsolate] = useState(false);
   const [isolating, setIsolating] = useState(false);
+  const [actingId, setActingId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -66,6 +69,18 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       // non-401 ActionError already toasted by runAction
     } finally {
       setIsolating(false);
+    }
+  };
+
+  const doThreatAction = async (threatId: string, action: S1ThreatActionType) => {
+    setActingId(threatId);
+    try {
+      await runS1ThreatAction(orgId, threatId, action);
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+    } finally {
+      setActingId(null);
     }
   };
 
@@ -111,6 +126,22 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                   </div>
                   {t.filePath && <p className="mt-1 text-xs text-muted-foreground" title={t.filePath}>{t.filePath}</p>}
                   <p className="mt-1 text-xs text-muted-foreground">Detected: {fmt(t.detectedAt, timezone)}</p>
+                  {t.status === 'active' && (
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      {(['kill', 'quarantine', 'rollback'] as const).map((action) => (
+                        <button
+                          key={action}
+                          type="button"
+                          data-testid={`edr-threat-${action}-${t.id}`}
+                          onClick={() => doThreatAction(t.id, action)}
+                          disabled={actingId === t.id}
+                          className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium capitalize hover:bg-muted disabled:opacity-60"
+                        >
+                          {actingId === t.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{action}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -46,11 +46,11 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
     setError(undefined);
     try {
       const [s1, hi] = await Promise.all([
-        fetchS1Threats(orgId, deviceId),
-        fetchHuntressIncidents(orgId, deviceId),
+        fetchS1Threats({ orgId, deviceId, limit: 50 }),
+        fetchHuntressIncidents({ orgId, deviceId, limit: 50 }),
       ]);
-      setThreats(s1);
-      setIncidents(hi);
+      setThreats(s1.rows);
+      setIncidents(hi.rows);
     } catch (err) {
       setError(friendlyFetchError(err));
     } finally {

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -11,7 +11,7 @@ import {
   type HuntressIncident,
   type S1ThreatActionType,
 } from '../../lib/edr';
-import { ActionError } from '../../lib/runAction';
+import { handleActionError } from '../../lib/runAction';
 
 const severityBadge: Record<string, string> = {
   low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
@@ -37,7 +37,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
   const [incidents, setIncidents] = useState<HuntressIncident[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [confirmIsolate, setConfirmIsolate] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<null | 'isolate' | 'unisolate'>(null);
   const [isolating, setIsolating] = useState(false);
   const [actingId, setActingId] = useState<string | null>(null);
 
@@ -58,17 +58,16 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
     }
   }, [orgId, deviceId]);
 
-  const doIsolate = async () => {
+  const doIsolate = async (isolate: boolean) => {
     setIsolating(true);
     try {
-      await isolateDevice(orgId, deviceId, true);
-      setConfirmIsolate(false);
+      await isolateDevice(orgId, deviceId, isolate);
       await load();
     } catch (err) {
-      if (err instanceof ActionError && err.status === 401) return; // auth redirect handles it
-      // non-401 ActionError already toasted by runAction
+      handleActionError(err, isolate ? 'Failed to isolate device' : 'Failed to remove isolation');
     } finally {
       setIsolating(false);
+      setConfirmAction(null);
     }
   };
 
@@ -78,7 +77,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       await runS1ThreatAction(orgId, threatId, action);
       await load();
     } catch (err) {
-      if (err instanceof ActionError && err.status === 401) return;
+      handleActionError(err, `Failed to ${action} threat`);
     } finally {
       setActingId(null);
     }
@@ -94,10 +93,18 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
         <button
           type="button"
           data-testid="edr-isolate-btn"
-          onClick={() => setConfirmIsolate(true)}
+          onClick={() => setConfirmAction('isolate')}
           className="ml-auto inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
         >
           Isolate device
+        </button>
+        <button
+          type="button"
+          data-testid="edr-unisolate-btn"
+          onClick={() => setConfirmAction('unisolate')}
+          className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+        >
+          Remove isolation
         </button>
       </div>
 
@@ -118,7 +125,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
               {threats.map((t) => (
                 <div key={t.id} className="rounded-md border bg-background p-3" data-testid="edr-s1-row">
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-sm font-medium">{t.threatName}</p>
+                    <p className="text-sm font-medium">{t.threatName ?? 'Unknown threat'}</p>
                     <div className="flex items-center gap-2">
                       <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(t.severity)}`}>{t.severity ?? 'unknown'}</span>
                       <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{t.status}</span>
@@ -162,7 +169,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <p className="text-sm font-medium">{i.title}</p>
                     <div className="flex items-center gap-2">
-                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(i.severity)}`}>{i.severity}</span>
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(i.severity)}`}>{i.severity ?? 'unknown'}</span>
                       <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{i.status}</span>
                     </div>
                   </div>
@@ -175,7 +182,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
         </div>
       </div>
 
-      {confirmIsolate && (
+      {confirmAction !== null && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
           role="dialog"
@@ -183,20 +190,24 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
           aria-labelledby="edr-isolate-dialog-title"
         >
           <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
-            <h4 id="edr-isolate-dialog-title" className="text-base font-semibold">Isolate this device?</h4>
+            <h4 id="edr-isolate-dialog-title" className="text-base font-semibold">
+              {confirmAction === 'isolate' ? 'Isolate this device?' : 'Remove isolation?'}
+            </h4>
             <p className="mt-2 text-sm text-muted-foreground">
-              SentinelOne will cut the device off the network until you remove isolation. Active sessions will drop.
+              {confirmAction === 'isolate'
+                ? 'SentinelOne will cut the device off the network until you remove isolation. Active sessions will drop.'
+                : "SentinelOne will restore this device's network connectivity."}
             </p>
             <div className="mt-4 flex justify-end gap-2">
-              <button type="button" onClick={() => setConfirmIsolate(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
+              <button type="button" onClick={() => setConfirmAction(null)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
               <button
                 type="button"
-                data-testid="edr-isolate-confirm"
-                onClick={doIsolate}
+                data-testid={`edr-${confirmAction}-confirm`}
+                onClick={() => doIsolate(confirmAction === 'isolate')}
                 disabled={isolating}
                 className="inline-flex items-center gap-2 rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:opacity-90 disabled:opacity-60"
               >
-                {isolating && <Loader2 className="h-4 w-4 animate-spin" />}Isolate
+                {isolating && <Loader2 className="h-4 w-4 animate-spin" />}{confirmAction === 'isolate' ? 'Isolate' : 'Remove isolation'}
               </button>
             </div>
           </div>

--- a/apps/web/src/components/devices/DeviceEdrPanel.tsx
+++ b/apps/web/src/components/devices/DeviceEdrPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, ShieldAlert, Activity } from 'lucide-react';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
+import { navigateTo } from '@/lib/navigation';
 import { friendlyFetchError } from '../../lib/utils';
 import {
   fetchS1Threats,
@@ -11,6 +12,7 @@ import {
   type HuntressIncident,
   type S1ThreatActionType,
 } from '../../lib/edr';
+import { promoteToIncident, s1ThreatToIncident, huntressIncidentToIncident } from '../../lib/incidents';
 import { handleActionError } from '../../lib/runAction';
 
 const severityBadge: Record<string, string> = {
@@ -40,6 +42,7 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
   const [confirmAction, setConfirmAction] = useState<null | 'isolate' | 'unisolate'>(null);
   const [isolating, setIsolating] = useState(false);
   const [actingId, setActingId] = useState<string | null>(null);
+  const [promotingId, setPromotingId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -80,6 +83,18 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
       handleActionError(err, `Failed to ${action} threat`);
     } finally {
       setActingId(null);
+    }
+  };
+
+  const promote = async (key: string, input: import('../../lib/incidents').CreateIncidentInput) => {
+    setPromotingId(key);
+    try {
+      const { id } = await promoteToIncident(input);
+      navigateTo(`/incidents/${id}`);
+    } catch (err) {
+      handleActionError(err, 'Failed to create incident');
+    } finally {
+      setPromotingId(null);
     }
   };
 
@@ -149,6 +164,17 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                       ))}
                     </div>
                   )}
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      data-testid={`edr-s1-promote-${t.id}`}
+                      onClick={() => promote(t.id, s1ThreatToIncident(t))}
+                      disabled={promotingId === t.id}
+                      className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
+                    >
+                      Promote to Incident
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>
@@ -175,6 +201,17 @@ export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
                   </div>
                   {i.recommendation && <p className="mt-1 text-xs text-muted-foreground">{i.recommendation}</p>}
                   <p className="mt-1 text-xs text-muted-foreground">Reported: {fmt(i.reportedAt, timezone)}</p>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      data-testid={`edr-huntress-promote-${i.id}`}
+                      onClick={() => promote(i.id, huntressIncidentToIncident(i))}
+                      disabled={promotingId === i.id}
+                      className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
+                    >
+                      Promote to Incident
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/apps/web/src/components/devices/DeviceSecurityTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceSecurityTab.test.tsx
@@ -4,8 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DeviceSecurityTab from './DeviceSecurityTab';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../lib/featureFlags', () => ({
-  ENABLE_ENDPOINT_AV_FEATURES: true
+vi.mock('../../lib/featureFlags', async (orig) => ({
+  ...(await orig<typeof import('../../lib/featureFlags')>()),
+  ENABLE_ENDPOINT_AV_FEATURES: true,
+  ENABLE_EDR_INTEGRATIONS: true
+}));
+
+vi.mock('./DeviceEdrPanel', () => ({
+  default: ({ orgId }: { orgId: string }) => <div data-testid="edr-panel-stub">{orgId}</div>
 }));
 
 vi.mock('../../stores/auth', () => ({
@@ -23,6 +29,7 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
   }) as unknown as Response;
 
 const deviceId = '11111111-1111-1111-1111-111111111111';
+const orgId = '22222222-2222-2222-2222-222222222222';
 
 describe('DeviceSecurityTab', () => {
   beforeEach(() => {
@@ -95,7 +102,7 @@ describe('DeviceSecurityTab', () => {
   });
 
   it('renders device security status, recent threats, and recent scans', async () => {
-    render(<DeviceSecurityTab deviceId={deviceId} />);
+    render(<DeviceSecurityTab deviceId={deviceId} orgId={orgId} />);
 
     await screen.findByText(/FIN-WS-014/i);
     await screen.findByText('Trojan:Win32/Emotet');
@@ -106,8 +113,14 @@ describe('DeviceSecurityTab', () => {
     expect(fetchWithAuthMock).toHaveBeenCalledWith(`/security/scans/${deviceId}?limit=10`);
   });
 
+  it('renders the EDR panel with the device orgId when the flag is on', async () => {
+    render(<DeviceSecurityTab deviceId="dev-1" orgId="org-9" />);
+
+    expect(await screen.findByTestId('edr-panel-stub')).toHaveTextContent('org-9');
+  });
+
   it('runs a full scan from the device security operations panel', async () => {
-    render(<DeviceSecurityTab deviceId={deviceId} />);
+    render(<DeviceSecurityTab deviceId={deviceId} orgId={orgId} />);
 
     await screen.findByText(/FIN-WS-014/i);
 
@@ -122,7 +135,7 @@ describe('DeviceSecurityTab', () => {
   });
 
   it('quarantines an active threat from the threat card', async () => {
-    render(<DeviceSecurityTab deviceId={deviceId} />);
+    render(<DeviceSecurityTab deviceId={deviceId} orgId={orgId} />);
 
     await screen.findByText('Trojan:Win32/Emotet');
 

--- a/apps/web/src/components/devices/DeviceSecurityTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceSecurityTab.test.tsx
@@ -1,13 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DeviceSecurityTab from './DeviceSecurityTab';
 import { fetchWithAuth } from '../../stores/auth';
 
+let edrFlagOn = true;
 vi.mock('../../lib/featureFlags', async (orig) => ({
   ...(await orig<typeof import('../../lib/featureFlags')>()),
   ENABLE_ENDPOINT_AV_FEATURES: true,
-  ENABLE_EDR_INTEGRATIONS: true
+  get ENABLE_EDR_INTEGRATIONS() { return edrFlagOn; },
 }));
 
 vi.mock('./DeviceEdrPanel', () => ({
@@ -32,6 +33,10 @@ const deviceId = '11111111-1111-1111-1111-111111111111';
 const orgId = '22222222-2222-2222-2222-222222222222';
 
 describe('DeviceSecurityTab', () => {
+  afterEach(() => {
+    edrFlagOn = true;
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -117,6 +122,12 @@ describe('DeviceSecurityTab', () => {
     render(<DeviceSecurityTab deviceId="dev-1" orgId="org-9" />);
 
     expect(await screen.findByTestId('edr-panel-stub')).toHaveTextContent('org-9');
+  });
+
+  it('does NOT render the EDR panel when ENABLE_EDR_INTEGRATIONS is off', async () => {
+    edrFlagOn = false;
+    render(<DeviceSecurityTab deviceId="dev-1" orgId="org-9" />);
+    await waitFor(() => expect(screen.queryByTestId('edr-panel-stub')).toBeNull());
   });
 
   it('runs a full scan from the device security operations panel', async () => {

--- a/apps/web/src/components/devices/DeviceSecurityTab.tsx
+++ b/apps/web/src/components/devices/DeviceSecurityTab.tsx
@@ -10,11 +10,12 @@ import {
   ShieldOff
 } from 'lucide-react';
 
-import { ENABLE_ENDPOINT_AV_FEATURES } from '../../lib/featureFlags';
+import { ENABLE_EDR_INTEGRATIONS, ENABLE_ENDPOINT_AV_FEATURES } from '../../lib/featureFlags';
 import { friendlyFetchError } from '../../lib/utils';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
 import DeviceSecurityStatus from '../security/DeviceSecurityStatus';
+import DeviceEdrPanel from './DeviceEdrPanel';
 
 type ThreatSeverity = 'low' | 'medium' | 'high' | 'critical';
 type ThreatStatus = 'active' | 'quarantined' | 'removed';
@@ -40,6 +41,7 @@ type ScanRecord = {
 
 type DeviceSecurityTabProps = {
   deviceId: string;
+  orgId: string;
   timezone?: string;
 };
 
@@ -76,7 +78,7 @@ function compactPath(value: string): string {
   return `...${value.slice(-45)}`;
 }
 
-export default function DeviceSecurityTab({ deviceId, timezone }: DeviceSecurityTabProps) {
+export default function DeviceSecurityTab({ deviceId, orgId, timezone }: DeviceSecurityTabProps) {
   const [threats, setThreats] = useState<ThreatRecord[]>([]);
   const [scans, setScans] = useState<ScanRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -174,6 +176,7 @@ export default function DeviceSecurityTab({ deviceId, timezone }: DeviceSecurity
     return (
       <div className="space-y-6">
         <DeviceSecurityStatus deviceId={deviceId} showAvActions={false} />
+        {ENABLE_EDR_INTEGRATIONS && <DeviceEdrPanel deviceId={deviceId} orgId={orgId} timezone={timezone} />}
       </div>
     );
   }
@@ -181,6 +184,7 @@ export default function DeviceSecurityTab({ deviceId, timezone }: DeviceSecurity
   return (
     <div className="space-y-6">
       <DeviceSecurityStatus deviceId={deviceId} showAvActions />
+      {ENABLE_EDR_INTEGRATIONS && <DeviceEdrPanel deviceId={deviceId} orgId={orgId} timezone={timezone} />}
 
       {error && (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -59,6 +59,7 @@ import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
 import { getJwtClaims } from '../../lib/authScope';
 import BrandHeader from './BrandHeader';
+import { ENABLE_EDR_INTEGRATIONS } from '../../lib/featureFlags';
 
 interface SidebarProps {
   currentPath?: string;
@@ -211,6 +212,9 @@ export const navSections: NavSection[] = [
     // A billing-only role has no devices:read grant, so the whole section hides.
     items: [
       { name: 'Security', href: '/security', icon: ShieldCheck, requiredPermission: { resource: 'devices', action: 'read' } },
+      ...(ENABLE_EDR_INTEGRATIONS
+        ? [{ name: 'EDR', href: '/security/edr', icon: ShieldAlert, requiredPermission: { resource: 'devices', action: 'read' } } satisfies NavItem]
+        : []),
       { name: 'DNS Security', href: '/dns-security', icon: Network, requiredPermission: { resource: 'devices', action: 'read' } },
       { name: 'PAM', href: '/pam', icon: KeyRound, requiredPermission: { resource: 'devices', action: 'read' } },
       { name: 'User Risk', href: '/security/user-risk', icon: UserCheck, requiredPermission: { resource: 'devices', action: 'read' } },

--- a/apps/web/src/components/security/EdrPage.test.tsx
+++ b/apps/web/src/components/security/EdrPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./S1ThreatList', () => ({ default: () => <div data-testid="s1-list" /> }));
+vi.mock('./HuntressIncidentList', () => ({ default: () => <div data-testid="huntress-list" /> }));
+
+import EdrPage from './EdrPage';
+
+describe('EdrPage', () => {
+  it('defaults to the SentinelOne tab and switches to Huntress', () => {
+    render(<EdrPage />);
+    expect(screen.getByTestId('s1-list')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('edr-tab-huntress'));
+    expect(screen.getByTestId('huntress-list')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#huntress');
+  });
+});

--- a/apps/web/src/components/security/EdrPage.tsx
+++ b/apps/web/src/components/security/EdrPage.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { ShieldAlert, Activity } from 'lucide-react';
+import S1ThreatList from './S1ThreatList';
+import HuntressIncidentList from './HuntressIncidentList';
+
+type EdrTab = 'sentinelone' | 'huntress';
+
+const TABS: { id: EdrTab; label: string; testid: string }[] = [
+  { id: 'sentinelone', label: 'SentinelOne Threats', testid: 'edr-tab-sentinelone' },
+  { id: 'huntress', label: 'Huntress Incidents', testid: 'edr-tab-huntress' },
+];
+
+function tabFromHash(): EdrTab {
+  if (typeof window === 'undefined') return 'sentinelone';
+  const h = window.location.hash.replace(/^#/, '');
+  return h === 'huntress' ? 'huntress' : 'sentinelone';
+}
+
+export default function EdrPage() {
+  const [activeTab, setActiveTab] = useState<EdrTab>(tabFromHash);
+
+  useEffect(() => {
+    const onHash = () => setActiveTab(tabFromHash());
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  const switchTab = (t: EdrTab) => {
+    window.location.hash = t;
+    setActiveTab(t);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Endpoint Detection &amp; Response</h1>
+        <p className="text-sm text-muted-foreground">
+          Threats and incidents across your fleet from SentinelOne and Huntress.
+        </p>
+      </div>
+      <div className="flex gap-2 border-b">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            data-testid={t.testid}
+            onClick={() => switchTab(t.id)}
+            className={`flex items-center gap-2 border-b-2 px-3 py-2 text-sm font-medium ${
+              activeTab === t.id
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t.id === 'sentinelone' ? <ShieldAlert className="h-4 w-4" /> : <Activity className="h-4 w-4" />}
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === 'sentinelone' ? <S1ThreatList /> : <HuntressIncidentList />}
+    </div>
+  );
+}

--- a/apps/web/src/components/security/EdrSummaryPanel.dashboard.test.tsx
+++ b/apps/web/src/components/security/EdrSummaryPanel.dashboard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { fetchWithAuth } = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn()
+}));
+
+vi.mock('../../lib/featureFlags', async (orig) => ({
+  ...(await orig<typeof import('../../lib/featureFlags')>()),
+  ENABLE_EDR_INTEGRATIONS: true
+}));
+
+vi.mock('./EdrSummaryPanel', () => ({
+  default: () => <div data-testid="edr-summary-stub" />
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth
+}));
+
+import SecurityDashboard from './SecurityDashboard';
+
+const makeTextResponse = (payload: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: vi.fn().mockResolvedValue(JSON.stringify(payload))
+  }) as unknown as Response;
+
+describe('SecurityDashboard EDR panel', () => {
+  it('renders the EDR summary panel when the flag is on', async () => {
+    fetchWithAuth.mockResolvedValue(makeTextResponse({}));
+
+    render(<SecurityDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edr-summary-stub')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/security/EdrSummaryPanel.test.tsx
+++ b/apps/web/src/components/security/EdrSummaryPanel.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { fetchWithAuth } = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn()
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth
+}));
+
+import EdrSummaryPanel from './EdrSummaryPanel';
+
+function ok(b: unknown) {
+  return { ok: true, status: 200, json: async () => b } as Response;
+}
+
+function routeStatus(s1: unknown, huntress: unknown) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/s1/status')) return Promise.resolve(ok(s1));
+    if (url.startsWith('/huntress/status')) return Promise.resolve(ok(huntress));
+    return Promise.resolve(ok({}));
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('EdrSummaryPanel', () => {
+  it('renders S1 + Huntress cards from both status endpoints', async () => {
+    routeStatus(
+      {
+        integration: { id: 'i1' },
+        summary: {
+          totalAgents: 10,
+          mappedDevices: 8,
+          infectedAgents: 2,
+          activeThreats: 3,
+          highOrCriticalThreats: 1,
+          pendingActions: 0,
+          reportedThreatCount: 5
+        }
+      },
+      {
+        integration: { id: 'h1' },
+        coverage: {
+          totalAgents: 12,
+          mappedAgents: 9,
+          unmappedAgents: 3,
+          offlineAgents: 1
+        },
+        incidents: { open: 4, bySeverity: [], byStatus: [] }
+      }
+    );
+    render(<EdrSummaryPanel />);
+    expect(await screen.findByTestId('edr-card-s1-active-threats')).toHaveTextContent('3');
+    expect(screen.getByTestId('edr-card-huntress-open-incidents')).toHaveTextContent('4');
+    expect(screen.getByTestId('edr-card-huntress-coverage')).toHaveTextContent('9/12');
+  });
+
+  it('hides a provider whose integration is null', async () => {
+    routeStatus(
+      {
+        integration: null,
+        summary: {
+          totalAgents: 0,
+          mappedDevices: 0,
+          infectedAgents: 0,
+          activeThreats: 0,
+          highOrCriticalThreats: 0,
+          pendingActions: 0,
+          reportedThreatCount: 0
+        }
+      },
+      {
+        integration: { id: 'h1' },
+        coverage: {
+          totalAgents: 5,
+          mappedAgents: 5,
+          unmappedAgents: 0,
+          offlineAgents: 0
+        },
+        incidents: { open: 0, bySeverity: [], byStatus: [] }
+      }
+    );
+    render(<EdrSummaryPanel />);
+    expect(await screen.findByTestId('edr-card-huntress-open-incidents')).toBeInTheDocument();
+    expect(screen.queryByTestId('edr-card-s1-active-threats')).toBeNull();
+  });
+
+  it('renders Huntress cards even when /s1/status fails (allSettled)', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/s1/status')) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: 'err',
+          json: async () => ({})
+        } as Response);
+      }
+      if (url.startsWith('/huntress/status')) {
+        return Promise.resolve(
+          ok({
+            integration: { id: 'h1' },
+            coverage: {
+              totalAgents: 5,
+              mappedAgents: 5,
+              unmappedAgents: 0,
+              offlineAgents: 0
+            },
+            incidents: { open: 2, bySeverity: [], byStatus: [] }
+          })
+        );
+      }
+      return Promise.resolve(ok({}));
+    });
+    render(<EdrSummaryPanel />);
+    await waitFor(() =>
+      expect(screen.getByTestId('edr-card-huntress-open-incidents')).toHaveTextContent('2')
+    );
+    expect(screen.queryByTestId('edr-card-s1-active-threats')).toBeNull();
+  });
+});

--- a/apps/web/src/components/security/EdrSummaryPanel.tsx
+++ b/apps/web/src/components/security/EdrSummaryPanel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import { Activity, Loader2, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import SecurityStatCard from './SecurityStatCard';
+
+interface S1Summary {
+  totalAgents: number;
+  mappedDevices: number;
+  infectedAgents: number;
+  activeThreats: number;
+  highOrCriticalThreats: number;
+  pendingActions: number;
+  reportedThreatCount: number;
+}
+
+interface S1Status {
+  integration: { id: string } | null;
+  summary: S1Summary;
+}
+
+interface HuntressStatus {
+  integration: { id: string } | null;
+  coverage: {
+    totalAgents: number;
+    mappedAgents: number;
+    unmappedAgents: number;
+    offlineAgents: number;
+  };
+  incidents: {
+    open: number;
+  };
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as T;
+}
+
+export default function EdrSummaryPanel() {
+  const [s1, setS1] = useState<S1Status | null>(null);
+  const [huntress, setHuntress] = useState<HuntressStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const [s1Res, huntressRes] = await Promise.allSettled([
+        getJson<S1Status>('/s1/status'),
+        getJson<HuntressStatus>('/huntress/status')
+      ]);
+
+      if (cancelled) return;
+
+      setS1(s1Res.status === 'fulfilled' ? s1Res.value : null);
+      setHuntress(
+        huntressRes.status === 'fulfilled' ? huntressRes.value : null
+      );
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const showS1 = s1?.integration != null;
+  const showHuntress = huntress?.integration != null;
+
+  if (loading) {
+    return (
+      <div
+        className="rounded-lg border bg-card p-6 shadow-sm"
+        data-testid="edr-summary-panel"
+      >
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading EDR posture...
+        </div>
+      </div>
+    );
+  }
+
+  if (!showS1 && !showHuntress) return null;
+
+  return (
+    <div
+      className="rounded-lg border bg-card p-6 shadow-sm"
+      data-testid="edr-summary-panel"
+    >
+      <div className="mb-4 flex items-center gap-2">
+        <ShieldAlert className="h-4 w-4 text-primary" />
+        <h3 className="text-lg font-semibold">
+          Endpoint Detection &amp; Response
+        </h3>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {showS1 && s1 && (
+          <>
+            <div data-testid="edr-card-s1-active-threats">
+              <SecurityStatCard
+                icon={ShieldAlert}
+                label="SentinelOne Active Threats"
+                value={s1.summary.activeThreats}
+                variant={s1.summary.activeThreats > 0 ? 'danger' : 'success'}
+                detail={`${s1.summary.highOrCriticalThreats} high/critical`}
+              />
+            </div>
+            <div data-testid="edr-card-s1-coverage">
+              <SecurityStatCard
+                icon={ShieldCheck}
+                label="SentinelOne Agents"
+                value={`${s1.summary.mappedDevices}/${s1.summary.totalAgents}`}
+                detail={`${s1.summary.infectedAgents} infected`}
+                variant={s1.summary.infectedAgents > 0 ? 'warning' : 'default'}
+              />
+            </div>
+          </>
+        )}
+
+        {showHuntress && huntress && (
+          <>
+            <div data-testid="edr-card-huntress-open-incidents">
+              <SecurityStatCard
+                icon={Activity}
+                label="Huntress Open Incidents"
+                value={huntress.incidents.open}
+                variant={huntress.incidents.open > 0 ? 'danger' : 'success'}
+              />
+            </div>
+            <div data-testid="edr-card-huntress-coverage">
+              <SecurityStatCard
+                icon={ShieldCheck}
+                label="Huntress Agents"
+                value={`${huntress.coverage.mappedAgents}/${huntress.coverage.totalAgents}`}
+                detail={`${huntress.coverage.offlineAgents} offline, ${huntress.coverage.unmappedAgents} unmapped`}
+                variant={
+                  huntress.coverage.unmappedAgents > 0 ? 'warning' : 'default'
+                }
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/security/HuntressIncidentList.test.tsx
+++ b/apps/web/src/components/security/HuntressIncidentList.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+const navigateTo = vi.fn();
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+import HuntressIncidentList from './HuntressIncidentList';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as Response;
+}
+
+type IncidentFixture = {
+  id: string;
+  deviceId?: string | null;
+  deviceHostname?: string | null;
+  title: string;
+  severity?: string | null;
+  status: string;
+  category?: string | null;
+  reportedAt?: string | null;
+};
+
+function routeFetch(rows: IncidentFixture[] = [], total = rows.length) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/huntress/incidents')) {
+      return Promise.resolve(ok({ data: rows, total, limit: 100, offset: 0 }));
+    }
+    return Promise.resolve(ok({ data: [] }));
+  });
+}
+
+function getHuntressUrls() {
+  return fetchWithAuth.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.startsWith('/huntress/incidents'));
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  navigateTo.mockReset();
+});
+
+describe('HuntressIncidentList', () => {
+  it('lists incidents from the flat envelope and navigates rows to the device', async () => {
+    routeFetch([
+      {
+        id: 'i1',
+        deviceId: 'dev-3',
+        deviceHostname: 'SRV-2',
+        title: 'Persistence',
+        severity: 'critical',
+        status: 'open',
+        category: 'malware',
+        reportedAt: '2026-06-21T00:00:00Z',
+      },
+    ]);
+
+    render(<HuntressIncidentList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(desktop.getByText('Persistence')).toBeInTheDocument();
+    fireEvent.click(await desktop.findByTestId('huntress-row-i1'));
+
+    expect(navigateTo).toHaveBeenCalledWith('/devices/dev-3');
+    const firstUrl = getHuntressUrls()[0];
+    expect(firstUrl).toContain('/huntress/incidents');
+    expect(firstUrl).toContain('limit=100');
+    expect(firstUrl).not.toContain('orgId=');
+  });
+
+  it('sends the status filter in the query', async () => {
+    routeFetch([]);
+
+    render(<HuntressIncidentList />);
+    await waitFor(() => expect(getHuntressUrls().length).toBeGreaterThan(0));
+    fetchWithAuth.mockClear();
+
+    fireEvent.change(screen.getByTestId('huntress-filter-status'), { target: { value: 'open' } });
+
+    await waitFor(() => {
+      const latestUrl = getHuntressUrls().at(-1) ?? '';
+      const params = new URL(latestUrl, 'http://localhost').searchParams;
+      expect(params.get('status')).toBe('open');
+      expect(params.get('orgId')).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/security/HuntressIncidentList.test.tsx
+++ b/apps/web/src/components/security/HuntressIncidentList.test.tsx
@@ -6,6 +6,7 @@ const navigateTo = vi.fn();
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 
 import HuntressIncidentList from './HuntressIncidentList';
 
@@ -15,6 +16,7 @@ function ok(body: unknown) {
 
 type IncidentFixture = {
   id: string;
+  orgId?: string;
   deviceId?: string | null;
   deviceHostname?: string | null;
   title: string;
@@ -87,5 +89,46 @@ describe('HuntressIncidentList', () => {
       expect(params.get('status')).toBe('open');
       expect(params.get('orgId')).toBeNull();
     });
+  });
+
+  it('promotes an incident to an incident record and navigates', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/huntress/incidents')) {
+        return Promise.resolve(ok({
+          data: [
+            {
+              id: 'i1',
+              orgId: 'org-3',
+              deviceId: 'dev-3',
+              deviceHostname: 'SRV-2',
+              title: 'Persistence',
+              severity: 'critical',
+              status: 'open',
+              category: 'malware',
+              reportedAt: '2026-06-21T00:00:00Z',
+            },
+          ],
+          total: 1,
+          limit: 100,
+          offset: 0,
+        }));
+      }
+      if (url === '/incidents') {
+        body = JSON.parse(String(init?.body));
+        return Promise.resolve({ ok: true, status: 201, json: async () => ({ id: 'inc-3' }) } as Response);
+      }
+      return Promise.resolve(ok({ data: [] }));
+    });
+
+    render(<HuntressIncidentList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(await desktop.findByTestId('huntress-promote-i1'));
+
+    await waitFor(() => expect((body as any).orgId).toBe('org-3'));
+    expect((body as any).classification).toBe('huntress-incident');
+    expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-3');
+    expect(navigateTo).not.toHaveBeenCalledWith('/devices/dev-3');
   });
 });

--- a/apps/web/src/components/security/HuntressIncidentList.tsx
+++ b/apps/web/src/components/security/HuntressIncidentList.tsx
@@ -4,6 +4,8 @@ import { Loader2, RefreshCw, Search } from 'lucide-react';
 import { navigateTo } from '@/lib/navigation';
 import { cn, friendlyFetchError } from '../../lib/utils';
 import { fetchHuntressIncidents, type HuntressIncident } from '../../lib/edr';
+import { promoteToIncident, huntressIncidentToIncident } from '../../lib/incidents';
+import { handleActionError } from '../../lib/runAction';
 import { formatDateTime } from '../../lib/dateTimeFormat';
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
 
@@ -39,6 +41,7 @@ export default function HuntressIncidentList() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [promotingId, setPromotingId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -69,6 +72,18 @@ export default function HuntressIncidentList() {
     if (incident.deviceId) navigateTo(`/devices/${incident.deviceId}`);
   };
 
+  const promote = async (incident: HuntressIncident) => {
+    setPromotingId(incident.id);
+    try {
+      const { id } = await promoteToIncident(huntressIncidentToIncident(incident));
+      navigateTo(`/incidents/${id}`);
+    } catch (err) {
+      handleActionError(err, 'Failed to create incident');
+    } finally {
+      setPromotingId(null);
+    }
+  };
+
   const renderSeverityBadge = (incident: HuntressIncident) => (
     <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(incident.severity, severityBadge))}>
       {incident.severity ?? 'unknown'}
@@ -82,6 +97,22 @@ export default function HuntressIncidentList() {
   );
 
   const deviceLabel = (incident: HuntressIncident) => incident.deviceHostname ?? incident.deviceId ?? '-';
+
+  const renderActions = (incident: HuntressIncident) => (
+    <button
+      type="button"
+      data-testid={`huntress-promote-${incident.id}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        void promote(incident);
+      }}
+      disabled={promotingId === incident.id}
+      className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
+    >
+      {promotingId === incident.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+      Promote to Incident
+    </button>
+  );
 
   return (
     <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="huntress-list">
@@ -162,12 +193,13 @@ export default function HuntressIncidentList() {
                 <th className="px-4 py-3">Severity</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Reported</th>
+                <th className="px-4 py-3">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {loading ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-muted-foreground">
                     <span className="inline-flex items-center gap-2">
                       <Loader2 className="h-4 w-4 animate-spin" />
                       Loading Huntress incidents...
@@ -176,7 +208,7 @@ export default function HuntressIncidentList() {
                 </tr>
               ) : incidents.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-muted-foreground">
                     No Huntress incidents found.
                   </td>
                 </tr>
@@ -194,6 +226,9 @@ export default function HuntressIncidentList() {
                     <td className="px-4 py-3">{renderSeverityBadge(incident)}</td>
                     <td className="px-4 py-3">{renderStatusBadge(incident)}</td>
                     <td className="px-4 py-3 text-xs text-muted-foreground">{formatReported(incident.reportedAt)}</td>
+                    <td className="px-4 py-3" onClick={(event) => event.stopPropagation()}>
+                      {renderActions(incident)}
+                    </td>
                   </tr>
                 ))
               )}
@@ -229,6 +264,9 @@ export default function HuntressIncidentList() {
                   <CardField label="Status">{renderStatusBadge(incident)}</CardField>
                   <CardField label="Reported">
                     <span className="text-xs text-muted-foreground">{formatReported(incident.reportedAt)}</span>
+                  </CardField>
+                  <CardField label="Actions">
+                    <div onClick={(event) => event.stopPropagation()}>{renderActions(incident)}</div>
                   </CardField>
                 </div>
               </DataCard>

--- a/apps/web/src/components/security/HuntressIncidentList.tsx
+++ b/apps/web/src/components/security/HuntressIncidentList.tsx
@@ -1,0 +1,3 @@
+export default function HuntressIncidentList() {
+  return <div data-testid="huntress-list" />;
+}

--- a/apps/web/src/components/security/HuntressIncidentList.tsx
+++ b/apps/web/src/components/security/HuntressIncidentList.tsx
@@ -1,3 +1,241 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, RefreshCw, Search } from 'lucide-react';
+
+import { navigateTo } from '@/lib/navigation';
+import { cn, friendlyFetchError } from '../../lib/utils';
+import { fetchHuntressIncidents, type HuntressIncident } from '../../lib/edr';
+import { formatDateTime } from '../../lib/dateTimeFormat';
+import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+
+const severityBadge: Record<string, string> = {
+  low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
+  medium: 'bg-yellow-500/20 text-yellow-800 border-yellow-500/40',
+  high: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
+  critical: 'bg-red-500/20 text-red-700 border-red-500/40',
+};
+
+const statusBadge: Record<string, string> = {
+  open: 'bg-red-500/15 text-red-700 border-red-500/30',
+  in_progress: 'bg-blue-500/15 text-blue-700 border-blue-500/30',
+  resolved: 'bg-emerald-500/20 text-emerald-700 border-emerald-500/40',
+  dismissed: 'bg-muted text-muted-foreground border-border',
+};
+
+function badgeClass(value: string | null | undefined, classes: Record<string, string>): string {
+  return classes[(value ?? '').toLowerCase()] ?? 'bg-muted text-muted-foreground border-border';
+}
+
+function formatReported(value: string | null): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '-' : formatDateTime(date);
+}
+
 export default function HuntressIncidentList() {
-  return <div data-testid="huntress-list" />;
+  const [query, setQuery] = useState('');
+  const [severityFilter, setSeverityFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [incidents, setIncidents] = useState<HuntressIncident[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const result = await fetchHuntressIncidents({
+        limit: 100,
+        search: query.trim() || undefined,
+        severity: severityFilter === 'all' ? undefined : severityFilter,
+        status: statusFilter === 'all' ? undefined : statusFilter,
+      });
+      setIncidents(result.rows);
+      setTotal(result.total);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+      setIncidents([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [query, severityFilter, statusFilter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openDevice = (incident: HuntressIncident) => {
+    if (incident.deviceId) navigateTo(`/devices/${incident.deviceId}`);
+  };
+
+  const renderSeverityBadge = (incident: HuntressIncident) => (
+    <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(incident.severity, severityBadge))}>
+      {incident.severity ?? 'unknown'}
+    </span>
+  );
+
+  const renderStatusBadge = (incident: HuntressIncident) => (
+    <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(incident.status, statusBadge))}>
+      {incident.status}
+    </span>
+  );
+
+  const deviceLabel = (incident: HuntressIncident) => incident.deviceHostname ?? incident.deviceId ?? '-';
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="huntress-list">
+      {error && (
+        <div
+          className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          data-testid="huntress-error"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Huntress Incidents</h2>
+          <p className="text-sm text-muted-foreground">
+            {loading ? 'Loading fleet incidents...' : `${total} incidents match your filters`}
+          </p>
+        </div>
+        <div className="flex flex-1 flex-col gap-2 lg:flex-row lg:items-center lg:justify-end">
+          <div className="relative w-full lg:w-64">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="search"
+              data-testid="huntress-filter-search"
+              placeholder="Search incidents"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="h-10 w-full rounded-md border bg-background pl-9 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <select
+              data-testid="huntress-filter-severity"
+              value={severityFilter}
+              onChange={(event) => setSeverityFilter(event.target.value)}
+              className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="all">All severities</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="critical">Critical</option>
+            </select>
+            <select
+              data-testid="huntress-filter-status"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+              className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="all">All statuses</option>
+              <option value="open">Open</option>
+              <option value="in_progress">In progress</option>
+              <option value="resolved">Resolved</option>
+              <option value="dismissed">Dismissed</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-3 text-sm hover:bg-muted"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ResponsiveTable
+        className="mt-6"
+        table={
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Device</th>
+                <th className="px-4 py-3">Title</th>
+                <th className="px-4 py-3">Category</th>
+                <th className="px-4 py-3">Severity</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Reported</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    <span className="inline-flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading Huntress incidents...
+                    </span>
+                  </td>
+                </tr>
+              ) : incidents.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    No Huntress incidents found.
+                  </td>
+                </tr>
+              ) : (
+                incidents.map((incident) => (
+                  <tr
+                    key={incident.id}
+                    data-testid={`huntress-row-${incident.id}`}
+                    onClick={() => openDevice(incident)}
+                    className={cn('text-sm transition hover:bg-muted/40', incident.deviceId && 'cursor-pointer')}
+                  >
+                    <td className="px-4 py-3 font-medium">{deviceLabel(incident)}</td>
+                    <td className="px-4 py-3">{incident.title}</td>
+                    <td className="px-4 py-3">{incident.category ?? '-'}</td>
+                    <td className="px-4 py-3">{renderSeverityBadge(incident)}</td>
+                    <td className="px-4 py-3">{renderStatusBadge(incident)}</td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">{formatReported(incident.reportedAt)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        }
+        cards={
+          loading ? (
+            <DataCard>
+              <p className="inline-flex items-center justify-center gap-2 py-2 text-center text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading Huntress incidents...
+              </p>
+            </DataCard>
+          ) : incidents.length === 0 ? (
+            <DataCard>
+              <p className="py-2 text-center text-sm text-muted-foreground">No Huntress incidents found.</p>
+            </DataCard>
+          ) : (
+            incidents.map((incident) => (
+              <DataCard key={incident.id} onClick={incident.deviceId ? () => openDevice(incident) : undefined}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold">{incident.title}</div>
+                    <div className="truncate text-xs text-muted-foreground">{deviceLabel(incident)}</div>
+                  </div>
+                  <div className="shrink-0">{renderSeverityBadge(incident)}</div>
+                </div>
+                <div className="mt-3 space-y-2 border-t pt-3">
+                  <CardField label="Category">
+                    <span>{incident.category ?? '-'}</span>
+                  </CardField>
+                  <CardField label="Status">{renderStatusBadge(incident)}</CardField>
+                  <CardField label="Reported">
+                    <span className="text-xs text-muted-foreground">{formatReported(incident.reportedAt)}</span>
+                  </CardField>
+                </div>
+              </DataCard>
+            ))
+          )
+        }
+      />
+    </div>
+  );
 }

--- a/apps/web/src/components/security/S1ThreatList.test.tsx
+++ b/apps/web/src/components/security/S1ThreatList.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+const navigateTo = vi.fn();
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+import S1ThreatList from './S1ThreatList';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as Response;
+}
+
+type ThreatFixture = {
+  id: string;
+  orgId: string;
+  deviceId?: string | null;
+  deviceName?: string | null;
+  threatName?: string | null;
+  severity?: string | null;
+  status: string;
+  detectedAt?: string | null;
+};
+
+function routeFetch(rows: ThreatFixture[] = [], total = rows.length) {
+  fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.startsWith('/s1/threats')) {
+      return Promise.resolve(ok({ data: rows, pagination: { total, limit: 100, offset: 0 } }));
+    }
+    if (url === '/s1/threat-action' && init?.method === 'POST') {
+      return Promise.resolve(ok({ success: true }));
+    }
+    return Promise.resolve(ok({ data: [] }));
+  });
+}
+
+function getS1ThreatUrls() {
+  return fetchWithAuth.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.startsWith('/s1/threats'));
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  navigateTo.mockReset();
+});
+
+describe('S1ThreatList', () => {
+  it('fetches fleet threats without orgId and navigates rows to the device', async () => {
+    routeFetch([
+      {
+        id: 't1',
+        orgId: 'org-1',
+        deviceId: 'dev-1',
+        deviceName: 'Workstation 1',
+        threatName: 'Emotet',
+        severity: 'critical',
+        status: 'active',
+        detectedAt: '2026-06-20T00:00:00Z',
+      },
+    ]);
+
+    render(<S1ThreatList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(await desktop.findByTestId('s1-row-t1'));
+
+    expect(navigateTo).toHaveBeenCalledWith('/devices/dev-1');
+    const firstUrl = getS1ThreatUrls()[0];
+    expect(firstUrl).toContain('/s1/threats');
+    expect(firstUrl).toContain('limit=100');
+    expect(firstUrl).not.toContain('orgId=');
+  });
+
+  it('re-runs reads with non-empty filters and omits all/empty filters', async () => {
+    routeFetch([
+      {
+        id: 't2',
+        orgId: 'org-2',
+        deviceId: 'dev-2',
+        threatName: 'Blocked script',
+        severity: 'medium',
+        status: 'in_progress',
+        detectedAt: '2026-06-21T00:00:00Z',
+      },
+    ]);
+
+    render(<S1ThreatList />);
+    await waitFor(() => expect(getS1ThreatUrls().length).toBeGreaterThan(0));
+    fetchWithAuth.mockClear();
+
+    fireEvent.change(screen.getByTestId('s1-filter-search'), { target: { value: 'script' } });
+    fireEvent.change(screen.getByTestId('s1-filter-severity'), { target: { value: 'high' } });
+    fireEvent.change(screen.getByTestId('s1-filter-status'), { target: { value: 'active' } });
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-06-01' } });
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-06-25' } });
+
+    await waitFor(() => {
+      const latestUrl = getS1ThreatUrls().at(-1) ?? '';
+      const params = new URL(latestUrl, 'http://localhost').searchParams;
+      expect(params.get('search')).toBe('script');
+      expect(params.get('severity')).toBe('high');
+      expect(params.get('status')).toBe('active');
+      expect(params.get('start')).toBeTruthy();
+      expect(params.get('end')).toBeTruthy();
+      expect(params.get('orgId')).toBeNull();
+    });
+
+    fireEvent.change(screen.getByTestId('s1-filter-severity'), { target: { value: 'all' } });
+
+    await waitFor(() => {
+      const latestUrl = getS1ThreatUrls().at(-1) ?? '';
+      const params = new URL(latestUrl, 'http://localhost').searchParams;
+      expect(params.get('severity')).toBeNull();
+      expect(params.get('search')).toBe('script');
+    });
+  });
+
+  it('POSTs a threat action with the threat row orgId', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) {
+        return Promise.resolve(ok({
+          data: [
+            {
+              id: 't1',
+              orgId: 'org-7',
+              deviceId: 'dev-9',
+              threatName: 'X',
+              severity: 'high',
+              status: 'active',
+              detectedAt: '2026-06-20T00:00:00Z',
+            },
+          ],
+          pagination: { total: 1, limit: 100, offset: 0 },
+        }));
+      }
+      if (url === '/s1/threat-action' && init?.method === 'POST') {
+        body = JSON.parse(String(init.body));
+        return Promise.resolve(ok({ success: true }));
+      }
+      return Promise.resolve(ok({ data: [] }));
+    });
+
+    render(<S1ThreatList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(await desktop.findByTestId('s1-threat-quarantine-t1'));
+
+    await waitFor(() =>
+      expect(body).toEqual({ orgId: 'org-7', action: 'quarantine', threatIds: ['t1'] }),
+    );
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('renders no action buttons for non-active threats', async () => {
+    routeFetch([
+      {
+        id: 't9',
+        orgId: 'org-9',
+        deviceId: 'dev-9',
+        threatName: 'Resolved item',
+        severity: 'low',
+        status: 'resolved',
+        detectedAt: '2026-06-20T00:00:00Z',
+      },
+    ]);
+
+    render(<S1ThreatList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    await desktop.findByTestId('s1-row-t9');
+    expect(desktop.queryByTestId('s1-threat-kill-t9')).toBeNull();
+    expect(desktop.queryByTestId('s1-threat-quarantine-t9')).toBeNull();
+    expect(desktop.queryByTestId('s1-threat-rollback-t9')).toBeNull();
+  });
+
+  it('shows empty and error states', async () => {
+    routeFetch([]);
+    const { unmount } = render(<S1ThreatList />);
+    expect(await screen.findAllByText('No SentinelOne threats found.')).toHaveLength(2);
+    unmount();
+
+    fetchWithAuth.mockReset();
+    fetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: async () => ({}),
+    } as Response);
+
+    render(<S1ThreatList />);
+    expect(await screen.findByTestId('s1-error')).toHaveTextContent('Server error');
+  });
+});

--- a/apps/web/src/components/security/S1ThreatList.test.tsx
+++ b/apps/web/src/components/security/S1ThreatList.test.tsx
@@ -156,7 +156,44 @@ describe('S1ThreatList', () => {
     expect(navigateTo).not.toHaveBeenCalled();
   });
 
-  it('renders no action buttons for non-active threats', async () => {
+  it('promotes a threat to an incident and navigates', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) {
+        return Promise.resolve(ok({
+          data: [
+            {
+              id: 't1',
+              orgId: 'org-7',
+              deviceId: 'dev-9',
+              threatName: 'X',
+              severity: 'high',
+              status: 'active',
+              detectedAt: '2026-06-20T00:00:00Z',
+            },
+          ],
+          pagination: { total: 1, limit: 100, offset: 0 },
+        }));
+      }
+      if (url === '/incidents') {
+        body = JSON.parse(String(init?.body));
+        return Promise.resolve({ ok: true, status: 201, json: async () => ({ id: 'inc-2' }) } as Response);
+      }
+      return Promise.resolve(ok({ data: [] }));
+    });
+
+    render(<S1ThreatList />);
+
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(await desktop.findByTestId('s1-promote-t1'));
+
+    await waitFor(() => expect((body as any).orgId).toBe('org-7'));
+    expect((body as any).classification).toBe('sentinelone-threat');
+    expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-2');
+    expect(navigateTo).not.toHaveBeenCalledWith('/devices/dev-9');
+  });
+
+  it('renders no remediation buttons for non-active threats', async () => {
     routeFetch([
       {
         id: 't9',
@@ -176,6 +213,7 @@ describe('S1ThreatList', () => {
     expect(desktop.queryByTestId('s1-threat-kill-t9')).toBeNull();
     expect(desktop.queryByTestId('s1-threat-quarantine-t9')).toBeNull();
     expect(desktop.queryByTestId('s1-threat-rollback-t9')).toBeNull();
+    expect(desktop.getByTestId('s1-promote-t9')).toBeInTheDocument();
   });
 
   it('shows empty and error states', async () => {

--- a/apps/web/src/components/security/S1ThreatList.tsx
+++ b/apps/web/src/components/security/S1ThreatList.tsx
@@ -1,0 +1,3 @@
+export default function S1ThreatList() {
+  return <div data-testid="s1-list" />;
+}

--- a/apps/web/src/components/security/S1ThreatList.tsx
+++ b/apps/web/src/components/security/S1ThreatList.tsx
@@ -1,3 +1,315 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Filter, Loader2, RefreshCw, Search } from 'lucide-react';
+
+import { navigateTo } from '@/lib/navigation';
+import { cn, friendlyFetchError } from '../../lib/utils';
+import { handleActionError } from '../../lib/runAction';
+import { fetchS1Threats, runS1ThreatAction, type S1Threat, type S1ThreatActionType } from '../../lib/edr';
+import { formatDateTime } from '../../lib/dateTimeFormat';
+import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+
+const severityBadge: Record<string, string> = {
+  low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
+  medium: 'bg-yellow-500/20 text-yellow-800 border-yellow-500/40',
+  high: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
+  critical: 'bg-red-500/20 text-red-700 border-red-500/40',
+};
+
+const statusBadge: Record<string, string> = {
+  active: 'bg-red-500/15 text-red-700 border-red-500/30',
+  in_progress: 'bg-blue-500/15 text-blue-700 border-blue-500/30',
+  quarantined: 'bg-amber-500/20 text-amber-800 border-amber-500/40',
+  resolved: 'bg-emerald-500/20 text-emerald-700 border-emerald-500/40',
+};
+
+function badgeClass(value: string | null | undefined, classes: Record<string, string>): string {
+  return classes[(value ?? '').toLowerCase()] ?? 'bg-muted text-muted-foreground border-border';
+}
+
+function formatDetected(value: string | null): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '-' : formatDateTime(date);
+}
+
+function toStartIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function toEndIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  date.setHours(23, 59, 59, 999);
+  return date.toISOString();
+}
+
 export default function S1ThreatList() {
-  return <div data-testid="s1-list" />;
+  const [query, setQuery] = useState('');
+  const [severityFilter, setSeverityFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [threats, setThreats] = useState<S1Threat[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [actingId, setActingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const result = await fetchS1Threats({
+        limit: 100,
+        search: query.trim() || undefined,
+        severity: severityFilter === 'all' ? undefined : severityFilter,
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        start: toStartIso(startDate),
+        end: toEndIso(endDate),
+      });
+      setThreats(result.rows);
+      setTotal(result.total);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+      setThreats([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [endDate, query, severityFilter, startDate, statusFilter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const doThreatAction = async (threat: S1Threat, action: S1ThreatActionType) => {
+    setActingId(threat.id);
+    try {
+      await runS1ThreatAction(threat.orgId, threat.id, action);
+      await load();
+    } catch (err) {
+      handleActionError(err, `Failed to ${action} threat`);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const openDevice = (threat: S1Threat) => {
+    if (threat.deviceId) navigateTo(`/devices/${threat.deviceId}`);
+  };
+
+  const renderSeverityBadge = (threat: S1Threat) => (
+    <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(threat.severity, severityBadge))}>
+      {threat.severity ?? 'unknown'}
+    </span>
+  );
+
+  const renderStatusBadge = (threat: S1Threat) => (
+    <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(threat.status, statusBadge))}>
+      {threat.status}
+    </span>
+  );
+
+  const renderActions = (threat: S1Threat) => {
+    if (threat.status !== 'active') return <span className="text-xs text-muted-foreground">-</span>;
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        {(['kill', 'quarantine', 'rollback'] as const).map((action) => (
+          <button
+            key={action}
+            type="button"
+            data-testid={`s1-threat-${action}-${threat.id}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              void doThreatAction(threat, action);
+            }}
+            disabled={actingId === threat.id}
+            className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium capitalize hover:bg-muted disabled:opacity-60"
+          >
+            {actingId === threat.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {action}
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="s1-list">
+      {error && (
+        <div
+          className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          data-testid="s1-error"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">SentinelOne Threats</h2>
+          <p className="text-sm text-muted-foreground">
+            {loading ? 'Loading fleet threats...' : `${total} threats match your filters`}
+          </p>
+        </div>
+        <div className="flex flex-1 flex-col gap-2 lg:flex-row lg:items-center lg:justify-end">
+          <div className="relative w-full lg:w-64">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="search"
+              data-testid="s1-filter-search"
+              placeholder="Search threats"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="h-10 w-full rounded-md border bg-background pl-9 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <select
+              data-testid="s1-filter-severity"
+              value={severityFilter}
+              onChange={(event) => setSeverityFilter(event.target.value)}
+              className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="all">All severities</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="critical">Critical</option>
+            </select>
+            <select
+              data-testid="s1-filter-status"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+              className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="all">All statuses</option>
+              <option value="active">Active</option>
+              <option value="in_progress">In progress</option>
+              <option value="quarantined">Quarantined</option>
+              <option value="resolved">Resolved</option>
+            </select>
+            <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm">
+              <Filter className="h-4 w-4 text-muted-foreground" />
+              <input
+                type="date"
+                aria-label="Start date"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+                className="bg-transparent text-sm focus:outline-none"
+              />
+              <span className="text-muted-foreground">to</span>
+              <input
+                type="date"
+                aria-label="End date"
+                value={endDate}
+                onChange={(event) => setEndDate(event.target.value)}
+                className="bg-transparent text-sm focus:outline-none"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-3 text-sm hover:bg-muted"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ResponsiveTable
+        className="mt-6"
+        table={
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Device</th>
+                <th className="px-4 py-3">Threat</th>
+                <th className="px-4 py-3">Severity</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Detected</th>
+                <th className="px-4 py-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    <span className="inline-flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading SentinelOne threats...
+                    </span>
+                  </td>
+                </tr>
+              ) : threats.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    No SentinelOne threats found.
+                  </td>
+                </tr>
+              ) : (
+                threats.map((threat) => (
+                  <tr
+                    key={threat.id}
+                    data-testid={`s1-row-${threat.id}`}
+                    onClick={() => openDevice(threat)}
+                    className={cn('text-sm transition hover:bg-muted/40', threat.deviceId && 'cursor-pointer')}
+                  >
+                    <td className="px-4 py-3 font-medium">{threat.deviceName ?? threat.deviceId ?? '-'}</td>
+                    <td className="px-4 py-3">{threat.threatName ?? 'Unknown threat'}</td>
+                    <td className="px-4 py-3">{renderSeverityBadge(threat)}</td>
+                    <td className="px-4 py-3">{renderStatusBadge(threat)}</td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">{formatDetected(threat.detectedAt)}</td>
+                    <td className="px-4 py-3" onClick={(event) => event.stopPropagation()}>
+                      {renderActions(threat)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        }
+        cards={
+          loading ? (
+            <DataCard>
+              <p className="inline-flex items-center justify-center gap-2 py-2 text-center text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading SentinelOne threats...
+              </p>
+            </DataCard>
+          ) : threats.length === 0 ? (
+            <DataCard>
+              <p className="py-2 text-center text-sm text-muted-foreground">No SentinelOne threats found.</p>
+            </DataCard>
+          ) : (
+            threats.map((threat) => (
+              <DataCard key={threat.id} onClick={threat.deviceId ? () => openDevice(threat) : undefined}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold">{threat.threatName ?? 'Unknown threat'}</div>
+                    <div className="truncate text-xs text-muted-foreground">{threat.deviceName ?? threat.deviceId ?? '-'}</div>
+                  </div>
+                  <div className="shrink-0">{renderSeverityBadge(threat)}</div>
+                </div>
+                <div className="mt-3 space-y-2 border-t pt-3">
+                  <CardField label="Status">{renderStatusBadge(threat)}</CardField>
+                  <CardField label="Detected">
+                    <span className="text-xs text-muted-foreground">{formatDetected(threat.detectedAt)}</span>
+                  </CardField>
+                  <CardField label="Actions">
+                    <div onClick={(event) => event.stopPropagation()}>{renderActions(threat)}</div>
+                  </CardField>
+                </div>
+              </DataCard>
+            ))
+          )
+        }
+      />
+    </div>
+  );
 }

--- a/apps/web/src/components/security/S1ThreatList.tsx
+++ b/apps/web/src/components/security/S1ThreatList.tsx
@@ -5,6 +5,7 @@ import { navigateTo } from '@/lib/navigation';
 import { cn, friendlyFetchError } from '../../lib/utils';
 import { handleActionError } from '../../lib/runAction';
 import { fetchS1Threats, runS1ThreatAction, type S1Threat, type S1ThreatActionType } from '../../lib/edr';
+import { promoteToIncident, s1ThreatToIncident } from '../../lib/incidents';
 import { formatDateTime } from '../../lib/dateTimeFormat';
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
 
@@ -57,6 +58,7 @@ export default function S1ThreatList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [actingId, setActingId] = useState<string | null>(null);
+  const [promotingId, setPromotingId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -101,6 +103,18 @@ export default function S1ThreatList() {
     if (threat.deviceId) navigateTo(`/devices/${threat.deviceId}`);
   };
 
+  const promote = async (threat: S1Threat) => {
+    setPromotingId(threat.id);
+    try {
+      const { id } = await promoteToIncident(s1ThreatToIncident(threat));
+      navigateTo(`/incidents/${id}`);
+    } catch (err) {
+      handleActionError(err, 'Failed to create incident');
+    } finally {
+      setPromotingId(null);
+    }
+  };
+
   const renderSeverityBadge = (threat: S1Threat) => (
     <span className={cn('inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold', badgeClass(threat.severity, severityBadge))}>
       {threat.severity ?? 'unknown'}
@@ -114,10 +128,9 @@ export default function S1ThreatList() {
   );
 
   const renderActions = (threat: S1Threat) => {
-    if (threat.status !== 'active') return <span className="text-xs text-muted-foreground">-</span>;
     return (
       <div className="flex flex-wrap items-center gap-2">
-        {(['kill', 'quarantine', 'rollback'] as const).map((action) => (
+        {threat.status === 'active' && (['kill', 'quarantine', 'rollback'] as const).map((action) => (
           <button
             key={action}
             type="button"
@@ -133,6 +146,19 @@ export default function S1ThreatList() {
             {action}
           </button>
         ))}
+        <button
+          type="button"
+          data-testid={`s1-promote-${threat.id}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            void promote(threat);
+          }}
+          disabled={promotingId === threat.id}
+          className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
+        >
+          {promotingId === threat.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          Promote to Incident
+        </button>
       </div>
     );
   };

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -24,6 +24,8 @@ import {
 } from 'recharts';
 import { cn, formatNumber, widthPercentClass } from '@/lib/utils';
 import { fetchWithAuth } from '@/stores/auth';
+import { ENABLE_EDR_INTEGRATIONS } from '../../lib/featureFlags';
+import EdrSummaryPanel from './EdrSummaryPanel';
 
 type Priority = 'critical' | 'high' | 'medium' | 'low';
 
@@ -607,6 +609,8 @@ export default function SecurityDashboard({ timezone }: SecurityDashboardProps) 
           </button>
         </div>
       )}
+
+      {ENABLE_EDR_INTEGRATIONS && <EdrSummaryPanel />}
 
       <div className="grid gap-6 lg:grid-cols-12">
         {isInitialLoading ? (

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -78,8 +78,10 @@ const TARGET_GLOBS = [
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
   'src/lib/edr.ts',
+  'src/lib/incidents.ts',
   'src/components/devices/DeviceEdrPanel.tsx',
   'src/components/security/S1ThreatList.tsx',
+  'src/components/security/HuntressIncidentList.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -271,7 +273,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(52);
+    expect(absoluteFiles.length).toBe(54);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -77,6 +77,8 @@ const TARGET_GLOBS = [
   'src/components/devices/DeviceVulnerabilitiesTab.tsx',
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
+  'src/lib/edr.ts',
+  'src/components/devices/DeviceEdrPanel.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -268,7 +270,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(49);
+    expect(absoluteFiles.length).toBe(51);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -79,6 +79,7 @@ const TARGET_GLOBS = [
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
   'src/lib/edr.ts',
   'src/components/devices/DeviceEdrPanel.tsx',
+  'src/components/security/S1ThreatList.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -270,7 +271,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(51);
+    expect(absoluteFiles.length).toBe(52);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/edr.test.ts
+++ b/apps/web/src/lib/edr.test.ts
@@ -12,10 +12,11 @@ function ok(body: unknown) {
 beforeEach(() => fetchWithAuth.mockReset());
 
 describe('fetchS1Threats', () => {
-  it('passes orgId + deviceId and unwraps pagination shape', async () => {
-    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 't1' }], pagination: { total: 1, limit: 100, offset: 0 } }));
-    const rows = await fetchS1Threats('org-1', 'dev-1');
+  it('passes filters and returns { rows, total } from the pagination shape', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 't1' }], pagination: { total: 5, limit: 100, offset: 0 } }));
+    const { rows, total } = await fetchS1Threats({ orgId: 'org-1', deviceId: 'dev-1' });
     expect(rows).toEqual([{ id: 't1' }]);
+    expect(total).toBe(5);
     const url = fetchWithAuth.mock.calls[0][0] as string;
     expect(url).toContain('/s1/threats');
     expect(url).toContain('orgId=org-1');
@@ -24,13 +25,14 @@ describe('fetchS1Threats', () => {
 });
 
 describe('fetchHuntressIncidents', () => {
-  it('unwraps the flat (non-pagination) shape', async () => {
-    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 'i1' }], total: 1, limit: 100, offset: 0 }));
-    const rows = await fetchHuntressIncidents('org-1', 'dev-1');
+  it('reads { rows, total } from the Huntress flat shape and omits empty filters', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 'i1' }], total: 3, limit: 100, offset: 0 }));
+    const { rows, total } = await fetchHuntressIncidents({ severity: 'high' });
     expect(rows).toEqual([{ id: 'i1' }]);
-    expect(fetchWithAuth.mock.calls[0][0]).toContain('/huntress/incidents');
+    expect(total).toBe(3);
     const url = fetchWithAuth.mock.calls[0][0] as string;
-    expect(url).toContain('orgId=org-1');
-    expect(url).toContain('deviceId=dev-1');
+    expect(url).toContain('/huntress/incidents');
+    expect(url).toContain('severity=high');
+    expect(url).not.toContain('orgId=');
   });
 });

--- a/apps/web/src/lib/edr.test.ts
+++ b/apps/web/src/lib/edr.test.ts
@@ -29,5 +29,8 @@ describe('fetchHuntressIncidents', () => {
     const rows = await fetchHuntressIncidents('org-1', 'dev-1');
     expect(rows).toEqual([{ id: 'i1' }]);
     expect(fetchWithAuth.mock.calls[0][0]).toContain('/huntress/incidents');
+    const url = fetchWithAuth.mock.calls[0][0] as string;
+    expect(url).toContain('orgId=org-1');
+    expect(url).toContain('deviceId=dev-1');
   });
 });

--- a/apps/web/src/lib/edr.test.ts
+++ b/apps/web/src/lib/edr.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+import { fetchS1Threats, fetchHuntressIncidents } from './edr';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('fetchS1Threats', () => {
+  it('passes orgId + deviceId and unwraps pagination shape', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 't1' }], pagination: { total: 1, limit: 100, offset: 0 } }));
+    const rows = await fetchS1Threats('org-1', 'dev-1');
+    expect(rows).toEqual([{ id: 't1' }]);
+    const url = fetchWithAuth.mock.calls[0][0] as string;
+    expect(url).toContain('/s1/threats');
+    expect(url).toContain('orgId=org-1');
+    expect(url).toContain('deviceId=dev-1');
+  });
+});
+
+describe('fetchHuntressIncidents', () => {
+  it('unwraps the flat (non-pagination) shape', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 'i1' }], total: 1, limit: 100, offset: 0 }));
+    const rows = await fetchHuntressIncidents('org-1', 'dev-1');
+    expect(rows).toEqual([{ id: 'i1' }]);
+    expect(fetchWithAuth.mock.calls[0][0]).toContain('/huntress/incidents');
+  });
+});

--- a/apps/web/src/lib/edr.ts
+++ b/apps/web/src/lib/edr.ts
@@ -43,29 +43,61 @@ export interface HuntressIncident {
   updatedAt: string;
 }
 
-export async function fetchS1Threats(orgId: string, deviceId: string): Promise<S1Threat[]> {
-  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
-  const res = await fetchWithAuth(`/s1/threats?${params.toString()}`);
+export interface S1ThreatFilters {
+  orgId?: string;
+  deviceId?: string;
+  status?: string;
+  severity?: string;
+  search?: string;
+  start?: string;
+  end?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface HuntressIncidentFilters {
+  orgId?: string;
+  deviceId?: string;
+  status?: string;
+  severity?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+function toParams(filters: Record<string, string | number | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== '') params.set(key, String(value));
+  }
+  return params.toString();
+}
+
+export async function fetchS1Threats(filters: S1ThreatFilters = {}): Promise<{ rows: S1Threat[]; total: number }> {
+  const qs = toParams({ limit: 100, ...filters });
+  const res = await fetchWithAuth(`/s1/threats?${qs}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = await res.json();
   if (!Array.isArray(body?.data)) {
     console.warn('[edr] /s1/threats returned non-array data');
-    return [];
+    return { rows: [], total: 0 };
   }
-  return body.data as S1Threat[];
+  return { rows: body.data as S1Threat[], total: Number(body?.pagination?.total ?? body.data.length) };
 }
 
 // Huntress returns a flat { data, total, limit, offset } envelope, not S1's { data, pagination } shape.
-export async function fetchHuntressIncidents(orgId: string, deviceId: string): Promise<HuntressIncident[]> {
-  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
-  const res = await fetchWithAuth(`/huntress/incidents?${params.toString()}`);
+export async function fetchHuntressIncidents(
+  filters: HuntressIncidentFilters = {},
+): Promise<{ rows: HuntressIncident[]; total: number }> {
+  const qs = toParams({ limit: 100, ...filters });
+  const res = await fetchWithAuth(`/huntress/incidents?${qs}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = await res.json();
   if (!Array.isArray(body?.data)) {
     console.warn('[edr] /huntress/incidents returned non-array data');
-    return [];
+    return { rows: [], total: 0 };
   }
-  return body.data as HuntressIncident[];
+  return { rows: body.data as HuntressIncident[], total: Number(body?.total ?? body.data.length) };
 }
 
 export async function isolateDevice(orgId: string, deviceId: string, isolate: boolean): Promise<void> {

--- a/apps/web/src/lib/edr.ts
+++ b/apps/web/src/lib/edr.ts
@@ -1,0 +1,86 @@
+import { fetchWithAuth } from '../stores/auth';
+import { runAction } from './runAction';
+
+export type S1ThreatActionType = 'kill' | 'quarantine' | 'rollback';
+
+export interface S1Threat {
+  id: string;
+  s1ThreatId: string;
+  orgId: string;
+  integrationId: string;
+  deviceId: string | null;
+  deviceName: string | null;
+  threatName: string;
+  classification: string | null;
+  severity: string | null;
+  status: string;
+  processName: string | null;
+  filePath: string | null;
+  mitreTactics: unknown;
+  detectedAt: string;
+  resolvedAt: string | null;
+  updatedAt: string;
+  details: unknown;
+}
+
+export interface HuntressIncident {
+  id: string;
+  orgId: string;
+  integrationId: string;
+  deviceId: string | null;
+  deviceHostname: string | null;
+  huntressIncidentId: string;
+  severity: string;
+  category: string | null;
+  title: string;
+  description: string | null;
+  recommendation: string | null;
+  status: string;
+  reportedAt: string;
+  resolvedAt: string | null;
+  details: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchS1Threats(orgId: string, deviceId: string): Promise<S1Threat[]> {
+  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
+  const res = await fetchWithAuth(`/s1/threats?${params.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  return Array.isArray(body?.data) ? (body.data as S1Threat[]) : [];
+}
+
+export async function fetchHuntressIncidents(orgId: string, deviceId: string): Promise<HuntressIncident[]> {
+  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
+  const res = await fetchWithAuth(`/huntress/incidents?${params.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  return Array.isArray(body?.data) ? (body.data as HuntressIncident[]) : [];
+}
+
+export async function isolateDevice(orgId: string, deviceId: string, isolate: boolean): Promise<void> {
+  await runAction({
+    request: () =>
+      fetchWithAuth('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId, deviceIds: [deviceId], isolate }),
+      }),
+    errorFallback: isolate ? 'Failed to isolate device' : 'Failed to remove isolation',
+    successMessage: isolate ? 'Device isolated' : 'Isolation removed',
+  });
+}
+
+export async function runS1ThreatAction(orgId: string, threatId: string, action: S1ThreatActionType): Promise<void> {
+  await runAction({
+    request: () =>
+      fetchWithAuth('/s1/threat-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId, action, threatIds: [threatId] }),
+      }),
+    errorFallback: `Failed to ${action} threat`,
+    successMessage: `Threat ${action} requested`,
+  });
+}

--- a/apps/web/src/lib/edr.ts
+++ b/apps/web/src/lib/edr.ts
@@ -10,14 +10,14 @@ export interface S1Threat {
   integrationId: string;
   deviceId: string | null;
   deviceName: string | null;
-  threatName: string;
+  threatName: string | null;
   classification: string | null;
   severity: string | null;
   status: string;
   processName: string | null;
   filePath: string | null;
   mitreTactics: unknown;
-  detectedAt: string;
+  detectedAt: string | null;
   resolvedAt: string | null;
   updatedAt: string;
   details: unknown;
@@ -30,13 +30,13 @@ export interface HuntressIncident {
   deviceId: string | null;
   deviceHostname: string | null;
   huntressIncidentId: string;
-  severity: string;
+  severity: string | null;
   category: string | null;
   title: string;
   description: string | null;
   recommendation: string | null;
   status: string;
-  reportedAt: string;
+  reportedAt: string | null;
   resolvedAt: string | null;
   details: unknown;
   createdAt: string;
@@ -48,15 +48,24 @@ export async function fetchS1Threats(orgId: string, deviceId: string): Promise<S
   const res = await fetchWithAuth(`/s1/threats?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = await res.json();
-  return Array.isArray(body?.data) ? (body.data as S1Threat[]) : [];
+  if (!Array.isArray(body?.data)) {
+    console.warn('[edr] /s1/threats returned non-array data');
+    return [];
+  }
+  return body.data as S1Threat[];
 }
 
+// Huntress returns a flat { data, total, limit, offset } envelope, not S1's { data, pagination } shape.
 export async function fetchHuntressIncidents(orgId: string, deviceId: string): Promise<HuntressIncident[]> {
   const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
   const res = await fetchWithAuth(`/huntress/incidents?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = await res.json();
-  return Array.isArray(body?.data) ? (body.data as HuntressIncident[]) : [];
+  if (!Array.isArray(body?.data)) {
+    console.warn('[edr] /huntress/incidents returned non-array data');
+    return [];
+  }
+  return body.data as HuntressIncident[];
 }
 
 export async function isolateDevice(orgId: string, deviceId: string, isolate: boolean): Promise<void> {

--- a/apps/web/src/lib/featureFlags.ts
+++ b/apps/web/src/lib/featureFlags.ts
@@ -15,6 +15,11 @@ export const ENABLE_ENDPOINT_AV_FEATURES = parseBoolean(
   false
 );
 
+export const ENABLE_EDR_INTEGRATIONS = parseBoolean(
+  import.meta.env.PUBLIC_ENABLE_EDR_INTEGRATIONS,
+  false
+);
+
 // Unified Devices list network arm (#1322): surface network-discovered assets
 // alongside agent endpoints in the Devices view. Off by default until the
 // remaining rough edges (unified sort/pagination, per-asset detail pages,

--- a/apps/web/src/lib/incidents.test.ts
+++ b/apps/web/src/lib/incidents.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { fetchWithAuth, showToast } = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock('../stores/auth', () => ({ fetchWithAuth }));
+vi.mock('../components/shared/Toast', () => ({ showToast }));
+
+import { mapEdrSeverity, s1ThreatToIncident, huntressIncidentToIncident, promoteToIncident } from './incidents';
+
+function ok(b: unknown) {
+  return { ok: true, status: 201, json: async () => b } as Response;
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+});
+
+describe('mapEdrSeverity', () => {
+  it('maps EDR severities to p1-p4 with a safe default', () => {
+    expect(mapEdrSeverity('critical')).toBe('p1');
+    expect(mapEdrSeverity('HIGH')).toBe('p2');
+    expect(mapEdrSeverity('medium')).toBe('p3');
+    expect(mapEdrSeverity('low')).toBe('p4');
+    expect(mapEdrSeverity(null)).toBe('p3');
+    expect(mapEdrSeverity('weird')).toBe('p3');
+  });
+});
+
+describe('mappers', () => {
+  it('builds an incident input from an S1 threat', () => {
+    const input = s1ThreatToIncident({
+      id: 't1',
+      orgId: 'org-1',
+      deviceId: 'dev-9',
+      deviceName: 'PC',
+      threatName: 'Emotet',
+      severity: 'critical',
+      status: 'active',
+      detectedAt: '2026-06-20T00:00:00Z',
+    } as any);
+    expect(input.orgId).toBe('org-1');
+    expect(input.severity).toBe('p1');
+    expect(input.affectedDevices).toEqual(['dev-9']);
+    expect(input.classification).toBe('sentinelone-threat');
+    expect(input.title).toContain('Emotet');
+  });
+
+  it('builds an incident input from a Huntress incident with no device', () => {
+    const input = huntressIncidentToIncident({
+      id: 'i1',
+      orgId: 'org-2',
+      deviceId: null,
+      title: 'Persistence',
+      severity: 'high',
+      status: 'open',
+      reportedAt: '2026-06-21T00:00:00Z',
+    } as any);
+    expect(input.orgId).toBe('org-2');
+    expect(input.severity).toBe('p2');
+    expect(input.affectedDevices).toEqual([]);
+    expect(input.classification).toBe('huntress-incident');
+  });
+});
+
+describe('promoteToIncident', () => {
+  it('POSTs /incidents and returns the new id', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((_url: string, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return Promise.resolve(ok({ id: 'inc-1' }));
+    });
+    const res = await promoteToIncident({
+      orgId: 'org-1',
+      title: 'X',
+      classification: 'sentinelone-threat',
+      severity: 'p1',
+      affectedDevices: ['dev-9'],
+    });
+    expect(res).toEqual({ id: 'inc-1' });
+    expect(fetchWithAuth.mock.calls[0][0]).toBe('/incidents');
+    expect((body as any).orgId).toBe('org-1');
+    expect((body as any).severity).toBe('p1');
+  });
+});

--- a/apps/web/src/lib/incidents.ts
+++ b/apps/web/src/lib/incidents.ts
@@ -65,7 +65,10 @@ export async function promoteToIncident(input: CreateIncidentInput): Promise<{ i
         body: JSON.stringify(input),
       }),
     errorFallback: 'Failed to create incident',
-    successMessage: 'Incident created',
+    // No successMessage: the caller navigates to /incidents/{id} on success,
+    // and that view transition unmounts the ToastContainer before a toast
+    // would render (it would be silently dropped). The navigation is the
+    // confirmation.
     parseSuccess: (data) => data as { id: string },
   });
 }

--- a/apps/web/src/lib/incidents.ts
+++ b/apps/web/src/lib/incidents.ts
@@ -1,0 +1,71 @@
+import { fetchWithAuth } from '../stores/auth';
+import { runAction } from './runAction';
+import type { S1Threat, HuntressIncident } from './edr';
+
+export type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
+
+export interface CreateIncidentInput {
+  orgId: string;
+  title: string;
+  classification: string;
+  severity: IncidentSeverity;
+  summary?: string;
+  affectedDevices?: string[];
+  detectedAt?: string;
+}
+
+const SEVERITY_MAP: Record<string, IncidentSeverity> = {
+  critical: 'p1',
+  high: 'p2',
+  medium: 'p3',
+  low: 'p4',
+};
+
+export function mapEdrSeverity(sev: string | null | undefined): IncidentSeverity {
+  return SEVERITY_MAP[(sev ?? '').toLowerCase()] ?? 'p3';
+}
+
+function clampTitle(value: string): string {
+  return value.length > 500 ? value.slice(0, 500) : value;
+}
+
+export function s1ThreatToIncident(t: S1Threat): CreateIncidentInput {
+  const device = t.deviceName ?? t.deviceId ?? 'an unknown device';
+  return {
+    orgId: t.orgId,
+    title: clampTitle(`SentinelOne: ${t.threatName ?? 'Unknown threat'}`),
+    classification: 'sentinelone-threat',
+    severity: mapEdrSeverity(t.severity),
+    summary: `Promoted from SentinelOne threat "${t.threatName ?? 'Unknown threat'}" on ${device}.`,
+    affectedDevices: t.deviceId ? [t.deviceId] : [],
+    detectedAt: t.detectedAt ?? undefined,
+  };
+}
+
+export function huntressIncidentToIncident(i: HuntressIncident): CreateIncidentInput {
+  const device = i.deviceHostname ?? i.deviceId ?? 'an unknown device';
+  const body = i.recommendation || i.description || '';
+  return {
+    orgId: i.orgId,
+    title: clampTitle(`Huntress: ${i.title}`),
+    classification: 'huntress-incident',
+    severity: mapEdrSeverity(i.severity),
+    summary: `Promoted from Huntress incident "${i.title}" on ${device}.${body ? ` ${body}` : ''}`.slice(0, 10000),
+    affectedDevices: i.deviceId ? [i.deviceId] : [],
+    detectedAt: i.reportedAt ?? undefined,
+  };
+}
+
+export async function promoteToIncident(input: CreateIncidentInput): Promise<{ id: string }> {
+  return runAction<{ id: string }>({
+    request: () =>
+      fetchWithAuth('/incidents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }),
+    errorFallback: 'Failed to create incident',
+    successMessage: 'Incident created',
+    parseSuccess: (data) => data as { id: string },
+  });
+}

--- a/apps/web/src/pages/security/edr.astro
+++ b/apps/web/src/pages/security/edr.astro
@@ -1,0 +1,10 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import EdrPage from '../../components/security/EdrPage';
+import Breadcrumbs from '../../components/layout/Breadcrumbs';
+---
+
+<DashboardLayout title="EDR">
+  <Breadcrumbs client:load items={[{ label: 'Security', href: '/security' }, { label: 'EDR' }]} />
+  <EdrPage client:load />
+</DashboardLayout>

--- a/docs/superpowers/plans/2026-06-25-edr-operations-surfacing.md
+++ b/docs/superpowers/plans/2026-06-25-edr-operations-surfacing.md
@@ -1,0 +1,178 @@
+# EDR Operations Surfacing — Phase Plan
+
+> **Status:** Phase plan / design doc for review. This is a *scoping* document, not a
+> bite-sized TDD implementation plan. Each pillar below gets its own
+> `docs/superpowers/plans/` implementation plan (written with `superpowers:writing-plans`)
+> once scope is locked. Open decisions at the bottom must be resolved before Pillar 1 starts.
+
+**Goal:** Surface the SentinelOne and Huntress data we already sync — and the actions the API
+already supports — in the places technicians actually work (device detail, fleet lists, the
+dashboard), then connect that EDR signal to the existing Incident Response module so a threat can
+be escalated, contained, and tracked end-to-end.
+
+**Author:** Todd Hebebrand · **Date:** 2026-06-25 · **Branch:** `huntress-sentinelone-ui-plan`
+
+---
+
+## Background — the stranded-investment problem
+
+Both EDR integrations have mature backends and **almost no operational UI**. Verified during research:
+
+| Capability | Backend | UI surface today |
+|---|---|---|
+| Huntress config + org mapping + webhook | `routes/huntress.ts`, `HuntressIntegration.tsx` | ✅ Integrations → Security → Huntress |
+| Huntress incidents (`/huntress/incidents`, paginated, site-scoped) | ✅ | ❌ **5-row preview in the config panel only** |
+| S1 config + site mapping + coverage | `routes/sentinelOne.ts`, `SecurityIntegration.tsx` | ✅ Integrations → Security → SentinelOne |
+| S1 threats (`GET /s1/threats`) | ✅ | ❌ **nowhere** |
+| S1 isolate / un-isolate (`POST /s1/isolate`) | ✅ (MFA + `devices:execute`) | ❌ **no button anywhere** |
+| S1 threat-action kill/quarantine/rollback (`POST /s1/threat-action`) | ✅ | ❌ **nowhere** |
+| Automation triggers (`s1.*`, `huntress.*`) | ✅ | ✅ AutomationForm |
+| AI tools (query + Tier-3 actions) | ✅ | ✅ via AI agent |
+
+**Critical confirmation:** `DeviceSecurityTab.tsx` and the fleet `ThreatList.tsx` both fetch the
+**generic** `/security/threats` endpoint — that is the agent's *own* AV detections
+(`security_threats` table). Neither view unions S1 threats or Huntress incidents. A human in the
+console literally cannot see a Huntress incident or isolate an S1 device today.
+
+### The Incident Response module (`incidents` page)
+
+`BE-32: Incident response automation (#305)`, March 2026 — **predates both EDR integrations**
+(Huntress migration `0049`, S1 `0052`). It is a general-purpose IR / war-room module:
+
+- `incidents` — severity `p1–p4`, lifecycle `detected → analyzing → contained → recovering → closed`,
+  `relatedAlerts[]`, `affectedDevices[]`, `timeline[]`, assignee.
+- `incident_evidence` — forensic evidence with SHA-256 hash / chain-of-custody.
+- `incident_actions` — containment actions with `reversible`, `approvalRef`, actor `user|brain|system`.
+
+It is **wired but starved**: populated today only by manual create (`POST /incidents`), the AI brain
+(`aiToolsIncident.ts`: `create_incident`, `execute_containment`), and audit-chain tamper detection.
+Nothing routinely feeds it — which is why it looks unused. Its `affectedDevices[]` / `relatedAlerts[]`
+/ reversible-containment-with-approval schema is *exactly* the right escalation target for EDR signal.
+**Pillar 4 connects them.**
+
+---
+
+## Huntress API capability (researched 2026-06-25 — corrects an earlier assumption)
+
+Our `huntressClient.ts` is **read-only today** — it only `GET`s `/agents`, `/incident_reports`,
+`/organizations`. But the Huntress public API is **no longer read-only**. Per the Huntress changelog
+"APIs for Escalations and Incident Report responses now available":
+
+- `POST /v1/incident_reports/{id}/resolution` — resolve a single incident report (all remediations
+  must be approved first). ("Create Incident Resolution.")
+- Bulk **Approve** / **Deny** Remediations for an incident report; List Remediations.
+- **Escalations API** — list, get details, resolve common escalations.
+
+Auth is unchanged from what we already do (API key pair → Basic auth, base `api.huntress.io/v1/`).
+
+**Implication:** Pillar 4's Huntress write-back is *feasible*, but it is **net-new client code** —
+`huntressClient.ts` currently has no write methods, and we don't yet sync remediations or escalations.
+So a true two-way Huntress flow is a scoped add-on, not free. S1 is already fully two-way.
+
+Sources:
+- https://feedback.huntress.com/changelog/apis-for-escalations-and-incident-report-responses-now-available
+- https://support.huntress.io/hc/en-us/articles/4780697192851-Huntress-REST-API-Overview
+- https://www.huntress.com/blog/huntress-api-is-now-in-public-beta
+
+---
+
+## The phase, as four pillars
+
+Sequence **1 → 2 → 3**, each independently shippable. **4** is a follow-on that depends on 1–2.
+
+### Pillar 1 — Device-detail EDR panel  *(highest value, reuses existing endpoints)*
+
+On the device Security tab, add an **Endpoint Protection** section distinct from the native-AV
+"Recent Threats" card:
+
+- S1 threats for the device via `GET /s1/threats?deviceId=<id>`; Huntress incidents via
+  `GET /huntress/incidents?deviceId=<id>`.
+- S1 inline actions: **Isolate / Un-isolate** (`POST /s1/isolate`) and **kill / quarantine / rollback**
+  (`POST /s1/threat-action`), each behind a confirm modal (API already enforces MFA + `devices:execute`).
+- Huntress incidents render read-only (severity / status / category / recommendation) in this phase.
+
+**Files:** `apps/web/src/components/devices/DeviceSecurityTab.tsx` (add EDR section, or extract a new
+`DeviceEdrPanel.tsx` it renders); new `apps/web/src/lib/edr.ts` shared types/fetchers; wrap all
+mutations in `runAction` per the web-mutation convention. No API changes.
+
+### Pillar 2 — Fleet EDR pages
+
+New **Security → EDR** area with two tabs:
+
+- **SentinelOne Threats** — `GET /s1/threats` with filters (severity / status / org / device / search /
+  date); row → device; inline isolate + threat-action.
+- **Huntress Incidents** — `GET /huntress/incidents` with the same filter shape; row → device; read-only.
+
+**Files:** `apps/web/src/pages/security/edr.astro`; `apps/web/src/components/security/EdrPage.tsx`
+(tab shell), `S1ThreatList.tsx`, `HuntressIncidentList.tsx`; reuse `ResponsiveTable` + severity-badge
+patterns from `ThreatList.tsx`; add a sidebar entry next to the existing Security links. No API changes.
+
+### Pillar 3 — Dashboard surfacing
+
+Add to `SecurityDashboard.tsx` (and/or the main dashboard): **open Huntress incidents**, **active S1
+threats**, **isolated-devices count**, and **EDR coverage gaps** (mapped vs. unmapped agents; devices
+with no EDR agent). The numbers already exist in `GET /huntress/status` and `GET /s1/status` — this is
+aggregation + presentation, no new query work.
+
+**Files:** `apps/web/src/components/security/SecurityDashboard.tsx`, reuse `SecurityStatCard.tsx`;
+possibly one thin `GET /security/edr-summary` aggregator if we don't want the dashboard fanning out to
+both status endpoints client-side (decision D4).
+
+### Pillar 4 — EDR → Incident escalation  *(the reframe; depends on 1–2)*
+
+Turn the starved Incident Response module into the top of the EDR funnel.
+
+- **Promote to Incident** action on an S1 threat or Huntress incident (device panel + fleet list):
+  `POST /incidents` with `relatedAlerts` / `affectedDevices` prefilled and an opening `timeline` entry.
+- **Containment logged as incident actions:** when an S1 isolate/quarantine/rollback is performed from
+  *inside* an incident, also write an `incident_actions` row (`reversible`, `approvalRef`). The IR
+  `containIncidentSchema` / `execute_containment` shape already matches the S1 action API — they just
+  aren't connected.
+- **Huntress write-back (scoped add-on, decision D3):** if we resolve a promoted Huntress incident in
+  Breeze, optionally call `POST /v1/incident_reports/{id}/resolution` (+ approve remediations) via
+  **new** write methods in `huntressClient.ts`. Requires syncing remediation state first.
+- **Optional auto-file:** on a `p1`/critical `s1.threat_detected` or `huntress.incident_created`,
+  auto-create an incident from the existing event triggers so the page gets organic inflow.
+
+**Files:** `apps/api/src/routes/incidents.ts` / `incidentActions.ts` (escalation + action-logging
+endpoints if not already sufficient); `apps/api/src/services/huntressClient.ts` (new write methods,
+D3 only); `apps/api/src/services/eventBus.ts` consumers for auto-file; web: "Promote to Incident"
+controls in the Pillar 1/2 components + `IncidentDetailPage.tsx` to show EDR-sourced evidence/actions.
+
+---
+
+## Cross-cutting requirements (apply to every pillar)
+
+- **Web mutations** wrap requests in `runAction` (`apps/web/src/lib/runAction.ts`); add any new mutation
+  handlers to the `no-silent-mutations` allowlist if they qualify.
+- **Site-scope:** `/s1/threats` and `/huntress/incidents` already enforce site-scope narrowing —
+  preserve it; don't widen via a new aggregator that bypasses it.
+- **Destructive S1 actions** keep MFA + `devices:execute`; UI adds a confirm modal, never one-click.
+- **No new tenant-scoped tables** are required for Pillars 1–3. Pillar 4 reuses existing `incidents*`
+  tables; any new Huntress remediation table (D3) follows the RLS workflow in `CLAUDE.md`.
+- **Tests:** API route tests + web component tests per the `breeze-testing` skill; Pillar 4 IR changes
+  need RLS coverage if any schema is added.
+
+---
+
+## Open decisions (resolve before Pillar 1)
+
+- **D1 — IA:** provider-specific tabs (recommended, ships faster, matches the bespoke-per-integration
+  pattern) **vs.** one unified cross-provider threat stream (S1 + Huntress + native AV). Unify later.
+- **D2 — S1 device-level isolate in this phase?** Recommended **yes**, confirm-modal + existing MFA gate.
+- **D3 — Huntress write-back scope:** (a) read-only in this phase, drive containment via Breeze/agent
+  only; **vs.** (b) build the new `huntressClient` write methods + remediation sync for true two-way.
+  Recommend **(a) for Pillars 1–3, defer (b) into Pillar 4** as an explicit sub-scope.
+- **D4 — Dashboard data path:** client fans out to both `status` endpoints **vs.** one new
+  `GET /security/edr-summary` aggregator. Recommend the aggregator if Pillar 3 widgets multiply.
+- **D5 — Auto-file incidents** on critical EDR events in this phase, or hold until promote-to-incident
+  is proven manually? Recommend **manual promote first**, auto-file as a fast follow.
+
+---
+
+## Out of scope (named, not silently dropped)
+
+- New EDR providers (Defender, CrowdStrike, Bitdefender) — framework is extensible but not this phase.
+- Huntress agent install/deploy orchestration from Breeze.
+- Rewriting the native-AV `ThreatList` / `DeviceSecurityTab` to be cross-provider (that's the D1
+  "unify" path, deferred).

--- a/docs/superpowers/plans/2026-06-25-edr-pillar1-device-panel.md
+++ b/docs/superpowers/plans/2026-06-25-edr-pillar1-device-panel.md
@@ -1,0 +1,713 @@
+# EDR Pillar 1 — Device-Detail EDR Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On the device Security tab, show this device's SentinelOne threats and Huntress incidents, and let a technician isolate/un-isolate the device and run S1 threat actions (kill/quarantine/rollback) inline — all backed by endpoints that already exist.
+
+**Architecture:** Web-only, no API changes. A new shared lib (`edr.ts`) holds typed fetchers/action-callers for the existing `/s1/*` and `/huntress/*` endpoints. A new `DeviceEdrPanel` component renders two read lists plus S1 action buttons (confirm-modal + `runAction`). It mounts inside `DeviceSecurityTab`, below the existing native-AV cards, gated behind a feature flag. The device's `orgId` is forwarded so partner-scoped (MSP) admins resolve the right tenant.
+
+**Tech Stack:** Astro + React islands, TypeScript, Vitest + jsdom, Tailwind, lucide-react. Fetch via `fetchWithAuth` (`apps/web/src/stores/auth`); mutations via `runAction` (`apps/web/src/lib/runAction`).
+
+## Global Constraints
+
+These apply to every task. Exact values, copied from the live API.
+
+**API contracts (no changes in this pillar):**
+
+- `GET /s1/threats?orgId=<uuid>&deviceId=<uuid>&limit=<n>` → `200 { data: S1Threat[], pagination: { total: number, limit: number, offset: number } }`
+  - `S1Threat = { id: string; s1ThreatId: string; orgId: string; integrationId: string; deviceId: string | null; deviceName: string | null; threatName: string; classification: string | null; severity: string | null; status: string; processName: string | null; filePath: string | null; mitreTactics: unknown; detectedAt: string; resolvedAt: string | null; updatedAt: string; details: unknown }`
+- `GET /huntress/incidents?orgId=<uuid>&deviceId=<uuid>&limit=<n>` → `200 { data: HuntressIncident[], total: number, limit: number, offset: number }` (NOTE: flat shape — `total` is top-level, NOT nested under `pagination` like S1)
+  - `HuntressIncident = { id: string; orgId: string; integrationId: string; deviceId: string | null; deviceHostname: string | null; huntressIncidentId: string; severity: string; category: string | null; title: string; description: string | null; recommendation: string | null; status: string; reportedAt: string; resolvedAt: string | null; details: unknown; createdAt: string; updatedAt: string }`
+- `POST /s1/isolate` body `{ orgId?: string; deviceIds: string[]; isolate?: boolean }` → `200 { data, warnings? }` · `404` no active integration · `403` site/MFA denied · `502 { error, data, warnings }` dispatch failed. **Requires MFA + `devices:execute`.**
+- `POST /s1/threat-action` body `{ orgId?: string; action: 'kill' | 'quarantine' | 'rollback'; threatIds: string[] }` → `200 { data, warnings? }` · `404` · `403` · `502`. **Requires MFA + `devices:execute`.** `threatIds` accepts the threat **row `id` (uuid)** — pass `threat.id`.
+
+**MFA is token-level, not per-request step-up.** `requireMfa()` returns `403 "MFA required"` only when the caller's *session* didn't satisfy MFA at login (or when `ENABLE_2FA` is off, it always passes). There is NO step-up token to attach. The UI does NOT build an MFA modal — a 403 simply surfaces as a `runAction` error toast.
+
+**orgId:** always send `?orgId=<device.orgId>`. Org-scoped users would resolve it from auth anyway, but partner-scoped (MSP) admins viewing a device in a sub-org MUST pass it. `Device.orgId` exists on the type (`apps/web/src/components/devices/DeviceList.tsx`).
+
+**Conventions:**
+- All mutations wrapped in `runAction`; catch per CLAUDE.md (401 → let auth redirect; non-401 `ActionError` already toasted).
+- Reads use `fetchWithAuth` directly (no `runAction` — they don't mutate).
+- Tests mock `fetchWithAuth` and **route by URL + method, never by call order** (positional `mockResolvedValueOnce` races the effect-load vs. click — see `web_userriskpage_toast_pollution_flake`).
+- Reuse the severity/status badge Tailwind classes already in `DeviceSecurityTab.tsx`.
+- Feature flag gates the whole panel for phased rollout, mirroring `ENABLE_ENDPOINT_AV_FEATURES`.
+
+## File Structure
+
+- Create: `apps/web/src/lib/edr.ts` — types (`S1Threat`, `HuntressIncident`), read fetchers, action callers.
+- Modify: `apps/web/src/lib/featureFlags.ts` — add `ENABLE_EDR_INTEGRATIONS`.
+- Create: `apps/web/src/components/devices/DeviceEdrPanel.tsx` — the panel.
+- Create: `apps/web/src/components/devices/DeviceEdrPanel.test.tsx` — component tests.
+- Modify: `apps/web/src/components/devices/DeviceSecurityTab.tsx` — accept `orgId`, render panel.
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx:362` — pass `orgId={device.orgId}`.
+
+---
+
+### Task 1: EDR feature flag + shared lib (types, read fetchers, action callers)
+
+**Files:**
+- Modify: `apps/web/src/lib/featureFlags.ts`
+- Create: `apps/web/src/lib/edr.ts`
+- Test: `apps/web/src/lib/edr.test.ts`
+
+**Interfaces:**
+- Produces: `ENABLE_EDR_INTEGRATIONS: boolean`; types `S1Threat`, `HuntressIncident`, `S1ThreatActionType`; functions
+  `fetchS1Threats(orgId, deviceId): Promise<S1Threat[]>`,
+  `fetchHuntressIncidents(orgId, deviceId): Promise<HuntressIncident[]>`,
+  `isolateDevice(orgId, deviceId, isolate): Promise<void>`,
+  `runS1ThreatAction(orgId, threatId, action): Promise<void>`.
+
+- [ ] **Step 1: Add the feature flag.** In `apps/web/src/lib/featureFlags.ts`, directly after the `ENABLE_ENDPOINT_AV_FEATURES` export, add:
+
+```ts
+export const ENABLE_EDR_INTEGRATIONS = parseBoolean(
+  import.meta.env.PUBLIC_ENABLE_EDR_INTEGRATIONS,
+  false,
+);
+```
+
+(Match the exact `parseBoolean(import.meta.env.X, default)` signature already used in this file — if the existing call passes no default, omit the second arg and rely on its falsy fallback.)
+
+- [ ] **Step 2: Write the failing fetcher test.** Create `apps/web/src/lib/edr.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+import { fetchS1Threats, fetchHuntressIncidents } from './edr';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('fetchS1Threats', () => {
+  it('passes orgId + deviceId and unwraps pagination shape', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 't1' }], pagination: { total: 1, limit: 100, offset: 0 } }));
+    const rows = await fetchS1Threats('org-1', 'dev-1');
+    expect(rows).toEqual([{ id: 't1' }]);
+    const url = fetchWithAuth.mock.calls[0][0] as string;
+    expect(url).toContain('/s1/threats');
+    expect(url).toContain('orgId=org-1');
+    expect(url).toContain('deviceId=dev-1');
+  });
+});
+
+describe('fetchHuntressIncidents', () => {
+  it('unwraps the flat (non-pagination) shape', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 'i1' }], total: 1, limit: 100, offset: 0 }));
+    const rows = await fetchHuntressIncidents('org-1', 'dev-1');
+    expect(rows).toEqual([{ id: 'i1' }]);
+    expect(fetchWithAuth.mock.calls[0][0]).toContain('/huntress/incidents');
+  });
+});
+```
+
+- [ ] **Step 3: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/edr.test.ts`
+Expected: FAIL — cannot resolve `./edr`.
+
+- [ ] **Step 4: Implement `edr.ts`.** Create `apps/web/src/lib/edr.ts`:
+
+```ts
+import { fetchWithAuth } from '../stores/auth';
+import { runAction } from './runAction';
+
+export type S1ThreatActionType = 'kill' | 'quarantine' | 'rollback';
+
+export interface S1Threat {
+  id: string;
+  s1ThreatId: string;
+  orgId: string;
+  integrationId: string;
+  deviceId: string | null;
+  deviceName: string | null;
+  threatName: string;
+  classification: string | null;
+  severity: string | null;
+  status: string;
+  processName: string | null;
+  filePath: string | null;
+  mitreTactics: unknown;
+  detectedAt: string;
+  resolvedAt: string | null;
+  updatedAt: string;
+  details: unknown;
+}
+
+export interface HuntressIncident {
+  id: string;
+  orgId: string;
+  integrationId: string;
+  deviceId: string | null;
+  deviceHostname: string | null;
+  huntressIncidentId: string;
+  severity: string;
+  category: string | null;
+  title: string;
+  description: string | null;
+  recommendation: string | null;
+  status: string;
+  reportedAt: string;
+  resolvedAt: string | null;
+  details: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchS1Threats(orgId: string, deviceId: string): Promise<S1Threat[]> {
+  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
+  const res = await fetchWithAuth(`/s1/threats?${params.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  return Array.isArray(body?.data) ? (body.data as S1Threat[]) : [];
+}
+
+export async function fetchHuntressIncidents(orgId: string, deviceId: string): Promise<HuntressIncident[]> {
+  const params = new URLSearchParams({ orgId, deviceId, limit: '50' });
+  const res = await fetchWithAuth(`/huntress/incidents?${params.toString()}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  return Array.isArray(body?.data) ? (body.data as HuntressIncident[]) : [];
+}
+
+export async function isolateDevice(orgId: string, deviceId: string, isolate: boolean): Promise<void> {
+  await runAction({
+    request: () =>
+      fetchWithAuth('/s1/isolate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId, deviceIds: [deviceId], isolate }),
+      }),
+    errorFallback: isolate ? 'Failed to isolate device' : 'Failed to remove isolation',
+    successMessage: isolate ? 'Device isolated' : 'Isolation removed',
+  });
+}
+
+export async function runS1ThreatAction(orgId: string, threatId: string, action: S1ThreatActionType): Promise<void> {
+  await runAction({
+    request: () =>
+      fetchWithAuth('/s1/threat-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId, action, threatIds: [threatId] }),
+      }),
+    errorFallback: `Failed to ${action} threat`,
+    successMessage: `Threat ${action} requested`,
+  });
+}
+```
+
+- [ ] **Step 5: Run test, verify it passes.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/edr.test.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/web/src/lib/featureFlags.ts apps/web/src/lib/edr.ts apps/web/src/lib/edr.test.ts
+git commit -m "feat(web): EDR shared lib + feature flag for device-level S1/Huntress"
+```
+
+---
+
+### Task 2: DeviceEdrPanel — read views (threats + incidents)
+
+**Files:**
+- Create: `apps/web/src/components/devices/DeviceEdrPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceEdrPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `fetchS1Threats`, `fetchHuntressIncidents`, `S1Threat`, `HuntressIncident` (Task 1).
+- Produces: `default function DeviceEdrPanel({ deviceId, orgId, timezone }: { deviceId: string; orgId: string; timezone?: string })`.
+
+- [ ] **Step 1: Write the failing test.** Create `apps/web/src/components/devices/DeviceEdrPanel.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+import DeviceEdrPanel from './DeviceEdrPanel';
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+// Route by URL + method — never positional (effect-load vs click race).
+function routeFetch(map: { s1?: unknown; huntress?: unknown }) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: map.s1 ?? [], pagination: { total: 0, limit: 50, offset: 0 } }));
+    if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: map.huntress ?? [], total: 0, limit: 50, offset: 0 }));
+    return Promise.resolve(ok({ data: [] }));
+  });
+}
+
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('DeviceEdrPanel', () => {
+  it('renders S1 threats and Huntress incidents for the device', async () => {
+    routeFetch({
+      s1: [{ id: 't1', threatName: 'Emotet', severity: 'high', status: 'active', filePath: 'C:/x.exe', detectedAt: '2026-06-20T00:00:00Z' }],
+      huntress: [{ id: 'i1', title: 'Suspicious persistence', severity: 'critical', status: 'open', category: 'malware', reportedAt: '2026-06-21T00:00:00Z' }],
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    expect(await screen.findByText('Emotet')).toBeInTheDocument();
+    expect(await screen.findByText('Suspicious persistence')).toBeInTheDocument();
+  });
+
+  it('shows empty states when there is no EDR data', async () => {
+    routeFetch({ s1: [], huntress: [] });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    await waitFor(() => expect(screen.getByTestId('edr-s1-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('edr-huntress-empty')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: FAIL — cannot resolve `./DeviceEdrPanel`.
+
+- [ ] **Step 3: Implement the read-only panel.** Create `apps/web/src/components/devices/DeviceEdrPanel.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, ShieldAlert, Activity } from 'lucide-react';
+import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
+import { friendlyFetchError } from '../../lib/utils';
+import {
+  fetchS1Threats,
+  fetchHuntressIncidents,
+  type S1Threat,
+  type HuntressIncident,
+} from '../../lib/edr';
+
+const severityBadge: Record<string, string> = {
+  low: 'bg-blue-500/20 text-blue-700 border-blue-500/30',
+  medium: 'bg-yellow-500/20 text-yellow-800 border-yellow-500/40',
+  high: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
+  critical: 'bg-red-500/20 text-red-700 border-red-500/40',
+};
+
+function sevClass(sev: string | null): string {
+  return severityBadge[(sev ?? '').toLowerCase()] ?? 'bg-muted text-muted-foreground border-border';
+}
+
+function fmt(value: string | null, timezone?: string): string {
+  if (!value) return '-';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '-' : formatUserDateTime(d, timezone ? { timeZone: timezone } : undefined);
+}
+
+type Props = { deviceId: string; orgId: string; timezone?: string };
+
+export default function DeviceEdrPanel({ deviceId, orgId, timezone }: Props) {
+  const [threats, setThreats] = useState<S1Threat[]>([]);
+  const [incidents, setIncidents] = useState<HuntressIncident[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const [s1, hi] = await Promise.all([
+        fetchS1Threats(orgId, deviceId),
+        fetchHuntressIncidents(orgId, deviceId),
+      ]);
+      setThreats(s1);
+      setIncidents(hi);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, deviceId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="device-edr-panel">
+      <div className="mb-4 flex items-center gap-2">
+        <ShieldAlert className="h-4 w-4 text-primary" />
+        <h3 className="text-lg font-semibold">Endpoint Protection (EDR)</h3>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* SentinelOne threats */}
+        <div>
+          <h4 className="mb-3 text-sm font-semibold">SentinelOne Threats</h4>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading…</div>
+          ) : threats.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="edr-s1-empty">No SentinelOne threats for this device.</p>
+          ) : (
+            <div className="space-y-3">
+              {threats.map((t) => (
+                <div key={t.id} className="rounded-md border bg-background p-3" data-testid="edr-s1-row">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium">{t.threatName}</p>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(t.severity)}`}>{t.severity ?? 'unknown'}</span>
+                      <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{t.status}</span>
+                    </div>
+                  </div>
+                  {t.filePath && <p className="mt-1 text-xs text-muted-foreground" title={t.filePath}>{t.filePath}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground">Detected: {fmt(t.detectedAt, timezone)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Huntress incidents (read-only this pillar) */}
+        <div>
+          <h4 className="mb-3 flex items-center gap-2 text-sm font-semibold"><Activity className="h-4 w-4" />Huntress Incidents</h4>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading…</div>
+          ) : incidents.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="edr-huntress-empty">No Huntress incidents for this device.</p>
+          ) : (
+            <div className="space-y-3">
+              {incidents.map((i) => (
+                <div key={i.id} className="rounded-md border bg-background p-3" data-testid="edr-huntress-row">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium">{i.title}</p>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${sevClass(i.severity)}`}>{i.severity}</span>
+                      <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border-border">{i.status}</span>
+                    </div>
+                  </div>
+                  {i.recommendation && <p className="mt-1 text-xs text-muted-foreground">{i.recommendation}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground">Reported: {fmt(i.reportedAt, timezone)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/web/src/components/devices/DeviceEdrPanel.tsx apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+git commit -m "feat(web): device EDR panel — S1 threats + Huntress incidents read views"
+```
+
+---
+
+### Task 3: S1 isolate / un-isolate with confirm modal
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceEdrPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceEdrPanel.test.tsx` (add cases)
+
+**Interfaces:**
+- Consumes: `isolateDevice(orgId, deviceId, isolate)` (Task 1).
+
+- [ ] **Step 1: Write the failing test.** Append to `DeviceEdrPanel.test.tsx`:
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+describe('DeviceEdrPanel isolate', () => {
+  it('confirms then POSTs /s1/isolate with the device id', async () => {
+    let isolateBody: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [], pagination: { total: 0, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/s1/isolate') { isolateBody = JSON.parse(String(init?.body)); return Promise.resolve(ok({ data: {} })); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-isolate-btn'));
+    // confirm modal
+    fireEvent.click(await screen.findByTestId('edr-isolate-confirm'));
+    await waitFor(() => expect(isolateBody).toEqual({ orgId: 'org-1', deviceIds: ['dev-1'], isolate: true }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx -t isolate`
+Expected: FAIL — no `edr-isolate-btn`.
+
+- [ ] **Step 3: Add isolate state + confirm modal + handler.** In `DeviceEdrPanel.tsx`: import `isolateDevice` and `ActionError` (`import { ActionError } from '../../lib/runAction';`), add state and handler inside the component:
+
+```tsx
+  const [confirmIsolate, setConfirmIsolate] = useState(false);
+  const [isolating, setIsolating] = useState(false);
+
+  const doIsolate = async () => {
+    setIsolating(true);
+    try {
+      await isolateDevice(orgId, deviceId, true);
+      setConfirmIsolate(false);
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return; // auth redirect handles it
+      // non-401 ActionError already toasted by runAction
+    } finally {
+      setIsolating(false);
+    }
+  };
+```
+
+Add an **Isolate device** button to the panel header (next to the `<h3>`), and a confirm modal at the end of the returned JSX:
+
+```tsx
+{/* header button — place beside the EDR title */}
+<button
+  type="button"
+  data-testid="edr-isolate-btn"
+  onClick={() => setConfirmIsolate(true)}
+  className="ml-auto inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+>
+  Isolate device
+</button>
+
+{/* confirm modal — append before the panel's closing </div> */}
+{confirmIsolate && (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+    <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+      <h4 className="text-base font-semibold">Isolate this device?</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        SentinelOne will cut the device off the network until you remove isolation. Active sessions will drop.
+      </p>
+      <div className="mt-4 flex justify-end gap-2">
+        <button type="button" onClick={() => setConfirmIsolate(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
+        <button
+          type="button"
+          data-testid="edr-isolate-confirm"
+          onClick={doIsolate}
+          disabled={isolating}
+          className="inline-flex items-center gap-2 rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:opacity-90 disabled:opacity-60"
+        >
+          {isolating && <Loader2 className="h-4 w-4 animate-spin" />}Isolate
+        </button>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+(To anchor the header button with `ml-auto`, wrap the title row in a `flex` container — the existing `<div className="mb-4 flex items-center gap-2">` already is a flex row; the button as a sibling with `ml-auto` will push right.)
+
+- [ ] **Step 4: Run test, verify it passes.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/web/src/components/devices/DeviceEdrPanel.tsx apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+git commit -m "feat(web): S1 isolate device action with confirm modal"
+```
+
+---
+
+### Task 4: S1 threat actions (kill / quarantine / rollback) per threat row
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceEdrPanel.tsx`
+- Test: `apps/web/src/components/devices/DeviceEdrPanel.test.tsx` (add case)
+
+**Interfaces:**
+- Consumes: `runS1ThreatAction(orgId, threatId, action)`, `S1ThreatActionType` (Task 1).
+
+- [ ] **Step 1: Write the failing test.** Append to `DeviceEdrPanel.test.tsx`:
+
+```tsx
+describe('DeviceEdrPanel threat actions', () => {
+  it('POSTs /s1/threat-action with the threat row id', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', threatName: 'Emotet', severity: 'high', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/s1/threat-action') { body = JSON.parse(String(init?.body)); return Promise.resolve(ok({ data: {} })); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-threat-quarantine-t1'));
+    await waitFor(() => expect(body).toEqual({ orgId: 'org-1', action: 'quarantine', threatIds: ['t1'] }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx -t "threat actions"`
+Expected: FAIL — no `edr-threat-quarantine-t1`.
+
+- [ ] **Step 3: Add a per-threat action handler + buttons.** In `DeviceEdrPanel.tsx`: import `runS1ThreatAction` and `S1ThreatActionType`, add:
+
+```tsx
+  const [actingId, setActingId] = useState<string | null>(null);
+
+  const doThreatAction = async (threatId: string, action: S1ThreatActionType) => {
+    setActingId(threatId);
+    try {
+      await runS1ThreatAction(orgId, threatId, action);
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+    } finally {
+      setActingId(null);
+    }
+  };
+```
+
+In the S1 threat row JSX, after the `Detected:` line, add an action row (only for active threats):
+
+```tsx
+{t.status === 'active' && (
+  <div className="mt-3 flex flex-wrap items-center gap-2">
+    {(['kill', 'quarantine', 'rollback'] as const).map((action) => (
+      <button
+        key={action}
+        type="button"
+        data-testid={`edr-threat-${action}-${t.id}`}
+        onClick={() => doThreatAction(t.id, action)}
+        disabled={actingId === t.id}
+        className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium capitalize hover:bg-muted disabled:opacity-60"
+      >
+        {actingId === t.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{action}
+      </button>
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Run test, verify it passes.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/web/src/components/devices/DeviceEdrPanel.tsx apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+git commit -m "feat(web): S1 per-threat kill/quarantine/rollback actions"
+```
+
+---
+
+### Task 5: Mount the panel in DeviceSecurityTab + pass orgId from DeviceDetails
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceSecurityTab.tsx`
+- Modify: `apps/web/src/components/devices/DeviceDetails.tsx` (line ~362)
+- Test: `apps/web/src/components/devices/DeviceSecurityTab.test.tsx` (add case)
+
+**Interfaces:**
+- Consumes: `DeviceEdrPanel` (Tasks 2–4), `ENABLE_EDR_INTEGRATIONS` (Task 1).
+- `DeviceSecurityTab` gains an `orgId: string` prop.
+
+- [ ] **Step 1: Write the failing test.** Add to `DeviceSecurityTab.test.tsx` a case asserting the EDR panel renders when the flag is on. Mock the flag module and `DeviceEdrPanel`:
+
+```tsx
+vi.mock('../../lib/featureFlags', async (orig) => ({
+  ...(await orig<typeof import('../../lib/featureFlags')>()),
+  ENABLE_EDR_INTEGRATIONS: true,
+}));
+vi.mock('./DeviceEdrPanel', () => ({ default: ({ orgId }: { orgId: string }) => <div data-testid="edr-panel-stub">{orgId}</div> }));
+
+it('renders the EDR panel with the device orgId when the flag is on', async () => {
+  // ...existing render of DeviceSecurityTab with deviceId="dev-1" orgId="org-9"...
+  render(<DeviceSecurityTab deviceId="dev-1" orgId="org-9" />);
+  expect(await screen.findByTestId('edr-panel-stub')).toHaveTextContent('org-9');
+});
+```
+
+(Reuse the file's existing `fetchWithAuth` mock + render harness; only the flag mock, the `DeviceEdrPanel` mock, and the new `orgId` prop are new.)
+
+- [ ] **Step 2: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceSecurityTab.test.tsx -t "EDR panel"`
+Expected: FAIL — `DeviceSecurityTab` doesn't accept `orgId` / doesn't render the panel.
+
+- [ ] **Step 3: Wire the panel into DeviceSecurityTab.** In `DeviceSecurityTab.tsx`:
+  - Add `import { ENABLE_EDR_INTEGRATIONS } from '../../lib/featureFlags';` and `import DeviceEdrPanel from './DeviceEdrPanel';`.
+  - Change the props type to `type DeviceSecurityTabProps = { deviceId: string; orgId: string; timezone?: string };` and destructure `orgId`.
+  - Render the panel inside the returned `<div className="space-y-6">`, after `<DeviceSecurityStatus ... />` and before the native "Security Operations" card:
+
+```tsx
+{ENABLE_EDR_INTEGRATIONS && <DeviceEdrPanel deviceId={deviceId} orgId={orgId} timezone={timezone} />}
+```
+
+  - Apply the same gate in the early-return branch (`if (!ENABLE_ENDPOINT_AV_FEATURES)`) so the EDR panel still shows when native-AV features are off:
+
+```tsx
+if (!ENABLE_ENDPOINT_AV_FEATURES) {
+  return (
+    <div className="space-y-6">
+      <DeviceSecurityStatus deviceId={deviceId} showAvActions={false} />
+      {ENABLE_EDR_INTEGRATIONS && <DeviceEdrPanel deviceId={deviceId} orgId={orgId} timezone={timezone} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Pass orgId from DeviceDetails.** In `DeviceDetails.tsx:362`, change:
+
+```tsx
+<DeviceSecurityTab deviceId={device.id} timezone={effectiveTimezone} />
+```
+
+to:
+
+```tsx
+<DeviceSecurityTab deviceId={device.id} orgId={device.orgId} timezone={effectiveTimezone} />
+```
+
+- [ ] **Step 5: Run the device test suite, verify it passes.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceSecurityTab.test.tsx src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/devices/DeviceSecurityTab.tsx apps/web/src/components/devices/DeviceSecurityTab.test.tsx apps/web/src/components/devices/DeviceDetails.tsx
+git commit -m "feat(web): mount EDR panel in device security tab behind ENABLE_EDR_INTEGRATIONS"
+```
+
+---
+
+## Verification (end of pillar)
+
+- [ ] `pnpm --filter @breeze/web exec vitest run src/components/devices src/lib/edr.test.ts` — all green.
+- [ ] `pnpm --filter @breeze/web exec tsc --noEmit` — clean.
+- [ ] Manual (local stack, `PUBLIC_ENABLE_EDR_INTEGRATIONS=true`): open a device with synced S1/Huntress data → EDR panel lists threats + incidents; isolate shows confirm modal then toasts; a `kill` on an active threat toasts and reloads. With a non-MFA session, the action toasts "MFA required" (403) rather than failing silently.
+- [ ] `no-silent-mutations` test passes (mutations route through `runAction`): `pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts`.
+
+## Notes for the next pillars
+
+- Fleet pages (Pillar 2) reuse `edr.ts` fetchers — generalize them to accept a filter object `{ orgId?, deviceId?, status?, severity?, search?, limit?, offset? }` and return the pagination total when Pillar 2 needs paging.
+- "Promote to Incident" (Pillar 4) hangs off these same rows — keep `S1Threat.id` / `HuntressIncident.id` and `huntressIncidentId` in the row props so the escalation call has the identifiers it needs.

--- a/docs/superpowers/plans/2026-06-25-edr-pillar2-fleet-pages.md
+++ b/docs/superpowers/plans/2026-06-25-edr-pillar2-fleet-pages.md
@@ -1,0 +1,570 @@
+# EDR Pillar 2 — Fleet EDR Pages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A Security → EDR area with two hash-routed tabs — **SentinelOne Threats** and **Huntress Incidents** — listing the partner's fleet (all customer orgs) with filters, row→device navigation, and inline S1 threat actions. Consumes existing endpoints plus one small additive API change so SentinelOne can list partner-wide like Huntress already does.
+
+**Architecture:** One backend change (`GET /s1/threats` gains a partner-wide branch mirroring the existing `GET /huntress/incidents` pattern). Web: generalize the `edr.ts` fetchers to a filter object returning `{ rows, total }`; add an `EdrPage` tab shell (hash routing), two list components reusing `ResponsiveTable`/badge patterns from `ThreatList.tsx`, an astro page, and a Sidebar entry.
+
+**Tech Stack:** Hono + Drizzle (API), Astro + React islands + Tailwind (web), Vitest (both).
+
+## Global Constraints
+
+**Decision (from phase brainstorm):** Option A — partner-wide S1 via a small API change, NOT an org-selector. Both tabs list partner-wide by default; org-scoped users auto-scope to their org; `orgId` is an optional filter.
+
+**API contracts after this pillar:**
+- `GET /s1/threats` accepts `{ partnerId?, orgId?, integrationId?, deviceId?, status?, severity?, search?, start?, end?, limit?(1-500,def 100), offset?(>=0) }` → `{ data: S1Threat[], pagination: { total, limit, offset } }`. After Task 1: a **partner-scoped** caller with no `orgId` (and >1 accessible org) gets threats across all the partner's active-integration orgs instead of a 400.
+- `GET /huntress/incidents` (unchanged) accepts `{ partnerId?, orgId?, integrationId?, status?, severity?, deviceId?, search?, limit?, offset? }` → `{ data: HuntressIncident[], total, limit, offset }` (flat — note: NO `pagination` wrapper, unlike S1). Already partner-wide.
+- `POST /s1/threat-action` body `{ orgId?, action: 'kill'|'quarantine'|'rollback', threatIds: [rowId] }`; MFA + `devices:execute`. (Reused from Pillar 1 via `runS1ThreatAction`.)
+
+**Tenancy/RLS (Task 1 is security-sensitive):** `s1_threats` is org-axis RLS (`breeze_has_org_access(org_id)`). The partner-wide read does NOT change the table's tenancy shape — it relies on the SAME `auth.orgCondition(s1Threats.orgId)` filter the handler already applies (line 626) plus an `integrationId IN (partner's active integrations)` narrowing. This mirrors `huntress.ts` `GET /incidents` lines 865-882 verbatim in shape. No new table, no allowlist change; `rls-coverage.integration.test.ts` must stay green unchanged.
+
+**Conventions:** mutations through `runAction`; reads via `fetchWithAuth`; tab/sub-tab state in `window.location.hash` (NOT query params); tests mock fetch by URL+method (not positional); `ResponsiveTable` renders desktop+mobile (scope assertions to `responsive-table-desktop` to avoid the jsdom dup-render gotcha); files ~500 lines soft cap.
+
+## File Structure
+- Modify: `apps/api/src/routes/sentinelOne.ts` (GET /threats partner-wide branch) + `apps/api/src/routes/sentinelOne.test.ts`.
+- Modify: `apps/web/src/lib/edr.ts` (+ `edr.test.ts`) — filter-object fetchers returning `{ rows, total }`; update Pillar 1 `DeviceEdrPanel.tsx` callers + its test.
+- Create: `apps/web/src/components/security/EdrPage.tsx` (+ test), `S1ThreatList.tsx` (+ test), `HuntressIncidentList.tsx` (+ test).
+- Create: `apps/web/src/pages/security/edr.astro`.
+- Modify: `apps/web/src/components/layout/Sidebar.tsx` (Security → EDR entry).
+
+---
+
+### Task 1: `GET /s1/threats` partner-wide branch (API)
+
+**Files:**
+- Modify: `apps/api/src/routes/sentinelOne.ts` — the `GET /threats` handler (lines 601-710).
+- Test: `apps/api/src/routes/sentinelOne.test.ts`.
+
+**Interfaces:**
+- Produces: `/s1/threats` returns partner-wide rows for partner-scoped callers without `orgId`. Org-scoped behavior unchanged.
+
+**Context — the template to mirror** is `apps/api/src/routes/huntress.ts` GET `/incidents` (lines 840-882): it computes a nullable `scopedOrgId`, and when there's no org scope but the caller is partner-scoped, it resolves the partner's active integrations and pushes `inArray(<table>.integrationId, integrationIds)` plus `auth.orgCondition`. Read it before editing.
+
+- [ ] **Step 1: Write the failing test.** In `sentinelOne.test.ts`, mirror the existing `GET /threats` org-scope test (find it; copy its app/mock/auth harness). Add a partner-scope case:
+
+```ts
+it('GET /threats lists across all partner orgs for a partner-scoped caller without orgId', async () => {
+  // auth: scope 'partner', partnerId set, accessibleOrgIds = [orgA, orgB] (>1 so the old code would 400)
+  // mock: two active s1_integrations for the partner; s1_threats rows in orgA and orgB
+  const res = await app.request('/threats', { headers: partnerAuthHeaders });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // both orgs' threats returned (no 400 'orgId is required')
+  expect(body.data.map((t: any) => t.orgId).sort()).toEqual([orgA, orgB].sort());
+});
+```
+
+Also keep/confirm an org-scope case still returns only that org's rows. Match the file's existing mock style for `db.select(...).from(s1Threats)` exactly — do not invent a new harness.
+
+- [ ] **Step 2: Run test, verify it fails.**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/sentinelOne.test.ts -t "partner orgs"`
+Expected: FAIL (400 "orgId is required for this scope").
+
+- [ ] **Step 3: Implement the partner-wide branch.** In the `GET /threats` handler, replace the unconditional `resolveOrgId` + single-org pin with a Huntress-shaped branch. The current head is:
+
+```ts
+const auth = c.get('auth');
+const query = c.req.valid('query');
+const orgResult = resolveOrgId(auth, query.orgId);
+if ('error' in orgResult) {
+  return c.json({ error: orgResult.error }, orgResult.status);
+}
+// ... timestamp validation ...
+const conditions: SQL[] = [eq(s1Threats.orgId, orgResult.orgId)];
+withOrgCondition(conditions, auth.orgCondition(s1Threats.orgId));
+```
+
+Change it to compute an optional org scope and branch (mirror huntress.ts:840-882):
+
+```ts
+const auth = c.get('auth');
+const query = c.req.valid('query');
+
+// Org scope when the caller is org-scoped or explicitly asked for one org.
+const requestedOrg = query.orgId;
+const wantsOrgScope = requestedOrg || auth.scope === 'organization';
+const orgResult = wantsOrgScope ? resolveOrgId(auth, requestedOrg) : null;
+if (orgResult && 'error' in orgResult) {
+  return c.json({ error: orgResult.error }, orgResult.status);
+}
+const scopedOrgId = orgResult && 'orgId' in orgResult ? orgResult.orgId : null;
+
+// ... keep the existing start/end timestamp validation here ...
+
+const conditions: SQL[] = [];
+if (scopedOrgId) {
+  conditions.push(eq(s1Threats.orgId, scopedOrgId));
+}
+withOrgCondition(conditions, auth.orgCondition(s1Threats.orgId));
+
+// Partner-wide: no single org → restrict to the partner's active integrations.
+if (!scopedOrgId) {
+  const partnerResult = resolvePartnerId(auth, query.partnerId);
+  if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
+  const integrations = await db
+    .select({ id: s1Integrations.id })
+    .from(s1Integrations)
+    .where(and(eq(s1Integrations.partnerId, partnerResult.partnerId), eq(s1Integrations.isActive, true)));
+  const integrationIds = integrations.map((i) => i.id);
+  if (integrationIds.length === 0) {
+    return c.json({ data: [], pagination: { total: 0, limit: query.limit ?? 100, offset: query.offset ?? 0 } });
+  }
+  conditions.push(inArray(s1Threats.integrationId, integrationIds));
+}
+```
+
+Then the **site-scope narrowing block** (the `if (perms?.allowedSiteIds)` section) must only run when `scopedOrgId` is set — site restriction is an org-user concept and `resolveSiteAllowedDeviceIds` needs an orgId. Guard it: `if (perms?.allowedSiteIds && scopedOrgId) { ... resolveSiteAllowedDeviceIds(scopedOrgId, perms) ... }`. Leave the rest of the handler (filters, query, response) unchanged — it already reads `query.integrationId/deviceId/status/severity/start/end/search` and returns `{ data, pagination }`.
+
+- [ ] **Step 4: Run test, verify it passes.**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/sentinelOne.test.ts`
+Expected: PASS (new partner case + existing org cases).
+
+- [ ] **Step 5: Confirm RLS coverage unaffected.**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: clean. (No schema/tenancy change → `rls-coverage` allowlists need no edit; do not modify that test.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/api/src/routes/sentinelOne.ts apps/api/src/routes/sentinelOne.test.ts
+git commit -m "feat(api): partner-wide GET /s1/threats (mirror huntress incidents fleet listing)"
+```
+
+---
+
+### Task 2: Generalize `edr.ts` fetchers to filter objects (and update Pillar 1)
+
+**Files:**
+- Modify: `apps/web/src/lib/edr.ts`, `apps/web/src/lib/edr.test.ts`.
+- Modify: `apps/web/src/components/devices/DeviceEdrPanel.tsx` (callers), `apps/web/src/components/devices/DeviceEdrPanel.test.tsx` (mock URLs unchanged, but verify).
+
+**Interfaces:**
+- Produces:
+  `type S1ThreatFilters = { orgId?: string; deviceId?: string; status?: string; severity?: string; search?: string; start?: string; end?: string; limit?: number; offset?: number }`
+  `type HuntressIncidentFilters = { orgId?: string; deviceId?: string; status?: string; severity?: string; search?: string; limit?: number; offset?: number }`
+  `fetchS1Threats(filters: S1ThreatFilters): Promise<{ rows: S1Threat[]; total: number }>`
+  `fetchHuntressIncidents(filters: HuntressIncidentFilters): Promise<{ rows: HuntressIncident[]; total: number }>`
+  (`isolateDevice`, `runS1ThreatAction` unchanged.)
+
+- [ ] **Step 1: Update the fetcher unit tests.** In `edr.test.ts`, change the two fetcher tests to the new shape:
+
+```ts
+it('passes filters and returns { rows, total } from the pagination shape', async () => {
+  fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 't1' }], pagination: { total: 5, limit: 100, offset: 0 } }));
+  const { rows, total } = await fetchS1Threats({ orgId: 'org-1', deviceId: 'dev-1' });
+  expect(rows).toEqual([{ id: 't1' }]);
+  expect(total).toBe(5);
+  const url = fetchWithAuth.mock.calls[0][0] as string;
+  expect(url).toContain('/s1/threats');
+  expect(url).toContain('orgId=org-1');
+  expect(url).toContain('deviceId=dev-1');
+});
+
+it('reads { rows, total } from the Huntress flat shape and omits empty filters', async () => {
+  fetchWithAuth.mockResolvedValue(ok({ data: [{ id: 'i1' }], total: 3, limit: 100, offset: 0 }));
+  const { rows, total } = await fetchHuntressIncidents({ severity: 'high' });
+  expect(rows).toEqual([{ id: 'i1' }]);
+  expect(total).toBe(3);
+  const url = fetchWithAuth.mock.calls[0][0] as string;
+  expect(url).toContain('/huntress/incidents');
+  expect(url).toContain('severity=high');
+  expect(url).not.toContain('orgId='); // undefined filters are omitted
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/edr.test.ts`
+Expected: FAIL (old signature).
+
+- [ ] **Step 3: Refactor the fetchers.** Replace the two fetcher bodies in `edr.ts`:
+
+```ts
+export interface S1ThreatFilters {
+  orgId?: string; deviceId?: string; status?: string; severity?: string;
+  search?: string; start?: string; end?: string; limit?: number; offset?: number;
+}
+export interface HuntressIncidentFilters {
+  orgId?: string; deviceId?: string; status?: string; severity?: string;
+  search?: string; limit?: number; offset?: number;
+}
+
+function toParams(filters: Record<string, string | number | undefined>): string {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(filters)) {
+    if (v !== undefined && v !== '') p.set(k, String(v));
+  }
+  return p.toString();
+}
+
+export async function fetchS1Threats(filters: S1ThreatFilters = {}): Promise<{ rows: S1Threat[]; total: number }> {
+  const qs = toParams({ limit: 100, ...filters });
+  const res = await fetchWithAuth(`/s1/threats?${qs}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  if (!Array.isArray(body?.data)) { console.warn('[edr] /s1/threats returned non-array data'); return { rows: [], total: 0 }; }
+  return { rows: body.data as S1Threat[], total: Number(body?.pagination?.total ?? body.data.length) };
+}
+
+// Huntress returns a FLAT { data, total, limit, offset } envelope (not the S1 { data, pagination } shape).
+export async function fetchHuntressIncidents(filters: HuntressIncidentFilters = {}): Promise<{ rows: HuntressIncident[]; total: number }> {
+  const qs = toParams({ limit: 100, ...filters });
+  const res = await fetchWithAuth(`/huntress/incidents?${qs}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = await res.json();
+  if (!Array.isArray(body?.data)) { console.warn('[edr] /huntress/incidents returned non-array data'); return { rows: [], total: 0 }; }
+  return { rows: body.data as HuntressIncident[], total: Number(body?.total ?? body.data.length) };
+}
+```
+
+- [ ] **Step 4: Update the Pillar 1 panel callers.** In `DeviceEdrPanel.tsx` `load()`, change:
+
+```ts
+const [s1, hi] = await Promise.all([
+  fetchS1Threats(orgId, deviceId),
+  fetchHuntressIncidents(orgId, deviceId),
+]);
+setThreats(s1);
+setIncidents(hi);
+```
+
+to:
+
+```ts
+const [s1, hi] = await Promise.all([
+  fetchS1Threats({ orgId, deviceId, limit: 50 }),
+  fetchHuntressIncidents({ orgId, deviceId, limit: 50 }),
+]);
+setThreats(s1.rows);
+setIncidents(hi.rows);
+```
+
+- [ ] **Step 5: Run web suites, verify green.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/edr.test.ts src/components/devices/DeviceEdrPanel.test.tsx`
+Expected: PASS. (The panel tests mock `fetchWithAuth` by URL; URLs still contain `orgId`+`deviceId`, so they pass unchanged.)
+Run: `pnpm --filter @breeze/web exec tsc --noEmit` → clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/web/src/lib/edr.ts apps/web/src/lib/edr.test.ts apps/web/src/components/devices/DeviceEdrPanel.tsx
+git commit -m "refactor(web): edr fetchers take filter objects, return { rows, total }"
+```
+
+---
+
+### Task 3: EdrPage tab shell + astro page + Sidebar entry
+
+**Files:**
+- Create: `apps/web/src/components/security/EdrPage.tsx`, `apps/web/src/components/security/EdrPage.test.tsx`.
+- Create: `apps/web/src/pages/security/edr.astro`.
+- Modify: `apps/web/src/components/layout/Sidebar.tsx`.
+
+**Interfaces:**
+- Consumes (Tasks 4-5, may be stubbed until then): `S1ThreatList`, `HuntressIncidentList` (default exports, no required props).
+- Produces: `default function EdrPage()` with hash-routed tabs `'sentinelone' | 'huntress'`.
+
+- [ ] **Step 1: Write the failing test.** `EdrPage.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('./S1ThreatList', () => ({ default: () => <div data-testid="s1-list" /> }));
+vi.mock('./HuntressIncidentList', () => ({ default: () => <div data-testid="huntress-list" /> }));
+import EdrPage from './EdrPage';
+
+describe('EdrPage', () => {
+  it('defaults to the SentinelOne tab and switches to Huntress', () => {
+    render(<EdrPage />);
+    expect(screen.getByTestId('s1-list')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('edr-tab-huntress'));
+    expect(screen.getByTestId('huntress-list')).toBeInTheDocument();
+    expect(window.location.hash).toBe('#huntress');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** (`cannot resolve ./EdrPage`).
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrPage.test.tsx`
+
+- [ ] **Step 3: Implement EdrPage.** Use the hash pattern from `DeviceDetails.tsx` (read on mount, `hashchange` listener, write on switch):
+
+```tsx
+import { useEffect, useState } from 'react';
+import { ShieldAlert, Activity } from 'lucide-react';
+import S1ThreatList from './S1ThreatList';
+import HuntressIncidentList from './HuntressIncidentList';
+
+type EdrTab = 'sentinelone' | 'huntress';
+const TABS: { id: EdrTab; label: string; testid: string }[] = [
+  { id: 'sentinelone', label: 'SentinelOne Threats', testid: 'edr-tab-sentinelone' },
+  { id: 'huntress', label: 'Huntress Incidents', testid: 'edr-tab-huntress' },
+];
+
+function tabFromHash(): EdrTab {
+  if (typeof window === 'undefined') return 'sentinelone';
+  const h = window.location.hash.replace(/^#/, '');
+  return h === 'huntress' ? 'huntress' : 'sentinelone';
+}
+
+export default function EdrPage() {
+  const [activeTab, setActiveTab] = useState<EdrTab>(tabFromHash);
+  useEffect(() => {
+    const onHash = () => setActiveTab(tabFromHash());
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+  const switchTab = (t: EdrTab) => { window.location.hash = t; setActiveTab(t); };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Endpoint Detection &amp; Response</h1>
+        <p className="text-sm text-muted-foreground">Threats and incidents across your fleet from SentinelOne and Huntress.</p>
+      </div>
+      <div className="flex gap-2 border-b">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            data-testid={t.testid}
+            onClick={() => switchTab(t.id)}
+            className={`flex items-center gap-2 border-b-2 px-3 py-2 text-sm font-medium ${activeTab === t.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+          >
+            {t.id === 'sentinelone' ? <ShieldAlert className="h-4 w-4" /> : <Activity className="h-4 w-4" />}
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === 'sentinelone' ? <S1ThreatList /> : <HuntressIncidentList />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create stubs so the shell compiles + test passes.** Create minimal `S1ThreatList.tsx` and `HuntressIncidentList.tsx` (replaced in Tasks 4-5):
+
+```tsx
+export default function S1ThreatList() { return <div data-testid="s1-list" />; }
+```
+```tsx
+export default function HuntressIncidentList() { return <div data-testid="huntress-list" />; }
+```
+
+- [ ] **Step 5: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Create the astro page.** `apps/web/src/pages/security/edr.astro` (mirror `vulnerabilities.astro`):
+
+```astro
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import EdrPage from '../../components/security/EdrPage';
+import Breadcrumbs from '../../components/layout/Breadcrumbs';
+---
+
+<DashboardLayout title="EDR">
+  <Breadcrumbs client:load items={[{ label: 'Security', href: '/security' }, { label: 'EDR' }]} />
+  <EdrPage client:load />
+</DashboardLayout>
+```
+
+- [ ] **Step 7: Add the Sidebar entry.** In `Sidebar.tsx`, in the `security` section `items` array, add after the `'Security'` entry:
+
+```tsx
+{ name: 'EDR', href: '/security/edr', icon: ShieldAlert, requiredPermission: { resource: 'devices', action: 'read' } },
+```
+
+Ensure `ShieldAlert` is imported from `lucide-react` (add to the existing import if absent).
+
+- [ ] **Step 8: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/EdrPage.tsx apps/web/src/components/security/EdrPage.test.tsx apps/web/src/components/security/S1ThreatList.tsx apps/web/src/components/security/HuntressIncidentList.tsx apps/web/src/pages/security/edr.astro apps/web/src/components/layout/Sidebar.tsx
+git commit -m "feat(web): EDR page shell (hash tabs) + astro route + sidebar entry"
+```
+
+---
+
+### Task 4: S1ThreatList — fleet SentinelOne threats with filters + actions
+
+**Files:**
+- Modify: `apps/web/src/components/security/S1ThreatList.tsx` (replace the stub).
+- Test: `apps/web/src/components/security/S1ThreatList.test.tsx`.
+
+**Interfaces:**
+- Consumes: `fetchS1Threats` (filter object → `{ rows, total }`), `runS1ThreatAction`, `S1Threat`, `S1ThreatActionType` (Task 2 / Pillar 1), `navigateTo` (`@/lib/navigation`).
+
+**Template:** mirror `apps/web/src/components/security/ThreatList.tsx` for the `ResponsiveTable` desktop/cards scaffolding and the search/severity/status filter controls. Read it.
+
+- [ ] **Step 1: Write the failing test.** `S1ThreatList.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
+import S1ThreatList from './S1ThreatList';
+
+function ok(b: unknown) { return { ok: true, status: 200, json: async () => b } as Response; }
+beforeEach(() => { fetchWithAuth.mockReset(); navigateTo.mockReset(); });
+
+describe('S1ThreatList', () => {
+  it('lists threats and navigates to the device on row click', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', deviceId: 'dev-9', deviceName: 'PC-1', threatName: 'Emotet', severity: 'high', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 100, offset: 0 } }));
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<S1ThreatList />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+    expect(within(desktop).getByText('Emotet')).toBeInTheDocument();
+    fireEvent.click(within(desktop).getByTestId('s1-row-t1'));
+    expect(navigateTo).toHaveBeenCalledWith('/devices/dev-9');
+  });
+
+  it('sends the severity filter in the query', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [], pagination: { total: 0, limit: 100, offset: 0 } }));
+    render(<S1ThreatList />);
+    fireEvent.change(await screen.findByTestId('s1-filter-severity'), { target: { value: 'critical' } });
+    await waitFor(() => expect((fetchWithAuth.mock.calls.at(-1)?.[0] as string)).toContain('severity=critical'));
+  });
+
+  it('POSTs a threat action with the row id', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', deviceId: 'dev-9', threatName: 'X', severity: 'high', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 100, offset: 0 } }));
+      if (url === '/s1/threat-action') { body = JSON.parse(String(init?.body)); return Promise.resolve(ok({ data: {} })); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<S1ThreatList />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+    fireEvent.click(within(desktop).getByTestId('s1-threat-quarantine-t1'));
+    await waitFor(() => expect(body).toEqual({ orgId: undefined, action: 'quarantine', threatIds: ['t1'] }));
+  });
+});
+```
+
+(Note: `orgId: undefined` — the fleet list passes no orgId; the threat's own org is resolved server-side from the threat row. If `runS1ThreatAction` requires an orgId, pass `threat.orgId` instead and update this assertion to that value. Confirm against the Pillar 1 `runS1ThreatAction` signature: `runS1ThreatAction(orgId, threatId, action)` — so pass `threat.orgId` and assert `orgId: 'org-...'`. Use the threat's `orgId` field.)
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/S1ThreatList.test.tsx`
+Expected: FAIL (stub renders nothing).
+
+- [ ] **Step 3: Implement S1ThreatList.** Mirror `ThreatList.tsx` structure. Requirements:
+  - State: `rows: S1Threat[]`, `loading`, `error`, `total`, and filters `search`, `severity` ('all'|low|medium|high|critical), `status` ('all'|active|in_progress|quarantined|resolved), `start`, `end`, plus `actingId`.
+  - `load()` (useCallback, deps = all filters): `const { rows, total } = await fetchS1Threats({ search: search||undefined, severity: severity==='all'?undefined:severity, status: status==='all'?undefined:status, start: start?new Date(start).toISOString():undefined, end: end?...:undefined, limit: 100 })`. try/catch → `friendlyFetchError`. No `orgId` (fleet/partner-wide).
+  - Filter controls with testids: `s1-filter-search`, `s1-filter-severity`, `s1-filter-status`, plus date inputs and a Refresh button. Changing a `<select>` triggers `load()` (via the useEffect on filter state).
+  - `ResponsiveTable` desktop `<table>`: columns Device, Threat, Severity (badge), Status (badge), Detected. Each row `<tr data-testid={\`s1-row-${t.id}\`}>` with `onClick={() => t.deviceId && navigateTo(\`/devices/${t.deviceId}\`)}` and `cursor-pointer`. Device cell shows `t.deviceName ?? '—'`. Threat name `{t.threatName ?? 'Unknown threat'}`. Severity `{t.severity ?? 'unknown'}` with the badge classes from ThreatList. For `t.status === 'active'`, render kill/quarantine/rollback buttons (testid `s1-threat-${action}-${t.id}`) calling `doThreatAction(t.orgId, t.id, action)` → `runS1ThreatAction(t.orgId, t.id, action)`; **stopPropagation** on the action cell so a button click doesn't trigger row navigation; disable while `actingId === t.id`; catch via `handleActionError`.
+  - Provide a `cards` arm for mobile mirroring ThreatList (DataCard/CardField); scope tests to `responsive-table-desktop` to avoid dup-render assertions.
+  - Loading and empty states; render the error banner (`data-testid="s1-error"`) when `error` set.
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/S1ThreatList.test.tsx`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/S1ThreatList.tsx apps/web/src/components/security/S1ThreatList.test.tsx
+git commit -m "feat(web): fleet SentinelOne threats list with filters + inline actions"
+```
+
+---
+
+### Task 5: HuntressIncidentList — fleet Huntress incidents (read-only)
+
+**Files:**
+- Modify: `apps/web/src/components/security/HuntressIncidentList.tsx` (replace the stub).
+- Test: `apps/web/src/components/security/HuntressIncidentList.test.tsx`.
+
+**Interfaces:**
+- Consumes: `fetchHuntressIncidents` (filter object → `{ rows, total }`), `HuntressIncident` (Task 2 / Pillar 1), `navigateTo`.
+
+- [ ] **Step 1: Write the failing test.** `HuntressIncidentList.test.tsx` (mirror Task 4's test, minus actions):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
+import HuntressIncidentList from './HuntressIncidentList';
+
+function ok(b: unknown) { return { ok: true, status: 200, json: async () => b } as Response; }
+beforeEach(() => { fetchWithAuth.mockReset(); navigateTo.mockReset(); });
+
+describe('HuntressIncidentList', () => {
+  it('lists incidents (flat envelope) and navigates to the device on row click', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [{ id: 'i1', deviceId: 'dev-3', deviceHostname: 'SRV-2', title: 'Persistence', severity: 'critical', status: 'open', category: 'malware', reportedAt: '2026-06-21T00:00:00Z' }], total: 1, limit: 100, offset: 0 }));
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<HuntressIncidentList />);
+    const desktop = await screen.findByTestId('responsive-table-desktop');
+    expect(within(desktop).getByText('Persistence')).toBeInTheDocument();
+    fireEvent.click(within(desktop).getByTestId('huntress-row-i1'));
+    expect(navigateTo).toHaveBeenCalledWith('/devices/dev-3');
+  });
+
+  it('sends the status filter in the query', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ data: [], total: 0, limit: 100, offset: 0 }));
+    render(<HuntressIncidentList />);
+    fireEvent.change(await screen.findByTestId('huntress-filter-status'), { target: { value: 'open' } });
+    await waitFor(() => expect((fetchWithAuth.mock.calls.at(-1)?.[0] as string)).toContain('status=open'));
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/HuntressIncidentList.test.tsx`
+
+- [ ] **Step 3: Implement HuntressIncidentList.** Same structure as S1ThreatList minus actions (read-only):
+  - State: `rows: HuntressIncident[]`, `loading`, `error`, `total`, filters `search`, `severity`, `status` ('all'|open|in_progress|resolved|dismissed). No date filters (the endpoint has none).
+  - `load()`: `fetchHuntressIncidents({ search, severity, status, limit: 100 })` with the same omit-empty pattern. No orgId (partner-wide).
+  - Filter testids: `huntress-filter-search`, `huntress-filter-severity`, `huntress-filter-status`, Refresh.
+  - `ResponsiveTable` desktop columns: Device (`deviceHostname ?? '—'`), Title, Category, Severity (badge, `i.severity ?? 'unknown'`), Status (badge), Reported. Row `<tr data-testid={\`huntress-row-${i.id}\`}>` `onClick={() => i.deviceId && navigateTo(\`/devices/${i.deviceId}\`)}` cursor-pointer. Provide the `cards` mobile arm.
+  - Loading/empty/error (`data-testid="huntress-error"`) states.
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/HuntressIncidentList.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/HuntressIncidentList.tsx apps/web/src/components/security/HuntressIncidentList.test.tsx
+git commit -m "feat(web): fleet Huntress incidents list (read-only)"
+```
+
+---
+
+## Verification (end of pillar)
+- [ ] `pnpm --filter @breeze/api exec vitest run src/routes/sentinelOne.test.ts` — green (partner + org cases).
+- [ ] `pnpm --filter @breeze/web exec vitest run src/components/security src/components/devices src/lib/edr.test.ts` — green.
+- [ ] `pnpm --filter @breeze/web exec tsc --noEmit` and `pnpm --filter @breeze/api exec tsc --noEmit` — clean.
+- [ ] `pnpm --filter @breeze/web exec vitest run src/lib/__tests__/no-silent-mutations.test.ts` — green (add `S1ThreatList.tsx` to TARGET_GLOBS + bump count if its threat-action mutation should be enforced; note the count-drift gotcha).
+- [ ] Manual (local, `PUBLIC_ENABLE_EDR_INTEGRATIONS` not required — fleet pages aren't flag-gated; confirm whether they SHOULD be before shipping): `/security/edr` lists threats/incidents partner-wide; tab hash works; row→device nav works; quarantine on an active S1 threat toasts + reloads.
+
+## Notes for Pillar 3 / 4
+- The fleet fetchers now return `{ rows, total }` — Pillar 3 dashboard widgets can reuse them for counts.
+- "Promote to Incident" (Pillar 4) attaches to these rows; keep `id`/`deviceId`/`orgId` in row props.
+- Decide before shipping: should the fleet pages be gated behind `ENABLE_EDR_INTEGRATIONS` like the device panel? (Pillar 1 is flag-gated; for consistency the nav entry + page likely should be too — raise with Todd.)

--- a/docs/superpowers/plans/2026-06-25-edr-pillar3-dashboard.md
+++ b/docs/superpowers/plans/2026-06-25-edr-pillar3-dashboard.md
@@ -1,0 +1,284 @@
+# EDR Pillar 3 — Dashboard Surfacing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Surface EDR posture on the Security dashboard — active SentinelOne threats, open Huntress incidents, and agent-coverage gaps — by fanning out client-side to the existing `/s1/status` and `/huntress/status` endpoints. No API change.
+
+**Architecture:** A self-contained `EdrSummaryPanel` component fetches both status endpoints in parallel (`Promise.allSettled` so one provider's failure doesn't blank the other), renders a grid of `SecurityStatCard`s per configured provider, and is mounted in `SecurityDashboard` behind `ENABLE_EDR_INTEGRATIONS`. Org-scoped users see their org; partner-scoped users see partner-wide aggregates (the endpoints already resolve this from auth context with no params).
+
+**Tech Stack:** React island + Tailwind, Vitest + jsdom.
+
+## Global Constraints
+
+**Endpoint contracts (no params → resolves from auth; org-scoped or partner-wide aggregates):**
+- `GET /s1/status` → `{ integration: {...}|null, mapped?: boolean, summary: { totalAgents, mappedDevices, infectedAgents, activeThreats, highOrCriticalThreats, pendingActions, reportedThreatCount } }`. `integration: null` ⇒ not configured (all-zero summary).
+- `GET /huntress/status` → `{ integration: {...}|null, mapped?: boolean, coverage: { totalAgents, mappedAgents, unmappedAgents, offlineAgents }, incidents: { open, bySeverity: [{severity,count}], byStatus: [{status,count}] } }`. `integration: null` ⇒ not configured.
+
+**Decisions:**
+- D4: **client-side fan-out**, no aggregator endpoint (widget count is small).
+- Gate the panel behind `ENABLE_EDR_INTEGRATIONS` (consistent with Pillars 1-2).
+- Use `Promise.allSettled` — a failed `/s1/status` must NOT blank the Huntress cards (the Pillar 1 review lesson; this is the always-on dashboard, so per-provider resilience matters here).
+- Hide a provider's cards when its `integration` is `null` (not configured). If neither is configured, render nothing.
+- "Isolated-devices count" from the original phase sketch is **out of scope** — `/s1/status` doesn't expose it without a new query; note it, don't invent.
+
+**Conventions:** reads via `fetchWithAuth` (no `runAction` — read-only); reuse `SecurityStatCard`; tests mock fetch by URL+method (not positional).
+
+## File Structure
+- Create: `apps/web/src/components/security/EdrSummaryPanel.tsx` (+ `EdrSummaryPanel.test.tsx`).
+- Modify: `apps/web/src/components/security/SecurityDashboard.tsx` (mount behind flag).
+
+---
+
+### Task 1: EdrSummaryPanel — fetch both status endpoints, render cards
+
+**Files:**
+- Create: `apps/web/src/components/security/EdrSummaryPanel.tsx`, `apps/web/src/components/security/EdrSummaryPanel.test.tsx`.
+
+**Interfaces:**
+- Produces: `default function EdrSummaryPanel()` — self-contained, no props.
+
+**Pre-step — confirm `SecurityStatCard` export + props.** Open `apps/web/src/components/security/SecurityStatCard.tsx`. Its props are `{ icon: LucideIcon; label: string; value: string | number; variant?: 'default'|'success'|'warning'|'danger'; detail?: string }`. Use the file's actual export form (default vs named) in the import.
+
+- [ ] **Step 1: Write the failing test.** `EdrSummaryPanel.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+import EdrSummaryPanel from './EdrSummaryPanel';
+
+function ok(b: unknown) { return { ok: true, status: 200, json: async () => b } as Response; }
+function routeStatus(s1: unknown, huntress: unknown) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/s1/status')) return Promise.resolve(ok(s1));
+    if (url.startsWith('/huntress/status')) return Promise.resolve(ok(huntress));
+    return Promise.resolve(ok({}));
+  });
+}
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('EdrSummaryPanel', () => {
+  it('renders S1 + Huntress cards from both status endpoints', async () => {
+    routeStatus(
+      { integration: { id: 'i1' }, summary: { totalAgents: 10, mappedDevices: 8, infectedAgents: 2, activeThreats: 3, highOrCriticalThreats: 1, pendingActions: 0, reportedThreatCount: 5 } },
+      { integration: { id: 'h1' }, coverage: { totalAgents: 12, mappedAgents: 9, unmappedAgents: 3, offlineAgents: 1 }, incidents: { open: 4, bySeverity: [], byStatus: [] } },
+    );
+    render(<EdrSummaryPanel />);
+    expect(await screen.findByTestId('edr-card-s1-active-threats')).toHaveTextContent('3');
+    expect(screen.getByTestId('edr-card-huntress-open-incidents')).toHaveTextContent('4');
+    expect(screen.getByTestId('edr-card-huntress-coverage')).toHaveTextContent('9/12');
+  });
+
+  it('hides a provider whose integration is null', async () => {
+    routeStatus(
+      { integration: null, summary: { totalAgents: 0, mappedDevices: 0, infectedAgents: 0, activeThreats: 0, highOrCriticalThreats: 0, pendingActions: 0, reportedThreatCount: 0 } },
+      { integration: { id: 'h1' }, coverage: { totalAgents: 5, mappedAgents: 5, unmappedAgents: 0, offlineAgents: 0 }, incidents: { open: 0, bySeverity: [], byStatus: [] } },
+    );
+    render(<EdrSummaryPanel />);
+    expect(await screen.findByTestId('edr-card-huntress-open-incidents')).toBeInTheDocument();
+    expect(screen.queryByTestId('edr-card-s1-active-threats')).toBeNull();
+  });
+
+  it('renders Huntress cards even when /s1/status fails (allSettled)', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/s1/status')) return Promise.resolve({ ok: false, status: 500, statusText: 'err', json: async () => ({}) } as Response);
+      if (url.startsWith('/huntress/status')) return Promise.resolve(ok({ integration: { id: 'h1' }, coverage: { totalAgents: 5, mappedAgents: 5, unmappedAgents: 0, offlineAgents: 0 }, incidents: { open: 2, bySeverity: [], byStatus: [] } }));
+      return Promise.resolve(ok({}));
+    });
+    render(<EdrSummaryPanel />);
+    await waitFor(() => expect(screen.getByTestId('edr-card-huntress-open-incidents')).toHaveTextContent('2'));
+    expect(screen.queryByTestId('edr-card-s1-active-threats')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** (`cannot resolve ./EdrSummaryPanel`).
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrSummaryPanel.test.tsx`
+
+- [ ] **Step 3: Implement EdrSummaryPanel.** Create `EdrSummaryPanel.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { ShieldAlert, Activity, ShieldCheck, Loader2 } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import SecurityStatCard from './SecurityStatCard'; // adjust if SecurityStatCard is a named export
+
+interface S1Summary { totalAgents: number; mappedDevices: number; infectedAgents: number; activeThreats: number; highOrCriticalThreats: number; pendingActions: number; reportedThreatCount: number; }
+interface S1Status { integration: { id: string } | null; summary: S1Summary; }
+interface HuntressStatus { integration: { id: string } | null; coverage: { totalAgents: number; mappedAgents: number; unmappedAgents: number; offlineAgents: number }; incidents: { open: number }; }
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as T;
+}
+
+export default function EdrSummaryPanel() {
+  const [s1, setS1] = useState<S1Status | null>(null);
+  const [huntress, setHuntress] = useState<HuntressStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [s1Res, hRes] = await Promise.allSettled([
+        getJson<S1Status>('/s1/status'),
+        getJson<HuntressStatus>('/huntress/status'),
+      ]);
+      if (cancelled) return;
+      setS1(s1Res.status === 'fulfilled' ? s1Res.value : null);
+      setHuntress(hRes.status === 'fulfilled' ? hRes.value : null);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const showS1 = s1?.integration != null;
+  const showHuntress = huntress?.integration != null;
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="edr-summary-panel">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading EDR posture…</div>
+      </div>
+    );
+  }
+  if (!showS1 && !showHuntress) return null; // no EDR integrations configured
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm" data-testid="edr-summary-panel">
+      <div className="mb-4 flex items-center gap-2">
+        <ShieldAlert className="h-4 w-4 text-primary" />
+        <h3 className="text-lg font-semibold">Endpoint Detection &amp; Response</h3>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {showS1 && s1 && (
+          <>
+            <div data-testid="edr-card-s1-active-threats">
+              <SecurityStatCard
+                icon={ShieldAlert}
+                label="SentinelOne Active Threats"
+                value={s1.summary.activeThreats}
+                variant={s1.summary.activeThreats > 0 ? 'danger' : 'success'}
+                detail={`${s1.summary.highOrCriticalThreats} high/critical`}
+              />
+            </div>
+            <div data-testid="edr-card-s1-coverage">
+              <SecurityStatCard
+                icon={ShieldCheck}
+                label="SentinelOne Agents"
+                value={`${s1.summary.mappedDevices}/${s1.summary.totalAgents}`}
+                detail={`${s1.summary.infectedAgents} infected`}
+                variant={s1.summary.infectedAgents > 0 ? 'warning' : 'default'}
+              />
+            </div>
+          </>
+        )}
+        {showHuntress && huntress && (
+          <>
+            <div data-testid="edr-card-huntress-open-incidents">
+              <SecurityStatCard
+                icon={Activity}
+                label="Huntress Open Incidents"
+                value={huntress.incidents.open}
+                variant={huntress.incidents.open > 0 ? 'danger' : 'success'}
+              />
+            </div>
+            <div data-testid="edr-card-huntress-coverage">
+              <SecurityStatCard
+                icon={ShieldCheck}
+                label="Huntress Agents"
+                value={`${huntress.coverage.mappedAgents}/${huntress.coverage.totalAgents}`}
+                detail={`${huntress.coverage.offlineAgents} offline · ${huntress.coverage.unmappedAgents} unmapped`}
+                variant={huntress.coverage.unmappedAgents > 0 ? 'warning' : 'default'}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+(If `SecurityStatCard` is a named export, change the import to `import { SecurityStatCard } from './SecurityStatCard';`.)
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrSummaryPanel.test.tsx`
+Expected: PASS (3 cases).
+
+- [ ] **Step 5: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/EdrSummaryPanel.tsx apps/web/src/components/security/EdrSummaryPanel.test.tsx
+git commit -m "feat(web): EDR summary panel (S1 + Huntress status cards, allSettled)"
+```
+
+---
+
+### Task 2: Mount EdrSummaryPanel in SecurityDashboard behind the flag
+
+**Files:**
+- Modify: `apps/web/src/components/security/SecurityDashboard.tsx`.
+- Test: add a case to `SecurityDashboard`'s existing test if present, else `apps/web/src/components/security/EdrSummaryPanel.dashboard.test.tsx`.
+
+**Interfaces:**
+- Consumes: `EdrSummaryPanel` (Task 1), `ENABLE_EDR_INTEGRATIONS`.
+
+- [ ] **Step 1: Write the failing test.** If `SecurityDashboard.test.tsx` exists, add a case mocking `ENABLE_EDR_INTEGRATIONS: true` and stubbing `./EdrSummaryPanel`, asserting the stub renders. If no such test file exists, create `EdrSummaryPanel.dashboard.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+vi.mock('../../lib/featureFlags', async (orig) => ({ ...(await orig<typeof import('../../lib/featureFlags')>()), ENABLE_EDR_INTEGRATIONS: true }));
+vi.mock('./EdrSummaryPanel', () => ({ default: () => <div data-testid="edr-summary-stub" /> }));
+const fetchWithAuth = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) } as Response));
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+import SecurityDashboard from './SecurityDashboard';
+
+describe('SecurityDashboard EDR panel', () => {
+  it('renders the EDR summary panel when the flag is on', async () => {
+    render(<SecurityDashboard />);
+    await waitFor(() => expect(screen.getByTestId('edr-summary-stub')).toBeInTheDocument());
+  });
+});
+```
+
+(If `SecurityDashboard` requires props or providers to render, mirror however its existing test/harness mounts it. Reuse the file's established mocks.)
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrSummaryPanel.dashboard.test.tsx`
+
+- [ ] **Step 3: Mount the panel.** In `SecurityDashboard.tsx`:
+  - Import: `import { ENABLE_EDR_INTEGRATIONS } from '../../lib/featureFlags';` and `import EdrSummaryPanel from './EdrSummaryPanel';`.
+  - Render `{ENABLE_EDR_INTEGRATIONS && <EdrSummaryPanel />}` inside the top-level `<div className="space-y-6">`, immediately after the header/error region and BEFORE the main 12-col grid (so EDR posture sits near the top). It is a full-width section (the panel manages its own internal grid).
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security/EdrSummaryPanel.dashboard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/SecurityDashboard.tsx apps/web/src/components/security/EdrSummaryPanel.dashboard.test.tsx
+git commit -m "feat(web): mount EDR summary panel on security dashboard behind flag"
+```
+
+---
+
+## Verification (end of pillar)
+- [ ] `pnpm --filter @breeze/web exec vitest run src/components/security` — green.
+- [ ] `pnpm --filter @breeze/web exec tsc --noEmit` — clean.
+- [ ] Manual (`PUBLIC_ENABLE_EDR_INTEGRATIONS=true`): `/security` shows the EDR panel near the top with S1/Huntress cards reflecting `/s1/status` + `/huntress/status`; with only one provider configured, only that provider's cards show; with neither, the panel is absent.
+
+## Notes
+- No mutations here → no `no-silent-mutations` enrollment needed.
+- "Isolated-devices count" deferred (needs a new `/s1/status` field or query). Raise if wanted.
+- Pillar 4 (EDR → Incident escalation) is the remaining pillar.

--- a/docs/superpowers/plans/2026-06-25-edr-pillar4a-promote-to-incident.md
+++ b/docs/superpowers/plans/2026-06-25-edr-pillar4a-promote-to-incident.md
@@ -1,0 +1,328 @@
+# EDR Pillar 4a — Promote to Incident — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a technician escalate a SentinelOne threat or Huntress incident into a tracked Breeze **Incident** (the BE-32 incident-response module) with one click — from the device EDR panel and the fleet EDR lists. This finally gives the starved Incidents page organic inflow. No API change — uses the existing `POST /incidents`.
+
+**Architecture:** A shared `incidents.ts` web lib exposes `promoteToIncident(input)` (wrapped in `runAction`) plus two pure mappers that turn an `S1Threat` / `HuntressIncident` into the `POST /incidents` body (with EDR-severity → p1–p4 mapping). A "Promote to Incident" control is added to the four EDR surfaces (device panel S1 + Huntress rows; fleet `S1ThreatList` + `HuntressIncidentList` rows). On success it navigates to `/incidents/{id}`.
+
+**Tech Stack:** React islands + Tailwind, Vitest.
+
+## Global Constraints
+
+**`POST /incidents` contract** (`apps/api/src/routes/incidents.ts`): requires `ALERTS_WRITE` (`alerts:write`) + MFA. Body (`createIncidentSchema`):
+`{ orgId?: string; title: string(3..500); classification: string(2..40); severity: 'p1'|'p2'|'p3'|'p4'; summary?: string(≤10000); relatedAlerts?: uuid[]; affectedDevices?: uuid[]; assignedTo?: uuid; detectedAt?: ISO; status?: 'detected'|'analyzing' }`.
+Scope rules: **org** scope ignores body `orgId` and uses `auth.orgId`; **partner** scope **requires** `orgId` and `canAccessOrg`-checks it; system requires `orgId`. Returns the created incident `{ id, orgId, ... }` with HTTP **201**.
+
+**Therefore:** always send `orgId` from the source row (`threat.orgId` / `incident.orgId`) — required for partner (fleet) callers, harmless for org callers.
+
+**EDR severity → incident severity map:** `critical→p1, high→p2, medium→p3, low→p4`, anything else (null/unknown) → `p3`.
+
+**Conventions:** the promote mutation goes through `runAction` (toasts success/failure; MFA 403 surfaces as a toast — no step-up modal). Caller catch via `handleActionError`. Tests mock fetch by URL+method. `navigateTo` from `@/lib/navigation` on success. Title clamps to 500 chars; classification is a fixed ≤40-char string.
+
+## File Structure
+- Create: `apps/web/src/lib/incidents.ts` (+ `incidents.test.ts`).
+- Modify: `apps/web/src/components/devices/DeviceEdrPanel.tsx` (+ test) — promote buttons on S1 + Huntress rows.
+- Modify: `apps/web/src/components/security/S1ThreatList.tsx` (+ test), `apps/web/src/components/security/HuntressIncidentList.tsx` (+ test) — promote in the row actions.
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` — enroll `incidents.ts` + `HuntressIncidentList.tsx` (count bump).
+
+---
+
+### Task 1: `incidents.ts` lib — promoteToIncident + mappers
+
+**Files:**
+- Create: `apps/web/src/lib/incidents.ts`, `apps/web/src/lib/incidents.test.ts`.
+
+**Interfaces:**
+- Produces:
+  `type IncidentSeverity = 'p1'|'p2'|'p3'|'p4'`
+  `mapEdrSeverity(sev: string | null | undefined): IncidentSeverity`
+  `s1ThreatToIncident(t: S1Threat): CreateIncidentInput`
+  `huntressIncidentToIncident(i: HuntressIncident): CreateIncidentInput`
+  `promoteToIncident(input: CreateIncidentInput): Promise<{ id: string }>`
+  where `CreateIncidentInput = { orgId: string; title: string; classification: string; severity: IncidentSeverity; summary?: string; affectedDevices?: string[]; detectedAt?: string }`.
+
+- [ ] **Step 1: Write the failing test.** `incidents.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+const fetchWithAuth = vi.fn();
+vi.mock('../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../components/shared/Toast', () => ({ showToast: vi.fn() }));
+import { mapEdrSeverity, s1ThreatToIncident, huntressIncidentToIncident, promoteToIncident } from './incidents';
+
+function ok(b: unknown) { return { ok: true, status: 201, json: async () => b } as Response; }
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('mapEdrSeverity', () => {
+  it('maps EDR severities to p1-p4 with a safe default', () => {
+    expect(mapEdrSeverity('critical')).toBe('p1');
+    expect(mapEdrSeverity('HIGH')).toBe('p2');
+    expect(mapEdrSeverity('medium')).toBe('p3');
+    expect(mapEdrSeverity('low')).toBe('p4');
+    expect(mapEdrSeverity(null)).toBe('p3');
+    expect(mapEdrSeverity('weird')).toBe('p3');
+  });
+});
+
+describe('mappers', () => {
+  it('builds an incident input from an S1 threat', () => {
+    const input = s1ThreatToIncident({ id: 't1', orgId: 'org-1', deviceId: 'dev-9', deviceName: 'PC', threatName: 'Emotet', severity: 'critical', status: 'active', detectedAt: '2026-06-20T00:00:00Z' } as any);
+    expect(input.orgId).toBe('org-1');
+    expect(input.severity).toBe('p1');
+    expect(input.affectedDevices).toEqual(['dev-9']);
+    expect(input.classification).toBe('sentinelone-threat');
+    expect(input.title).toContain('Emotet');
+  });
+  it('builds an incident input from a Huntress incident with no device', () => {
+    const input = huntressIncidentToIncident({ id: 'i1', orgId: 'org-2', deviceId: null, title: 'Persistence', severity: 'high', status: 'open', reportedAt: '2026-06-21T00:00:00Z' } as any);
+    expect(input.orgId).toBe('org-2');
+    expect(input.severity).toBe('p2');
+    expect(input.affectedDevices).toEqual([]);
+    expect(input.classification).toBe('huntress-incident');
+  });
+});
+
+describe('promoteToIncident', () => {
+  it('POSTs /incidents and returns the new id', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((_url: string, init?: RequestInit) => { body = JSON.parse(String(init?.body)); return Promise.resolve(ok({ id: 'inc-1' })); });
+    const res = await promoteToIncident({ orgId: 'org-1', title: 'X', classification: 'sentinelone-threat', severity: 'p1', affectedDevices: ['dev-9'] });
+    expect(res).toEqual({ id: 'inc-1' });
+    expect(fetchWithAuth.mock.calls[0][0]).toBe('/incidents');
+    expect((body as any).orgId).toBe('org-1');
+    expect((body as any).severity).toBe('p1');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/lib/incidents.test.ts`
+
+- [ ] **Step 3: Implement `incidents.ts`.**
+
+```ts
+import { fetchWithAuth } from '../stores/auth';
+import { runAction } from './runAction';
+import type { S1Threat, HuntressIncident } from './edr';
+
+export type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
+
+export interface CreateIncidentInput {
+  orgId: string;
+  title: string;
+  classification: string;
+  severity: IncidentSeverity;
+  summary?: string;
+  affectedDevices?: string[];
+  detectedAt?: string;
+}
+
+const SEVERITY_MAP: Record<string, IncidentSeverity> = {
+  critical: 'p1', high: 'p2', medium: 'p3', low: 'p4',
+};
+
+export function mapEdrSeverity(sev: string | null | undefined): IncidentSeverity {
+  return SEVERITY_MAP[(sev ?? '').toLowerCase()] ?? 'p3';
+}
+
+function clampTitle(value: string): string {
+  return value.length > 500 ? value.slice(0, 500) : value;
+}
+
+export function s1ThreatToIncident(t: S1Threat): CreateIncidentInput {
+  const device = t.deviceName ?? t.deviceId ?? 'an unknown device';
+  return {
+    orgId: t.orgId,
+    title: clampTitle(`SentinelOne: ${t.threatName ?? 'Unknown threat'}`),
+    classification: 'sentinelone-threat',
+    severity: mapEdrSeverity(t.severity),
+    summary: `Promoted from SentinelOne threat "${t.threatName ?? 'Unknown threat'}" on ${device}.`,
+    affectedDevices: t.deviceId ? [t.deviceId] : [],
+    detectedAt: t.detectedAt ?? undefined,
+  };
+}
+
+export function huntressIncidentToIncident(i: HuntressIncident): CreateIncidentInput {
+  const device = i.deviceHostname ?? i.deviceId ?? 'an unknown device';
+  const body = i.recommendation || i.description || '';
+  return {
+    orgId: i.orgId,
+    title: clampTitle(`Huntress: ${i.title}`),
+    classification: 'huntress-incident',
+    severity: mapEdrSeverity(i.severity),
+    summary: `Promoted from Huntress incident "${i.title}" on ${device}.${body ? ` ${body}` : ''}`.slice(0, 10000),
+    affectedDevices: i.deviceId ? [i.deviceId] : [],
+    detectedAt: i.reportedAt ?? undefined,
+  };
+}
+
+export async function promoteToIncident(input: CreateIncidentInput): Promise<{ id: string }> {
+  return runAction<{ id: string }>({
+    request: () =>
+      fetchWithAuth('/incidents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }),
+    errorFallback: 'Failed to create incident',
+    successMessage: 'Incident created',
+    parseSuccess: (data) => data as { id: string },
+  });
+}
+```
+
+- [ ] **Step 4: Run, verify pass.** `pnpm --filter @breeze/web exec vitest run src/lib/incidents.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/lib/incidents.ts apps/web/src/lib/incidents.test.ts
+git commit -m "feat(web): promoteToIncident lib + EDR->incident mappers"
+```
+
+---
+
+### Task 2: Promote buttons on the device EDR panel
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceEdrPanel.tsx`, `apps/web/src/components/devices/DeviceEdrPanel.test.tsx`.
+
+**Interfaces:** Consumes `promoteToIncident`, `s1ThreatToIncident`, `huntressIncidentToIncident` (Task 1), `navigateTo`, `handleActionError`.
+
+- [ ] **Step 1: Write the failing test.** Append to `DeviceEdrPanel.test.tsx`:
+
+```tsx
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
+
+describe('DeviceEdrPanel promote to incident', () => {
+  it('promotes an S1 threat then navigates to the new incident', async () => {
+    let body: unknown;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', orgId: 'org-1', deviceId: 'dev-1', threatName: 'Emotet', severity: 'critical', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 50, offset: 0 } }));
+      if (url.startsWith('/huntress/incidents')) return Promise.resolve(ok({ data: [], total: 0, limit: 50, offset: 0 }));
+      if (url === '/incidents') { body = JSON.parse(String(init?.body)); return Promise.resolve({ ok: true, status: 201, json: async () => ({ id: 'inc-9' }) } as Response); }
+      return Promise.resolve(ok({ data: [] }));
+    });
+    render(<DeviceEdrPanel deviceId="dev-1" orgId="org-1" />);
+    fireEvent.click(await screen.findByTestId('edr-s1-promote-t1'));
+    await waitFor(() => expect((body as any).classification).toBe('sentinelone-threat'));
+    expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-9');
+  });
+});
+```
+
+(Add `navigateTo.mockReset()` to the file's `beforeEach` if present, and ensure `fireEvent`/`waitFor` are imported.)
+
+- [ ] **Step 2: Run, verify fail.** `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx -t "promote"`
+
+- [ ] **Step 3: Implement.** In `DeviceEdrPanel.tsx`:
+  - Import `promoteToIncident, s1ThreatToIncident, huntressIncidentToIncident` from `../../lib/incidents`, and `navigateTo` from `@/lib/navigation`.
+  - Add a `promotingId` state and a handler:
+
+```tsx
+const [promotingId, setPromotingId] = useState<string | null>(null);
+const promote = async (key: string, input: import('../../lib/incidents').CreateIncidentInput) => {
+  setPromotingId(key);
+  try {
+    const { id } = await promoteToIncident(input);
+    navigateTo(`/incidents/${id}`);
+  } catch (err) {
+    handleActionError(err, 'Failed to create incident');
+  } finally {
+    setPromotingId(null);
+  }
+};
+```
+
+  - On each **S1 threat** row, add a button (works for any status, not only active):
+
+```tsx
+<button
+  type="button"
+  data-testid={`edr-s1-promote-${t.id}`}
+  onClick={() => promote(t.id, s1ThreatToIncident(t))}
+  disabled={promotingId === t.id}
+  className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60"
+>
+  Promote to Incident
+</button>
+```
+
+  - On each **Huntress incident** row, add the analogous button `data-testid={\`edr-huntress-promote-${i.id}\`}` calling `promote(i.id, huntressIncidentToIncident(i))`.
+
+- [ ] **Step 4: Run, verify pass.** `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEdrPanel.test.tsx` → PASS (all cases).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/devices/DeviceEdrPanel.tsx apps/web/src/components/devices/DeviceEdrPanel.test.tsx
+git commit -m "feat(web): promote S1 threat / Huntress incident to Incident from device panel"
+```
+
+---
+
+### Task 3: Promote in the fleet lists + no-silent-mutations enrollment
+
+**Files:**
+- Modify: `apps/web/src/components/security/S1ThreatList.tsx` (+ test), `apps/web/src/components/security/HuntressIncidentList.tsx` (+ test).
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`.
+
+**Interfaces:** same as Task 2.
+
+- [ ] **Step 1: Write the failing tests.** Add to `S1ThreatList.test.tsx`:
+
+```tsx
+it('promotes a threat to an incident and navigates', async () => {
+  let body: unknown;
+  fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.startsWith('/s1/threats')) return Promise.resolve(ok({ data: [{ id: 't1', orgId: 'org-7', deviceId: 'dev-9', threatName: 'X', severity: 'high', status: 'active', detectedAt: '2026-06-20T00:00:00Z' }], pagination: { total: 1, limit: 100, offset: 0 } }));
+    if (url === '/incidents') { body = JSON.parse(String(init?.body)); return Promise.resolve({ ok: true, status: 201, json: async () => ({ id: 'inc-2' }) } as Response); }
+    return Promise.resolve(ok({ data: [] }));
+  });
+  render(<S1ThreatList />);
+  const desktop = await screen.findByTestId('responsive-table-desktop');
+  fireEvent.click(within(desktop).getByTestId('s1-promote-t1'));
+  await waitFor(() => expect((body as any).orgId).toBe('org-7'));
+  expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-2');
+});
+```
+
+Add the analogous case to `HuntressIncidentList.test.tsx` (testid `huntress-promote-i1`, fixture incident with `orgId: 'org-3'`, assert `classification: 'huntress-incident'` and navigate to `/incidents/inc-3`). The Huntress list previously had no `navigateTo` for actions — it already mocks `@/lib/navigation` for row clicks, so reuse that mock.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.**
+  - **S1ThreatList.tsx:** import `promoteToIncident, s1ThreatToIncident`; add the same `promotingId` state + `promote` handler as Task 2. In the desktop Actions cell AND the mobile card Actions, add a `Promote to Incident` button `data-testid={\`s1-promote-${t.id}\`}` (available for all rows, not only active). Keep `stopPropagation` so it doesn't trigger row navigation.
+  - **HuntressIncidentList.tsx:** it is currently read-only with no Actions column. Add an **Actions** column (desktop) and an Actions `CardField` (mobile) containing a `Promote to Incident` button `data-testid={\`huntress-promote-${i.id}\`}` calling `promote(i.id, huntressIncidentToIncident(i))`. Add the `promotingId` state + handler + the `handleActionError` import + `promoteToIncident`/`huntressIncidentToIncident` imports. The row already navigates on click — wrap the actions cell with `stopPropagation`.
+
+- [ ] **Step 4: Enroll the new mutation surfaces.** In `no-silent-mutations.test.ts`, add `'src/lib/incidents.ts'` and `'src/components/security/HuntressIncidentList.tsx'` to `TARGET_GLOBS` and bump `expect(absoluteFiles.length).toBe(52)` → `54`. (`S1ThreatList.ts` and `DeviceEdrPanel.tsx` are already enrolled.)
+
+- [ ] **Step 5: Run, verify pass.**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/security src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+pnpm --filter @breeze/web exec tsc --noEmit
+git add apps/web/src/components/security/S1ThreatList.tsx apps/web/src/components/security/S1ThreatList.test.tsx apps/web/src/components/security/HuntressIncidentList.tsx apps/web/src/components/security/HuntressIncidentList.test.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(web): promote to incident from fleet EDR lists + guard enrollment"
+```
+
+---
+
+## Verification (end of pillar)
+- [ ] `pnpm --filter @breeze/web exec vitest run src/components/security src/components/devices src/lib/incidents.test.ts src/lib/__tests__/no-silent-mutations.test.ts` — green.
+- [ ] `pnpm --filter @breeze/web exec tsc --noEmit` — clean.
+- [ ] Manual (`PUBLIC_ENABLE_EDR_INTEGRATIONS=true`): on a device with EDR data, "Promote to Incident" on a threat creates an incident and lands on `/incidents/{id}` with the affected device + severity prefilled; same from `/security/edr`. With a non-MFA session, the action toasts "MFA required".
+
+## Deferred to Pillar 4b (raise with Todd)
+- **Huntress write-back** (resolve incident / approve remediations via the new `POST /v1/incident_reports/{id}/resolution`) — net-new `huntressClient.ts` write methods + remediation sync. Own PR.
+- **S1 containment logged as `incident_actions`** when isolate/quarantine is performed from inside an incident (links the IR `containIncidentSchema` to the S1 action API).
+- **Auto-file** incidents on p1/critical `s1.threat_detected` / `huntress.incident_created` events (D5 deferred manual-first).


### PR DESCRIPTION
## EDR Operations Surfacing — Pillars 1–4a

Takes the **SentinelOne** and **Huntress** integrations from "configured but invisible" to fully operational in the console. Both had mature backends (synced data, actions, AI tools) but almost no operational UI — a technician couldn't see a Huntress incident or isolate an S1 device anywhere. This wires that data and those actions into the places people actually work, then connects it to the incident-response module.

Everything is gated behind the `ENABLE_EDR_INTEGRATIONS` feature flag (off by default).

### What's included

- **Pillar 1 — Device-detail EDR panel.** On a device's Security tab: its SentinelOne threats + Huntress incidents, with inline **isolate / un-isolate** and **kill / quarantine / rollback** (existing endpoints; MFA enforced server-side).
- **Pillar 2 — Fleet EDR pages** at `/security/edr`: partner-wide **SentinelOne Threats** and **Huntress Incidents** lists with filters and row→device navigation. Includes one backend change — `GET /s1/threats` gains a partner-wide branch mirroring the existing, tested `GET /huntress/incidents` fleet pattern (isolation via `auth.orgCondition` + the partner's active-integration set + RLS).
- **Pillar 3 — Dashboard summary** cards on the Security dashboard: active S1 threats, open Huntress incidents, and agent-coverage gaps (`Promise.allSettled` so one provider's outage doesn't blank the other).
- **Pillar 4a — Promote to Incident.** One-click escalation of an S1 threat or Huntress incident into a tracked Breeze Incident (the BE-32 IR module), from every EDR surface — giving that previously-starved page organic inflow.

### Scope / tenancy notes

- The only backend change is the partner-wide `/s1/threats` branch. It adds **no table and no tenancy-shape change**; `rls-coverage` is untouched. It was hand-reviewed plus covered by a partner-scope functional test and a system-scope 400 guard test.
- All web mutations route through `runAction`; the five new mutation surfaces are enrolled in the `no-silent-mutations` guard.

### Testing

- API: `sentinelOne.test.ts` green (partner + org + system-scope cases).
- Web: security + devices + edr + incidents suites green (393 tests), both `tsc --noEmit` clean.
- Reviewed by a 5-agent pass on Pillar 1 and whole-branch reviews on Pillars 2 and 4a; findings fixed (canonical `handleActionError`, nullable DTOs, dialog a11y, lost-on-nav toast, test gaps).

### Deferred to a follow-up (Pillar 4b)

- Huntress API **write-back** (resolve incident / approve remediations via `POST /v1/incident_reports/{id}/resolution`) — net-new client code + remediation sync.
- S1 containment logged as reversible `incident_actions` when performed inside an incident.
- Auto-file incidents on p1/critical EDR events.

Plans: `docs/superpowers/plans/2026-06-25-edr-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
