### PR TITLE
feat(web): unified default sort for the merged Devices list (#1424)

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -485,7 +485,25 @@ export default function DeviceList({
   );
 
   const sortedDevices = useMemo(() => {
-    if (!sortField) return filteredDevices;
+    // Default ordering for the merged list (#1424, deferred item 1). With no
+    // column actively selected, agent rows arrive hostname-sorted from the
+    // cursor API while network rows arrive last-seen-sorted from the offset
+    // API, and DevicesPage concatenates them as `[...agents, ...network]`. The
+    // raw concatenation therefore renders as two differently-ordered blocks —
+    // the "merged list visibly alternates sort order" defect. Apply one unified
+    // key across the whole union: the same `displayName || hostname` the Device
+    // column sorts on, with `id` as a stable tiebreaker so client-side
+    // pagination is deterministic (a row can't hop pages between renders).
+    if (!sortField) {
+      const byName = sortValue.hostname;
+      return [...filteredDevices].sort((a, b) => {
+        const cmp = String(byName(a)).localeCompare(String(byName(b)), undefined, {
+          numeric: true,
+          sensitivity: 'base',
+        });
+        return cmp !== 0 ? cmp : a.id.localeCompare(b.id);
+      });
+    }
     const value = sortValue[sortField];
     const dir = sortDirection === 'desc' ? -1 : 1;
 

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -244,6 +244,14 @@ const statusSortRank: Record<DeviceStatus, number> = {
   decommissioned: 6,
 };
 
+// Single shared collator for every string sort in this list. `numeric` keeps
+// host-2 < host-10 and agent 0.9.x < 0.10.x; `base` sensitivity folds case and
+// accents so they don't fragment the order. Hoisted to module scope on purpose:
+// constructing an Intl.Collator per comparison is measurably costly on the
+// default landing view at the ~40k-row cap, where the sort runs over the whole
+// union on every render.
+const nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
 // One comparable value per column, mirroring what the cell displays.
 // `null` means "renders as a dash" — those rows sort last in BOTH
 // directions so blanks never bury the real data. Strings compare with
@@ -496,11 +504,24 @@ export default function DeviceList({
     // pagination is deterministic (a row can't hop pages between renders).
     if (!sortField) {
       const byName = sortValue.hostname;
+      // sortValue is typed `string | number | null`; a null/blank name must sort
+      // blanks-last (like the column-sort branch below) rather than become the
+      // string "null"/"" buried among real names. Two blanks tie and fall
+      // through to the id tiebreaker so client-side pagination stays stable.
+      const isBlank = (v: string | number | null) => v == null || String(v).trim() === '';
       return [...filteredDevices].sort((a, b) => {
-        const cmp = String(byName(a)).localeCompare(String(byName(b)), undefined, {
-          numeric: true,
-          sensitivity: 'base',
-        });
+        const av = byName(a);
+        const bv = byName(b);
+        const aBlank = isBlank(av);
+        const bBlank = isBlank(bv);
+        const cmp =
+          aBlank || bBlank
+            ? aBlank === bBlank
+              ? 0
+              : aBlank
+                ? 1
+                : -1
+            : nameCollator.compare(String(av), String(bv));
         return cmp !== 0 ? cmp : a.id.localeCompare(b.id);
       });
     }
@@ -515,7 +536,7 @@ export default function DeviceList({
       const cmp =
         typeof av === 'number' && typeof bv === 'number'
           ? av - bv
-          : String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' });
+          : nameCollator.compare(String(av), String(bv));
       return dir * cmp;
     });
   }, [filteredDevices, sortField, sortDirection]);

--- a/apps/web/src/components/devices/DeviceList.unified.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.unified.test.tsx
@@ -222,9 +222,8 @@ describe('DeviceList — unified agent + network (#1322)', () => {
 
       const { container } = render(<DeviceList devices={devices} pageSize={50} networkDevicesEnabled />);
 
-      // Both render the same hostname text; assert order via the row id by
-      // reading the select checkbox aria-label is overkill — instead re-render
-      // with the input reversed and confirm the DOM order is unchanged.
+      // Both rows render the same hostname text, so assert order via the class
+      // badge id and confirm reversing the input doesn't change the DOM order.
       const firstPass = Array.from(container.querySelectorAll('tbody tr')).map(tr =>
         tr.querySelector('[data-testid$="-class-badge"]')?.getAttribute('data-testid'),
       );
@@ -241,6 +240,41 @@ describe('DeviceList — unified agent + network (#1322)', () => {
         'device-b0000000-0000-0000-0000-0000000000ff-class-badge',
       ]);
       expect(secondPass).toEqual(firstPass);
+    });
+
+    it('applies the unified numeric collation even with zero network rows (agent-only fleet)', () => {
+      // The default sort is unconditional — gated only on "no active column
+      // sort", not on the network arm. So an agent-only fleet (feature flag off,
+      // no network rows) is still re-ordered to the unified key: host-2 sorts
+      // before host-10 rather than keeping the server's lexical order. This is
+      // intentional and deterministic, not a network-only behavior.
+      const devices: Device[] = [
+        mkAgent('a4444444-0000-0000-0000-000000000010', 'host-10'),
+        mkAgent('a4444444-0000-0000-0000-000000000002', 'host-2'),
+        mkAgent('a4444444-0000-0000-0000-000000000001', 'alpha'),
+      ];
+
+      const { container } = render(<DeviceList devices={devices} pageSize={50} />);
+
+      expect(rowOrder(container)).toEqual(['alpha', 'host-2', 'host-10']);
+    });
+
+    it('sorts a row with an empty/whitespace name last (blanks-last)', () => {
+      // `displayName || hostname` can be blank; such a row must sink to the
+      // bottom rather than collate as an empty string among the named rows —
+      // matching the column-sort branch's blanks-last rule.
+      const devices: Device[] = [
+        mkAgent('a5555555-0000-0000-0000-000000000001', '   '),
+        mkAgent('a5555555-0000-0000-0000-000000000002', 'bravo'),
+        mkAgent('a5555555-0000-0000-0000-000000000003', 'alpha'),
+      ];
+
+      const { container } = render(<DeviceList devices={devices} pageSize={50} networkDevicesEnabled />);
+
+      const order = rowOrder(container);
+      expect(order.slice(0, 2)).toEqual(['alpha', 'bravo']);
+      // The blank-named row renders last; its primary name span is whitespace.
+      expect(order[2]?.trim()).toBe('');
     });
   });
 });

