### PR TITLE
fix(catalog): coerce AI enrich output to schema instead of 502 (#1950)

### DIFF
--- a/apps/api/src/services/catalogEnrichmentService.test.ts
+++ b/apps/api/src/services/catalogEnrichmentService.test.ts
@@ -117,6 +117,63 @@ describe('enrichCatalogItem', () => {
     expect(res.provenance.suggestion).toEqual({ truncated: true });
   });
 
+  // Issue #1950: mainstream products (e.g. Microsoft 365 Business Premium) came
+  // back with off-enum itemTypes / oversized fields and were rejected with a
+  // blanket AI_PARSE/502. We now coerce the advisory output to fit the schema.
+  it('maps an off-enum itemType ("subscription") to software instead of rejecting', async () => {
+    create.mockResolvedValueOnce(aiMessage({
+      name: 'Microsoft 365 Business Premium', description: 'Office apps + security',
+      itemType: 'subscription', unitOfMeasure: 'user/month', taxable: true, taxCategory: null,
+      priceLow: 22, priceHigh: 22, currency: 'USD', confidence: 0.9, notes: '',
+    }));
+    const res = await enrichCatalogItem('Microsoft 365 Business Premium', undefined, actor);
+    expect(res.draft.itemType).toBe('software');
+    expect(res.draft.name).toBe('Microsoft 365 Business Premium');
+  });
+
+  it('normalizes a capitalized itemType ("Software")', async () => {
+    create.mockResolvedValueOnce(aiMessage({
+      name: 'Adobe Acrobat', description: null, itemType: 'Software',
+      unitOfMeasure: 'each', taxable: true, taxCategory: null,
+      priceLow: null, priceHigh: null, currency: null, confidence: 0.5, notes: '',
+    }));
+    const res = await enrichCatalogItem('Adobe Acrobat', undefined, actor);
+    expect(res.draft.itemType).toBe('software');
+  });
+
+  it('truncates an oversized description and name instead of throwing AI_PARSE', async () => {
+    create.mockResolvedValueOnce(aiMessage({
+      name: 'N'.repeat(400), description: 'd'.repeat(20_000), itemType: 'service',
+      unitOfMeasure: 'u'.repeat(80), taxable: true, taxCategory: 'c'.repeat(200),
+      priceLow: null, priceHigh: null, currency: null, confidence: 0.5, notes: '',
+    }));
+    const res = await enrichCatalogItem('Service X', undefined, actor);
+    expect(res.draft.name.length).toBe(255);
+    expect(res.draft.description?.length).toBe(10_000);
+    expect(res.draft.unitOfMeasure.length).toBe(50);
+    expect(res.draft.taxCategory?.length).toBe(100);
+  });
+
+  it('falls back to the query for the name when the model omits it', async () => {
+    create.mockResolvedValueOnce(aiMessage({
+      description: null, itemType: 'service',
+      unitOfMeasure: 'each', taxable: true, taxCategory: null,
+      priceLow: null, priceHigh: null, currency: null, confidence: 0.3, notes: '',
+    }));
+    const res = await enrichCatalogItem('Some Product', undefined, actor);
+    expect(res.draft.name).toBe('Some Product');
+  });
+
+  it('coerces a non-string description to null rather than failing', async () => {
+    create.mockResolvedValueOnce(aiMessage({
+      name: 'Thing', description: 42, itemType: 'service',
+      unitOfMeasure: 'each', taxable: true, taxCategory: null,
+      priceLow: null, priceHigh: null, currency: null, confidence: 0.5, notes: '',
+    }));
+    const res = await enrichCatalogItem('Thing', undefined, actor);
+    expect(res.draft.description).toBeNull();
+  });
+
   it('skips org-scoped guardrails and cost when orgId is null', async () => {
     create.mockResolvedValueOnce(aiMessage({
       name: 'N', description: null, itemType: 'service',

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -7,6 +7,7 @@ import { captureException } from './sentry';
 import {
   enrichDraftSchema,
   type CatalogItemType,
+  type EnrichDraft,
   type EnrichResponse,
   type EnrichmentProvenance,
 } from '@breeze/shared';
@@ -105,7 +106,7 @@ function coerceDraft(
   raw: Record<string, unknown>,
   query: string,
   hint: CatalogItemType | undefined,
-): { name: string; description: string | null; itemType: CatalogItemType; unitOfMeasure: string; taxable: boolean; taxCategory: string | null } | null {
+): EnrichDraft | null {
   const rawName = coerceString(raw.name)?.trim() || query.trim();
   const name = rawName.slice(0, NAME_MAX);
   if (!name) return null;

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -47,12 +47,84 @@ const SYSTEM_PROMPT =
   '"unitOfMeasure":string,"taxable":boolean,"taxCategory":string|null,' +
   '"priceLow":number|null,"priceHigh":number|null,"currency":string|null,' +
   '"confidence":number,"notes":string}\n' +
+  'itemType MUST be exactly one of "hardware", "software", or "service" — map any ' +
+  'subscription, SaaS, app, or license to "software". Keep description under 1000 ' +
+  'characters and name under 250 characters.\n' +
   'priceLow/priceHigh are a TYPICAL street-price RANGE in the item currency; never a ' +
   'single committed price. If unknown, use null. Do not invent a price you are unsure of.';
 
 function clampMoney(n: unknown): number | null {
   if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return null;
   return Math.min(n, MONEY_MAX);
+}
+
+// enrichDraftSchema bounds (mirrors catalog.ts). Keep in sync if the schema caps change.
+const NAME_MAX = 255;
+const DESCRIPTION_MAX = 10_000;
+const UNIT_OF_MEASURE_MAX = 50;
+const TAX_CATEGORY_MAX = 100;
+
+// Mainstream products (e.g. "Microsoft 365 Business Premium") routinely come back
+// with an itemType outside our 3-value enum ("subscription", "saas", "license",
+// or a capitalized "Software"). Map the common synonyms to the closest enum value
+// so the draft validates instead of throwing a blanket AI_PARSE/502 (issue #1950).
+const ITEM_TYPE_SYNONYMS: Record<string, CatalogItemType> = {
+  subscription: 'software',
+  saas: 'software',
+  license: 'software',
+  licence: 'software',
+  app: 'software',
+  application: 'software',
+  cloud: 'software',
+  device: 'hardware',
+  equipment: 'hardware',
+  appliance: 'hardware',
+  labor: 'service',
+  labour: 'service',
+  support: 'service',
+  managed: 'service',
+};
+
+function coerceString(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+function normalizeItemType(v: unknown, hint: CatalogItemType | undefined): CatalogItemType {
+  const s = typeof v === 'string' ? v.trim().toLowerCase() : '';
+  if (s === 'hardware' || s === 'software' || s === 'service') return s;
+  if (s && ITEM_TYPE_SYNONYMS[s]) return ITEM_TYPE_SYNONYMS[s];
+  return hint ?? 'service';
+}
+
+// Coerce the model's raw JSON into a draft that satisfies enrichDraftSchema.
+// The model output is advisory, not a contract: out-of-bounds values (a long
+// web-sourced description, an off-enum itemType, an oversized name/category) are
+// recoverable, so we trim/normalize them rather than reject the whole enrichment.
+// Returns null only when `name` is unsalvageable — the one field with no fallback.
+function coerceDraft(
+  raw: Record<string, unknown>,
+  query: string,
+  hint: CatalogItemType | undefined,
+): { name: string; description: string | null; itemType: CatalogItemType; unitOfMeasure: string; taxable: boolean; taxCategory: string | null } | null {
+  const rawName = coerceString(raw.name)?.trim() || query.trim();
+  const name = rawName.slice(0, NAME_MAX);
+  if (!name) return null;
+
+  const description = coerceString(raw.description)?.slice(0, DESCRIPTION_MAX) ?? null;
+
+  const rawUom = coerceString(raw.unitOfMeasure)?.trim();
+  const unitOfMeasure = (rawUom ? rawUom.slice(0, UNIT_OF_MEASURE_MAX) : '') || 'each';
+
+  const taxCategory = coerceString(raw.taxCategory)?.slice(0, TAX_CATEGORY_MAX) ?? null;
+
+  return {
+    name,
+    description,
+    itemType: normalizeItemType(raw.itemType, hint),
+    unitOfMeasure,
+    taxable: typeof raw.taxable === 'boolean' ? raw.taxable : true,
+    taxCategory,
+  };
 }
 
 function priceGuidanceFrom(low: number | null, high: number | null, currency: string | null): string | null {
@@ -147,15 +219,23 @@ export const aiEnrichmentProvider: EnrichmentProvider = {
       throw new EnrichmentError('Could not parse AI response', 'AI_PARSE', 502);
     }
 
-    const draftParse = enrichDraftSchema.safeParse({
-      name: raw.name,
-      description: raw.description ?? null,
-      itemType: raw.itemType ?? hint ?? 'service',
-      unitOfMeasure: typeof raw.unitOfMeasure === 'string' && raw.unitOfMeasure ? raw.unitOfMeasure : 'each',
-      taxable: typeof raw.taxable === 'boolean' ? raw.taxable : true,
-      taxCategory: (raw.taxCategory as string | null) ?? null,
-    });
-    if (!draftParse.success) throw new EnrichmentError('AI response missing required fields', 'AI_PARSE', 502);
+    // Coerce the advisory model output to fit enrichDraftSchema's bounds before
+    // validating, so a long web-sourced description or an off-enum itemType is
+    // normalized rather than rejected with a blanket 502 (issue #1950). The schema
+    // parse below is then a safety net that should only trip on a truly empty name.
+    const coerced = coerceDraft(raw, query, hint);
+    if (!coerced) {
+      console.error('[catalog-enrich] no usable name in AI output', { query, preview: finalText.slice(0, 200) });
+      throw new EnrichmentError('AI response missing a product name', 'AI_PARSE', 502);
+    }
+    const draftParse = enrichDraftSchema.safeParse(coerced);
+    if (!draftParse.success) {
+      console.error('[catalog-enrich] coerced draft failed validation', {
+        query,
+        issues: draftParse.error.issues.map((iss) => `${iss.path.join('.')}: ${iss.message}`),
+      });
+      throw new EnrichmentError('AI response missing required fields', 'AI_PARSE', 502);
+    }
 
     const low = clampMoney(raw.priceLow);
     const high = clampMoney(raw.priceHigh);


### PR DESCRIPTION
## Summary

Catalog AI auto-fill (#1942) returned `AI_PARSE`/HTTP 502 ("AI response missing required fields") for mainstream products like **Microsoft 365 Business Premium**. Root cause: `catalogEnrichmentService.ts` passed the model's *advisory* JSON straight into the strict `enrichDraftSchema`, so common, recoverable deviations tripped the schema and threw a blanket 502:

- **`itemType`** outside the 3-value enum — the model returns `"subscription"`, `"saas"`, `"license"`, or a capitalized `"Software"` for SaaS products like M365.
- **`description`** longer than the 10k cap (web-sourced product blurbs).
- **`name` / `unitOfMeasure` / `taxCategory`** exceeding their length bounds.

The model (`claude-sonnet-4-6` via `resolveDefaultModel`) is capable; the failure was an over-strict prompt↔schema contract, not the model or credentials.

## Fix

- Add a `coerceDraft` step that normalizes the raw model output to satisfy `enrichDraftSchema` instead of rejecting it:
  - `itemType`: lowercase/trim + a synonym map (`subscription`/`saas`/`license`/`app`/… → `software`, `device`/`equipment` → `hardware`, `support`/`labor` → `service`), falling back to the hint or `service`.
  - `name`: trim + truncate to 255; fall back to the request query when the model omits it.
  - `description` / `unitOfMeasure` / `taxCategory`: coerce to string-or-null + truncate to their caps.
- Keep the `enrichDraftSchema.safeParse` as a **safety net** (now only trips on a truly empty name) and log the offending Zod issues on failure for forensics.
- Harden the system prompt to steer the model toward the enum and length bounds, reducing the need for coercion in the first place.

`AI_PARSE` is now reserved for genuinely unusable output (no name); recoverable shape drift no longer 502s.

## Tests

- `apps/api/src/services/catalogEnrichmentService.test.ts` — 5 new cases: off-enum `itemType` → software, capitalized `"Software"`, oversized name/description/uom/taxCategory truncation, name fallback to query, non-string description → null. 14 passed.
- `apps/api/src/routes/catalog/enrich.test.ts` — 3 passed.
- `packages/shared/src/validators/catalog.test.ts` — 35 passed.
- `tsc --noEmit` clean.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)