### PR TITLE
feat(agent): AI tool to restart a wedged agent via the watchdog

### DIFF
--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -359,6 +359,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   // Agent version & remote session tools
   query_agent_versions: { resource: 'devices', action: 'read' },
   trigger_agent_upgrade: { resource: 'devices', action: 'execute' },
+  trigger_agent_restart: { resource: 'devices', action: 'execute' },
   list_remote_sessions: { resource: 'devices', action: 'read' },
   create_remote_session: { resource: 'devices', action: 'execute' },
   // Compliance policy tools
@@ -508,6 +509,7 @@ const TOOL_RATE_LIMITS: Record<string, { limit: number; windowSeconds: number }>
   test_webhook: { limit: 5, windowSeconds: 300 },
   // Agent version & remote session tools
   trigger_agent_upgrade: { limit: 5, windowSeconds: 600 },
+  trigger_agent_restart: { limit: 5, windowSeconds: 600 },
   create_remote_session: { limit: 10, windowSeconds: 300 },
   // Notification channel & saved filter tools
   manage_notification_channels: { limit: 10, windowSeconds: 300 },

--- a/apps/api/src/services/aiToolsAgentMgmt.test.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+// Importing aiGuardrails (for the gate-coverage assertion) pulls in the full
+// aiTools registry, whose other tools read CommandTypes constants. Provide a
+// Proxy so any `CommandTypes.X` access resolves to the string "X".
+vi.mock('./commandQueue', () => ({
+  executeCommand: vi.fn(),
+  queueCommandForExecution: vi.fn(),
+  CommandTypes: new Proxy({}, { get: (_t, prop) => String(prop) }),
+}));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { executeCommand } from './commandQueue';
+import { registerAgentMgmtTools } from './aiToolsAgentMgmt';
+import { TOOL_PERMISSIONS } from './aiGuardrails';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_DEVICE_ID = '44444444-4444-4444-4444-444444444444';
+
+function createQueryChain(rows: any[] = []) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return chain;
+}
+
+function mockSelectSequence(rowsList: any[][]) {
+  let index = 0;
+  vi.mocked(db.select).mockImplementation(() => createQueryChain(rowsList[index++] ?? []) as any);
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: vi.fn(() => undefined),
+  } as any;
+}
+
+function buildToolMap(): Map<string, AiTool> {
+  const toolMap = new Map<string, AiTool>();
+  registerAgentMgmtTools(toolMap);
+  return toolMap;
+}
+
+// A silent/wedged device — deliberately NOT online, since that is exactly the
+// state this tool exists to recover.
+function offlineDeviceRow() {
+  return { id: DEVICE_ID, orgId: ORG_ID, siteId: null, status: 'offline', hostname: 'wedged-pc' };
+}
+
+describe('trigger_agent_restart', () => {
+  let tool: AiTool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // executeCommand resolves a CommandResult; 'completed' = dispatched.
+    vi.mocked(executeCommand).mockResolvedValue({ status: 'completed', result: {} } as any);
+    tool = buildToolMap().get('trigger_agent_restart')!;
+  });
+
+  it('is registered as a Tier 3 device tool gating deviceIds', () => {
+    expect(tool).toBeDefined();
+    expect(tool.tier).toBe(3);
+    expect(tool.deviceArgs).toEqual(['deviceIds']);
+  });
+
+  it('is present in the TOOL_PERMISSIONS gate (dual-map drift guard)', () => {
+    // A tool absent from TOOL_PERMISSIONS 404s at execute time. Lock it here.
+    expect(TOOL_PERMISSIONS.trigger_agent_restart).toEqual({ resource: 'devices', action: 'execute' });
+  });
+
+  it('dispatches restart_agent to the WATCHDOG, even for an offline agent', async () => {
+    // select #1: verifyDeviceAccess. select #2: org-wide access check.
+    mockSelectSequence([[offlineDeviceRow()], [{ id: DEVICE_ID }]]);
+
+    const raw = await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth());
+    const result = JSON.parse(raw);
+
+    expect(result).toEqual({ requested: 1, queued: 1, action: 'restart_agent' });
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'restart_agent',
+      {},
+      expect.objectContaining({ targetRole: 'watchdog', userId: 'user-1' }),
+    );
+  });
+
+  it('counts a RETURNED status:failed as an error, not a queued success', async () => {
+    // executeCommand signals dispatch failure by returning, not throwing. The
+    // handler must surface it in `errors` and NOT increment `queued` — this is
+    // the regression guard for the silent-success bug.
+    mockSelectSequence([[offlineDeviceRow()], [{ id: DEVICE_ID }]]);
+    vi.mocked(executeCommand).mockResolvedValue({
+      status: 'failed',
+      error: 'Watchdog is not reporting; cannot dispatch watchdog command',
+    } as any);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.queued).toBe(0);
+    expect(result.requested).toBe(1);
+    expect(result.errors[DEVICE_ID]).toMatch(/watchdog is not reporting/i);
+  });
+
+  it('reports partial failure across multiple devices', async () => {
+    mockSelectSequence([[offlineDeviceRow()], [{ id: DEVICE_ID }, { id: OTHER_DEVICE_ID }]]);
+    vi.mocked(executeCommand)
+      .mockResolvedValueOnce({ status: 'completed', result: {} } as any)
+      .mockResolvedValueOnce({ status: 'failed', error: 'Device not found' } as any);
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID, OTHER_DEVICE_ID] }, makeAuth()),
+    );
+
+    expect(result).toEqual({
+      requested: 2,
+      queued: 1,
+      action: 'restart_agent',
+      errors: { [OTHER_DEVICE_ID]: 'Device not found' },
+    });
+    expect(executeCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('denies a device inside the org but outside the caller site allowlist', async () => {
+    // verifyDeviceAccess enforces a second axis: auth.canAccessSite(siteId).
+    const siteScopedAuth = { ...makeAuth(), canAccessSite: () => false } as any;
+    mockSelectSequence([[{ ...offlineDeviceRow(), siteId: 'site-out-of-scope' }]]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, siteScopedAuth));
+
+    expect(result.error).toMatch(/not found or access denied/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('refuses and dispatches nothing when a deviceId is outside the caller org', async () => {
+    // select #1 grants access to the first device; select #2 (org-wide) returns
+    // only DEVICE_ID, so OTHER_DEVICE_ID is denied and the whole call aborts.
+    mockSelectSequence([[offlineDeviceRow()], [{ id: DEVICE_ID }]]);
+
+    const raw = await tool.handler({ deviceIds: [DEVICE_ID, OTHER_DEVICE_ID] }, makeAuth());
+    const result = JSON.parse(raw);
+
+    expect(result.error).toContain(OTHER_DEVICE_ID);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty deviceIds list without touching the DB', async () => {
+    const raw = await tool.handler({ deviceIds: [] }, makeAuth());
+    expect(JSON.parse(raw).error).toMatch(/deviceIds/);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -4,6 +4,7 @@
  * Tools for managing agent versions and upgrades.
  * - query_agent_versions (Tier 1): List available agent versions and check upgrades
  * - trigger_agent_upgrade (Tier 3): Queue an agent upgrade for devices
+ * - trigger_agent_restart (Tier 3): Ask the watchdog to restart a wedged/silent agent
  */
 
 import { db } from '../db';
@@ -227,18 +228,24 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         try {
           // Agent upgrades are executed by the breeze-watchdog process, not
           // the agent. The watchdog handles type `update_agent` and reads
-          // `payload.version` — see agent/cmd/breeze-watchdog/main.go:605.
-          // It has no WS connection and polls via heartbeat, so we must tag
-          // the command with target_role='watchdog' or it will be dispatched
-          // to the agent WS and never picked up.
-          await executeCommand(deviceId, 'update_agent', {
+          // `payload.version` — see agent/cmd/breeze-watchdog/main.go
+          // (handleFailoverCommand). It has no WS connection and polls via
+          // heartbeat, so we must tag the command with target_role='watchdog'
+          // or it will be dispatched to the agent WS and never picked up.
+          // executeCommand RETURNS status:'failed' on dispatch failure rather
+          // than throwing, so inspect the result instead of assuming success.
+          const result = await executeCommand(deviceId, 'update_agent', {
             version: targetVersion,
           }, {
             userId: auth.user.id,
             timeoutMs: 60000,
             targetRole: 'watchdog',
           });
-          queued++;
+          if (result.status === 'failed') {
+            errors[deviceId] = result.error ?? 'Failed to queue upgrade';
+          } else {
+            queued++;
+          }
         } catch (err) {
           errors[deviceId] = err instanceof Error ? err.message : 'Failed to queue upgrade';
         }
@@ -247,6 +254,100 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
       return JSON.stringify({
         queued,
         targetVersion,
+        ...(Object.keys(errors).length > 0 ? { errors } : {}),
+      });
+    },
+  });
+
+  // ============================================
+  // trigger_agent_restart - Tier 3 (requires approval)
+  // ============================================
+
+  registerTool({
+    tier: 3 as AiToolTier,
+    deviceArgs: ['deviceIds'],
+    definition: {
+      name: 'trigger_agent_restart',
+      description:
+        'Ask the breeze-watchdog to restart the main agent on a device — recovers a wedged or silent agent (the "Agent silent · watchdog OK" state). Targets the watchdog, not the agent, so it works even when the agent itself is unresponsive. The watchdog acts on this when it is supervising/failing over the agent; a healthy agent is left untouched.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          deviceIds: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Device UUIDs whose agent should be restarted (max 50)',
+          },
+        },
+        required: ['deviceIds'],
+      },
+    },
+    handler: async (input, auth) => {
+      const deviceIds = (input.deviceIds as string[]).slice(0, 50);
+      if (deviceIds.length === 0) {
+        return JSON.stringify({ error: 'deviceIds array is required and must not be empty' });
+      }
+
+      // Verify access to the first device (org + site axes).
+      const firstAccess = await verifyDeviceAccess(deviceIds[0]!, auth);
+      if ('error' in firstAccess) return JSON.stringify({ error: firstAccess.error });
+
+      // Verify all deviceIds belong to the caller's org before dispatching.
+      const orgCond = auth.orgCondition(devices.orgId);
+      const accessConditions: SQL[] = [inArray(devices.id, deviceIds)];
+      if (orgCond) accessConditions.push(orgCond);
+
+      const accessibleDevices = await db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(and(...accessConditions));
+
+      const accessibleIds = new Set(accessibleDevices.map(d => d.id));
+      const deniedIds = deviceIds.filter(id => !accessibleIds.has(id));
+      if (deniedIds.length > 0) {
+        return JSON.stringify({ error: `Access denied for devices: ${deniedIds.join(', ')}` });
+      }
+
+      // Dispatch restart commands to the WATCHDOG, not the agent. The agent
+      // may be wedged with no live WS; the watchdog has no WS and polls via
+      // heartbeat, so the command must be tagged target_role='watchdog' or it
+      // would be dispatched to the (dead) agent WS and never picked up. The
+      // watchdog handles type `restart_agent` — see
+      // agent/cmd/breeze-watchdog/main.go (handleFailoverCommand). We do NOT
+      // require the device to be online: a silent agent is exactly the case
+      // this tool exists to recover.
+      const { executeCommand } = await getCommandQueue();
+      let queued = 0;
+      const errors: Record<string, string> = {};
+
+      for (const deviceId of deviceIds) {
+        try {
+          // executeCommand signals dispatch failure by RETURNING
+          // status:'failed' (device not found, watchdog not reporting, etc.) —
+          // it does not throw for those. Counting an awaited call as success
+          // would silently report a queued restart that never happened, which
+          // is especially likely here since this tool targets silent devices.
+          // A 'timeout' means the row was written and the watchdog will claim
+          // it on its next failover poll — that counts as queued.
+          const result = await executeCommand(deviceId, 'restart_agent', {}, {
+            userId: auth.user.id,
+            timeoutMs: 60000,
+            targetRole: 'watchdog',
+          });
+          if (result.status === 'failed') {
+            errors[deviceId] = result.error ?? 'Failed to queue restart';
+          } else {
+            queued++;
+          }
+        } catch (err) {
+          errors[deviceId] = err instanceof Error ? err.message : 'Failed to queue restart';
+        }
+      }
+
+      return JSON.stringify({
+        requested: deviceIds.length,
+        queued,
+        action: 'restart_agent',
         ...(Object.keys(errors).length > 0 ? { errors } : {}),
       });
     },

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -604,6 +604,7 @@ describe('command queue service', () => {
         agentId: 'agent-wd',
         orgId: 'org-1',
         hostname: 'host-wd',
+        watchdogLastSeen: new Date(),
       };
       const queued = { id: 'cmd-wd', type: 'update_agent' };
       const completed = {
@@ -662,6 +663,87 @@ describe('command queue service', () => {
       // Polling still returns the completed result (set by the watchdog's
       // command_result path, same as agent commands).
       expect(result.status).toBe('completed');
+    });
+
+    // A watchdog-targeted command must be ACCEPTED for an offline device as
+    // long as the watchdog itself is still reporting — that "agent silent,
+    // watchdog OK" state is precisely what watchdog restarts/upgrades recover.
+    // device.status reflects the (down) main agent, so gating on it would
+    // reject the entire population this path exists for.
+    it('accepts a watchdog command for an OFFLINE device with a fresh watchdog', async () => {
+      const device = {
+        id: 'dev-silent',
+        status: 'offline',
+        agentId: 'agent-silent',
+        orgId: 'org-1',
+        hostname: 'host-silent',
+        watchdogLastSeen: new Date(), // watchdog still reporting
+      };
+      let pollCall = 0;
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(() => {
+              pollCall += 1;
+              if (pollCall === 1) return Promise.resolve([device]);
+              return Promise.resolve([{ id: 'cmd-s', status: 'completed', result: { status: 'completed' } }]);
+            }),
+          }),
+        }),
+      }) as any);
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'cmd-s', type: 'restart_agent' }]),
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+      const result = await executeCommand(
+        'dev-silent',
+        'restart_agent',
+        {},
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      // Not rejected by the offline guard — the row is written.
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ targetRole: 'watchdog', type: 'restart_agent' }),
+      );
+      expect(result.status).toBe('completed');
+    });
+
+    // Inverse guard: if the watchdog itself has gone stale (box down, or agent
+    // healthy so the watchdog never failed over and isn't polling), fail fast
+    // instead of queueing a command nothing will ever claim.
+    it('rejects a watchdog command when watchdogLastSeen is stale', async () => {
+      const device = {
+        id: 'dev-dead',
+        status: 'offline',
+        agentId: 'agent-dead',
+        orgId: 'org-1',
+        hostname: 'host-dead',
+        watchdogLastSeen: new Date(Date.now() - 60 * 60 * 1000), // 1h stale
+      };
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([device]),
+          }),
+        }),
+      }) as any);
+      const insertValues = vi.fn();
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+      const result = await executeCommand(
+        'dev-dead',
+        'restart_agent',
+        {},
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/watchdog is not reporting/i);
+      // No row written — fail-fast before insert.
+      expect(insertValues).not.toHaveBeenCalled();
     });
 
     // Regression guard: default options (no targetRole) must still insert

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -17,6 +17,13 @@ import { recordCommandDispatch } from './anomalyMetrics';
 export const DEVICE_UNREACHABLE_ERROR =
   'Device is not currently reachable over the live connection. Please try again in a moment.';
 
