### PR TITLE
fix(compose): map CLIENT_AI_ENTRA_CLIENT_ID into api service (#1972)

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -114,6 +114,11 @@ services:
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Breeze AI for Office (Excel add-in). Entra app-registration client ID that
+      # gates the /client-ai exchange + admin surface. Empty/unmapped = surface
+      # stays dark (env.ts defaults to ''). Threaded through compose so the feature
+      # can be enabled from .env. Same gap class as IS_HOSTED above.
+      CLIENT_AI_ENTRA_CLIENT_ID: ${CLIENT_AI_ENTRA_CLIENT_ID:-}
       APP_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BREEZE_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BINARY_SOURCE: github

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -48,6 +48,11 @@ services:
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER}
       MFA_RECOVERY_CODE_PEPPER: ${MFA_RECOVERY_CODE_PEPPER}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Breeze AI for Office (Excel add-in) — Entra app-registration client ID that
+      # gates the /client-ai surface. Set in .env to unblock local Tier-A testing;
+      # empty = surface stays dark. (Merges with the base mapping; declared here for
+      # discoverability since dev is where this is exercised.)
+      CLIENT_AI_ENTRA_CLIENT_ID: ${CLIENT_AI_ENTRA_CLIENT_ID:-}
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-true}
       AUTH_COOKIE_SAME_SITE: ${AUTH_COOKIE_SAME_SITE:-Lax}
       PORTAL_COOKIE_SAME_SITE: ${PORTAL_COOKIE_SAME_SITE:-Lax}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,12 @@ services:
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Breeze AI for Office (Excel add-in). Entra app-registration client ID that
+      # gates the /client-ai exchange + admin surface. Empty/unmapped = surface
+      # stays dark (env.ts defaults to ''), so this must be threaded through compose
+      # for self-host/droplet deploys to enable it. Same compose-interpolation gap
+      # class as IS_HOSTED / RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS.
+      CLIENT_AI_ENTRA_CLIENT_ID: ${CLIENT_AI_ENTRA_CLIENT_ID:-}
       APP_VERSION: ${BREEZE_VERSION:-dev}
       BREEZE_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BINARY_SOURCE: ${BINARY_SOURCE:-github}


### PR DESCRIPTION
## Summary

The API reads `CLIENT_AI_ENTRA_CLIENT_ID` (`apps/api/src/config/env.ts:24`) to gate the Breeze AI-for-Office `/client-ai` exchange + admin surface. The var was **not mapped** in the `api` service `environment:` block of any tracked compose file, so — per the compose-interpolation rule in CLAUDE.md — setting it in `.env` had no effect on the running container. The surface defaults to dark (`env.ts` falls back to `''`), making this config-disabling rather than a boot failure, so it was easy to miss.

## Fix

Map `CLIENT_AI_ENTRA_CLIENT_ID: ${CLIENT_AI_ENTRA_CLIENT_ID:-}` in the `api` `environment:` block of:

- `docker-compose.yml` (base — carries through to all three override modes)
- `deploy/docker-compose.prod.yml`
- `docker-compose.override.yml.dev` — declared explicitly for discoverability (dev is where local Tier-A verification surfaced the gap; it otherwise merges from base)

The `ghcr` / `local-build` overrides inherit the base mapping and need no change.

Same compose-interpolation gap class as `IS_HOSTED` / `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` documented in CLAUDE.md.

## Verification

- All three edited files parse as valid YAML and resolve `CLIENT_AI_ENTRA_CLIENT_ID` into `services.api.environment`.

## Ops follow-up (manual, not in this PR)

The deployed droplet `/opt/breeze/docker-compose.yml` is hand-maintained and drifts from the repo; it must have the same line added so EU/US deploys can enable the surface.

Closes #1972

🤖 Generated with [Claude Code](https://claude.com/claude-code)