### PR TITLE
feat(billing): markup defaults, tax precision fix, catalog images, quote editing

### DIFF
--- a/apps/api/migrations/2026-07-02-c-partner-auto-tax-hardware.sql
+++ b/apps/api/migrations/2026-07-02-c-partner-auto-tax-hardware.sql
@@ -1,0 +1,1 @@
+ALTER TABLE partners ADD COLUMN IF NOT EXISTS auto_tax_hardware boolean NOT NULL DEFAULT true;

--- a/apps/api/migrations/2026-07-02-d-catalog-item-images.sql
+++ b/apps/api/migrations/2026-07-02-d-catalog-item-images.sql
@@ -1,0 +1,32 @@
+-- One manually-uploaded product image per catalog item, reused across quotes.
+-- Partner-axis RLS (shape 3) — partner_id is the isolation axis, mirroring
+-- catalog_items. Stored as a bytea blob like quote_images. Idempotent.
+CREATE TABLE IF NOT EXISTS catalog_item_images (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_item_id uuid NOT NULL REFERENCES catalog_items(id) ON DELETE CASCADE,
+  partner_id uuid NOT NULL REFERENCES partners(id),
+  image_data bytea NOT NULL,
+  mime varchar(64) NOT NULL,
+  byte_size integer NOT NULL,
+  sha256 char(64) NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+-- One image per item (upload replaces).
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_item_images_item_uq ON catalog_item_images (catalog_item_id);
+CREATE INDEX IF NOT EXISTS catalog_item_images_partner_idx ON catalog_item_images (partner_id);
+
+ALTER TABLE catalog_item_images ENABLE ROW LEVEL SECURITY;
+ALTER TABLE catalog_item_images FORCE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'catalog_item_images'
+      AND policyname = 'catalog_item_images_partner_access'
+  ) THEN
+    CREATE POLICY catalog_item_images_partner_access ON catalog_item_images
+      FOR ALL
+      USING (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id))
+      WITH CHECK (public.breeze_current_scope() = 'system' OR public.breeze_has_partner_access(partner_id));
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-07-02-partner-default-markup.sql
+++ b/apps/api/migrations/2026-07-02-partner-default-markup.sql
@@ -1,0 +1,7 @@
+-- Partner-level default markup over distributor cost (percent), used to pre-fill
+-- the listed sell price when importing catalog items (TD SYNNEX / external). It
+-- feeds the catalog `markup_percent` field, so it shares its numeric(6,2) bounds
+-- (0..9999.99). Stored as a percent value (e.g. 30.00). The import view shows
+-- the resulting gross margin alongside.
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS default_markup_percent numeric(6,2);

--- a/apps/api/migrations/2026-07-02-tax-rate-precision.sql
+++ b/apps/api/migrations/2026-07-02-tax-rate-precision.sql
@@ -1,0 +1,27 @@
+-- Tax rates are stored as a FRACTION (e.g. 8.95% -> 0.0895). The original
+-- numeric(6,3) scale only kept 3 fraction decimals, so any rate with more than
+-- one percent decimal was truncated on save (8.95% -> 0.089 -> shows 8.9%; NYC's
+-- 8.875% -> 0.089). Widen to numeric(8,5) (5 fraction decimals = 3 percent
+-- decimals). Widening is lossless for existing rows. Idempotent: only ALTER when
+-- the column is not already at scale 5.
+DO $$
+DECLARE
+  tgt RECORD;
+BEGIN
+  FOR tgt IN
+    SELECT * FROM (VALUES
+      ('partners',      'default_tax_rate'),
+      ('organizations', 'tax_rate'),
+      ('quotes',        'tax_rate'),
+      ('invoices',      'tax_rate')
+    ) AS t(tbl, col)
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = tgt.tbl AND column_name = tgt.col
+        AND (numeric_precision IS DISTINCT FROM 8 OR numeric_scale IS DISTINCT FROM 5)
+    ) THEN
+      EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE numeric(8,5)', tgt.tbl, tgt.col);
+    END IF;
+  END LOOP;
+END $$;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -151,6 +151,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // is NOT here — it carries a direct org_id column and is auto-discovered
   // as an ordinary shape-1 org-tenant table.
   ['catalog_items', 'partner_id'],
+  ['catalog_item_images', 'partner_id'],
   ['catalog_bundle_components', 'partner_id'],
   ['td_synnex_digital_bridge_integrations', 'partner_id'],
   ['td_synnex_ec_express_integrations', 'partner_id'],

--- a/apps/api/src/db/schema/catalog.ts
+++ b/apps/api/src/db/schema/catalog.ts
@@ -1,10 +1,10 @@
 import { sql, type SQL } from 'drizzle-orm';
 import {
-  pgTable, uuid, text, varchar, boolean, numeric, integer, jsonb, timestamp, pgEnum,
+  pgTable, uuid, text, varchar, char, boolean, numeric, integer, jsonb, timestamp, pgEnum,
   index, uniqueIndex
 } from 'drizzle-orm/pg-core';
 import { partners, organizations } from './orgs';
-import { users } from './users';
+import { users, bytea } from './users';
 
 export const catalogItemTypeEnum = pgEnum('catalog_item_type', ['hardware', 'software', 'service']);
 export const catalogBillingTypeEnum = pgEnum('catalog_billing_type', ['one_time', 'recurring']);
