### PR TITLE
test(web): pin #1976 — partner-settings save surfaces Zod field message

### DIFF
--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -80,6 +80,41 @@ describe('runPartnerSave', () => {
     expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
   });
 
+  // Regression for #1976: a partner-settings save that fails server-side Zod
+  // validation must surface the specific field message — not collapse into the
+  // generic "Failed to save settings" fallback. The save flows through runAction,
+  // which (via extractApiError) recovers issues from @hono/zod-validator's default
+  // 400 body. Under zod v4 the ZodError's `issues` are non-enumerable, so they are
+  // JSON-stringified into `error.message`; this mirrors that exact wire shape.
+  it('surfaces the specific Zod validation message (not the generic fallback) on a 400', async () => {
+    const zodValidatorBody = {
+      success: false,
+      error: {
+        name: 'ZodError',
+        message: JSON.stringify([
+          {
+            code: 'custom',
+            path: ['settings', 'remoteAccessProviders', 0, 'urlTemplate'],
+            message: 'Template must include the {id} placeholder for the per-device value',
+          },
+        ]),
+      },
+    };
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse(zodValidatorBody, false, 400));
+
+    await expect(runPartnerSave(PAYLOAD, { onUnauthorized: vi.fn() })).rejects.toThrow(
+      'Template must include the {id} placeholder for the per-device value'
+    );
+
+    expect(showToastMock).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'Template must include the {id} placeholder for the per-device value',
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Failed to save settings' })
+    );
+  });
+
   it('calls onUnauthorized and does not show a toast on 401', async () => {
     fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 401));
     const onUnauthorized = vi.fn();

--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -106,10 +106,12 @@ describe('runPartnerSave', () => {
       'Template must include the {id} placeholder for the per-device value'
     );
 
-    expect(showToastMock).toHaveBeenCalledWith({
-      type: 'error',
-      message: 'Template must include the {id} placeholder for the per-device value',
-    });
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: 'Template must include the {id} placeholder for the per-device value',
+      })
+    );
     expect(showToastMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Failed to save settings' })
     );


### PR DESCRIPTION
## Summary

#1976 reported that saving partner settings collapsed a detailed `ZodError`
into the generic **"Failed to save settings"** toast, hiding which field was
invalid (bad URL scheme vs missing `{id}` token, etc.).

**Root cause / current state:** the reported behavior no longer reproduces on
`main`. The issue was surfaced by the **2026-05-15** UI QA sweep, observing the
*pre-runAction* handler. One day later the WS-A action-feedback work (#740)
routed the save through `runAction`, and the zod-v4 upgrade (#1452) taught
`extractApiError` (`apps/web/src/lib/apiError.ts`) to recover issues from
`@hono/zod-validator`'s default 400 body — under zod v4 the `ZodError.issues`
are non-enumerable, so they are JSON-stringified into `error.message`, and
`extractApiError` parses them back out. The save handler
(`PartnerSettingsPage.tsx` `handleSave` → `runPartnerSave` → `runAction`) is the
only save path, so the specific field message is already shown in the toast.

I verified this with a throwaway repro feeding the exact zod-v4 400 wire shape:
the toast carries `"Template must include the {id} placeholder for the
per-device value"`, not the fallback. The issue's 2026-06-26 re-verification
appears to have been a static read of the catch block that missed the
`runAction` layer above it.

## What this PR does

Adds a **regression test** to `PartnerSettingsPage.test.tsx` that pins the
#1976 scenario: a 400 carrying the real zod-v4 `ZodError` body surfaces the
field-level message through `runPartnerSave`, and explicitly asserts the generic
`"Failed to save settings"` fallback is **not** shown. This converts
"works incidentally" into "guaranteed by test" and guards against a future
regression that re-collapses validation detail.

No production code changes — behavior is already correct; this locks it in.

## Testing

- `vitest run apps/web/src/components/settings/PartnerSettingsPage.test.tsx` — 14 passed (13 existing + 1 new).
- `tsc --noEmit` (apps/web) — clean.

Closes #1976

🤖 Generated with [Claude Code](https://claude.com/claude-code)