### PR TITLE
fix(reliability): correct agent event classification + de-saturate the score

### DIFF
--- a/agent/internal/collectors/eventlogs_windows.go
+++ b/agent/internal/collectors/eventlogs_windows.go
@@ -129,7 +129,7 @@ func (c *EventLogCollector) collectSystemErrors(since time.Time) ([]EventLogEntr
 		results = append(results, EventLogEntry{
 			Timestamp: truncateCollectorString(e.TimeCreated),
 			Level:     mapWinLevel(e.Level),
-			Category:  "hardware",
+			Category:  "system",
 			Source:    truncateCollectorString(e.ProviderName),
 			EventID:   truncateCollectorString(fmt.Sprintf("%d:%d", e.Id, e.RecordId)),
 			Message:   truncateString(e.Message, 500),

--- a/agent/internal/collectors/reliability.go
+++ b/agent/internal/collectors/reliability.go
@@ -202,15 +202,19 @@ var scmFailureEventIDs = map[int]bool{
 	7034: true, // service terminated unexpectedly (no recovery configured)
 }
 
-// isWERSource returns true when srcLower (already lowercased) indicates the
-// Windows Error Reporting provider. Real provider names seen in the wild:
-//
-//	"windows error reporting", "wer", "wer-systemarchive",
-//	"wer-systemerrorreporting", "systemerrorreporting"
-func isWERSource(srcLower string) bool {
-	return strings.Contains(srcLower, "wer") ||
-		strings.Contains(srcLower, "systemerrorreporting") ||
-		strings.Contains(srcLower, "windows error reporting")
+// eventLogName returns the Windows log a collected event came from
+// (Details["logName"], set by every Windows collector — "System", "Application",
+// "Security"). Empty when unknown. Used to keep the EventID-1001 crash branch
+// scoped to the System log: a System-log 1001 is a BugCheck/BSOD report, whereas
+// an Application-log 1001 ("Windows Error Reporting") is a routine per-app
+// APPCRASH/APPHANG and must NOT inflate the kernel-crash factor.
+func eventLogName(entry EventLogEntry) string {
+	if v, ok := entry.Details["logName"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // classifyEventLogEntry routes a single event log entry into exactly one
@@ -227,7 +231,8 @@ func classifyEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
 
 	// ── 1. Crash ─────────────────────────────────────────────────────────────
 	switch {
-	case strings.Contains(msg, "bugcheck"), strings.Contains(msg, "blue screen"):
+	case strings.Contains(msg, "bugcheck"), strings.Contains(msg, "blue screen"),
+		strings.Contains(msg, "bluescreen"): // WER BSOD reports say "Event Name: BlueScreen" (no space)
 		appendCrash(metrics, "bsod", ts, map[string]any{
 			"source":  entry.Source,
 			"eventId": entry.EventID,
@@ -250,8 +255,11 @@ func classifyEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
 		})
 		return
 
-	case nid == 1001 && isWERSource(src):
-		// Real BugCheck report from Windows Error Reporting — NOT DCOM 10010
+	case nid == 1001 && strings.EqualFold(eventLogName(entry), "System"):
+		// System-log 1001 is a BugCheck/BSOD report. Gating on the System log (not
+		// just a "WER-ish" source name) excludes Application-log "Windows Error
+		// Reporting" 1001 APPCRASH/APPHANG, which would otherwise inflate crashes.
+		// (DCOM 10010 never reaches here: matched by EQUALITY on 1001, not substring.)
 		appendCrash(metrics, "bsod", ts, map[string]any{
 			"source":  entry.Source,
 			"eventId": entry.EventID,
@@ -300,15 +308,8 @@ func classifyEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
 
 	// ── 4. Hardware error ─────────────────────────────────────────────────────
 	// Gate on genuine hardware signals only — NOT on entry.Category.
-	hwType := classifyHardwareType(entry.Message, entry.Source, nid)
-	if hwType != "unknown" || isHardwareSource(src) {
-		metrics.HardwareErrors = append(metrics.HardwareErrors, HardwareError{
-			Type:      hwType,
-			Severity:  severityFromLevel(entry.Level),
-			Timestamp: ts,
-			Source:    entry.Source,
-			EventID:   entry.EventID,
-		})
+	if classifyHardwareType(entry.Message, entry.Source, nid) != "unknown" || isHardwareSource(src) {
+		appendHardwareError(metrics, entry, ts)
 		return
 	}
 }

--- a/agent/internal/collectors/reliability.go
+++ b/agent/internal/collectors/reliability.go
@@ -2,6 +2,8 @@ package collectors
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -109,21 +111,205 @@ func severityFromLevel(level string) string {
 	}
 }
 
-func classifyHardwareType(message, source, eventID string) string {
+// classifyHardwareType returns a hardware error category string.
+// numericID is the parsed integer event ID (pass numericEventID(entry) before calling).
+// Returns "unknown" when the event does not match a known hardware signal.
+func classifyHardwareType(message, source string, numericID int) string {
 	msg := strings.ToLower(message)
 	src := strings.ToLower(source)
-	eid := strings.ToLower(eventID)
 	switch {
 	case strings.Contains(src, "whea"), strings.Contains(msg, "machine check"), strings.Contains(msg, "mce"):
 		return "mce"
 	case strings.Contains(msg, "memory"), strings.Contains(msg, "edac"),
-		eid == "13" || eid == "50" || eid == "51":
+		numericID == 13 || numericID == 50 || numericID == 51:
 		return "memory"
 	case strings.Contains(msg, "disk"), strings.Contains(msg, "i/o"), strings.Contains(msg, "blk_update_request"),
-		eid == "7" || eid == "11" || eid == "15":
+		numericID == 7 || numericID == 11 || numericID == 15:
 		return "disk"
 	default:
 		return "unknown"
+	}
+}
+
+// numericEventID extracts the numeric event ID from an EventLogEntry.
+// It first checks Details["eventId"] (set as an int by all Windows collectors),
+// then falls back to parsing the integer prefix of EventID ("id:recordId").
+func numericEventID(entry EventLogEntry) int {
+	if v, ok := entry.Details["eventId"]; ok {
+		switch n := v.(type) {
+		case int:
+			return n
+		case int64:
+			return int(n)
+		case float64:
+			return int(n)
+		}
+	}
+	// Fall back: parse integer prefix before the first ':'
+	raw := entry.EventID
+	if idx := strings.IndexByte(raw, ':'); idx >= 0 {
+		raw = raw[:idx]
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(raw))
+	return n
+}
+
+// reServiceName extracts the failing service name from SCM messages like
+// "The <ServiceName> service terminated unexpectedly".
+var reServiceName = regexp.MustCompile(`(?i)the (.+?) service\b`)
+
+// parseServiceName extracts the service name from an SCM message.
+// Falls back to fallback (typically entry.Source) if no match.
+func parseServiceName(message, fallback string) string {
+	if m := reServiceName.FindStringSubmatch(message); len(m) >= 2 {
+		name := strings.TrimSpace(m[1])
+		if name != "" {
+			return name
+		}
+	}
+	return fallback
+}
+
+// knownHardwareSources lists provider name substrings that always indicate a
+// genuine hardware/driver event, even when classifyHardwareType returns "unknown".
+var knownHardwareSources = []string{
+	"whea", "disk", "ntfs", "volmgr", "storahci", "stornvme",
+	"nvme", "iastor", "msahci", "nvlddmkm", "amdkmdag", "igfx",
+}
+
+// isHardwareSource returns true when the source (lowercased) matches a known
+// hardware/driver provider name.
+func isHardwareSource(srcLower string) bool {
+	for _, kw := range knownHardwareSources {
+		if strings.Contains(srcLower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// scmFailureEventIDs is the set of Service Control Manager event IDs that
+// represent genuine service failures (start failure, crash, exit, etc.).
+// 7036 (state-change), 7040 (start-type change), 7045 (service installed) are
+// routine and are intentionally excluded.
+var scmFailureEventIDs = map[int]bool{
+	7000: true, // service failed to start
+	7022: true, // service hung on start
+	7023: true, // service terminated with error
+	7024: true, // service terminated with service-specific error
+	7026: true, // boot/system start driver failed to load
+	7031: true, // service terminated unexpectedly
+	7034: true, // service terminated unexpectedly (no recovery configured)
+}
+
+// isWERSource returns true when srcLower (already lowercased) indicates the
+// Windows Error Reporting provider. Real provider names seen in the wild:
+//
+//	"windows error reporting", "wer", "wer-systemarchive",
+//	"wer-systemerrorreporting", "systemerrorreporting"
+func isWERSource(srcLower string) bool {
+	return strings.Contains(srcLower, "wer") ||
+		strings.Contains(srcLower, "systemerrorreporting") ||
+		strings.Contains(srcLower, "windows error reporting")
+}
+
+// classifyEventLogEntry routes a single event log entry into exactly one
+// reliability factor (crash / service-failure / hang / hardware-error) or none.
+// Priority order: crash → service → hang → hardware.
+// Each event goes to AT MOST ONE factor; no double-counting.
+//
+// Platform-neutral (no build tag) so it is unit-testable on Linux CI.
+func classifyEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
+	ts := normalizeEventTimestamp(entry.Timestamp)
+	msg := strings.ToLower(entry.Message)
+	src := strings.ToLower(entry.Source)
+	nid := numericEventID(entry)
+
+	// ── 1. Crash ─────────────────────────────────────────────────────────────
+	switch {
+	case strings.Contains(msg, "bugcheck"), strings.Contains(msg, "blue screen"):
+		appendCrash(metrics, "bsod", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+			"level":   entry.Level,
+		})
+		return
+
+	case strings.Contains(msg, "kernel panic"):
+		appendCrash(metrics, "kernel_panic", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+		})
+		return
+
+	case nid == 41: // Kernel-Power: unexpected power loss / bugcheck
+		appendCrash(metrics, "bsod", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+			"level":   entry.Level,
+		})
+		return
+
+	case nid == 1001 && isWERSource(src):
+		// Real BugCheck report from Windows Error Reporting — NOT DCOM 10010
+		appendCrash(metrics, "bsod", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+			"level":   entry.Level,
+		})
+		return
+
+	case nid == 6008: // Unexpected shutdown (previous boot)
+		appendCrash(metrics, "bsod", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+			"level":   entry.Level,
+		})
+		return
+
+	case strings.Contains(msg, "unexpected shutdown"):
+		appendCrash(metrics, "bsod", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+			"level":   entry.Level,
+		})
+		return
+	}
+
+	// ── 2. Service failure ────────────────────────────────────────────────────
+	isScm := strings.Contains(src, "service control manager")
+	if isScm && scmFailureEventIDs[nid] {
+		svcName := parseServiceName(entry.Message, entry.Source)
+		appendServiceFailure(metrics, svcName, ts, entry.EventID)
+		return
+	}
+	// Secondary: message-based fallback (non-SCM sources that talk about service failures)
+	if !isScm && strings.Contains(msg, "service") &&
+		(strings.Contains(msg, "terminated") || strings.Contains(msg, "failed to start")) {
+		svcName := parseServiceName(entry.Message, entry.Source)
+		appendServiceFailure(metrics, svcName, ts, entry.EventID)
+		return
+	}
+
+	// ── 3. Hang ───────────────────────────────────────────────────────────────
+	if strings.Contains(msg, "hang") || strings.Contains(msg, "not responding") ||
+		strings.Contains(src, "application hang") || nid == 1002 {
+		appendHang(metrics, entry.Source, ts)
+		return
+	}
+
+	// ── 4. Hardware error ─────────────────────────────────────────────────────
+	// Gate on genuine hardware signals only — NOT on entry.Category.
+	hwType := classifyHardwareType(entry.Message, entry.Source, nid)
+	if hwType != "unknown" || isHardwareSource(src) {
+		metrics.HardwareErrors = append(metrics.HardwareErrors, HardwareError{
+			Type:      hwType,
+			Severity:  severityFromLevel(entry.Level),
+			Timestamp: ts,
+			Source:    entry.Source,
+			EventID:   entry.EventID,
+		})
+		return
 	}
 }
 
@@ -161,7 +347,7 @@ func appendServiceFailure(metrics *ReliabilityMetrics, serviceName string, ts ti
 
 func appendHardwareError(metrics *ReliabilityMetrics, entry EventLogEntry, ts time.Time) {
 	metrics.HardwareErrors = append(metrics.HardwareErrors, HardwareError{
-		Type:      classifyHardwareType(entry.Message, entry.Source, entry.EventID),
+		Type:      classifyHardwareType(entry.Message, entry.Source, numericEventID(entry)),
 		Severity:  severityFromLevel(entry.Level),
 		Timestamp: ts,
 		Source:    entry.Source,

--- a/agent/internal/collectors/reliability_test.go
+++ b/agent/internal/collectors/reliability_test.go
@@ -20,3 +20,407 @@ func TestNewReliabilityCollectorInitialLookback(t *testing.T) {
 		t.Fatalf("unexpected lastCollectTime: got %s expected within [%s, %s]", actual, minExpected, maxExpected)
 	}
 }
+
+// newMetrics returns an empty ReliabilityMetrics suitable for classifier tests.
+func newMetrics() *ReliabilityMetrics {
+	return &ReliabilityMetrics{
+		CrashEvents:     []CrashEvent{},
+		AppHangs:        []AppHang{},
+		ServiceFailures: []ServiceFailure{},
+		HardwareErrors:  []HardwareError{},
+	}
+}
+
+// totalFactors sums up how many factor entries exist across all four slices.
+func totalFactors(m *ReliabilityMetrics) int {
+	return len(m.CrashEvents) + len(m.AppHangs) + len(m.ServiceFailures) + len(m.HardwareErrors)
+}
+
+func TestNumericEventID(t *testing.T) {
+	tests := []struct {
+		name   string
+		entry  EventLogEntry
+		wantID int
+	}{
+		{
+			name: "Details int takes priority",
+			entry: EventLogEntry{
+				EventID: "99:12345",
+				Details: map[string]any{"eventId": 1001},
+			},
+			wantID: 1001,
+		},
+		{
+			name: "Details float64 (JSON unmarshal)",
+			entry: EventLogEntry{
+				EventID: "99:12345",
+				Details: map[string]any{"eventId": float64(7031)},
+			},
+			wantID: 7031,
+		},
+		{
+			name: "Fallback to EventID prefix",
+			entry: EventLogEntry{
+				EventID: "10010:66601",
+				Details: map[string]any{},
+			},
+			wantID: 10010,
+		},
+		{
+			name: "No colon in EventID",
+			entry: EventLogEntry{
+				EventID: "41",
+				Details: map[string]any{},
+			},
+			wantID: 41,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := numericEventID(tc.entry)
+			if got != tc.wantID {
+				t.Errorf("numericEventID = %d, want %d", got, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestParseServiceName(t *testing.T) {
+	tests := []struct {
+		msg      string
+		fallback string
+		want     string
+	}{
+		{"The Spooler service terminated unexpectedly.", "Service Control Manager", "Spooler"},
+		{"The Windows Update service failed to start.", "Service Control Manager", "Windows Update"},
+		{"No match here", "Service Control Manager", "Service Control Manager"},
+		{"", "Service Control Manager", "Service Control Manager"},
+	}
+	for _, tc := range tests {
+		got := parseServiceName(tc.msg, tc.fallback)
+		if got != tc.want {
+			t.Errorf("parseServiceName(%q) = %q, want %q", tc.msg, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyEventLogEntry(t *testing.T) {
+	ts := "2026-01-15T10:00:00Z"
+
+	tests := []struct {
+		name            string
+		entry           EventLogEntry
+		wantCrashes     int
+		wantServices    int
+		wantHangs       int
+		wantHardware    int
+		wantCrashType   string // optional: check first crash type
+		wantServiceName string // optional: check first service name
+		wantHWType      string // optional: check first hardware type
+	}{
+		// ── Bug #1: DCOM 10010 must NOT become a crash ──────────────────────
+		{
+			name: "DCOM 10010 is dropped (not a crash, service failure, or hardware error)",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Microsoft-Windows-DistributedCOM",
+				EventID:   "10010:66601",
+				Message:   "The server {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} did not register with DCOM within the required timeout.",
+				Details:   map[string]any{"eventId": 10010},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 0,
+		},
+
+		// ── Bug #1 (mirror): real WER 1001 BugCheck IS a crash ─────────────
+		{
+			name: "WER BugCheck EventID 1001 (source=WER) is a bsod crash",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "Windows Error Reporting",
+				EventID:   "1001:55001",
+				Message:   "Fault bucket type 5, fault bucket , type 5 Event Name: BlueScreen",
+				Details:   map[string]any{"eventId": 1001},
+			},
+			wantCrashes:   1,
+			wantServices:  0,
+			wantHardware:  0,
+			wantCrashType: "bsod",
+		},
+
+		// ── WER via Details int (exercises Details["eventId"] path) ─────────
+		{
+			name: "WER 1001 via Details int — Details path",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "SystemErrorReporting",
+				EventID:   "1001:12",
+				Message:   "BugCheck report",
+				Details:   map[string]any{"eventId": 1001},
+			},
+			wantCrashes:   1,
+			wantCrashType: "bsod",
+		},
+
+		// ── WER 1001 via EventID string prefix (exercises fallback parse) ───
+		{
+			name: "WER 1001 via EventID string prefix fallback",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "WER-SystemErrorReporting",
+				EventID:   "1001:999",
+				Message:   "BugCheck",
+				Details:   map[string]any{}, // no Details["eventId"]
+			},
+			wantCrashes:   1,
+			wantCrashType: "bsod",
+		},
+
+		// ── Kernel-Power 41 → bsod ──────────────────────────────────────────
+		{
+			name: "Kernel-Power EventID 41 is a bsod crash",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "critical",
+				Category:  "system",
+				Source:    "Microsoft-Windows-Kernel-Power",
+				EventID:   "41:100",
+				Message:   "The system has rebooted without cleanly shutting down first.",
+				Details:   map[string]any{"eventId": 41},
+			},
+			wantCrashes:   1,
+			wantServices:  0,
+			wantHardware:  0,
+			wantCrashType: "bsod",
+		},
+
+		// ── SCM 7031 → exactly ONE service failure; serviceName parsed ───────
+		{
+			name: "SCM 7031 Spooler → one service failure, name Spooler, no hardware error",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7031:200",
+				Message:   "The Spooler service terminated unexpectedly. It has done this 1 time(s).",
+				Details:   map[string]any{"eventId": 7031},
+			},
+			wantCrashes:     0,
+			wantServices:    1,
+			wantHangs:       0,
+			wantHardware:    0,
+			wantServiceName: "Spooler",
+		},
+
+		// ── SCM 7036 (state change) → dropped ───────────────────────────────
+		{
+			name: "SCM 7036 entered running state is dropped",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "info",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7036:201",
+				Message:   "The Windows Update service entered the running state.",
+				Details:   map[string]any{"eventId": 7036},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 0,
+		},
+
+		// ── SCM 7000 (failed to start) → service failure ────────────────────
+		{
+			name: "SCM 7000 service failed to start",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7000:300",
+				Message:   "The MyService service failed to start due to the following error: The service did not respond.",
+				Details:   map[string]any{"eventId": 7000},
+			},
+			wantCrashes:  0,
+			wantServices: 1,
+			wantHardware: 0,
+		},
+
+		// ── WHEA-Logger → hardware error mce, nothing else ──────────────────
+		{
+			name: "WHEA-Logger hardware event → one hardware error type mce",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Microsoft-Windows-WHEA-Logger",
+				EventID:   "18:500",
+				Message:   "A corrected hardware error has occurred. Machine check details: MCE.",
+				Details:   map[string]any{"eventId": 18},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 1,
+			wantHWType:   "mce",
+		},
+
+		// ── Disk error → hardware error type disk ───────────────────────────
+		{
+			name: "Disk source → one hardware error type disk",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "disk",
+				EventID:   "11:600",
+				Message:   "The driver detected a controller error on \\Device\\Harddisk0.",
+				Details:   map[string]any{"eventId": 11},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 1,
+			wantHWType:   "disk",
+		},
+
+		// ── Application hang 1002 → one hang, nothing else ──────────────────
+		{
+			name: "Application hang EventID 1002 → one hang",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "Application Hang",
+				EventID:   "1002:700",
+				Message:   "The program explorer.exe stopped interacting with Windows.",
+				Details:   map[string]any{"eventId": 1002},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    1,
+			wantHardware: 0,
+		},
+
+		// ── Category "hardware" alone must NOT cause hardware error ──────────
+		{
+			name: "System log event with old Category=hardware but benign DCOM source is dropped",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "hardware", // old stale value; classifier must not trust it
+				Source:    "Microsoft-Windows-DistributedCOM",
+				EventID:   "10010:801",
+				Message:   "Some DCOM timeout message",
+				Details:   map[string]any{"eventId": 10010},
+			},
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 0,
+		},
+
+		// ── 6008 unexpected shutdown → bsod ─────────────────────────────────
+		{
+			name: "EventID 6008 unexpected previous shutdown → bsod",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "warning",
+				Category:  "system",
+				Source:    "EventLog",
+				EventID:   "6008:900",
+				Message:   "The previous system shutdown at was unexpected.",
+				Details:   map[string]any{"eventId": 6008},
+			},
+			wantCrashes:   1,
+			wantCrashType: "bsod",
+		},
+
+		// ── "bugcheck" in message → bsod ────────────────────────────────────
+		{
+			name: "Message contains bugcheck → bsod",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "critical",
+				Category:  "system",
+				Source:    "SomeOtherSource",
+				EventID:   "999:1",
+				Message:   "A bugcheck was triggered: 0x0000007E",
+				Details:   map[string]any{"eventId": 999},
+			},
+			wantCrashes:   1,
+			wantCrashType: "bsod",
+		},
+
+		// ── kernel panic in message → kernel_panic ───────────────────────────
+		{
+			name: "Message contains kernel panic → kernel_panic",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "critical",
+				Category:  "system",
+				Source:    "SomeSource",
+				EventID:   "888:1",
+				Message:   "Kernel panic - not syncing: VFS: Unable to mount root fs",
+				Details:   map[string]any{"eventId": 888},
+			},
+			wantCrashes:   1,
+			wantCrashType: "kernel_panic",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newMetrics()
+			classifyEventLogEntry(m, tc.entry)
+
+			// Assert no double-counting: total across all factors must be 0 or 1
+			total := totalFactors(m)
+			if total > 1 {
+				t.Errorf("double-counted: crashes=%d services=%d hangs=%d hardware=%d (total=%d)",
+					len(m.CrashEvents), len(m.ServiceFailures), len(m.AppHangs), len(m.HardwareErrors), total)
+			}
+
+			if len(m.CrashEvents) != tc.wantCrashes {
+				t.Errorf("crashEvents: got %d, want %d", len(m.CrashEvents), tc.wantCrashes)
+			}
+			if len(m.ServiceFailures) != tc.wantServices {
+				t.Errorf("serviceFailures: got %d, want %d", len(m.ServiceFailures), tc.wantServices)
+			}
+			if len(m.AppHangs) != tc.wantHangs {
+				t.Errorf("appHangs: got %d, want %d", len(m.AppHangs), tc.wantHangs)
+			}
+			if len(m.HardwareErrors) != tc.wantHardware {
+				t.Errorf("hardwareErrors: got %d, want %d", len(m.HardwareErrors), tc.wantHardware)
+			}
+
+			if tc.wantCrashType != "" && len(m.CrashEvents) > 0 {
+				if m.CrashEvents[0].Type != tc.wantCrashType {
+					t.Errorf("crashEvents[0].Type = %q, want %q", m.CrashEvents[0].Type, tc.wantCrashType)
+				}
+			}
+			if tc.wantServiceName != "" && len(m.ServiceFailures) > 0 {
+				if m.ServiceFailures[0].ServiceName != tc.wantServiceName {
+					t.Errorf("serviceFailures[0].ServiceName = %q, want %q", m.ServiceFailures[0].ServiceName, tc.wantServiceName)
+				}
+			}
+			if tc.wantHWType != "" && len(m.HardwareErrors) > 0 {
+				if m.HardwareErrors[0].Type != tc.wantHWType {
+					t.Errorf("hardwareErrors[0].Type = %q, want %q", m.HardwareErrors[0].Type, tc.wantHWType)
+				}
+			}
+		})
+	}
+}

--- a/agent/internal/collectors/reliability_test.go
+++ b/agent/internal/collectors/reliability_test.go
@@ -154,36 +154,59 @@ func TestClassifyEventLogEntry(t *testing.T) {
 			wantCrashType: "bsod",
 		},
 
-		// ── WER via Details int (exercises Details["eventId"] path) ─────────
+		// ── System-log 1001 via Details int, NEUTRAL message → bsod ─────────
+		// Neutral message (no "bugcheck"/"bluescreen") so this exercises the
+		// `nid==1001 && System-log` branch + the Details["eventId"] int path.
 		{
-			name: "WER 1001 via Details int — Details path",
+			name: "System-log 1001 (Details int, neutral message) → bsod",
 			entry: EventLogEntry{
 				Timestamp: ts,
 				Level:     "error",
-				Category:  "application",
-				Source:    "SystemErrorReporting",
+				Category:  "system",
+				Source:    "Microsoft-Windows-WER-SystemErrorReporting",
 				EventID:   "1001:12",
-				Message:   "BugCheck report",
-				Details:   map[string]any{"eventId": 1001},
+				Message:   "Fault bucket 1234567890, type 0",
+				Details:   map[string]any{"eventId": 1001, "logName": "System"},
 			},
 			wantCrashes:   1,
 			wantCrashType: "bsod",
 		},
 
-		// ── WER 1001 via EventID string prefix (exercises fallback parse) ───
+		// ── System-log 1001 via EventID prefix (no Details eventId) → bsod ──
 		{
-			name: "WER 1001 via EventID string prefix fallback",
+			name: "System-log 1001 (EventID prefix fallback, neutral message) → bsod",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Microsoft-Windows-WER-SystemErrorReporting",
+				EventID:   "1001:999",
+				Message:   "Fault bucket report",
+				Details:   map[string]any{"logName": "System"}, // no eventId → prefix parse
+			},
+			wantCrashes:   1,
+			wantCrashType: "bsod",
+		},
+
+		// ── REGRESSION: Application-log WER 1001 APPCRASH is NOT a crash ─────
+		// Ordinary per-app crashes log as "Windows Error Reporting" 1001 in the
+		// Application log. Gating the 1001 crash branch on the System log keeps
+		// these out of the (heavily-weighted) kernel-crash factor.
+		{
+			name: "Application-log WER 1001 APPCRASH is NOT a crash",
 			entry: EventLogEntry{
 				Timestamp: ts,
 				Level:     "error",
 				Category:  "application",
-				Source:    "WER-SystemErrorReporting",
-				EventID:   "1001:999",
-				Message:   "BugCheck",
-				Details:   map[string]any{}, // no Details["eventId"]
+				Source:    "Windows Error Reporting",
+				EventID:   "1001:42",
+				Message:   "Fault bucket 99, type 4 Event Name: APPCRASH Faulting application name: foo.exe",
+				Details:   map[string]any{"eventId": 1001, "logName": "Application"},
 			},
-			wantCrashes:   1,
-			wantCrashType: "bsod",
+			wantCrashes:  0,
+			wantServices: 0,
+			wantHangs:    0,
+			wantHardware: 0,
 		},
 
 		// ── Kernel-Power 41 → bsod ──────────────────────────────────────────
@@ -378,6 +401,104 @@ func TestClassifyEventLogEntry(t *testing.T) {
 			},
 			wantCrashes:   1,
 			wantCrashType: "kernel_panic",
+		},
+
+		// ── SCM 7034 → service failure, name parsed ─────────────────────────
+		{
+			name: "SCM 7034 terminated unexpectedly → service failure, name parsed",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7034:55",
+				Message:   "The Print Spooler service terminated unexpectedly. It has done this 3 time(s).",
+				Details:   map[string]any{"eventId": 7034},
+			},
+			wantServices:    1,
+			wantServiceName: "Print Spooler",
+		},
+
+		// ── SCM 7022 ("hung on start") → service failure, NOT a hang ─────────
+		{
+			name: "SCM 7022 hung on start → service failure, not a hang",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7022:56",
+				Message:   "The Foo service hung on starting.",
+				Details:   map[string]any{"eventId": 7022},
+			},
+			wantServices:    1,
+			wantHangs:       0,
+			wantServiceName: "Foo",
+		},
+
+		// ── Non-SCM source w/ service-failure message → service via fallback ─
+		{
+			name: "Non-SCM source with service-failure message → service failure",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "SomeAppProvider",
+				EventID:   "5000:57",
+				Message:   "The Backup service terminated unexpectedly.",
+				Details:   map[string]any{"eventId": 5000},
+			},
+			wantServices:    1,
+			wantServiceName: "Backup",
+		},
+
+		// ── Priority: SCM service event mentioning "disk" stays a service ────
+		{
+			name: "SCM 7031 whose message mentions disk → service failure, not hardware",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Service Control Manager",
+				EventID:   "7031:58",
+				Message:   "The DiskBackup service terminated unexpectedly.",
+				Details:   map[string]any{"eventId": 7031},
+			},
+			wantServices:    1,
+			wantHardware:    0,
+			wantServiceName: "DiskBackup",
+		},
+
+		// ── Memory hardware type (classifyHardwareType "memory" branch) ─────
+		{
+			name: "Memory error → hardware error type memory",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "system",
+				Source:    "Microsoft-Windows-Kernel-General",
+				EventID:   "13:59",
+				Message:   "A memory error was detected by the hardware.",
+				Details:   map[string]any{"eventId": 13},
+			},
+			wantHardware: 1,
+			wantHWType:   "memory",
+		},
+
+		// ── isHardwareSource-only: known driver, generic message → hardware ─
+		{
+			name: "Known driver source (nvlddmkm) generic message → hardware error type unknown",
+			entry: EventLogEntry{
+				Timestamp: ts,
+				Level:     "error",
+				Category:  "application",
+				Source:    "nvlddmkm",
+				EventID:   "153:60",
+				Message:   "Display driver stopped and has recovered.",
+				Details:   map[string]any{"eventId": 153},
+			},
+			wantHardware: 1,
+			wantHWType:   "unknown",
 		},
 	}
 