@@ -47,6 +47,23 @@ export const catalogItems = pgTable('catalog_items', {
   // (the real partial unique index is created in the SQL migration; drizzle-kit
   // only needs the predicate for drift detection)
   uniqueIndex('catalog_items_partner_sku_uq').on(t.partnerId, t.sku).where(sqlSkuNotNull(t))
+]);
+
+// Partner-axis (RLS shape 3). One manually-uploaded product image per catalog
+// item, stored as a bytea blob (mirrors quote_images). partner_id denormalized
+// for the partner-axis policy; cascades when the item is deleted.
+export const catalogItemImages = pgTable('catalog_item_images', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  catalogItemId: uuid('catalog_item_id').notNull().references(() => catalogItems.id, { onDelete: 'cascade' }),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  imageData: bytea('image_data').notNull(),
+  mime: varchar('mime', { length: 64 }).notNull(),
+  byteSize: integer('byte_size').notNull(),
+  sha256: char('sha256', { length: 64 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull()
+}, (t) => [
+  uniqueIndex('catalog_item_images_item_uq').on(t.catalogItemId),
+  index('catalog_item_images_partner_idx').on(t.partnerId)
 ]);
 
 // Org-axis (RLS shape 1, direct org_id). Per-customer sell-price override.

--- a/apps/api/src/db/schema/invoices.ts
+++ b/apps/api/src/db/schema/invoices.ts
@@ -35,7 +35,7 @@ export const invoices = pgTable('invoices', {
   issueDate: date('issue_date'),
   dueDate: date('due_date'),
   subtotal: numeric('subtotal', { precision: 12, scale: 2 }).notNull().default('0'),
-  taxRate: numeric('tax_rate', { precision: 6, scale: 3 }),
+  taxRate: numeric('tax_rate', { precision: 8, scale: 5 }),
   taxTotal: numeric('tax_total', { precision: 12, scale: 2 }).notNull().default('0'),
   total: numeric('total', { precision: 12, scale: 2 }).notNull().default('0'),
   amountPaid: numeric('amount_paid', { precision: 12, scale: 2 }).notNull().default('0'),

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -34,7 +34,7 @@ export const partners = pgTable('partners', {
   paymentMethodAttachedAt: timestamp('payment_method_attached_at', { withTimezone: true }),
   stripeCustomerId: text('stripe_customer_id'),
   currencyCode: char('currency_code', { length: 3 }).notNull().default('USD'),
-  defaultTaxRate: numeric('default_tax_rate', { precision: 6, scale: 3 }),
+  defaultTaxRate: numeric('default_tax_rate', { precision: 8, scale: 5 }),
   invoiceNumberPrefix: varchar('invoice_number_prefix', { length: 12 }).notNull().default('INV'),
   invoiceTermsDays: integer('invoice_terms_days').notNull().default(30),
   invoiceFooter: text('invoice_footer'),
@@ -48,6 +48,15 @@ export const partners = pgTable('partners', {
   billingAddressPostalCode: varchar('billing_address_postal_code', { length: 40 }),
   billingAddressCountry: char('billing_address_country', { length: 2 }),
   billingTermsAndConditions: text('billing_terms_and_conditions'),
+  // Default markup over distributor cost (percent) used to pre-fill the listed
+  // price when importing catalog items; feeds the catalog `markupPercent` field.
+  // Percent value 0..9999.99. (The import view shows the resulting gross margin
+  // alongside.)
+  defaultMarkupPercent: numeric('default_markup_percent', { precision: 6, scale: 2 }),
+  // When true (default), hardware catalog items are pre-flagged as taxable when
+  // added or imported. Partners can opt out if their jurisdiction treats hardware
+  // as non-taxable or they prefer to set taxability item-by-item.
+  autoTaxHardware: boolean('auto_tax_hardware').notNull().default(true),
   // AI for Office is a per-partner entitlement the platform operator grants
   // (off by default). The session-minting exchange and the /client-ai/admin
   // surface gate on this; it is NOT in settings JSONB because that is
@@ -70,7 +79,7 @@ export const organizations = pgTable('organizations', {
   billingContact: jsonb('billing_contact'),
   taxId: varchar('tax_id', { length: 100 }),
   taxExempt: boolean('tax_exempt').notNull().default(false),
-  taxRate: numeric('tax_rate', { precision: 6, scale: 3 }),
+  taxRate: numeric('tax_rate', { precision: 8, scale: 5 }),
   billingAddressLine1: varchar('billing_address_line1', { length: 255 }),
   billingAddressLine2: varchar('billing_address_line2', { length: 255 }),
   billingAddressCity: varchar('billing_address_city', { length: 120 }),

--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -32,7 +32,7 @@ export const quotes = pgTable('quotes', {
   declinedAt: timestamp('declined_at'),
   convertedAt: timestamp('converted_at'),
   subtotal: numeric('subtotal', { precision: 12, scale: 2 }).notNull().default('0'),
-  taxRate: numeric('tax_rate', { precision: 6, scale: 3 }),
+  taxRate: numeric('tax_rate', { precision: 8, scale: 5 }),
   taxTotal: numeric('tax_total', { precision: 12, scale: 2 }).notNull().default('0'),
   total: numeric('total', { precision: 12, scale: 2 }).notNull().default('0'),
   oneTimeTotal: numeric('one_time_total', { precision: 12, scale: 2 }).notNull().default('0'),

--- a/apps/api/src/routes/catalog/catalog.test.ts
+++ b/apps/api/src/routes/catalog/catalog.test.ts
@@ -16,6 +16,15 @@ vi.mock('../../services/catalogService', () => ({
   }
 }));
 
+vi.mock('../../services/catalogImageStorage', () => ({
+  writeCatalogItemImage: vi.fn(),
+  readCatalogItemImage: vi.fn(),
+  deleteCatalogItemImage: vi.fn(),
+  fetchImageFromUrl: vi.fn(),
+  sniffImageMime: vi.fn(),
+  MAX_CATALOG_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
+}));
+
 vi.mock('../../services/tdSynnexDigitalBridge', () => ({
   getTdSynnexDigitalBridgeStatus: vi.fn(),
   saveTdSynnexDigitalBridgeConfig: vi.fn(),
@@ -67,6 +76,7 @@ vi.mock('../../middleware/auth', () => ({
 
 import { catalogRoutes } from './index';
 import * as svc from '../../services/catalogService';
+import * as imgSvc from '../../services/catalogImageStorage';
 import * as tdSvc from '../../services/tdSynnexDigitalBridge';
 import * as ecSvc from '../../services/tdSynnexEcExpress';
 
@@ -119,6 +129,108 @@ describe('catalog routes', () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.code).toBe('DUPLICATE_SKU');
+  });
+});
+
+describe('catalog item image routes', () => {
+  const ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POST /:id/image uploads a sniffed image (ownership-checked)', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.sniffImageMime as any).mockReturnValue('image/png');
+    (imgSvc.writeCatalogItemImage as any).mockResolvedValue({ id: 'img1', byteSize: 4, sha256: 'x' });
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1, 2, 3, 4])], 'p.png', { type: 'image/png' }));
+    const res = await app().request(`/${ID}/image`, { method: 'POST', body: form });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.imageId).toBe('img1');
+    expect(svc.getCatalogItem).toHaveBeenCalledWith(ID, expect.anything());
+    expect(imgSvc.writeCatalogItemImage).toHaveBeenCalledWith(ID, 'p1', 'image/png', expect.anything());
+  });
+
+  it('POST /:id/image rejects an unsniffable file (415)', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.sniffImageMime as any).mockReturnValue(null);
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([0, 0])], 'x.txt', { type: 'text/plain' }));
+    const res = await app().request(`/${ID}/image`, { method: 'POST', body: form });
+    expect(res.status).toBe(415);
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/image 404s when the item is not the partner’s', async () => {
+    (svc.getCatalogItem as any).mockRejectedValue(new (svc as any).CatalogServiceError('not found', 404, 'NOT_FOUND'));
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1])], 'p.png', { type: 'image/png' }));
+    const res = await app().request(`/${ID}/image`, { method: 'POST', body: form });
+    expect(res.status).toBe(404);
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/image/from-url downloads and stores the image (ownership-checked)', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.fetchImageFromUrl as any).mockResolvedValue({ mime: 'image/png', buffer: Buffer.from([1, 2, 3, 4]) });
+    (imgSvc.writeCatalogItemImage as any).mockResolvedValue({ id: 'img1', byteSize: 4, sha256: 'x' });
+    const res = await app().request(`/${ID}/image/from-url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://example.com/p.png' })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.imageId).toBe('img1');
+    expect(imgSvc.fetchImageFromUrl).toHaveBeenCalledWith('https://example.com/p.png');
+    expect(imgSvc.writeCatalogItemImage).toHaveBeenCalledWith(ID, 'p1', 'image/png', expect.anything());
+  });
+
+  it('POST /:id/image/from-url returns 400 (and does not store) when the download fails/blocked', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.fetchImageFromUrl as any).mockRejectedValue(new Error('blocked address'));
+    const res = await app().request(`/${ID}/image/from-url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://internal.example/p.png' })
+    });
+    expect(res.status).toBe(400);
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/image/from-url rejects an invalid url body (400, no download)', async () => {
+    const res = await app().request(`/${ID}/image/from-url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'not-a-url' })
+    });
+    expect(res.status).toBe(400);
+    expect(imgSvc.fetchImageFromUrl).not.toHaveBeenCalled();
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
+  it('GET /:id/image serves the bytes', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.readCatalogItemImage as any).mockResolvedValue({ data: Buffer.from([1, 2, 3]), mime: 'image/png', byteSize: 3 });
+    const res = await app().request(`/${ID}/image`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/png');
+  });
+
+  it('GET /:id/image 404s when there is no image', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.readCatalogItemImage as any).mockResolvedValue(null);
+    const res = await app().request(`/${ID}/image`, { method: 'GET' });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /:id/image removes the image', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.deleteCatalogItemImage as any).mockResolvedValue(undefined);
+    const res = await app().request(`/${ID}/image`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.ok).toBe(true);
+    expect(imgSvc.deleteCatalogItemImage).toHaveBeenCalledWith(ID);
   });
 });
 

--- a/apps/api/src/routes/catalog/catalog.ts
+++ b/apps/api/src/routes/catalog/catalog.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
@@ -10,6 +11,10 @@ import {
   createCatalogItem, updateCatalogItem, archiveCatalogItem, listCatalogItems, getCatalogItem,
   CatalogServiceError, type CatalogActor
 } from '../../services/catalogService';
+import {
+  writeCatalogItemImage, readCatalogItemImage, deleteCatalogItemImage,
+  fetchImageFromUrl, sniffImageMime, MAX_CATALOG_IMAGE_SIZE_BYTES,
+} from '../../services/catalogImageStorage';
 
 export const catalogItemRoutes = new Hono();
 
@@ -69,5 +74,80 @@ catalogItemRoutes.post('/:id/archive', scopes, deletePerm, zValidator('param', i
   try {
     const item = await archiveCatalogItem(c.req.valid('param').id, catalogActorFrom(c));
     return c.json({ data: item });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+// POST /:id/image — multipart product-image upload (magic-byte sniff + 5 MB cap),
+// one image per item (replaces). catalog:write. getCatalogItem 404s if the item
+// is not this partner's, before any bytes are written.
+catalogItemRoutes.post('/:id/image',
+  scopes, writePerm, zValidator('param', idParam),
+  bodyLimit({ maxSize: MAX_CATALOG_IMAGE_SIZE_BYTES + 64 * 1024, onError: (c) => c.json({ error: 'Image too large (max 5 MB)' }, 413) }),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    const actor = catalogActorFrom(c);
+    try {
+      await getCatalogItem(id, actor); // 404 if not this partner's
+      if (!actor.partnerId) return c.json({ error: 'Catalog is partner-scoped' }, 400);
+      let body: Record<string, unknown>;
+      try { body = await c.req.parseBody({ all: true }); } catch { return c.json({ error: 'Invalid multipart body' }, 400); }
+      const file = body.file;
+      if (!(file instanceof File)) return c.json({ error: 'file field is required' }, 400);
+      if (file.size === 0) return c.json({ error: 'file is empty' }, 400);
+      if (file.size > MAX_CATALOG_IMAGE_SIZE_BYTES) return c.json({ error: 'Image too large (max 5 MB)' }, 413);
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const mime = sniffImageMime(buffer);
+      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' }, 415);
+      const written = await writeCatalogItemImage(id, actor.partnerId, mime, buffer);
+      return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
+    } catch (err) { return handleServiceError(c, err); }
+  });
+
+// POST /:id/image/from-url — server-side download of a product image from a
+// user-supplied URL (SSRF-guarded via safeFetch), then store it (replaces). The
+// download/validation failure is mapped to a single generic 400 so internal
+// fetch/SSRF errors don't leak to the client. catalog:write; ownership-checked.
+catalogItemRoutes.post('/:id/image/from-url',
+  scopes, writePerm, zValidator('param', idParam),
+  zValidator('json', z.object({ url: z.string().url() })),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    const { url } = c.req.valid('json');
+    const actor = catalogActorFrom(c);
+    try {
+      await getCatalogItem(id, actor); // 404 if not this partner's
+      if (!actor.partnerId) return c.json({ error: 'Catalog is partner-scoped' }, 400);
+      let mime: string, buffer: Buffer;
+      try {
+        ({ mime, buffer } = await fetchImageFromUrl(url));
+      } catch {
+        return c.json({ error: 'Could not download a valid image from that URL.' }, 400);
+      }
+      const written = await writeCatalogItemImage(id, actor.partnerId, mime, buffer);
+      return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
+    } catch (err) { return handleServiceError(c, err); }
+  });
+
+// GET /:id/image — serve the product image. catalog:read. Ownership-checked first.
+catalogItemRoutes.get('/:id/image', scopes, readPerm, zValidator('param', idParam), async (c) => {
+  const id = c.req.valid('param').id;
+  try {
+    await getCatalogItem(id, catalogActorFrom(c)); // 404 if not owned
+    const img = await readCatalogItemImage(id);
+    if (!img) return c.json({ error: 'Image not found' }, 404);
+    return new Response(new Uint8Array(img.data), {
+      status: 200,
+      headers: { 'Content-Type': img.mime, 'Content-Length': String(img.byteSize), 'Cache-Control': 'private, max-age=300' },
+    });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
+// DELETE /:id/image — remove the product image. catalog:write.
+catalogItemRoutes.delete('/:id/image', scopes, writePerm, zValidator('param', idParam), async (c) => {
+  const id = c.req.valid('param').id;
+  try {
+    await getCatalogItem(id, catalogActorFrom(c)); // 404 if not owned
+    await deleteCatalogItemImage(id);
+    return c.json({ data: { ok: true } });
   } catch (err) { return handleServiceError(c, err); }
 });

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../services/quoteService', () => ({
   updateQuote: vi.fn(),
   deleteDraftQuote: vi.fn(),
   addBlock: vi.fn(),
+  updateBlock: vi.fn(),
   deleteBlock: vi.fn(),
   addManualLine: vi.fn(),
   addCatalogLine: vi.fn(),
@@ -166,6 +167,33 @@ describe('quote crud + lines routes', () => {
     const body = await res.json();
     expect(body.data.ok).toBe(true);
     expect(svc.deleteDraftQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything());
+  });
+
+  it('PATCH /:id/blocks/:blockId updates a heading block (200, forwards body)', async () => {
+    (svc.updateBlock as any).mockResolvedValue({ id: BLOCK_ID, blockType: 'heading', content: { text: 'New title', level: 2 } });
+    const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ blockType: 'heading', content: { text: 'New title', level: 2 } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.content.text).toBe('New title');
+    expect(svc.updateBlock).toHaveBeenCalledWith(
+      QUOTE_ID, BLOCK_ID,
+      { blockType: 'heading', content: { text: 'New title', level: 2 } },
+      expect.anything(),
+    );
+  });
+
+  it('PATCH /:id/blocks/:blockId rejects an invalid content shape (400)', async () => {
+    const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ blockType: 'heading', content: { text: '' } }), // empty heading text
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateBlock).not.toHaveBeenCalled();
   });
 
   it('DELETE /:id/blocks/:blockId deletes a block (200, forwards ids)', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -10,11 +10,12 @@ import {
 } from '@breeze/shared';
 import {
   createQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
-  addManualLine, addCatalogLine, updateLine, removeLine, addBlock, deleteBlock,
+  addManualLine, addCatalogLine, updateLine, removeLine, addBlock, updateBlock, deleteBlock,
 } from '../../services/quoteService';
 import { QuoteServiceError, type QuoteActor } from '../../services/quoteTypes';
 import { db } from '../../db';
 import { quoteImages } from '../../db/schema/quotes';
+import { readCatalogItemImage } from '../../services/catalogImageStorage';
 import { safeContentDispositionFilename } from '../../utils/httpHeaders';
 import { resolveQuoteBranding } from '../../services/quoteBranding';
 
@@ -63,6 +64,10 @@ quoteCrudRoutes.delete('/:id', scopes, writePerm, zValidator('param', idParam), 
 });
 quoteCrudRoutes.post('/:id/blocks', scopes, writePerm, zValidator('param', idParam), zValidator('json', quoteBlockInputSchema), async (c) => {
   try { return c.json({ data: await addBlock(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+quoteCrudRoutes.patch('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), zValidator('json', quoteBlockInputSchema), async (c) => {
+  try { const p = c.req.valid('param'); return c.json({ data: await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.delete('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), async (c) => {
@@ -120,8 +125,16 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
       return img?.data ? { data: img.data } : null;
     };
 
+    // Product-image loader for catalog-sourced lines. RLS (partner-axis on
+    // catalog_item_images) scopes reads to this partner's items; a failed/absent
+    // image degrades to "no thumbnail" inside the renderer.
+    const loadCatalogImage = async (catalogItemId: string): Promise<{ data: Buffer } | null> => {
+      const img = await readCatalogItemImage(catalogItemId);
+      return img?.data ? { data: img.data } : null;
+    };
+
     const { renderQuotePdf } = await import('../../services/quotePdf');
-    const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, branding);
+    const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, branding, loadCatalogImage);
 
     const filename = safeContentDispositionFilename(`quote-${quote.quoteNumber || quote.id}.pdf`);
     return new Response(new Uint8Array(pdf), {

--- a/apps/api/src/services/catalogImageStorage.test.ts
+++ b/apps/api/src/services/catalogImageStorage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// fetchImageFromUrl is the SSRF/size/format guard for the "import image from URL"
+// path. The route mocks this whole module, so its real branch logic is only
+// exercised here. safeFetch (the SSRF wrapper) and sniffImageMime are mocked;
+// db is unused by fetchImageFromUrl but imported by the module, so it's stubbed.
+const safeFetch = vi.fn();
+vi.mock('./urlSafety', () => ({ safeFetch: (...a: unknown[]) => safeFetch(...a) }));
+const sniffImageMime = vi.fn();
+vi.mock('./avatarStorage', () => ({ sniffImageMime: (...a: unknown[]) => sniffImageMime(...a) }));
+vi.mock('../db', () => ({ db: {} }));
+
+import { fetchImageFromUrl, MAX_CATALOG_IMAGE_SIZE_BYTES } from './catalogImageStorage';
+
+function fakeRes(opts: { ok?: boolean; status?: number; headers?: Record<string, string>; body?: Uint8Array }) {
+  const { ok = true, status = 200, headers = {}, body = new Uint8Array([1, 2, 3]) } = opts;
+  return {
+    ok,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  };
+}
+
+describe('fetchImageFromUrl', () => {
+  beforeEach(() => { safeFetch.mockReset(); sniffImageMime.mockReset(); });
+
+  it('returns the SNIFFED mime + buffer, ignoring the Content-Type header', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ headers: { 'content-type': 'text/plain' }, body: new Uint8Array([1, 2, 3, 4]) }));
+    sniffImageMime.mockReturnValue('image/png');
+    const out = await fetchImageFromUrl('https://example.test/a.png');
+    expect(out.mime).toBe('image/png');
+    expect(out.buffer.length).toBe(4);
+    expect(safeFetch).toHaveBeenCalledWith('https://example.test/a.png', { timeoutMs: 10_000 });
+  });
+
+  it('throws on a non-OK response (and never sniffs)', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ ok: false, status: 403 }));
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow();
+    expect(sniffImageMime).not.toHaveBeenCalled();
+  });
+
+  it('rejects early when Content-Length exceeds the cap', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ headers: { 'content-length': String(MAX_CATALOG_IMAGE_SIZE_BYTES + 1) } }));
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(/too large/i);
+  });
+
+  it('rejects when the actual body exceeds the cap despite a missing/lying header', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ body: new Uint8Array(MAX_CATALOG_IMAGE_SIZE_BYTES + 1) }));
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(/too large/i);
+  });
+
+  it('rejects an empty body', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ body: new Uint8Array([]) }));
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(/empty/i);
+  });
+
+  it('rejects an unsniffable (non-image) body', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ body: new Uint8Array([0, 0, 0]) }));
+    sniffImageMime.mockReturnValue(null);
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(/unsupported/i);
+  });
+});

--- a/apps/api/src/services/catalogImageStorage.ts
+++ b/apps/api/src/services/catalogImageStorage.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { catalogItemImages } from '../db/schema/catalog';
+import { sniffImageMime } from './avatarStorage';
+import { safeFetch } from './urlSafety';
+
+export { sniffImageMime };
+export const MAX_CATALOG_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // reuse the avatar/quote cap
+
+/**
+ * Download a product image from a user-supplied URL, SSRF-guarded. The fetch goes
+ * through `safeFetch` (never global fetch) so a tenant URL can't reach internal
+ * addresses; a 10s timeout bounds the request. Size is checked twice: an early
+ * Content-Length reject, then the actual byte count after read. The format is
+ * confirmed by magic-byte sniffing (the Content-Type header is untrusted).
+ * Throws plain Errors; the route maps them to a generic 4xx.
+ */
+export async function fetchImageFromUrl(url: string): Promise<{ mime: string; buffer: Buffer }> {
+  const res = await safeFetch(url, { timeoutMs: 10_000 });
+  if (!res.ok) throw new Error(`Image download failed (HTTP ${res.status})`);
+
+  const declaredLength = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_CATALOG_IMAGE_SIZE_BYTES) {
+    throw new Error('Image too large (max 5 MB)');
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer());
+  if (buffer.length === 0) throw new Error('Downloaded image is empty');
+  if (buffer.length > MAX_CATALOG_IMAGE_SIZE_BYTES) throw new Error('Image too large (max 5 MB)');
+
+  const mime = sniffImageMime(buffer);
+  if (!mime) throw new Error('Unsupported image format. Allowed: PNG, JPEG, WebP.');
+
+  return { mime, buffer };
+}
+
+/**
+ * Persist a catalog item's product image as a bytea blob on `catalog_item_images`,
+ * scoped to its partner. One image per item: any existing row is cleared first
+ * (upload replaces). The partner-axis RLS on `catalog_item_images` is the access
+ * boundary; the caller must be inside a request/system DB access context.
+ * Magic-byte sniffing and the size cap are enforced by the route before this.
+ */
+export async function writeCatalogItemImage(
+  catalogItemId: string,
+  partnerId: string,
+  mime: string,
+  buffer: Buffer
+): Promise<{ id: string; byteSize: number; sha256: string }> {
+  const sha256 = createHash('sha256').update(buffer).digest('hex');
+  await db.delete(catalogItemImages).where(eq(catalogItemImages.catalogItemId, catalogItemId));
+  const [row] = await db.insert(catalogItemImages).values({
+    catalogItemId, partnerId, imageData: buffer, mime, byteSize: buffer.length, sha256,
+  }).returning({ id: catalogItemImages.id });
+  return { id: row!.id, byteSize: buffer.length, sha256 };
+}
+
+/** Read the (single) image for a catalog item. RLS + the route's ownership check
+ *  are the access boundary. */
+export async function readCatalogItemImage(
+  catalogItemId: string
+): Promise<{ data: Buffer; mime: string; byteSize: number } | null> {
+  const [img] = await db.select({
+    data: catalogItemImages.imageData, mime: catalogItemImages.mime, byteSize: catalogItemImages.byteSize,
+  }).from(catalogItemImages).where(eq(catalogItemImages.catalogItemId, catalogItemId)).limit(1);
+  return img?.data ? { data: img.data, mime: img.mime, byteSize: img.byteSize } : null;
+}
+
+export async function deleteCatalogItemImage(catalogItemId: string): Promise<void> {
+  await db.delete(catalogItemImages).where(eq(catalogItemImages.catalogItemId, catalogItemId));
+}

--- a/apps/api/src/services/invoiceMath.test.ts
+++ b/apps/api/src/services/invoiceMath.test.ts
@@ -32,14 +32,18 @@ describe('computeInvoiceTotals', () => {
 
 describe('resolveEffectiveTaxRate', () => {
   it('exempt overrides everything', () => {
-    expect(resolveEffectiveTaxRate({ taxExempt: true, orgRate: '0.1', partnerRate: '0.2' })).toBe('0.000');
+    expect(resolveEffectiveTaxRate({ taxExempt: true, orgRate: '0.1', partnerRate: '0.2' })).toBe('0.00000');
   });
   it('org rate beats partner rate', () => {
-    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: '0.075', partnerRate: '0.2' })).toBe('0.075');
+    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: '0.075', partnerRate: '0.2' })).toBe('0.07500');
   });
   it('falls back to partner then zero', () => {
-    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: null, partnerRate: '0.2' })).toBe('0.200');
-    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: null, partnerRate: null })).toBe('0.000');
+    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: null, partnerRate: '0.2' })).toBe('0.20000');
+    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: null, partnerRate: null })).toBe('0.00000');
+  });
+  it('preserves sub-percent precision (8.95%, 8.875%)', () => {
+    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: '0.0895', partnerRate: null })).toBe('0.08950');
+    expect(resolveEffectiveTaxRate({ taxExempt: false, orgRate: '0.08875', partnerRate: null })).toBe('0.08875');
   });
 });
 

--- a/apps/api/src/services/invoiceMath.ts
+++ b/apps/api/src/services/invoiceMath.ts
@@ -52,9 +52,10 @@ export function resolveEffectiveTaxRate(input: {
   orgRate: string | null;
   partnerRate: string | null;
 }): string {
-  if (input.taxExempt) return '0.000';
+  // Fraction with scale 5 (3 percent decimals) — see numeric(8,5) tax_rate columns.
+  if (input.taxExempt) return '0.00000';
   const rate = input.orgRate ?? input.partnerRate ?? '0';
-  return Number(rate).toFixed(3);
+  return Number(rate).toFixed(5);
 }
 
 export function deriveInvoiceStatus(input: {

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -32,6 +32,7 @@ vi.mock('./catalogService', () => ({ resolvePrice: vi.fn(), computeBundleEconomi
 vi.mock('./invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
 
 import * as svc from './invoiceService';
+import { db } from '../db';
 import { InvoiceServiceError } from './invoiceTypes';
 import { resolvePrice } from './catalogService';
 
@@ -147,6 +148,42 @@ describe('invoiceService guards', () => {
     );
     expect(row.currencyCode).toBe('EUR');
     expect(row.invoiceNumberPrefix).toBe('EU');
+  });
+
+  it('updatePartnerBillingSettings includes autoTaxHardware in the returned row', async () => {
+    queueResult([{ currencyCode: 'USD', defaultTaxRate: null, invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, invoiceFooter: null, autoTaxHardware: false }]);
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+    const row = await svc.updatePartnerBillingSettings(
+      { currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, autoTaxHardware: false },
+      actor
+    );
+    expect(row.autoTaxHardware).toBe(false);
+  });
+
+  it('updatePartnerBillingSettings persists a scale-5 tax rate and a 2-decimal markup', async () => {
+    queueResult([{ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 }]);
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+    await svc.updatePartnerBillingSettings(
+      { currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, defaultTaxRate: 0.08875, defaultMarkupPercent: 12.5 },
+      actor,
+    );
+    const setMock = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set;
+    const setArg = setMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+    expect(setArg.defaultTaxRate).toBe('0.08875'); // numeric(8,5): 3 percent decimals preserved
+    expect(setArg.defaultMarkupPercent).toBe('12.50'); // numeric(6,2)
+  });
+
+  it('updatePartnerBillingSettings clears the tax rate and markup when null', async () => {
+    queueResult([{ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 }]);
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+    await svc.updatePartnerBillingSettings(
+      { currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, defaultTaxRate: null, defaultMarkupPercent: null },
+      actor,
+    );
+    const setMock = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set;
+    const setArg = setMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+    expect(setArg.defaultTaxRate).toBeNull();
+    expect(setArg.defaultMarkupPercent).toBeNull();
   });
 
   it('updateOrgBillingSettings denies an actor without access to the org (ORG_DENIED 403)', async () => {

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -305,7 +305,8 @@ export async function listInvoices(query: { orgId?: string; status?: string; lim
 export async function updatePartnerBillingSettings(
   patch: {
     currencyCode: string; defaultTaxRate?: number | null; invoiceNumberPrefix: string;
-    invoiceTermsDays: number; invoiceFooter?: string | null;
+    invoiceTermsDays: number; defaultMarkupPercent?: number | null; autoTaxHardware?: boolean;
+    invoiceFooter?: string | null;
     billingCompanyName?: string | null; billingPhone?: string | null; billingWebsite?: string | null;
     billingAddressLine1?: string | null; billingAddressLine2?: string | null; billingAddressCity?: string | null;
     billingAddressRegion?: string | null; billingAddressPostalCode?: string | null; billingAddressCountry?: string | null;
@@ -321,8 +322,12 @@ export async function updatePartnerBillingSettings(
   };
   // Numeric columns take fixed-string values; null clears the optional rate/footer.
   if (patch.defaultTaxRate !== undefined) {
-    set.defaultTaxRate = patch.defaultTaxRate === null ? null : Number(patch.defaultTaxRate).toFixed(3);
+    set.defaultTaxRate = patch.defaultTaxRate === null ? null : Number(patch.defaultTaxRate).toFixed(5);
   }
+  if (patch.defaultMarkupPercent !== undefined) {
+    set.defaultMarkupPercent = patch.defaultMarkupPercent === null ? null : Number(patch.defaultMarkupPercent).toFixed(2);
+  }
+  if (patch.autoTaxHardware !== undefined) set.autoTaxHardware = patch.autoTaxHardware;
   if (patch.invoiceFooter !== undefined) set.invoiceFooter = patch.invoiceFooter;
   for (const key of [
     'billingCompanyName', 'billingPhone', 'billingWebsite', 'billingAddressLine1', 'billingAddressLine2',
@@ -334,6 +339,7 @@ export async function updatePartnerBillingSettings(
   const [row] = await db.update(partners).set(set).where(eq(partners.id, partnerId)).returning({
     currencyCode: partners.currencyCode, defaultTaxRate: partners.defaultTaxRate,
     invoiceNumberPrefix: partners.invoiceNumberPrefix, invoiceTermsDays: partners.invoiceTermsDays,
+    defaultMarkupPercent: partners.defaultMarkupPercent, autoTaxHardware: partners.autoTaxHardware,
     invoiceFooter: partners.invoiceFooter,
   });
   if (!row) throw new InvoiceServiceError('Partner could not be resolved', 400, 'PARTNER_UNRESOLVABLE');
@@ -354,7 +360,7 @@ export async function updateOrgBillingSettings(
   const set: Record<string, unknown> = {};
   if (patch.taxId !== undefined) set.taxId = patch.taxId;
   if (patch.taxExempt !== undefined) set.taxExempt = patch.taxExempt;
-  if (patch.taxRate !== undefined) set.taxRate = patch.taxRate === null ? null : Number(patch.taxRate).toFixed(3);
+  if (patch.taxRate !== undefined) set.taxRate = patch.taxRate === null ? null : Number(patch.taxRate).toFixed(5);
   if (patch.billingAddressLine1 !== undefined) set.billingAddressLine1 = patch.billingAddressLine1;
   if (patch.billingAddressLine2 !== undefined) set.billingAddressLine2 = patch.billingAddressLine2;
   if (patch.billingAddressCity !== undefined) set.billingAddressCity = patch.billingAddressCity;

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -40,6 +40,32 @@ describe('renderQuotePdf', () => {
     expect(buf.length).toBeGreaterThan(800);
   });
 
+  it('embeds a product thumbnail for a catalog-sourced line via loadCatalogImage', async () => {
+    const requested: string[] = [];
+    const buf = await renderQuotePdf(
+      { id: 'q1', quoteNumber: 'Q-3', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '100.00', currencyCode: 'USD' },
+      [{ id: 'b2', blockType: 'line_items', sortOrder: 0, content: {} }],
+      [{ id: 'l1', blockId: 'b2', catalogItemId: 'cat-9', description: 'Laptop', quantity: '1', unitPrice: '100', lineTotal: '100.00', recurrence: 'one_time' }],
+      async () => null,
+      {},
+      async (catalogItemId) => { requested.push(catalogItemId); return { data: ONE_BY_ONE_PNG }; },
+    );
+    expect(requested).toEqual(['cat-9']);
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('skips the thumbnail (no throw) when loadCatalogImage rejects', async () => {
+    const buf = await renderQuotePdf(
+      { id: 'q1', quoteNumber: 'Q-4', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '100.00', currencyCode: 'USD' },
+      [{ id: 'b2', blockType: 'line_items', sortOrder: 0, content: {} }],
+      [{ id: 'l1', blockId: 'b2', catalogItemId: 'cat-9', description: 'Laptop', quantity: '1', unitPrice: '100', lineTotal: '100.00', recurrence: 'one_time' }],
+      async () => null,
+      {},
+      async () => { throw new Error('image store down'); },
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
   it('renders mixed one-time + monthly + annual lines without throwing', async () => {
     const buf = await renderQuotePdf(
       {

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -111,12 +111,17 @@ interface QuoteBlock {
 interface QuoteLine {
   id: string;
   blockId?: string | null;
+  catalogItemId?: string | null;
   description: string;
   quantity: string | number;
   unitPrice: string | number;
   lineTotal?: string | number | null;
   recurrence?: string | null;
 }
+
+/** Loads a catalog item's product image bytes (or null). Injected so renderQuotePdf
+ *  stays pure / DB-free; the route supplies the real readCatalogItemImage loader. */
+type LoadCatalogImage = (catalogItemId: string) => Promise<{ data: Buffer } | null>;
 
 // ---------------------------------------------------------------------------
 // Layout constants (shared between the line table + summary so columns align).
@@ -160,9 +165,33 @@ function ensureSpace(doc: PDFKit.PDFDocument, y: number, needed = 40): number {
 // Returns the y position below the table.
 // ---------------------------------------------------------------------------
 
-function renderLineTable(doc: PDFKit.PDFDocument, lines: QuoteLine[], currency: string, startY: number): number {
+async function renderLineTable(
+  doc: PDFKit.PDFDocument,
+  lines: QuoteLine[],
+  currency: string,
+  startY: number,
+  loadCatalogImage: LoadCatalogImage,
+): Promise<number> {
   const c = columnsFor(doc);
   let y = ensureSpace(doc, startY, 60);
+
+  // Pre-load product images (DB I/O) for catalog-sourced lines. A failed load
+  // degrades to "no thumbnail" — never aborts the document.
+  const THUMB = 30;
+  const imageByLine = new Map<string, Buffer>();
+  for (const l of lines) {
+    if (!l.catalogItemId) continue;
+    try {
+      const img = await loadCatalogImage(l.catalogItemId);
+      if (img?.data) imageByLine.set(l.id, img.data);
+    } catch (e) {
+      console.error('[quotePdf] loadCatalogImage failed', l.catalogItemId, e instanceof Error ? e.message : e);
+    }
+  }
+  // Reserve a thumbnail gutter only when at least one line has an image, so the
+  // description column stays aligned across rows.
+  const gutter = imageByLine.size > 0 ? THUMB + 8 : 0;
+  const descW = c.contentWidth * 0.46 - gutter;
 
   // Header row with a light fill bar.
   doc.save();
@@ -178,15 +207,19 @@ function renderLineTable(doc: PDFKit.PDFDocument, lines: QuoteLine[], currency: 
 
   const descX = c.colQtyX + c.contentWidth * 0.12;
   for (const l of lines) {
-    y = ensureSpace(doc, y, 30);
+    y = ensureSpace(doc, y, Math.max(30, gutter));
     doc.fillColor('#1f2937').fontSize(10).font('Helvetica');
-    const descHeight = doc.heightOfString(l.description, { width: c.contentWidth * 0.46 });
+    const descHeight = doc.heightOfString(l.description, { width: descW });
     doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
-    doc.text(l.description, descX, y, { width: c.contentWidth * 0.46 });
+    const img = imageByLine.get(l.id);
+    if (img) {
+      try { doc.image(img, descX, y, { fit: [THUMB, THUMB] }); } catch { /* corrupt image: skip */ }
+    }
+    doc.text(l.description, descX + gutter, y, { width: descW });
     doc.text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
     const suffix = recurrenceSuffix(l.recurrence);
     doc.text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
-    y += Math.max(descHeight, 12) + 6;
+    y += Math.max(descHeight, img ? THUMB : 12) + 6;
   }
   return y + 6;
 }
@@ -256,6 +289,8 @@ export async function renderQuotePdf(
   lines: QuoteLine[],
   loadImage: (imageId: string) => Promise<{ data: Buffer } | null>,
   branding: QuotePdfBranding,
+  // Optional so existing callers/tests compile; the route injects the real loader.
+  loadCatalogImage: LoadCatalogImage = async () => null,
 ): Promise<Buffer> {
   const currency = quote.currencyCode ?? branding.currencyCode ?? 'USD';
   const primary = hexToColor(branding.primaryColor, '#2563eb');
@@ -372,14 +407,14 @@ export async function renderQuotePdf(
           doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
           y = doc.y + 6;
         }
-        y = renderLineTable(doc, blockLines, currency, y);
+        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage);
       }
     }
   }
 
   // ---- Trailing default table for lines with no block ----------------------
   const orphanLines = lines.filter((l) => !l.blockId);
-  if (orphanLines.length) y = renderLineTable(doc, orphanLines, currency, y);
+  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage);
 
   // ---- Recurring summary footer -------------------------------------------
   y = renderRecurringSummary(doc, quote, currency, primary, y);

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -152,7 +152,7 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
   if (input.termsAndConditions !== undefined) set.termsAndConditions = input.termsAndConditions;
   if (input.billToName !== undefined) set.billToName = input.billToName;
   // Numeric tax_rate takes a fixed-string value; null clears it.
-  if (input.taxRate !== undefined) set.taxRate = input.taxRate === null ? null : Number(input.taxRate).toFixed(3);
+  if (input.taxRate !== undefined) set.taxRate = input.taxRate === null ? null : Number(input.taxRate).toFixed(5);
   await db.update(quotes).set(set).where(eq(quotes.id, id));
   await recomputeAndPersist(id);
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
@@ -178,6 +178,30 @@ export async function addBlock(quoteId: string, input: QuoteBlockInput, actor: Q
     content: input.content,
     sortOrder,
   }).returning();
+  return row!;
+}
+
+/**
+ * Update a block's content in place (heading text/level, rich-text html, image
+ * caption/width, or a line_items section title). The block type is immutable —
+ * the request must restate the existing type so the discriminated-union content
+ * shape is validated, and a mismatch is rejected. Content edits never touch
+ * lines, so no totals recompute is needed.
+ */
+export async function updateBlock(quoteId: string, blockId: string, input: QuoteBlockInput, actor: QuoteActor) {
+  await loadDraft(quoteId, actor);
+  const [existing] = await db.select({ blockType: quoteBlocks.blockType })
+    .from(quoteBlocks)
+    .where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quoteId)))
+    .limit(1);
+  if (!existing) throw new QuoteServiceError('Block not found', 404, 'BLOCK_NOT_FOUND');
+  if (existing.blockType !== input.blockType) {
+    throw new QuoteServiceError('Block type cannot be changed', 400, 'BLOCK_TYPE_MISMATCH');
+  }
+  const [row] = await db.update(quoteBlocks)
+    .set({ content: input.content })
+    .where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quoteId)))
+    .returning();
   return row!;
 }
 

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -19,6 +19,7 @@ export type QuoteServiceErrorCode =
   | 'NOT_A_DRAFT'
   | 'LINE_NOT_FOUND'
   | 'BLOCK_NOT_FOUND'
+  | 'BLOCK_TYPE_MISMATCH'
   | 'IMAGE_NOT_FOUND'
   | 'INVALID_IMAGE'
   | 'CATALOG_ITEM_NOT_FOUND'

--- a/apps/web/src/components/billing/OrgBillingSettings.tsx
+++ b/apps/web/src/components/billing/OrgBillingSettings.tsx
@@ -119,7 +119,7 @@ export default function OrgBillingSettings({ orgId }: Props) {
           <div>
             <label className="text-sm font-medium" htmlFor="ob-taxrate">Tax rate (%)</label>
             <input
-              id="ob-taxrate" type="number" min={0} max={100} step="0.1" value={taxPercent}
+              id="ob-taxrate" type="number" min={0} max={100} step="0.001" value={taxPercent}
               onChange={(e) => setTaxPercent(e.target.value)} placeholder="Partner default"
               disabled={taxExempt}
               data-testid="org-billing-taxrate"

--- a/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
@@ -64,6 +64,32 @@ describe('PartnerBillingSettings', () => {
     });
   });
 
+  it('sends autoTaxHardware in the PATCH body and toggles it via checkbox', async () => {
+    fetchMock.mockImplementation(async (_input: string, opts?: RequestInit) => {
+      if (opts?.method === 'PATCH') return json({ data: {} });
+      return json({
+        currencyCode: 'USD', defaultTaxRate: null, invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+        autoTaxHardware: true, invoiceFooter: null,
+      });
+    });
+    render(<PartnerBillingSettings />);
+    await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+
+    // Checkbox should start checked (loaded true from server)
+    const checkbox = screen.getByTestId('partner-billing-auto-tax-hardware') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+
+    // Uncheck it and save — PATCH body must carry autoTaxHardware: false
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByTestId('partner-billing-save'));
+
+    await waitFor(() => {
+      const patch = fetchMock.mock.calls.find((c) => c[0] === '/partner/billing-settings' && (c[1] as RequestInit)?.method === 'PATCH');
+      expect(patch).toBeTruthy();
+      expect(JSON.parse((patch![1] as RequestInit).body as string)).toMatchObject({ autoTaxHardware: false });
+    });
+  });
+
   it('uppercases billingAddressCountry and normalizes whitespace-only address fields to null on save', async () => {
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
       if (opts?.method === 'PATCH') return json({ data: {} });

--- a/apps/web/src/components/billing/PartnerBillingSettings.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.tsx
@@ -11,6 +11,8 @@ interface PartnerBilling {
   defaultTaxRate: string | null;
   invoiceNumberPrefix: string;
   invoiceTermsDays: number;
+  defaultMarkupPercent: string | null;
+  autoTaxHardware: boolean;
   invoiceFooter: string | null;
   billingCompanyName: string | null;
   billingPhone: string | null;
@@ -34,6 +36,10 @@ export default function PartnerBillingSettings() {
   const [taxPercent, setTaxPercent] = useState('');
   const [prefix, setPrefix] = useState('INV');
   const [termsDays, setTermsDays] = useState('30');
+  // Default markup over distributor cost used to pre-fill catalog import prices.
+  const [markupPercent, setMarkupPercent] = useState('');
+  // When true, hardware catalog items default to taxable on import.
+  const [autoTaxHardware, setAutoTaxHardware] = useState(true);
   const [footer, setFooter] = useState('');
   const [companyName, setCompanyName] = useState('');
   const [phone, setPhone] = useState('');
@@ -58,6 +64,8 @@ export default function PartnerBillingSettings() {
       setTaxPercent(pctFromFraction(p.defaultTaxRate));
       setPrefix(p.invoiceNumberPrefix ?? 'INV');
       setTermsDays(String(p.invoiceTermsDays ?? 30));
+      setMarkupPercent(p.defaultMarkupPercent != null ? String(Number(p.defaultMarkupPercent)) : '');
+      setAutoTaxHardware(p.autoTaxHardware ?? true);
       setFooter(p.invoiceFooter ?? '');
       setCompanyName(p.billingCompanyName ?? '');
       setPhone(p.billingPhone ?? '');
@@ -84,6 +92,8 @@ export default function PartnerBillingSettings() {
     try {
       const pct = taxPercent.trim();
       const defaultTaxRate = pct === '' ? null : Number(pct) / 100;
+      const markupTrimmed = markupPercent.trim();
+      const defaultMarkupPercent = markupTrimmed === '' ? null : Number(markupTrimmed);
       await runAction({
         request: () => fetchWithAuth('/partner/billing-settings', {
           method: 'PATCH',
@@ -92,6 +102,8 @@ export default function PartnerBillingSettings() {
             defaultTaxRate,
             invoiceNumberPrefix: prefix.trim(),
             invoiceTermsDays: Number(termsDays),
+            defaultMarkupPercent,
+            autoTaxHardware,
             invoiceFooter: footer.trim() === '' ? null : footer,
             billingCompanyName: companyName.trim() === '' ? null : companyName.trim(),
             billingPhone: phone.trim() === '' ? null : phone.trim(),
@@ -115,7 +127,7 @@ export default function PartnerBillingSettings() {
     } finally {
       setSaving(false);
     }
-  }, [saving, currencyCode, taxPercent, prefix, termsDays, footer,
+  }, [saving, currencyCode, taxPercent, prefix, termsDays, markupPercent, autoTaxHardware, footer,
       companyName, phone, website, addr1, addr2, city, region, postal, country, terms, load]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading billing settings…</p>;
@@ -148,7 +160,7 @@ export default function PartnerBillingSettings() {
           <div>
             <label className="text-sm font-medium" htmlFor="pb-tax">Default tax rate (%)</label>
             <input
-              id="pb-tax" type="number" min={0} max={100} step="0.1" value={taxPercent}
+              id="pb-tax" type="number" min={0} max={100} step="0.001" value={taxPercent}
               onChange={(e) => setTaxPercent(e.target.value)} placeholder="None"
               data-testid="partner-billing-tax"
               className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
@@ -172,6 +184,35 @@ export default function PartnerBillingSettings() {
               className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
             />
           </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="pb-markup">Default markup (%)</label>
+            <input
+              id="pb-markup" type="number" min={0} max={9999.99} step="0.01" value={markupPercent}
+              onChange={(e) => setMarkupPercent(e.target.value)} placeholder="None"
+              data-testid="partner-billing-markup"
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Default markup over distributor cost, used to pre-fill the sell price when importing catalog
+              items. The resulting gross margin is shown as you import.
+            </p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              id="pb-auto-tax-hardware"
+              type="checkbox"
+              checked={autoTaxHardware}
+              onChange={(e) => setAutoTaxHardware(e.target.checked)}
+              data-testid="partner-billing-auto-tax-hardware"
+              className="h-4 w-4 rounded border"
+            />
+            <span className="text-sm font-medium">Auto-tax hardware items</span>
+          </label>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Newly imported hardware defaults to taxable.
+          </p>
         </div>
         <div className="mt-4">
           <label className="text-sm font-medium" htmlFor="pb-footer">Invoice footer</label>

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -149,8 +149,9 @@ export function formatMoney(value: string | number | null | undefined, currencyC
 }
 
 /** Convert a stored tax-rate FRACTION (e.g. '0.07') to a percent string for an
- *  input ('7'), rounding to 3 decimals to match the numeric(6,3)-on-fraction
- *  scale. Avoids float noise like `String(0.07 * 100)` → '7.000000000000001'.
+ *  input ('7'), rounding the percent to 3 decimals — equivalently the numeric(8,5)
+ *  fraction scale (5 fraction decimals = 3 percent decimals, e.g. 8.875%). Avoids
+ *  float noise like `String(0.07 * 100)` → '7.000000000000001'.
  *  Returns '' for null/empty so the input shows its placeholder. */
 export function pctFromFraction(frac: string | number | null): string {
   if (frac === null || frac === '') return '';

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { updateLine } from '../../../lib/api/quotes';
+
+// Writer permissions so the inline line editor renders (read-only hides it).
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  removeLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Monthly services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const line: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: 'Managed support', quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'monthly', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '50.00', taxRate: null,
+    taxTotal: '0.00', total: '50.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '50.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [block],
+  lines: [line],
+};
+
+const updateLineMock = vi.mocked(updateLine);
+
+describe('QuoteEditor — inline line editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateLineMock.mockResolvedValue(
+      { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+    );
+  });
+
+  it('renders existing lines with editable fields', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    expect((screen.getByTestId('quote-line-desc-line-1') as HTMLTextAreaElement).value).toBe('Managed support');
+    expect((screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement).value).toBe('1.00');
+    expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('50.00');
+    expect(screen.getByTestId('quote-line-recurrence-line-1')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-line-taxable-line-1')).toBeInTheDocument();
+    // the description editor is a multi-line textarea
+    expect(screen.getByTestId('quote-line-desc-line-1').tagName).toBe('TEXTAREA');
+  });
+
+  it('editing the description and blurring PATCHes the line, then refreshes', async () => {
+    const onChanged = vi.fn();
+    render(<QuoteEditor detail={detail} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const descEl = screen.getByTestId('quote-line-desc-line-1');
+    fireEvent.change(descEl, { target: { value: 'Premium managed support' } });
+    fireEvent.blur(descEl);
+
+    await waitFor(() => {
+      expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support' });
+    });
+    expect(onChanged).toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Line updated' }));
+  });
+
+  it('changing quantity sends a numeric quantity', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qtyEl = screen.getByTestId('quote-line-qty-line-1');
+    fireEvent.change(qtyEl, { target: { value: '3' } });
+    fireEvent.blur(qtyEl);
+
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { quantity: 3 }));
+  });
+
+  it('toggling taxable PATCHes immediately', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-line-taxable-line-1'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { taxable: true }));
+  });
+
+  it('changing recurrence PATCHes immediately', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-line-recurrence-line-1'), { target: { value: 'one_time' } });
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { recurrence: 'one_time' }));
+  });
+
+  it('blurring an unchanged field does not PATCH', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.blur(screen.getByTestId('quote-line-desc-line-1'));
+    fireEvent.blur(screen.getByTestId('quote-line-qty-line-1'));
+    fireEvent.blur(screen.getByTestId('quote-line-price-line-1'));
+    expect(updateLineMock).not.toHaveBeenCalled();
+  });
+
+  it('the manual-line Description is a multi-line textarea', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // switch the add-line builder to the Manual tab
+    fireEvent.click(screen.getByTestId('quote-line-mode-blk-1-manual'));
+    const manualDesc = screen.getByTestId('quote-manual-desc-blk-1');
+    expect(manualDesc.tagName).toBe('TEXTAREA');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -5,14 +5,17 @@ import { runAction, handleActionError } from '../../../lib/runAction';
 import { usePermissions } from '../../../lib/permissions';
 import {
   addBlock,
+  updateBlock,
   deleteBlock,
   addManualLine,
   addCatalogLine,
+  updateLine,
   removeLine,
   uploadQuoteImage,
   quoteImageUrl,
 } from '../../../lib/api/quotes';
-import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
+import type { QuoteBlockInput } from '@breeze/shared';
+import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
 import CatalogEnrichButton from '../../catalog/CatalogEnrichButton';
@@ -28,10 +31,11 @@ import {
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
-// Phase 2: the add-block menu now offers `image` as well. Because there is no
-// block-update endpoint (blocks are add/remove only), an image block is created
-// with its uploaded `imageId` already in `content` — the editor uploads the file
-// first (POST /:id/images), then adds the block with `{ imageId }`.
+// Phase 2: the add-block menu now offers `image` as well. An image block is
+// created with its uploaded `imageId` already in `content` — the editor uploads
+// the file first (POST /:id/images), then adds the block with `{ imageId }`.
+// Heading/rich-text block content is editable in place via PATCH /:id/blocks/:blockId
+// (updateBlock); the block type itself is immutable.
 type AddableBlockType = 'heading' | 'rich_text' | 'image' | 'line_items';
 const ADD_BLOCK_OPTIONS: { value: AddableBlockType; label: string }[] = [
   { value: 'heading', label: 'Heading' },
@@ -46,6 +50,17 @@ const BLOCK_TYPE_LABELS: Record<string, string> = {
   image: 'Image',
   line_items: 'Pricing table',
 };
+
+// Changed-fields payload for an inline line edit. Subset of
+// updateQuoteLineSchema (description/quantity/unitPrice/taxable/recurrence) —
+// the only fields the inline editor exposes.
+type LineUpdate = Partial<{
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxable: boolean;
+  recurrence: QuoteLineRecurrence;
+}>;
 
 interface Props {
   detail: QuoteDetailData;
@@ -363,6 +378,48 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     }
   }, [busy, quote.id, refresh]);
 
+  // Inline edit of an existing line. `body` carries only the changed fields
+  // (matches updateQuoteLineSchema). Routed through runAction so success/failure
+  // is surfaced, then refresh() re-pulls the quote so totals recompute.
+  const editLine = useCallback(async (lineId: string, body: LineUpdate) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => updateLine(quote.id, lineId, body),
+        errorFallback: 'Could not update the line.',
+        successMessage: 'Line updated',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not update the line.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, quote.id, refresh]);
+
+  // Inline edit of a block's content (heading text/level, rich-text html). The
+  // block type is restated so the server validates the content shape; it is
+  // immutable and never changes here.
+  const editBlock = useCallback(async (block: QuoteBlock, content: Record<string, unknown>) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => updateBlock(quote.id, block.id, { blockType: block.blockType, content } as QuoteBlockInput),
+        errorFallback: 'Could not update the block.',
+        successMessage: 'Block updated',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not update the block.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, quote.id, refresh]);
+
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
 
@@ -390,6 +447,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 onAddCatalog={addCatalog}
                 onImportAddDistributor={importAndAddDistributor}
                 onAddManual={addManual}
+                onEditLine={editLine}
+                onEditBlock={editBlock}
                 onRemoveLine={deleteLine}
                 onRemoveBlock={removeBlock}
               />
@@ -551,7 +610,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, catalog, busy, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, catalog, busy, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onRemoveLine, onRemoveBlock,
 }: {
   block: QuoteBlock;
   quoteId: string;
@@ -567,6 +626,8 @@ function BlockCard({
     blockId: string,
     form: { description: string; quantity: string; unitPrice: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean },
   ) => void;
+  onEditLine: (lineId: string, body: LineUpdate) => void;
+  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => void;
   onRemoveLine: (lineId: string) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
 }) {
@@ -584,6 +645,23 @@ function BlockCard({
   const tableLabel = (block.content?.label as string | undefined) ?? '';
   const imageId = (block.content?.imageId as string | undefined) ?? '';
   const imageCaption = (block.content?.caption as string | undefined) ?? '';
+
+  // Inline drafts for editable block content; resync if the persisted value
+  // changes (e.g. after a refresh) so server normalization wins.
+  const [headingDraft, setHeadingDraft] = useState(heading);
+  const [richDraft, setRichDraft] = useState(html);
+  useEffect(() => { setHeadingDraft(heading); }, [heading]);
+  useEffect(() => { setRichDraft(html); }, [html]);
+
+  const commitHeading = () => {
+    const text = headingDraft.trim();
+    if (!text || text === heading) { setHeadingDraft(heading); return; }
+    onEditBlock(block, { text, level: (block.content?.level as number | undefined) ?? 2 });
+  };
+  const commitRich = () => {
+    if (richDraft === html) return;
+    onEditBlock(block, { html: richDraft });
+  };
 
   const submitManual = () => {
     onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
@@ -612,10 +690,33 @@ function BlockCard({
 
       <div className="p-4">
         {block.blockType === 'heading' && (
-          <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
+          canWrite ? (
+            <input
+              value={headingDraft}
+              onChange={(e) => setHeadingDraft(e.target.value)}
+              onBlur={commitHeading}
+              disabled={busy}
+              data-testid={`quote-block-heading-input-${block.id}`}
+              className="w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold"
+            />
+          ) : (
+            <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
+          )
         )}
         {block.blockType === 'rich_text' && (
-          <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
+          canWrite ? (
+            <textarea
+              value={richDraft}
+              onChange={(e) => setRichDraft(e.target.value)}
+              onBlur={commitRich}
+              disabled={busy}
+              rows={4}
+              data-testid={`quote-block-rich-input-${block.id}`}
+              className="w-full resize-y rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          ) : (
+            <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
+          )
         )}
         {block.blockType === 'image' && (
           imageId ? (
@@ -649,32 +750,36 @@ function BlockCard({
                     </td>
                   </tr>
                 ) : (
-                  lines.map((l) => (
-                    <tr key={l.id} className="border-t" data-testid={`quote-line-${l.id}`}>
-                      <td className="px-2 py-2">{l.description}</td>
-                      <td className="px-2 py-2 text-right tabular-nums">{l.quantity}</td>
-                      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
-                      <td className="px-2 py-2">
-                        <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                          {formatRecurrence(l.recurrence)}
-                        </span>
-                      </td>
-                      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
-                      <td className="px-2 py-2 text-right">
-                        {canWrite && (
-                          <button
-                            type="button"
-                            onClick={() => onRemoveLine(l.id)}
-                            disabled={busy}
-                            data-testid={`quote-line-remove-${l.id}`}
-                            className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                          >
-                            Remove
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  ))
+                  lines.map((l) =>
+                    canWrite ? (
+                      <EditableLineRow
+                        key={l.id}
+                        line={l}
+                        currency={currency}
+                        busy={busy}
+                        onEdit={onEditLine}
+                        onRemove={onRemoveLine}
+                      />
+                    ) : (
+                      <tr key={l.id} className="border-t" data-testid={`quote-line-${l.id}`}>
+                        <td className="px-2 py-2">
+                          <div className="flex items-start gap-2">
+                            {l.catalogItemId && <CatalogLineThumb catalogItemId={l.catalogItemId} />}
+                            <span>{l.description}</span>
+                          </div>
+                        </td>
+                        <td className="px-2 py-2 text-right tabular-nums">{l.quantity}</td>
+                        <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
+                        <td className="px-2 py-2">
+                          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {formatRecurrence(l.recurrence)}
+                          </span>
+                        </td>
+                        <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
+                        <td className="px-2 py-2 text-right" />
+                      </tr>
+                    ),
+                  )
                 )}
               </tbody>
             </table>
@@ -730,12 +835,13 @@ function BlockCard({
                       setTaxable(d.taxable);
                     }}
                   />
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_70px_90px_110px]">
-                    <input
-                      type="text" placeholder="Description" value={desc}
+                  <div className="grid grid-cols-1 items-start gap-2 sm:grid-cols-[1fr_70px_90px_110px]">
+                    <textarea
+                      placeholder="Description" value={desc}
                       onChange={(e) => setDesc(e.target.value)}
+                      rows={2}
                       data-testid={`quote-manual-desc-${block.id}`}
-                      className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      className="min-h-[2.25rem] resize-y rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     <input
                       type="number" min="0" step="0.01" placeholder="Qty" value={qty}
@@ -790,6 +896,152 @@ function BlockCard({
       </div>
     </div>
   );
+}
+
+// ── A single editable pricing-table line (writers only) ───────────────────
+// Each field is locally controlled and committed on blur (text/number) or on
+// change (taxable checkbox, recurrence select) — but only when the value
+// actually differs from the persisted line, so a focus-without-edit doesn't
+// fire a redundant PATCH. The parent's onEdit routes through updateLine +
+// runAction and then refresh()es, which re-pulls the line; we resync local
+// state to the incoming prop so server-side normalization (e.g. recomputed
+// totals, clamped quantity) wins.
+function EditableLineRow({
+  line, currency, busy, onEdit, onRemove,
+}: {
+  line: QuoteLine;
+  currency: string;
+  busy: boolean;
+  onEdit: (lineId: string, body: LineUpdate) => void;
+  onRemove: (lineId: string) => void;
+}) {
+  const [desc, setDesc] = useState(line.description);
+  const [qty, setQty] = useState(line.quantity);
+  const [price, setPrice] = useState(line.unitPrice);
+
+  // Resync when the persisted line changes (after a refresh()).
+  useEffect(() => { setDesc(line.description); }, [line.description]);
+  useEffect(() => { setQty(line.quantity); }, [line.quantity]);
+  useEffect(() => { setPrice(line.unitPrice); }, [line.unitPrice]);
+
+  const commitDesc = () => {
+    const next = desc.trim();
+    if (!next || next === line.description) { setDesc(line.description); return; }
+    onEdit(line.id, { description: next });
+  };
+  const commitQty = () => {
+    const n = Number(qty);
+    if (!Number.isFinite(n) || n <= 0 || n === Number(line.quantity)) { setQty(line.quantity); return; }
+    onEdit(line.id, { quantity: n });
+  };
+  const commitPrice = () => {
+    const n = Number(price);
+    if (!Number.isFinite(n) || n < 0 || n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; }
+    onEdit(line.id, { unitPrice: n });
+  };
+
+  return (
+    <tr className="border-t align-top" data-testid={`quote-line-${line.id}`}>
+      <td className="px-2 py-2">
+        <div className="flex items-start gap-2">
+          {line.catalogItemId && <CatalogLineThumb catalogItemId={line.catalogItemId} />}
+          <textarea
+            value={desc}
+            onChange={(e) => setDesc(e.target.value)}
+            onBlur={commitDesc}
+            rows={2}
+            disabled={busy}
+            data-testid={`quote-line-desc-${line.id}`}
+            className="min-h-[2.25rem] w-full resize-y rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+          />
+        </div>
+      </td>
+      <td className="px-2 py-2 text-right">
+        <input
+          type="number" min="0" step="0.01"
+          value={qty}
+          onChange={(e) => setQty(e.target.value)}
+          onBlur={commitQty}
+          disabled={busy}
+          data-testid={`quote-line-qty-${line.id}`}
+          className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+        />
+      </td>
+      <td className="px-2 py-2 text-right">
+        <input
+          type="number" min="0" step="0.01"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          onBlur={commitPrice}
+          disabled={busy}
+          data-testid={`quote-line-price-${line.id}`}
+          className="h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+        />
+      </td>
+      <td className="px-2 py-2">
+        <select
+          value={line.recurrence}
+          onChange={(e) => onEdit(line.id, { recurrence: e.target.value as QuoteLineRecurrence })}
+          disabled={busy}
+          data-testid={`quote-line-recurrence-${line.id}`}
+          className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+        >
+          <option value="one_time">One-time</option>
+          <option value="monthly">Monthly</option>
+          <option value="annual">Annual</option>
+        </select>
+        <label className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={line.taxable}
+            onChange={(e) => onEdit(line.id, { taxable: e.target.checked })}
+            disabled={busy}
+            data-testid={`quote-line-taxable-${line.id}`}
+          />
+          Taxable
+        </label>
+      </td>
+      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(line.lineTotal, currency)}</td>
+      <td className="px-2 py-2 text-right">
+        <button
+          type="button"
+          onClick={() => onRemove(line.id)}
+          disabled={busy}
+          data-testid={`quote-line-remove-${line.id}`}
+          className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+        >
+          Remove
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+// Small product thumbnail for a catalog-sourced quote line. GET /catalog/:id/image
+// needs the Bearer header (a bare <img src> would 401), and 404s when the item has
+// no image — so we fetchWithAuth → blob → object URL and render nothing on miss.
+function CatalogLineThumb({ catalogItemId }: { catalogItemId: string }) {
+  const [url, setUrl] = useState<string>();
+  useEffect(() => {
+    let objectUrl: string | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(catalogItemImagePath(catalogItemId));
+        if (!res.ok) return; // 404 = no image; render nothing
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = window.URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      } catch {
+        // no image / load failure — render nothing
+      }
+    })();
+    return () => { cancelled = true; if (objectUrl) window.URL.revokeObjectURL(objectUrl); };
+  }, [catalogItemId]);
+
+  if (!url) return null;
+  return <img src={url} alt="" className="h-10 w-10 shrink-0 rounded border object-contain" data-testid="quote-line-thumb" />;
 }
 
 // Editor image preview. GET /quotes/:id/images/:imageId requires the Bearer auth

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -9,9 +9,11 @@ import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext, getJwtClaims } from '../../lib/authScope';
 import { usePermissions } from '../../lib/permissions';
 import { useOrgStore } from '@/stores/orgStore';
+import { fetchWithAuth } from '../../stores/auth';
 import {
   createCatalogItem, updateCatalogItem, getCatalogItem, setBundleComponents,
   setOrgPriceOverride, removeOrgPriceOverride,
+  uploadCatalogItemImage, importCatalogItemImageFromUrl, catalogItemImagePath, deleteCatalogItemImageRequest,
   computeMargin, formatMargin, marginTone,
   CATALOG_TYPE_LABELS, CATALOG_TYPE_ORDER,
   type CatalogItem, type CatalogItemType, type CatalogItemDetail, type OrgPriceOverride,
@@ -95,6 +97,14 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
   // persisted under attributes.enrichment on create. Null for plain/edited items.
   const [enrichment, setEnrichment] = useState<EnrichmentProvenance | null>(null);
   const effectiveId = editId ?? committedId;
+
+  // Product image (one per item; manual upload, shown on quotes). Only available
+  // once the item is persisted (effectiveId). `imageVersion` bumps to refetch the
+  // preview after an upload/remove.
+  const [imageBusy, setImageBusy] = useState(false);
+  const [imageVersion, setImageVersion] = useState(0);
+  const [imageUrl, setImageUrl] = useState('');
+  const imageInputRef = useRef<HTMLInputElement>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
@@ -268,6 +278,65 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
       setOverrideBusy(false);
     }
   }, [overrideBusy, effectiveId]);
+
+  // ---- product image (#5) --------------------------------------------------
+  const uploadImage = useCallback(async (file: File) => {
+    if (!effectiveId || imageBusy) return;
+    setImageBusy(true);
+    try {
+      await runAction({
+        request: () => uploadCatalogItemImage(effectiveId, file),
+        errorFallback: 'Could not upload the image. Retry.',
+        successMessage: 'Image uploaded',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setImageVersion((v) => v + 1);
+    } catch (err) {
+      handleActionError(err, 'Could not upload the image. Retry.');
+    } finally {
+      setImageBusy(false);
+      if (imageInputRef.current) imageInputRef.current.value = '';
+    }
+  }, [effectiveId, imageBusy]);
+
+  const importFromUrl = useCallback(async () => {
+    if (!effectiveId || imageBusy) return;
+    const url = imageUrl.trim();
+    if (!url) { showToast({ message: 'Enter an image URL.', type: 'error' }); return; }
+    setImageBusy(true);
+    try {
+      await runAction({
+        request: () => importCatalogItemImageFromUrl(effectiveId, url),
+        errorFallback: 'Could not import the image from that URL. Retry.',
+        successMessage: 'Image imported',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setImageVersion((v) => v + 1);
+      setImageUrl('');
+    } catch (err) {
+      handleActionError(err, 'Could not import the image from that URL. Retry.');
+    } finally {
+      setImageBusy(false);
+    }
+  }, [effectiveId, imageBusy, imageUrl]);
+
+  const removeImage = useCallback(async () => {
+    if (!effectiveId || imageBusy) return;
+    setImageBusy(true);
+    try {
+      await runAction({
+        request: () => deleteCatalogItemImageRequest(effectiveId),
+        errorFallback: 'Could not remove the image. Retry.',
+        successMessage: 'Image removed',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setImageVersion((v) => v + 1);
+    } catch (err) {
+      handleActionError(err, 'Could not remove the image. Retry.');
+    } finally {
+      setImageBusy(false);
+    }
+  }, [effectiveId, imageBusy]);
 
   // ---- save ----------------------------------------------------------------
   const priceNum = Number(unitPrice);
@@ -488,6 +557,63 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
             </span>
           </div>
 
+          {/* Product image (#5) — manual upload, shown on quotes */}
+          {canWrite && (
+            <div className="space-y-2 rounded-md border p-3" data-testid="catalog-form-image">
+              <span className="text-xs font-medium text-muted-foreground">Product image</span>
+              {effectiveId ? (
+                <>
+                  <CatalogImagePreview itemId={effectiveId} version={imageVersion} />
+                  <div className="flex items-center gap-2">
+                    <input
+                      ref={imageInputRef}
+                      type="file"
+                      accept="image/png,image/jpeg,image/webp"
+                      disabled={imageBusy}
+                      onChange={(e) => { const f = e.target.files?.[0]; if (f) void uploadImage(f); }}
+                      className="block w-full text-xs file:mr-2 file:rounded-md file:border file:bg-muted file:px-2 file:py-1 file:text-xs file:font-medium disabled:opacity-50"
+                      data-testid="catalog-form-image-input"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void removeImage()}
+                      disabled={imageBusy}
+                      className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                      data-testid="catalog-form-image-remove"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="url"
+                      value={imageUrl}
+                      onChange={(e) => setImageUrl(e.target.value)}
+                      disabled={imageBusy}
+                      placeholder="https://example.com/product.png"
+                      className={`${fieldCls} text-xs disabled:opacity-50`}
+                      data-testid="catalog-form-image-url"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void importFromUrl()}
+                      disabled={imageBusy || imageUrl.trim() === ''}
+                      className="shrink-0 rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                      data-testid="catalog-form-image-url-btn"
+                    >
+                      Import from URL
+                    </button>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">PNG, JPEG, or WebP up to 5 MB.</p>
+                </>
+              ) : (
+                <p className="text-xs text-muted-foreground" data-testid="catalog-form-image-hint">
+                  Save the item first, then add a product image.
+                </p>
+              )}
+            </div>
+          )}
+
           {/* Bundle toggle */}
           <label className="flex items-center gap-2.5 rounded-md border px-3 py-2.5 text-sm">
             <input
@@ -698,4 +824,39 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
     </div>,
     document.body,
   );
+}
+
+// Product-image preview. GET /catalog/:id/image needs the Bearer auth header, so a
+// bare <img src> would 401 — fetchWithAuth → blob → object URL (mirrors
+// QuoteImagePreview). 404 means the item simply has no image yet. `version` bumps
+// to refetch after an upload/remove.
+function CatalogImagePreview({ itemId, version }: { itemId: string; version: number }) {
+  const [url, setUrl] = useState<string>();
+  const [state, setState] = useState<'loading' | 'none' | 'error' | 'ok'>('loading');
+
+  useEffect(() => {
+    let objectUrl: string | undefined;
+    let cancelled = false;
+    setState('loading');
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(catalogItemImagePath(itemId));
+        if (res.status === 404) { if (!cancelled) setState('none'); return; }
+        if (!res.ok) { if (!cancelled) setState('error'); return; }
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = window.URL.createObjectURL(blob);
+        setUrl(objectUrl);
+        setState('ok');
+      } catch {
+        if (!cancelled) setState('error');
+      }
+    })();
+    return () => { cancelled = true; if (objectUrl) window.URL.revokeObjectURL(objectUrl); };
+  }, [itemId, version]);
+
+  if (state === 'loading') return <div className="h-32 w-full animate-pulse rounded border bg-muted" data-testid="catalog-image-loading" />;
+  if (state === 'none') return <p className="rounded border border-dashed py-6 text-center text-xs text-muted-foreground" data-testid="catalog-image-empty">No image yet.</p>;
+  if (state === 'error' || !url) return <p className="text-xs text-muted-foreground">Image preview unavailable.</p>;
+  return <img src={url} alt="Product" className="max-h-40 rounded border" data-testid="catalog-image-preview" />;
 }

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.test.tsx
@@ -54,10 +54,58 @@ const product = {
   lastRefreshedAt: '2026-06-18T00:00:00.000Z',
 };
 
+// Route fetch by URL (not call order) so the panel's extra GET /orgs/partners/me
+// on mount can't shift a positional mock queue (the no-positional-mock lesson).
+let statusResponse: Response;
+let meResponse: Response;
+let searchResponse: Response;
+let importResponse: Response;
+let testResponse: Response;
+let configResponse: Response;
+let enrichResponse: Response;
+
 describe('TdSynnexCatalogPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchWithAuth.mockResolvedValue(jsonResponse(statusPayload));
+    statusResponse = jsonResponse(statusPayload);
+    meResponse = jsonResponse({ defaultMarkupPercent: null, autoTaxHardware: true });
+    searchResponse = jsonResponse({ data: [] });
+    importResponse = jsonResponse({ data: { id: 'catalog-1' } });
+    testResponse = jsonResponse(statusPayload);
+    configResponse = jsonResponse(statusPayload);
+    enrichResponse = jsonResponse({
+      data: {
+        draft: {
+          name: 'Dell Pro 14 Laptop (Ultra 5 235U, 16GB, 512GB SSD)',
+          description: 'Dell Pro 14 business laptop with Intel Core Ultra 5 235U, 16 GB RAM, 512 GB SSD, and a 14" FHD+ non-touch display.',
+          itemType: 'hardware',
+          unitOfMeasure: 'each',
+          taxable: true,
+          taxCategory: null,
+        },
+        priceGuidance: 'Typical street price 900-1100 USD',
+        provenance: {
+          source: 'ai_enrich',
+          model: 'test-model',
+          query: 'Dell Pro 14',
+          suggestion: {},
+          enrichedAt: '2026-06-26T00:00:00.000Z',
+          enrichedBy: 'user-1',
+        },
+      },
+    });
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (typeof url === 'string') {
+        if (url.includes('/orgs/partners/me')) return Promise.resolve(meResponse);
+        if (url.includes('/catalog/enrich')) return Promise.resolve(enrichResponse);
+        if (url.includes('/td-synnex/search')) return Promise.resolve(searchResponse);
+        if (url.includes('/td-synnex/import')) return Promise.resolve(importResponse);
+        if (url.includes('/td-synnex/test')) return Promise.resolve(testResponse);
+        if (url.includes('/td-synnex/config')) return Promise.resolve(configResponse);
+        if (url.includes('/td-synnex/status')) return Promise.resolve(statusResponse);
+      }
+      return Promise.resolve(statusResponse);
+    });
   });
 
   it('loads and renders masked credential status', async () => {
@@ -69,10 +117,6 @@ describe('TdSynnexCatalogPanel', () => {
   });
 
   it('saves configuration with runAction', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse(statusPayload));
-
     render(<TdSynnexCatalogPanel />);
     await screen.findByTestId('td-synnex-panel');
     fireEvent.change(screen.getByTestId('td-synnex-base-url'), { target: { value: 'https://digitalbridge.example.test' } });
@@ -88,9 +132,7 @@ describe('TdSynnexCatalogPanel', () => {
   });
 
   it('searches and renders pricing and availability', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ data: [product] }));
+    searchResponse = jsonResponse({ data: [product] });
 
     render(<TdSynnexCatalogPanel />);
     await screen.findByTestId('td-synnex-panel');
@@ -104,10 +146,7 @@ describe('TdSynnexCatalogPanel', () => {
 
   it('imports a selected product and calls the imported callback', async () => {
     const onImported = vi.fn();
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ data: [product] }))
-      .mockResolvedValueOnce(jsonResponse({ data: { id: 'catalog-1' } }));
+    searchResponse = jsonResponse({ data: [product] });
 
     render(<TdSynnexCatalogPanel onImported={onImported} />);
     await screen.findByTestId('td-synnex-panel');
@@ -128,10 +167,8 @@ describe('TdSynnexCatalogPanel', () => {
 
   it('surfaces an import failure and does not fire the imported callback', async () => {
     const onImported = vi.fn();
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ data: [product] }))
-      .mockResolvedValueOnce(jsonResponse({ error: 'An item with this SKU already exists', code: 'DUPLICATE_SKU' }, 409));
+    searchResponse = jsonResponse({ data: [product] });
+    importResponse = jsonResponse({ error: 'An item with this SKU already exists', code: 'DUPLICATE_SKU' }, 409);
 
     render(<TdSynnexCatalogPanel onImported={onImported} />);
     await screen.findByTestId('td-synnex-panel');
@@ -147,10 +184,60 @@ describe('TdSynnexCatalogPanel', () => {
     expect(onImported).not.toHaveBeenCalled();
   });
 
+  it('pre-fills the sell price from the partner default markup and shows the margin calc', async () => {
+    searchResponse = jsonResponse({ data: [product] });
+    meResponse = jsonResponse({ defaultMarkupPercent: 25, autoTaxHardware: true });
+
+    render(<TdSynnexCatalogPanel />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+    fireEvent.click(await screen.findByTestId('td-synnex-import-open-td-1'));
+
+    // cost 100 + 25% markup -> 125.00 sell price.
+    expect((screen.getByTestId('td-synnex-import-price') as HTMLInputElement).value).toBe('125');
+    const margin = screen.getByTestId('td-synnex-import-margin');
+    expect(margin.textContent).toContain('Markup 25.0%');
+    expect(margin.textContent).toContain('Margin 20.0%');
+    expect(margin.textContent).toContain('Profit USD 25.00');
+  });
+
+  it('applies an AI enrich result to the description without changing the sell price', async () => {
+    searchResponse = jsonResponse({ data: [product] });
+    meResponse = jsonResponse({ defaultMarkupPercent: 25, autoTaxHardware: true });
+
+    render(<TdSynnexCatalogPanel />);
+    await screen.findByTestId('td-synnex-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-search-query'), { target: { value: 'dock' } });
+    fireEvent.click(screen.getByTestId('td-synnex-search'));
+    fireEvent.click(await screen.findByTestId('td-synnex-import-open-td-1'));
+
+    // cost 100 + 25% markup -> 125.00 sell price (pre-fill must survive the enrich).
+    expect((screen.getByTestId('td-synnex-import-price') as HTMLInputElement).value).toBe('125');
+
+    fireEvent.change(screen.getByTestId('catalog-enrich-input-td-synnex-import'), { target: { value: 'Dell Pro 14' } });
+    fireEvent.click(screen.getByTestId('catalog-enrich-btn-td-synnex-import'));
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        '/catalog/enrich',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      expect((screen.getByTestId('td-synnex-import-description') as HTMLTextAreaElement).value)
+        .toContain('Dell Pro 14 business laptop');
+    });
+    // Name also refreshed from the cleaned-up draft.
+    expect((screen.getByTestId('td-synnex-import-name') as HTMLInputElement).value)
+      .toBe('Dell Pro 14 Laptop (Ultra 5 235U, 16GB, 512GB SSD)');
+    // Pricing/margin logic stays intact — sell price unchanged by enrich.
+    expect((screen.getByTestId('td-synnex-import-price') as HTMLInputElement).value).toBe('125');
+  });
+
   it('treats an HTTP-200 { success:false } search body as a failure', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ success: false, error: 'Search backend down' }, 200));
+    searchResponse = jsonResponse({ success: false, error: 'Search backend down' }, 200);
 
     render(<TdSynnexCatalogPanel />);
     await screen.findByTestId('td-synnex-panel');

--- a/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
+++ b/apps/web/src/components/settings/TdSynnexCatalogPanel.tsx
@@ -6,6 +6,8 @@ import { isApiFailure, extractApiError } from '../../lib/apiError';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
+import { computeMarginBreakdown, priceFromCostMarkup, formatMarginSummary } from './marginMath';
+import CatalogEnrichButton from '../catalog/CatalogEnrichButton';
 
 const MASKED = '********';
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
@@ -102,16 +104,26 @@ function configFromStatus(status: IntegrationStatus | null): ConfigForm {
   };
 }
 
-function productImportDefaults(product: TdSynnexProduct): ImportForm {
+function productImportDefaults(
+  product: TdSynnexProduct,
+  defaultMarkupPct: number | null,
+  autoTaxHardware: boolean,
+): ImportForm {
   const cost = product.cost ?? '';
+  const costNum = Number(cost);
+  // Apply the partner's default markup (over cost) to pre-fill the sell
+  // price when we have a numeric cost. Fall back to cost == price otherwise.
+  const hasMarkup = defaultMarkupPct != null && cost !== '' && Number.isFinite(costNum);
+  const unitPrice = hasMarkup ? String(priceFromCostMarkup(costNum, defaultMarkupPct)) : cost;
   return {
     name: product.name,
     sku: product.sku ?? product.manufacturerPartNumber ?? '',
     description: product.description ?? '',
-    unitPrice: cost,
+    unitPrice,
     costBasis: cost,
-    markupPercent: '',
-    taxable: true,
+    markupPercent: hasMarkup ? String(defaultMarkupPct) : '',
+    // Distributor imports are hardware; default taxable to the partner policy.
+    taxable: autoTaxHardware,
   };
 }
 
@@ -133,6 +145,10 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
   const [draftProduct, setDraftProduct] = useState<TdSynnexProduct | null>(null);
   const [importForm, setImportForm] = useState<ImportForm | null>(null);
   const [importing, setImporting] = useState(false);
+  // Partner-level default markup % used to pre-fill the sell price.
+  const [defaultMarkupPct, setDefaultMarkupPct] = useState<number | null>(null);
+  // Partner policy: do newly imported (hardware) items default to taxable?
+  const [autoTaxHardware, setAutoTaxHardware] = useState(true);
   const endpointReady = config.searchPath.trim().length > 0;
 
   const loadStatus = useCallback(async () => {
@@ -156,6 +172,27 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
   }, []);
 
   useEffect(() => { void loadStatus(); }, [loadStatus]);
+
+  // Load the partner default markup once so imports can pre-fill the sell price.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth('/orgs/partners/me');
+        if (!res.ok) return;
+        const p = (await res.json()) as { defaultMarkupPercent?: string | number | null; autoTaxHardware?: boolean };
+        if (cancelled) return;
+        if (p.defaultMarkupPercent != null) {
+          const pct = Number(p.defaultMarkupPercent);
+          if (Number.isFinite(pct)) setDefaultMarkupPct(pct);
+        }
+        if (typeof p.autoTaxHardware === 'boolean') setAutoTaxHardware(p.autoTaxHardware);
+      } catch {
+        // Non-fatal: import just falls back to cost == price.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   const connectionLabel = useMemo(() => {
     if (status?.lastTestStatus === 'success') return 'Last test succeeded';
@@ -246,7 +283,7 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
 
   const openImport = (product: TdSynnexProduct) => {
     setDraftProduct(product);
-    setImportForm(productImportDefaults(product));
+    setImportForm(productImportDefaults(product, defaultMarkupPct, autoTaxHardware));
   };
 
   const importProduct = useCallback(async () => {
@@ -543,11 +580,40 @@ export default function TdSynnexCatalogPanel({ onImported }: { onImported?: () =
                 <input type="checkbox" checked={importForm.taxable} onChange={(e) => setImportForm((f) => f && ({ ...f, taxable: e.target.checked }))} data-testid="td-synnex-import-taxable" />
                 Taxable
               </label>
+              <div className="md:col-span-2" data-testid="td-synnex-import-enrich">
+                <p className="text-xs font-medium">Clean up name &amp; description with AI</p>
+                <p className="mb-2 mt-0.5 text-xs text-muted-foreground">
+                  Search the web by product name or SKU to rewrite the raw distributor text. Pricing stays untouched.
+                </p>
+                <CatalogEnrichButton
+                  hint="hardware"
+                  idSuffix="td-synnex-import"
+                  onApply={(result) => setImportForm((f) => f && ({
+                    ...f,
+                    name: result.draft.name || f.name,
+                    description: result.draft.description ?? f.description,
+                  }))}
+                />
+              </div>
               <label className="text-xs font-medium md:col-span-2">
                 Description
                 <textarea value={importForm.description} onChange={(e) => setImportForm((f) => f && ({ ...f, description: e.target.value }))} className="mt-1 min-h-20 w-full rounded-md border bg-background px-2.5 py-1.5 text-sm" data-testid="td-synnex-import-description" />
               </label>
             </div>
+            {(() => {
+              const breakdown = computeMarginBreakdown(toMoney(importForm.costBasis), toMoney(importForm.unitPrice));
+              if (!breakdown) return null;
+              const negative = breakdown.profit < 0;
+              return (
+                <p
+                  className={`text-xs font-medium ${negative ? 'text-red-600' : 'text-muted-foreground'}`}
+                  data-testid="td-synnex-import-margin"
+                >
+                  {formatMarginSummary(breakdown, draftProduct.currency ?? 'USD')}
+                  {negative ? ' — selling below cost' : ''}
+                </p>
+              );
+            })()}
             <div className="flex gap-2">
               <button
                 type="button"

--- a/apps/web/src/components/settings/TdSynnexEcExpressPanel.test.tsx
+++ b/apps/web/src/components/settings/TdSynnexEcExpressPanel.test.tsx
@@ -48,10 +48,35 @@ const product = {
   raw: {},
 };
 
+// Route fetch by URL (not call order) so the panel's extra GET /orgs/partners/me
+// on mount can't shift a positional mock queue (the no-positional-mock lesson).
+let statusResponse: Response;
+let meResponse: Response;
+let lookupResponse: Response;
+let importResponse: Response;
+let testResponse: Response;
+let configResponse: Response;
+
 describe('TdSynnexEcExpressPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchWithAuth.mockResolvedValue(jsonResponse(statusPayload));
+    statusResponse = jsonResponse(statusPayload);
+    meResponse = jsonResponse({ defaultMarkupPercent: null, autoTaxHardware: true });
+    lookupResponse = jsonResponse({ data: [] });
+    importResponse = jsonResponse({ data: { id: 'catalog-1' } });
+    testResponse = jsonResponse(statusPayload);
+    configResponse = jsonResponse(statusPayload);
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (typeof url === 'string') {
+        if (url.includes('/orgs/partners/me')) return Promise.resolve(meResponse);
+        if (url.includes('/td-synnex-ec/lookup')) return Promise.resolve(lookupResponse);
+        if (url.includes('/td-synnex-ec/import')) return Promise.resolve(importResponse);
+        if (url.includes('/td-synnex-ec/test')) return Promise.resolve(testResponse);
+        if (url.includes('/td-synnex-ec/config')) return Promise.resolve(configResponse);
+        if (url.includes('/td-synnex-ec/status')) return Promise.resolve(statusResponse);
+      }
+      return Promise.resolve(statusResponse);
+    });
   });
 
   it('renders config fields and the SKU lookup box after loading status', async () => {
@@ -67,10 +92,6 @@ describe('TdSynnexEcExpressPanel', () => {
   });
 
   it('saves configuration with runAction', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse(statusPayload));
-
     render(<TdSynnexEcExpressPanel />);
     await screen.findByTestId('td-synnex-ec-panel');
     fireEvent.change(screen.getByTestId('td-synnex-ec-customer-no'), { target: { value: 'CUST-2' } });
@@ -98,9 +119,7 @@ describe('TdSynnexEcExpressPanel', () => {
         lastTestError: null,
       },
     };
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload)) // initial status load
-      .mockResolvedValueOnce(jsonResponse(testResult)); // POST /test
+    testResponse = jsonResponse(testResult); // POST /test
 
     render(<TdSynnexEcExpressPanel />);
     await screen.findByTestId('td-synnex-ec-panel');
@@ -138,14 +157,13 @@ describe('TdSynnexEcExpressPanel', () => {
         lastTestError: 'TD SYNNEX authentication failed',
       },
     };
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload)) // initial status load
-      .mockResolvedValueOnce(jsonResponse({ error: 'TD SYNNEX authentication failed', code: 'EC_AUTH_FAILED' }, 422)) // POST /test fails
-      .mockResolvedValueOnce(jsonResponse(failedResult)); // loadStatus reload after the failed test
+    testResponse = jsonResponse({ error: 'TD SYNNEX authentication failed', code: 'EC_AUTH_FAILED' }, 422); // POST /test fails
 
     render(<TdSynnexEcExpressPanel />);
     await screen.findByTestId('td-synnex-ec-panel');
 
+    // After the failed test, testConnection reloads status — surface the failure state.
+    statusResponse = jsonResponse(failedResult);
     fireEvent.click(screen.getByTestId('td-synnex-ec-test'));
 
     await waitFor(() => {
@@ -164,9 +182,7 @@ describe('TdSynnexEcExpressPanel', () => {
   });
 
   it('looks up a SKU and renders pricing, availability, and warehouse stock', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ data: [product] }));
+    lookupResponse = jsonResponse({ data: [product] });
 
     render(<TdSynnexEcExpressPanel />);
     await screen.findByTestId('td-synnex-ec-panel');
@@ -181,11 +197,25 @@ describe('TdSynnexEcExpressPanel', () => {
     expect(within(card).getByText('CA')).toBeTruthy();
   });
 
+  it('pre-fills the sell price from the partner default markup and shows the margin calc', async () => {
+    lookupResponse = jsonResponse({ data: [product] });
+    meResponse = jsonResponse({ defaultMarkupPercent: 25, autoTaxHardware: true });
+
+    render(<TdSynnexEcExpressPanel />);
+    await screen.findByTestId('td-synnex-ec-panel');
+    fireEvent.change(screen.getByTestId('td-synnex-ec-lookup-query'), { target: { value: 'SNX-1' } });
+    fireEvent.click(screen.getByTestId('td-synnex-ec-lookup'));
+
+    const card = await screen.findByTestId('td-synnex-ec-result-SNX-1');
+    // cost 100 + 25% markup -> 125.00 (overrides the MSRP default of 150).
+    expect((within(card).getByTestId('td-synnex-ec-sell-price') as HTMLInputElement).value).toBe('125.00');
+    const margin = within(card).getByTestId('td-synnex-ec-margin-SNX-1');
+    expect(margin.textContent).toContain('Markup 25.0%');
+    expect(margin.textContent).toContain('Margin 20.0%');
+  });
+
   it('imports a result with sell price prefilled from msrp', async () => {
-    fetchWithAuth
-      .mockResolvedValueOnce(jsonResponse(statusPayload))
-      .mockResolvedValueOnce(jsonResponse({ data: [product] }))
-      .mockResolvedValueOnce(jsonResponse({ data: { id: 'catalog-1' } }));
+    lookupResponse = jsonResponse({ data: [product] });
 
     render(<TdSynnexEcExpressPanel />);
     await screen.findByTestId('td-synnex-ec-panel');

--- a/apps/web/src/components/settings/TdSynnexEcExpressPanel.tsx
+++ b/apps/web/src/components/settings/TdSynnexEcExpressPanel.tsx
@@ -6,6 +6,7 @@ import { isApiFailure, extractApiError } from '../../lib/apiError';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
+import { computeMarginBreakdown, priceFromCostMarkup, formatMarginSummary } from './marginMath';
 
 const MASKED = '********';
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
@@ -80,7 +81,12 @@ function toMoney(value: string): number | null {
   return Number.isFinite(parsed) ? Number(parsed.toFixed(2)) : null;
 }
 
-function sellPriceDefault(product: EcProduct): string {
+function sellPriceDefault(product: EcProduct, defaultMarkupPct: number | null): string {
+  // Prefer the partner default markup (over cost) when we have a cost;
+  // otherwise fall back to MSRP, then cost.
+  if (defaultMarkupPct != null && product.cost != null && Number.isFinite(product.cost)) {
+    return priceFromCostMarkup(product.cost, defaultMarkupPct).toFixed(2);
+  }
   const value = product.msrp ?? product.cost;
   return value === null || value === undefined ? '' : value.toFixed(2);
 }
@@ -96,6 +102,10 @@ function TdSynnexEcExpressPanel() {
   const [products, setProducts] = useState<EcProduct[]>([]);
   const [sellPrices, setSellPrices] = useState<Record<string, string>>({});
   const [importingSku, setImportingSku] = useState<string | null>(null);
+  // Partner-level default markup % used to pre-fill sell prices.
+  const [defaultMarkupPct, setDefaultMarkupPct] = useState<number | null>(null);
+  // Partner policy: do newly imported (hardware) items default to taxable?
+  const [autoTaxHardware, setAutoTaxHardware] = useState(true);
 
   const loadStatus = useCallback(async () => {
     setLoading(true);
@@ -124,6 +134,27 @@ function TdSynnexEcExpressPanel() {
   }, []);
 
   useEffect(() => { void loadStatus(); }, [loadStatus]);
+
+  // Load the partner default markup once so lookups can pre-fill the sell price.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth('/orgs/partners/me');
+        if (!res.ok) return;
+        const p = (await res.json()) as { defaultMarkupPercent?: string | number | null; autoTaxHardware?: boolean };
+        if (cancelled) return;
+        if (p.defaultMarkupPercent != null) {
+          const pct = Number(p.defaultMarkupPercent);
+          if (Number.isFinite(pct)) setDefaultMarkupPct(pct);
+        }
+        if (typeof p.autoTaxHardware === 'boolean') setAutoTaxHardware(p.autoTaxHardware);
+      } catch {
+        // Non-fatal: sell price just falls back to MSRP/cost.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   const connectionLabel = useMemo(() => {
     if (status?.lastTestStatus === 'success') return 'Last test succeeded';
@@ -204,13 +235,13 @@ function TdSynnexEcExpressPanel() {
       }
       const results = body?.data ?? [];
       setProducts(results);
-      setSellPrices(Object.fromEntries(results.map((p) => [p.synnexSku, sellPriceDefault(p)])));
+      setSellPrices(Object.fromEntries(results.map((p) => [p.synnexSku, sellPriceDefault(p, defaultMarkupPct)])));
     } catch (err) {
       showToast({ message: err instanceof Error ? err.message : 'TD SYNNEX Pricing lookup failed.', type: 'error' });
     } finally {
       setSearching(false);
     }
-  }, [query]);
+  }, [query, defaultMarkupPct]);
 
   const importProduct = useCallback(async (product: EcProduct) => {
     const sellPrice = toMoney(sellPrices[product.synnexSku] ?? '');
@@ -233,6 +264,7 @@ function TdSynnexEcExpressPanel() {
               costBasis: product.cost !== null && Number.isFinite(product.cost)
                 ? Number(product.cost.toFixed(2))
                 : null,
+              taxable: autoTaxHardware,
             },
           }),
         }),
@@ -245,7 +277,7 @@ function TdSynnexEcExpressPanel() {
     } finally {
       setImportingSku(null);
     }
-  }, [sellPrices]);
+  }, [sellPrices, autoTaxHardware]);
 
   if (loading) {
     return <p className="text-sm text-muted-foreground" data-testid="td-synnex-ec-loading">Loading TD SYNNEX Pricing.</p>;
@@ -453,6 +485,20 @@ function TdSynnexEcExpressPanel() {
                     {importingSku === product.synnexSku ? 'Importing.' : 'Import to catalog'}
                   </button>
                 </div>
+                {(() => {
+                  const breakdown = computeMarginBreakdown(product.cost, toMoney(sellPrices[product.synnexSku] ?? ''));
+                  if (!breakdown) return null;
+                  const negative = breakdown.profit < 0;
+                  return (
+                    <p
+                      className={`text-xs font-medium ${negative ? 'text-red-600' : 'text-muted-foreground'}`}
+                      data-testid={`td-synnex-ec-margin-${product.synnexSku}`}
+                    >
+                      {formatMarginSummary(breakdown, product.currency ?? 'USD')}
+                      {negative ? ' — selling below cost' : ''}
+                    </p>
+                  );
+                })()}
               </div>
             ))}
           </div>

--- a/apps/web/src/components/settings/marginMath.test.ts
+++ b/apps/web/src/components/settings/marginMath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { priceFromCostMarkup, computeMarginBreakdown, formatMarginSummary } from './marginMath';
+
+describe('priceFromCostMarkup', () => {
+  it('applies markup over cost, rounded to cents', () => {
+    expect(priceFromCostMarkup(100, 25)).toBe(125);
+    expect(priceFromCostMarkup(100, 0)).toBe(100);
+    expect(priceFromCostMarkup(33.33, 30)).toBe(43.33); // 43.329 -> 43.33
+  });
+});
+
+describe('computeMarginBreakdown', () => {
+  it('returns null when cost or price is missing', () => {
+    expect(computeMarginBreakdown(null, 100)).toBeNull();
+    expect(computeMarginBreakdown(100, null)).toBeNull();
+  });
+
+  it('computes markup, margin, and profit', () => {
+    const b = computeMarginBreakdown(100, 125)!;
+    expect(b.profit).toBe(25);
+    expect(b.markupPct).toBeCloseTo(25, 5); // 25/100
+    expect(b.marginPct).toBeCloseTo(20, 5); // 25/125
+  });
+
+  it('reports negative profit when selling below cost', () => {
+    const b = computeMarginBreakdown(100, 80)!;
+    expect(b.profit).toBe(-20);
+    expect(b.markupPct).toBeCloseTo(-20, 5);
+  });
+
+  it('avoids divide-by-zero on a zero cost', () => {
+    const b = computeMarginBreakdown(0, 50)!;
+    expect(b.markupPct).toBe(0);
+    expect(b.marginPct).toBeCloseTo(100, 5);
+  });
+});
+
+describe('formatMarginSummary', () => {
+  it('renders a one-line summary with currency', () => {
+    const b = computeMarginBreakdown(100, 125)!;
+    expect(formatMarginSummary(b, 'USD')).toBe('Margin 20.0% · Markup 25.0% · Profit USD 25.00');
+  });
+});

--- a/apps/web/src/components/settings/marginMath.ts
+++ b/apps/web/src/components/settings/marginMath.ts
@@ -1,0 +1,36 @@
+// Shared margin/markup helpers for the distributor catalog-import panels.
+// "Margin" in Breeze's catalog is stored as `markupPercent` (markup OVER COST),
+// so the default applies as a markup. We surface BOTH figures in the UI so the
+// number is unambiguous when adding an item:
+//   markup% = profit / cost   (drives the sell price from cost)
+//   margin% = profit / price  (share of revenue that is profit)
+
+export interface MarginBreakdown {
+  cost: number;
+  price: number;
+  profit: number;
+  /** (price - cost) / cost * 100 — matches the catalog `markupPercent` field. */
+  markupPct: number;
+  /** (price - cost) / price * 100 — gross margin as a share of the sell price. */
+  marginPct: number;
+}
+
+/** Sell price implied by a cost + markup% (markup over cost), rounded to cents. */
+export function priceFromCostMarkup(cost: number, markupPct: number): number {
+  return Number((cost * (1 + markupPct / 100)).toFixed(2));
+}
+
+/** Live margin breakdown from a cost + sell price; null if either is missing. */
+export function computeMarginBreakdown(cost: number | null, price: number | null): MarginBreakdown | null {
+  if (cost === null || price === null || !Number.isFinite(cost) || !Number.isFinite(price)) return null;
+  const profit = price - cost;
+  const markupPct = cost > 0 ? (profit / cost) * 100 : 0;
+  const marginPct = price > 0 ? (profit / price) * 100 : 0;
+  return { cost, price, profit, markupPct, marginPct };
+}
+
+/** Format a margin breakdown as a one-line summary, e.g.
+ *  "Margin 22.6% · Markup 29.2% · Profit USD 30.00". */
+export function formatMarginSummary(b: MarginBreakdown, currency = 'USD'): string {
+  return `Margin ${b.marginPct.toFixed(1)}% · Markup ${b.markupPct.toFixed(1)}% · Profit ${currency} ${b.profit.toFixed(2)}`;
+}

--- a/apps/web/src/lib/api/catalog.ts
+++ b/apps/web/src/lib/api/catalog.ts
@@ -163,6 +163,34 @@ export function archiveCatalogItem(id: string): Promise<Response> {
   return fetchWithAuth(`/catalog/${id}/archive`, { method: 'POST' });
 }
 
+// Product image (one per item). Multipart upload — no JSON Content-Type so the
+// browser sets the multipart boundary itself. Responds { data: { imageId, ... } }.
+export function uploadCatalogItemImage(id: string, file: File): Promise<Response> {
+  const form = new FormData();
+  form.append('file', file);
+  return fetchWithAuth(`/catalog/${id}/image`, { method: 'POST', body: form });
+}
+
+// Server-side image import from a URL. The server downloads + validates (SSRF-
+// guarded) and stores it. Responds { data: { imageId, ... } }.
+export function importCatalogItemImageFromUrl(id: string, url: string): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/image/from-url`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ url }),
+  });
+}
+
+/** Path for the auth'd image GET. A bare <img src> would 401, so callers
+ *  fetchWithAuth this then objectURL the blob (see CatalogImagePreview). */
+export function catalogItemImagePath(id: string): string {
+  return `/catalog/${id}/image`;
+}
+
+export function deleteCatalogItemImageRequest(id: string): Promise<Response> {
+  return fetchWithAuth(`/catalog/${id}/image`, { method: 'DELETE' });
+}
+
 export function setBundleComponents(id: string, components: BundleComponentInput[]): Promise<Response> {
   return fetchWithAuth(`/catalog/${id}/components`, {
     method: 'PUT',

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -89,6 +89,16 @@ export function addBlock(id: string, body: QuoteBlockInput): Promise<Response> {
   });
 }
 
+/** Update a block's content in place (PATCH /quotes/:id/blocks/:blockId). The
+ *  body restates the (immutable) blockType so content is validated by shape. */
+export function updateBlock(id: string, blockId: string, body: QuoteBlockInput): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/blocks/${blockId}`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
 /** Delete a block and its lines (DELETE /quotes/:id/blocks/:blockId). */
 export function deleteBlock(id: string, blockId: string): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}/blocks/${blockId}`, { method: 'DELETE' });

