### PR TITLE
fix(web): suppress "add first site" nag when org already has a site (#1978)

### DIFF
--- a/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
@@ -34,7 +34,7 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
  * endpoint returns for the freshly created org, letting each test simulate an
  * org with or without a pre-existing (default) site.
  */
-function mockApi(sitesForNewOrg: unknown[]) {
+function mockApi(sitesForNewOrg: unknown[] | 'fail') {
   fetchMock.mockImplementation(async (input, init) => {
     const url = String(input);
     const method = init?.method;
@@ -49,6 +49,7 @@ function mockApi(sitesForNewOrg: unknown[]) {
       return makeJsonResponse({ settings: {} });
     }
     if (url.startsWith('/orgs/sites?organizationId=')) {
+      if (sitesForNewOrg === 'fail') return makeJsonResponse({ error: 'boom' }, false, 500);
       return makeJsonResponse({ data: sitesForNewOrg });
     }
     return makeJsonResponse({ data: [] });
@@ -87,16 +88,36 @@ describe('OrganizationsPage — first-site guidance', () => {
 
     await submitNewOrg();
 
-    // The org-create POST resolved and sites were fetched; give the guidance
-    // branch a chance to (not) fire.
+    // Wait for a post-decision signal: the fetched site rendering in the detail
+    // panel proves fetchSites resolved AND its setState flushed, so the gating
+    // branch has already run. Asserting on the bare fetch call would race the
+    // (broken) nag's setState and could pass even with the regression present.
+    // (SiteList renders the name in both desktop and mobile layouts.)
+    expect((await screen.findAllByText('Main Office')).length).toBeGreaterThan(0);
+
+    expect(screen.queryByText(/Add the first site for/i)).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the first-site nag when the sites fetch fails (fail closed)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockApi('fail');
+    render(<OrganizationsPage />);
+
+    await submitNewOrg();
+
+    // The sites fetch failed → fetchSites returns null and logs a warning. The
+    // warn firing is the post-decision signal: it happens inside the catch,
+    // immediately before fetchSites resolves null and the synchronous gating
+    // branch runs. A guess-and-nag failure mode would re-introduce #1978.
     await waitFor(() => {
-      expect(
-        fetchMock.mock.calls.some(([input]) =>
-          String(input).startsWith(`/orgs/sites?organizationId=${NEW_ORG_ID}`)
-        )
-      ).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[OrganizationsPage] failed to fetch sites for org',
+        NEW_ORG_ID,
+        expect.anything()
+      );
     });
 
     expect(screen.queryByText(/Add the first site for/i)).not.toBeInTheDocument();
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
@@ -34,7 +34,7 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
  * endpoint returns for the freshly created org, letting each test simulate an
  * org with or without a pre-existing (default) site.
  */
-function mockApi(sitesForNewOrg: unknown[] | 'fail') {
+function mockApi(sitesForNewOrg: unknown[] | 'fail' | 'malformed') {
   fetchMock.mockImplementation(async (input, init) => {
     const url = String(input);
     const method = init?.method;
@@ -50,6 +50,8 @@ function mockApi(sitesForNewOrg: unknown[] | 'fail') {
     }
     if (url.startsWith('/orgs/sites?organizationId=')) {
       if (sitesForNewOrg === 'fail') return makeJsonResponse({ error: 'boom' }, false, 500);
+      // 200 OK but the body is not a parseable array of sites.
+      if (sitesForNewOrg === 'malformed') return makeJsonResponse({ data: null });
       return makeJsonResponse({ data: sitesForNewOrg });
     }
     return makeJsonResponse({ data: [] });
@@ -112,6 +114,30 @@ describe('OrganizationsPage — first-site guidance', () => {
     await waitFor(() => {
       expect(warnSpy).toHaveBeenCalledWith(
         '[OrganizationsPage] failed to fetch sites for org',
+        NEW_ORG_ID,
+        expect.anything()
+      );
+    });
+
+    expect(screen.queryByText(/Add the first site for/i)).not.toBeInTheDocument();
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT show the first-site nag on a malformed 200 sites body (fail closed)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 200 OK whose body is { data: null } — not a parseable array. This used to
+    // fall through to [] and wrongly fire the nag (#1978); it must now fail closed.
+    mockApi('malformed');
+    render(<OrganizationsPage />);
+
+    await submitNewOrg();
+
+    // The malformed-body warning is the post-decision signal: it fires inside
+    // fetchSites immediately before it resolves null and the synchronous gating
+    // branch runs, so once we see it the nag decision has been made.
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[OrganizationsPage] sites response was ok but not a parseable array for org',
         NEW_ORG_ID,
         expect.anything()
       );

--- a/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+// useOrgStore.getState().fetchOrganizations() is called during refreshOrgs.
+const storeFetchOrganizations = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ fetchOrganizations: storeFetchOrganizations }) }
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const NEW_ORG_ID = '11111111-2222-4333-8444-555566667777';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+/**
+ * Drive the create-organization flow. `sitesForNewOrg` is what the sites
+ * endpoint returns for the freshly created org, letting each test simulate an
+ * org with or without a pre-existing (default) site.
+ */
+function mockApi(sitesForNewOrg: unknown[]) {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method;
+
+    if (url === '/orgs/organizations' && method === 'POST') {
+      return makeJsonResponse({ id: NEW_ORG_ID });
+    }
+    if (url === '/orgs/organizations' && !method) {
+      return makeJsonResponse({ data: [] });
+    }
+    if (url === '/orgs/partners/me') {
+      return makeJsonResponse({ settings: {} });
+    }
+    if (url.startsWith('/orgs/sites?organizationId=')) {
+      return makeJsonResponse({ data: sitesForNewOrg });
+    }
+    return makeJsonResponse({ data: [] });
+  });
+}
+
+async function submitNewOrg() {
+  fireEvent.click(await screen.findByRole('button', { name: /add organization/i }));
+  const nameInput = await screen.findByLabelText(/organization name/i);
+  fireEvent.change(nameInput, { target: { value: 'Acme Corp' } });
+  fireEvent.click(screen.getByRole('button', { name: /create organization/i }));
+}
+
+describe('OrganizationsPage — first-site guidance', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    navigateTo.mockReset();
+    storeFetchOrganizations.mockClear();
+    window.location.hash = '';
+  });
+
+  it('shows the "Add the first site" nag when the new org has no sites', async () => {
+    mockApi([]);
+    render(<OrganizationsPage />);
+
+    await submitNewOrg();
+
+    expect(
+      await screen.findByText(`Add the first site for Acme Corp`)
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT show the first-site nag when the new org already has a default site', async () => {
+    mockApi([{ id: 'site-1', name: 'Main Office', orgId: NEW_ORG_ID }]);
+    render(<OrganizationsPage />);
+
+    await submitNewOrg();
+
+    // The org-create POST resolved and sites were fetched; give the guidance
+    // branch a chance to (not) fire.
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          String(input).startsWith(`/orgs/sites?organizationId=${NEW_ORG_ID}`)
+        )
+      ).toBe(true);
+    });
+
+    expect(screen.queryByText(/Add the first site for/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -111,18 +111,24 @@ export default function OrganizationsPage() {
     }
   }, [fetchOrganizations]);
 
-  const fetchSites = useCallback(async (orgId: string): Promise<Site[]> => {
+  // Returns the fetched site list, or null when the fetch failed. The null
+  // signal lets callers distinguish "confirmed zero sites" from "couldn't
+  // tell" — important for the first-site nudge, which must not fire on a guess
+  // (a transient failure on an org that DOES have sites would otherwise
+  // re-introduce the misleading nag of #1978).
+  const fetchSites = useCallback(async (orgId: string): Promise<Site[] | null> => {
     setSitesLoading(true);
     try {
       const response = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}`);
-      if (!response.ok) throw new Error('Failed to fetch sites');
+      if (!response.ok) throw new Error(`Failed to fetch sites (status ${response.status})`);
       const data = await response.json();
       const siteList = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];
       setSites(siteList);
       return siteList;
-    } catch {
+    } catch (err) {
       setSites([]);
-      return [];
+      console.warn('[OrganizationsPage] failed to fetch sites for org', orgId, err);
+      return null;
     } finally {
       setSitesLoading(false);
     }
@@ -270,10 +276,12 @@ export default function OrganizationsPage() {
       handleCloseModal();
 
       // Select the new org. Only nudge the user into the "add the first site"
-      // flow when the org genuinely has no sites — a default site may already
-      // exist (e.g. the partner's bootstrap org ships with one), in which case
-      // the first-site nag would be misleading. fetchSites also primes the
-      // sites list for the just-selected org.
+      // flow when we positively confirm the org has zero sites — a default site
+      // may already exist (e.g. the partner's bootstrap org ships with one), in
+      // which case the first-site nag would be misleading. We need the count
+      // synchronously to make this decision, so call fetchSites directly rather
+      // than rely on the selectedOrg effect's fire-and-forget refresh. On a
+      // fetch failure (null) we skip the nag rather than guess.
       if (createdOrg?.id) {
         const newOrg: Organization = {
           id: createdOrg.id,
@@ -286,7 +294,7 @@ export default function OrganizationsPage() {
         window.location.hash = createdOrg.id;
 
         const existingSites = await fetchSites(createdOrg.id);
-        if (existingSites.length === 0) {
+        if (existingSites?.length === 0) {
           setSelectedSite(null);
           setGuidingFirstSite(true);
           setSiteModalMode('add');

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -111,7 +111,7 @@ export default function OrganizationsPage() {
     }
   }, [fetchOrganizations]);
 
-  const fetchSites = useCallback(async (orgId: string) => {
+  const fetchSites = useCallback(async (orgId: string): Promise<Site[]> => {
     setSitesLoading(true);
     try {
       const response = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}`);
@@ -119,8 +119,10 @@ export default function OrganizationsPage() {
       const data = await response.json();
       const siteList = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];
       setSites(siteList);
+      return siteList;
     } catch {
       setSites([]);
+      return [];
     } finally {
       setSitesLoading(false);
     }
@@ -267,7 +269,11 @@ export default function OrganizationsPage() {
       await refreshOrgs();
       handleCloseModal();
 
-      // Guide the user straight into adding their first site for the new org.
+      // Select the new org. Only nudge the user into the "add the first site"
+      // flow when the org genuinely has no sites — a default site may already
+      // exist (e.g. the partner's bootstrap org ships with one), in which case
+      // the first-site nag would be misleading. fetchSites also primes the
+      // sites list for the just-selected org.
       if (createdOrg?.id) {
         const newOrg: Organization = {
           id: createdOrg.id,
@@ -278,9 +284,13 @@ export default function OrganizationsPage() {
         };
         setSelectedOrg(newOrg);
         window.location.hash = createdOrg.id;
-        setSelectedSite(null);
-        setGuidingFirstSite(true);
-        setSiteModalMode('add');
+
+        const existingSites = await fetchSites(createdOrg.id);
+        if (existingSites.length === 0) {
+          setSelectedSite(null);
+          setGuidingFirstSite(true);
+          setSiteModalMode('add');
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, type DragEvent } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type DragEvent } from 'react';
 import type { Organization } from './OrganizationList';
 import OrganizationForm from './OrganizationForm';
 import SiteList, { type Site } from './SiteList';
@@ -62,6 +62,10 @@ export default function OrganizationsPage() {
   // Partner's configured timezone, used to pre-select the timezone for new sites
   // instead of falling back to UTC. Undefined until loaded / if unavailable.
   const [partnerTimezone, setPartnerTimezone] = useState<string>();
+  // When org creation has already fetched sites synchronously for a freshly
+  // created org, record its id here so the selectedOrg effect skips the
+  // redundant duplicate GET it would otherwise fire (#1978 follow-up).
+  const skipSiteFetchForOrgId = useRef<string | null>(null);
 
   const filteredOrgs = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -111,18 +115,29 @@ export default function OrganizationsPage() {
     }
   }, [fetchOrganizations]);
 
-  // Returns the fetched site list, or null when the fetch failed. The null
-  // signal lets callers distinguish "confirmed zero sites" from "couldn't
-  // tell" — important for the first-site nudge, which must not fire on a guess
-  // (a transient failure on an org that DOES have sites would otherwise
-  // re-introduce the misleading nag of #1978).
+  // Returns the fetched site list, or null when we couldn't determine the real
+  // count. The null signal lets callers distinguish "confirmed zero sites" from
+  // "couldn't tell" — important for the first-site nudge, which must not fire on
+  // a guess (a transient failure, or an org that DOES have sites, would
+  // otherwise re-introduce the misleading nag of #1978). We fail closed (null)
+  // on BOTH a failed request AND a malformed HTTP-200 body (e.g. {}, {data:null},
+  // or any non-array payload): a 200 whose body isn't a parseable array of sites
+  // tells us nothing about the count, so it must not be read as "zero sites".
+  // Only a genuine empty array returns [] (legitimately zero → show the nag).
   const fetchSites = useCallback(async (orgId: string): Promise<Site[] | null> => {
     setSitesLoading(true);
     try {
       const response = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}`);
       if (!response.ok) throw new Error(`Failed to fetch sites (status ${response.status})`);
       const data = await response.json();
-      const siteList = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];
+      const siteList = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : null;
+      if (siteList === null) {
+        // 200 OK but the body isn't a parseable array of sites — fail closed so
+        // callers suppress the nag rather than treat this as confirmed zero.
+        setSites([]);
+        console.warn('[OrganizationsPage] sites response was ok but not a parseable array for org', orgId, data);
+        return null;
+      }
       setSites(siteList);
       return siteList;
     } catch (err) {
@@ -168,6 +183,12 @@ export default function OrganizationsPage() {
 
   useEffect(() => {
     if (selectedOrg) {
+      // Skip the fetch if org creation already fetched sites for this org
+      // synchronously — avoids a redundant concurrent GET per create.
+      if (skipSiteFetchForOrgId.current === selectedOrg.id) {
+        skipSiteFetchForOrgId.current = null;
+        return;
+      }
       fetchSites(selectedOrg.id);
     } else {
       setSites([]);
@@ -290,6 +311,9 @@ export default function OrganizationsPage() {
           deviceCount: 0,
           createdAt: new Date().toISOString()
         };
+        // We fetch sites synchronously just below, so tell the selectedOrg
+        // effect to skip the duplicate GET it would otherwise fire for this org.
+        skipSiteFetchForOrgId.current = createdOrg.id;
         setSelectedOrg(newOrg);
         window.location.hash = createdOrg.id;
 


### PR DESCRIPTION
## Summary

After creating an organization, `OrganizationsPage` unconditionally opened the guided **"Add the first site for &lt;org&gt;"** onboarding modal. When the org already has a site — e.g. a partner's bootstrap org that ships with a default "Main Office" site created in `partnerCreate.ts` — the first-site nag is misleading (the org is not actually site-less).

## Root cause

`apps/web/src/components/settings/OrganizationsPage.tsx` — `handleSubmit` set `guidingFirstSite = true` and opened the site-add modal **unconditionally** right after org creation, never checking whether the org had zero sites (issue evidence: line 282; nag copy at lines 728-730).

## Fix

- `fetchSites` now **returns** the fetched site list (in addition to setting state).
- After creating the org and selecting it, the create flow `await`s `fetchSites(newOrgId)` and only enters the guided first-site flow when `existingSites.length === 0`. Orgs that already have a site no longer get the nag.

## Tests

Adds `OrganizationsPage.firstSite.test.tsx`:
- zero sites → "Add the first site for &lt;org&gt;" modal **is** shown.
- pre-existing default site → nag is **suppressed**.

Verified the test fails against the pre-fix component (non-vacuous) and passes with the fix. `tsc --noEmit` clean for `apps/web`.

Closes #1978

🤖 Generated with [Claude Code](https://claude.com/claude-code)