--- a/agent/internal/collectors/reliability_windows.go
+++ b/agent/internal/collectors/reliability_windows.go
@@ -4,7 +4,6 @@ package collectors
 
 import (
 	"log/slog"
-	"strings"
 )
 
 // Collect gathers reliability metrics from uptime + Windows event signals.
@@ -21,45 +20,7 @@ func (c *ReliabilityCollector) Collect() (*ReliabilityMetrics, error) {
 	}
 
 	for _, entry := range events {
-		ts := normalizeEventTimestamp(entry.Timestamp)
-		msg := strings.ToLower(entry.Message)
-		src := strings.ToLower(entry.Source)
-		eid := strings.ToLower(entry.EventID)
-		level := strings.ToLower(entry.Level)
-
-		switch {
-		case strings.Contains(msg, "bugcheck"), strings.Contains(msg, "blue screen"),
-			strings.Contains(msg, "unexpected shutdown"), strings.Contains(eid, "1001"), strings.Contains(eid, "6008"):
-			appendCrash(metrics, "bsod", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-				"level":   entry.Level,
-			})
-
-		case strings.Contains(msg, "kernel panic"):
-			appendCrash(metrics, "kernel_panic", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-
-		case strings.Contains(msg, "service") && (strings.Contains(msg, "terminated") || strings.Contains(msg, "failed") || strings.Contains(eid, "7034")):
-			appendServiceFailure(metrics, entry.Source, ts, entry.EventID)
-
-		case strings.Contains(msg, "hang"), strings.Contains(msg, "not responding"):
-			appendHang(metrics, entry.Source, ts)
-		}
-
-		if entry.Category == "hardware" || strings.Contains(src, "whea") || strings.Contains(msg, "disk") || strings.Contains(msg, "memory") {
-			appendHardwareError(metrics, entry, ts)
-			continue
-		}
-
-		if level == "critical" && entry.Category == "system" && strings.Contains(msg, "crash") {
-			appendCrash(metrics, "system_crash", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-		}
+		classifyEventLogEntry(metrics, entry)
 	}
 
 	return metrics, nil

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -78,11 +78,8 @@ describe('reliabilityScoringInternals', () => {
 
   it('builds trend points only for observed days (no default-100 gaps)', () => {
     const now = new Date('2026-02-21T00:00:00.000Z');
-    // Issue #1908: the new saturating scoreDailyBucket produces gentler per-day
-    // scores, so we need multiple fault factors to produce a clearly degrading
-    // slope (single-factor crash-only 0→1→4 yields slope ≈ -0.95, below the
-    // -2 threshold). Using multi-factor faults that produce scores 100→76→42
-    // (slope ≈ -3.1) gives an unambiguous degrading signal.
+    // Issue #1908: scoreDailyBucket sums per-factor lost points (full 0–100 range),
+    // so a worsening fault load over time produces a clearly negative slope.
     const buckets = [
       makeBucket({ date: '2026-02-01', crashCount: 0, serviceFailureCount: 0, hangCount: 0 }),
       makeBucket({ date: '2026-02-10', crashCount: 2, serviceFailureCount: 2, hangCount: 1 }),
@@ -95,6 +92,33 @@ describe('reliabilityScoringInternals', () => {
     const trend = reliabilityScoringInternals.computeTrend(buckets, now);
     expect(trend.direction).toBe('degrading');
     expect(trend.confidence).toBeGreaterThan(0);
+  });
+
+  it('detects an improving trend when faults decrease over time', () => {
+    const now = new Date('2026-02-21T00:00:00.000Z');
+    const buckets = [
+      makeBucket({ date: '2026-02-01', crashCount: 5, serviceFailureCount: 5, hangCount: 3, hardwareCriticalCount: 1 }),
+      makeBucket({ date: '2026-02-10', crashCount: 2, serviceFailureCount: 2, hangCount: 1 }),
+      makeBucket({ date: '2026-02-20', crashCount: 0, serviceFailureCount: 0, hangCount: 0 }),
+    ] as any[];
+
+    const trend = reliabilityScoringInternals.computeTrend(buckets, now);
+    expect(trend.direction).toBe('improving');
+  });
+
+  it('reads a shallow single-factor change as stable (slope within ±2)', () => {
+    // One crash on the final observed day only → day scores 100, 100, 72 over a
+    // 20-day span → slope ≈ -1.4, inside the ±2 deadband → stable, not degrading.
+    // Locks the trend threshold against the gentler curve over-triggering.
+    const now = new Date('2026-02-21T00:00:00.000Z');
+    const buckets = [
+      makeBucket({ date: '2026-02-01' }),
+      makeBucket({ date: '2026-02-10' }),
+      makeBucket({ date: '2026-02-20', crashCount: 1 }),
+    ] as any[];
+
+    const trend = reliabilityScoringInternals.computeTrend(buckets, now);
+    expect(trend.direction).toBe('stable');
   });
 
   it('computes MTBF from aggregated failures and observed up-days', () => {
@@ -524,9 +548,9 @@ describe('saturatingScore', () => {
 
   it('returns 100 for zero weighted count', () => expect(saturatingScore(0, 5)).toBe(100));
   it('returns 100 for negative weighted count', () => expect(saturatingScore(-1, 5)).toBe(100));
-  it('returns 100 for non-finite input', () => {
-    expect(saturatingScore(NaN, 5)).toBe(100);
-    expect(saturatingScore(Infinity, 5)).toBe(100);
+  it('returns 0 (not 100) for non-finite input — corrupted data must not read as perfect health', () => {
+    expect(saturatingScore(NaN, 5)).toBe(0);
+    expect(saturatingScore(Infinity, 5)).toBe(0);
   });
   it('at weightedCount = k the score is approximately 37 (exp(-1) ≈ 36.8)', () => {
     // exp(-k/k) = exp(-1) ≈ 0.368, so score ≈ 37 after rounding.

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -78,10 +78,15 @@ describe('reliabilityScoringInternals', () => {
 
   it('builds trend points only for observed days (no default-100 gaps)', () => {
     const now = new Date('2026-02-21T00:00:00.000Z');
+    // Issue #1908: the new saturating scoreDailyBucket produces gentler per-day
+    // scores, so we need multiple fault factors to produce a clearly degrading
+    // slope (single-factor crash-only 0→1→4 yields slope ≈ -0.95, below the
+    // -2 threshold). Using multi-factor faults that produce scores 100→76→42
+    // (slope ≈ -3.1) gives an unambiguous degrading signal.
     const buckets = [
-      makeBucket({ date: '2026-02-01', crashCount: 0 }),
-      makeBucket({ date: '2026-02-10', crashCount: 1 }),
-      makeBucket({ date: '2026-02-20', crashCount: 4 }),
+      makeBucket({ date: '2026-02-01', crashCount: 0, serviceFailureCount: 0, hangCount: 0 }),
+      makeBucket({ date: '2026-02-10', crashCount: 2, serviceFailureCount: 2, hangCount: 1 }),
+      makeBucket({ date: '2026-02-20', crashCount: 5, serviceFailureCount: 5, hangCount: 3, hardwareCriticalCount: 1 }),
     ] as any[];
 
     const points = reliabilityScoringInternals.buildDailyTrendPoints(buckets, 30, now);
@@ -513,48 +518,213 @@ describe('computeUptimePercent', () => {
   });
 });
 
+// Issue #1908: saturating curve helper — the foundation for all factor scorers.
+describe('saturatingScore', () => {
+  const { saturatingScore } = reliabilityScoringInternals;
+
+  it('returns 100 for zero weighted count', () => expect(saturatingScore(0, 5)).toBe(100));
+  it('returns 100 for negative weighted count', () => expect(saturatingScore(-1, 5)).toBe(100));
+  it('returns 100 for non-finite input', () => {
+    expect(saturatingScore(NaN, 5)).toBe(100);
+    expect(saturatingScore(Infinity, 5)).toBe(100);
+  });
+  it('at weightedCount = k the score is approximately 37 (exp(-1) ≈ 36.8)', () => {
+    // exp(-k/k) = exp(-1) ≈ 0.368, so score ≈ 37 after rounding.
+    expect(saturatingScore(5, 5)).toBe(37);
+    expect(saturatingScore(3, 3)).toBe(37);
+  });
+  it('is strictly decreasing for counts 1 through 10 with k=5', () => {
+    for (let n = 1; n <= 10; n++) {
+      expect(saturatingScore(n, 5)).toBeLessThan(saturatingScore(n - 1, 5));
+    }
+  });
+  it('never returns below 0 or above 100', () => {
+    expect(saturatingScore(1000, 1)).toBeGreaterThanOrEqual(0);
+    expect(saturatingScore(0.001, 5)).toBeLessThanOrEqual(100);
+  });
+});
+
+// Issue #1908: scoreCrashes uses saturatingScore with K_CRASHES=3.
+// weightedCount = crashCount30d + crashCount7d * 0.5
 describe('scoreCrashes', () => {
   const { scoreCrashes } = reliabilityScoringInternals;
 
   it('returns 100 with no crashes', () => expect(scoreCrashes(0, 0)).toBe(100));
-  it('reduces score proportionally', () => expect(scoreCrashes(0, 1)).toBe(80));
-  it('applies 0.5x weight to 7d crashes', () => expect(scoreCrashes(2, 0)).toBe(80));
-  it('clamps to 0 with many crashes', () => expect(scoreCrashes(10, 10)).toBe(0));
+  // 1 crash (30d): weightedCount=1 → round(100*exp(-1/3)) = 72
+  it('one 30d crash dents the score to ~72', () => expect(scoreCrashes(0, 1)).toBe(72));
+  // 2 crashes (7d): weightedCount=2*0.5=1 → same curve → 72
+  it('applies 0.5x weight to 7d crashes (2 seven-day crashes = 1 weighted)', () => expect(scoreCrashes(2, 0)).toBe(72));
+  // reference: weightedCount=3 → exp(-3/3)=exp(-1) ≈ 37
+  it('at weighted-count 3 the score is ~37 (exp(-1) reference point)', () => {
+    // crashCount30d=3, crashCount7d=0: weightedCount=3
+    expect(scoreCrashes(0, 3)).toBe(37);
+  });
+  // strict monotonicity across 30d crash counts 1..10 (no plateaus in meaningful range)
+  it('is strictly monotonically decreasing for 1..10 crashes (no plateau)', () => {
+    for (let n = 1; n <= 10; n++) {
+      expect(scoreCrashes(0, n)).toBeLessThan(scoreCrashes(0, n - 1));
+    }
+  });
+  // many crashes still produce a low but non-zero, finite value
+  it('very many crashes approach but do not floor at 0 artificially (large count → low score)', () => {
+    const score = scoreCrashes(10, 10); // weightedCount=10+5=15 → round(100*exp(-5)) ≈ 1
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThan(5);
+  });
 });
 
+// Issue #1908: scoreHangs uses saturatingScore with K_HANGS=6.
+// weightedCount = hangCount30d + unresolvedHangCount30d (unresolved double-counted)
 describe('scoreHangs', () => {
   const { scoreHangs } = reliabilityScoringInternals;
 
   it('returns 100 with no hangs', () => expect(scoreHangs(0, 0)).toBe(100));
-  it('unresolved hangs carry 2x penalty vs resolved (no double-count)', () => {
-    // A resolved hang costs 10 (→90); an unresolved hang costs 10 + 10 = 20
-    // (→80), NOT 30. `unresolvedHangCount` is a subset of `hangCount`, so it adds
-    // a single extra 10 rather than being penalised twice.
-    const oneResolved = scoreHangs(1, 0);
-    const oneUnresolved = scoreHangs(1, 1);
-    expect(oneResolved).toBe(90);
-    expect(oneUnresolved).toBe(80);
+  // 1 resolved hang: weightedCount=1+0=1 → round(100*exp(-1/6)) ≈ 85
+  it('one resolved hang → ~85', () => expect(scoreHangs(1, 0)).toBe(85));
+  // 1 unresolved hang: weightedCount=1+1=2 → round(100*exp(-2/6)) ≈ 72
+  it('one unresolved hang costs more than one resolved hang (2x weighted)', () => {
+    const oneResolved = scoreHangs(1, 0);     // 85
+    const oneUnresolved = scoreHangs(1, 1);   // 72
+    expect(oneResolved).toBe(85);
+    expect(oneUnresolved).toBe(72);
+    expect(oneUnresolved).toBeLessThan(oneResolved);
   });
-  it('clamps to 0', () => expect(scoreHangs(20, 20)).toBe(0));
+  // reference: weightedCount=6 (6 hangs, 0 unresolved) → exp(-1) ≈ 37
+  it('at weighted-count 6 the score is ~37 (exp(-1) reference point)', () => {
+    expect(scoreHangs(6, 0)).toBe(37);
+  });
+  // strict monotonicity: more hangs = lower score (no plateau in 1..12)
+  it('is strictly monotonically decreasing for 1..12 hangs (no plateau)', () => {
+    for (let n = 1; n <= 12; n++) {
+      expect(scoreHangs(n, 0)).toBeLessThan(scoreHangs(n - 1, 0));
+    }
+  });
+  it('approaches 0 with many hangs', () => expect(scoreHangs(20, 20)).toBe(0));
 });
 
+// Issue #1908: scoreServiceFailures uses saturatingScore with K_SERVICES=5.
+// weightedCount = max(0, failures - recovered * 0.5)
 describe('scoreServiceFailures', () => {
   const { scoreServiceFailures } = reliabilityScoringInternals;
 
   it('returns 100 with no failures', () => expect(scoreServiceFailures(0, 0)).toBe(100));
-  it('recovered services add 5 points each', () => expect(scoreServiceFailures(1, 1)).toBe(90));
-  it('clamps to 0 with many failures', () => expect(scoreServiceFailures(10, 0)).toBe(0));
-  it('clamps to 100 even with many recoveries', () => expect(scoreServiceFailures(0, 10)).toBe(100));
+  // 1 failure, 1 recovered: weightedCount=max(0, 1-0.5)=0.5 → round(100*exp(-0.5/5)) ≈ 90
+  it('recovered failures get half-weight credit', () => expect(scoreServiceFailures(1, 1)).toBe(90));
+  // many recoveries with no failures: weightedCount=max(0, 0-5)=0 → still 100
+  it('recoveries alone cannot push score above 100', () => expect(scoreServiceFailures(0, 10)).toBe(100));
+  // reference: 5 failures 0 recovered → weightedCount=5 → exp(-1) ≈ 37
+  it('at 5 failures (0 recovered) the score is ~37 (exp(-1) reference point)', () => {
+    expect(scoreServiceFailures(5, 0)).toBe(37);
+  });
+  // The headline regression (#1908): 1 vs 3 vs 5 failures yield DISTINCT descending scores
+  it('discrimination: 1, 3, and 5 failures produce three distinct descending scores', () => {
+    const s1 = scoreServiceFailures(1, 0); // 82
+    const s3 = scoreServiceFailures(3, 0); // 55
+    const s5 = scoreServiceFailures(5, 0); // 37
+    expect(s1).toBe(82);
+    expect(s3).toBe(55);
+    expect(s5).toBe(37);
+    expect(s1).toBeGreaterThan(s3);
+    expect(s3).toBeGreaterThan(s5);
+  });
+  // strict monotonicity: more failures = lower score (no plateau in 1..10)
+  it('is strictly monotonically decreasing for 1..10 failures (no plateau)', () => {
+    for (let n = 1; n <= 10; n++) {
+      expect(scoreServiceFailures(n, 0)).toBeLessThan(scoreServiceFailures(n - 1, 0));
+    }
+  });
+  it('10 failures (0 recovered) → low score (~14), not floored to 0', () => {
+    expect(scoreServiceFailures(10, 0)).toBe(14);
+  });
 });
 
+// Issue #1908: scoreHardwareErrors uses saturatingScore with K_HARDWARE=3.
+// weightedCount = critical*2 + error*1 + warning*0.34
 describe('scoreHardwareErrors', () => {
   const { scoreHardwareErrors } = reliabilityScoringInternals;
 
   it('returns 100 with no errors', () => expect(scoreHardwareErrors(0, 0, 0)).toBe(100));
-  it('one critical error removes 30 points', () => expect(scoreHardwareErrors(1, 0, 0)).toBe(70));
-  it('one error severity removes 15 points', () => expect(scoreHardwareErrors(0, 1, 0)).toBe(85));
-  it('one warning removes 5 points', () => expect(scoreHardwareErrors(0, 0, 1)).toBe(95));
-  it('clamps to 0 with 4+ critical errors', () => expect(scoreHardwareErrors(4, 0, 0)).toBe(0));
+  // 1 critical: weightedCount=2 → round(100*exp(-2/3)) ≈ 51
+  it('one critical error (w=2) → ~51', () => expect(scoreHardwareErrors(1, 0, 0)).toBe(51));
+  // 1 error: weightedCount=1 → round(100*exp(-1/3)) ≈ 72
+  it('one error-severity event (w=1) → ~72', () => expect(scoreHardwareErrors(0, 1, 0)).toBe(72));
+  // 1 warning: weightedCount=0.34 → round(100*exp(-0.34/3)) ≈ 89
+  it('one warning (w=0.34) → ~89', () => expect(scoreHardwareErrors(0, 0, 1)).toBe(89));
+  // reference: 2 criticals → weightedCount=4 → round(100*exp(-4/3)) ≈ 26
+  it('two critical errors → ~26 (severity-weighting reference point)', () => expect(scoreHardwareErrors(2, 0, 0)).toBe(26));
+  // strict severity ordering
+  it('critical costs more than error which costs more than warning (strict ordering)', () => {
+    expect(scoreHardwareErrors(1, 0, 0)).toBeLessThan(scoreHardwareErrors(0, 1, 0));
+    expect(scoreHardwareErrors(0, 1, 0)).toBeLessThan(scoreHardwareErrors(0, 0, 1));
+  });
+  // strict monotonicity: more criticals = lower score in 1..6
+  it('is strictly monotonically decreasing for 1..6 critical errors (no plateau)', () => {
+    for (let n = 1; n <= 6; n++) {
+      expect(scoreHardwareErrors(n, 0, 0)).toBeLessThan(scoreHardwareErrors(n - 1, 0, 0));
+    }
+  });
+  // 4 criticals: weightedCount=8 → round(100*exp(-8/3)) ≈ 7 (no longer clamps to 0 artificially)
+  it('4 critical errors → low score (~7), not hard-floored at 0', () => {
+    expect(scoreHardwareErrors(4, 0, 0)).toBe(7);
+  });
+});
+
+// Issue #1908: scoreDailyBucket is kept in lockstep with the headline scorers —
+// both now use saturatingScore, so a day with more faults always scores lower.
+describe('scoreDailyBucket', () => {
+  const { scoreDailyBucket } = reliabilityScoringInternals;
+
+  function emptyBucket(overrides: Record<string, number> = {}) {
+    return makeBucket({
+      crashCount: 0,
+      hangCount: 0,
+      unresolvedHangCount: 0,
+      serviceFailureCount: 0,
+      recoveredServiceCount: 0,
+      hardwareCriticalCount: 0,
+      hardwareErrorSeverityCount: 0,
+      hardwareWarningCount: 0,
+      ...overrides,
+    });
+  }
+
+  it('returns 100 for a perfectly clean bucket', () => {
+    expect(scoreDailyBucket(emptyBucket())).toBe(100);
+  });
+
+  it('a bucket with 1 crash scores lower than a clean bucket', () => {
+    expect(scoreDailyBucket(emptyBucket({ crashCount: 1 }))).toBeLessThan(100);
+  });
+
+  it('a bucket with more crashes scores strictly lower than one with fewer', () => {
+    const s1 = scoreDailyBucket(emptyBucket({ crashCount: 1 }));
+    const s2 = scoreDailyBucket(emptyBucket({ crashCount: 2 }));
+    const s4 = scoreDailyBucket(emptyBucket({ crashCount: 4 }));
+    expect(s1).toBeGreaterThan(s2);
+    expect(s2).toBeGreaterThan(s4);
+  });
+
+  it('a bucket with 1 service failure scores lower than a clean bucket', () => {
+    expect(scoreDailyBucket(emptyBucket({ serviceFailureCount: 1 }))).toBeLessThan(100);
+  });
+
+  it('a bucket with more service failures scores strictly lower (no plateau)', () => {
+    for (let n = 1; n <= 8; n++) {
+      const prev = scoreDailyBucket(emptyBucket({ serviceFailureCount: n - 1 }));
+      const curr = scoreDailyBucket(emptyBucket({ serviceFailureCount: n }));
+      expect(curr).toBeLessThan(prev);
+    }
+  });
+
+  it('a bucket with 1 critical hardware error scores lower than a clean bucket', () => {
+    expect(scoreDailyBucket(emptyBucket({ hardwareCriticalCount: 1 }))).toBeLessThan(100);
+  });
+
+  it('a bucket with mixed faults scores lower than a single-fault bucket', () => {
+    const oneCrash = scoreDailyBucket(emptyBucket({ crashCount: 1 }));
+    const mixed = scoreDailyBucket(emptyBucket({ crashCount: 1, serviceFailureCount: 2, hardwareCriticalCount: 1 }));
+    expect(mixed).toBeLessThan(oneCrash);
+  });
 });
 
 describe('scoreBand', () => {

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -258,6 +258,33 @@ function round2(value: number): number {
   return Math.round(value * 100) / 100;
 }
 
+// Issue #1908: saturating per-factor curve. Linear `100 - count*N` clamped at 0
+// floored any factor past ~5 events, so 14 and 1466 scored identically and the
+// number stopped discriminating. Exponential decay keeps 0→100, stays strictly
+// monotonic, and gives distinct scores across the low range that matters most.
+//
+// factorScore(weightedCount, k) = clampScore(100 * Math.exp(-weightedCount / k))
+// Properties: 0 events → 100; strictly decreasing (no plateau); smooth; at
+// weightedCount = k the score is ~37 (exp(-1) ≈ 0.368), which is the tuning
+// reference point for each k constant below.
+function saturatingScore(weightedCount: number, k: number): number {
+  if (!Number.isFinite(weightedCount) || weightedCount <= 0) return 100;
+  return clampScore(100 * Math.exp(-Math.max(0, weightedCount) / k));
+}
+
+// k=3: one crash (w=1) → ~72, three crashes (w=3) → ~37, five → ~19, ten → ~3.
+// Crashes are severe so k is small — the curve falls quickly.
+const K_CRASHES = 3;
+
+// k=6: one hang (w=1) → ~85, six hangs (w=6) → ~37, twelve → ~14.
+const K_HANGS = 6;
+
+// k=5: one net failure (w=1) → ~82, five → ~37, ten → ~14.
+const K_SERVICES = 5;
+
+// k=3: one critical (w=2) → ~51, two criticals (w=4) → ~26, one error (w=1) → ~72.
+const K_HARDWARE = 3;
+
 function scoreRangeBounds(range: ReliabilityScoreRange): [number, number] {
   if (range === 'critical') return [0, 50];
   if (range === 'poor') return [51, 70];
@@ -379,25 +406,36 @@ function scoreUptime(uptimePercent: number): number {
 }
 
 function scoreCrashes(crashCount7d: number, crashCount30d: number): number {
-  const weightedCrashes = crashCount30d + crashCount7d * 0.5;
-  return clampScore(100 - weightedCrashes * 20);
+  // Issue #1908: weightedCount = 30d crashes + 0.5 × 7d crashes (recent events
+  // weighted more heavily, matching the original intent). K_CRASHES=3 so a single
+  // crash dents ~28 points and the curve reaches ~37 at 3 weighted events.
+  const weightedCount = crashCount30d + crashCount7d * 0.5;
+  return saturatingScore(weightedCount, K_CRASHES);
 }
 
 function scoreHangs(hangCount30d: number, unresolvedHangCount30d: number): number {
-  // Every hang costs 10; unresolved hangs cost an extra 10 on top (20 total).
-  // `unresolvedHangCount30d` is a subset of `hangCount30d`, so the extra penalty
-  // is +10, NOT +20 — the old *20 here double-counted unresolved hangs against
-  // the base *10 (30 each) and disagreed with `scoreDailyBucket`'s per-day
-  // weighting (10 each). This aligns the two.
-  return clampScore(100 - hangCount30d * 10 - unresolvedHangCount30d * 10);
+  // Issue #1908: unresolvedHangCount is a subset of hangCount, so unresolved
+  // hangs count double in the weighted sum (they appear in both terms), which
+  // matches the original intent that unresolved hangs cost 2× a resolved hang.
+  // K_HANGS=6 so one hang → ~85, six hangs → ~37.
+  const weightedCount = hangCount30d + unresolvedHangCount30d;
+  return saturatingScore(weightedCount, K_HANGS);
 }
 
 function scoreServiceFailures(serviceFailureCount30d: number, recoveredCount30d: number): number {
-  return clampScore(100 - serviceFailureCount30d * 15 + recoveredCount30d * 5);
+  // Issue #1908: recovered failures get half-weight credit, preserving the
+  // "recovery is good" intent without ever pushing the score above 100 (recovery
+  // credit is bounded by the failure count, and Math.max(0,...) stops it going
+  // negative). K_SERVICES=5 so one net failure → ~82, five → ~37.
+  const weightedCount = Math.max(0, serviceFailureCount30d - recoveredCount30d * 0.5);
+  return saturatingScore(weightedCount, K_SERVICES);
 }
 
 function scoreHardwareErrors(criticalCount30d: number, errorCount30d: number, warningCount30d: number): number {
-  return clampScore(100 - criticalCount30d * 30 - errorCount30d * 15 - warningCount30d * 5);
+  // Issue #1908: severity weighting mirrors the old 30/15/5 ratio (≈ 2/1/0.34).
+  // K_HARDWARE=3 so one critical (w=2) → ~51, two criticals (w=4) → ~26.
+  const weightedCount = criticalCount30d * 2 + errorCount30d * 1 + warningCount30d * 0.34;
+  return saturatingScore(weightedCount, K_HARDWARE);
 }
 
 function linearRegression(points: Array<{ x: number; y: number }>): { slope: number; r2: number } {
@@ -732,23 +770,34 @@ function sumBucketsInWindow(
 }
 
 function scoreDailyBucket(bucket: DailyAggregateBucket): number {
-  // Per-day score used only to compute the trend slope. Penalty weights are kept
-  // in lockstep with the headline factor scorers (scoreCrashes/scoreHangs/
-  // scoreServiceFailures/scoreHardwareErrors) so the trend reflects the same
-  // notion of "bad day" as the score itself. Service-failure/recovery were 12/+4
-  // here vs 15/+5 in scoreServiceFailures — aligned to 15/+5. Uptime is
-  // intentionally absent: it is not a per-day-bucket quantity.
-  return clampScore(
-    100
-    - bucket.crashCount * 20
-    - bucket.hangCount * 10
-    - bucket.unresolvedHangCount * 10
-    - bucket.serviceFailureCount * 15
-    + bucket.recoveredServiceCount * 5
-    - bucket.hardwareCriticalCount * 30
-    - bucket.hardwareErrorSeverityCount * 15
-    - bucket.hardwareWarningCount * 5
+  // Issue #1908: kept in lockstep with the headline factor scorers by applying
+  // the SAME saturatingScore + k constants to each day's counts, then averaging
+  // the four per-factor scores to produce a single 0–100 day quality score.
+  // Uptime is intentionally absent: it is not a per-day-bucket quantity.
+  //
+  // Using the same helpers as the headline scorers means "bad day" tracks the
+  // same exponential decay rather than the old linear-clamp-at-0, so a day with
+  // more faults always scores strictly lower than one with fewer.
+  const crashScore = saturatingScore(
+    bucket.crashCount + 0, // crashCount7d is unavailable per-day; use 30d count only
+    K_CRASHES
   );
+  const hangScore = saturatingScore(
+    bucket.hangCount + bucket.unresolvedHangCount,
+    K_HANGS
+  );
+  const serviceScore = saturatingScore(
+    Math.max(0, bucket.serviceFailureCount - bucket.recoveredServiceCount * 0.5),
+    K_SERVICES
+  );
+  const hwScore = saturatingScore(
+    bucket.hardwareCriticalCount * 2 + bucket.hardwareErrorSeverityCount * 1 + bucket.hardwareWarningCount * 0.34,
+    K_HARDWARE
+  );
+  // Average the four fault-factor scores: each is 0–100, and the result is 0–100.
+  // A fully-clean day yields (100+100+100+100)/4 = 100. Any fault drives the
+  // average down, smoothly, with no hard floor.
+  return clampScore((crashScore + hangScore + serviceScore + hwScore) / 4);
 }
 
 function buildDailyTrendPoints(
@@ -1835,4 +1884,10 @@ export const reliabilityScoringInternals = {
   isWorkstationRole,
   INFRA_FACTOR_WEIGHTS,
   WORKSTATION_FACTOR_WEIGHTS,
+  // Exposed for testing (#1908 saturating curve)
+  saturatingScore,
+  K_CRASHES,
+  K_HANGS,
+  K_SERVICES,
+  K_HARDWARE,
 };

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -268,11 +268,18 @@ function round2(value: number): number {
 // weightedCount = k the score is ~37 (exp(-1) ≈ 0.368), which is the tuning
 // reference point for each k constant below.
 function saturatingScore(weightedCount: number, k: number): number {
-  if (!Number.isFinite(weightedCount) || weightedCount <= 0) return 100;
-  return clampScore(100 * Math.exp(-Math.max(0, weightedCount) / k));
+  // A non-finite weightedCount (NaN/Infinity) means upstream count arithmetic
+  // produced garbage. Return 0, never 100 — corrupted telemetry must not read as
+  // perfect health (a "100" hides the data fault; nobody investigates a perfect
+  // score). Counts are coerced finite & non-negative upstream, so this is a
+  // defensive floor, not an expected path. `weightedCount <= 0` is the real
+  // "clean device" case and returns 100.
+  if (!Number.isFinite(weightedCount)) return 0;
+  if (weightedCount <= 0) return 100;
+  return clampScore(100 * Math.exp(-weightedCount / k));
 }
 
-// k=3: one crash (w=1) → ~72, three crashes (w=3) → ~37, five → ~19, ten → ~3.
+// k=3: one crash (w=1) → ~72, three crashes (w=3) → ~37, five → ~19, ten → ~4.
 // Crashes are severe so k is small — the curve falls quickly.
 const K_CRASHES = 3;
 
@@ -424,9 +431,10 @@ function scoreHangs(hangCount30d: number, unresolvedHangCount30d: number): numbe
 
 function scoreServiceFailures(serviceFailureCount30d: number, recoveredCount30d: number): number {
   // Issue #1908: recovered failures get half-weight credit, preserving the
-  // "recovery is good" intent without ever pushing the score above 100 (recovery
-  // credit is bounded by the failure count, and Math.max(0,...) stops it going
-  // negative). K_SERVICES=5 so one net failure → ~82, five → ~37.
+  // "recovery is good" intent. The score never exceeds 100 because saturatingScore
+  // returns <=100 for any weightedCount >= 0 (and exactly 100 when it is <= 0); the
+  // Math.max(0, ...) floor handles recovered exceeding failures. K_SERVICES=5 so one
+  // net failure → ~82, five → ~37.
   const weightedCount = Math.max(0, serviceFailureCount30d - recoveredCount30d * 0.5);
   return saturatingScore(weightedCount, K_SERVICES);
 }
@@ -770,34 +778,31 @@ function sumBucketsInWindow(
 }
 
 function scoreDailyBucket(bucket: DailyAggregateBucket): number {
-  // Issue #1908: kept in lockstep with the headline factor scorers by applying
-  // the SAME saturatingScore + k constants to each day's counts, then averaging
-  // the four per-factor scores to produce a single 0–100 day quality score.
-  // Uptime is intentionally absent: it is not a per-day-bucket quantity.
-  //
-  // Using the same helpers as the headline scorers means "bad day" tracks the
-  // same exponential decay rather than the old linear-clamp-at-0, so a day with
-  // more faults always scores strictly lower than one with fewer.
-  const crashScore = saturatingScore(
-    bucket.crashCount + 0, // crashCount7d is unavailable per-day; use 30d count only
-    K_CRASHES
-  );
-  const hangScore = saturatingScore(
-    bucket.hangCount + bucket.unresolvedHangCount,
-    K_HANGS
-  );
-  const serviceScore = saturatingScore(
-    Math.max(0, bucket.serviceFailureCount - bucket.recoveredServiceCount * 0.5),
-    K_SERVICES
-  );
-  const hwScore = saturatingScore(
-    bucket.hardwareCriticalCount * 2 + bucket.hardwareErrorSeverityCount * 1 + bucket.hardwareWarningCount * 0.34,
-    K_HARDWARE
-  );
-  // Average the four fault-factor scores: each is 0–100, and the result is 0–100.
-  // A fully-clean day yields (100+100+100+100)/4 = 100. Any fault drives the
-  // average down, smoothly, with no hard floor.
-  return clampScore((crashScore + hangScore + serviceScore + hwScore) / 4);
+  // Issue #1908: per-day score used ONLY for the trend slope (computeTrend). Each
+  // factor uses the SAME saturatingScore + k constants as the headline scorers, so
+  // "bad day" tracks the same exponential decay (not the old linear-clamp-at-0).
+  // The four per-factor scores are combined by SUMMING their lost points
+  // (100 - score) and subtracting from 100 — NOT averaging. Averaging divides a
+  // single-factor spike by four and, with the exponential floor, squeezes every
+  // day into a narrow ~78–100 band; that flattens the regression slope and weakens
+  // computeTrend's `degrading` detection (slope < -2). Summing lost points keeps
+  // the full 0–100 range and preserves "more faults ⇒ strictly lower day score"
+  // across factors. Uptime is intentionally absent: not a per-day-bucket quantity.
+  const lost = (score: number): number => 100 - score;
+  const lostPoints =
+    lost(saturatingScore(bucket.crashCount, K_CRASHES))
+    + lost(saturatingScore(bucket.hangCount + bucket.unresolvedHangCount, K_HANGS))
+    + lost(saturatingScore(
+      Math.max(0, bucket.serviceFailureCount - bucket.recoveredServiceCount * 0.5),
+      K_SERVICES,
+    ))
+    + lost(saturatingScore(
+      bucket.hardwareCriticalCount * 2 + bucket.hardwareErrorSeverityCount * 1 + bucket.hardwareWarningCount * 0.34,
+      K_HARDWARE,
+    ));
+  // Clean day → 100 - 0 = 100. Faults across multiple factors accumulate and the
+  // result clamps at 0. Adding any fault strictly lowers the day score.
+  return clampScore(100 - lostPoints);
 }
 
 function buildDailyTrendPoints(


### PR DESCRIPTION
## Why

Investigating reliability accuracy on a customer fleet (US prod, agents 0.83.3): **5 of 9 workstations scored an identical 21** despite service-failure counts ranging from 14 to 1466. The score had no discriminating power. The previous three iterations (#1905 dedup, #1906 cadence, #1907 drill-down/tooltips) all shipped but none touched the two root causes — which is why "only the tooltips ever changed."

## Root causes (both verified against live event payloads)

**Agent — Windows event classification (`agent/internal/collectors/`)**
1. **DCOM 10010 counted as BSODs.** EventID is formatted `"<id>:<record>"` (e.g. `"10010:66601"`) and the classifier used `strings.Contains(eid, "1001")` — `10010` contains `1001`. One workstation's "54 crashes" were 54 benign DCOM timeouts.
2. **Entire System log hard-tagged `Category:"hardware"`.** Service Control Manager, DCOM, Kerberos, WindowsUpdate, Bluetooth all became "hardware errors"; the real WHEA/disk/memory detection was dead code. One workstation's 1489 "hardware errors" were ~1980 raw Service Control Manager events.
3. **Same event double-counted across factors** — the switch (crash/service) ran, then an independent `if Category=="hardware"` also ran. That's why service failures (1466) ≈ hardware errors (1489): the same events, counted twice.
4. **serviceName = the provider** ("Service Control Manager") instead of the failing service, so the #1907 drill-down was useless.

**API — formula saturation (#1908, never merged)**
- Linear `100 − count×N` clamped at 0 floored any factor past ~5 events, so 14 and 1466 scored the same and every fault-heavy workstation collapsed to 21 (hangScore 100 × 0.21 workstation weight).

## What changed

**Agent**
- Match event IDs by **equality on the numeric ID** (never substring on the formatted string).
- Gate hardware errors on **genuine hardware signals** (WHEA/disk/memory/known drivers), not `Category`.
- Route each event into **exactly one factor** (priority crash→service→hang→hardware) — no cross-category double count.
- Service failures: allowlist real SCM failure IDs (7000/7022–7026/7031/7034; exclude 7036 noise) and **parse the real service name** from the message.
- Extracted classification into a platform-neutral `classifyEventLogEntry` so it's **unit-testable on CI** (was inline in the windows-only `Collect()`).

**API**
- Replaced the linear clamp with a smooth **exponential-decay curve** per factor (`100·e^(−weightedCount/k)`): 0 events → 100, strictly monotonic, distinct scores across the low range. `scoreDailyBucket` (trend) kept in lockstep with the same curves.

## Tests
- `go test -race ./internal/collectors/...` — green (new table-driven coverage incl. the DCOM-10010 regression and a no-double-count assertion).
- `pnpm exec vitest run src/services/reliabilityScoring.test.ts` — 110/110 (monotonicity guards + curve reference values).
- Builds verified for linux/darwin/windows.

## Deploy note
The agent half only takes effect once the fleet runs a build containing it. `AGENT_AUTO_PROMOTE=false`, so a new agent version must be built and **manually promoted** before the noisy counts stop. The API half (de-saturation) takes effect on the next nightly reliability recompute after deploy; historical noisy counts will keep depressing scores until agents are upgraded and the 30/90-day windows roll forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)