### PR TITLE
fix(web): tooltip on disabled Record payment button (#1975)

### DIFF
--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -83,9 +83,13 @@ describe('InvoiceDetail', () => {
     // Submit disabled until an amount is entered, with a tooltip explaining why (#1975).
     expect(screen.getByTestId('invoice-payment-submit')).toBeDisabled();
     expect(screen.getByTestId('invoice-payment-submit')).toHaveAttribute('title', 'Enter a payment amount to record it');
+    // Reason is also exposed to assistive tech via aria-describedby (#1975).
+    expect(screen.getByTestId('invoice-payment-submit')).toHaveAttribute('aria-describedby', 'invoice-payment-submit-hint');
+    expect(document.getElementById('invoice-payment-submit-hint')).toHaveTextContent('Enter a payment amount to record it');
     fireEvent.change(screen.getByTestId('invoice-payment-amount'), { target: { value: '50' } });
-    // Tooltip clears once an amount is present.
+    // Tooltip and aria-describedby clear once an amount is present.
     expect(screen.getByTestId('invoice-payment-submit')).not.toHaveAttribute('title');
+    expect(screen.getByTestId('invoice-payment-submit')).not.toHaveAttribute('aria-describedby');
     fireEvent.change(screen.getByTestId('invoice-payment-method'), { target: { value: 'check' } });
     fireEvent.click(screen.getByTestId('invoice-payment-submit'));
 

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -80,9 +80,12 @@ describe('InvoiceDetail', () => {
     render(<InvoiceDetail detail={issued} onChanged={onChanged} />);
     await waitFor(() => expect(screen.getByTestId('invoice-payment-form')).toBeInTheDocument());
 
-    // Submit disabled until an amount is entered.
+    // Submit disabled until an amount is entered, with a tooltip explaining why (#1975).
     expect(screen.getByTestId('invoice-payment-submit')).toBeDisabled();
+    expect(screen.getByTestId('invoice-payment-submit')).toHaveAttribute('title', 'Enter a payment amount to record it');
     fireEvent.change(screen.getByTestId('invoice-payment-amount'), { target: { value: '50' } });
+    // Tooltip clears once an amount is present.
+    expect(screen.getByTestId('invoice-payment-submit')).not.toHaveAttribute('title');
     fireEvent.change(screen.getByTestId('invoice-payment-method'), { target: { value: 'check' } });
     fireEvent.click(screen.getByTestId('invoice-payment-submit'));
 

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -463,11 +463,15 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                 <button
                   type="button" onClick={() => void recordPayment()} disabled={busy || !payAmount}
                   title={!payAmount ? 'Enter a payment amount to record it' : undefined}
+                  aria-describedby={!payAmount ? 'invoice-payment-submit-hint' : undefined}
                   data-testid="invoice-payment-submit"
                   className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
                   Record payment
                 </button>
+                <span id="invoice-payment-submit-hint" className="sr-only">
+                  Enter a payment amount to record it
+                </span>
               </div>
             )}
           </div>

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -462,6 +462,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                 </div>
                 <button
                   type="button" onClick={() => void recordPayment()} disabled={busy || !payAmount}
+                  title={!payAmount ? 'Enter a payment amount to record it' : undefined}
                   data-testid="invoice-payment-submit"
                   className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >


### PR DESCRIPTION
## Summary

On an issued invoice, the **Record payment** button (`InvoiceDetail.tsx`) was disabled with no `title`, so the user couldn't tell *why* it was inert — it read as a dead control.

The button's disabled gate is `busy || !payAmount`. The user-relevant blocking condition is the empty amount field. This adds a conditional `title` that surfaces the reason and clears once an amount is entered:

```tsx
title={!payAmount ? 'Enter a payment amount to record it' : undefined}
```

Tightly scoped to the tooltip — no behavior change to the gating logic itself.

## Testing

- Extended `InvoiceDetail.test.tsx` "records a payment via the form" to assert the tooltip is present while disabled and absent once an amount is entered.
- `vitest run src/components/billing/InvoiceDetail.test.tsx` — 6 passed.
- `tsc --noEmit` (apps/web) — clean.

Closes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)