+// How fresh `watchdogLastSeen` must be for a watchdog-targeted command to be
+// dispatched. The watchdog only heartbeats while supervising/failing over a
+// silent agent, so a stale value means either the agent is healthy (no
+// watchdog to receive the command) or the whole box is down — in both cases
+// the command can't be delivered, so fail fast instead of queueing forever.
+export const WATCHDOG_STALE_MS = 10 * 60 * 1000;
+
 // Number of times we attempt sendCommandToAgent before releasing the claim
 // and short-circuiting with DEVICE_UNREACHABLE_ERROR. With a 500 ms gap this
 // gives a transient WS hiccup ~1s of grace before the user sees a failure.
@@ -649,6 +656,7 @@ export async function executeCommand(
       agentId: devices.agentId,
       orgId: devices.orgId,
       hostname: devices.hostname,
+      watchdogLastSeen: devices.watchdogLastSeen,
     })
     .from(devices)
     .where(eq(devices.id, deviceId))
@@ -658,7 +666,27 @@ export async function executeCommand(
     return { status: 'failed', error: 'Device not found' };
   }
 
-  if (device.status !== 'online') {
+  if (targetRole === 'watchdog') {
+    // `device.status` reflects the MAIN agent's liveness (only the main-agent
+    // heartbeat branch writes status/lastSeenAt; the watchdog branch does
+    // not — see routes/agents/heartbeat.ts). A wedged/silent agent is exactly
+    // when a watchdog restart is needed, so gating watchdog commands on
+    // `status === 'online'` would reject the entire population this path
+    // exists for. Gate on the WATCHDOG's own liveness instead. Nothing ever
+    // sets watchdogStatus='offline', so freshness of watchdogLastSeen is the
+    // only reliable signal — and the watchdog only heartbeats while in
+    // FAILOVER (when it actually polls for these commands), so a fresh
+    // watchdogLastSeen also means the command will be claimed.
+    const watchdogAgeMs = device.watchdogLastSeen
+      ? Date.now() - device.watchdogLastSeen.getTime()
+      : Infinity;
+    if (watchdogAgeMs > WATCHDOG_STALE_MS) {
+      return {
+        status: 'failed',
+        error: 'Watchdog is not reporting; cannot dispatch watchdog command',
+      };
+    }
+  } else if (device.status !== 'online') {
     return { status: 'failed', error: `Device is ${device.status}, cannot execute command` };
   }
 

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -207,6 +207,7 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'manage_monitors (create/update/delete)', description: 'Create, update, or delete monitors', category: 'Monitoring & Analytics' },
       // Integrations
       { name: 'trigger_agent_upgrade', description: 'Queue agent upgrade', category: 'Integrations' },
