### PR TITLE
fix(web): migrate Patches page tab state to #hash (#1977)

### DIFF
--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -378,6 +378,32 @@ describe('PatchesPage', () => {
     expect(window.location.search).toBe('');
   });
 
+  it('falls back to the Compliance tab when the URL hash is not a valid tab', async () => {
+    // A malformed / unknown hash (stale bookmark, hand-edited URL) must resolve
+    // to the default Compliance tab rather than rendering a blank/none tab.
+    jwtScope.scope = 'partner';
+    orgState.currentOrgId = 'org-1';
+    window.history.replaceState({}, '', '/#bogus');
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/update-rings') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
+      if (url === '/patches/compliance') return makeJsonResponse({ data: { totalDevices: 0, compliantDevices: 0, devicesNeedingPatches: [] } });
+      if (url === '/devices?limit=200') return makeJsonResponse({ devices: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    // The Compliance tab content (PatchComplianceView fetches /patches/compliance) renders.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/patches/compliance');
+    });
+    // The Compliance nav tab carries the active styling (it is the first match).
+    const [complianceTab] = screen.getAllByRole('button', { name: /Compliance/i });
+    expect(complianceTab).toHaveClass('border-primary');
+  });
+
   it('org scope: hides the Update Rings tab and disables New Ring with partner-level hint', async () => {
     // Org-scoped users don't manage rings — they should not see the tab at all.
     jwtScope.scope = 'organization';

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // PatchList renders through ResponsiveTable — a desktop <table> and a mobile
@@ -450,6 +450,93 @@ describe('PatchesPage', () => {
 
     // Rings-only body content must NOT be rendered.
     expect(screen.queryByRole('button', { name: /New Ring/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Update Rings/i })).toBeNull();
+  });
+
+  // Standard empty-data fetch mock shared by the hash-sync tests below.
+  const emptyDataFetch = async (input: unknown): Promise<Response> => {
+    const url = String(input);
+    if (url === '/update-rings') return makeJsonResponse({ data: [] });
+    if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
+    if (url === '/patches/compliance') {
+      return makeJsonResponse({ data: { totalDevices: 0, compliantDevices: 0, devicesNeedingPatches: [] } });
+    }
+    if (url === '/devices?limit=200') return makeJsonResponse({ devices: [] });
+    return makeJsonResponse({}, false, 404);
+  };
+
+  // The tab nav buttons are the only buttons carrying the `border-b-2` class; this
+  // disambiguates them from any same-named buttons rendered by the tab bodies
+  // (e.g. PatchComplianceView also surfaces "Compliance" text).
+  const navTab = (name: string) =>
+    screen.getAllByRole('button', { name }).find(b => b.className.includes('border-b-2'))!;
+
+  it('syncs the active tab on hashchange (browser back/forward, manual hash edits)', async () => {
+    // Mirrors DiscoveryPage: a hashchange (back/forward navigation or a manual
+    // URL edit) must re-select the active tab, not just the initial mount read.
+    jwtScope.scope = 'partner';
+    orgState.currentOrgId = 'org-1';
+    window.history.replaceState({}, '', '/#compliance');
+    fetchMock.mockImplementation(emptyDataFetch);
+
+    render(<PatchesPage />);
+
+    // Starts on Compliance.
+    await waitFor(() => expect(navTab('Compliance')).toHaveClass('border-primary'));
+
+    // Forward-nav to #patches re-selects the Patches tab.
+    act(() => {
+      window.location.hash = '#patches';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    await waitFor(() => expect(navTab('Patches')).toHaveClass('border-primary'));
+    expect(navTab('Compliance')).not.toHaveClass('border-primary');
+
+    // Back-nav to the default (empty hash) restores Compliance.
+    act(() => {
+      window.location.hash = '';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    await waitFor(() => expect(navTab('Compliance')).toHaveClass('border-primary'));
+    expect(navTab('Patches')).not.toHaveClass('border-primary');
+  });
+
+  it('clears the stale #rings hash when an org user is downgraded to Compliance at init', async () => {
+    // An org user landing on /patches#rings (stale bookmark / shared partner link)
+    // falls back to Compliance — and the URL must not keep #rings while Compliance
+    // is shown.
+    jwtScope.scope = 'organization';
+    orgState.currentOrgId = 'org-1';
+    window.history.replaceState({}, '', '/#rings');
+    fetchMock.mockImplementation(emptyDataFetch);
+
+    render(<PatchesPage />);
+
+    await screen.findByRole('button', { name: /Compliance/i });
+    // Stale hash wiped from the URL.
+    await waitFor(() => expect(window.location.hash).toBe(''));
+    // Rings-only chrome/body never rendered.
+    expect(screen.queryByRole('button', { name: /Update Rings/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /New Ring/i })).toBeNull();
+  });
+
+  it('re-applies the org-scope guard on hashchange and clears the hash (back/forward to #rings)', async () => {
+    // Post-mount navigation to a #rings history entry the org user can't access
+    // must re-downgrade to Compliance and clear the stale hash, not just on mount.
+    jwtScope.scope = 'organization';
+    orgState.currentOrgId = 'org-1';
+    window.history.replaceState({}, '', '/#compliance');
+    fetchMock.mockImplementation(emptyDataFetch);
+
+    render(<PatchesPage />);
+    await screen.findByRole('button', { name: /Compliance/i });
+
+    act(() => {
+      window.location.hash = '#rings';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    await waitFor(() => expect(window.location.hash).toBe(''));
     expect(screen.queryByRole('button', { name: /Update Rings/i })).toBeNull();
   });
 

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -57,7 +57,7 @@ describe('PatchesPage', () => {
     vi.clearAllMocks();
     orgState.currentOrgId = null;
     jwtScope.scope = 'partner';
-    window.history.replaceState({}, '', '/?tab=patches');
+    window.history.replaceState({}, '', '/#patches');
   });
 
   it('keeps failed bulk approvals pending when the API only approves some patches', async () => {
@@ -286,7 +286,7 @@ describe('PatchesPage', () => {
 
   it('Deploy on an approved patch routes to the Compliance tab with feedback (no dead click)', async () => {
     orgState.currentOrgId = 'org-1';
-    window.history.replaceState({}, '', '/?tab=patches');
+    window.history.replaceState({}, '', '/#patches');
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
@@ -331,7 +331,7 @@ describe('PatchesPage', () => {
     // should see the tab and be able to open the create form.
     jwtScope.scope = 'partner';
     orgState.currentOrgId = null;
-    window.history.replaceState({}, '', '/?tab=rings');
+    window.history.replaceState({}, '', '/#rings');
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
@@ -350,11 +350,39 @@ describe('PatchesPage', () => {
     expect(newRing).not.toHaveAttribute('title');
   });
 
+  it('persists the selected tab in the URL hash (#hash convention, not ?tab=)', async () => {
+    // Tab state must live in window.location.hash per the project convention,
+    // and the default `compliance` tab keeps the hash empty so the URL stays clean.
+    jwtScope.scope = 'partner';
+    orgState.currentOrgId = 'org-1';
+    window.history.replaceState({}, '', '/#compliance');
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/update-rings') return makeJsonResponse({ data: [] });
+      if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
+      if (url === '/patches/compliance') return makeJsonResponse({ data: { totalDevices: 0, compliantDevices: 0, devicesNeedingPatches: [] } });
+      if (url === '/devices?limit=200') return makeJsonResponse({ devices: [] });
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchesPage />);
+
+    // Switching to Patches writes #patches to the hash (and never a ?tab= query param).
+    fireEvent.click(await screen.findByRole('button', { name: /Patches/i }));
+    await waitFor(() => expect(window.location.hash).toBe('#patches'));
+    expect(window.location.search).toBe('');
+
+    // Returning to the default Compliance tab clears the hash entirely.
+    fireEvent.click(screen.getByRole('button', { name: /Compliance/i }));
+    await waitFor(() => expect(window.location.hash).toBe(''));
+    expect(window.location.search).toBe('');
+  });
+
   it('org scope: hides the Update Rings tab and disables New Ring with partner-level hint', async () => {
     // Org-scoped users don't manage rings — they should not see the tab at all.
     jwtScope.scope = 'organization';
     orgState.currentOrgId = 'org-1';
-    window.history.replaceState({}, '', '/?tab=compliance');
+    window.history.replaceState({}, '', '/#compliance');
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
@@ -373,13 +401,13 @@ describe('PatchesPage', () => {
     expect(screen.queryByRole('button', { name: /Update Rings/i })).toBeNull();
   });
 
-  it('org scope: falls back to compliance when URL contains ?tab=rings (bookmark guard)', async () => {
-    // If an org user navigates to /patches?tab=rings (e.g. a stale bookmark or
+  it('org scope: falls back to compliance when URL contains #rings (bookmark guard)', async () => {
+    // If an org user navigates to /patches#rings (e.g. a stale bookmark or
     // shared link from a partner), the initializer guard must redirect to compliance
     // so rings body content (UpdateRingList / New Ring button) is never rendered.
     jwtScope.scope = 'organization';
     orgState.currentOrgId = 'org-1';
-    window.history.replaceState({}, '', '/?tab=rings');
+    window.history.replaceState({}, '', '/#rings');
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);
       if (url === '/update-rings') return makeJsonResponse({ data: [] });
@@ -401,7 +429,7 @@ describe('PatchesPage', () => {
 
   it('enables New Ring when a specific org is selected and creates the ring (orgId auto-injected) with a success toast', async () => {
     orgState.currentOrgId = 'org-1';
-    window.history.replaceState({}, '', '/?tab=rings');
+    window.history.replaceState({}, '', '/#rings');
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       if (url === '/update-rings' && (!init || init.method === undefined)) {
@@ -439,7 +467,7 @@ describe('PatchesPage', () => {
 
   it('surfaces a failure toast (and keeps the dialog open) when create-ring fails', async () => {
     orgState.currentOrgId = 'org-1';
-    window.history.replaceState({}, '', '/?tab=rings');
+    window.history.replaceState({}, '', '/#rings');
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       if (url === '/update-rings' && (!init || init.method === undefined)) {

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -64,8 +64,11 @@ export default function PatchesPage() {
     setTabInHash(tab);
   }, []);
 
-  // Guard against hash changes after mount that could re-introduce rings
-  // for an org-scoped user (e.g. back-navigation replaying the URL).
+  // Defense-in-depth: if activeTab ever resolves to rings while the user can't
+  // manage rings (e.g. scope/permissions become known after the initial render),
+  // downgrade to compliance so the rings body is never shown without access. The
+  // hash is read only on mount (no hashchange listener), so this re-check is for
+  // permission state arriving late, not for post-mount URL edits.
   useEffect(() => {
     if (activeTab === 'rings' && !canManageRings) {
       setActiveTab('compliance');

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -26,21 +26,20 @@ import { runAction, ActionError } from '@/lib/runAction';
 type TabKey = 'rings' | 'patches' | 'compliance';
 const validTabs: TabKey[] = ['rings', 'patches', 'compliance'];
 
-function getTabFromUrl(): TabKey {
+// Tab state lives in window.location.hash (`#patches`) per the project
+// convention for transient UI state (CLAUDE.md), matching DiscoveryPage and
+// DeviceDetails. The default `compliance` tab keeps the hash empty so the URL
+// stays clean.
+function getTabFromHash(): TabKey {
   if (typeof window === 'undefined') return 'compliance';
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get('tab');
-  return tab && validTabs.includes(tab as TabKey) ? (tab as TabKey) : 'compliance';
+  const hash = window.location.hash.replace(/^#/, '');
+  return validTabs.includes(hash as TabKey) ? (hash as TabKey) : 'compliance';
 }
 
-function setTabInUrl(tab: TabKey) {
+function setTabInHash(tab: TabKey) {
   if (typeof window === 'undefined') return;
   const url = new URL(window.location.href);
-  if (tab === 'compliance') {
-    url.searchParams.delete('tab');
-  } else {
-    url.searchParams.set('tab', tab);
-  }
+  url.hash = tab === 'compliance' ? '' : tab;
   window.history.replaceState({}, '', url.toString());
 }
 
@@ -54,18 +53,18 @@ export default function PatchesPage() {
   const canManageRings = scope === 'partner' || scope === 'system';
   const RING_SCOPE_HINT = 'Update rings are managed at the partner level';
 
-  // If an org user lands with ?tab=rings (e.g. a bookmark), fall back to compliance
+  // If an org user lands with #rings (e.g. a bookmark), fall back to compliance
   // so the rings body is never rendered without navigation access.
   const [activeTab, setActiveTabState] = useState<TabKey>(() => {
-    const tab = getTabFromUrl();
+    const tab = getTabFromHash();
     return tab === 'rings' && !canManageRings ? 'compliance' : tab;
   });
   const setActiveTab = useCallback((tab: TabKey) => {
     setActiveTabState(tab);
-    setTabInUrl(tab);
+    setTabInHash(tab);
   }, []);
 
-  // Guard against hash/search changes after mount that could re-introduce rings
+  // Guard against hash changes after mount that could re-introduce rings
   // for an org-scoped user (e.g. back-navigation replaying the URL).
   useEffect(() => {
     if (activeTab === 'rings' && !canManageRings) {

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -43,6 +43,13 @@ function setTabInHash(tab: TabKey) {
   window.history.replaceState({}, '', url.toString());
 }
 
+// Resolve a hash-derived tab against the user's access. Rings are partner-scoped:
+// an org user landing on #rings (a stale bookmark, a hand-edited URL, or browser
+// back/forward) can't see the rings body, so fall back to compliance.
+function resolveTab(tab: TabKey, canManageRings: boolean): TabKey {
+  return tab === 'rings' && !canManageRings ? 'compliance' : tab;
+}
+
 const DEVICE_SCAN_PAGE_LIMIT = 100;
 
 export default function PatchesPage() {
@@ -53,27 +60,39 @@ export default function PatchesPage() {
   const canManageRings = scope === 'partner' || scope === 'system';
   const RING_SCOPE_HINT = 'Update rings are managed at the partner level';
 
-  // If an org user lands with #rings (e.g. a bookmark), fall back to compliance
-  // so the rings body is never rendered without navigation access.
-  const [activeTab, setActiveTabState] = useState<TabKey>(() => {
-    const tab = getTabFromHash();
-    return tab === 'rings' && !canManageRings ? 'compliance' : tab;
-  });
+  // Seed from the hash, applying the org-scope guard: an org user landing on
+  // #rings (e.g. a bookmark) falls back to compliance so the rings body is never
+  // rendered without navigation access.
+  const [activeTab, setActiveTabState] = useState<TabKey>(() =>
+    resolveTab(getTabFromHash(), canManageRings)
+  );
   const setActiveTab = useCallback((tab: TabKey) => {
     setActiveTabState(tab);
     setTabInHash(tab);
   }, []);
 
-  // Defense-in-depth: if activeTab ever resolves to rings while the user can't
-  // manage rings (e.g. scope/permissions become known after the initial render),
-  // downgrade to compliance so the rings body is never shown without access. The
-  // hash is read only on mount (no hashchange listener), so this re-check is for
-  // permission state arriving late, not for post-mount URL edits.
+  // Sync the active tab from the hash on mount and on every hashchange — browser
+  // back/forward and manual hash edits re-select the tab, mirroring DiscoveryPage.
+  // The org-scope guard is re-applied on each sync (resolveTab): a #rings hash an
+  // org user can't access falls back to compliance, and when that downgrade fires
+  // we route through setActiveTab so the stale #rings is cleared from the URL
+  // rather than left pointing at a tab the user isn't on. Depending on
+  // canManageRings also re-runs the guard when scope/permissions arrive after the
+  // first render (defense-in-depth).
   useEffect(() => {
-    if (activeTab === 'rings' && !canManageRings) {
-      setActiveTab('compliance');
-    }
-  }, [activeTab, canManageRings, setActiveTab]);
+    const syncFromHash = () => {
+      const raw = getTabFromHash();
+      const resolved = resolveTab(raw, canManageRings);
+      if (resolved !== raw) {
+        setActiveTab(resolved); // downgrade — also clears the stale hash
+      } else {
+        setActiveTabState(resolved);
+      }
+    };
+    syncFromHash();
+    window.addEventListener('hashchange', syncFromHash);
+    return () => window.removeEventListener('hashchange', syncFromHash);
+  }, [canManageRings, setActiveTab]);
   const [selectedRingId, setSelectedRingId] = useState<string | null>(null);
   const [selectedPatch, setSelectedPatch] = useState<Patch | null>(null);
   const [modalOpen, setModalOpen] = useState(false);


### PR DESCRIPTION
## Summary

The Patches page stored its selected tab in a `?tab=` **query param**, contradicting the project convention (CLAUDE.md) that transient UI tab state must live in `window.location.hash` (`#value`). Discovery (`DiscoveryPage.tsx`) and device-detail already use `#hash`.

This migrates `PatchesPage.tsx` tab state to `#hash`, matching the canonical `DiscoveryPage` pattern.

## Changes

- `getTabFromUrl` → `getTabFromHash`: reads `window.location.hash` instead of `URLSearchParams(window.location.search)`.
- `setTabInUrl` → `setTabInHash`: writes `url.hash` via `history.replaceState` instead of `searchParams`.

## Deep-link behavior preserved

- Default `compliance` tab keeps the hash empty (clean URL), exactly as the old code deleted the `?tab=` param.
- Other tabs write `#patches` / `#rings`.
- The org-scope bookmark guard is retained: an org-scoped user landing on `#rings` (e.g. a partner's shared link) still falls back to `compliance` so the rings body never renders without access.

## Tests

- Existing `PatchesPage.test.tsx` initial-state setup migrated from `/?tab=…` to `/#…`.
- Added a test asserting the selected tab is persisted to `window.location.hash` (`#patches`) and the default tab clears the hash — and that `window.location.search` stays empty (never a `?tab=` query param).
- All 22 tests pass single-fork; `tsc --noEmit` clean.

Closes #1977

🤖 Generated with [Claude Code](https://claude.com/claude-code)