### PR TITLE
fix(catalog): block bundle save when detail load fails (#1944)

### DIFF
--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
@@ -5,6 +5,7 @@ import CatalogItemEditorDrawer from './CatalogItemEditorDrawer';
 import type { CatalogItem } from '../../lib/api/catalog';
 import * as catalogApi from '../../lib/api/catalog';
 import * as authScope from '../../lib/authScope';
+import { showToast } from '../shared/Toast';
 
 // Keep the real presentation helpers + constants; stub only the network calls.
 vi.mock('../../lib/api/catalog', async (importActual) => {
@@ -14,6 +15,9 @@ vi.mock('../../lib/api/catalog', async (importActual) => {
     getCatalogItem: vi.fn(),
     setOrgPriceOverride: vi.fn(),
     removeOrgPriceOverride: vi.fn(),
+    createCatalogItem: vi.fn(),
+    updateCatalogItem: vi.fn(),
+    setBundleComponents: vi.fn(),
   };
 });
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
@@ -108,5 +112,94 @@ describe('CatalogItemEditorDrawer — per-org pricing (#1368)', () => {
     renderDrawer();
     await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
     expect(screen.queryByTestId('catalog-org-pricing')).not.toBeInTheDocument();
+  });
+});
+
+// #1944 — a failed detail load must NOT masquerade as "this bundle has no
+// components": empty `components` saved back would wipe the real bundle.
+describe('CatalogItemEditorDrawer — detail load failure (#1944)', () => {
+  const toastMock = vi.mocked(showToast);
+  const createMock = vi.mocked(catalogApi.createCatalogItem);
+  const updateMock = vi.mocked(catalogApi.updateCatalogItem);
+  const bundleMock = vi.mocked(catalogApi.setBundleComponents);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    claimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    updateMock.mockResolvedValue(json({ data: item({ isBundle: true }) }));
+    createMock.mockResolvedValue(json({ data: item({ isBundle: true }) }));
+    bundleMock.mockResolvedValue(json({ data: {} }));
+  });
+
+  const renderBundle = () =>
+    render(
+      <CatalogItemEditorDrawer
+        open
+        item={item({ isBundle: true })}
+        allItems={[]}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+  it('toasts and flags an inline error when the bundle detail load returns non-401 failure', async () => {
+    getMock.mockResolvedValue(json(null, false)); // status 500
+    renderBundle();
+    expect(await screen.findByTestId('catalog-bundle-load-error')).toBeInTheDocument();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('treats a malformed (no data) body as a failure, not an empty bundle', async () => {
+    getMock.mockResolvedValue(json({ notData: true }));
+    renderBundle();
+    expect(await screen.findByTestId('catalog-bundle-load-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('catalog-bundle-empty')).not.toBeInTheDocument();
+  });
+
+  it('treats a rejected detail fetch as a failure', async () => {
+    getMock.mockRejectedValue(new Error('network'));
+    renderBundle();
+    expect(await screen.findByTestId('catalog-bundle-load-error')).toBeInTheDocument();
+  });
+
+  it('disables Save and never calls setBundleComponents after a failed bundle load', async () => {
+    getMock.mockResolvedValue(json(null, false));
+    renderBundle();
+    await screen.findByTestId('catalog-bundle-load-error');
+
+    const saveBtn = screen.getByTestId('catalog-form-save') as HTMLButtonElement;
+    expect(saveBtn).toBeDisabled();
+
+    // Even if invoked directly (e.g. enabled by other state), the guard holds.
+    fireEvent.click(saveBtn);
+    await waitFor(() => expect(screen.getByTestId('catalog-bundle-load-error')).toBeInTheDocument());
+    expect(bundleMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('still saves normally when the detail load succeeds (no false positive)', async () => {
+    getMock.mockResolvedValue(
+      json({ data: { item: item({ isBundle: true }), components: [{ componentItemId: 'c-1', quantity: '2', showOnInvoice: false }], overrides: [] } }),
+    );
+    render(
+      <CatalogItemEditorDrawer
+        open
+        item={item({ isBundle: true })}
+        allItems={[{ ...item(), id: 'c-1', name: 'Component', isBundle: false, isActive: true }]}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    // Loaded component renders, no error banner.
+    await screen.findByTestId('catalog-bundle-row-0');
+    expect(screen.queryByTestId('catalog-bundle-load-error')).not.toBeInTheDocument();
+
+    const saveBtn = screen.getByTestId('catalog-form-save') as HTMLButtonElement;
+    expect(saveBtn).not.toBeDisabled();
+    fireEvent.click(saveBtn);
+    await waitFor(() => expect(bundleMock).toHaveBeenCalled());
+    expect(bundleMock).toHaveBeenCalledWith('item-1', [
+      { componentItemId: 'c-1', quantity: 2, showOnInvoice: false },
+    ]);
   });
 });

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -76,6 +76,10 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
   const [isBundle, setIsBundle] = useState(false);
   const [components, setComponents] = useState<ComponentDraft[]>([]);
   const [componentsLoading, setComponentsLoading] = useState(false);
+  // True when the detail load (components + overrides) failed for an existing
+  // item. Empty `components` is then "we couldn't load them", NOT "this item has
+  // none" — so the bundle save path must be blocked to avoid wiping the bundle.
+  const [detailLoadFailed, setDetailLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
   // Per-org price overrides (#1368). Loaded for an existing item and edited as a
   // sub-resource — each set/remove applies immediately (the item already exists),
@@ -105,6 +109,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
     setOverrides([]);
     setNewOverrideOrgId('');
     setNewOverridePrice('');
+    setDetailLoadFailed(false);
     if (item) {
       setItemType(item.itemType);
       setName(item.name);
@@ -116,19 +121,33 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
       // Existing items carry sub-resources (bundle components + per-org price
       // overrides) — load the detail once and hydrate both.
       setComponentsLoading(item.isBundle);
+      const failDetailLoad = () => {
+        // The detail load is load-bearing: it drives what the bundle save writes
+        // back. Surfacing the failure (and flagging it) prevents a silent "empty
+        // bundle" that a save would persist as zero components (#1944). Contrast
+        // QuoteEditor's loadEcStatus, where `if (!res.ok) return` is intentional
+        // optional context.
+        setDetailLoadFailed(true);
+        showToast({
+          message: 'Could not load this item’s components and pricing. Reopen to retry before saving.',
+          type: 'error',
+        });
+      };
       void getCatalogItem(item.id)
         .then(async (res) => {
           if (res.status === 401) return UNAUTHORIZED();
-          if (!res.ok) return;
+          if (!res.ok) return failDetailLoad();
           const body = (await res.json().catch(() => null)) as { data?: CatalogItemDetail } | null;
-          const rows = body?.data?.components ?? [];
+          if (!body?.data) return failDetailLoad();
+          const rows = body.data.components ?? [];
           setComponents(rows.map((r) => ({
             componentItemId: r.componentItemId,
             quantity: r.quantity,
             showOnInvoice: r.showOnInvoice,
           })));
-          setOverrides(body?.data?.overrides ?? []);
+          setOverrides(body.data.overrides ?? []);
         })
+        .catch(() => failDetailLoad())
         .finally(() => setComponentsLoading(false));
     } else {
       setItemType('service');
@@ -254,12 +273,24 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
   const priceNum = Number(unitPrice);
   const priceValid = unitPrice.trim() !== '' && Number.isFinite(priceNum);
   const marginPreview = computeMargin(unitPrice, costBasis);
-  const canSave = !saving && name.trim() !== '' && priceValid;
+  // Block saving a bundle whose components never loaded — an empty save would
+  // wipe the real components (#1944).
+  const canSave = !saving && name.trim() !== '' && priceValid && !(isBundle && detailLoadFailed);
 
   const save = useCallback(async () => {
     if (saving) return;
     if (!name.trim()) { showToast({ message: 'Enter an item name.', type: 'error' }); return; }
     if (!priceValid) { showToast({ message: 'Enter a valid unit price.', type: 'error' }); return; }
+    // If the detail load failed, our `components` state is unknown — not empty.
+    // Saving a bundle would overwrite its real components with this stale/empty
+    // set, wiping the bundle (#1944). Block until the user reopens and reloads.
+    if (isBundle && detailLoadFailed) {
+      showToast({
+        message: 'This bundle’s components could not be loaded. Reopen the item to retry before saving.',
+        type: 'error',
+      });
+      return;
+    }
 
     const comps = isBundle ? components : [];
     for (const c of comps) {
@@ -317,7 +348,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
     } finally {
       setSaving(false);
     }
-  }, [saving, name, priceValid, isBundle, components, itemType, sku, priceNum, costBasis, enrichment, effectiveId, editId, onSaved, onClose]);
+  }, [saving, name, priceValid, isBundle, detailLoadFailed, components, itemType, sku, priceNum, costBasis, enrichment, effectiveId, editId, onSaved, onClose]);
 
   // Auto-fill a NEW item from the web: fill the fields this form actually edits
   // (name + type) and stash provenance. Price is never auto-set — the button shows
@@ -491,6 +522,13 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
 
               {componentsLoading ? (
                 <p className="py-2 text-center text-xs text-muted-foreground">Loading components.</p>
+              ) : detailLoadFailed ? (
+                <p
+                  className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-center text-xs text-destructive"
+                  data-testid="catalog-bundle-load-error"
+                >
+                  Could not load this bundle’s components. Reopen the item to retry — saving now is disabled to avoid wiping the bundle.
+                </p>
               ) : components.length === 0 ? (
                 <p className="py-2 text-center text-xs text-muted-foreground" data-testid="catalog-bundle-empty">
                   No components yet. Add the items this bundle includes.


### PR DESCRIPTION
## Problem

Closes #1944.

In `CatalogItemEditorDrawer.tsx`, the hydration effect loaded an existing item's bundle components + per-org overrides via `getCatalogItem(item.id)` but **swallowed any non-401 failure** (403/404/500) and parse failures silently:

```ts
if (res.status === 401) return UNAUTHORIZED();
if (!res.ok) return;                      // non-401 errors swallowed
const body = (await res.json().catch(() => null)) as ... // parse failure -> null, also silent
```

A bundle item then opened showing **zero components** with no feedback — and saving in that state fired `setBundleComponents(savedId, [])`, **wiping the bundle's real components** (data loss). Found by `silent-failure-hunter` during the #1942 review.

## Fix

The detail load is *load-bearing* here (it drives what the save writes back) — unlike `QuoteEditor`'s `loadEcStatus`, where `if (!res.ok) return` is intentional optional context.

- **Surface the failure**: toast + an inline error banner in the bundle builder (`catalog-bundle-load-error`) instead of rendering an empty bundle.
- **Block the wipe**: a new `detailLoadFailed` flag disables Save for a bundle and guards the `save()` path, so an unloaded bundle can never be persisted as empty.
- Treat a **malformed / no-`data` body** and a **rejected fetch** as failures too (previously a null body fell through to "empty").

## Tests

Added 5 cases (`describe — detail load failure (#1944)`): non-401 HTTP failure, malformed body, rejected fetch, the save-block (`setBundleComponents` / `updateCatalogItem` never called + Save disabled), and the success path (no false positive, components still save). All 11 tests in the file pass.

## Verification

- `vitest run CatalogItemEditorDrawer.test.tsx` — 11 passed
- `vitest run no-silent-mutations.test.ts` — 68 passed
- `tsc --noEmit` — clean (exit 0)
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)