--- a/apps/web/src/components/devices/DeviceList.unified.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.unified.test.tsx
@@ -159,29 +159,56 @@ describe('DeviceList — unified agent + network (#1322)', () => {
   // visibly alternates sort order"). The default ordering must instead apply one
   // unified key across the whole union so the classes interleave coherently.
   describe('unified default sort across the merged union (#1424)', () => {
-    // Hostnames of rendered rows, in DOM order. Each fixture uses a unique
-    // hostname and no displayName, so the hostname cell holds exactly one span.
+    // Primary display name of each rendered row, in DOM order. The hostname
+    // cell renders the primary name (`displayName || hostname`) in a
+    // `font-medium` span and, only when a distinct displayName is present, the
+    // raw hostname in a second muted span — so target the primary span
+    // explicitly rather than every span in the cell.
     const rowOrder = (container: HTMLElement) =>
-      Array.from(container.querySelectorAll('tbody tr td:nth-child(2) span')).map(el => el.textContent);
+      Array.from(container.querySelectorAll('tbody tr td:nth-child(2) span.font-medium')).map(
+        el => el.textContent,
+      );
 
     const mkAgent = (id: string, hostname: string): Device => ({ ...agent, id, hostname });
     const mkNetwork = (id: string, hostname: string): Device => ({ ...networkPrinter, id, hostname });
 
-    it('interleaves agent and network rows alphabetically instead of as two blocks', () => {
+    it('interleaves agent and network rows by name (numeric collation) instead of as two blocks', () => {
       // Input arrives as the DevicesPage concatenation: all agents first (in
       // their server hostname order), then all network rows (in last-seen
-      // order). Names are chosen so a coherent default sort must interleave the
-      // two classes (a-b-c-d), which a raw concatenation never would.
+      // order). Names force a coherent default sort to interleave the two
+      // classes, which a raw concatenation never would. `node-2`/`node-10` also
+      // pin the numeric collation: a lexical sort would order `node-10` first.
       const devices: Device[] = [
+        mkAgent('a1111111-0000-0000-0000-000000000010', 'node-10'),
         mkAgent('a1111111-0000-0000-0000-000000000001', 'alpha-pc'),
-        mkAgent('a1111111-0000-0000-0000-000000000003', 'charlie-pc'),
-        mkNetwork('b2222222-0000-0000-0000-000000000002', 'bravo-switch'),
-        mkNetwork('b2222222-0000-0000-0000-000000000004', 'delta-printer'),
+        mkNetwork('b2222222-0000-0000-0000-000000000002', 'node-2'),
+        mkNetwork('b2222222-0000-0000-0000-000000000003', 'bravo-switch'),
       ];
 
       const { container } = render(<DeviceList devices={devices} pageSize={50} networkDevicesEnabled />);
 
-      expect(rowOrder(container)).toEqual(['alpha-pc', 'bravo-switch', 'charlie-pc', 'delta-printer']);
+      // agent, network, network, agent — interleaved, and node-2 before node-10.
+      expect(rowOrder(container)).toEqual(['alpha-pc', 'bravo-switch', 'node-2', 'node-10']);
+    });
+
+    it('orders by displayName when present, not the raw hostname', () => {
+      // The default key is `displayName || hostname` (the same the Device column
+      // sorts on). A device whose displayName disagrees with its hostname order
+      // must sort by the displayName the cell actually shows — sorting by raw
+      // hostname would place `zzz-machine` last instead of first.
+      const labeled: Device = {
+        ...agent,
+        id: 'a3333333-0000-0000-0000-000000000001',
+        hostname: 'zzz-machine',
+        displayName: 'aaa-friendly',
+      };
+      const plain = mkAgent('a3333333-0000-0000-0000-000000000002', 'mmm-machine');
+
+      const { container } = render(
+        <DeviceList devices={[plain, labeled]} pageSize={50} networkDevicesEnabled />,
+      );
+
+      expect(rowOrder(container)).toEqual(['aaa-friendly', 'mmm-machine']);
     });
 
     it('breaks hostname ties by id so client-side pagination is deterministic', () => {

--- a/apps/web/src/components/devices/DeviceList.unified.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.unified.test.tsx
@@ -151,4 +151,69 @@ describe('DeviceList — unified agent + network (#1322)', () => {
       expect(within(roleCell).queryByLabelText(/workstation|server|printer/i)).toBeNull();
     });
   });
+
+  // #1424 (deferred item 1): with no column actively selected, the agent arm
+  // arrives hostname-sorted and the network arm last-seen-sorted, and
+  // DevicesPage concatenates them as `[...agents, ...network]`. The raw
+  // concatenation renders as two differently-ordered blocks ("the merged list
+  // visibly alternates sort order"). The default ordering must instead apply one
+  // unified key across the whole union so the classes interleave coherently.
+  describe('unified default sort across the merged union (#1424)', () => {
+    // Hostnames of rendered rows, in DOM order. Each fixture uses a unique
+    // hostname and no displayName, so the hostname cell holds exactly one span.
+    const rowOrder = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('tbody tr td:nth-child(2) span')).map(el => el.textContent);
+
+    const mkAgent = (id: string, hostname: string): Device => ({ ...agent, id, hostname });
+    const mkNetwork = (id: string, hostname: string): Device => ({ ...networkPrinter, id, hostname });
+
+    it('interleaves agent and network rows alphabetically instead of as two blocks', () => {
+      // Input arrives as the DevicesPage concatenation: all agents first (in
+      // their server hostname order), then all network rows (in last-seen
+      // order). Names are chosen so a coherent default sort must interleave the
+      // two classes (a-b-c-d), which a raw concatenation never would.
+      const devices: Device[] = [
+        mkAgent('a1111111-0000-0000-0000-000000000001', 'alpha-pc'),
+        mkAgent('a1111111-0000-0000-0000-000000000003', 'charlie-pc'),
+        mkNetwork('b2222222-0000-0000-0000-000000000002', 'bravo-switch'),
+        mkNetwork('b2222222-0000-0000-0000-000000000004', 'delta-printer'),
+      ];
+
+      const { container } = render(<DeviceList devices={devices} pageSize={50} networkDevicesEnabled />);
+
+      expect(rowOrder(container)).toEqual(['alpha-pc', 'bravo-switch', 'charlie-pc', 'delta-printer']);
+    });
+
+    it('breaks hostname ties by id so client-side pagination is deterministic', () => {
+      // Two rows share a hostname; without a stable tiebreaker their relative
+      // order would depend on input/merge order and a row could hop pages
+      // between renders. The id tiebreaker pins the order.
+      const devices: Device[] = [
+        mkNetwork('b0000000-0000-0000-0000-0000000000ff', 'shared-host'),
+        mkAgent('a0000000-0000-0000-0000-000000000001', 'shared-host'),
+      ];
+
+      const { container } = render(<DeviceList devices={devices} pageSize={50} networkDevicesEnabled />);
+
+      // Both render the same hostname text; assert order via the row id by
+      // reading the select checkbox aria-label is overkill — instead re-render
+      // with the input reversed and confirm the DOM order is unchanged.
+      const firstPass = Array.from(container.querySelectorAll('tbody tr')).map(tr =>
+        tr.querySelector('[data-testid$="-class-badge"]')?.getAttribute('data-testid'),
+      );
+      const { container: container2 } = render(
+        <DeviceList devices={[...devices].reverse()} pageSize={50} networkDevicesEnabled />,
+      );
+      const secondPass = Array.from(container2.querySelectorAll('tbody tr')).map(tr =>
+        tr.querySelector('[data-testid$="-class-badge"]')?.getAttribute('data-testid'),
+      );
+
+      // a000... sorts before b000..., regardless of input order.
+      expect(firstPass).toEqual([
+        'device-a0000000-0000-0000-0000-000000000001-class-badge',
+        'device-b0000000-0000-0000-0000-0000000000ff-class-badge',
+      ]);
+      expect(secondPass).toEqual(firstPass);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

First slice of **#1424** (Unified Devices list phase 2). Fixes the named **deferred item 1** defect — *"the merged list visibly alternates sort order"* — without the larger server-side cursor-coordinator rework (tracked as follow-ups below).

**Root cause.** The unified list (#1322) fetches both arms fully into memory (`fetchAllDevices` walks the agent keyset cursor; `fetchAllNetworkDevices` walks the network offset pages) and `DevicesPage` concatenates them as `[...agents, ...network]`. The agent arm arrives `hostname ASC`, the network arm `lastSeen DESC`. `DeviceList`'s `sortedDevices` returned that raw concatenation whenever **no column was actively selected** (`sortField === null`), so the default view rendered as two differently-ordered blocks.

**Fix.** When no column sort is active, apply one unified default key across the whole union — the same `displayName || hostname` the Device column already sorts on (numeric collation, case-insensitive) — with `id` as a stable tiebreaker so client-side pagination is deterministic (a row can't hop pages between renders). Explicit header-sort behavior is unchanged.

**Note on agent-only fleets.** The default sort runs unconditionally (gated only on `sortField === null`, not on the presence of network rows), so agent-only fleets **are** re-ordered to the unified key. This is intentional: a fleet with `displayName`s, or numeric-suffix hostnames like `host-2`/`host-10`, now sorts by the same `displayName || hostname` numeric collation the Device column uses (`host-2` before `host-10`) rather than the server's raw lexical hostname order. The result is deterministic (`id` tiebreaker) and consistent with explicit Device-column sort. It is **not** a no-op for agent-only fleets — the earlier "unaffected" framing was inaccurate.

Scope: one `useMemo` in `DeviceList.tsx` + tests. No API, schema, or RLS changes.

## Test plan
- [x] `DeviceList.unified.test.tsx` — `unified default sort` describe: interleaves agent+network rows by numeric collation (not two blocks), applies the unified collation on the agent-only / network-flag-off path, sorts empty/whitespace names blanks-last, and breaks hostname ties by id deterministically.
- [x] Affected web suites green single-run.
- [x] `tsc --noEmit` clean (web); eslint clean on changed files.

## Remaining phase-2 work (follow-up PRs, do not close #1424)
1. Per-asset native detail/overview pages for network rows (currently link out to Discovery).
2. Inline approval / reclassify / link-unlink from the Devices list.
3. (Optional, scaling) Server-side unified cursor coordinator + network keyset cursor, if the full client-side walk becomes a perf concern at large fleet sizes. Not required for correctness under the current full-walk model.
4. Flip `PUBLIC_ENABLE_NETWORK_DEVICES_IN_LIST` on once 1–2 land, then remove the flag.

Refs #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
