### PR TITLE
fix(installer): use parens for MSI filename-bootstrap token, not brackets (#1956)

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -300,8 +300,15 @@
     <!-- Capture the launched MSI path + bootstrap inputs while the original
          session properties are still readable (immediate CA). OriginalDatabase
          points at the user's downloaded file here; by deferred execution the
-         package is cached to C:\Windows\Installer and the [TOKEN@HOST] name is
-         gone. Packed pipe-delimited because deferred CAs only see CustomActionData. -->
+         package is cached to C:\Windows\Installer and the (TOKEN@HOST) name is
+         gone. Packed pipe-delimited because deferred CAs only see CustomActionData.
+
+         The download filename carries the token in PARENTHESES — Breeze Agent
+         (TOKEN@HOST).msi — NOT square brackets. OriginalDatabase is a Formatted
+         field, so a "[...]" substring in the path would be read as an MSI
+         property reference and stripped to empty, silently dropping the token
+         (issue #1956). Parens are literal in Formatted fields and survive into
+         CustomActionData. The agent parser accepts both forms. -->
     <CustomAction
       Id="SetBootstrapData"
       Property="BootstrapEnroll"

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -304,11 +304,12 @@
          gone. Packed pipe-delimited because deferred CAs only see CustomActionData.
 
          The download filename carries the token in PARENTHESES — Breeze Agent
-         (TOKEN@HOST).msi — NOT square brackets. OriginalDatabase is a Formatted
-         field, so a "[...]" substring in the path would be read as an MSI
-         property reference and stripped to empty, silently dropping the token
-         (issue #1956). Parens are literal in Formatted fields and survive into
-         CustomActionData. The agent parser accepts both forms. -->
+         (TOKEN@HOST).msi — NOT square brackets. This value flows through MSI's
+         Formatted-field engine, where "[...]" is the property-reference
+         delimiter, and a bracketed token substring gets stripped along the way,
+         silently dropping the token (observed in #1956). Parens are literal in
+         Formatted fields and survive into CustomActionData. The agent parser
+         accepts both forms. -->
     <CustomAction
       Id="SetBootstrapData"
       Property="BootstrapEnroll"

--- a/agent/internal/agentapp/bootstrap_test.go
+++ b/agent/internal/agentapp/bootstrap_test.go
@@ -22,6 +22,14 @@ func TestResolveBootstrapInputs(t *testing.T) {
 			wantServer: "https://eu.2breeze.app",
 		},
 		{
+			// Real-world Windows shape: NinjaRMM silent install, parens delimiter,
+			// empty BOOTSTRAP_TOKEN/SERVER_URL properties (issue #1956).
+			name:       "paren filename token (windows MSI form)",
+			data:       `C:\ProgramData\NinjaRMMAgent\download\Breeze Agent (6KE9MDUG56@us.2breeze.app).msi||`,
+			wantToken:  "6KE9MDUG56",
+			wantServer: "https://us.2breeze.app",
+		},
+		{
 			name:       "property token + server wins over filename",
 			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|https://us.2breeze.app`,
 			wantToken:  "ZZZZZ99999",

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -12,17 +12,19 @@ var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
 // installerTokenParenRe is the canonical Windows form: a 10-char base36 token
 // and a host wrapped in PARENTHESES. The Windows MSI download filename uses
 // parens (not brackets) because the path travels through MSI's Formatted-field
-// engine — OriginalDatabase -> SetBootstrapData -> CustomActionData — where a
-// "[...]" substring is interpreted as a property reference and stripped to
-// empty, silently dropping the token (issue #1956). Parens are not special in
-// MSI Formatted fields, so they survive intact.
+// engine — OriginalDatabase -> SetBootstrapData -> CustomActionData -> agent
+// --install-data — and a "[...]" substring (brackets are that engine's
+// property-reference delimiter) gets stripped along the way, silently dropping
+// the token (observed in #1956). Parens are not special in MSI Formatted
+// fields, so they survive intact.
 var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\)`)
 
-// installerTokenBracketRe is the legacy / macOS form: [TOKEN@HOST] in square
-// brackets (mirrors FilenameTokenParser.swift). macOS reads the token from the
-// renamed .app bundle name or its embedded bootstrap.json and never passes
-// through MSI formatting, so brackets remain safe there. Still accepted here
-// for backward compatibility and cross-platform parity.
+// installerTokenBracketRe is the legacy form: [TOKEN@HOST] in square brackets
+// (mirrors FilenameTokenParser.swift). The current macOS path carries the token
+// in an embedded bootstrap.json (no filename delimiter); the bracketed .app
+// bundle name only appears under the opt-in MACOS_INSTALLER_FILENAME_TOKEN_COMPAT
+// mode. Neither macOS path passes through MSI formatting, so brackets are safe
+// there. Still accepted here for backward compatibility with older downloads.
 var installerTokenBracketRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
 
 // parseInstallerFilenameToken extracts the bootstrap token and API host from an

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -5,21 +5,37 @@ import (
 	"regexp"
 )
 
-// errNoFilenameToken is returned when a filename carries no [TOKEN@HOST] group.
+// errNoFilenameToken is returned when a filename carries no (TOKEN@HOST) /
+// [TOKEN@HOST] group.
 var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
 
-// installerTokenRe mirrors FilenameTokenParser.swift: a 10-char base36 token
-// and a host, wrapped in square brackets. The token charset is uppercase to
-// avoid ambiguity; the host allows letters, digits, dots, and hyphens.
-var installerTokenRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
+// installerTokenParenRe is the canonical Windows form: a 10-char base36 token
+// and a host wrapped in PARENTHESES. The Windows MSI download filename uses
+// parens (not brackets) because the path travels through MSI's Formatted-field
+// engine — OriginalDatabase -> SetBootstrapData -> CustomActionData — where a
+// "[...]" substring is interpreted as a property reference and stripped to
+// empty, silently dropping the token (issue #1956). Parens are not special in
+// MSI Formatted fields, so they survive intact.
+var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\)`)
+
+// installerTokenBracketRe is the legacy / macOS form: [TOKEN@HOST] in square
+// brackets (mirrors FilenameTokenParser.swift). macOS reads the token from the
+// renamed .app bundle name or its embedded bootstrap.json and never passes
+// through MSI formatting, so brackets remain safe there. Still accepted here
+// for backward compatibility and cross-platform parity.
+var installerTokenBracketRe = regexp.MustCompile(`\[([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\]`)
 
 // parseInstallerFilenameToken extracts the bootstrap token and API host from an
 // installer path or basename. It searches anywhere in the string, so a browser
-// "(1)" dedup suffix or a full path does not break matching.
+// "(1)" dedup suffix or a full path does not break matching. The paren form is
+// tried first (canonical Windows); the bracket form is the legacy/macOS
+// fallback. The host charset excludes spaces and the delimiter characters, so a
+// trailing " (1)" dedup suffix can never be folded into a match.
 func parseInstallerFilenameToken(name string) (token string, host string, err error) {
-	m := installerTokenRe.FindStringSubmatch(name)
-	if m == nil {
-		return "", "", errNoFilenameToken
+	for _, re := range []*regexp.Regexp{installerTokenParenRe, installerTokenBracketRe} {
+		if m := re.FindStringSubmatch(name); m != nil {
+			return m[1], m[2], nil
+		}
 	}
-	return m[1], m[2], nil
+	return "", "", errNoFilenameToken
 }

--- a/agent/internal/agentapp/installer_filename_test.go
+++ b/agent/internal/agentapp/installer_filename_test.go
@@ -10,13 +10,24 @@ func TestParseInstallerFilenameToken(t *testing.T) {
 		wantHost  string
 		wantError bool
 	}{
-		{"clean", "Breeze Agent [ABCDE12345@eu.2breeze.app].msi", "ABCDE12345", "eu.2breeze.app", false},
-		{"browser dup suffix", "Breeze Agent [ABCDE12345@us.2breeze.app] (1).msi", "ABCDE12345", "us.2breeze.app", false},
-		{"full path", `C:\Users\me\Downloads\Breeze Agent [Z9Y8X7W6V5@host.example.com].msi`, "Z9Y8X7W6V5", "host.example.com", false},
-		{"host with hyphen", "Breeze Agent [ABCDE12345@my-rmm.example].msi", "ABCDE12345", "my-rmm.example", false},
-		{"no brackets", "breeze-agent.msi", "", "", true},
-		{"token too short", "Breeze Agent [ABCDE1234@host].msi", "", "", true},
-		{"token lowercase", "Breeze Agent [abcde12345@host].msi", "", "", true},
+		// Parenthesis form — canonical for Windows MSI. Square brackets collide
+		// with MSI's Formatted-field [property] syntax and get stripped when the
+		// download filename flows through OriginalDatabase -> CustomActionData,
+		// so the Windows installer download uses parens instead (issue #1956).
+		{"paren clean", "Breeze Agent (ABCDE12345@eu.2breeze.app).msi", "ABCDE12345", "eu.2breeze.app", false},
+		{"paren full windows path", `C:\ProgramData\NinjaRMMAgent\download\Breeze Agent (6KE9MDUG56@us.2breeze.app).msi`, "6KE9MDUG56", "us.2breeze.app", false},
+		{"paren browser dup suffix", "Breeze Agent (ABCDE12345@us.2breeze.app) (1).msi", "ABCDE12345", "us.2breeze.app", false},
+		{"paren host with hyphen", "Breeze Agent (ABCDE12345@my-rmm.example).msi", "ABCDE12345", "my-rmm.example", false},
+		{"paren token too short", "Breeze Agent (ABCDE1234@host).msi", "", "", true},
+		{"paren token lowercase", "Breeze Agent (abcde12345@host).msi", "", "", true},
+		// Bracket form — legacy / macOS (.app bundle name). Still accepted.
+		{"bracket clean", "Breeze Agent [ABCDE12345@eu.2breeze.app].msi", "ABCDE12345", "eu.2breeze.app", false},
+		{"bracket browser dup suffix", "Breeze Agent [ABCDE12345@us.2breeze.app] (1).msi", "ABCDE12345", "us.2breeze.app", false},
+		{"bracket full path", `C:\Users\me\Downloads\Breeze Agent [Z9Y8X7W6V5@host.example.com].msi`, "Z9Y8X7W6V5", "host.example.com", false},
+		{"bracket host with hyphen", "Breeze Agent [ABCDE12345@my-rmm.example].msi", "ABCDE12345", "my-rmm.example", false},
+		{"no delimiter", "breeze-agent.msi", "", "", true},
+		{"bracket token too short", "Breeze Agent [ABCDE1234@host].msi", "", "", true},
+		{"bracket token lowercase", "Breeze Agent [abcde12345@host].msi", "", "", true},
 		{"empty", "", "", "", true},
 	}
 	for _, tc := range cases {

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -84,7 +84,7 @@ vi.mock("../services/installerBuilder", () => ({
   assertMacosInstallerPkgsReachable: vi.fn(async () => {}),
   fetchMacosInstallerAppZip: vi.fn(async () => null),
   serveWindowsBootstrapMsi: vi.fn((c: any, args: { msi: Buffer; token: string; apiHost: string }) => {
-    const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+    const filename = `Breeze Agent (${args.token}@${args.apiHost}).msi`;
     c.header("Content-Type", "application/octet-stream");
     c.header("Content-Disposition", `attachment; filename="${filename}"`);
     c.header("Content-Length", String(args.msi.length));
@@ -863,7 +863,7 @@ describe("GET /public-download/:platform", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
     expect(res.headers.get("Content-Disposition")).toMatch(
-      /^attachment; filename="Breeze Agent \[ABCDE12345@api\.example\.com\]\.msi"$/,
+      /^attachment; filename="Breeze Agent \(ABCDE12345@api\.example\.com\)\.msi"$/,
     );
     // No db.update — download does not consume enrollment slots
     expect(db.update).not.toHaveBeenCalled();

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -72,7 +72,7 @@ vi.mock('../services/installerBuilder', () => ({
   fetchMacosInstallerAppZip: vi.fn(async () => null),
   // Windows bootstrap path — serves static MSI with token in the filename.
   serveWindowsBootstrapMsi: vi.fn((c: any, args: { msi: Buffer; token: string; apiHost: string }) => {
-    const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+    const filename = `Breeze Agent (${args.token}@${args.apiHost}).msi`;
     c.header('Content-Type', 'application/octet-stream');
     c.header('Content-Disposition', `attachment; filename="${filename}"`);
     c.header('Content-Length', String(args.msi.length));
@@ -301,7 +301,7 @@ describe('enrollment key routes — installer download', () => {
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toBe('application/octet-stream');
       expect(res.headers.get('content-disposition')).toBe(
-        'attachment; filename="Breeze Agent [ABCDE12345@breeze.example.com].msi"',
+        'attachment; filename="Breeze Agent (ABCDE12345@breeze.example.com).msi"',
       );
       // The static signed MSI bytes are served as-is.
       const body = Buffer.from(await res.arrayBuffer());

--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -9,7 +9,9 @@ import {
   buildWindowsInstallerZip,
   fetchRegularMsi,
   assertMacosInstallerPkgsReachable,
+  serveWindowsBootstrapMsi,
 } from './installerBuilder';
+import type { Context } from 'hono';
 
 // Real keys are 64 lowercase hex chars produced by randomBytes(32).toString('hex').
 // Tests use that exact generator so a future drift between generator and validator
@@ -344,5 +346,53 @@ describe('buildWindowsInstallerZip', () => {
     const successIdx = batScript.indexOf('installed and enrolled successfully');
     expect(guardIdx).toBeGreaterThan(-1);
     expect(guardIdx).toBeLessThan(successIdx);
+  });
+});
+
+describe('serveWindowsBootstrapMsi', () => {
+  // Minimal Hono Context stub capturing headers + body. Both Windows download
+  // routes (enrollmentKeys.ts) delegate here, so this is the single source of
+  // truth for the download filename.
+  function fakeContext(): { c: Context; headers: Map<string, string>; body: Buffer | null } {
+    const headers = new Map<string, string>();
+    const state: { body: Buffer | null } = { body: null };
+    const c = {
+      header: (k: string, v: string) => headers.set(k.toLowerCase(), v),
+      body: (b: Buffer) => {
+        state.body = b;
+        return new Response();
+      },
+    } as unknown as Context;
+    return { c, headers, body: state.body };
+  }
+
+  it('wraps the bootstrap token in PARENTHESES, never square brackets', () => {
+    const { c, headers } = fakeContext();
+    serveWindowsBootstrapMsi(c, {
+      msi: Buffer.from('signed-msi-bytes'),
+      token: 'ABCDE12345',
+      apiHost: 'api.example.com',
+    });
+
+    const cd = headers.get('content-disposition');
+    expect(cd).toBe(
+      'attachment; filename="Breeze Agent (ABCDE12345@api.example.com).msi"',
+    );
+    // Regression guard for #1956: a square-bracket [TOKEN@HOST] delimiter is
+    // eaten by MSI's Formatted-field engine, dropping the token so agents never
+    // enroll. If someone reverts the delimiter, this fails — the route-level
+    // tests can't catch it because they mock this function.
+    expect(cd).not.toContain('[');
+    expect(cd).not.toContain(']');
+  });
+
+  it('serves the MSI bytes unmodified with octet-stream + no-store headers', () => {
+    const { c, headers } = fakeContext();
+    const msi = Buffer.from('signed-msi-bytes');
+    serveWindowsBootstrapMsi(c, { msi, token: 'ZZZZZ99999', apiHost: 'eu.2breeze.app' });
+
+    expect(headers.get('content-type')).toBe('application/octet-stream');
+    expect(headers.get('content-length')).toBe(String(msi.length));
+    expect(headers.get('cache-control')).toBe('no-store');
   });
 });

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -395,11 +395,12 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
  *
  * The token is wrapped in PARENTHESES, not square brackets. At install time the
  * download path travels through MSI's Formatted-field engine (OriginalDatabase
- * -> SetBootstrapData -> CustomActionData), where a "[...]" substring is read
- * as a property reference and stripped to empty, silently dropping the token —
- * agents then log "no bootstrap token present" and never enroll (issue #1956).
- * Parens are not special in MSI Formatted fields, so they survive. The agent
- * parser (installer_filename.go) accepts both forms; macOS still uses brackets.
+ * -> SetBootstrapData -> CustomActionData), and a "[...]" substring (brackets
+ * are that engine's property-reference delimiter) gets stripped along the way,
+ * silently dropping the token — agents then log "no bootstrap token present"
+ * and never enroll (observed in #1956). Parens are not special in MSI Formatted
+ * fields, so they survive. The agent parser (installer_filename.go) accepts
+ * both forms; the macOS download carries the token in bootstrap.json instead.
  */
 export function serveWindowsBootstrapMsi(
   c: Context,

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -392,12 +392,20 @@ export async function probeMacosInstallerApp(): Promise<boolean> {
  * download filename — the Windows analogue of the macOS renamed-app zip. The
  * MSI bytes are never modified, so the Authenticode signature stays intact and
  * every customer shares one file hash (SmartScreen reputation accrues).
+ *
+ * The token is wrapped in PARENTHESES, not square brackets. At install time the
+ * download path travels through MSI's Formatted-field engine (OriginalDatabase
+ * -> SetBootstrapData -> CustomActionData), where a "[...]" substring is read
+ * as a property reference and stripped to empty, silently dropping the token —
+ * agents then log "no bootstrap token present" and never enroll (issue #1956).
+ * Parens are not special in MSI Formatted fields, so they survive. The agent
+ * parser (installer_filename.go) accepts both forms; macOS still uses brackets.
  */
 export function serveWindowsBootstrapMsi(
   c: Context,
   args: { msi: Buffer; token: string; apiHost: string },
 ): Response {
-  const filename = `Breeze Agent [${args.token}@${args.apiHost}].msi`;
+  const filename = `Breeze Agent (${args.token}@${args.apiHost}).msi`;
   c.header('Content-Type', 'application/octet-stream');
   c.header('Content-Disposition', `attachment; filename="${filename}"`);
   c.header('Content-Length', String(args.msi.length));


### PR DESCRIPTION
## Problem
Windows agents installed via the #1902 filename-bootstrap MSI install successfully but **never enroll** — they log `no bootstrap token present; skipping enrollment` and sit idle (no check-in). Hit in the field on a NinjaRMM silent deploy.

## Root cause
The download filename embeds the token in **square brackets**: `Breeze Agent [TOKEN@HOST].msi`. At install time the path travels through MSI's *Formatted-field* engine:

`OriginalDatabase` → `SetBootstrapData` (type-51) → `CustomActionData` → agent `bootstrap --install-data`

A `[...]` substring in a Formatted field is read as an MSI **property reference**. `[6KE9MDUG56@us.2breeze.app]` resolves to an undefined property and is **stripped to empty** before the agent sees it. macOS is unaffected (reads the `.app` name / embedded `bootstrap.json` at runtime, never through MSI).

Verbatim verbose-log proof — token present in `OriginalDatabase`, CA ran, agent got nothing:
```
OriginalDatabase = C:\ProgramData\NinjaRMMAgent\download\...\Breeze Agent [6KE9MDUG56@us.2breeze.app].msi
BootstrapEnroll = **********
Action ended: BootstrapEnroll. Return value 1.
```

## Fix
Switch the Windows delimiter to **parentheses** `Breeze Agent (TOKEN@HOST).msi` (parens are literal in Formatted fields and survive intact). The agent parser now accepts **both** paren and bracket forms; macOS stays on brackets.

- `apps/api`: `serveWindowsBootstrapMsi` emits parens
- `agent`: `installer_filename.go` parses `( )` and `[ ]`; `installer_filename_test.go` + `bootstrap_test.go` cover the real NinjaRMM silent-install path
- `breeze.wxs`: comment documenting the collision

## ⚠️ Deploy ordering (both required)
The static signed MSI **contains the agent binary**, so the paren-aware agent must be built into a **re-signed MSI** AND the API must serve paren filenames. The new agent accepts both forms, so shipping agent-in-MSI + API together is safe.

## Workaround for already-stuck machines (no reinstall)
```
breeze-agent.exe bootstrap --install-data "x|<TOKEN>|https://us.2breeze.app"
```
(`<TOKEN>` from the downloaded filename; 24h TTL — token passes via the property path, which the existing agent already supports.)

## Testing
- Go `agentapp`: `go vet` + `go build` + `go test -race` green (parser + resolver cover paren & bracket, incl. the exact failing NinjaRMM path)
- API: `enrollmentKeys.test.ts`, `enrollmentKeys_installer.test.ts`, `installer.test.ts`, `installerBootstrapToken.test.ts` green

Closes #1956. Regression from #1902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)