--- a/packages/shared/src/validators/invoices.test.ts
+++ b/packages/shared/src/validators/invoices.test.ts
@@ -36,6 +36,26 @@ describe('partnerBillingSettingsSchema', () => {
   it('accepts currency, tax rate, prefix, terms', () => {
     expect(partnerBillingSettingsSchema.safeParse({ currencyCode: 'USD', defaultTaxRate: 0.085, invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 }).success).toBe(true);
   });
+
+  it('accepts autoTaxHardware as a boolean and omits it when absent', () => {
+    const withTrue = partnerBillingSettingsSchema.parse({ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, autoTaxHardware: true });
+    expect(withTrue.autoTaxHardware).toBe(true);
+    const withFalse = partnerBillingSettingsSchema.parse({ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, autoTaxHardware: false });
+    expect(withFalse.autoTaxHardware).toBe(false);
+    const omitted = partnerBillingSettingsSchema.parse({ currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 });
+    expect(omitted.autoTaxHardware).toBeUndefined();
+  });
+
+  it('bounds defaultMarkupPercent to 0..9999.99 with 2-decimal precision', () => {
+    const base = { currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 };
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 0 }).success).toBe(true);
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 150 }).success).toBe(true); // markup > 100% is valid
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 9999.99 }).success).toBe(true);
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: null }).success).toBe(true);
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: -1 }).success).toBe(false);
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 10000 }).success).toBe(false);
+    expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 12.345 }).success).toBe(false); // multipleOf 0.01
+  });
 });
 
 

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -83,6 +83,13 @@ export const partnerBillingSettingsSchema = z.object({
   defaultTaxRate: taxRate.nullable().optional(),
   invoiceNumberPrefix: z.string().min(1).max(12),
   invoiceTermsDays: z.number().int().min(0).max(365),
+  // Default markup over distributor cost (percent) used to pre-fill the sell price
+  // when importing catalog items. It feeds the catalog `markupPercent` field, so it
+  // shares that field's bounds (numeric(6,2), 0..9999.99). The import view shows
+  // the resulting gross margin alongside.
+  defaultMarkupPercent: z.number().min(0).max(9999.99).multipleOf(0.01).nullable().optional(),
+  // When true, hardware catalog items default to taxable when added/imported.
+  autoTaxHardware: z.boolean().optional(),
   invoiceFooter: z.string().max(5000).nullable().optional(),
   // Seller "From" contact profile (snapshotted onto each document at issue).
   billingCompanyName: z.string().max(255).nullable().optional(),


### PR DESCRIPTION
Billing/catalog/quoting feature set for MSP product quoting. One branch; the
pieces share files (tax fix, markup, auto-tax, and images all touch
invoiceService/PartnerBillingSettings/catalog), so it's a single PR.

## What's in it

**Partner billing settings**
- **Default markup (%)** — pre-fills the sell price when importing catalog items.
- **Auto-tax hardware items** toggle — newly imported hardware defaults to taxable per partner policy.

**🐛 Tax-rate precision fix**
- Tax rates are stored as a *fraction* in `numeric(6,3)`, which truncated anything past one percent decimal: `8.95% → 8.9%`, NYC's `8.875% → 8.9%`. Widened `tax_rate` on **partners / organizations / quotes / invoices** to `numeric(8,5)` and moved the whole conversion chain (`invoiceService`, `quoteService`, `invoiceMath.resolveEffectiveTaxRate`) to `toFixed(5)`; settings inputs to `step="0.001"`.

**Catalog import (TD SYNNEX Digital Bridge + EC Express)**
- Pre-fills the sell price from the partner default markup, shows a live **Margin · Markup · Profit** summary (turns red below cost), defaults taxable from the auto-tax policy, and wires the existing AI **"Auto-fill from web"** enrich into the import editor to clean up distributor descriptions.

**Quote editor**
- Inline-edit line items (description / qty / price / taxable / recurrence) and **heading / rich-text blocks** via a new `PATCH /quotes/:id/blocks/:blockId` (block type immutable). Expandable description; **product thumbnails** on catalog-sourced lines.

**Catalog item images**
- New **partner-axis** `catalog_item_images` table (RLS: ENABLE+FORCE, `breeze_has_partner_access` + system scope; added to `PARTNER_TENANT_TABLES`). Storage service + `POST/GET/DELETE /catalog/:id/image` (ownership-checked, 5 MB cap, magic-byte sniff) and **`POST /catalog/:id/image/from-url`** (server-side download via the SSRF-guarded `safeFetch`). Upload/URL UI in the catalog item editor; rendered on quotes (editor thumbnails + PDF line table, fails soft). Same table is the drop target for the future daily-FTP auto-import.

## Migrations (4, idempotent)
- `2026-07-02-partner-default-markup.sql` — `partners.default_markup_percent`
- `2026-07-02-tax-rate-precision.sql` — widen 4 `tax_rate` cols to `numeric(8,5)`
- `2026-07-02-c-partner-auto-tax-hardware.sql` — `partners.auto_tax_hardware`
- `2026-07-02-d-catalog-item-images.sql` — new table + partner-axis RLS

## Review
Ran the multi-agent PR review (code / tests / errors / types / comments). No critical defects. Findings actioned: the original field was mislabeled "gross margin" but applied as markup → **renamed to markup end-to-end** and fixed the validation cap (was blocking valid >100% markups); added the missing tests (`fetchImageFromUrl` SSRF/size/format unit test, persisted scale-5 conversion test, validator bounds). RLS / SSRF / runAction / migrations verified clean.

## Tests
`tsc` clean on `apps/api` + `apps/web`; all touched suites green locally (API + web + shared). Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
