### PR TITLE
test(web): lock single-emit toast invariant; #1301 verified dev-only (#1301)

### DIFF
--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -127,6 +127,28 @@ describe('ToastContainer', () => {
     });
   });
 
+  it('with two containers both mounted, a single live showToast renders exactly one toast (#1301 duplicate-island symptom)', async () => {
+    // The closest runtime analog of the #1301 "×2 toast" report: two
+    // ToastContainers simultaneously mounted/registered (the Astro island
+    // duplication / view-transition overlap case), then a SINGLE live
+    // showToast call. The single module-level emitter slot means the second
+    // mount overwrote the first's registration, so only one container renders
+    // the toast — a single emit must produce exactly one DOM toast, never two.
+    // (The pre-mount-queue test above exercises the splice-drain path; this
+    // one exercises the live-emit path through addToastFn.)
+    render(<ToastContainer />);
+    render(<ToastContainer />);
+
+    act(() => {
+      showToast({ type: 'success', message: 'single-live-emit' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('single-live-emit')).toBeInTheDocument();
+    });
+    expect(screen.getAllByTestId('toast')).toHaveLength(1);
+  });
+
   it('renders a warning toast with role=status and the correct data-toast-type', () => {
     render(<ToastContainer />);
 

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -9,6 +9,16 @@ interface ToastData {
   duration?: number;
 }
 
+// Single module-level emitter slot: only one ToastContainer is ever the
+// registered emitter at a time (see the effect below — a second mount overwrites
+// rather than adds a listener). This is why showToast cannot fan a single call
+// out to multiple toasts. The "duplicate success toasts" reported in #1301 were
+// an Astro/Vite *dev-server* render double-invoke (no <StrictMode> in the app;
+// prod ships production React), verified absent in a production build. Do NOT
+// add a time-window dedupe here to "fix" duplicates — it silently drops two
+// legitimately-distinct identical successes (e.g. two quick "Saved" toasts). The
+// rejected PR #1332 took that path; the call-count guard in runAction.test.ts
+// asserts the real single-emit invariant instead.
 let addToastFn: ((toast: Omit<ToastData, 'id'>) => void) | null = null;
 const pendingToasts: Array<Omit<ToastData, 'id'>> = [];
 

--- a/apps/web/src/lib/runAction.test.ts
+++ b/apps/web/src/lib/runAction.test.ts
@@ -14,13 +14,20 @@ function res(body: unknown, status = 200): Response {
 beforeEach(() => showToast.mockReset());
 
 describe('runAction', () => {
-  it('returns parsed data and toasts success when successMessage given', async () => {
+  it('returns parsed data and toasts success EXACTLY ONCE when successMessage given', async () => {
+    // Regression guard for #1301 ("duplicate success toasts on runAction").
+    // The ×2 toast reported there was an Astro/Vite dev-server render
+    // double-invoke that does not exist in a production build (the app has no
+    // <StrictMode>, and the prod bundle ships production React). runAction must
+    // emit a single success toast per call — asserting the call COUNT, not just
+    // `toHaveBeenCalledWith`, is what locks that single-emit guarantee in.
     const out = await runAction<{ id: string }>({
       request: async () => res({ id: 'x' }),
       successMessage: 'Done',
       errorFallback: 'fb',
     });
     expect(out).toEqual({ id: 'x' });
+    expect(showToast).toHaveBeenCalledTimes(1);
     expect(showToast).toHaveBeenCalledWith({ message: 'Done', type: 'success' });
   });
 


### PR DESCRIPTION
## Summary

Issue #1301 ("Duplicate success toasts on runAction mutations") was flagged **dev-observed; verify prod build**. This PR completes that verification step and locks in the result. **Refs #1301** (not `Closes` — the dev-only disposition / close-as-not-a-bug is the maintainer's call; see the issue comment).

**Finding: the duplicate toast does NOT reproduce in a production build — it is a dev-server artifact.** Empirically confirmed via `pnpm --filter @breeze/web build` (build succeeds; output inspected):

- The prod client bundle ships **production React** — `react.development` is absent — so the dev-mode effect/handler double-invocation that produced the `×2` toast does not exist.
- There is **no app-level `<StrictMode>`** wrapper (the only `StrictMode` strings in the bundle are React's own internal symbol name / devtools hook, e.g. `case Ha:return"StrictMode"`).
- The Toast chunk ships the **single module-level emitter slot** (`splice` snapshot-drain) with **no time-window dedupe** — so a single `showToast` call yields a single toast.

This corroborates the prior static analysis on the issue (single emitter slot; `runAction` emits once; no caller double-emits) with runtime build evidence.

## What changed (no runtime fix — by design)

A time-window dedupe was explicitly **rejected** (closed PR #1332): it silently drops two legitimately-distinct identical successes (e.g. two quick "Saved" toasts). Instead this PR locks the real invariant:

- `apps/web/src/lib/runAction.test.ts` — assert the success toast fires **exactly once** (call **count**, not just `toHaveBeenCalledWith`). This was the one missing guard: the "exactly once" assertion previously existed only on the failure path.
- `apps/web/src/components/shared/Toast.tsx` — comment documenting the single-emitter-slot invariant and why a dedupe must not be re-introduced.

## Verification

- `vitest run Toast.test.tsx runAction.test.ts` → 22/22 passed (jsdom renders without StrictMode = production render semantics).
- `tsc --noEmit` (apps/web) → clean.
- `pnpm --filter @breeze/web build` → succeeds; bundle inspected as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)