+      { name: 'trigger_agent_restart', description: 'Restart a wedged/silent agent via the watchdog', category: 'Integrations' },
       // Configuration Policies
       { name: 'manage_configuration_policy (create/update/delete)', description: 'Create, update, or delete config policies', category: 'Configuration Policies' },
       // Fleet Operations
@@ -291,6 +292,7 @@ export const RATE_LIMIT_CONFIGS: RateLimitConfig[] = [
   // Integrations
   { toolName: 'test_webhook', limit: 5, windowSeconds: 300, tier: 2, permission: 'devices.write', category: 'Integrations' },
   { toolName: 'trigger_agent_upgrade', limit: 5, windowSeconds: 600, tier: 3, permission: 'devices.execute', category: 'Integrations' },
+  { toolName: 'trigger_agent_restart', limit: 5, windowSeconds: 600, tier: 3, permission: 'devices.execute', category: 'Integrations' },
   { toolName: 'manage_notification_channels', limit: 10, windowSeconds: 300, tier: 1, permission: 'alerts.read', category: 'Alerts & Notifications' },
   { toolName: 'manage_saved_filters', limit: 15, windowSeconds: 300, tier: 1, permission: 'devices.read', category: 'Other' },
   // Fleet Operations
@@ -411,6 +413,7 @@ export const RBAC_MAPPINGS: Record<string, string | Record<string, string>> = {
   // Agent management
   query_agent_versions: 'devices.read',
   trigger_agent_upgrade: 'devices.execute',
+  trigger_agent_restart: 'devices.execute',
   // Remote sessions
   list_remote_sessions: 'devices.read',
   create_remote_session: 'devices.execute',


### PR DESCRIPTION
## Summary

- Adds the Tier-3 `trigger_agent_restart` AI tool (mirroring `trigger_agent_upgrade`) that dispatches `restart_agent` to the breeze-watchdog (`targetRole='watchdog'`) to recover a silent/wedged main agent — the watchdog already handled the command; only the server-side emitter was missing.
- Fixes the shared dispatch path so it works on the offline devices it targets: `executeCommand` now lets watchdog-targeted commands through for an offline device, gating on the watchdog's own freshness (`watchdogLastSeen < WATCHDOG_STALE_MS`) instead of the main-agent `status`, which is exactly what's down when a restart is needed.
- Both agent-mgmt handlers now inspect the returned `CommandResult.status` (executeCommand returns `status:'failed'` rather than throwing), so a rejected dispatch is surfaced in `errors` instead of being silently counted as queued; registers the tool in the dual-map gate (TOOL_PERMISSIONS + TOOL_RATE_LIMITS) and the web risk config.

## Type of Change

- [x] New feature
- [x] Bug fix

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [ ] Manual testing (describe below)

Added unit tests for dispatch + watchdog targeting, returned-failure counted as error, multi-device partial failure, site-axis denial, and the `commandQueue` watchdog-freshness exemption (offline-but-fresh accepted; stale rejected). Ran the new suites plus the AI-tool gate/contract and other `executeCommand` consumers — all green; typecheck clean on changed files.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [ ] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included