### PR TITLE
test(web): cover org-scope toggle on DeviceStatusChart + MonitoringIntegration

### DIFF
--- a/apps/web/src/components/dashboard/DeviceStatusChart.test.tsx
+++ b/apps/web/src/components/dashboard/DeviceStatusChart.test.tsx
@@ -1,0 +1,83 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceStatusChart from './DeviceStatusChart';
+import { fetchWithAuth } from '../../stores/auth';
+
+// The global Current/All-orgs pill is modeled by currentOrgId: a concrete id
+// means "this org", and null means the explicit All-orgs scope (see orgStore).
+let mockOrgState: { currentOrgId: string | null };
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../stores/orgStore', () => ({
+  // Selector-aware mock: the component calls useOrgStore((s) => s.currentOrgId).
+  useOrgStore: Object.assign(
+    (selector?: (s: typeof mockOrgState) => unknown) =>
+      selector ? selector(mockOrgState) : mockOrgState,
+    { getState: () => mockOrgState },
+  ),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const devicesResponse = (): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      devices: [
+        { id: 'd1', name: 'alpha', status: 'online' },
+        { id: 'd2', name: 'bravo', status: 'offline' },
+      ],
+    }),
+  }) as unknown as Response;
+
+beforeEach(() => {
+  mockOrgState = { currentOrgId: 'org-1' };
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue(devicesResponse());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeviceStatusChart — honors the global org-scope toggle', () => {
+  it('refetches /devices when the scope flips Current -> All orgs', async () => {
+    const { rerender } = render(<DeviceStatusChart />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+    expect(fetchWithAuthMock).toHaveBeenLastCalledWith('/devices');
+
+    // Flipping the top-bar pill to All orgs clears currentOrgId to null. The
+    // fetch effect depends on currentOrgId, so it must refire — guarding the
+    // regression where the widget kept showing the previously-scoped fleet.
+    mockOrgState.currentOrgId = null;
+    rerender(<DeviceStatusChart />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('refetches when the selected org changes within Current scope', async () => {
+    const { rerender } = render(<DeviceStatusChart />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    mockOrgState.currentOrgId = 'org-2';
+    rerender(<DeviceStatusChart />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not refetch on an unrelated re-render (deps unchanged)', async () => {
+    const { rerender } = render(<DeviceStatusChart />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    rerender(<DeviceStatusChart />);
+    // Give any erroneous effect a chance to fire before asserting stability.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/integrations/MonitoringIntegration.test.tsx
+++ b/apps/web/src/components/integrations/MonitoringIntegration.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MonitoringIntegration from './MonitoringIntegration';
+import { fetchWithAuth } from '../../stores/auth';
+
+// All-orgs scope is modeled by currentOrgId === null (see orgStore): monitoring
+// settings are per-org, so there is no single org to load under All orgs.
+let mockOrgState: { currentOrgId: string | null };
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: Object.assign(
+    (selector?: (s: typeof mockOrgState) => unknown) =>
+      selector ? selector(mockOrgState) : mockOrgState,
+    { getState: () => mockOrgState },
+  ),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const monitoringResponse = (): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+  }) as unknown as Response;
+
+beforeEach(() => {
+  mockOrgState = { currentOrgId: 'org-1' };
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue(monitoringResponse());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MonitoringIntegration — per-org page under All-orgs scope', () => {
+  it('shows the switch-to-a-single-org prompt and fires no doomed request under All orgs', async () => {
+    mockOrgState.currentOrgId = null;
+    render(<MonitoringIntegration />);
+
+    expect(
+      screen.getByText(/configured per organization/i),
+    ).toBeInTheDocument();
+
+    // The whole point of the skip-and-prompt shape: never call the API that
+    // would 400 without a single org in context.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('loads settings normally when scoped to a single org', async () => {
+    mockOrgState.currentOrgId = 'org-1';
+    render(<MonitoringIntegration />);
+
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/integrations/monitoring'),
+    );
+    expect(
+      screen.queryByText(/configured per organization/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('starts fetching after flipping back from All orgs to a single org', async () => {
+    mockOrgState.currentOrgId = null;
+    const { rerender } = render(<MonitoringIntegration />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+
+    mockOrgState.currentOrgId = 'org-1';
+    rerender(<MonitoringIntegration />);
+
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith('/integrations/monitoring'),
+    );
+  });
+});


### PR DESCRIPTION
**What & why.** PR #1064 fixed `DeviceStatusChart` and `MonitoringIntegration` to honor the global org-scope pill, but merged without tests. This adds the missing regression coverage. No production code changes — test-only.

**Modeled against the real store contract.** The All-orgs scope is `currentOrgId === null` (see `apps/web/src/stores/orgStore.ts:36` — "currentOrgId is null on purpose"); there is no `orgScope` enum. The tests drive that real shape rather than a fabricated field.

**Coverage added:**
- `DeviceStatusChart.test.tsx` — refetches `/devices` when `currentOrgId` changes (Current→All-orgs and org→org), and does **not** refetch on unrelated re-renders. Guards the `[retryCount, currentOrgId]` effect dep (`DeviceStatusChart.tsx:61`).
- `MonitoringIntegration.test.tsx` — under All orgs shows the per-org prompt and fires **no** request (the doomed-call guard at `MonitoringIntegration.tsx:251`), and loads settings once a single org is selected.

**Verification.** Both files pass locally (6/6) against `main`'s component versions via `vitest run`.

Refs #1064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)