### PR TITLE
feat(config-policy): virtual "Breeze Defaults" baseline (#1725)

### DIFF
--- a/apps/api/src/routes/agents/pamSettings.ts
+++ b/apps/api/src/routes/agents/pamSettings.ts
@@ -1,3 +1,5 @@
+import { getPamBaseline } from '../../services/policyBaselineDefaults';
+
 /**
  * PAM config-policy feature ('pam') — inline settings shape.
  *
@@ -18,9 +20,7 @@ export interface PamSettings {
  * grandfathered back to ON via pam_org_config.uac_interception_enabled — see
  * resolveDevicePamSettings and migration 2026-07-01-pam-uac-opt-in-grandfathering.
  */
-export const PAM_DEFAULTS: PamSettings = {
-  uacInterceptionEnabled: false,
-};
+export const PAM_DEFAULTS: PamSettings = getPamBaseline();
 
 export function parsePamSettings(inlineSettings: unknown): PamSettings {
   if (!inlineSettings || typeof inlineSettings !== 'object') return PAM_DEFAULTS;

--- a/apps/api/src/routes/configurationPolicies/resolution.test.ts
+++ b/apps/api/src/routes/configurationPolicies/resolution.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  resolveEffectiveConfigMock,
+  previewEffectiveConfigMock,
+  configFeatureTypes,
+} = vi.hoisted(() => ({
+  resolveEffectiveConfigMock: vi.fn(),
+  previewEffectiveConfigMock: vi.fn(),
+  configFeatureTypes: [
+    'patch',
+    'alert_rule',
+    'backup',
+    'security',
+    'monitoring',
+    'maintenance',
+    'compliance',
+    'automation',
+    'event_log',
+    'software_policy',
+    'sensitive_data',
+    'peripheral_control',
+    'warranty',
+    'helper',
+    'remote_access',
+    'pam',
+    'onedrive_helper',
+  ],
+}));
+
+vi.mock('../../services/configurationPolicy', () => ({
+  CONFIG_FEATURE_TYPES: configFeatureTypes,
+  resolveEffectiveConfig: resolveEffectiveConfigMock,
+  previewEffectiveConfig: previewEffectiveConfigMock,
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => next()),
+  requireScope: vi.fn(() => (c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+}));
+
+vi.mock('../../db', () => ({
+  db: {},
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'id', siteId: 'site_id' },
+}));
+
+import { resolutionRoutes } from './resolution';
+import { getPolicyBaselineDefaults } from '../../services/policyBaselineDefaults';
+import { requireScope, requirePermission } from '../../middleware/auth';
+
+// Auth wiring is asserted in its own block (no beforeEach clearAllMocks) so the
+// import-time guard registrations on the routes are still recorded. Without this,
+// stripping the guards from /baseline would leave the 200 route test green.
+describe('resolution routes auth wiring', () => {
+  it('registers the same scope + permission guards as sibling routes', () => {
+    expect(requireScope).toHaveBeenCalledWith('organization', 'partner', 'system');
+    expect(requirePermission).toHaveBeenCalled();
+  });
+});
+
+// The handler returns the static registry verbatim. We assert the registry's
+// shape is what the endpoint will serialize (no DB needed).
+describe('GET /baseline payload shape', () => {
+  it('returns every feature with label/applied/behavior', () => {
+    const features = getPolicyBaselineDefaults();
+    expect(features.length).toBeGreaterThanOrEqual(17);
+    for (const f of features) {
+      expect(typeof f.label).toBe('string');
+      expect(typeof f.behavior).toBe('string');
+      expect(typeof f.applied).toBe('boolean');
+    }
+    const ra = features.find((f) => f.featureType === 'remote_access')!;
+    expect(ra.applied).toBe(true);
+  });
+});
+
+describe('configurationPolicies resolution routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/', resolutionRoutes);
+  });
+
+  it('returns the static baseline registry', async () => {
+    const res = await app.request('/baseline');
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json.features)).toBe(true);
+    expect(json.features).toEqual(getPolicyBaselineDefaults());
+  });
+});

--- a/apps/api/src/routes/configurationPolicies/resolution.ts
+++ b/apps/api/src/routes/configurationPolicies/resolution.ts
@@ -11,6 +11,7 @@ import {
   resolveEffectiveConfig,
   previewEffectiveConfig,
 } from '../../services/configurationPolicy';
+import { getPolicyBaselineDefaults } from '../../services/policyBaselineDefaults';
 import { diffSchema, deviceIdParamSchema } from './schemas';
 
 export const resolutionRoutes = new Hono();
@@ -36,6 +37,14 @@ async function canAccessDeviceSite(c: Context, deviceId: string): Promise<{ ok: 
   return { ok: true };
 }
 
+// GET /baseline — static "Breeze Defaults" registry (read-only, no tenant data)
+resolutionRoutes.get(
+  '/baseline',
+  requireScope('organization', 'partner', 'system'),
+  requireConfigPolicyRead,
+  (c) => c.json({ features: getPolicyBaselineDefaults() })
+);
+
 // GET /effective/:deviceId — resolve effective configuration
 resolutionRoutes.get(
   '/effective/:deviceId',
@@ -54,7 +63,7 @@ resolutionRoutes.get(
       return c.json({ error: 'Device not found or access denied' }, 404);
     }
 
-    const result = await resolveEffectiveConfig(deviceId, auth);
+    const result = await resolveEffectiveConfig(deviceId, auth, { includeBaseline: true });
     if (!result) return c.json({ error: 'Device not found or access denied' }, 404);
 
     return c.json(result);

--- a/apps/api/src/services/configFeatureTypes.ts
+++ b/apps/api/src/services/configFeatureTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical list of configuration-policy feature types.
+ *
+ * This lives in its own LEAF module (no heavy imports) on purpose. Light
+ * consumers — `policyBaselineDefaults.ts`, and transitively `pamSettings.ts`
+ * and the agent `helpers.ts` — need the feature-type list without dragging in
+ * the full `configurationPolicy.ts` service, which references DB schema tables
+ * at module-eval (e.g. FEATURE_TABLE_MAP). Importing the list from here instead
+ * of from `configurationPolicy.ts` breaks the configurationPolicy ⇄
+ * policyBaselineDefaults import cycle and keeps route/helper test suites (which
+ * use partial `db/schema` mocks) from crash-loading the service. (#1725)
+ *
+ * `configurationPolicy.ts` re-exports both names, so existing importers that
+ * pull `ConfigFeatureType` / `CONFIG_FEATURE_TYPES` from there keep working.
+ *
+ * A parity test asserts this list matches the Drizzle `configFeatureTypeEnum`.
+ */
+export const CONFIG_FEATURE_TYPES = [
+  'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
+  'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
+  'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'onedrive_helper',
+] as const;
+
+export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number];

--- a/apps/api/src/services/configurationPolicy.baseline.test.ts
+++ b/apps/api/src/services/configurationPolicy.baseline.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { resolveEffectiveConfig } from './configurationPolicy';
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+
+// Thenable chain — every chainable method returns itself; await resolves to rows.
+// This satisfies all four DB query shapes the resolver uses:
+//   select().from().where().limit()              (device + org)
+//   select().from().where()                      (group memberships)
+//   select().from().innerJoin().innerJoin().where().orderBy()  (assignments join)
+function selectChain(rows: unknown[]) {
+  const chain: any = {
+    then(resolve: (v: unknown) => void) {
+      resolve(rows);
+    },
+  };
+  for (const m of ['from', 'where', 'innerJoin', 'orderBy', 'limit']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+// The resolver makes 4 db.select() calls in order:
+//   1. device row        (devices table, limit 1)
+//   2. org row           (organizations table, limit 1)
+//   3. group memberships (deviceGroupMemberships, no limit)
+//   4. assignments join  (configPolicyAssignments + innerJoins + orderBy)
+function mockResolverCalls(
+  deviceRows: unknown[],
+  orgRows: unknown[],
+  groupRows: unknown[],
+  assignmentRows: unknown[],
+) {
+  vi.mocked(db.select)
+    .mockReturnValueOnce(selectChain(deviceRows) as any)
+    .mockReturnValueOnce(selectChain(orgRows) as any)
+    .mockReturnValueOnce(selectChain(groupRows) as any)
+    .mockReturnValueOnce(selectChain(assignmentRows) as any);
+}
+
+const DEVICE = {
+  id: 'dev-1',
+  orgId: 'org-1',
+  siteId: 'site-1',
+  deviceRole: 'workstation',
+  osType: 'windows',
+};
+const ORG = { partnerId: 'ptr-1' };
+
+const systemAuth = {
+  user: { id: 'system', email: 'system', name: 'System', isPlatformAdmin: false },
+  token: {} as any,
+  partnerId: null,
+  orgId: null,
+  scope: 'system',
+  accessibleOrgIds: null,
+  orgCondition: () => undefined,
+  canAccessOrg: () => true,
+} as unknown as AuthContext;
+
+describe('resolveEffectiveConfig includeBaseline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits baseline by default (features empty for unassigned device)', async () => {
+    mockResolverCalls([DEVICE], [ORG], [], []);
+    const r = await resolveEffectiveConfig('dev-1', systemAuth);
+    expect(r).not.toBeNull();
+    expect(Object.keys(r!.features)).toHaveLength(0);
+    expect(r!.inheritanceChain).toHaveLength(0);
+  });
+
+  it('synthesizes the default layer when includeBaseline is true', async () => {
+    mockResolverCalls([DEVICE], [ORG], [], []);
+    const r = await resolveEffectiveConfig('dev-1', systemAuth, { includeBaseline: true });
+    expect(r).not.toBeNull();
+    const ra = r!.features.remote_access!;
+    expect(ra.sourceLevel).toBe('default');
+    expect(ra.sourcePolicyName).toBe('Breeze Defaults');
+    expect((ra.inlineSettings as Record<string, unknown>).webrtcDesktop).toBe(true);
+    expect(r!.features.patch!.sourceLevel).toBe('default');
+    expect(r!.features.patch!.inlineSettings).toBeNull();
+
+    // Full sentinel assertions on a synthesized feature.
+    expect(ra.sourcePolicyId).toBe('breeze-defaults');
+    expect(ra.sourceTargetId).toBe('breeze-defaults');
+    expect(ra.sourcePriority).toBe(0);
+    expect(ra.featurePolicyId).toBeNull();
+
+    const defaultNode = r!.inheritanceChain.find((n) => n.level === 'default');
+    expect(defaultNode).toBeTruthy();
+    expect(defaultNode!.policyName).toBe('Breeze Defaults');
+    expect(defaultNode!.policyId).toBe('breeze-defaults');
+    expect(defaultNode!.targetId).toBe('breeze-defaults');
+    expect(defaultNode!.priority).toBe(0);
+    expect(defaultNode!.featureTypes).toContain('remote_access');
+    expect(defaultNode!.featureTypes).toContain('patch');
+  });
+
+  it('a real winning assignment blocks baseline synthesis for that feature type', async () => {
+    // One real, active org-level remote_access assignment wins; every other
+    // feature type still falls through to the synthesized baseline.
+    const realAssignmentRow = {
+      assignmentId: 'asg-1',
+      assignmentLevel: 'organization',
+      assignmentTargetId: 'org-1',
+      assignmentPriority: 10,
+      assignmentCreatedAt: new Date('2026-01-01T00:00:00Z'),
+      policyId: 'real-policy-1',
+      policyName: 'Org Remote Access Policy',
+      featureLinkId: 'link-1',
+      featureType: 'remote_access',
+      featurePolicyId: null,
+      inlineSettings: { sessionPromptMode: 'consent' },
+    };
+    mockResolverCalls([DEVICE], [ORG], [], [realAssignmentRow]);
+
+    const r = await resolveEffectiveConfig('dev-1', systemAuth, { includeBaseline: true });
+    expect(r).not.toBeNull();
+
+    // remote_access resolves from the real policy, not the baseline.
+    const ra = r!.features.remote_access!;
+    expect(ra.sourceLevel).not.toBe('default');
+    expect(ra.sourceLevel).toBe('organization');
+    expect(ra.sourcePolicyName).toBe('Org Remote Access Policy');
+    expect(ra.sourcePolicyId).toBe('real-policy-1');
+
+    // A still-unconfigured type falls through to the baseline.
+    expect(r!.features.patch!.sourceLevel).toBe('default');
+
+    // The default inheritance node must NOT claim remote_access.
+    const defaultNode = r!.inheritanceChain.find((n) => n.level === 'default');
+    expect(defaultNode).toBeTruthy();
+    expect(defaultNode!.featureTypes).not.toContain('remote_access');
+    expect(defaultNode!.featureTypes).toContain('patch');
+  });
+});

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -84,6 +84,8 @@ const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {
   partner: 1,
 };
 
+const BREEZE_DEFAULTS_SENTINEL = 'breeze-defaults';
+
 interface ResolvedFeature {
   featureType: ConfigFeatureType;
   featurePolicyId: string | null;
@@ -1352,6 +1354,10 @@ async function resolveEffectiveConfigWithExecutor(
     featureTypes: Array.from(entry.featureTypes),
   }));
 
