### PR TITLE
fix(web): structured, validated agent-update maintenance window (#1963)

### DIFF
--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -17,12 +17,13 @@
  *
  * Timezone note: the org `maintenanceWindow` is a string with no timezone
  * component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC server
- * time. As of issue #1963 both write paths reject malformed values at save time
- * — the org route (PATCH /organizations/:id) and the partner route
- * (PATCH /partners/me) — so new writes only ever produce a valid window or the
- * always state. Any legacy malformed value still fails open (no restriction)
- * rather than permanently blocking, and is logged once when ignored (see
- * getOrgAgentUpdatePolicy) so the lifted restriction is observable.
+ * time. This gate reads ORG settings only (getOrgAgentUpdatePolicy), so the
+ * gate-relevant write path is PATCH /organizations/:id — validated at save time
+ * as of issue #1963. (The partner route PATCH /partners/me validates the same
+ * field too, but only for UX parity; partner settings never reach this gate.)
+ * Any legacy malformed value still fails open (no restriction) rather than
+ * permanently blocking, and is logged the first time it is ignored per org (per
+ * process; see getOrgAgentUpdatePolicy) so the lifted restriction is observable.
  *
  * This module is pure and side-effect free so it can be unit tested without a
  * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -10,18 +10,22 @@
  *                 maintenance window (when one is set)
  *
  * In addition, a configured `maintenanceWindow` suppresses upgrades outside the
- * window for both `auto` and `staged`. A device with no maintenance window set
- * may upgrade at any time (this preserves the historical behaviour for orgs
- * that never configured the policy).
+ * window for both `auto` and `staged`. The explicit "24/7" / empty state (see
+ * `isAlwaysMaintenanceWindow` in @breeze/shared) means no restriction — upgrade
+ * at any time. This preserves the historical behaviour for orgs that never
+ * configured the policy.
  *
- * Timezone note: the org `maintenanceWindow` is a free-form string with no
- * timezone component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC
- * server time. Malformed windows fail open (no time restriction) so a typo
- * never permanently blocks updates.
+ * Timezone note: the org `maintenanceWindow` is a string with no timezone
+ * component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC server
+ * time. As of issue #1963 the API rejects malformed values at save time, so the
+ * gate only ever sees a valid window or the always state; any legacy malformed
+ * value still fails open (no restriction) rather than permanently blocking.
  *
  * This module is pure and side-effect free so it can be unit tested without a
  * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).
  */
+
+import { parseMaintenanceWindow } from '@breeze/shared';
 
 export type AgentUpdatePolicy = 'auto' | 'staged' | 'manual';
 
@@ -35,18 +39,10 @@ export interface AgentUpdateGate {
   reason: 'allowed' | 'manual-approval' | 'outside-maintenance-window';
 }
 
