### PR TITLE
fix(alerts): average metric window instead of requiring every sample (#1980)

### DIFF
--- a/apps/api/src/services/alertConditions/handlers/threshold.test.ts
+++ b/apps/api/src/services/alertConditions/handlers/threshold.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getRecentMetricsMock } = vi.hoisted(() => ({
+  getRecentMetricsMock: vi.fn(),
+}));
+
+// getRecentMetrics touches the db; mock only it and keep the pure helpers real.
+vi.mock('../utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils')>();
+  return { ...actual, getRecentMetrics: getRecentMetricsMock };
+});
+
+import { thresholdHandler } from './threshold';
+
+const DEVICE_ID = 'device-1';
+
+/** Build deviceMetrics-shaped rows from a list of values for a single column. */
+function rows(column: string, values: Array<number | null>) {
+  return values.map((v) => ({ [column]: v })) as never[];
+}
+
+describe('thresholdHandler (averaged window semantics)', () => {
+  beforeEach(() => {
+    getRecentMetricsMock.mockReset();
+  });
+
+  it('declares type "threshold" with a "metric" alias', () => {
+    expect(thresholdHandler.type).toBe('threshold');
+    expect(thresholdHandler.aliases).toContain('metric');
+  });
+
+  it('fires when the window AVERAGE exceeds the threshold even though some samples dip below', async () => {
+    // avg(95, 88, 94) = 92.33 > 90. Strict all-samples (.every) would NOT fire because 88 < 90.
+    getRecentMetricsMock.mockResolvedValue(rows('ramPercent', [95, 88, 94]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'ram', operator: 'gt', value: 90 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('does NOT fire when the average is below the threshold even if a single sample spikes above', async () => {
+    // avg(99, 80, 80) = 86.33, threshold gt 90 → no fire.
+    getRecentMetricsMock.mockResolvedValue(rows('cpuPercent', [99, 80, 80]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'cpu', operator: 'gt', value: 90 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('skips null samples instead of counting them as below-threshold', async () => {
+    // Non-null avg(94, 92) = 93 > 90. With null-as-fail this would never fire.
+    getRecentMetricsMock.mockResolvedValue(rows('diskPercent', [94, null, 92]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'disk', operator: 'gt', value: 90 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('reports the averaged value it evaluated as actualValue', async () => {
+    getRecentMetricsMock.mockResolvedValue(rows('ramPercent', [90, 100]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'ram', operator: 'gt', value: 80 },
+      DEVICE_ID
+    );
+
+    expect(result.actualValue).toBe(95);
+  });
+
+  it('does not fire when every sample in the window is null', async () => {
+    getRecentMetricsMock.mockResolvedValue(rows('ramPercent', [null, null]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'ram', operator: 'gt', value: 50 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('returns "No metrics available" when the window is empty', async () => {
+    getRecentMetricsMock.mockResolvedValue([]);
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'cpu', operator: 'gt', value: 90 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.description).toContain('No metrics');
+  });
+
+  it('returns "Unknown metric" for an unmapped metric name', async () => {
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'network', operator: 'gt', value: 50 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.description).toContain('Unknown metric');
+  });
+
+  it('treats cpu/ram/disk symmetrically (disk averaged the same way)', async () => {
+    // avg(86, 84) = 85, threshold gte 85 → fire.
+    getRecentMetricsMock.mockResolvedValue(rows('diskPercent', [86, 84]));
+
+    const result = await thresholdHandler.evaluate(
+      { type: 'metric', metric: 'disk', operator: 'gte', value: 85 },
+      DEVICE_ID
+    );
+
+    expect(result.passed).toBe(true);
+  });
+});

--- a/apps/api/src/services/alertConditions/handlers/threshold.ts
+++ b/apps/api/src/services/alertConditions/handlers/threshold.ts
@@ -21,19 +21,26 @@ export const thresholdHandler: ConditionHandler = {
       return { passed: false, description: `No metrics available for ${cond.metric}` };
     }
 
-    const allExceed = metrics.every(m => {
-      const value = m[metricName];
-      if (value === null || value === undefined) return false;
-      return compareValue(value, cond.operator, cond.value);
-    });
+    // Average the window rather than requiring every sample to exceed. Strict
+    // all-samples semantics let a single dip below (or one null sample) silently
+    // suppress a sustained-high condition — the CPU-fires-but-RAM/Disk-don't bug
+    // in #1854. Null/undefined samples are skipped, not counted as below-threshold.
+    const values = metrics
+      .map(m => m[metricName])
+      .filter((v): v is number => typeof v === 'number');
 
-    const latestValue = metrics[0]?.[metricName] ?? undefined;
+    if (values.length === 0) {
+      return { passed: false, description: `No metrics available for ${cond.metric}` };
+    }
+
+    const average = values.reduce((sum, v) => sum + v, 0) / values.length;
+    const passed = compareValue(average, cond.operator, cond.value);
     const operatorDisplay = getOperatorDisplay(cond.operator);
 
     return {
-      passed: allExceed,
+      passed,
       description: `${cond.metric} ${operatorDisplay} ${cond.value} for ${durationMinutes}min`,
-      actualValue: latestValue ?? undefined
+      actualValue: average
     };
   },
 

--- a/apps/api/src/services/alertConditions/index.test.ts
+++ b/apps/api/src/services/alertConditions/index.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // utils.ts (transitively imported by the handlers) pulls in the db module at
 // import time; stub it so importing the registry doesn't open a connection.
 vi.mock('../../db', () => ({ db: {} }));
 
+const { getRecentMetricsMock, getLatestMetricMock } = vi.hoisted(() => ({
+  getRecentMetricsMock: vi.fn(),
+  getLatestMetricMock: vi.fn(),
+}));
+
+// Mock only the db-touching helpers; keep the pure metric-map/compare helpers real.
+vi.mock('./utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils')>();
+  return { ...actual, getRecentMetrics: getRecentMetricsMock, getLatestMetric: getLatestMetricMock };
+});
+
 import './index';
+import { evaluateConditions } from './index';
 import { conditionRegistry } from './registry';
 import { offlineHandler } from './handlers/offline';
 
@@ -24,5 +36,33 @@ describe('condition registry wiring (issue #1857)', () => {
     );
     expect(result.passed).toBe(false);
     expect(result.description).toMatch(/Unknown condition type/);
+  });
+});
+
+describe('evaluateConditions context.actualValue (issue #1980)', () => {
+  beforeEach(() => {
+    getRecentMetricsMock.mockReset();
+    getLatestMetricMock.mockReset();
+  });
+
+  it('reports the window average (not the latest raw sample) for a fired metric rule', async () => {
+    // avg(88, 95, 94) = 92.33 > 90 → fires. Latest raw sample is 88 (sub-threshold).
+    getRecentMetricsMock.mockResolvedValue([
+      { ramPercent: 88 },
+      { ramPercent: 95 },
+      { ramPercent: 94 },
+    ] as never);
+    getLatestMetricMock.mockResolvedValue({ ramPercent: 88 } as never);
+
+    const result = await evaluateConditions(
+      [{ type: 'metric', metric: 'ram', operator: 'gt', value: 90 }],
+      'device-1'
+    );
+
+    expect(result.triggered).toBe(true);
+    expect(result.context.metric).toBe('ram');
+    expect(result.context.actualValue).toBeCloseTo(92.33, 1);
+    // Must not be the latest sub-threshold sample.
+    expect(result.context.actualValue).not.toBe(88);
   });
 });

--- a/apps/api/src/services/alertConditions/index.ts
+++ b/apps/api/src/services/alertConditions/index.ts
@@ -79,7 +79,7 @@ function isConditionGroup(condition: RootCondition): condition is ConditionGroup
 async function evaluateConditionRecursive(
   condition: RootCondition,
   deviceId: string,
-  results: { met: string[]; notMet: string[] }
+  results: { met: string[]; notMet: string[]; primaryActualValue?: number }
 ): Promise<boolean> {
   if (isConditionGroup(condition)) {
     const evaluations = await Promise.all(
@@ -102,6 +102,19 @@ async function evaluateConditionRecursive(
       results.met.push(result.description);
     } else {
       results.notMet.push(result.description);
+    }
+
+    // Capture the value the threshold/metric handler actually evaluated (the
+    // window average) so context.actualValue reflects what drove the decision
+    // rather than the latest raw sample — which can be sub-threshold once the
+    // window is averaged (#1980).
+    const condType = (condition as { type?: string }).type;
+    if (
+      (condType === 'threshold' || condType === 'metric') &&
+      results.primaryActualValue === undefined &&
+      typeof result.actualValue === 'number'
+    ) {
+      results.primaryActualValue = result.actualValue;
     }
 
     return result.passed;
@@ -148,7 +161,11 @@ export async function evaluateConditions(
     };
   }
 
-  const results = { met: [] as string[], notMet: [] as string[] };
+  const results = { met: [] as string[], notMet: [] as string[] } as {
+    met: string[];
+    notMet: string[];
+    primaryActualValue?: number;
+  };
   const triggered = await evaluateConditionRecursive(rootCondition, deviceId, results);
 
   // Get latest metric for context
@@ -164,17 +181,20 @@ export async function evaluateConditions(
         if (found) return found;
       }
       return undefined;
-    } else if (cond.type === 'threshold') {
+    } else if (cond.type === 'threshold' || cond.type === 'metric') {
       return cond as ThresholdCondition;
     }
     return undefined;
   };
 
   const primaryThreshold = findFirstThreshold(rootCondition);
-  if (primaryThreshold && latestMetric) {
+  if (primaryThreshold) {
     const normalizedMetric = normalizeMetricName(primaryThreshold.metric);
+    const latestValue = normalizedMetric ? latestMetric?.[normalizedMetric] ?? undefined : undefined;
     context.metric = primaryThreshold.metric;
-    context.actualValue = normalizedMetric ? latestMetric[normalizedMetric] ?? undefined : undefined;
+    // Prefer the averaged value the handler evaluated; fall back to the latest
+    // raw sample only when no handler value was captured (e.g. window empty).
+    context.actualValue = results.primaryActualValue ?? latestValue;
     context.threshold = primaryThreshold.value;
     context.operator = getOperatorDisplay(primaryThreshold.operator);
     context.durationMinutes = primaryThreshold.durationMinutes;


### PR DESCRIPTION
## What & why

Config Policy **metric alert rules (CPU / RAM / Disk)** evaluated the window with `metrics.every(sample => sample > threshold)` — so a *single* sample dipping below the threshold, or *any* null sample (which was treated as a hard fail), silently suppressed an otherwise-sustained-high condition.

That's the exact **"CPU fires but RAM/Disk don't"** asymmetry reported in #1854: CPU pinned >95 stays over every sample and fires, while RAM ~90 / Disk 85-95 routinely dip for one sample (or carry an intermittent null) and never fire — even though the pipeline is fully metric-symmetric (same metric map, comparator, query, sweep).

## The change

`apps/api/src/services/alertConditions/handlers/threshold.ts`:
- **Average the non-null samples** in the window and compare the mean against the threshold, instead of requiring every sample to exceed.
- **Skip null/undefined samples** rather than counting them as below-threshold. An all-null (or empty) window still does not fire.
- `actualValue` now reports the **averaged value** that drove the decision (was: the latest sample).

Window source (`getRecentMetrics`, default `durationMinutes || 1`) and the 60s online-device sweep are unchanged.

## Tests

New `threshold.test.ts` (TDD — written failing first against the old `.every()` behavior):
- fires when the window **average** exceeds despite individual dips
- does **not** fire when the average is below even with a single spike
- **null samples skipped**, not counted as fail
- all-null window → no fire; empty window → "No metrics"; unknown metric → "Unknown metric"
- `actualValue` = averaged value
- cpu/ram/disk symmetry

Full `alertConditions` suite (30) + alertService/alertWorker consumers (8) green; no new typecheck errors.

Refs #1854. Closes #1980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)