### PR TITLE
fix(catalog): record AI enrich spend to org budget (#1949)

### DIFF
--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { calculateCostCents, recordUsageFromSdkResult } from './aiCostTracker';
+import { calculateCostCents, recordUsage, recordUsageFromSdkResult } from './aiCostTracker';
 import { db } from '../db';
 
 // ============================================
@@ -70,7 +70,10 @@ const mockDb = db as unknown as {
  * `sessionModel` is returned by the session-model lookup `db.select(...).limit(1)`.
  */
 function setupDbMocks(sessionModel: string | null) {
-  const capture: { sessionSet?: Record<string, unknown> } = {};
+  const capture: {
+    sessionSet?: Record<string, unknown>;
+    aggregateValues: Array<Record<string, unknown>>;
+  } = { aggregateValues: [] };
 
   mockDb.update.mockReturnValue({
     set: vi.fn((values: Record<string, unknown>) => {
@@ -80,9 +83,10 @@ function setupDbMocks(sessionModel: string | null) {
   });
 
   mockDb.insert.mockReturnValue({
-    values: vi.fn(() => ({
-      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-    })),
+    values: vi.fn((values: Record<string, unknown>) => {
+      capture.aggregateValues.push(values);
+      return { onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) };
+    }),
   });
 
   // db.select(...) is used both for the session-model lookup and for the
@@ -294,5 +298,52 @@ describe('recordUsageFromSdkResult', () => {
     });
 
     expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================
+// recordUsage — sessionless org-budget path (issue #1949)
+// ============================================
+
+describe('recordUsage', () => {
+  it('records the session row when a real sessionId is given', async () => {
+    const captured = setupDbMocks(null);
+
+    // sonnet-4-6 1M/1M → 1800 cents on the session row.
+    await recordUsage('sess-1', 'org-1', 'claude-sonnet-4-6', 1_000_000, 1_000_000, true);
+
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(recordedCostCents(captured.sessionSet)).toBe(1800);
+  });
+
+  it('skips the ai_sessions update but still writes org aggregates when sessionId is null', async () => {
+    // The catalog AI enrichment flow has no ai_sessions row. Passing null must
+    // NOT touch ai_sessions (the old non-UUID label threw and bypassed budgets,
+    // issue #1949) yet must still record the org-budget aggregates.
+    const captured = setupDbMocks(null);
+
+    await recordUsage(null, 'org-1', 'claude-sonnet-4-6', 1_000_000, 1_000_000, true);
+
+    // No session update at all.
+    expect(mockDb.update).not.toHaveBeenCalled();
+
+    // Both daily and monthly aggregate inserts still happen, carrying the spend.
+    expect(captured.aggregateValues.length).toBe(2);
+    const periods = captured.aggregateValues.map((v) => v.period).sort();
+    expect(periods).toEqual(['daily', 'monthly']);
+    for (const agg of captured.aggregateValues) {
+      expect(agg.orgId).toBe('org-1');
+      expect(agg.totalCostCents).toBe(1800); // 1M/1M sonnet-4-6
+      expect(agg.inputTokens).toBe(1_000_000);
+      expect(agg.outputTokens).toBe(1_000_000);
+      expect(agg.toolExecutionCount).toBe(1); // isToolExecution=true
+    }
+  });
+
+  it('does not throw on the sessionless path (budget enforcement always sees the spend)', async () => {
+    setupDbMocks(null);
+    await expect(
+      recordUsage(null, 'org-1', 'claude-sonnet-4-6', 100, 50, true),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -243,9 +243,17 @@ export async function checkAiRateLimit(
 
 /**
  * Record token usage for a message and update aggregates.
+ *
+ * `sessionId` is `null` for sessionless flows (e.g. the one-shot catalog AI
+ * enrichment, which has no `ai_sessions` row). In that case the per-session
+ * totals update is skipped, but the org-budget aggregates (`ai_cost_usage`)
+ * are still written so per-org budget enforcement still sees the spend. Passing
+ * a non-UUID label as the session id used to throw `invalid input syntax for
+ * type uuid` and abort before the aggregate write, silently bypassing budgets
+ * (issue #1949).
  */
 export async function recordUsage(
-  sessionId: string,
+  sessionId: string | null,
   orgId: string,
   model: string,
   inputTokens: number,
@@ -260,21 +268,23 @@ export async function recordUsage(
   // Run queries individually instead of in a transaction to avoid
   // SAVEPOINT errors with the postgres.js driver (postgres@3.4.8).
   // These are additive counters so partial failure is acceptable.
-  try {
-    await db
-      .update(aiSessions)
-      .set({
-        totalInputTokens: sql`${aiSessions.totalInputTokens} + ${inputTokens}`,
-        totalOutputTokens: sql`${aiSessions.totalOutputTokens} + ${outputTokens}`,
-        totalCostCents: sql`${aiSessions.totalCostCents} + ${costCents}`,
-        turnCount: sql`${aiSessions.turnCount} + 1`,
-        lastActivityAt: new Date(),
-        updatedAt: new Date()
-      })
-      .where(eq(aiSessions.id, sessionId));
-  } catch (err) {
-    console.error(`[AI] Failed to update session totals for session=${sessionId}, cost=${costCents}:`, err);
-    throw err;
+  if (sessionId !== null) {
+    try {
+      await db
+        .update(aiSessions)
+        .set({
+          totalInputTokens: sql`${aiSessions.totalInputTokens} + ${inputTokens}`,
+          totalOutputTokens: sql`${aiSessions.totalOutputTokens} + ${outputTokens}`,
+          totalCostCents: sql`${aiSessions.totalCostCents} + ${costCents}`,
+          turnCount: sql`${aiSessions.turnCount} + 1`,
+          lastActivityAt: new Date(),
+          updatedAt: new Date()
+        })
+        .where(eq(aiSessions.id, sessionId));
+    } catch (err) {
+      console.error(`[AI] Failed to update session totals for session=${sessionId}, cost=${costCents}:`, err);
+      throw err;
+    }
   }
 
   // Update daily/monthly aggregates
@@ -565,7 +575,7 @@ export async function getRemainingBudgetUsd(orgId: string): Promise<number | nul
  * Logs warnings for sessions consuming too much budget.
  */
 async function checkCostAnomalies(
-  sessionId: string,
+  sessionId: string | null,
   orgId: string,
   costCents: number,
   dailyKey: string
@@ -578,12 +588,16 @@ async function checkCostAnomalies(
 
   if (!budget || !budget.dailyBudgetCents) return;
 
-  // Check if single session exceeds 10% of daily budget
-  const [session] = await db
-    .select({ totalCostCents: aiSessions.totalCostCents })
-    .from(aiSessions)
-    .where(eq(aiSessions.id, sessionId))
-    .limit(1);
+  // Check if single session exceeds 10% of daily budget. Sessionless flows
+  // (sessionId === null, e.g. catalog enrichment) have no per-session row, so
+  // skip straight to the org-level daily check.
+  const [session] = sessionId === null
+    ? [undefined]
+    : await db
+        .select({ totalCostCents: aiSessions.totalCostCents })
+        .from(aiSessions)
+        .where(eq(aiSessions.id, sessionId))
+        .limit(1);
 
   if (session && session.totalCostCents > budget.dailyBudgetCents * 0.1) {
     console.warn(

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -1,6 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
-import { randomUUID } from 'node:crypto';
 import { resolveDefaultModel } from './aiAgent';
 import { checkBudget, checkAiRateLimit, recordUsage } from './aiCostTracker';
 import { captureException } from './sentry';
@@ -122,7 +121,11 @@ export const aiEnrichmentProvider: EnrichmentProvider = {
     }
 
     if (actor.orgId) {
-      recordUsage('catalog-enrich-' + randomUUID(), actor.orgId, model, totalIn, totalOut, true)
+      // Sessionless flow: there is no ai_sessions row for catalog enrichment, so
+      // pass null and let recordUsage write only the org-budget aggregates. The
+      // previous 'catalog-enrich-<uuid>' label was not a valid uuid and threw
+      // before any spend was recorded, bypassing budget enforcement (issue #1949).
+      recordUsage(null, actor.orgId, model, totalIn, totalOut, true)
         .catch((err) => {
           console.error('[catalog-enrich] recordUsage failed:', err);
           captureException(err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
## Problem

The catalog AI auto-fill endpoint (#1942) recorded **zero** AI usage: every call logged `invalid input syntax for type uuid` and the spend (~30k tokens/call) was never written, so **per-org AI budget enforcement was bypassed** for this endpoint (issue #1949).

## Root cause

`catalogEnrichmentService.ts` passed `'catalog-enrich-' + randomUUID()` as the session id to `recordUsage`. That argument is written as `ai_sessions.id`, a **`uuid`** column, so the very first statement (`UPDATE ai_sessions ... WHERE id = sessionId`) threw `invalid input syntax for type uuid` and aborted **before** the `ai_cost_usage` aggregate insert — the table per-org budget checks actually read. Because the call is fire-and-forget (`.catch` → log + Sentry), the enrich still returned 200 while the spend silently vanished.

Note: even a *bare* `randomUUID()` (the issue's first proposed fix) would only swap the throw for a 0-row no-op UPDATE — correct for budgets but a misleading phantom session write. Catalog enrichment is a one-shot flow with **no `ai_sessions` row**, so the right model is "sessionless".

## Fix

- `recordUsage` (and `checkCostAnomalies`) now accept `sessionId: string | null`. When `null`, the per-session `ai_sessions` UPDATE is skipped entirely and only the org-budget aggregates + org-level anomaly check run — so budget enforcement always sees the spend.
- `catalogEnrichmentService` passes `null` and drops the spurious `randomUUID` label/import.

## Tests

- Added a `recordUsage` describe block to `aiCostTracker.test.ts`: asserts the sessionless (`null`) path does **not** touch `ai_sessions` but still writes both daily+monthly `ai_cost_usage` aggregates carrying the full spend, and never throws. Existing real-sessionId behavior is covered too.
- Affected suite green: `vitest run src/services/aiCostTracker.test.ts src/services/catalogEnrichmentService.test.ts` → 30 passed.
- `tsc --noEmit` clean for `apps/api`.

Closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)