### PR TITLE
feat(web): move Stripe key entry into Integrations as a Payments tab

### DIFF
--- a/apps/web/src/components/billing/PartnerBillingSettings.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.tsx
@@ -3,7 +3,6 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { pctFromFraction } from './invoiceTypes';
-import StripeConnectCard from './StripeConnectCard';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -286,8 +285,6 @@ export default function PartnerBillingSettings() {
           />
         </div>
       </section>
-
-      <StripeConnectCard />
 
       <div className="flex justify-end">
         <button

--- a/apps/web/src/components/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import {
   Activity,
   Boxes,
-  CreditCard,
   DollarSign,
   MessageSquare,
   Plug,
@@ -25,10 +24,11 @@ import QuickbooksIntegration from './QuickbooksIntegration';
 import StripePaymentsIntegration from './StripePaymentsIntegration';
 import { getJwtClaims } from '../../lib/authScope';
 
-type TabId = 'webhooks' | 'notifications' | 'psa' | 'security' | 'monitoring' | 'identity' | 'distributors' | 'accounting' | 'payments';
+type TabId = 'webhooks' | 'notifications' | 'psa' | 'security' | 'monitoring' | 'identity' | 'distributors' | 'accounting';
 type SecuritySubTab = 'sentinelone' | 'huntress';
 type IdentitySubTab = 'google' | 'm365';
 type DistributorSubTab = 'pax8' | 'tdsynnex' | 'tdsynnex-ec';
+type AccountingSubTab = 'quickbooks' | 'stripe';
 
 const tabs: { id: TabId; label: string; icon: typeof Activity }[] = [
   { id: 'webhooks', label: 'Webhooks', icon: Webhook },
@@ -39,7 +39,6 @@ const tabs: { id: TabId; label: string; icon: typeof Activity }[] = [
   { id: 'identity', label: 'Identity', icon: Users },
   { id: 'distributors', label: 'Distributors', icon: Boxes },
   { id: 'accounting', label: 'Accounting', icon: DollarSign },
-  { id: 'payments', label: 'Payments', icon: CreditCard },
 ];
 
 const securitySubTabs: { id: SecuritySubTab; label: string }[] = [
@@ -62,6 +61,11 @@ const distributorSubTabs: { id: DistributorSubTab; label: string }[] = [
   { id: 'tdsynnex-ec', label: 'TD SYNNEX Pricing' },
 ];
 
+const accountingSubTabs: { id: AccountingSubTab; label: string }[] = [
+  { id: 'quickbooks', label: 'QuickBooks' },
+  { id: 'stripe', label: 'Payments' },
+];
+
 interface IntegrationsPageProps {
   initialTab?: TabId;
 }
@@ -76,6 +80,7 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
     securitySub?: SecuritySubTab;
     identitySub?: IdentitySubTab;
     distributorSub?: DistributorSubTab;
+    accountingSub?: AccountingSubTab;
   } = (() => {
     if (typeof window === 'undefined') return { tab: initialTab };
     const hash = window.location.hash.replace(/^#/, '');
@@ -83,12 +88,14 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
     if (securitySubTabs.some((s) => s.id === hash)) return { tab: 'security', securitySub: hash as SecuritySubTab };
     if (identitySubTabs.some((s) => s.id === hash)) return { tab: 'identity', identitySub: hash as IdentitySubTab };
     if (distributorSubTabs.some((s) => s.id === hash)) return { tab: 'distributors', distributorSub: hash as DistributorSubTab };
+    if (accountingSubTabs.some((s) => s.id === hash)) return { tab: 'accounting', accountingSub: hash as AccountingSubTab };
     return { tab: initialTab };
   })();
   const [activeTab, setActiveTab] = useState<TabId>(initialFromHash.tab);
   const [securitySubTab, setSecuritySubTab] = useState<SecuritySubTab>(initialFromHash.securitySub ?? 'sentinelone');
   const [identitySubTab, setIdentitySubTab] = useState<IdentitySubTab>(initialFromHash.identitySub ?? 'google');
   const [distributorSubTab, setDistributorSubTab] = useState<DistributorSubTab>(initialFromHash.distributorSub ?? 'pax8');
+  const [accountingSubTab, setAccountingSubTab] = useState<AccountingSubTab>(initialFromHash.accountingSub ?? 'quickbooks');
 
   // Pax8 and TD SYNNEX APIs both enforce requireScope('partner','system'). Gate
   // the Distributors tab on the JWT scope (never on useOrgStore().partners.length,
@@ -201,6 +208,29 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
         </div>
       )}
 
+      {/* Accounting sub-tabs (hidden for org-scope users, who can't use these APIs) */}
+      {activeTab === 'accounting' && !isOrgScoped && (
+        <div className="flex gap-2">
+          {accountingSubTabs.map((sub) => {
+            const isActive = sub.id === accountingSubTab;
+            return (
+              <button
+                key={sub.id}
+                type="button"
+                onClick={() => setAccountingSubTab(sub.id)}
+                className={`rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                  isActive
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border bg-background text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {sub.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {/* Tab content */}
       {activeTab === 'webhooks' && <WebhooksPage />}
       {activeTab === 'notifications' && <CommunicationIntegrations />}
@@ -229,16 +259,8 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
           Accounting integrations are available to partner accounts only.
         </p>
       )}
-      {activeTab === 'accounting' && !isOrgScoped && <QuickbooksIntegration />}
-      {activeTab === 'payments' && isOrgScoped && (
-        <p
-          className="py-12 text-center text-sm text-muted-foreground"
-          data-testid="payments-org-scope"
-        >
-          Payment integrations are available to partner accounts only.
-        </p>
-      )}
-      {activeTab === 'payments' && !isOrgScoped && <StripePaymentsIntegration />}
+      {activeTab === 'accounting' && !isOrgScoped && accountingSubTab === 'quickbooks' && <QuickbooksIntegration />}
+      {activeTab === 'accounting' && !isOrgScoped && accountingSubTab === 'stripe' && <StripePaymentsIntegration />}
     </div>
   );
 }

--- a/apps/web/src/components/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationsPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Activity,
   Boxes,
+  CreditCard,
   DollarSign,
   MessageSquare,
   Plug,
@@ -21,9 +22,10 @@ import Pax8Integration from './Pax8Integration';
 import TdSynnexCatalogPanel from '../settings/TdSynnexCatalogPanel';
 import TdSynnexEcExpressPanel from '../settings/TdSynnexEcExpressPanel';
 import QuickbooksIntegration from './QuickbooksIntegration';
+import StripePaymentsIntegration from './StripePaymentsIntegration';
 import { getJwtClaims } from '../../lib/authScope';
 
-type TabId = 'webhooks' | 'notifications' | 'psa' | 'security' | 'monitoring' | 'identity' | 'distributors' | 'accounting';
+type TabId = 'webhooks' | 'notifications' | 'psa' | 'security' | 'monitoring' | 'identity' | 'distributors' | 'accounting' | 'payments';
 type SecuritySubTab = 'sentinelone' | 'huntress';
 type IdentitySubTab = 'google' | 'm365';
 type DistributorSubTab = 'pax8' | 'tdsynnex' | 'tdsynnex-ec';
@@ -37,6 +39,7 @@ const tabs: { id: TabId; label: string; icon: typeof Activity }[] = [
   { id: 'identity', label: 'Identity', icon: Users },
   { id: 'distributors', label: 'Distributors', icon: Boxes },
   { id: 'accounting', label: 'Accounting', icon: DollarSign },
+  { id: 'payments', label: 'Payments', icon: CreditCard },
 ];
 
 const securitySubTabs: { id: SecuritySubTab; label: string }[] = [
@@ -227,6 +230,15 @@ export default function IntegrationsPage({ initialTab = 'webhooks' }: Integratio
         </p>
       )}
       {activeTab === 'accounting' && !isOrgScoped && <QuickbooksIntegration />}
+      {activeTab === 'payments' && isOrgScoped && (
+        <p
+          className="py-12 text-center text-sm text-muted-foreground"
+          data-testid="payments-org-scope"
+        >
+          Payment integrations are available to partner accounts only.
+        </p>
+      )}
+      {activeTab === 'payments' && !isOrgScoped && <StripePaymentsIntegration />}
     </div>
   );
 }

--- a/apps/web/src/components/integrations/StripePaymentsIntegration.tsx
+++ b/apps/web/src/components/integrations/StripePaymentsIntegration.tsx
@@ -20,7 +20,7 @@ function maskAccountId(id: string): string {
   return `acct_••••${id.slice(-4)}`;
 }
 
-export default function StripeConnectCard() {
+export default function StripePaymentsIntegration() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [busy, setBusy] = useState(false);


### PR DESCRIPTION
## What

Moves the Stripe key entry out of the **company billing profile** and surfaces it as a first-class **integration** — a **Payments** sub-tab under the **Accounting** tab in the Integrations page (next to QuickBooks).

## Why

The Stripe secret/restricted key is connection credentials for a third-party service, so it belongs alongside the other integrations rather than buried at the bottom of the billing settings form.

## Changes

- **New** `integrations/StripePaymentsIntegration.tsx` — the "Online payments" card relocated from `components/billing/StripeConnectCard.tsx`, renamed to match the integration naming convention. Identical logic; all `data-testid`s preserved.
- **Deleted** `components/billing/StripeConnectCard.tsx`.
- **`PartnerBillingSettings.tsx`** — removed the import and the `<StripeConnectCard />` render.
- **`IntegrationsPage.tsx`** — added an **Accounting → Payments** sub-tab (next to QuickBooks), deep-linkable at `/integrations#stripe`. Org-scope users see the existing accounting partner-only notice.

## Backend

Untouched. The `/partner/stripe-connect` routes, `stripe_connect_accounts` table, and the invoice/webhook code that reads the key all stay as-is, so **existing Stripe connections keep working** — this is purely where the credential UI lives.

## Notes

- This Conductor worktree has no `node_modules`, so `tsc`/`astro check` were not run locally — change is type-safe by inspection; relying on CI for the compile check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)