+  // Synthesizes the virtual bottom-of-hierarchy "Breeze Defaults" layer for every
+  // feature type with no real winner. The BREEZE_DEFAULTS_SENTINEL ids, priority 0,
+  // and sourceLevel:'default' are sentinels the UI keys off to exclude this node from
+  // assigned-policy counts. Opt-in so existing callers are unaffected.
   if (opts?.includeBaseline) {
     const synthesized: ConfigFeatureType[] = [];
     for (const entry of getPolicyBaselineDefaults()) {
@@ -1361,8 +1367,8 @@ async function resolveEffectiveConfigWithExecutor(
         featurePolicyId: null,
         inlineSettings: entry.inlineSettings,
         sourceLevel: 'default',
-        sourceTargetId: 'breeze-defaults',
-        sourcePolicyId: 'breeze-defaults',
+        sourceTargetId: BREEZE_DEFAULTS_SENTINEL,
+        sourcePolicyId: BREEZE_DEFAULTS_SENTINEL,
         sourcePolicyName: 'Breeze Defaults',
         sourcePriority: 0,
       };
@@ -1371,8 +1377,8 @@ async function resolveEffectiveConfigWithExecutor(
     if (synthesized.length > 0) {
       inheritanceChain.push({
         level: 'default',
-        targetId: 'breeze-defaults',
-        policyId: 'breeze-defaults',
+        targetId: BREEZE_DEFAULTS_SENTINEL,
+        policyId: BREEZE_DEFAULTS_SENTINEL,
         policyName: 'Breeze Defaults',
         priority: 0,
         featureTypes: synthesized,

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -35,6 +35,7 @@ import { eventLogInlineSettingsSchema, monitoringInlineSettingsSchema } from '@b
 import type { AuthContext } from '../middleware/auth';
 import { normalizePatchInlineSettings, tryNormalizePatchInlineSettings } from './configPolicyPatching';
 import { resolvePartnerIdForOrg } from '../routes/patches/helpers';
+import { getPolicyBaselineDefaults } from './policyBaselineDefaults';
 
 // ============================================
 // Inline settings schemas
@@ -87,7 +88,7 @@ interface ResolvedFeature {
   featureType: ConfigFeatureType;
   featurePolicyId: string | null;
   inlineSettings: unknown;
-  sourceLevel: ConfigAssignmentLevel;
+  sourceLevel: ConfigAssignmentLevel | 'default';
   sourceTargetId: string;
   sourcePolicyId: string;
   sourcePolicyName: string;
@@ -100,7 +101,7 @@ export interface EffectiveConfiguration {
   deviceId: string;
   features: Record<string, ResolvedFeature>;
   inheritanceChain: Array<{
-    level: ConfigAssignmentLevel;
+    level: ConfigAssignmentLevel | 'default';
     targetId: string;
     policyId: string;
     policyName: string;
@@ -1197,7 +1198,8 @@ export async function listAssignmentsForTarget(level: ConfigAssignmentLevel, tar
 async function resolveEffectiveConfigWithExecutor(
   executor: DbExecutor,
   deviceId: string,
-  auth: AuthContext
+  auth: AuthContext,
+  opts?: { includeBaseline?: boolean }
 ): Promise<EffectiveConfiguration | null> {
   // 1. Load device
   const deviceConditions: SQL[] = [eq(devices.id, deviceId)];
@@ -1345,16 +1347,48 @@ async function resolveEffectiveConfigWithExecutor(
     }
   }
 
-  const inheritanceChain = Array.from(chainMap.values()).map((entry) => ({
+  const inheritanceChain: EffectiveConfiguration['inheritanceChain'] = Array.from(chainMap.values()).map((entry) => ({
     ...entry,
     featureTypes: Array.from(entry.featureTypes),
   }));
 
+  if (opts?.includeBaseline) {
+    const synthesized: ConfigFeatureType[] = [];
+    for (const entry of getPolicyBaselineDefaults()) {
+      if (features[entry.featureType]) continue;
+      features[entry.featureType] = {
+        featureType: entry.featureType,
+        featurePolicyId: null,
+        inlineSettings: entry.inlineSettings,
+        sourceLevel: 'default',
+        sourceTargetId: 'breeze-defaults',
+        sourcePolicyId: 'breeze-defaults',
+        sourcePolicyName: 'Breeze Defaults',
+        sourcePriority: 0,
+      };
+      synthesized.push(entry.featureType);
+    }
+    if (synthesized.length > 0) {
+      inheritanceChain.push({
+        level: 'default',
+        targetId: 'breeze-defaults',
+        policyId: 'breeze-defaults',
+        policyName: 'Breeze Defaults',
+        priority: 0,
+        featureTypes: synthesized,
+      });
+    }
+  }
+
   return { deviceId, features, inheritanceChain };
 }
 
-export async function resolveEffectiveConfig(deviceId: string, auth: AuthContext): Promise<EffectiveConfiguration | null> {
-  return resolveEffectiveConfigWithExecutor(db, deviceId, auth);
+export async function resolveEffectiveConfig(
+  deviceId: string,
+  auth: AuthContext,
+  opts?: { includeBaseline?: boolean }
+): Promise<EffectiveConfiguration | null> {
+  return resolveEffectiveConfigWithExecutor(db, deviceId, auth, opts);
 }
 
 // ============================================

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -67,7 +67,12 @@ export const pamInlineSettingsSchema = z
 // Types
 // ============================================
 
-type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam' | 'onedrive_helper';
+export const CONFIG_FEATURE_TYPES = [
+  'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
+  'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
+  'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'onedrive_helper',
+] as const;
+export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number];
 export type ConfigAssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
 
 const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -68,12 +68,13 @@ export const pamInlineSettingsSchema = z
 // Types
 // ============================================
 
-export const CONFIG_FEATURE_TYPES = [
-  'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
-  'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
-  'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'onedrive_helper',
-] as const;
-export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number];
+// CONFIG_FEATURE_TYPES / ConfigFeatureType live in a leaf module to avoid a
+// configurationPolicy ⇄ policyBaselineDefaults import cycle (and to keep route/
+// helper test suites from transitively crash-loading this service). Re-exported
+// here so existing importers that read them from configurationPolicy still work.
+import { CONFIG_FEATURE_TYPES, type ConfigFeatureType } from './configFeatureTypes';
+export { CONFIG_FEATURE_TYPES };
+export type { ConfigFeatureType };
 export type ConfigAssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
 
 const LEVEL_PRIORITY: Record<ConfigAssignmentLevel, number> = {

--- a/apps/api/src/services/policyBaselineDefaults.test.ts
+++ b/apps/api/src/services/policyBaselineDefaults.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { CONFIG_FEATURE_TYPES } from './configurationPolicy';
 import { getPolicyBaselineDefaults, getRemoteAccessBaseline, getPamBaseline } from './policyBaselineDefaults';
 import { PAM_DEFAULTS } from '../routes/agents/pamSettings';
+import { configFeatureTypeEnum } from '../db/schema/configurationPolicies';
 
 describe('policyBaselineDefaults', () => {
   it('has exactly one entry per ConfigFeatureType', () => {
@@ -46,5 +47,45 @@ describe('policyBaselineDefaults', () => {
 describe('pam defaults single source of truth', () => {
   it('PAM_DEFAULTS equals the canonical pam baseline', () => {
     expect(PAM_DEFAULTS).toEqual(getPamBaseline());
+  });
+});
+
+describe('getRemoteAccessBaseline IS_HOSTED clipboard branching', () => {
+  it('clipboardHostToViewer is false when IS_HOSTED=true', async () => {
+    const saved = process.env.IS_HOSTED;
+    try {
+      process.env.IS_HOSTED = 'true';
+      vi.resetModules();
+      const { getRemoteAccessBaseline: fresh } = await import('./policyBaselineDefaults');
+      const s = fresh();
+      expect(s.clipboardHostToViewer).toBe(false);
+      expect(s.clipboardViewerToHost).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.IS_HOSTED;
+      else process.env.IS_HOSTED = saved;
+      vi.resetModules();
+    }
+  });
+
+  it('clipboardHostToViewer is true when IS_HOSTED is unset', async () => {
+    const saved = process.env.IS_HOSTED;
+    try {
+      delete process.env.IS_HOSTED;
+      vi.resetModules();
+      const { getRemoteAccessBaseline: fresh } = await import('./policyBaselineDefaults');
+      const s = fresh();
+      expect(s.clipboardHostToViewer).toBe(true);
+      expect(s.clipboardViewerToHost).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.IS_HOSTED;
+      else process.env.IS_HOSTED = saved;
+      vi.resetModules();
+    }
+  });
+});
+
+describe('CONFIG_FEATURE_TYPES parity with DB enum', () => {
+  it('matches configFeatureTypeEnum.enumValues exactly', () => {
+    expect([...CONFIG_FEATURE_TYPES].sort()).toEqual([...configFeatureTypeEnum.enumValues].sort());
   });
 });

--- a/apps/api/src/services/policyBaselineDefaults.test.ts
+++ b/apps/api/src/services/policyBaselineDefaults.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { CONFIG_FEATURE_TYPES } from './configurationPolicy';
+import { getPolicyBaselineDefaults, getRemoteAccessBaseline, getPamBaseline } from './policyBaselineDefaults';
+
+describe('policyBaselineDefaults', () => {
+  it('has exactly one entry per ConfigFeatureType', () => {
+    const entries = getPolicyBaselineDefaults();
+    const types = entries.map((e) => e.featureType).sort();
+    expect(types).toEqual([...CONFIG_FEATURE_TYPES].sort());
+    expect(entries.length).toBe(CONFIG_FEATURE_TYPES.length);
+  });
+
+  it('marks remote_access as applied with desktop/vnc/tools ON', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'remote_access')!;
+    expect(entry.applied).toBe(true);
+    expect(entry.inlineSettings).toMatchObject({ webrtcDesktop: true, vncRelay: true, remoteTools: true });
+  });
+
+  it('marks pam as applied with UAC interception OFF (opt-in)', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'pam')!;
+    expect(entry.applied).toBe(true);
+    expect(entry.inlineSettings).toEqual({ uacInterceptionEnabled: false });
+  });
+
+  it('marks patch (and other unenforced features) as not applied', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'patch')!;
+    expect(entry.applied).toBe(false);
+    expect(entry.inlineSettings).toBeNull();
+    expect(entry.behavior.length).toBeGreaterThan(0);
+  });
+
+  it('getRemoteAccessBaseline returns the full settings shape', () => {
+    const s = getRemoteAccessBaseline();
+    expect(s.webrtcDesktop).toBe(true);
+    expect(s.maxConcurrentTunnels).toBe(5);
+    expect(s.idleTimeoutMinutes).toBe(5);
+    expect(s.maxSessionDurationHours).toBe(8);
+  });
+
+  it('getPamBaseline returns UAC off', () => {
+    expect(getPamBaseline()).toEqual({ uacInterceptionEnabled: false });
+  });
+});

--- a/apps/api/src/services/policyBaselineDefaults.test.ts
+++ b/apps/api/src/services/policyBaselineDefaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { CONFIG_FEATURE_TYPES } from './configurationPolicy';
 import { getPolicyBaselineDefaults, getRemoteAccessBaseline, getPamBaseline } from './policyBaselineDefaults';
+import { PAM_DEFAULTS } from '../routes/agents/pamSettings';
 
 describe('policyBaselineDefaults', () => {
   it('has exactly one entry per ConfigFeatureType', () => {
@@ -39,5 +40,11 @@ describe('policyBaselineDefaults', () => {
 
   it('getPamBaseline returns UAC off', () => {
     expect(getPamBaseline()).toEqual({ uacInterceptionEnabled: false });
+  });
+});
+
+describe('pam defaults single source of truth', () => {
+  it('PAM_DEFAULTS equals the canonical pam baseline', () => {
+    expect(PAM_DEFAULTS).toEqual(getPamBaseline());
   });
 });

--- a/apps/api/src/services/policyBaselineDefaults.ts
+++ b/apps/api/src/services/policyBaselineDefaults.ts
@@ -9,7 +9,10 @@
  * enforcement paths (remoteAccessPolicy.ts / pamSettings.ts) so there is exactly
  * one definition each.
  */
-import { CONFIG_FEATURE_TYPES, type ConfigFeatureType } from './configurationPolicy';
+// Import the feature-type list from the leaf module, NOT from configurationPolicy
+// — importing from the service would create a runtime cycle and pull the heavy
+// service into pamSettings/helpers test suites (#1725 PR review).
+import { CONFIG_FEATURE_TYPES, type ConfigFeatureType } from './configFeatureTypes';
 import type { RemoteAccessSettings } from './remoteAccessPolicy';
 
 export interface BaselineEntry {

--- a/apps/api/src/services/policyBaselineDefaults.ts
+++ b/apps/api/src/services/policyBaselineDefaults.ts
@@ -24,8 +24,13 @@ export interface BaselineEntry {
 }
 
 // Hosted multi-tenant SaaS defaults the silent-exfil direction (remote host
-// clipboard → operator viewer) OFF. Self-hosted preserves the historical
-// bidirectional default. Mirrors the rationale in remoteAccessPolicy.ts.
+// clipboard → operator viewer) OFF, so an MSP operator can't passively harvest
+// whatever a customer copies during a session. Operator→host paste stays on for
+// usability. Self-hosted (single-tenant, IS_HOSTED!='true') preserves the
+// historical bidirectional default so an upgrade doesn't silently change
+// behavior for an admin running their own instance. There's no dedicated
+// clipboard-direction UI yet (one is being added separately), but both
+// defaults are overridable via an explicit `remote_access` policy. Finding #7.
 const isHosted = process.env.IS_HOSTED === 'true';
 
 export function getRemoteAccessBaseline(): RemoteAccessSettings {

--- a/apps/api/src/services/policyBaselineDefaults.ts
+++ b/apps/api/src/services/policyBaselineDefaults.ts
@@ -1,0 +1,95 @@
+/**
+ * Canonical "Breeze Defaults" — the single source of truth for how an UNASSIGNED
+ * device behaves (no config policy anywhere in its hierarchy). Surfaced read-only
+ * in the UI as the bottom of the assignment hierarchy (#1725).
+ *
+ * Semantics = runtime behavior, not form-fill values. Most feature types are
+ * "Not enforced" (their resolvers return null/[] with no policy). Only
+ * remote_access and pam carry applied defaults — and those are imported BY the
+ * enforcement paths (remoteAccessPolicy.ts / pamSettings.ts) so there is exactly
+ * one definition each.
+ */
+import { CONFIG_FEATURE_TYPES, type ConfigFeatureType } from './configurationPolicy';
+import type { RemoteAccessSettings } from './remoteAccessPolicy';
+
+export interface BaselineEntry {
+  featureType: ConfigFeatureType;
+  label: string;
+  /** Does anything actually apply to an unassigned device? */
+  applied: boolean;
+  /** Resolved settings when applied; null when "Not enforced". */
+  inlineSettings: Record<string, unknown> | null;
+  /** Human-readable behavior label for the UI. */
+  behavior: string;
+}
+
+// Hosted multi-tenant SaaS defaults the silent-exfil direction (remote host
+// clipboard → operator viewer) OFF. Self-hosted preserves the historical
+// bidirectional default. Mirrors the rationale in remoteAccessPolicy.ts.
+const isHosted = process.env.IS_HOSTED === 'true';
+
+export function getRemoteAccessBaseline(): RemoteAccessSettings {
+  return {
+    webrtcDesktop: true,
+    vncRelay: true,
+    remoteTools: true,
+    clipboardHostToViewer: !isHosted,
+    clipboardViewerToHost: true,
+    enableProxy: true,
+    defaultAllowedPorts: [],
+    autoEnableProxy: false,
+    maxConcurrentTunnels: 5,
+    idleTimeoutMinutes: 5,
+    maxSessionDurationHours: 8,
+  };
+}
+
+export function getPamBaseline(): { uacInterceptionEnabled: boolean } {
+  return { uacInterceptionEnabled: false };
+}
+
+// label + behavior + applied/inlineSettings for every feature type. Order
+// follows CONFIG_FEATURE_TYPES. "Not enforced" entries describe the real-world
+// effect of having no policy.
+const NOT_ENFORCED: Record<Exclude<ConfigFeatureType, 'remote_access' | 'pam'>, { label: string; behavior: string }> = {
+  patch:             { label: 'Patches',            behavior: 'Not enforced — no patch deployments are created from policy.' },
+  alert_rule:        { label: 'Alerts',             behavior: 'Not enforced — no policy alert rules fire.' },
+  backup:            { label: 'Backup',             behavior: 'Not enforced — no backups are scheduled.' },
+  security:          { label: 'Security',           behavior: 'Not enforced — no security posture is applied.' },
+  monitoring:        { label: 'Monitoring',         behavior: 'Not enforced — no service/process monitoring runs.' },
+  maintenance:       { label: 'Maintenance',        behavior: 'Not enforced — no maintenance windows apply.' },
+  compliance:        { label: 'Compliance',         behavior: 'Not enforced — no compliance checks run.' },
+  automation:        { label: 'Automations',        behavior: 'Not enforced — no automations execute.' },
+  event_log:         { label: 'Event Logs',         behavior: 'Not enforced — no event-log collection tuning applies.' },
+  software_policy:   { label: 'Software Policy',     behavior: 'Not enforced — no allow/block software rules apply.' },
+  sensitive_data:    { label: 'Data Discovery',     behavior: 'Not enforced — no sensitive-data scans run.' },
+  peripheral_control:{ label: 'Peripheral Control', behavior: 'Not enforced — peripherals are unrestricted.' },
+  warranty:          { label: 'Warranty',           behavior: 'Not enforced — no warranty alerts apply.' },
+  helper:            { label: 'Breeze Assist',      behavior: 'Not enforced — Breeze Assist uses its built-in defaults.' },
+  onedrive_helper:   { label: 'OneDrive Helper',    behavior: 'Not enforced — no OneDrive helper config applies.' },
+};
+
+export function getPolicyBaselineDefaults(): BaselineEntry[] {
+  return CONFIG_FEATURE_TYPES.map((ft): BaselineEntry => {
+    if (ft === 'remote_access') {
+      return {
+        featureType: ft,
+        label: 'Remote Access',
+        applied: true,
+        inlineSettings: getRemoteAccessBaseline() as unknown as Record<string, unknown>,
+        behavior: 'Remote Desktop, VNC, and Remote Tools are ON by default; session limits apply.',
+      };
+    }
+    if (ft === 'pam') {
+      return {
+        featureType: ft,
+        label: 'Privileged Access',
+        applied: true,
+        inlineSettings: getPamBaseline(),
+        behavior: 'UAC elevation capture is OFF by default (opt-in via a policy).',
+      };
+    }
+    const meta = NOT_ENFORCED[ft];
+    return { featureType: ft, label: meta.label, applied: false, inlineSettings: null, behavior: meta.behavior };
+  });
+}

--- a/apps/api/src/services/remoteAccessPolicy.test.ts
+++ b/apps/api/src/services/remoteAccessPolicy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getRemoteAccessBaseline } from './policyBaselineDefaults';
+
+// Guards the security-sensitive default: Remote Desktop / VNC / Remote Tools
+// must stay ON-by-default after sourcing DEFAULTS from the canonical module.
+describe('remote access baseline defaults (single source of truth)', () => {
+  it('keeps the permissive remote capabilities ON by default', () => {
+    const d = getRemoteAccessBaseline();
+    expect(d.webrtcDesktop).toBe(true);
+    expect(d.vncRelay).toBe(true);
+    expect(d.remoteTools).toBe(true);
+    expect(d.enableProxy).toBe(true);
+    expect(d.autoEnableProxy).toBe(false);
+    expect(d.maxConcurrentTunnels).toBe(5);
+    expect(d.idleTimeoutMinutes).toBe(5);
+    expect(d.maxSessionDurationHours).toBe(8);
+    expect(d.clipboardViewerToHost).toBe(true);
+  });
+});

--- a/apps/api/src/services/remoteAccessPolicy.test.ts
+++ b/apps/api/src/services/remoteAccessPolicy.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./configurationPolicy', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    resolveEffectiveConfig: vi.fn(),
+  };
+});
+
 import { getRemoteAccessBaseline } from './policyBaselineDefaults';
+import { resolveRemoteAccessForDevice, invalidateRemoteAccessCache } from './remoteAccessPolicy';
+import { resolveEffectiveConfig } from './configurationPolicy';
 
 // Guards the security-sensitive default: Remote Desktop / VNC / Remote Tools
 // must stay ON-by-default after sourcing DEFAULTS from the canonical module.
@@ -15,5 +26,29 @@ describe('remote access baseline defaults (single source of truth)', () => {
     expect(d.idleTimeoutMinutes).toBe(5);
     expect(d.maxSessionDurationHours).toBe(8);
     expect(d.clipboardViewerToHost).toBe(true);
+  });
+});
+
+describe('resolveRemoteAccessForDevice no-policy fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateRemoteAccessCache();
+  });
+
+  it('resolves permissive defaults when no remote_access feature is assigned', async () => {
+    const deviceId = `test-device-nopolicy-${Date.now()}`;
+
+    vi.mocked(resolveEffectiveConfig).mockResolvedValueOnce({
+      deviceId,
+      features: {},
+      inheritanceChain: [],
+    });
+
+    const result = await resolveRemoteAccessForDevice(deviceId);
+    expect(result.settings.webrtcDesktop).toBe(true);
+    expect(result.settings.vncRelay).toBe(true);
+    expect(result.settings.remoteTools).toBe(true);
+    expect(result.policyName).toBeNull();
+    expect(result.policyId).toBeNull();
   });
 });

--- a/apps/api/src/services/remoteAccessPolicy.ts
+++ b/apps/api/src/services/remoteAccessPolicy.ts
@@ -5,7 +5,8 @@
  * and provides granular capability checks. Used by remote session, tunnel,
  * system tool, and WebSocket routes to block access when policy disables it.
  *
- * When no policy is assigned, all capabilities default to enabled (permissive).
+ * When no policy is assigned, all capabilities default to enabled (permissive) —
+ * except the hosted clipboard host→viewer direction; see policyBaselineDefaults.ts.
  */
 
 import { resolveEffectiveConfig } from './configurationPolicy';
@@ -48,9 +49,9 @@ export interface PolicyCheckResult {
 
 export type RemoteCapability = 'webrtcDesktop' | 'vncRelay' | 'remoteTools' | 'proxy';
 
-// Applied defaults for an unassigned device live in the canonical baseline
-// module (single source of truth, #1725). isHosted-dependent clipboard default
-// is encoded there.
+// Applied defaults for an unassigned device — including the isHosted-dependent
+// clipboard direction (Finding #7) — live in policyBaselineDefaults.ts
+// (single source of truth, #1725).
 const DEFAULTS: RemoteAccessSettings = getRemoteAccessBaseline();
 
 const CAPABILITY_LABELS: Record<RemoteCapability, string> = {

--- a/apps/api/src/services/remoteAccessPolicy.ts
+++ b/apps/api/src/services/remoteAccessPolicy.ts
@@ -11,6 +11,7 @@
 import { resolveEffectiveConfig } from './configurationPolicy';
 import { remoteAccessInlineSettingsSchema } from '@breeze/shared/validators';
 import type { AuthContext } from '../middleware/auth';
+import { getRemoteAccessBaseline } from './policyBaselineDefaults';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,29 +48,10 @@ export interface PolicyCheckResult {
 
 export type RemoteCapability = 'webrtcDesktop' | 'vncRelay' | 'remoteTools' | 'proxy';
 
-// Hosted multi-tenant SaaS defaults the silent-exfil direction (remote host
-// clipboard → operator viewer) OFF, so an MSP operator can't passively harvest
-// whatever a customer copies during a session. Operator→host paste stays on for
-// usability. Self-hosted (single-tenant, IS_HOSTED!='true') preserves the
-// historical bidirectional default so an upgrade doesn't silently change
-// behavior for an admin running their own instance. There's no dedicated
-// clipboard-direction UI yet (one is being added separately), but both
-// defaults are overridable via an explicit `remote_access` policy. Finding #7.
-const isHosted = process.env.IS_HOSTED === 'true';
-
-const DEFAULTS: RemoteAccessSettings = {
-  webrtcDesktop: true,
-  vncRelay: true,
-  remoteTools: true,
-  clipboardHostToViewer: !isHosted,
-  clipboardViewerToHost: true,
-  enableProxy: true,
-  defaultAllowedPorts: [],
-  autoEnableProxy: false,
-  maxConcurrentTunnels: 5,
-  idleTimeoutMinutes: 5,
-  maxSessionDurationHours: 8,
-};
+// Applied defaults for an unassigned device live in the canonical baseline
+// module (single source of truth, #1725). isHosted-dependent clipboard default
+// is encoded there.
+const DEFAULTS: RemoteAccessSettings = getRemoteAccessBaseline();
 
 const CAPABILITY_LABELS: Record<RemoteCapability, string> = {
   webrtcDesktop: 'Remote desktop',

--- a/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx
@@ -35,4 +35,12 @@ describe('BreezeDefaultsPage', () => {
     expect(links.length).toBeGreaterThanOrEqual(2);
     expect(links[0]).toHaveAttribute('href', expect.stringContaining('/configuration-policies/new'));
   });
+
+  it('summarizes inlineSettings into human-readable lines', async () => {
+    render(<BreezeDefaultsPage />);
+    // The remote_access card's boolean settings render via summarize() as
+    // "<key>: on" — exercises the boolean→on/off + key-humanization branch.
+    await waitFor(() => expect(screen.getByText('Remote Access')).toBeInTheDocument());
+    expect(screen.getByText('webrtc desktop: on')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import BreezeDefaultsPage from './BreezeDefaultsPage';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      features: [
+        { featureType: 'remote_access', label: 'Remote Access', applied: true,
+          inlineSettings: { webrtcDesktop: true, vncRelay: true, remoteTools: true }, behavior: 'Remote Desktop, VNC, and Remote Tools are ON by default; session limits apply.' },
+        { featureType: 'patch', label: 'Patches', applied: false, inlineSettings: null, behavior: 'Not enforced — no patch deployments are created from policy.' },
+      ],
+    }),
+  })),
+}));
+
+describe('BreezeDefaultsPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the applied remote access default and its behavior', async () => {
+    render(<BreezeDefaultsPage />);
+    await waitFor(() => expect(screen.getByText('Remote Access')).toBeInTheDocument());
+    expect(screen.getByText(/Remote Desktop, VNC, and Remote Tools are ON/)).toBeInTheDocument();
+  });
+
+  it('renders a not-enforced feature and a create-override link', async () => {
+    render(<BreezeDefaultsPage />);
+    await waitFor(() => expect(screen.getByText('Patches')).toBeInTheDocument());
+    // Two matches expected: the "Not enforced" badge AND the behavior paragraph
+    // ("Not enforced — ..."). >= 2 guards against the applied-branch badge silently
+    // disappearing while the behavior text still renders.
+    expect(screen.getAllByText(/Not enforced/).length).toBeGreaterThanOrEqual(2);
+    const links = screen.getAllByRole('link', { name: /create override/i });
+    expect(links.length).toBeGreaterThanOrEqual(2);
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('/configuration-policies/new'));
+  });
+});

--- a/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx
+++ b/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx
@@ -37,7 +37,13 @@ export default function BreezeDefaultsPage() {
       const res = await fetchWithAuth('/configuration-policies/baseline');
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       const data = await res.json();
-      setFeatures(Array.isArray(data.features) ? data.features : []);
+      // Surface a malformed 200 (missing/non-array features) as an error rather
+      // than silently rendering an empty page — this endpoint always returns a
+      // populated array, so a non-array means schema drift or a broken response.
+      if (!Array.isArray(data.features)) {
+        throw new Error('Received an invalid response from the server.');
+      }
+      setFeatures(data.features);
     } catch (err) {
       setError(friendlyFetchError(err));
     } finally {

--- a/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx
+++ b/apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldCheck, Layers } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { friendlyFetchError } from '../../lib/utils';
+
+type BaselineFeature = {
+  featureType: string;
+  label: string;
+  applied: boolean;
+  inlineSettings: Record<string, unknown> | null;
+  behavior: string;
+};
+
+function summarize(settings: Record<string, unknown> | null): string[] {
+  if (!settings) return [];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(settings)) {
+    if (v === null || v === undefined) continue;
+    const label = k.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').trim().toLowerCase();
+    if (typeof v === 'boolean') out.push(`${label}: ${v ? 'on' : 'off'}`);
+    else if (typeof v === 'string' || typeof v === 'number') out.push(`${label}: ${v}`);
+    else if (Array.isArray(v)) out.push(`${label}: ${v.length} item${v.length !== 1 ? 's' : ''}`);
+    if (out.length >= 6) break;
+  }
+  return out;
+}
+
+export default function BreezeDefaultsPage() {
+  const [features, setFeatures] = useState<BaselineFeature[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const res = await fetchWithAuth('/configuration-policies/baseline');
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const data = await res.json();
+      setFeatures(Array.isArray(data.features) ? data.features : []);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center rounded-lg border bg-card py-12 shadow-sm">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <button type="button" onClick={load} className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90">Retry</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Layers className="h-5 w-5" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold">Breeze Defaults</h2>
+          <p className="text-sm text-muted-foreground">
+            How devices behave out of the box with no configuration policy assigned. These are
+            read-only — create a policy to override any of them.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {features.map((f) => {
+          const settings = summarize(f.inlineSettings);
+          return (
+            <div key={f.featureType} className="rounded-lg border bg-card p-5 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <h4 className="font-semibold">{f.label}</h4>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${f.applied ? 'bg-primary/10 text-primary' : 'bg-muted/50 text-muted-foreground'}`}>
+                  {f.applied ? <ShieldCheck className="h-3 w-3" /> : null}
+                  {f.applied ? 'Active default' : 'Not enforced'}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">{f.behavior}</p>
+              {settings.length > 0 && (
+                <ul className="mt-3 space-y-0.5 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  {settings.map((s) => <li key={s} className="capitalize">{s}</li>)}
+                </ul>
+              )}
+              <a
+                href={`/configuration-policies/new?feature=${encodeURIComponent(f.featureType)}`}
+                className="mt-3 inline-block text-xs font-medium text-primary hover:underline"
+              >
+                Create override policy
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx
@@ -118,13 +118,22 @@ export default function ConfigurationPoliciesPage() {
             Bundle feature settings into reusable policies and assign them across your hierarchy.
           </p>
         </div>
-        <a
-          href="/configuration-policies/new"
-          className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-        >
-          <Plus className="h-4 w-4" />
-          New Policy
-        </a>
+        <div className="flex items-center gap-2">
+          <a
+            href="/configuration-policies/defaults"
+            className="inline-flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-sm font-medium hover:bg-muted"
+          >
+            <Layers className="h-4 w-4" />
+            Breeze Defaults
+          </a>
+          <a
+            href="/configuration-policies/new"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" />
+            New Policy
+          </a>
+        </div>
       </div>
 
       {error && (

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import DeviceEffectiveConfigTab from './DeviceEffectiveConfigTab';
+
+// Device with ONLY baseline (synthetic 'default') features — no real assigned policy.
+const baselineOnlyResponse = {
+  deviceId: 'dev-1',
+  features: {
+    patch: { featureType: 'patch', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+    alert_rule: { featureType: 'alert_rule', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+  },
+  inheritanceChain: [
+    { level: 'default', targetId: 'breeze-defaults', policyId: 'breeze-defaults', policyName: 'Breeze Defaults', priority: 0, featureTypes: ['patch', 'alert_rule'] },
+  ],
+};
+
+// Device with one REAL org-level policy plus baseline fall-through for the rest.
+// The inheritance chain carries BOTH a real org node and the synthetic default node.
+const mixedResponse = {
+  deviceId: 'dev-2',
+  features: {
+    patch: { featureType: 'patch', featurePolicyId: null, inlineSettings: null, sourceLevel: 'organization', sourceTargetId: 'org-1', sourcePolicyId: 'pol-org', sourcePolicyName: 'Org Patch Policy', sourcePriority: 10 },
+    alert_rule: { featureType: 'alert_rule', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+  },
+  inheritanceChain: [
+    { level: 'organization', targetId: 'org-1', policyId: 'pol-org', policyName: 'Org Patch Policy', priority: 10, featureTypes: ['patch'] },
+    { level: 'default', targetId: 'breeze-defaults', policyId: 'breeze-defaults', policyName: 'Breeze Defaults', priority: 0, featureTypes: ['alert_rule'] },
+  ],
+};
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async (url: string) => {
+    const body = url.includes('dev-2') ? mixedResponse : baselineOnlyResponse;
+    return { ok: true, status: 200, statusText: 'OK', json: async () => body };
+  }),
+}));
+
+describe('DeviceEffectiveConfigTab baseline labeling', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the empty state with a Breeze Defaults link when only the baseline is present', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-1" />);
+    await waitFor(() =>
+      expect(screen.getByText('No Configuration Policies')).toBeInTheDocument(),
+    );
+    const link = screen.getByText('View Breeze Defaults');
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/configuration-policies/defaults');
+  });
+
+  it('labels baseline fall-through features as sourced from Breeze Defaults', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-2" />);
+    // Real assigned policy still renders normally...
+    await waitFor(() => expect(screen.getAllByText('Org Patch Policy').length).toBeGreaterThan(0));
+    // ...and the baseline fall-through feature shows "Breeze Defaults" as its source.
+    expect(screen.getAllByText(/Breeze Defaults/).length).toBeGreaterThan(0);
+  });
+
+  it('excludes the synthetic default node from the assigned-policy count', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-2" />);
+    // Chain has 2 entries (org + default); the count must report only the 1 real policy.
+    await waitFor(() =>
+      expect(screen.getByText(/1 assigned/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/2 assigned/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
@@ -66,4 +66,16 @@ describe('DeviceEffectiveConfigTab baseline labeling', () => {
     );
     expect(screen.queryByText(/2 assigned/i)).not.toBeInTheDocument();
   });
+
+  it('omits the synthetic default node from the inheritance-chain table (no dead link)', async () => {
+    const { container } = render(<DeviceEffectiveConfigTab deviceId="dev-2" />);
+    // The real org policy links into the chain table...
+    await waitFor(() =>
+      expect(container.querySelector('a[href="/configuration-policies/pol-org"]')).toBeTruthy(),
+    );
+    // ...but the synthetic baseline node must NOT render a (broken) policy link.
+    expect(
+      container.querySelector('a[href="/configuration-policies/breeze-defaults"]'),
+    ).toBeNull();
+  });
 });

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
@@ -54,6 +54,8 @@ describe('DeviceEffectiveConfigTab baseline labeling', () => {
     await waitFor(() => expect(screen.getAllByText('Org Patch Policy').length).toBeGreaterThan(0));
     // ...and the baseline fall-through feature shows "Breeze Defaults" as its source.
     expect(screen.getAllByText(/Breeze Defaults/).length).toBeGreaterThan(0);
+    // ...and is explicitly marked "Not enforced" so it never reads as configured.
+    expect(screen.getByText('Not enforced')).toBeInTheDocument();
   });
 
   it('excludes the synthetic default node from the assigned-policy count', async () => {

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
@@ -240,6 +240,10 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
           const settings = summarizeSettings(
             feature.inlineSettings as Record<string, unknown> | null
           );
+          // A feature resolving from the virtual baseline (sourceLevel 'default')
+          // is not enforced for any of the types this tab tracks — say so
+          // explicitly so a baseline card never reads as actively "configured".
+          const isBaseline = feature.sourceLevel === 'default';
 
           return (
             <div key={ft} className="rounded-lg border bg-card p-5 shadow-sm">
@@ -248,7 +252,14 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
                   {meta.icon}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h4 className="font-semibold">{meta.label}</h4>
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-semibold">{meta.label}</h4>
+                    {isBaseline && (
+                      <span className="inline-flex items-center rounded-full border bg-muted/50 px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                        Not enforced
+                      </span>
+                    )}
+                  </div>
                   <p className="mt-0.5 text-xs text-muted-foreground">
                     From: <span className="font-medium text-foreground">{feature.sourcePolicyName}</span>
                     {' '}

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
@@ -206,9 +206,13 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
   }
 
   const { features, inheritanceChain } = data;
+  // The synthetic "Breeze Defaults" layer (level 'default') is excluded from the
+  // assigned-policy count AND the inheritance-chain table below — it is not a real
+  // assigned policy, has no policy page to link to, and lists feature types this
+  // tab does not render. Baseline coverage is surfaced per-card ("Not enforced —
+  // Breeze Defaults") and on the dedicated /configuration-policies/defaults page.
   const assignedChain = inheritanceChain.filter((e) => e.level !== 'default');
   const configuredTypes = ALL_FEATURE_TYPES.filter((ft) => features[ft]);
-  const unconfiguredTypes = ALL_FEATURE_TYPES.filter((ft) => !features[ft]);
 
   return (
     <div className="space-y-6">
@@ -240,9 +244,13 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
           const settings = summarizeSettings(
             feature.inlineSettings as Record<string, unknown> | null
           );
-          // A feature resolving from the virtual baseline (sourceLevel 'default')
-          // is not enforced for any of the types this tab tracks — say so
-          // explicitly so a baseline card never reads as actively "configured".
+          // Safe ONLY while ALL_FEATURE_TYPES excludes remote_access/pam (the two
+          // applied baselines). For every type this tab tracks, a baseline source
+          // ('default') means "not enforced", so we label it as such instead of
+          // letting it read as actively "configured". If remote_access/pam are
+          // ever added to this tab, gate this on the feature being non-applied
+          // rather than on sourceLevel alone, or an applied default (e.g. Remote
+          // Desktop ON) would be mislabeled "Not enforced".
           const isBaseline = feature.sourceLevel === 'default';
 
           return (
@@ -291,31 +299,11 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
             </div>
           );
         })}
-
-        {/* Unconfigured feature placeholders */}
-        {unconfiguredTypes.map((ft) => {
-          const meta = FEATURE_META[ft];
-          return (
-            <div
-              key={ft}
-              className="rounded-lg border border-dashed bg-card/50 p-5 shadow-sm opacity-60"
-            >
-              <div className="flex items-start gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                  {meta.icon}
-                </div>
-                <div>
-                  <h4 className="font-semibold text-muted-foreground">{meta.label}</h4>
-                  <p className="mt-0.5 text-xs text-muted-foreground">No policy assigned</p>
-                </div>
-              </div>
-            </div>
-          );
-        })}
       </div>
 
-      {/* Inheritance chain */}
-      {inheritanceChain.length > 0 && (
+      {/* Inheritance chain — real assigned policies only (the synthetic
+          "Breeze Defaults" node is excluded; see assignedChain above). */}
+      {assignedChain.length > 0 && (
         <div className="rounded-lg border bg-card p-6 shadow-sm">
           <h4 className="font-semibold mb-3">Inheritance Chain</h4>
           <p className="text-xs text-muted-foreground mb-4">
@@ -333,7 +321,7 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {inheritanceChain.map((entry) => (
+                {assignedChain.map((entry) => (
                   <tr key={`${entry.policyId}-${entry.level}-${entry.targetId}`} className="text-sm">
                     <td className="px-4 py-3 text-muted-foreground">{entry.priority}</td>
                     <td className="px-4 py-3">

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
@@ -28,7 +28,7 @@ type FeatureType =
   | 'compliance'
   | 'automation';
 
-type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device';
+type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device' | 'default';
 
 type ResolvedFeature = {
   featureType: FeatureType;
@@ -86,6 +86,7 @@ const LEVEL_LABELS: Record<AssignmentLevel, string> = {
   site: 'Site',
   device_group: 'Device Group',
   device: 'Device',
+  default: 'Breeze Defaults',
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -176,7 +177,10 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
 
   // ── Empty state ────────────────────────────────────────────────────
 
-  if (!data || Object.keys(data.features).length === 0) {
+  const hasRealFeatures = data
+    ? Object.values(data.features).some((f) => f.sourceLevel !== 'default')
+    : false;
+  if (!data || !hasRealFeatures) {
     return (
       <div className="rounded-lg border bg-card p-8 text-center shadow-sm">
         <Layers className="mx-auto h-10 w-10 text-muted-foreground/50" />
@@ -191,11 +195,18 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
         >
           Go to Config Policies
         </a>
+        <a
+          href="/configuration-policies/defaults"
+          className="mt-2 inline-block text-sm font-medium text-primary hover:underline"
+        >
+          View Breeze Defaults
+        </a>
       </div>
     );
   }
 
   const { features, inheritanceChain } = data;
+  const assignedChain = inheritanceChain.filter((e) => e.level !== 'default');
   const configuredTypes = ALL_FEATURE_TYPES.filter((ft) => features[ft]);
   const unconfiguredTypes = ALL_FEATURE_TYPES.filter((ft) => !features[ft]);
 
@@ -206,8 +217,8 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
         <div>
           <h3 className="text-lg font-semibold">Effective Configuration</h3>
           <p className="text-sm text-muted-foreground">
-            Resolved configuration from {inheritanceChain.length} assigned{' '}
-            {inheritanceChain.length === 1 ? 'policy' : 'policies'} across{' '}
+            Resolved configuration from {assignedChain.length} assigned{' '}
+            {assignedChain.length === 1 ? 'policy' : 'policies'} across{' '}
             {configuredTypes.length} feature{configuredTypes.length !== 1 ? 's' : ''}
           </p>
         </div>

--- a/apps/web/src/pages/configuration-policies/defaults.astro
+++ b/apps/web/src/pages/configuration-policies/defaults.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import BreezeDefaultsPage from '../../components/configurationPolicies/BreezeDefaultsPage';
+---
+
+<DashboardLayout title="Breeze Defaults">
+  <BreezeDefaultsPage client:load />
+</DashboardLayout>

--- a/docs/superpowers/plans/2026-06-26-config-policy-baseline-defaults.md
+++ b/docs/superpowers/plans/2026-06-26-config-policy-baseline-defaults.md
@@ -1,0 +1,1028 @@
+# Config Policy Baseline "Breeze Defaults" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface a read-only, virtual "Breeze Defaults" baseline at the bottom of the configuration-policy hierarchy so admins can see how unassigned devices behave out of the box, sourced from a single canonical defaults module.
+
+**Architecture:** A new canonical defaults module (`policyBaselineDefaults.ts`) becomes the single source of truth for the applied no-policy defaults (`remote_access`, `pam`); the live enforcement paths import from it. `resolveEffectiveConfig` gains an opt-in `includeBaseline` flag that synthesizes a `sourceLevel: 'default'` layer for unconfigured features (existing callers unchanged). A new read-only `GET /baseline` endpoint and a dedicated web page surface the full registry; the per-device effective-config view labels fall-through features as "Breeze Defaults".
+
+**Tech Stack:** Hono (API), Drizzle (no schema changes — baseline is virtual), Vitest (API), Astro + React + Tailwind + lucide-react (web), Vitest + jsdom (web).
+
+## Global Constraints
+
+- **No DB migration.** The baseline is a virtual resolution-layer; no rows are created or seeded. Do not add tables, columns, or seed data.
+- **Single source of truth.** Applied defaults (`remote_access`, `pam`) live ONLY in `apps/api/src/services/policyBaselineDefaults.ts`. `remoteAccessPolicy.ts` and `pamSettings.ts` import from it — no duplicated literals.
+- **`ConfigAssignmentLevel` is NOT widened.** You still cannot *assign* at `'default'`. Only `ResolvedFeature.sourceLevel` and the inheritance-chain `level` widen to `ConfigAssignmentLevel | 'default'`.
+- **`includeBaseline` defaults to `false`.** Every existing caller of `resolveEffectiveConfig` must keep its current behavior (the `features` map contains only real winners). Only the `GET /effective/:deviceId` route opts in.
+- **Runtime-behavior semantics.** The baseline shows what actually happens to an unassigned device: `remote_access` ON, `pam` `uacInterceptionEnabled: false`, everything else "Not enforced". Not form-fill/schema defaults.
+- **Scope = config-policy feature types only.** The 17 members of `ConfigFeatureType`. Out-of-band defaults (AI/SSO/portal/OneDrive) are explicitly out of scope.
+- **Display labels live in the API baseline response.** The web `FeatureType` union is missing `onedrive_helper`; the baseline page renders whatever `GET /baseline` returns (label + value + behavior) rather than mapping enum→label client-side.
+- Spec: `docs/superpowers/specs/2026-06-26-config-policy-baseline-defaults-design.md`. Issue: #1725.
+
+---
+
+### Task 1: Canonical defaults module + feature-type list
+
+Establishes the single source of truth and a runtime feature-type list (so both the contract test and the resolver synthesis loop can iterate the 17 types).
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts:70` (convert `type ConfigFeatureType` to a const-array-derived, exported type)
+- Create: `apps/api/src/services/policyBaselineDefaults.ts`
+- Test: `apps/api/src/services/policyBaselineDefaults.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (foundation task).
+- Produces:
+  - `export const CONFIG_FEATURE_TYPES: readonly ConfigFeatureType[]` and `export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number]` in `configurationPolicy.ts`.
+  - In `policyBaselineDefaults.ts`:
+    - `export interface RemoteAccessSettings` is NOT redefined here — import the type from `remoteAccessPolicy.ts` (type-only).
+    - `export type BaselineEntry = { featureType: ConfigFeatureType; label: string; applied: boolean; inlineSettings: Record<string, unknown> | null; behavior: string }`
+    - `export function getRemoteAccessBaseline(): RemoteAccessSettings`
+    - `export function getPamBaseline(): { uacInterceptionEnabled: boolean }`
+    - `export function getPolicyBaselineDefaults(): BaselineEntry[]` (one entry per feature type, in `CONFIG_FEATURE_TYPES` order)
+
+- [ ] **Step 1: Export a runtime feature-type list in `configurationPolicy.ts`**
+
+Replace line 70:
+```ts
+type ConfigFeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam' | 'onedrive_helper';
+```
+with:
+```ts
+export const CONFIG_FEATURE_TYPES = [
+  'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
+  'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
+  'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'onedrive_helper',
+] as const;
+export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number];
+```
+
+- [ ] **Step 2: Write the failing contract test**
+
+Create `apps/api/src/services/policyBaselineDefaults.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { CONFIG_FEATURE_TYPES } from './configurationPolicy';
+import { getPolicyBaselineDefaults, getRemoteAccessBaseline, getPamBaseline } from './policyBaselineDefaults';
+
+describe('policyBaselineDefaults', () => {
+  it('has exactly one entry per ConfigFeatureType', () => {
+    const entries = getPolicyBaselineDefaults();
+    const types = entries.map((e) => e.featureType).sort();
+    expect(types).toEqual([...CONFIG_FEATURE_TYPES].sort());
+    expect(entries.length).toBe(CONFIG_FEATURE_TYPES.length);
+  });
+
+  it('marks remote_access as applied with desktop/vnc/tools ON', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'remote_access')!;
+    expect(entry.applied).toBe(true);
+    expect(entry.inlineSettings).toMatchObject({ webrtcDesktop: true, vncRelay: true, remoteTools: true });
+  });
+
+  it('marks pam as applied with UAC interception OFF (opt-in)', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'pam')!;
+    expect(entry.applied).toBe(true);
+    expect(entry.inlineSettings).toEqual({ uacInterceptionEnabled: false });
+  });
+
+  it('marks patch (and other unenforced features) as not applied', () => {
+    const entry = getPolicyBaselineDefaults().find((e) => e.featureType === 'patch')!;
+    expect(entry.applied).toBe(false);
+    expect(entry.inlineSettings).toBeNull();
+    expect(entry.behavior.length).toBeGreaterThan(0);
+  });
+
+  it('getRemoteAccessBaseline returns the full settings shape', () => {
+    const s = getRemoteAccessBaseline();
+    expect(s.webrtcDesktop).toBe(true);
+    expect(s.maxConcurrentTunnels).toBe(5);
+    expect(s.idleTimeoutMinutes).toBe(5);
+    expect(s.maxSessionDurationHours).toBe(8);
+  });
+
+  it('getPamBaseline returns UAC off', () => {
+    expect(getPamBaseline()).toEqual({ uacInterceptionEnabled: false });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/policyBaselineDefaults.test.ts`
+Expected: FAIL — cannot resolve `./policyBaselineDefaults`.
+
+- [ ] **Step 4: Create the module**
+
+Create `apps/api/src/services/policyBaselineDefaults.ts`:
+```ts
+/**
+ * Canonical "Breeze Defaults" — the single source of truth for how an UNASSIGNED
+ * device behaves (no config policy anywhere in its hierarchy). Surfaced read-only
+ * in the UI as the bottom of the assignment hierarchy (#1725).
+ *
+ * Semantics = runtime behavior, not form-fill values. Most feature types are
+ * "Not enforced" (their resolvers return null/[] with no policy). Only
+ * remote_access and pam carry applied defaults — and those are imported BY the
+ * enforcement paths (remoteAccessPolicy.ts / pamSettings.ts) so there is exactly
+ * one definition each.
+ */
+import { CONFIG_FEATURE_TYPES, type ConfigFeatureType } from './configurationPolicy';
+import type { RemoteAccessSettings } from './remoteAccessPolicy';
+
+export interface BaselineEntry {
+  featureType: ConfigFeatureType;
+  label: string;
+  /** Does anything actually apply to an unassigned device? */
+  applied: boolean;
+  /** Resolved settings when applied; null when "Not enforced". */
+  inlineSettings: Record<string, unknown> | null;
+  /** Human-readable behavior label for the UI. */
+  behavior: string;
+}
+
+// Hosted multi-tenant SaaS defaults the silent-exfil direction (remote host
+// clipboard → operator viewer) OFF. Self-hosted preserves the historical
+// bidirectional default. Mirrors the rationale in remoteAccessPolicy.ts.
+const isHosted = process.env.IS_HOSTED === 'true';
+
+export function getRemoteAccessBaseline(): RemoteAccessSettings {
+  return {
+    webrtcDesktop: true,
+    vncRelay: true,
+    remoteTools: true,
+    clipboardHostToViewer: !isHosted,
+    clipboardViewerToHost: true,
+    enableProxy: true,
+    defaultAllowedPorts: [],
+    autoEnableProxy: false,
+    maxConcurrentTunnels: 5,
+    idleTimeoutMinutes: 5,
+    maxSessionDurationHours: 8,
+  };
+}
+
+export function getPamBaseline(): { uacInterceptionEnabled: boolean } {
+  return { uacInterceptionEnabled: false };
+}
+
+// label + behavior + applied/inlineSettings for every feature type. Order
+// follows CONFIG_FEATURE_TYPES. "Not enforced" entries describe the real-world
+// effect of having no policy.
+const NOT_ENFORCED: Record<Exclude<ConfigFeatureType, 'remote_access' | 'pam'>, { label: string; behavior: string }> = {
+  patch:             { label: 'Patches',            behavior: 'Not enforced — no patch deployments are created from policy.' },
+  alert_rule:        { label: 'Alerts',             behavior: 'Not enforced — no policy alert rules fire.' },
+  backup:            { label: 'Backup',             behavior: 'Not enforced — no backups are scheduled.' },
+  security:          { label: 'Security',           behavior: 'Not enforced — no security posture is applied.' },
+  monitoring:        { label: 'Monitoring',         behavior: 'Not enforced — no service/process monitoring runs.' },
+  maintenance:       { label: 'Maintenance',        behavior: 'Not enforced — no maintenance windows apply.' },
+  compliance:        { label: 'Compliance',         behavior: 'Not enforced — no compliance checks run.' },
+  automation:        { label: 'Automations',        behavior: 'Not enforced — no automations execute.' },
+  event_log:         { label: 'Event Logs',         behavior: 'Not enforced — no event-log collection tuning applies.' },
+  software_policy:   { label: 'Software Policy',     behavior: 'Not enforced — no allow/block software rules apply.' },
+  sensitive_data:    { label: 'Data Discovery',     behavior: 'Not enforced — no sensitive-data scans run.' },
+  peripheral_control:{ label: 'Peripheral Control', behavior: 'Not enforced — peripherals are unrestricted.' },
+  warranty:          { label: 'Warranty',           behavior: 'Not enforced — no warranty alerts apply.' },
+  helper:            { label: 'Breeze Assist',      behavior: 'Not enforced — Breeze Assist uses its built-in defaults.' },
+  onedrive_helper:   { label: 'OneDrive Helper',    behavior: 'Not enforced — no OneDrive helper config applies.' },
+};
+
+export function getPolicyBaselineDefaults(): BaselineEntry[] {
+  return CONFIG_FEATURE_TYPES.map((ft): BaselineEntry => {
+    if (ft === 'remote_access') {
+      return {
+        featureType: ft,
+        label: 'Remote Access',
+        applied: true,
+        inlineSettings: getRemoteAccessBaseline() as unknown as Record<string, unknown>,
+        behavior: 'Remote Desktop, VNC, and Remote Tools are ON by default; session limits apply.',
+      };
+    }
+    if (ft === 'pam') {
+      return {
+        featureType: ft,
+        label: 'Privileged Access',
+        applied: true,
+        inlineSettings: getPamBaseline(),
+        behavior: 'UAC elevation capture is OFF by default (opt-in via a policy).',
+      };
+    }
+    const meta = NOT_ENFORCED[ft];
+    return { featureType: ft, label: meta.label, applied: false, inlineSettings: null, behavior: meta.behavior };
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/policyBaselineDefaults.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Typecheck the API package**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: no new errors. (The `ConfigFeatureType` change is widening a private type to an exported one; existing usages still compile.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/policyBaselineDefaults.ts apps/api/src/services/policyBaselineDefaults.test.ts apps/api/src/services/configurationPolicy.ts
+git commit -m "feat(config-policy): canonical baseline defaults module (#1725)"
+```
+
+---
+
+### Task 2: Source remote_access enforcement defaults from the canonical module
+
+Makes `remoteAccessPolicy.ts` use `getRemoteAccessBaseline()` instead of its private `DEFAULTS` const — single source of truth — and proves the permissive defaults did not change (security-sensitive).
+
+**Files:**
+- Modify: `apps/api/src/services/remoteAccessPolicy.ts:58-72` (remove inline `DEFAULTS`, derive from module)
+- Create: `apps/api/src/services/remoteAccessPolicy.test.ts`
+
+**Interfaces:**
+- Consumes: `getRemoteAccessBaseline()` from Task 1.
+- Produces: no signature changes — `resolveRemoteAccessForDevice`, `checkRemoteAccess`, `RemoteAccessSettings` unchanged.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `apps/api/src/services/remoteAccessPolicy.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { getRemoteAccessBaseline } from './policyBaselineDefaults';
+
+// Guards the security-sensitive default: Remote Desktop / VNC / Remote Tools
+// must stay ON-by-default after sourcing DEFAULTS from the canonical module.
+describe('remote access baseline defaults (single source of truth)', () => {
+  it('keeps the permissive remote capabilities ON by default', () => {
+    const d = getRemoteAccessBaseline();
+    expect(d.webrtcDesktop).toBe(true);
+    expect(d.vncRelay).toBe(true);
+    expect(d.remoteTools).toBe(true);
+    expect(d.enableProxy).toBe(true);
+    expect(d.autoEnableProxy).toBe(false);
+    expect(d.maxConcurrentTunnels).toBe(5);
+    expect(d.idleTimeoutMinutes).toBe(5);
+    expect(d.maxSessionDurationHours).toBe(8);
+    expect(d.clipboardViewerToHost).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes against Task 1's module**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/remoteAccessPolicy.test.ts`
+Expected: PASS (the module from Task 1 already provides these values). This test exists to lock the values; the refactor below must keep it green.
+
+- [ ] **Step 3: Refactor `remoteAccessPolicy.ts` to use the module**
+
+In `apps/api/src/services/remoteAccessPolicy.ts`, add the import near the top (after the existing imports, around line 13):
+```ts
+import { getRemoteAccessBaseline } from './policyBaselineDefaults';
+```
+
+Delete the `isHosted` const and the entire `DEFAULTS` literal (lines 50-72, the block of comment + `const isHosted` + `const DEFAULTS: RemoteAccessSettings = { ... };`) and replace with:
+```ts
+// Applied defaults for an unassigned device live in the canonical baseline
+// module (single source of truth, #1725). isHosted-dependent clipboard default
+// is encoded there.
+const DEFAULTS: RemoteAccessSettings = getRemoteAccessBaseline();
+```
+Leave `clampSettings`, the cache, `resolveRemoteAccessForDevice`, and `checkRemoteAccess` untouched — they keep referencing the local `DEFAULTS`.
+
+- [ ] **Step 4: Run the regression test + the existing remote-access resolver tests**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/remoteAccessPolicy.test.ts src/services/configurationPolicy.remoteAccess.test.ts`
+Expected: PASS for both.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/remoteAccessPolicy.ts apps/api/src/services/remoteAccessPolicy.test.ts
+git commit -m "refactor(config-policy): source remote_access defaults from baseline module (#1725)"
+```
+
+---
+
+### Task 3: Source pam enforcement defaults from the canonical module
+
+Makes `pamSettings.ts` derive `PAM_DEFAULTS` from `getPamBaseline()` so the baseline display and enforcement agree. `helpers.ts` keeps importing `PAM_DEFAULTS` from `pamSettings.ts` (no change there).
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/pamSettings.ts:21-23`
+- Test: reuse `apps/api/src/services/policyBaselineDefaults.test.ts` (already asserts pam OFF) — add one assertion tying `PAM_DEFAULTS` to the module.
+
+**Interfaces:**
+- Consumes: `getPamBaseline()` from Task 1.
+- Produces: `PAM_DEFAULTS` retains its type `PamSettings` and value `{ uacInterceptionEnabled: false }`.
+
+- [ ] **Step 1: Write the failing test (tie-through assertion)**
+
+Append to `apps/api/src/services/policyBaselineDefaults.test.ts`:
+```ts
+import { PAM_DEFAULTS } from '../routes/agents/pamSettings';
+
+describe('pam defaults single source of truth', () => {
+  it('PAM_DEFAULTS equals the canonical pam baseline', () => {
+    expect(PAM_DEFAULTS).toEqual(getPamBaseline());
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it passes (values already match) — then make the source single**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/policyBaselineDefaults.test.ts`
+Expected: PASS (values match today). The refactor below removes the duplicated literal.
+
+- [ ] **Step 3: Refactor `pamSettings.ts`**
+
+Replace lines 21-23:
+```ts
+export const PAM_DEFAULTS: PamSettings = {
+  uacInterceptionEnabled: false,
+};
+```
+with:
+```ts
+import { getPamBaseline } from '../../services/policyBaselineDefaults';
+
+export const PAM_DEFAULTS: PamSettings = getPamBaseline();
+```
+(Place the `import` with the other imports at the top of the file, not inline — move it above the `PamSettings` interface. Keep the explanatory comment block at lines 12-20.)
+
+- [ ] **Step 4: Run the test + existing pam/helper tests**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/policyBaselineDefaults.test.ts src/routes/agents/pamSettings.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck (watch for import cycles)**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: no new errors. (`policyBaselineDefaults` imports `pamSettings` only in the test file, and `pamSettings` imports `getPamBaseline` as a value — `getPamBaseline` does not import `pamSettings`, so no runtime cycle.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/agents/pamSettings.ts apps/api/src/services/policyBaselineDefaults.test.ts
+git commit -m "refactor(config-policy): source pam defaults from baseline module (#1725)"
+```
+
+---
+
+### Task 4: `includeBaseline` option on `resolveEffectiveConfig`
+
+Adds the opt-in synthetic `'default'` layer to the resolver. Default off → existing callers unaffected.
+
+**Files:**
+- Modify: `apps/api/src/services/configurationPolicy.ts` — `ResolvedFeature` (81-90), `EffectiveConfiguration` (94-105), `resolveEffectiveConfigWithExecutor` (1192-1349), `resolveEffectiveConfig` (1351-1353).
+- Test: `apps/api/src/services/configurationPolicy.baseline.test.ts`
+
+**Interfaces:**
+- Consumes: `getPolicyBaselineDefaults()` from Task 1.
+- Produces:
+  - `ResolvedFeature.sourceLevel: ConfigAssignmentLevel | 'default'`
+  - `EffectiveConfiguration.inheritanceChain[].level: ConfigAssignmentLevel | 'default'`
+  - `resolveEffectiveConfig(deviceId, auth, opts?: { includeBaseline?: boolean })`
+  - When `includeBaseline` is true: every `ConfigFeatureType` absent from real winners gets a synthetic `ResolvedFeature` with `sourceLevel: 'default'`, `sourcePolicyId: 'breeze-defaults'`, `sourcePolicyName: 'Breeze Defaults'`, `sourceTargetId: 'breeze-defaults'`, `sourcePriority: 0`, `featurePolicyId: null`, `inlineSettings` from the baseline entry (or `null` for not-enforced). A single inheritance-chain node `{ level: 'default', policyId: 'breeze-defaults', policyName: 'Breeze Defaults', targetId: 'breeze-defaults', priority: 0, featureTypes: [<all synthesized types>] }` is appended last.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/configurationPolicy.baseline.test.ts`:
+```ts
+import { describe, it, expect, vi } from 'vitest';
+
+// We test the pure synthesis behavior by exercising resolveEffectiveConfig with
+// includeBaseline against a device that has NO assignments. The DB layer is
+// mocked to return a device with no policy rows.
+vi.mock('../db', () => {
+  const chain = (rows: unknown[]) => {
+    const b: any = {};
+    for (const m of ['select','from','where','innerJoin','orderBy','limit']) b[m] = () => b;
+    b.then = (r: (v: unknown) => void) => r(rows);
+    return b;
+  };
+  // device row, org row, no group memberships, no assignment rows
+  let call = 0;
+  const db: any = {
+    select: () => {
+      call += 1;
+      if (call === 1) return chain([{ id: 'dev-1', orgId: 'org-1', siteId: 'site-1', deviceRole: 'workstation', osType: 'windows' }]);
+      if (call === 2) return chain([{ partnerId: 'ptr-1' }]);
+      if (call === 3) return chain([]); // group memberships
+      return chain([]); // assignments join
+    },
+  };
+  return { db };
+});
+
+import { resolveEffectiveConfig } from './configurationPolicy';
+import type { AuthContext } from '../middleware/auth';
+
+const systemAuth = {
+  user: { id: 'system', email: 'system', name: 'System', isPlatformAdmin: false },
+  token: {} as any, partnerId: null, orgId: null, scope: 'system',
+  accessibleOrgIds: null, orgCondition: () => undefined, canAccessOrg: () => true,
+} as unknown as AuthContext;
+
+describe('resolveEffectiveConfig includeBaseline', () => {
+  it('omits baseline by default (features empty for unassigned device)', async () => {
+    const r = await resolveEffectiveConfig('dev-1', systemAuth);
+    expect(r).not.toBeNull();
+    expect(Object.keys(r!.features)).toHaveLength(0);
+    expect(r!.inheritanceChain).toHaveLength(0);
+  });
+
+  it('synthesizes the default layer when includeBaseline is true', async () => {
+    const r = await resolveEffectiveConfig('dev-1', systemAuth, { includeBaseline: true });
+    expect(r).not.toBeNull();
+    const ra = r!.features.remote_access;
+    expect(ra.sourceLevel).toBe('default');
+    expect(ra.sourcePolicyName).toBe('Breeze Defaults');
+    expect((ra.inlineSettings as Record<string, unknown>).webrtcDesktop).toBe(true);
+    expect(r!.features.patch.sourceLevel).toBe('default');
+    expect(r!.features.patch.inlineSettings).toBeNull();
+    const defaultNode = r!.inheritanceChain.find((n) => n.level === 'default');
+    expect(defaultNode).toBeTruthy();
+    expect(defaultNode!.policyName).toBe('Breeze Defaults');
+  });
+});
+```
+
+> Note: if the existing `configurationPolicy.test.ts` already establishes a richer DB-mock harness, mirror that harness instead of the inline mock above — match the file's established pattern. The assertions stay the same.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/configurationPolicy.baseline.test.ts`
+Expected: FAIL — `resolveEffectiveConfig` ignores the third arg; `features` is empty even with `includeBaseline`.
+
+- [ ] **Step 3: Widen the source-level types**
+
+In `configurationPolicy.ts`, change `ResolvedFeature.sourceLevel` (line 85):
+```ts
+  sourceLevel: ConfigAssignmentLevel | 'default';
+```
+and the inheritance-chain `level` (line 98):
+```ts
+    level: ConfigAssignmentLevel | 'default';
+```
+
+- [ ] **Step 4: Thread the option through both entry points**
+
+Replace `resolveEffectiveConfig` (lines 1351-1353):
+```ts
+export async function resolveEffectiveConfig(
+  deviceId: string,
+  auth: AuthContext,
+  opts?: { includeBaseline?: boolean }
+): Promise<EffectiveConfiguration | null> {
+  return resolveEffectiveConfigWithExecutor(db, deviceId, auth, opts);
+}
+```
+Update the `resolveEffectiveConfigWithExecutor` signature (line 1192-1196):
+```ts
+async function resolveEffectiveConfigWithExecutor(
+  executor: DbExecutor,
+  deviceId: string,
+  auth: AuthContext,
+  opts?: { includeBaseline?: boolean }
+): Promise<EffectiveConfiguration | null> {
+```
+And in `previewEffectiveConfig`, the internal call at line 1396 stays as-is (no baseline for diffs).
+
+- [ ] **Step 5: Synthesize the baseline before returning**
+
+Add this import at the top of `configurationPolicy.ts` (with the other service imports):
+```ts
+import { getPolicyBaselineDefaults } from './policyBaselineDefaults';
+```
+Then replace the final `return { deviceId, features, inheritanceChain };` (line 1348) with:
+```ts
+  if (opts?.includeBaseline) {
+    const synthesized: ConfigFeatureType[] = [];
+    for (const entry of getPolicyBaselineDefaults()) {
+      if (features[entry.featureType]) continue;
+      features[entry.featureType] = {
+        featureType: entry.featureType,
+        featurePolicyId: null,
+        inlineSettings: entry.inlineSettings,
+        sourceLevel: 'default',
+        sourceTargetId: 'breeze-defaults',
+        sourcePolicyId: 'breeze-defaults',
+        sourcePolicyName: 'Breeze Defaults',
+        sourcePriority: 0,
+      };
+      synthesized.push(entry.featureType);
+    }
+    if (synthesized.length > 0) {
+      inheritanceChain.push({
+        level: 'default',
+        targetId: 'breeze-defaults',
+        policyId: 'breeze-defaults',
+        policyName: 'Breeze Defaults',
+        priority: 0,
+        featureTypes: synthesized,
+      });
+    }
+  }
+
+  return { deviceId, features, inheritanceChain };
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/configurationPolicy.baseline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Run the broader config-policy suite to confirm no regression**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/configurationPolicy.test.ts src/services/configurationPolicy.remoteAccess.test.ts src/services/configurationPolicy.onedrive.test.ts src/services/aiToolsConfigPolicy.test.ts`
+Expected: PASS (existing callers pass no `opts`, so behavior is unchanged).
+
+- [ ] **Step 8: Typecheck + commit**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: no new errors.
+```bash
+git add apps/api/src/services/configurationPolicy.ts apps/api/src/services/configurationPolicy.baseline.test.ts
+git commit -m "feat(config-policy): opt-in baseline layer in resolveEffectiveConfig (#1725)"
+```
+
+---
+
+### Task 5: API surface — `GET /baseline` + opt-in on `GET /effective/:deviceId`
+
+Exposes the static baseline registry for the dedicated page and makes the per-device effective endpoint surface the baseline layer.
+
+**Files:**
+- Modify: `apps/api/src/routes/configurationPolicies/resolution.ts` (add `GET /baseline`; pass `includeBaseline: true` at line 57)
+- Test: `apps/api/src/routes/configurationPolicies/resolution.test.ts` (create if absent; otherwise extend)
+
+**Interfaces:**
+- Consumes: `getPolicyBaselineDefaults()` (Task 1), `resolveEffectiveConfig(..., { includeBaseline: true })` (Task 4).
+- Produces: `GET /configuration-policies/baseline` → `{ features: BaselineEntry[] }`.
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `apps/api/src/routes/configurationPolicies/resolution.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { getPolicyBaselineDefaults } from '../../services/policyBaselineDefaults';
+
+// The handler returns the static registry verbatim. We assert the registry's
+// shape is what the endpoint will serialize (no DB needed).
+describe('GET /baseline payload shape', () => {
+  it('returns every feature with label/applied/behavior', () => {
+    const features = getPolicyBaselineDefaults();
+    expect(features.length).toBeGreaterThanOrEqual(17);
+    for (const f of features) {
+      expect(typeof f.label).toBe('string');
+      expect(typeof f.behavior).toBe('string');
+      expect(typeof f.applied).toBe('boolean');
+    }
+    const ra = features.find((f) => f.featureType === 'remote_access')!;
+    expect(ra.applied).toBe(true);
+  });
+});
+```
+
+> If the repo has an established Hono route-test harness (look at `crud.test.ts` / `assignments.test.ts` in the same folder), add an integration-style test that mounts `resolutionRoutes` and asserts `GET /baseline` returns 200 with the registry, following that harness. Keep the payload-shape test above regardless.
+
+- [ ] **Step 2: Run to verify it passes (shape) — fails later steps drive the route**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/configurationPolicies/resolution.test.ts`
+Expected: PASS for the shape test.
+
+- [ ] **Step 3: Add the `GET /baseline` route**
+
+In `resolution.ts`, add the import:
+```ts
+import { resolveEffectiveConfig, previewEffectiveConfig } from '../../services/configurationPolicy';
+import { getPolicyBaselineDefaults } from '../../services/policyBaselineDefaults';
+```
+Add the route after the `resolutionRoutes` / `requireConfigPolicyRead` declarations (before `GET /effective/:deviceId`):
+```ts
+// GET /baseline — static "Breeze Defaults" registry (read-only, no tenant data)
+resolutionRoutes.get(
+  '/baseline',
+  requireScope('organization', 'partner', 'system'),
+  requireConfigPolicyRead,
+  (c) => c.json({ features: getPolicyBaselineDefaults() })
+);
+```
+> `GET /baseline` is a static path and must be registered before `/:id` catches it — it lives in `resolutionRoutes`, which `index.ts` already mounts before `crudRoutes` (line 14), so ordering is satisfied.
+
+- [ ] **Step 4: Opt the effective endpoint into the baseline**
+
+In `resolution.ts`, change line 57:
+```ts
+    const result = await resolveEffectiveConfig(deviceId, auth, { includeBaseline: true });
+```
+
+- [ ] **Step 5: Run the test + typecheck**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/configurationPolicies/resolution.test.ts && pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/configurationPolicies/resolution.ts apps/api/src/routes/configurationPolicies/resolution.test.ts
+git commit -m "feat(config-policy): /baseline endpoint + baseline on /effective (#1725)"
+```
+
+---
+
+### Task 6: Web — dedicated read-only "Breeze Defaults" page
+
+Lists every feature's baseline value + behavior with a "Create override policy" deep-link per row.
+
+**Files:**
+- Create: `apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx`
+- Create: `apps/web/src/pages/configuration-policies/defaults.astro`
+- Modify: `apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx` (header link to the defaults page)
+- Test: `apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `GET /configuration-policies/baseline` → `{ features: Array<{ featureType: string; label: string; applied: boolean; inlineSettings: Record<string, unknown> | null; behavior: string }> }`.
+- Produces: a page reachable at `/configuration-policies/defaults`.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx`:
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import BreezeDefaultsPage from './BreezeDefaultsPage';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      features: [
+        { featureType: 'remote_access', label: 'Remote Access', applied: true,
+          inlineSettings: { webrtcDesktop: true, vncRelay: true, remoteTools: true }, behavior: 'Remote Desktop, VNC, and Remote Tools are ON by default; session limits apply.' },
+        { featureType: 'patch', label: 'Patches', applied: false, inlineSettings: null, behavior: 'Not enforced — no patch deployments are created from policy.' },
+      ],
+    }),
+  })),
+}));
+
+describe('BreezeDefaultsPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the applied remote access default and its behavior', async () => {
+    render(<BreezeDefaultsPage />);
+    await waitFor(() => expect(screen.getByText('Remote Access')).toBeInTheDocument());
+    expect(screen.getByText(/Remote Desktop, VNC, and Remote Tools are ON/)).toBeInTheDocument();
+  });
+
+  it('renders a not-enforced feature and a create-override link', async () => {
+    render(<BreezeDefaultsPage />);
+    await waitFor(() => expect(screen.getByText('Patches')).toBeInTheDocument());
+    expect(screen.getByText(/Not enforced/)).toBeInTheDocument();
+    const links = screen.getAllByRole('link', { name: /create override/i });
+    expect(links.length).toBeGreaterThanOrEqual(2);
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('/configuration-policies/new'));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/configurationPolicies/BreezeDefaultsPage.test.tsx`
+Expected: FAIL — cannot resolve `./BreezeDefaultsPage`.
+
+- [ ] **Step 3: Create the page component**
+
+Create `apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx`:
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldCheck, Layers } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { friendlyFetchError } from '../../lib/utils';
+
+type BaselineFeature = {
+  featureType: string;
+  label: string;
+  applied: boolean;
+  inlineSettings: Record<string, unknown> | null;
+  behavior: string;
+};
+
+function summarize(settings: Record<string, unknown> | null): string[] {
+  if (!settings) return [];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(settings)) {
+    if (v === null || v === undefined) continue;
+    const label = k.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').trim().toLowerCase();
+    if (typeof v === 'boolean') out.push(`${label}: ${v ? 'on' : 'off'}`);
+    else if (typeof v === 'string' || typeof v === 'number') out.push(`${label}: ${v}`);
+    else if (Array.isArray(v)) out.push(`${label}: ${v.length} item${v.length !== 1 ? 's' : ''}`);
+    if (out.length >= 6) break;
+  }
+  return out;
+}
+
+export default function BreezeDefaultsPage() {
+  const [features, setFeatures] = useState<BaselineFeature[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const res = await fetchWithAuth('/configuration-policies/baseline');
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const data = await res.json();
+      setFeatures(Array.isArray(data.features) ? data.features : []);
+    } catch (err) {
+      setError(friendlyFetchError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center rounded-lg border bg-card py-12 shadow-sm">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <button type="button" onClick={load} className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90">Retry</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Layers className="h-5 w-5" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold">Breeze Defaults</h2>
+          <p className="text-sm text-muted-foreground">
+            How devices behave out of the box with no configuration policy assigned. These are
+            read-only — create a policy to override any of them.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {features.map((f) => {
+          const settings = summarize(f.inlineSettings);
+          return (
+            <div key={f.featureType} className="rounded-lg border bg-card p-5 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <h4 className="font-semibold">{f.label}</h4>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${f.applied ? 'bg-primary/10 text-primary' : 'bg-muted/50 text-muted-foreground'}`}>
+                  {f.applied ? <ShieldCheck className="h-3 w-3" /> : null}
+                  {f.applied ? 'Active default' : 'Not enforced'}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">{f.behavior}</p>
+              {settings.length > 0 && (
+                <ul className="mt-3 space-y-0.5 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  {settings.map((s) => <li key={s} className="capitalize">{s}</li>)}
+                </ul>
+              )}
+              <a
+                href={`/configuration-policies/new?feature=${encodeURIComponent(f.featureType)}`}
+                className="mt-3 inline-block text-xs font-medium text-primary hover:underline"
+              >
+                Create override policy
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the component test to verify it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/configurationPolicies/BreezeDefaultsPage.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Create the Astro route**
+
+Create `apps/web/src/pages/configuration-policies/defaults.astro`:
+```astro
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import BreezeDefaultsPage from '../../components/configurationPolicies/BreezeDefaultsPage';
+---
+
+<DashboardLayout title="Breeze Defaults">
+  <BreezeDefaultsPage client:load />
+</DashboardLayout>
+```
+
+- [ ] **Step 6: Add a link from the Configuration Policies page**
+
+In `apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx`, the header already imports `Layers` from lucide-react. Add an anchor next to the existing "New policy" control (search for the `Plus` button in the header JSX) so admins can reach the baseline. Add this anchor immediately before the New-policy button:
+```tsx
+<a
+  href="/configuration-policies/defaults"
+  className="inline-flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-sm font-medium hover:bg-muted"
+>
+  <Layers className="h-4 w-4" />
+  Breeze Defaults
+</a>
+```
+
+- [ ] **Step 7: Run web typecheck + the new test**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/configurationPolicies/BreezeDefaultsPage.test.tsx && pnpm --filter @breeze/web exec astro check`
+Expected: test PASS; `astro check` no new errors. (Note: `astro check` does not typecheck `.astro` page bodies deeply, but will catch import errors.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/configurationPolicies/BreezeDefaultsPage.tsx apps/web/src/components/configurationPolicies/BreezeDefaultsPage.test.tsx apps/web/src/pages/configuration-policies/defaults.astro apps/web/src/components/configurationPolicies/ConfigurationPoliciesPage.tsx
+git commit -m "feat(web): read-only Breeze Defaults page (#1725)"
+```
+
+---
+
+### Task 7: Web — label baseline source in the per-device effective-config view
+
+When a feature resolves from the baseline, the device's Effective Configuration tab shows "Breeze Defaults" as the source instead of "No policy assigned", and the "assigned policies" count excludes the synthetic default node.
+
+**Files:**
+- Modify: `apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx`
+- Test: `apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `GET /configuration-policies/effective/:deviceId` (now includes `sourceLevel: 'default'` features + a `'default'` inheritance node, from Task 5).
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx`:
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import DeviceEffectiveConfigTab from './DeviceEffectiveConfigTab';
+
+const baselineResponse = {
+  deviceId: 'dev-1',
+  features: {
+    patch: { featureType: 'patch', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+    alert_rule: { featureType: 'alert_rule', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+  },
+  inheritanceChain: [
+    { level: 'default', targetId: 'breeze-defaults', policyId: 'breeze-defaults', policyName: 'Breeze Defaults', priority: 0, featureTypes: ['patch', 'alert_rule'] },
+  ],
+};
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', json: async () => baselineResponse })),
+}));
+
+describe('DeviceEffectiveConfigTab baseline labeling', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows Breeze Defaults as the source for baseline features', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-1" />);
+    await waitFor(() => expect(screen.getAllByText(/Breeze Defaults/).length).toBeGreaterThan(0));
+  });
+
+  it('reports zero assigned policies when only the baseline is present', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-1" />);
+    await waitFor(() => expect(screen.getByText(/0 assigned/i)).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEffectiveConfigTab.test.tsx`
+Expected: FAIL — the component does not know the `'default'` level (`LEVEL_LABELS['default']` is undefined) and the header text says "from N assigned policies" counting the default node.
+
+- [ ] **Step 3: Add the `'default'` level + adjust the assigned-policy count**
+
+In `DeviceEffectiveConfigTab.tsx`:
+
+(a) Widen `AssignmentLevel` (line 31):
+```ts
+type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device' | 'default';
+```
+
+(b) Add the label (in `LEVEL_LABELS`, after `device`):
+```ts
+  device: 'Device',
+  default: 'Breeze Defaults',
+```
+
+(c) The header at lines 207-212 counts `inheritanceChain.length` as "assigned policies". Exclude the synthetic default node. Replace the count expression. Just before the `return (` at line 202, add:
+```ts
+  const assignedChain = inheritanceChain.filter((e) => e.level !== 'default');
+```
+Then in the header text (lines 209-212) replace `inheritanceChain.length` with `assignedChain.length` in both the count and the singular/plural check:
+```tsx
+            Resolved configuration from {assignedChain.length} assigned{' '}
+            {assignedChain.length === 1 ? 'policy' : 'policies'} across{' '}
+            {configuredTypes.length} feature{configuredTypes.length !== 1 ? 's' : ''}
+```
+
+(d) The empty-state guard at line 179 (`Object.keys(data.features).length === 0`) would no longer fire now that baseline always populates `features`. Change it to fire when there are no real (non-default) configured features, so the "No Configuration Policies" empty state still appears for genuinely-unassigned devices. Replace line 179's condition:
+```ts
+  const hasRealFeatures = data ? Object.values(data.features).some((f) => f.sourceLevel !== 'default') : false;
+  if (!data || !hasRealFeatures) {
+```
+Keep the existing empty-state JSX, but add a link to the new Breeze Defaults page inside it (after the existing "Go to Config Policies" anchor):
+```tsx
+        <a
+          href="/configuration-policies/defaults"
+          className="mt-2 inline-block text-sm font-medium text-primary hover:underline"
+        >
+          View Breeze Defaults
+        </a>
+```
+
+> The inheritance-chain table already renders any level via `LEVEL_LABELS[entry.level]` and `FEATURE_META[ft]?.label ?? ft`, so the `'default'` node renders without further change once the label exists. Baseline features for the 8 shown types now appear in the "configured" grid with source "Breeze Defaults".
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/DeviceEffectiveConfigTab.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the existing device-tab / related tests to confirm no regression**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/devices/`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `pnpm --filter @breeze/web exec astro check`
+Expected: no new errors.
+```bash
+git add apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
+git commit -m "feat(web): label Breeze Defaults source in device effective-config (#1725)"
+```
+
+---
+
+### Task 8: Full-suite verification + final commit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: API package tests**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/policyBaselineDefaults.test.ts src/services/remoteAccessPolicy.test.ts src/services/configurationPolicy.baseline.test.ts src/routes/configurationPolicies/resolution.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 2: API typecheck**
+
+Run: `pnpm --filter @breeze/api exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Web package tests + check**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/configurationPolicies/BreezeDefaultsPage.test.tsx src/components/devices/DeviceEffectiveConfigTab.test.tsx && pnpm --filter @breeze/web exec astro check`
+Expected: all PASS, no new check errors.
+
+- [ ] **Step 4: Confirm no migration / schema drift was introduced**
+
+Run: `git diff --name-only main... | grep -E 'migrations/|db/schema/' || echo "no schema/migration changes (expected)"`
+Expected: prints "no schema/migration changes (expected)".
+
+- [ ] **Step 5: Final review commit (if any uncommitted verification fixes)**
+
+```bash
+git status
+# commit any stragglers, otherwise nothing to do
+```
+
+---
+
+## Manual verification (post-merge / local stack)
+
+These confirm the user-facing behavior the issue asked for. Run against a local stack with at least one device.
+
+1. Navigate to **Configuration Policies → Breeze Defaults**. Confirm Remote Access shows **"Active default"** with `webrtc desktop: on`, `vnc relay: on`, `remote tools: on`; confirm Patches/Alerts/etc. show **"Not enforced"**; confirm each row has a **Create override policy** link.
+2. Click **Create override policy** on Patches → lands on the new-policy page with `?feature=patch`.
+3. Open a device with **no** assigned policies → **Effective Configuration** tab → confirm the empty-state offers **View Breeze Defaults**, OR (depending on whether the device shows the 8 tracked features) the tracked features show source **"Breeze Defaults"** and the inheritance chain has a **Breeze Defaults** row; header reads **"0 assigned policies"**.
+4. Assign a real policy with a patch feature to that device → confirm Patch now shows the real policy as source (baseline no longer wins for patch), while still-unconfigured features show Breeze Defaults.
+
+## Out of scope (do not implement here)
+
+- Out-of-band defaults (AI/SSO/portal/OneDrive) — separate future issue.
+- Editable baseline / seeded per-partner rows.
+- Fixing #1854 enforcement bugs.
+- Wiring `?feature=` pre-selection logic in the new-policy page beyond passing the query param (the deep-link lands the user on policy creation; honoring the param to pre-open a tab is a nice-to-have, not required by #1725).

--- a/docs/superpowers/specs/2026-06-26-config-policy-baseline-defaults-design.md
+++ b/docs/superpowers/specs/2026-06-26-config-policy-baseline-defaults-design.md
@@ -1,0 +1,183 @@
+# Design: Virtual Baseline "Breeze Defaults" for Configuration Policies
+
+**Issue:** [#1725 — Ship a default/baseline Configuration Policy that surfaces all out-of-the-box defaults](https://github.com/LanternOps/breeze/issues/1725)
+**Date:** 2026-06-26
+**Status:** Approved (design)
+
+## Goal
+
+When any tenant — a fresh install, or an existing one after upgrade — opens Configuration
+Policies, they should see a **"Breeze Defaults"** entry that honestly shows *how their
+devices behave out of the box with nothing configured*. To change any of it, they create
+their own policy, which overrides the baseline through the normal assignment hierarchy. The
+baseline is never edited, so every install shows the same truthful baseline and the only
+thing that diverges device behavior is policies the admin deliberately added.
+
+This closes the motivating gap from the issue: today, with no policy assigned, Remote
+Desktop / VNC / Remote Tools are **ON** and nothing in the UI explains it. An admin has no
+way to discover "what is Breeze doing to my devices right now if I haven't configured
+anything?"
+
+## Decisions (resolved during brainstorming)
+
+| Fork | Decision |
+|---|---|
+| Mechanism | **Virtual baseline** — synthetic lowest-precedence layer derived from a canonical defaults module. No DB rows, no per-tenant backfill. Upgrade case is free. |
+| Editability | **Read-only.** Editing a default deep-links into creating a real override policy; the baseline is never mutated. |
+| Scope | **Config-policy feature types only** (the 17 in `configFeatureTypeEnum`). Out-of-band tenant defaults (AI, SSO, portal, OneDrive) deferred. |
+| Semantics | **Runtime behavior** — what actually happens to an unassigned device (mostly "Not enforced", `remote_access` ON), not aspirational form-fill values. |
+| Source of truth | **Single canonical module.** `remoteAccessPolicy.ts` and `pamSettings.ts` import their applied defaults from it (satisfies AC#1, no duplication). |
+| UI | Baseline node in the per-device effective-config view **+** a dedicated read-only "Breeze Defaults" page with per-feature "Create override" actions. |
+
+## Semantics: what "baseline" means per feature
+
+The baseline represents the **runtime behavior of an unassigned device** — the truth, not
+the values a new feature link would pre-fill with. For each feature type:
+
+- `remote_access` → live permissive defaults (Remote Desktop / VNC / Remote Tools **ON**,
+  `clipboardHostToViewer = !isHosted`, `clipboardViewerToHost` ON, proxy ON,
+  `maxConcurrentTunnels` 5, idle 5 min, max session 8 hr).
+- `pam` → `uacInterceptionEnabled: false` (UAC interception is **off / opt-in** — this
+  corrects the issue's stale "ON by default" claim; the file was edited after the audit).
+- Every other feature type (`patch`, `alert_rule`, `backup`, `security`, `monitoring`,
+  `maintenance`, `compliance`, `automation`, `event_log`, `software_policy`,
+  `sensitive_data`, `peripheral_control`, `warranty`, `helper`, `onedrive_helper`) →
+  **"Not enforced"**, with a one-line description of the real-world effect (e.g. "No
+  patching is performed", "No alerts fire").
+
+> Verified during brainstorming: per-feature resolvers in `featureConfigResolver.ts`
+> return `null`/`[]` on the no-policy path for all feature types **except** `remote_access`
+> (and `pam`), which carry hard-coded applied defaults. So "Not enforced" is the honest
+> baseline for the rest.
+
+## Architecture
+
+### 1. Canonical defaults module (single source of truth)
+
+New file: **`apps/api/src/services/policyBaselineDefaults.ts`**
+
+```ts
+import type { ConfigFeatureType } from './configurationPolicy';
+import type { RemoteAccessSettings } from './remoteAccessPolicy';
+
+export type BaselineEntry = {
+  /** Does anything actually apply to an unassigned device? */
+  applied: boolean;
+  /** Resolved settings when applied (remote_access / pam); null when "Not enforced". */
+  inlineSettings: Record<string, unknown> | null;
+  /** Human-readable behavior label for the UI. */
+  behavior: string;
+};
+
+/** Env-dependent (isHosted) — computed, not a frozen const. */
+export function getRemoteAccessBaseline(): RemoteAccessSettings;
+
+/** Covers every member of configFeatureTypeEnum. Guarded by a contract test. */
+export const POLICY_BASELINE_DEFAULTS: Record<ConfigFeatureType, BaselineEntry>;
+```
+
+- `remoteAccessPolicy.ts` deletes its inline `DEFAULTS` const and sources it from
+  `getRemoteAccessBaseline()`. It keeps its own `clampSettings` / cache / Zod-validation
+  logic unchanged.
+- `pamSettings.ts` deletes its inline `PAM_DEFAULTS` and imports from the module.
+- The module's `remote_access` and `pam` entries derive their `inlineSettings` from the same
+  source the enforcement path uses, so display and runtime can never drift.
+
+### 2. Resolver integration (opt-in, low blast radius)
+
+`resolveEffectiveConfig(deviceId, auth, opts?)` in `configurationPolicy.ts` gains
+`opts.includeBaseline` (default **`false`**):
+
+- **`false`** (all existing callers — per-feature resolvers, `resolveRemoteAccessForDevice`):
+  behavior is **unchanged**. The `features` map still contains only real winners.
+- **`true`** (only the effective-config endpoint): for every feature type with no winning
+  row, append a synthetic `ResolvedFeature` and an `inheritanceChain` node with
+  `sourceLevel: 'default'`, `sourcePolicyName: 'Breeze Defaults'`, settings drawn from the
+  canonical module.
+
+`ResolvedFeature.sourceLevel` and the inheritance-chain level type widen to
+`ConfigAssignmentLevel | 'default'`. **`ConfigAssignmentLevel` itself is NOT changed** — you
+still cannot *assign* at `'default'`, so the assignment API, validators, and DB enum are
+untouched. The synthetic layer is purely a resolution/display concept.
+
+This opt-in shape is deliberate: it guarantees the existing per-feature resolvers (which
+read `effective.features.<type>` and treat absence as "not enforced") keep working exactly
+as before.
+
+### 3. API surface
+
+- `GET /configuration-policies/effective/:deviceId` passes `includeBaseline: true` so the
+  response shows the baseline as the bottom of the inheritance chain.
+- **New:** `GET /configuration-policies/baseline` → returns the full
+  `POLICY_BASELINE_DEFAULTS` registry for the dedicated page. Read-only; returns no tenant
+  data (static shipped defaults), so no RLS surface is added. Auth required (any
+  authenticated user with config-policy read access).
+
+### 4. Web UI
+
+- **Effective-config / resolution view (per device):** render the `'default'` node at the
+  bottom of the inheritance chain, labeled "Breeze Defaults", visually distinct
+  (muted / read-only). A previously unexplained value now reads "Remote Desktop: ON —
+  Breeze Defaults".
+- **New read-only "Breeze Defaults" page** under Configuration Policies: lists every feature
+  type with its baseline value + behavior label. Each row has a **"Create override policy"**
+  action that deep-links into policy creation pre-seeded with that feature type. There is no
+  inline editing anywhere — the only way to change behavior is to create a real policy.
+
+## Testing
+
+- **Contract test:** `POLICY_BASELINE_DEFAULTS` has an entry for every member of
+  `configFeatureTypeEnum`. Fails when a new feature type is added without a baseline entry
+  (same spirit as the RLS allowlist drift guards).
+- **Resolver unit test:** unassigned device with `includeBaseline: true` returns
+  `remote_access` ON via `sourceLevel: 'default'`; a feature *with* an assigned policy still
+  wins over the baseline; `includeBaseline` omitted ⇒ `features` map identical to today.
+- **Regression test (security-sensitive):** `resolveRemoteAccessForDevice` still returns the
+  permissive defaults after sourcing `DEFAULTS` from the canonical module — the applied
+  defaults must not flip. (Hardening/refactor PRs are the most common source of regressions;
+  this path gates remote-session access.)
+- **Web component tests:** Breeze Defaults page renders all feature rows + "Create override"
+  actions; effective-config view renders the baseline node at the bottom of the chain.
+
+## Out of scope (deferred follow-ups)
+
+- **Out-of-band tenant defaults** that don't flow through the config-policy resolver:
+  AI-enabled (`ai.ts`), SSO JIT auto-provisioning (`sso.ts`), public customer portal
+  (`portal.ts`), OneDrive KFM silent opt-in (`onedriveHelper.ts`). These are arguably the
+  most surprising defaults, but surfacing them is a separate, larger lift (they have no
+  resolver to hook). Noted for a future issue.
+- **Editable baseline** and **seeded per-partner rows** — explicitly rejected in favor of
+  the read-only virtual layer.
+- Consolidating the **form-fill / schema column defaults** (the "(b)" values a new feature
+  link pre-fills with) into the canonical module. Not needed for runtime-behavior
+  semantics; could be a later enhancement if we ever want a "recommended baseline" view.
+
+## Related work: #1854 (kept separate)
+
+[#1854 — Multiple Configuration Policy Features Not Functioning as Expected](https://github.com/LanternOps/breeze/issues/1854)
+is a distinct class of problem: eight *enforcement* bugs ("I configured X and the device
+ignored it") spread across the alert/monitoring/automation workers (the automation case logs
+an RLS error), the Go agent (peripheral control, helper config propagation, PAM UAC
+interception), and the compliance UI. It shares no code with this work and is tracked as its
+own systematic-debugging track.
+
+**Synergy worth noting:** the effective-config view built here is the diagnostic tool a user
+in #1854's situation needs. If a feature resolves to `source = Breeze Defaults (Not
+enforced)` despite the admin having assigned a policy, that points at an
+assignment/resolution failure rather than a broken worker — narrowing #1854 triage. This
+spec does **not** fix any #1854 enforcement bug.
+
+## Acceptance criteria mapping (from #1725)
+
+- [x] Canonical single-source-of-truth defaults module → `policyBaselineDefaults.ts`;
+  `remoteAccessPolicy.ts` / `pamSettings.ts` import from it.
+- [x] Config-policy UI shows a baseline "Breeze Defaults" as the bottom of the hierarchy →
+  dedicated page + inheritance-chain node.
+- [x] Effective-config for an unassigned device shows the baseline as explicit source →
+  `sourceLevel: 'default'` via `includeBaseline`.
+- [x] Every config-policy default represented and labeled → registry covers all 17 types,
+  contract-tested.
+- [x] Decision recorded for editable-vs-read-only and retroactive edits → read-only,
+  edits create real overrides, baseline never mutates.
+- [x] Remote-access ON-by-default surfaced and explained → primary motivating gap closed.
+- [~] "Broader tenant defaults" (AI/SSO/portal/OneDrive) → **deferred** (documented above).


### PR DESCRIPTION
Closes #1725

## What

Surfaces a read-only, virtual **"Breeze Defaults"** layer at the bottom of the configuration-policy hierarchy so admins can see how an unassigned device behaves out of the box — and why (e.g. *"Remote Desktop: ON — Breeze Defaults"*). The motivating gap: Remote Desktop/VNC/Remote Tools are ON by default and nothing in the UI explained it.

Because the layer is **virtual** (no DB rows, no seeding), it lights up for every tenant — fresh installs and existing ones — the moment this ships. No migration.

## How

- **Canonical defaults module** (`apps/api/src/services/policyBaselineDefaults.ts`) — single source of truth. `remoteAccessPolicy.ts` and `pamSettings.ts` now import their applied defaults from it (no duplicated literals).
- **Opt-in resolver layer** — `resolveEffectiveConfig(deviceId, auth, { includeBaseline })` synthesizes a `sourceLevel: 'default'` "Breeze Defaults" layer for feature types with no real winner. Defaults to **false**, so every existing caller (per-feature resolvers, remote-access enforcement, preview/diff) is unchanged. `ConfigAssignmentLevel` is **not** widened — you still cannot assign at `'default'`.
- **`GET /configuration-policies/baseline`** returns the static registry; `GET /effective/:deviceId` opts into the baseline.
- **Read-only "Breeze Defaults" page** with per-feature "Create override policy" deep-links (editing a default = creating a real policy; the baseline is never mutated).
- **Device Effective-Config tab** labels fall-through features "Breeze Defaults" + "Not enforced", and excludes the baseline from the "assigned policies" count.

## Semantics

Runtime behavior, not form-fill values: `remote_access` ON, `pam` `uacInterceptionEnabled: false`, every other feature type **"Not enforced"**.

## Scope

Config-policy feature types only. Out-of-band defaults (AI / SSO / portal / OneDrive) are **deferred** to a follow-up — they don't flow through the resolver. Separately, #1854 (config-policy features not *functioning*) is a distinct enforcement-bug track, not addressed here.

## Testing

- API: `policyBaselineDefaults`, `remoteAccessPolicy` (security regression — defaults still ON), `configurationPolicy.baseline` (incl. real-winner-blocks-baseline invariant), `resolution`, plus existing `configurationPolicy`/`pamSettings` suites — all green.
- Web: `BreezeDefaultsPage`, `DeviceEffectiveConfigTab` — green.
- No schema/migration changes (virtual baseline). Security gate confirmed: remote_access defaults field-for-field identical before/after the single-source refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)