### PR TITLE
fix(web): gate /auth#signup on runtime registration flag (#1979)

### DIFF
--- a/apps/web/src/components/auth/AuthPage.test.tsx
+++ b/apps/web/src/components/auth/AuthPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the heavy children — this test only exercises tab-switch behavior.
+// Mock the heavy children — this test only exercises tab-switch / gating behavior.
 vi.mock('./LoginPage', () => ({
   default: ({ next }: { next?: string }) => (
     <div data-testid="mock-login" data-next={next ?? ''} />
@@ -13,12 +13,22 @@ vi.mock('./PartnerRegisterPage', () => ({
   ),
 }));
 
+// Control the runtime registration gate. Default to enabled+loaded so the
+// existing tab-behavior tests exercise the open-registration path; individual
+// tests below override it for the disabled / not-yet-loaded cases.
+const registrationGate = vi.hoisted(() => ({ enabled: true, loaded: true }));
+vi.mock('../../stores/featuresStore', () => ({
+  useRegistrationGate: () => registrationGate,
+}));
+
 import AuthPage from './AuthPage';
 
 describe('AuthPage', () => {
   beforeEach(() => {
     // Clean any leftover hash between tests
     window.location.hash = '';
+    registrationGate.enabled = true;
+    registrationGate.loaded = true;
   });
 
   afterEach(() => {
@@ -66,5 +76,47 @@ describe('AuthPage', () => {
   it('forwards an unsafe `next` unchanged — LoginPage/PartnerRegisterPage rewrite it before navigating', () => {
     render(<AuthPage next="https://evil.example.com" />);
     expect(screen.getByTestId('mock-login').getAttribute('data-next')).toBe('https://evil.example.com');
+  });
+
+  describe('registration disabled (#1979)', () => {
+    it('hides the Create account tab when registration is disabled', () => {
+      registrationGate.enabled = false;
+      registrationGate.loaded = true;
+      render(<AuthPage />);
+      expect(screen.queryByTestId('tab-signup')).toBeNull();
+      expect(screen.queryByTestId('tab-signin')).toBeNull();
+      // Sign-in view still renders without the tablist.
+      expect(screen.getByTestId('mock-login')).toBeTruthy();
+    });
+
+    it('shows a closed notice instead of the form for a direct /auth#signup link when disabled', () => {
+      registrationGate.enabled = false;
+      registrationGate.loaded = true;
+      window.location.hash = '#signup';
+      render(<AuthPage />);
+      expect(screen.getByTestId('registration-disabled-notice')).toBeTruthy();
+      // Critically: the registration form is NOT rendered.
+      expect(screen.queryByTestId('mock-register')).toBeNull();
+    });
+
+    it('lets the user return to sign in from the closed notice', () => {
+      registrationGate.enabled = false;
+      registrationGate.loaded = true;
+      window.location.hash = '#signup';
+      render(<AuthPage />);
+      fireEvent.click(screen.getByTestId('back-to-signin'));
+      expect(window.location.hash).toBe('#signin');
+      expect(screen.getByTestId('mock-login')).toBeTruthy();
+      expect(screen.queryByTestId('registration-disabled-notice')).toBeNull();
+    });
+
+    it('does not flash the form or the notice while the gate is still loading', () => {
+      registrationGate.enabled = false;
+      registrationGate.loaded = false;
+      window.location.hash = '#signup';
+      render(<AuthPage />);
+      expect(screen.queryByTestId('mock-register')).toBeNull();
+      expect(screen.queryByTestId('registration-disabled-notice')).toBeNull();
+    });
   });
 });

--- a/apps/web/src/components/auth/AuthPage.test.tsx
+++ b/apps/web/src/components/auth/AuthPage.test.tsx
@@ -44,11 +44,25 @@ describe('AuthPage', () => {
   });
 
   it('switches to signup when the Create account tab is clicked and updates the hash', () => {
-    render(<AuthPage />);
+    render(<AuthPage next="/oauth/consent?uid=abc" />);
     fireEvent.click(screen.getByTestId('tab-signup'));
     expect(window.location.hash).toBe('#signup');
-    expect(screen.getByTestId('mock-register')).toBeTruthy();
+    const register = screen.getByTestId('mock-register');
+    expect(register).toBeTruthy();
+    // `next` is forwarded to the registration form, not only the login form.
+    expect(register.getAttribute('data-next')).toBe('/oauth/consent?uid=abc');
     expect(screen.queryByTestId('mock-login')).toBeNull();
+  });
+
+  it('still renders the sign-in view while the gate is loading (default route, no hash)', () => {
+    // Every normal visitor lands here before /config resolves; the sign-in view
+    // must render immediately rather than leaving the page blank. The tablist
+    // stays hidden until registration is confirmed open.
+    registrationGate.enabled = false;
+    registrationGate.loaded = false;
+    render(<AuthPage />);
+    expect(screen.getByTestId('mock-login')).toBeTruthy();
+    expect(screen.queryByTestId('tab-signup')).toBeNull();
   });
 
   it('honors #signup hash present at mount', () => {

--- a/apps/web/src/components/auth/AuthPage.test.tsx
+++ b/apps/web/src/components/auth/AuthPage.test.tsx
@@ -113,6 +113,19 @@ describe('AuthPage', () => {
       expect(screen.queryByTestId('mock-register')).toBeNull();
     });
 
+    it('exposes the closed notice as a polite live region for screen readers', () => {
+      // A directly-shared /auth#signup link lands a screen-reader user on this
+      // notice; live-region semantics ensure the "registration closed" context
+      // is announced rather than silently swapped in.
+      registrationGate.enabled = false;
+      registrationGate.loaded = true;
+      window.location.hash = '#signup';
+      render(<AuthPage />);
+      const notice = screen.getByTestId('registration-disabled-notice');
+      expect(notice.getAttribute('role')).toBe('status');
+      expect(notice.getAttribute('aria-live')).toBe('polite');
+    });
+
     it('lets the user return to sign in from the closed notice', () => {
       registrationGate.enabled = false;
       registrationGate.loaded = true;

--- a/apps/web/src/components/auth/AuthPage.tsx
+++ b/apps/web/src/components/auth/AuthPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import LoginPage from './LoginPage';
 import PartnerRegisterPage from './PartnerRegisterPage';
+import { useRegistrationGate } from '../../stores/featuresStore';
 
 interface AuthPageProps {
   next?: string;
@@ -16,6 +17,13 @@ function getInitialTab(): Tab {
 export default function AuthPage({ next }: AuthPageProps) {
   const [tab, setTab] = useState<Tab>(getInitialTab);
 
+  // Runtime registration gate (#1308 / #1979). The server enforces
+  // ENABLE_REGISTRATION on /auth/register-partner; mirror it client-side so the
+  // signup tab/form is never offered (then dead-ended) when registration is
+  // disabled. The gate is read from runtime /config, the same source of truth
+  // PartnerRegisterPage and LoginForm consult — not a build-time PUBLIC_ flag.
+  const { enabled: registrationEnabled, loaded: gateLoaded } = useRegistrationGate();
+
   useEffect(() => {
     const onHashChange = () => {
       setTab(window.location.hash === '#signup' ? 'signup' : 'signin');
@@ -29,39 +37,72 @@ export default function AuthPage({ next }: AuthPageProps) {
     setTab(newTab);
   };
 
+  const wantsSignup = tab === 'signup';
+
   return (
     <div data-testid="auth-page">
-      <div className="mb-6 flex rounded-lg border bg-muted/40 p-1" role="tablist">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'signin'}
-          data-testid="tab-signin"
-          onClick={() => handleTabChange('signin')}
-          className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition ${
-            tab === 'signin' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          Sign in
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'signup'}
-          data-testid="tab-signup"
-          onClick={() => handleTabChange('signup')}
-          className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition ${
-            tab === 'signup' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          Create account
-        </button>
-      </div>
+      {/* Only offer the signup tab when self-service registration is open. A
+          login-only deployment shows just the sign-in view rather than a
+          "Create account" tab that dead-ends into a disabled form (#1979). */}
+      {registrationEnabled && (
+        <div className="mb-6 flex rounded-lg border bg-muted/40 p-1" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'signin'}
+            data-testid="tab-signin"
+            onClick={() => handleTabChange('signin')}
+            className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition ${
+              tab === 'signin' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'signup'}
+            data-testid="tab-signup"
+            onClick={() => handleTabChange('signup')}
+            className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition ${
+              tab === 'signup' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Create account
+          </button>
+        </div>
+      )}
 
-      {tab === 'signin' ? (
+      {!wantsSignup ? (
         <LoginPage next={next} />
-      ) : (
+      ) : registrationEnabled ? (
         <PartnerRegisterPage next={next} />
+      ) : gateLoaded ? (
+        // Hash points at #signup but registration is disabled. Show a closed
+        // notice instead of the form (which would otherwise mount and redirect
+        // off-page) so a directly-shared /auth#signup link isn't a dead end.
+        <div data-testid="registration-disabled-notice">
+          <div className="mb-8">
+            <p className="text-sm font-medium text-muted-foreground">Registration closed</p>
+            <h1 className="mt-1 text-2xl font-bold tracking-tight">Sign-ups are disabled</h1>
+          </div>
+          <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200">
+            New registrations are currently disabled. Please contact your administrator for an
+            invitation.
+          </div>
+          <button
+            type="button"
+            data-testid="back-to-signin"
+            onClick={() => handleTabChange('signin')}
+            className="font-medium text-primary hover:underline"
+          >
+            Back to sign in
+          </button>
+        </div>
+      ) : (
+        // Gate not resolved yet — render nothing rather than flashing the form
+        // or the closed notice before /config answers.
+        null
       )}
     </div>
   );

--- a/apps/web/src/components/auth/AuthPage.tsx
+++ b/apps/web/src/components/auth/AuthPage.tsx
@@ -81,7 +81,7 @@ export default function AuthPage({ next }: AuthPageProps) {
         // Hash points at #signup but registration is disabled. Show a closed
         // notice instead of the form (which would otherwise mount and redirect
         // off-page) so a directly-shared /auth#signup link isn't a dead end.
-        <div data-testid="registration-disabled-notice">
+        <div data-testid="registration-disabled-notice" role="status" aria-live="polite">
           <div className="mb-8">
             <p className="text-sm font-medium text-muted-foreground">Registration closed</p>
             <h1 className="mt-1 text-2xl font-bold tracking-tight">Sign-ups are disabled</h1>


### PR DESCRIPTION
## Problem

When `ENABLE_REGISTRATION` is off, `/auth#signup` still rendered the full signup tab and form — a dead-end UX. `AuthPage` always rendered both tabs and `PartnerRegisterPage` without consulting the registration gate; the form would mount and immediately redirect off-page (to `/login?reason=registration-disabled`), away from `/auth`. `PartnerRegisterPage` and `LoginForm` already gate on the runtime flag; `AuthPage` did not.

## Root cause

`apps/web/src/components/auth/AuthPage.tsx` rendered the tablist + `PartnerRegisterPage` unconditionally, never reading `useRegistrationGate()` (the runtime `GET /api/v1/config` `registration.enabled` value — the same source of truth the API enforces on `/auth/register-partner`, intentionally not a build-time `PUBLIC_` flag per #1308).

## Fix

Drive the signup tab/view from `useRegistrationGate()`:

- **Hide the "Create account" tab** when registration is disabled, so a login-only deployment shows just the sign-in view (no dead-end tab).
- **Direct `/auth#signup` link with registration disabled** → show a "registration closed" notice (with a *Back to sign in* action) instead of the form.
- **While the gate is still loading** → render nothing rather than flashing the form or the notice before `/config` answers (matches the existing default-closed pattern).

The sign-in path is unchanged. `PartnerRegisterPage` now only mounts when registration is enabled, so its standalone disabled-redirect branch no longer fires from within `AuthPage`.

## Tests

`apps/web/src/components/auth/AuthPage.test.tsx` — existing tab-behavior tests updated to mock the gate (open path); added coverage for: signup tab hidden when disabled, closed notice shown for `#signup` when disabled (form NOT rendered), return-to-sign-in from the notice, and no flash while the gate loads. All 10 AuthPage tests pass; full `src/components/auth/` suite green (27 passed); `tsc --noEmit` clean.

Closes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)