-const DAY_OF_WEEK: Record<string, number> = {
-  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
-};
-
-interface ParsedWindow {
-  /** UTC day-of-week the window starts on (0=Sun), or null for "any day" (daily). */
-  day: number | null;
-  /** Minutes-since-midnight the window opens. */
-  startMin: number;
-  /** Minutes-since-midnight the window closes. */
-  endMin: number;
-}
+// The window grammar/parser lives in @breeze/shared so the web editor and this
+// gate validate against the exact same shape. Re-exported here so existing
+// callers/tests in this module keep their import surface.
+export { parseMaintenanceWindow };
 
 /**
  * Coerce an arbitrary stored value into a known policy. Unknown / absent values
@@ -57,37 +53,6 @@ interface ParsedWindow {
 export function normalizeAgentUpdatePolicy(raw: unknown): AgentUpdatePolicy {
   if (raw === 'auto' || raw === 'staged' || raw === 'manual') return raw;
   return 'staged';
-}
-
-/**
- * Parse a maintenance window string of the form "Sun 02:00-04:00" (optional
- * 3-letter day prefix; "02:00-04:00" means daily). Returns null when the input
- * is empty or malformed — callers treat null as "no time restriction".
- */
-export function parseMaintenanceWindow(raw: string | null | undefined): ParsedWindow | null {
-  if (typeof raw !== 'string') return null;
-  const trimmed = raw.trim();
-  if (!trimmed) return null;
-
-  const m = trimmed.match(/^(?:([A-Za-z]{3})\s+)?(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
-  if (!m) return null;
-
-  const [, dayStr, sh, sm, eh, em] = m;
-  let day: number | null = null;
-  if (dayStr) {
-    const d = DAY_OF_WEEK[dayStr.toLowerCase()];
-    if (d === undefined) return null;
-    day = d;
-  }
-
-  const startH = Number(sh), startM = Number(sm), endH = Number(eh), endM = Number(em);
-  if (startH > 23 || endH > 23 || startM > 59 || endM > 59) return null;
-
-  const startMin = startH * 60 + startM;
-  const endMin = endH * 60 + endM;
-  if (startMin === endMin) return null; // zero-length window is meaningless
-
-  return { day, startMin, endMin };
 }
 
 /**

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -17,9 +17,12 @@
  *
  * Timezone note: the org `maintenanceWindow` is a string with no timezone
  * component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC server
- * time. As of issue #1963 the API rejects malformed values at save time, so the
- * gate only ever sees a valid window or the always state; any legacy malformed
- * value still fails open (no restriction) rather than permanently blocking.
+ * time. As of issue #1963 both write paths reject malformed values at save time
+ * — the org route (PATCH /organizations/:id) and the partner route
+ * (PATCH /partners/me) — so new writes only ever produce a valid window or the
+ * always state. Any legacy malformed value still fails open (no restriction)
+ * rather than permanently blocking, and is logged once when ignored (see
+ * getOrgAgentUpdatePolicy) so the lifted restriction is observable.
  *
  * This module is pure and side-effect free so it can be unit tested without a
  * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -140,6 +140,20 @@ describe('getOrgAgentUpdatePolicy', () => {
     });
   });
 
+  it('normalizes the explicit "24/7" always-state to null (no restriction)', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '24/7' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'auto', maintenanceWindow: null,
+    });
+  });
+
+  it('normalizes "always"/"none" aliases to null', async () => {
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'staged', maintenanceWindow: ' Always ' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
   it('normalizes a non-string window to null', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 42 } } }]);
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -154,6 +154,20 @@ describe('getOrgAgentUpdatePolicy', () => {
     });
   });
 
+  it('keeps a legacy malformed window but logs that the time restriction is lifted', async () => {
+    // New writes are validated (issue #1963); a legacy malformed value still
+    // fails open in the gate, but getOrgAgentUpdatePolicy must log it so the
+    // silently-lifted restriction is observable rather than invisible.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' } } }]);
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'auto', maintenanceWindow: 'Sundays 2am',
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('malformed maintenance window'));
+    warn.mockRestore();
+  });
+
   it('normalizes a non-string window to null', async () => {
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 42 } } }]);
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -110,13 +110,14 @@ vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => 
 // ---------------------------------------------------------------------------
 // Import under test — AFTER all mocks are installed.
 // ---------------------------------------------------------------------------
-import { getOrgAgentUpdatePolicy } from './helpers';
+import { getOrgAgentUpdatePolicy, __resetMalformedWindowWarnCache } from './helpers';
 
 const ORG_ID = '00000000-0000-4000-8000-000000000001';
 
 describe('getOrgAgentUpdatePolicy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetMalformedWindowWarnCache();
   });
 
   it('reads a fully configured policy + maintenance window', async () => {
@@ -154,15 +155,18 @@ describe('getOrgAgentUpdatePolicy', () => {
     });
   });
 
-  it('keeps a legacy malformed window but logs that the time restriction is lifted', async () => {
+  it('keeps a legacy malformed window but logs once per org that the restriction is lifted', async () => {
     // New writes are validated (issue #1963); a legacy malformed value still
     // fails open in the gate, but getOrgAgentUpdatePolicy must log it so the
-    // silently-lifted restriction is observable rather than invisible.
+    // silently-lifted restriction is observable. The read runs on the heartbeat
+    // hot path, so the warn is deduped per org — two reads, one warn.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' } } }]);
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'auto', maintenanceWindow: 'Sundays 2am',
     });
+    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' } } }]);
+    await getOrgAgentUpdatePolicy(ORG_ID); // second heartbeat read for the same org
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('malformed maintenance window'));
     warn.mockRestore();

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -59,6 +59,7 @@ import {
   normalizeAgentUpdatePolicy,
   type AgentUpdateSettings,
 } from './agentUpdatePolicy';
+import { isAlwaysMaintenanceWindow } from '@breeze/shared';
 import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
@@ -2009,10 +2010,11 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
   const settings = isObject(org?.settings) ? org.settings : {};
   const defaults = isObject(settings.defaults) ? settings.defaults : {};
   const policy = normalizeAgentUpdatePolicy(defaults.agentUpdatePolicy);
-  const maintenanceWindow =
-    typeof defaults.maintenanceWindow === 'string' && defaults.maintenanceWindow.trim()
-      ? defaults.maintenanceWindow.trim()
-      : null;
+  const rawWindow =
+    typeof defaults.maintenanceWindow === 'string' ? defaults.maintenanceWindow.trim() : '';
+  // The explicit "24/7"/empty always-state means "no restriction" → null, same
+  // as an absent window. Only a real window string is carried through to the gate.
+  const maintenanceWindow = rawWindow && !isAlwaysMaintenanceWindow(rawWindow) ? rawWindow : null;
   return { policy, maintenanceWindow };
 }
 

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1995,6 +1995,16 @@ export function generateApiKey(): string {
 // mTLS
 // ============================================
 
+// Per-process dedup for the malformed-maintenance-window warning. The read
+// below runs on the heartbeat hot path; without this, a single misconfigured
+// org would emit one warn per device per heartbeat. Cleared by tests.
+const warnedMalformedWindowOrgs = new Set<string>();
+
+/** Test-only: reset the malformed-window warn dedup so cases stay isolated. */
+export function __resetMalformedWindowWarnCache(): void {
+  warnedMalformedWindowOrgs.clear();
+}
+
 /**
  * Read the org-level agent update policy from `organizations.settings.defaults`
  * (Org > General). Returns a normalized policy plus the raw maintenance-window
@@ -2017,9 +2027,16 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
   const maintenanceWindow = rawWindow && !isAlwaysMaintenanceWindow(rawWindow) ? rawWindow : null;
   // New writes are validated at save time (issue #1963), but a legacy malformed
   // value still parses to null in the gate and fails open (lifts the time
-  // restriction). Log it once here so that silently-lifted restriction is
-  // observable rather than an invisible 24/7-updates surprise.
-  if (maintenanceWindow !== null && parseMaintenanceWindow(maintenanceWindow) === null) {
+  // restriction). Surface that so the silently-lifted restriction is observable
+  // rather than an invisible 24/7-updates surprise. This runs on the heartbeat
+  // hot path (once per device per heartbeat), so dedupe per org for the process
+  // lifetime — otherwise one misconfigured org spams the log every heartbeat.
+  if (
+    maintenanceWindow !== null &&
+    parseMaintenanceWindow(maintenanceWindow) === null &&
+    !warnedMalformedWindowOrgs.has(orgId)
+  ) {
+    warnedMalformedWindowOrgs.add(orgId);
     console.warn(
       `[agents/helpers] Ignoring malformed maintenance window for org ${orgId}; ` +
       `agent updates are NOT time-restricted (failing open). value=${JSON.stringify(maintenanceWindow)}`,

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -59,7 +59,7 @@ import {
   normalizeAgentUpdatePolicy,
   type AgentUpdateSettings,
 } from './agentUpdatePolicy';
-import { isAlwaysMaintenanceWindow } from '@breeze/shared';
+import { isAlwaysMaintenanceWindow, parseMaintenanceWindow } from '@breeze/shared';
 import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
@@ -2015,6 +2015,16 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
   // The explicit "24/7"/empty always-state means "no restriction" → null, same
   // as an absent window. Only a real window string is carried through to the gate.
   const maintenanceWindow = rawWindow && !isAlwaysMaintenanceWindow(rawWindow) ? rawWindow : null;
+  // New writes are validated at save time (issue #1963), but a legacy malformed
+  // value still parses to null in the gate and fails open (lifts the time
+  // restriction). Log it once here so that silently-lifted restriction is
+  // observable rather than an invisible 24/7-updates surprise.
+  if (maintenanceWindow !== null && parseMaintenanceWindow(maintenanceWindow) === null) {
+    console.warn(
+      `[agents/helpers] Ignoring malformed maintenance window for org ${orgId}; ` +
+      `agent updates are NOT time-restricted (failing open). value=${JSON.stringify(maintenanceWindow)}`,
+    );
+  }
   return { policy, maintenanceWindow };
 }
 

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1299,6 +1299,22 @@ describe('org routes', () => {
       expect(res.status).toBe(404);
     });
 
+    // issue #1963: the org write path feeds getOrgAgentUpdatePolicy, so a
+    // malformed maintenance window must be rejected here (settings is z.any(),
+    // so the handler validates this field explicitly) before it can reach the
+    // heartbeat gate and silently fail open. Validation runs before any DB work.
+    it('rejects a malformed agent-update maintenance window with 400', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { maintenanceWindow: '0000-2359' } } })
+      });
+
+      expect(res.status).toBe(400);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     it('should allow system scope updates without partnerId context', async () => {
       setAuthContext({ scope: 'system', partnerId: null });
       vi.mocked(db.update).mockReturnValue({

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1315,6 +1315,34 @@ describe('org routes', () => {
       expect(db.update).not.toHaveBeenCalled();
     });
 
+    // Guards the accept branch of the same guard: a valid window must NOT be
+    // rejected (catches a future inversion of the condition). db.select is
+    // overridden so assertNotLocked('defaults', ...) resolves with no locks.
+    it('accepts a valid agent-update maintenance window (200)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ partnerId: 'partner-123', settings: {} }])
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { maintenanceWindow: 'Sun 02:00-04:00' } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
     it('should allow system scope updates without partnerId context', async () => {
       setAuthContext({ scope: 'system', partnerId: null });
       vi.mocked(db.update).mockReturnValue({

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -299,6 +299,12 @@ const dayScheduleSchema = z.object({
   closed: z.boolean().optional()
 });
 
+// Shared rejection message for a malformed agent-update maintenance window
+// (issue #1963), used on both the partner (/partners/me, via schema refine) and
+// org (/organizations/:id, via explicit handler check) write paths.
+const MAINTENANCE_WINDOW_ERROR_MESSAGE =
+  'Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".';
+
 const partnerSettingsSchema = z.object({
   // Partner tz is the canonical default for every downstream tz field (#1318),
   // so police it as a real IANA zone on write (was previously unvalidated).
@@ -380,7 +386,7 @@ const partnerSettingsSchema = z.object({
     // or a "[Day ]HH:MM-HH:MM" window; see isValidMaintenanceWindow.
     maintenanceWindow: z.string().max(64).optional().refine(
       (v) => v === undefined || isValidMaintenanceWindow(v),
-      { message: 'Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".' },
+      { message: MAINTENANCE_WINDOW_ERROR_MESSAGE },
     ),
   }).optional(),
   branding: z.object({
@@ -1099,9 +1105,25 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  // Enforce partner locks on settings categories (after auth check)
   if (data.settings) {
     const settingsObj = data.settings as Record<string, unknown>;
+
+    // Reject a malformed agent-update maintenance window before any DB work
+    // (issue #1963). This is the path getOrgAgentUpdatePolicy reads, so without
+    // this check a typo'd window would silently fail the heartbeat gate open.
+    // The org `settings` blob is `z.any()`, so the window is the one field
+    // validated explicitly here rather than in updateOrganizationSchema.
+    const defaults = settingsObj.defaults;
+    if (defaults && typeof defaults === 'object') {
+      const mw = (defaults as Record<string, unknown>).maintenanceWindow;
+      // null/undefined clears the window (treated as the always state); any
+      // present value must be a valid window string.
+      if (mw !== undefined && mw !== null && (typeof mw !== 'string' || !isValidMaintenanceWindow(mw))) {
+        return c.json({ error: MAINTENANCE_WINDOW_ERROR_MESSAGE }, 400);
+      }
+    }
+
+    // Enforce partner locks on settings categories (after auth check)
     for (const category of ['security', 'notifications', 'eventLogs', 'defaults', 'branding']) {
       if (settingsObj[category] && typeof settingsObj[category] === 'object') {
         const fields = Object.keys(settingsObj[category] as Record<string, unknown>);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -20,7 +20,7 @@ import {
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
-import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE } from '@breeze/shared';
 import type { IpAllowlistStatus } from '@breeze/shared';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
@@ -299,11 +299,6 @@ const dayScheduleSchema = z.object({
   closed: z.boolean().optional()
 });
 
-// Shared rejection message for a malformed agent-update maintenance window
-// (issue #1963), used on both the partner (/partners/me, via schema refine) and
-// org (/organizations/:id, via explicit handler check) write paths.
-const MAINTENANCE_WINDOW_ERROR_MESSAGE =
-  'Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".';
 
 const partnerSettingsSchema = z.object({
   // Partner tz is the canonical default for every downstream tz field (#1318),
@@ -381,9 +376,12 @@ const partnerSettingsSchema = z.object({
       sendWelcome: z.boolean(),
     }).optional(),
     agentUpdatePolicy: z.string().optional(),
-    // Reject malformed windows at save time (issue #1963) so the heartbeat gate
-    // never silently fails open on a typo. Accepts the "24/7"/empty always-state
-    // or a "[Day ]HH:MM-HH:MM" window; see isValidMaintenanceWindow.
+    // Reject malformed windows on the partner (/partners/me) write path at save
+    // time (issue #1963), for consistency with the org route. NOTE: the agent
+    // heartbeat gate reads ORG settings (see updateOrgHandler /
+    // getOrgAgentUpdatePolicy), so this partner-level check is UX parity — the
+    // org-route check is what actually protects the gate. Accepts the
+    // "24/7"/empty always-state or a "[Day ]HH:MM-HH:MM" window.
     maintenanceWindow: z.string().max(64).optional().refine(
       (v) => v === undefined || isValidMaintenanceWindow(v),
       { message: MAINTENANCE_WINDOW_ERROR_MESSAGE },

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -20,7 +20,7 @@ import {
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
-import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow } from '@breeze/shared';
 import type { IpAllowlistStatus } from '@breeze/shared';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
@@ -375,7 +375,13 @@ const partnerSettingsSchema = z.object({
       sendWelcome: z.boolean(),
     }).optional(),
     agentUpdatePolicy: z.string().optional(),
-    maintenanceWindow: z.string().optional(),
+    // Reject malformed windows at save time (issue #1963) so the heartbeat gate
+    // never silently fails open on a typo. Accepts the "24/7"/empty always-state
+    // or a "[Day ]HH:MM-HH:MM" window; see isValidMaintenanceWindow.
+    maintenanceWindow: z.string().max(64).optional().refine(
+      (v) => v === undefined || isValidMaintenanceWindow(v),
+      { message: 'Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".' },
+    ),
   }).optional(),
   branding: z.object({
     logoUrl: z.string().max(400_000, 'Logo data exceeds maximum size (400 KB)').optional(),

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -77,20 +77,28 @@ describe('OrgDefaultsEditor — maintenance window', () => {
     expect(screen.getByTestId('maintenance-mode-always')).toBeChecked();
   });
 
-  it('warns when the stored window is invalid and marks the form dirty so the fix persists', () => {
+  it('resets an invalid stored window to the always-state, warns, and marks dirty so the fix persists', async () => {
+    const user = userEvent.setup();
     const onDirty = vi.fn();
+    const onSave = vi.fn();
     render(
       <OrgDefaultsEditor
         organizationName={ORG}
         defaults={{ maintenanceWindow: '0000-2359' }}
         onDirty={onDirty}
+        onSave={onSave}
       />,
     );
-    // The malformed value was reset to an editable window; the operator is told.
+    // The malformed value failed open at runtime (update anytime), so the editor
+    // resets it to the always-state — a careless Save preserves that, not a
+    // surprise restrictive window. The operator is told it was ignored.
     expect(screen.getByTestId('maintenance-stored-invalid')).toBeInTheDocument();
-    expect(screen.getByTestId('maintenance-mode-window')).toBeChecked();
-    // Marked dirty on mount so saving actually overwrites the invalid stored value.
+    expect(screen.getByTestId('maintenance-mode-always')).toBeChecked();
+    // Marked dirty on mount so saving overwrites the invalid stored value.
     expect(onDirty).toHaveBeenCalled();
+    // Saving persists the durable always sentinel, replacing the bad value.
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave.mock.calls[0][0].maintenanceWindow).toBe('24/7');
   });
 
   it('does not show the invalid-stored notice for a clean window', () => {

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -76,4 +76,27 @@ describe('OrgDefaultsEditor — maintenance window', () => {
     );
     expect(screen.getByTestId('maintenance-mode-always')).toBeChecked();
   });
+
+  it('warns when the stored window is invalid and marks the form dirty so the fix persists', () => {
+    const onDirty = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        defaults={{ maintenanceWindow: '0000-2359' }}
+        onDirty={onDirty}
+      />,
+    );
+    // The malformed value was reset to an editable window; the operator is told.
+    expect(screen.getByTestId('maintenance-stored-invalid')).toBeInTheDocument();
+    expect(screen.getByTestId('maintenance-mode-window')).toBeChecked();
+    // Marked dirty on mount so saving actually overwrites the invalid stored value.
+    expect(onDirty).toHaveBeenCalled();
+  });
+
+  it('does not show the invalid-stored notice for a clean window', () => {
+    render(
+      <OrgDefaultsEditor organizationName={ORG} defaults={{ maintenanceWindow: 'Sun 02:00-04:00' }} />,
+    );
+    expect(screen.queryByTestId('maintenance-stored-invalid')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import OrgDefaultsEditor from './OrgDefaultsEditor';
+
+const ORG = 'Acme Corp';
+
+describe('OrgDefaultsEditor — maintenance window', () => {
+  it('defaults an unconfigured org to the explicit "always (24/7)" state and saves it durably', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={onSave} />);
+
+    // Always mode is selected by default; the window fields are hidden.
+    expect(screen.getByTestId('maintenance-mode-always')).toBeChecked();
+    expect(screen.queryByTestId('maintenance-start')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].maintenanceWindow).toBe('24/7');
+  });
+
+  it('hydrates a stored window into structured day/start/end fields', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        defaults={{ maintenanceWindow: 'Sun 02:00-04:00' }}
+      />,
+    );
+    expect(screen.getByTestId('maintenance-mode-window')).toBeChecked();
+    expect((screen.getByTestId('maintenance-day') as HTMLSelectElement).value).toBe('Sun');
+    expect((screen.getByTestId('maintenance-start') as HTMLInputElement).value).toBe('02:00');
+    expect((screen.getByTestId('maintenance-end') as HTMLInputElement).value).toBe('04:00');
+  });
+
+  it('builds a canonical window string from the structured inputs on save', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={onSave} />);
+
+    await user.click(screen.getByTestId('maintenance-mode-window'));
+    await user.selectOptions(screen.getByTestId('maintenance-day'), 'Wed');
+    await user.click(screen.getByTestId('save-defaults'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    // Default seeded times are 02:00–04:00.
+    expect(onSave.mock.calls[0][0].maintenanceWindow).toBe('Wed 02:00-04:00');
+  });
+
+  it('blocks saving an invalid window (start === end) and shows an error', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        defaults={{ maintenanceWindow: '02:00-04:00' }}
+      />,
+    );
+
+    // Force end to equal start → invalid, zero-length window.
+    const end = screen.getByTestId('maintenance-end') as HTMLInputElement;
+    await user.clear(end);
+    await user.type(end, '02:00');
+
+    expect(screen.getByTestId('maintenance-error')).toBeInTheDocument();
+    expect(screen.getByTestId('save-defaults')).toBeDisabled();
+
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('treats a legacy "24/7" sentinel as the always state on load', () => {
+    render(
+      <OrgDefaultsEditor organizationName={ORG} defaults={{ maintenanceWindow: '24/7' }} />,
+    );
+    expect(screen.getByTestId('maintenance-mode-always')).toBeChecked();
+  });
+});

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
 import {
   MAINTENANCE_WINDOW_ALWAYS,
   MAINTENANCE_DAYS,
   isAlwaysMaintenanceWindow,
+  isValidMaintenanceWindow,
   parseMaintenanceWindow,
   formatMaintenanceWindow,
   minutesToHHMM,
@@ -95,6 +96,13 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
   const [autoEnrollment, setAutoEnrollment] = useState(initialData.autoEnrollment || defaultValues.autoEnrollment!);
   const [agentUpdatePolicy, setAgentUpdatePolicy] = useState(initialData.agentUpdatePolicy || defaultValues.agentUpdatePolicy!);
   const initialWindow = deriveWindowState(initialData.maintenanceWindow);
+  // A stored value that is neither the always-state nor a parseable window was
+  // silently reset to seeded defaults by deriveWindowState. Surface that so the
+  // operator knows their previous config was invalid and being ignored.
+  const storedWindowInvalid =
+    typeof initialData.maintenanceWindow === 'string' &&
+    initialData.maintenanceWindow.trim() !== '' &&
+    !isValidMaintenanceWindow(initialData.maintenanceWindow);
   const [windowMode, setWindowMode] = useState<WindowMode>(initialWindow.mode);
   const [windowDay, setWindowDay] = useState(initialWindow.day);
   const [windowStart, setWindowStart] = useState(initialWindow.start);
@@ -114,6 +122,13 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
   const markDirty = () => {
     onDirty?.();
   };
+
+  // If the stored window was invalid, the editor is already showing a corrected
+  // value — mark the form dirty on mount so saving actually persists the fix.
+  useEffect(() => {
+    if (storedWindowInvalid) onDirty?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSave = () => {
     if (windowError || !builtWindow) return; // never persist an invalid window
@@ -299,6 +314,12 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
             <span className="text-xs font-medium uppercase text-muted-foreground">
               Maintenance window
             </span>
+            {storedWindowInvalid && (
+              <p data-testid="maintenance-stored-invalid" className="text-xs text-destructive">
+                Your saved maintenance window was invalid and is being ignored. Review the value
+                below and save to apply a valid window.
+              </p>
+            )}
             <div className="space-y-2">
               <label className="flex items-center gap-2 text-sm">
                 <input

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -1,5 +1,37 @@
 import { useState } from 'react';
 import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
+import {
+  MAINTENANCE_WINDOW_ALWAYS,
+  MAINTENANCE_DAYS,
+  isAlwaysMaintenanceWindow,
+  parseMaintenanceWindow,
+  formatMaintenanceWindow,
+  minutesToHHMM,
+} from '@breeze/shared';
+
+type WindowMode = 'always' | 'window';
+
+type WindowState = { mode: WindowMode; day: string; start: string; end: string };
+
+// Derive the structured editor state from the stored maintenance-window string.
+// The "always/24/7/empty" state maps to mode 'always'; a valid window unpacks
+// into day + start + end. Legacy malformed values fall back to an editable
+// window seeded with sane defaults so the operator can correct them in place.
+function deriveWindowState(raw: string | undefined): WindowState {
+  if (isAlwaysMaintenanceWindow(raw)) {
+    return { mode: 'always', day: '', start: '02:00', end: '04:00' };
+  }
+  const parsed = parseMaintenanceWindow(raw);
+  if (parsed) {
+    return {
+      mode: 'window',
+      day: parsed.day === null ? '' : MAINTENANCE_DAYS[parsed.day],
+      start: minutesToHHMM(parsed.startMin),
+      end: minutesToHHMM(parsed.endMin),
+    };
+  }
+  return { mode: 'window', day: '', start: '02:00', end: '04:00' };
+}
 
 type DefaultsData = {
   policyDefaults?: Record<string, string>;
@@ -35,7 +67,10 @@ const defaultValues: DefaultsData = {
     sendWelcome: true
   },
   agentUpdatePolicy: 'staged',
-  maintenanceWindow: 'Sun 02:00-04:00'
+  // Default to the explicit "always" state so an unconfigured org matches the
+  // backend's permissive default (staged + no window = update anytime) instead
+  // of silently committing to a Sunday window the first time defaults are saved.
+  maintenanceWindow: MAINTENANCE_WINDOW_ALWAYS
 };
 
 const policyOptions = [
@@ -59,20 +94,36 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
   const [alertThreshold, setAlertThreshold] = useState(initialData.alertThreshold || defaultValues.alertThreshold!);
   const [autoEnrollment, setAutoEnrollment] = useState(initialData.autoEnrollment || defaultValues.autoEnrollment!);
   const [agentUpdatePolicy, setAgentUpdatePolicy] = useState(initialData.agentUpdatePolicy || defaultValues.agentUpdatePolicy!);
-  const [maintenanceWindow, setMaintenanceWindow] = useState(initialData.maintenanceWindow || defaultValues.maintenanceWindow!);
+  const initialWindow = deriveWindowState(initialData.maintenanceWindow);
+  const [windowMode, setWindowMode] = useState<WindowMode>(initialWindow.mode);
+  const [windowDay, setWindowDay] = useState(initialWindow.day);
+  const [windowStart, setWindowStart] = useState(initialWindow.start);
+  const [windowEnd, setWindowEnd] = useState(initialWindow.end);
+
+  // Canonical value to persist; null when the window inputs are invalid
+  // (e.g. start === end). 'always' always resolves to the durable sentinel.
+  const builtWindow =
+    windowMode === 'always'
+      ? MAINTENANCE_WINDOW_ALWAYS
+      : formatMaintenanceWindow(windowDay || null, windowStart, windowEnd);
+  const windowError =
+    windowMode === 'window' && !builtWindow
+      ? 'Enter a valid window — start and end times must differ.'
+      : null;
 
   const markDirty = () => {
     onDirty?.();
   };
 
   const handleSave = () => {
+    if (windowError || !builtWindow) return; // never persist an invalid window
     const data: DefaultsData = {
       policyDefaults,
       deviceGroup,
       alertThreshold,
       autoEnrollment,
       agentUpdatePolicy,
-      maintenanceWindow
+      maintenanceWindow: builtWindow
     };
     onSave?.(data);
   };
@@ -89,7 +140,9 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
         <button
           type="button"
           onClick={handleSave}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+          disabled={!!windowError}
+          data-testid="save-defaults"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Save className="h-4 w-4" />
           Save defaults
@@ -242,24 +295,106 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
             <option value="staged">Staged rollout</option>
             <option value="manual">Manual approval</option>
           </select>
-          <div className="space-y-2">
-            <label className="text-xs font-medium uppercase text-muted-foreground">
+          <div className="space-y-3">
+            <span className="text-xs font-medium uppercase text-muted-foreground">
               Maintenance window
-            </label>
-            <input
-              type="text"
-              value={maintenanceWindow}
-              onChange={event => {
-                setMaintenanceWindow(event.target.value);
-                markDirty();
-              }}
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              placeholder="Sun 02:00-04:00"
-            />
+            </span>
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="maintenanceWindowMode"
+                  value="always"
+                  checked={windowMode === 'always'}
+                  onChange={() => {
+                    setWindowMode('always');
+                    markDirty();
+                  }}
+                  data-testid="maintenance-mode-always"
+                  className="h-4 w-4"
+                />
+                <span>Always — agents may update anytime (24/7)</span>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="maintenanceWindowMode"
+                  value="window"
+                  checked={windowMode === 'window'}
+                  onChange={() => {
+                    setWindowMode('window');
+                    markDirty();
+                  }}
+                  data-testid="maintenance-mode-window"
+                  className="h-4 w-4"
+                />
+                <span>Only during a maintenance window</span>
+              </label>
+            </div>
+
+            {windowMode === 'window' && (
+              <div className="space-y-2 rounded-md border bg-background/60 p-3">
+                <div className="grid grid-cols-3 gap-2">
+                  <label className="space-y-1 text-xs">
+                    <span className="text-muted-foreground">Day</span>
+                    <select
+                      value={windowDay}
+                      onChange={event => {
+                        setWindowDay(event.target.value);
+                        markDirty();
+                      }}
+                      data-testid="maintenance-day"
+                      className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                    >
+                      <option value="">Every day</option>
+                      {MAINTENANCE_DAYS.map(day => (
+                        <option key={day} value={day}>
+                          {day}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="space-y-1 text-xs">
+                    <span className="text-muted-foreground">Start (UTC)</span>
+                    <input
+                      type="time"
+                      value={windowStart}
+                      onChange={event => {
+                        setWindowStart(event.target.value);
+                        markDirty();
+                      }}
+                      data-testid="maintenance-start"
+                      className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs">
+                    <span className="text-muted-foreground">End (UTC)</span>
+                    <input
+                      type="time"
+                      value={windowEnd}
+                      onChange={event => {
+                        setWindowEnd(event.target.value);
+                        markDirty();
+                      }}
+                      data-testid="maintenance-end"
+                      className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                    />
+                  </label>
+                </div>
+                {windowError && (
+                  <p data-testid="maintenance-error" className="text-xs text-destructive">
+                    {windowError}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              {windowMode === 'always'
+                ? 'Agents may install updates at any time, subject to the update policy above.'
+                : 'Agents install updates only inside this window. Times are evaluated in UTC. A window may span midnight (e.g. 22:00–02:00).'}
+            </p>
           </div>
-          <p className="text-xs text-muted-foreground">
-            Agents update during the maintenance window when possible.
-          </p>
         </div>
       </div>
     </section>

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -125,9 +125,10 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
 
   // If the stored window was invalid, the editor is already showing a corrected
   // value — mark the form dirty on mount so saving actually persists the fix.
+  // Mount-only: intentionally empty deps (onDirty/storedWindowInvalid are stable
+  // for the editor's lifetime).
   useEffect(() => {
     if (storedWindowInvalid) onDirty?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSave = () => {

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -3,7 +3,6 @@ import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-re
 import {
   MAINTENANCE_WINDOW_ALWAYS,
   MAINTENANCE_DAYS,
-  isAlwaysMaintenanceWindow,
   isValidMaintenanceWindow,
   parseMaintenanceWindow,
   formatMaintenanceWindow,
@@ -16,12 +15,11 @@ type WindowState = { mode: WindowMode; day: string; start: string; end: string }
 
 // Derive the structured editor state from the stored maintenance-window string.
 // The "always/24/7/empty" state maps to mode 'always'; a valid window unpacks
-// into day + start + end. Legacy malformed values fall back to an editable
-// window seeded with sane defaults so the operator can correct them in place.
+// into day + start + end. A legacy malformed value falls back to the always
+// state — that matches its actual runtime behavior (the gate fails open on an
+// unparseable window), so a careless Save preserves "update anytime" rather than
+// silently flipping the org into a restrictive 02:00-04:00 window it never had.
 function deriveWindowState(raw: string | undefined): WindowState {
-  if (isAlwaysMaintenanceWindow(raw)) {
-    return { mode: 'always', day: '', start: '02:00', end: '04:00' };
-  }
   const parsed = parseMaintenanceWindow(raw);
   if (parsed) {
     return {
@@ -31,7 +29,9 @@ function deriveWindowState(raw: string | undefined): WindowState {
       end: minutesToHHMM(parsed.endMin),
     };
   }
-  return { mode: 'window', day: '', start: '02:00', end: '04:00' };
+  // Always-state and malformed both land here as 'always' (seeded window times
+  // are only used if the operator switches to the window mode).
+  return { mode: 'always', day: '', start: '02:00', end: '04:00' };
 }
 
 type DefaultsData = {
@@ -316,8 +316,8 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
             </span>
             {storedWindowInvalid && (
               <p data-testid="maintenance-stored-invalid" className="text-xs text-destructive">
-                Your saved maintenance window was invalid and is being ignored. Review the value
-                below and save to apply a valid window.
+                Your saved maintenance window was invalid and is being ignored, so agents may
+                currently update at any time. Choose a valid setting below and save to fix it.
               </p>
             )}
             <div className="space-y-2">

--- a/apps/web/src/components/settings/PartnerDefaultsTab.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.tsx
@@ -1,4 +1,5 @@
 import type { InheritableDefaultSettings } from '@breeze/shared';
+import { isValidMaintenanceWindow } from '@breeze/shared';
 
 type Props = {
   data: InheritableDefaultSettings;
@@ -12,6 +13,9 @@ export default function PartnerDefaultsTab({ data, onChange }: Props) {
     onChange({ ...data, ...patch });
 
   const autoEnrollment = data.autoEnrollment ?? { enabled: false, requireApproval: true, sendWelcome: true };
+
+  const maintenanceWindow = data.maintenanceWindow ?? '';
+  const maintenanceWindowInvalid = maintenanceWindow.trim() !== '' && !isValidMaintenanceWindow(maintenanceWindow);
 
   return (
     <div className="space-y-6">
@@ -34,14 +38,25 @@ export default function PartnerDefaultsTab({ data, onChange }: Props) {
           <label className="text-sm font-medium">Maintenance Window</label>
           <input
             type="text"
-            value={data.maintenanceWindow ?? ''}
+            value={maintenanceWindow}
             onChange={e => set({ maintenanceWindow: e.target.value || undefined })}
-            placeholder="e.g. Sun 02:00-06:00"
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            placeholder="e.g. Sun 02:00-06:00, 02:00-04:00, or 24/7"
+            aria-invalid={maintenanceWindowInvalid}
+            className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${
+              maintenanceWindowInvalid ? 'border-destructive' : ''
+            }`}
           />
-          <p className="text-xs text-muted-foreground">
-            Time window for automatic updates and reboots.
-          </p>
+          {maintenanceWindowInvalid ? (
+            <p className="text-xs text-destructive">
+              Use a UTC window like <code>Sun 02:00-04:00</code> or <code>02:00-04:00</code>, or{' '}
+              <code>24/7</code> for always-on. Leave empty to let orgs configure it.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Time window (UTC) for automatic updates and reboots. Use <code>24/7</code> for
+              always-on, or leave empty so orgs configure it individually.
+            </p>
+          )}
         </div>
 
         <div className="space-y-2">

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -35,6 +35,7 @@ import type {
   InheritableRemoteAccessSettings,
   IpAllowlistStatus
 } from '@breeze/shared';
+import { isValidMaintenanceWindow } from '@breeze/shared';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 
@@ -246,6 +247,15 @@ export default function PartnerSettingsPage() {
   }, []);
 
   const handleSave = async () => {
+    // Block a malformed maintenance window client-side (issue #1963) so the
+    // inline feedback in PartnerDefaultsTab actually prevents the round-trip,
+    // matching the org editor. The server also rejects it as defense-in-depth.
+    const mw = defaultsData.maintenanceWindow;
+    if (typeof mw === 'string' && mw.trim() !== '' && !isValidMaintenanceWindow(mw)) {
+      setError('Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".');
+      return;
+    }
+
     setSaving(true);
     setError(undefined);
 

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -35,7 +35,7 @@ import type {
   InheritableRemoteAccessSettings,
   IpAllowlistStatus
 } from '@breeze/shared';
-import { isValidMaintenanceWindow } from '@breeze/shared';
+import { isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE } from '@breeze/shared';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 
@@ -252,7 +252,7 @@ export default function PartnerSettingsPage() {
     // matching the org editor. The server also rejects it as defense-in-depth.
     const mw = defaultsData.maintenanceWindow;
     if (typeof mw === 'string' && mw.trim() !== '' && !isValidMaintenanceWindow(mw)) {
-      setError('Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".');
+      setError(MAINTENANCE_WINDOW_ERROR_MESSAGE);
       return;
     }
 

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -22,6 +22,7 @@ export * from './invoices';
 export * from './contracts';
 export * from './mlFeedback';
 export * from './quotes';
+export * from './maintenanceWindow';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/maintenanceWindow.test.ts
+++ b/packages/shared/src/validators/maintenanceWindow.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAINTENANCE_WINDOW_ALWAYS,
+  MAINTENANCE_DAYS,
+  isAlwaysMaintenanceWindow,
+  parseMaintenanceWindow,
+  isValidMaintenanceWindow,
+  minutesToHHMM,
+  formatMaintenanceWindow,
+} from './maintenanceWindow';
+
+describe('isAlwaysMaintenanceWindow', () => {
+  it('treats empty / whitespace / null / undefined as always', () => {
+    expect(isAlwaysMaintenanceWindow('')).toBe(true);
+    expect(isAlwaysMaintenanceWindow('   ')).toBe(true);
+    expect(isAlwaysMaintenanceWindow(null)).toBe(true);
+    expect(isAlwaysMaintenanceWindow(undefined)).toBe(true);
+  });
+
+  it('recognizes the 24/7 sentinel and tolerated aliases (case-insensitive)', () => {
+    expect(isAlwaysMaintenanceWindow('24/7')).toBe(true);
+    expect(isAlwaysMaintenanceWindow(MAINTENANCE_WINDOW_ALWAYS)).toBe(true);
+    expect(isAlwaysMaintenanceWindow('Always')).toBe(true);
+    expect(isAlwaysMaintenanceWindow('NONE')).toBe(true);
+    expect(isAlwaysMaintenanceWindow(' anytime ')).toBe(true);
+  });
+
+  it('is false for real windows and malformed strings', () => {
+    expect(isAlwaysMaintenanceWindow('Sun 02:00-04:00')).toBe(false);
+    expect(isAlwaysMaintenanceWindow('02:00-04:00')).toBe(false);
+    expect(isAlwaysMaintenanceWindow('0000-2359')).toBe(false);
+  });
+});
+
+describe('parseMaintenanceWindow', () => {
+  it('parses day-prefixed, daily, and loosely-spaced windows', () => {
+    expect(parseMaintenanceWindow('Sun 02:00-04:00')).toEqual({ day: 0, startMin: 120, endMin: 240 });
+    expect(parseMaintenanceWindow('02:00-04:00')).toEqual({ day: null, startMin: 120, endMin: 240 });
+    expect(parseMaintenanceWindow('  mON  22:30 - 23:45 ')).toEqual({ day: 1, startMin: 1350, endMin: 1425 });
+    expect(parseMaintenanceWindow('2:00-4:00')).toEqual({ day: null, startMin: 120, endMin: 240 });
+  });
+
+  it('returns null for always sentinels, empty, and malformed input', () => {
+    expect(parseMaintenanceWindow('')).toBeNull();
+    expect(parseMaintenanceWindow('24/7')).toBeNull();
+    expect(parseMaintenanceWindow(null)).toBeNull();
+    expect(parseMaintenanceWindow('0000-2359')).toBeNull(); // no colons (issue #1963 repro)
+    expect(parseMaintenanceWindow('sometime soon')).toBeNull();
+    expect(parseMaintenanceWindow('Xyz 02:00-04:00')).toBeNull(); // bad day
+    expect(parseMaintenanceWindow('25:00-26:00')).toBeNull(); // bad hour
+    expect(parseMaintenanceWindow('02:00-02:00')).toBeNull(); // zero-length
+  });
+});
+
+describe('isValidMaintenanceWindow', () => {
+  it('accepts the always state and parseable windows', () => {
+    expect(isValidMaintenanceWindow('')).toBe(true);
+    expect(isValidMaintenanceWindow('24/7')).toBe(true);
+    expect(isValidMaintenanceWindow('Sun 02:00-04:00')).toBe(true);
+    expect(isValidMaintenanceWindow('22:00-02:00')).toBe(true);
+  });
+
+  it('rejects malformed values (so the API can refuse them at save time)', () => {
+    expect(isValidMaintenanceWindow('0000-2359')).toBe(false);
+    expect(isValidMaintenanceWindow('every other tuesday')).toBe(false);
+    expect(isValidMaintenanceWindow('02:00-02:00')).toBe(false);
+  });
+});
+
+describe('minutesToHHMM', () => {
+  it('zero-pads hours and minutes', () => {
+    expect(minutesToHHMM(0)).toBe('00:00');
+    expect(minutesToHHMM(120)).toBe('02:00');
+    expect(minutesToHHMM(1425)).toBe('23:45');
+  });
+});
+
+describe('formatMaintenanceWindow', () => {
+  it('builds a canonical window string round-trippable through the parser', () => {
+    expect(formatMaintenanceWindow('Sun', '02:00', '04:00')).toBe('Sun 02:00-04:00');
+    expect(formatMaintenanceWindow('', '02:00', '04:00')).toBe('02:00-04:00');
+    expect(formatMaintenanceWindow(null, '22:00', '02:00')).toBe('22:00-02:00');
+    expect(parseMaintenanceWindow(formatMaintenanceWindow('Mon', '22:30', '23:45')!))
+      .toEqual({ day: 1, startMin: 1350, endMin: 1425 });
+  });
+
+  it('returns null when the result would be an invalid window', () => {
+    expect(formatMaintenanceWindow('Sun', '02:00', '02:00')).toBeNull(); // zero-length
+    expect(formatMaintenanceWindow(null, '', '04:00')).toBeNull();
+  });
+
+  it('every MAINTENANCE_DAYS label is accepted by the parser', () => {
+    MAINTENANCE_DAYS.forEach((label, idx) => {
+      expect(parseMaintenanceWindow(`${label} 01:00-02:00`)).toEqual({
+        day: idx, startMin: 60, endMin: 120,
+      });
+    });
+  });
+});

--- a/packages/shared/src/validators/maintenanceWindow.ts
+++ b/packages/shared/src/validators/maintenanceWindow.ts
@@ -1,0 +1,119 @@
+/**
+ * Agent-update maintenance window — shared grammar + validation.
+ *
+ * The org/partner "Agent update policy" stores a single free-form string,
+ * `maintenanceWindow`, that gates when the heartbeat handler may hand an agent
+ * an upgrade target. This module is the ONE source of truth for that string's
+ * shape so the web editor (client-side validation + structured control) and the
+ * API (save-time rejection + heartbeat gating) never drift.
+ *
+ * Value space:
+ *   - "always allowed" / no restriction → empty, or the explicit sentinel
+ *     `"24/7"` (also tolerated: "always", "none"). Agents may update anytime.
+ *   - a window → `"[Day ]HH:MM-HH:MM"` (optional 3-letter day prefix; no day
+ *     means "daily"). Times are evaluated in **UTC** (the string carries no
+ *     timezone), so the UI must say so explicitly.
+ *
+ * Anything else is malformed. The API rejects malformed values at save time
+ * (issue #1963) so the heartbeat gate never has to silently fail open on a typo.
+ */
+
+/** Canonical sentinel persisted for the "update anytime" / no-window state. */
+export const MAINTENANCE_WINDOW_ALWAYS = '24/7';
+
+/** Display labels indexed by UTC day-of-week (0 = Sunday). */
+export const MAINTENANCE_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+const DAY_OF_WEEK: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+// Values (besides empty/whitespace) that mean "no maintenance window".
+const ALWAYS_TOKENS = new Set(['24/7', 'always', 'none', 'anytime']);
+
+export interface ParsedMaintenanceWindow {
+  /** UTC day-of-week the window starts on (0=Sun), or null for "any day" (daily). */
+  day: number | null;
+  /** Minutes-since-midnight the window opens. */
+  startMin: number;
+  /** Minutes-since-midnight the window closes. */
+  endMin: number;
+}
+
+/**
+ * True when `raw` represents the "update anytime / no maintenance window" state:
+ * empty / whitespace-only / the `24/7` sentinel (or the tolerated aliases).
+ */
+export function isAlwaysMaintenanceWindow(raw: string | null | undefined): boolean {
+  if (typeof raw !== 'string') return raw == null; // null/undefined → always; other non-strings → not
+  const trimmed = raw.trim();
+  if (!trimmed) return true;
+  return ALWAYS_TOKENS.has(trimmed.toLowerCase());
+}
+
+/**
+ * Parse a maintenance window string of the form "Sun 02:00-04:00" (optional
+ * 3-letter day prefix; "02:00-04:00" means daily). Returns null when the input
+ * is empty, an "always" sentinel, or malformed — callers treat null as
+ * "no time restriction".
+ */
+export function parseMaintenanceWindow(
+  raw: string | null | undefined,
+): ParsedMaintenanceWindow | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const m = trimmed.match(/^(?:([A-Za-z]{3})\s+)?(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
+  if (!m) return null;
+
+  const [, dayStr, sh, sm, eh, em] = m;
+  let day: number | null = null;
+  if (dayStr) {
+    const d = DAY_OF_WEEK[dayStr.toLowerCase()];
+    if (d === undefined) return null;
+    day = d;
+  }
+
+  const startH = Number(sh), startM = Number(sm), endH = Number(eh), endM = Number(em);
+  if (startH > 23 || endH > 23 || startM > 59 || endM > 59) return null;
+
+  const startMin = startH * 60 + startM;
+  const endMin = endH * 60 + endM;
+  if (startMin === endMin) return null; // zero-length window is meaningless
+
+  return { day, startMin, endMin };
+}
+
+/**
+ * Whether `raw` is an acceptable value to persist: either the "always" state or
+ * a parseable window. Used by both the API save guard and the web editor so a
+ * malformed value can never be silently stored.
+ */
+export function isValidMaintenanceWindow(raw: string | null | undefined): boolean {
+  return isAlwaysMaintenanceWindow(raw) || parseMaintenanceWindow(raw) !== null;
+}
+
+/** Format minutes-since-midnight as zero-padded "HH:MM". */
+export function minutesToHHMM(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * Build a canonical window string from UI fields. `dayLabel` is one of
+ * MAINTENANCE_DAYS or null/"" for daily; `start`/`end` are "HH:MM". Returns the
+ * canonical `"[Day ]HH:MM-HH:MM"` string, or `null` if the result would not be a
+ * valid window (caller should treat null as "invalid input", distinct from the
+ * always sentinel).
+ */
+export function formatMaintenanceWindow(
+  dayLabel: string | null | undefined,
+  start: string,
+  end: string,
+): string | null {
+  const prefix = dayLabel ? `${dayLabel} ` : '';
+  const candidate = `${prefix}${start}-${end}`;
+  return parseMaintenanceWindow(candidate) ? candidate : null;
+}

--- a/packages/shared/src/validators/maintenanceWindow.ts
+++ b/packages/shared/src/validators/maintenanceWindow.ts
@@ -9,7 +9,8 @@
  *
  * Value space:
  *   - "always allowed" / no restriction → empty, or the explicit sentinel
- *     `"24/7"` (also tolerated: "always", "none"). Agents may update anytime.
+ *     `"24/7"` (also tolerated: "always", "none", "anytime"). Agents may update
+ *     anytime. The canonical persisted form is `MAINTENANCE_WINDOW_ALWAYS`.
  *   - a window → `"[Day ]HH:MM-HH:MM"` (optional 3-letter day prefix; no day
  *     means "daily"). Times are evaluated in **UTC** (the string carries no
  *     timezone), so the UI must say so explicitly.
@@ -24,7 +25,10 @@ export const MAINTENANCE_WINDOW_ALWAYS = '24/7';
 /** Display labels indexed by UTC day-of-week (0 = Sunday). */
 export const MAINTENANCE_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
-const DAY_OF_WEEK: Record<string, number> = {
+/** UTC day-of-week index, 0=Sun … 6=Sat (matches Date.getUTCDay / MAINTENANCE_DAYS). */
+export type MaintenanceDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+const DAY_OF_WEEK: Record<string, MaintenanceDayIndex> = {
   sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
 };
 
@@ -33,10 +37,10 @@ const ALWAYS_TOKENS = new Set(['24/7', 'always', 'none', 'anytime']);
 
 export interface ParsedMaintenanceWindow {
   /** UTC day-of-week the window starts on (0=Sun), or null for "any day" (daily). */
-  day: number | null;
-  /** Minutes-since-midnight the window opens. */
+  day: MaintenanceDayIndex | null;
+  /** Minutes-since-midnight the window opens (0..1439, parser-guaranteed). */
   startMin: number;
-  /** Minutes-since-midnight the window closes. */
+  /** Minutes-since-midnight the window closes (0..1439, parser-guaranteed). */
   endMin: number;
 }
 
@@ -68,7 +72,7 @@ export function parseMaintenanceWindow(
   if (!m) return null;
 
   const [, dayStr, sh, sm, eh, em] = m;
-  let day: number | null = null;
+  let day: MaintenanceDayIndex | null = null;
   if (dayStr) {
     const d = DAY_OF_WEEK[dayStr.toLowerCase()];
     if (d === undefined) return null;

--- a/packages/shared/src/validators/maintenanceWindow.ts
+++ b/packages/shared/src/validators/maintenanceWindow.ts
@@ -22,6 +22,10 @@
 /** Canonical sentinel persisted for the "update anytime" / no-window state. */
 export const MAINTENANCE_WINDOW_ALWAYS = '24/7';
 
+/** Single source of the rejection message shared by every save path + the UI. */
+export const MAINTENANCE_WINDOW_ERROR_MESSAGE =
+  'Maintenance window must be "24/7" or a UTC window like "Sun 02:00-04:00".';
+
 /** Display labels indexed by UTC day-of-week (0 = Sunday). */
 export const MAINTENANCE_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 


### PR DESCRIPTION
## Summary

Closes #1963.

The agent-update **maintenance window** (Org Settings → General → Default settings → Agent update policy) was a free-text field with unclear, fragile semantics. This makes it explicit and validated end-to-end.

What the issue reported, and how it's addressed:

- **Free-text accepts anything / no validation** → the org editor is now a structured control (mode toggle + day + start/end), and the API rejects malformed windows at save time.
- **No UTC explanation** → start/end are labeled **(UTC)** with helper text ("Times are evaluated in UTC").
- **No explicit 24/7 / always option** → an explicit **"Always — agents may update anytime (24/7)"** mode, persisted durably as the `24/7` sentinel.
- **Clearing isn't durable (falls back to `Sun 02:00-04:00`)** → removed the `|| default` fallback; the always state round-trips across reloads. An unconfigured org now defaults to **always**, matching the backend's permissive default instead of silently committing to a Sunday window the first time defaults are saved.
- **Malformed values fail open (remove the restriction)** → can no longer be saved (API `400`); the heartbeat gate keeps failing open only for legacy/pre-existing malformed data rather than permanently blocking.

## Changes

- **`packages/shared/src/validators/maintenanceWindow.ts`** — single source of truth for the window grammar: `24/7`/empty always-state + `[Day ]HH:MM-HH:MM` window, with `isAlwaysMaintenanceWindow` / `parseMaintenanceWindow` / `isValidMaintenanceWindow` / `formatMaintenanceWindow` / `minutesToHHMM`.
- **`orgs.ts`** — `defaults.maintenanceWindow` now validated; malformed → `400`.
- **`agents/agentUpdatePolicy.ts`** — sources the parser from `@breeze/shared` (re-exported) so web + API share one grammar; gate logic unchanged.
- **`agents/helpers.ts`** — `getOrgAgentUpdatePolicy` maps the `24/7`/always sentinel to `null` (no restriction).
- **`OrgDefaultsEditor.tsx`** — structured, validated, UTC-labeled control; Save disabled on an invalid window.
- **`PartnerDefaultsTab.tsx`** — UTC/format guidance + inline invalid-value feedback (empty still = "orgs configure individually").

## Testing

- `packages/shared` validator unit tests (11) — green.
- `OrgDefaultsEditor.test.tsx` (5: default-always, hydrate window, build canonical, block invalid, durable `24/7`) — green.
- `helpers.agentUpdatePolicy.test.ts` (+2 always-sentinel cases), `agentUpdatePolicy.test.ts`, `heartbeat.test.ts`, `orgs.test.ts` — green.
- `tsc --noEmit` (shared, api) and `astro check` (web) — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)