### PR TITLE
feat(automations): Software Deployment action type (#1981)

### DIFF
--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -8,8 +8,20 @@ import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 import { authMiddleware } from '../middleware/auth';
 import { inArray, eq } from 'drizzle-orm';
+import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
+import { createSoftwareDeployment } from '../services/softwareDeployment';
+
+// Hoist the createSoftwareDeployment mock factory so the reference is available
+// both inside the vi.mock factory and in the test body.
+const { createDeploymentMock } = vi.hoisted(() => ({
+  createDeploymentMock: vi.fn(),
+}));
 
 vi.mock('../services', () => ({}));
+
+vi.mock('../services/softwareDeployment', () => ({
+  createSoftwareDeployment: createDeploymentMock,
+}));
 
 // Wrap drizzle's condition builders in spies (behavior preserved) so tests can
 // assert the actual org-scoping WHERE condition, not just that a query ran.
@@ -457,6 +469,150 @@ describe('software routes', () => {
         body: JSON.stringify({ softwareId: '11111111-1111-1111-1111-111111111111' })
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /software/deployments', () => {
+    // Shared fixture UUIDs
+    const VERSION_ID = '11111111-1111-4111-8111-111111111111';
+    const DEVICE_ID  = '22222222-2222-4222-8222-222222222222';
+    const MW_ID      = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    const versionRow = {
+      id: VERSION_ID,
+      catalogId: 'cat-1',
+      version: '1.0.0',
+      s3Key: null,
+      downloadUrl: 'https://example.com/pkg.exe',
+    };
+    const catalogRow = {
+      id: 'cat-1',
+      orgId: 'org-123',
+      name: 'TestApp',
+      integrationProvider: null,
+    };
+
+    // Helper that resolves like the Drizzle chain regardless of chain depth.
+    const selectResult = (rows: any): any => {
+      const p: any = new Proxy(() => p, {
+        get: (_t, prop) => (prop === 'then' ? (resolve: any) => resolve(rows) : () => p),
+      });
+      return p;
+    };
+
+    it('returns 201 with the full deployment object on a successful immediate install', async () => {
+      // The route does two db.select() calls before handing off to the service.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResult([versionRow]))   // version lookup
+        .mockReturnValueOnce(selectResult([catalogRow]));  // catalog lookup
+
+      vi.mocked(resolveDeploymentTargets).mockResolvedValueOnce([DEVICE_ID]);
+
+      const mockDeployment = {
+        id: 'dep-1',
+        orgId: 'org-123',
+        name: 'Test Deploy',
+        softwareVersionId: VERSION_ID,
+        deploymentType: 'install',
+        targetType: 'devices',
+        targetIds: [DEVICE_ID],
+        scheduleType: 'immediate',
+        maintenanceWindowId: null,
+        createdBy: 'user-123',
+        createdAt: new Date().toISOString(),
+        scheduledAt: null,
+        options: null,
+      };
+      createDeploymentMock.mockResolvedValueOnce({
+        deploymentId: mockDeployment.id,
+        deployment: mockDeployment,
+        status: 'pending',
+        dispatchedDeviceIds: [DEVICE_ID],
+      });
+
+      const res = await app.request('/software/deployments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Test Deploy',
+          softwareVersionId: VERSION_ID,
+          deploymentType: 'install',
+          targetType: 'devices',
+          targetIds: [DEVICE_ID],
+          scheduleType: 'immediate',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data).toEqual(mockDeployment);
+    });
+
+    it('passes maintenanceWindowId through to the service when supplied', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResult([versionRow]))
+        .mockReturnValueOnce(selectResult([catalogRow]));
+
+      vi.mocked(resolveDeploymentTargets).mockResolvedValueOnce([DEVICE_ID]);
+
+      createDeploymentMock.mockResolvedValueOnce({
+        deploymentId: 'dep-2',
+        deployment: { id: 'dep-2' },
+        status: 'pending',
+        dispatchedDeviceIds: [],
+      });
+
+      await app.request('/software/deployments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'MW Deploy',
+          softwareVersionId: VERSION_ID,
+          deploymentType: 'install',
+          targetType: 'devices',
+          targetIds: [DEVICE_ID],
+          scheduleType: 'maintenance',
+          maintenanceWindowId: MW_ID,
+        }),
+      });
+
+      expect(createDeploymentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ maintenanceWindowId: MW_ID })
+      );
+    });
+
+    it('stores non-devices targetType as given (not coerced to "devices")', async () => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectResult([versionRow]))
+        .mockReturnValueOnce(selectResult([catalogRow]));
+
+      // targetType:'all' resolves to a list of all org devices
+      vi.mocked(resolveDeploymentTargets).mockResolvedValueOnce([DEVICE_ID]);
+
+      createDeploymentMock.mockResolvedValueOnce({
+        deploymentId: 'dep-3',
+        deployment: { id: 'dep-3', targetType: 'all', targetIds: null },
+        status: 'pending',
+        dispatchedDeviceIds: [DEVICE_ID],
+      });
+
+      const res = await app.request('/software/deployments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'All-Devices Deploy',
+          softwareVersionId: VERSION_ID,
+          deploymentType: 'install',
+          targetType: 'all',
+          scheduleType: 'immediate',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      // The service must receive the original targetType, not a hardcoded 'devices'.
+      expect(createDeploymentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ targetType: 'all' })
+      );
     });
   });
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -1078,6 +1078,10 @@ softwareRoutes.post(
           : payload.options ?? undefined,
     });
 
+    if (result.status === 'failed') {
+      return c.json({ data: { id: result.deploymentId, status: result.status, message: result.message } }, 200);
+    }
+
     writeRouteAudit(c, {
       orgId,
       action: 'software.deployment.create',
@@ -1091,9 +1095,6 @@ softwareRoutes.post(
       },
     });
 
-    if (result.status === 'failed') {
-      return c.json({ data: { id: result.deploymentId, status: result.status, message: result.message } }, 200);
-    }
     return c.json({ data: result.deployment }, 201);
   }
 );

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -28,6 +28,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { createSoftwareDeployment } from '../services/softwareDeployment';
 
 export const softwareRoutes = new Hono();
 const requireSoftwareRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -1059,123 +1060,29 @@ softwareRoutes.post(
     }
     const targetDeviceIds = resolvedTargets.deviceIds;
 
-    // Insert deployment
-    const [deployment] = await db.insert(softwareDeployments).values({
+    const result = await createSoftwareDeployment({
       orgId,
-      name: payload.name,
       softwareVersionId: payload.softwareVersionId,
       deploymentType: payload.deploymentType,
+      deviceIds: targetDeviceIds,
+      scheduleType: payload.scheduleType,
+      createdBy: auth.user?.id ?? null,
+      name: payload.name,
+      scheduledAt: payload.scheduledAt ? new Date(payload.scheduledAt) : undefined,
+      maintenanceWindowId: payload.maintenanceWindowId ?? null,
       targetType: payload.targetType,
       targetIds: payload.targetIds ?? null,
-      scheduleType: payload.scheduleType,
-      scheduledAt: payload.scheduledAt ? new Date(payload.scheduledAt) : null,
-      maintenanceWindowId: payload.maintenanceWindowId ?? null,
-      options: payload.targetType === 'filter'
-        ? {
-            ...(payload.options ?? {}),
-            targetFilter: payload.targetFilter ?? null,
-          }
-        : payload.options ?? null,
-      createdBy: auth.user?.id ?? null,
-    }).returning();
-
-    // Insert per-device results
-    if (targetDeviceIds.length > 0) {
-      await db.insert(deploymentResults).values(
-        targetDeviceIds.map(deviceId => ({
-          deploymentId: deployment!.id,
-          deviceId,
-          status: 'pending' as const,
-        }))
-      );
-    }
-
-    // For immediate deployments, dispatch install commands to online agents
-    if (payload.scheduleType === 'immediate' && payload.deploymentType === 'install' && targetDeviceIds.length > 0) {
-      // Get presigned URL for download
-      let downloadUrl: string | null = null;
-      if (versionRecord.s3Key && isS3Configured()) {
-        try {
-          downloadUrl = await getPresignedUrl(versionRecord.s3Key, 3600);
-        } catch (err) {
-          // Don't swallow: a transport/auth fault must be visible even though we
-          // still fall back to the stored downloadUrl below (#1808).
-          console[isS3NotFound(err) ? 'warn' : 'error'](
-            `[software-deploy] S3 presign failed for ${versionRecord.s3Key}, falling back to stored downloadUrl:`,
-            err,
-          );
-        }
-      }
-      downloadUrl = downloadUrl ?? versionRecord.downloadUrl;
-
-      // Built-in EDR packages: resolve per-org keys server-side BEFORE the dispatch
-      // gate. On resolution failure, mark every result failed and return — never
-      // dispatch and never silently no-op.
-      let resolvedInstaller: ResolvedInstaller | null = null;
-      if (catalogItem.integrationProvider === 'huntress' || catalogItem.integrationProvider === 'sentinelone') {
-        const resolved = await resolveEdrInstaller({
-          provider: catalogItem.integrationProvider,
-          orgId,
-          downloadUrlTemplate: versionRecord.downloadUrl,
-          silentInstallArgsTemplate: versionRecord.silentInstallArgs,
-        });
-        if ('error' in resolved) {
-          await db.update(deploymentResults)
-            .set({ status: 'failed', errorMessage: resolved.error, completedAt: new Date() })
-            .where(eq(deploymentResults.deploymentId, deployment!.id));
-          return c.json({ data: { id: deployment!.id, status: 'failed', message: resolved.error } }, 200);
-        }
-        resolvedInstaller = resolved;
-      }
-
-      const finalDownloadUrl = resolvedInstaller?.downloadUrl ?? downloadUrl;
-      const finalSilentInstallArgs = resolvedInstaller?.silentInstallArgs ?? versionRecord.silentInstallArgs;
-
-      if (!finalDownloadUrl) {
-        // No installer binary/URL to dispatch — fail the results instead of leaving
-        // them 'pending' forever and reporting a false success to the caller.
-        await db.update(deploymentResults)
-          .set({
-            status: 'failed',
-            errorMessage: 'No installer available for this version — upload an installer (or check storage configuration) before deploying.',
-            completedAt: new Date(),
-          })
-          .where(eq(deploymentResults.deploymentId, deployment!.id));
-        return c.json({ data: { id: deployment!.id, status: 'failed', message: 'No installer available for this version' } }, 200);
-      }
-
-      // Get agentIds for target devices
-      const targetDevices = await db.select({ id: devices.id, agentId: devices.agentId })
-        .from(devices)
-        .where(and(
-          eq(devices.orgId, orgId),
-          inArray(devices.id, targetDeviceIds),
-        ));
-
-      for (const device of targetDevices) {
-        const command: AgentCommand = {
-          id: `sw-install-${deployment!.id}-${device.id}`,
-          type: 'software_install',
-          payload: {
-            deploymentId: deployment!.id,
-            downloadUrl: finalDownloadUrl,
-            checksum: versionRecord.checksum,
-            fileName: versionRecord.originalFileName ?? `package.${versionRecord.fileType ?? 'exe'}`,
-            fileType: versionRecord.fileType ?? 'exe',
-            silentInstallArgs: finalSilentInstallArgs,
-            softwareName: catalogItem.name,
-            version: versionRecord.version,
-          },
-        };
-        sendCommandToAgent(device.agentId, command);
-      }
-    }
+      options:
+        payload.targetType === 'filter'
+          ? { ...(payload.options ?? {}), targetFilter: payload.targetFilter ?? null }
+          : payload.options ?? undefined,
+    });
 
     writeRouteAudit(c, {
       orgId,
       action: 'software.deployment.create',
       resourceType: 'software_deployment',
-      resourceId: deployment!.id,
+      resourceId: result.deploymentId,
       resourceName: payload.name,
       details: {
         deploymentType: payload.deploymentType,
@@ -1184,7 +1091,10 @@ softwareRoutes.post(
       },
     });
 
-    return c.json({ data: deployment }, 201);
+    if (result.status === 'failed') {
+      return c.json({ data: { id: result.deploymentId, status: result.status, message: result.message } }, 200);
+    }
+    return c.json({ data: result.deployment }, 201);
   }
 );
 

--- a/apps/api/src/services/automationRuntime.deploySoftware.test.ts
+++ b/apps/api/src/services/automationRuntime.deploySoftware.test.ts
@@ -57,7 +57,7 @@ vi.mock('./notificationSenders', () => ({
   sendWebhookNotification: vi.fn().mockResolvedValue({ success: false }),
 }));
 
-import { executeDeploySoftwareActions } from './automationRuntime';
+import { executeDeploySoftwareActions, normalizeAutomationActions } from './automationRuntime';
 
 const WIN = { id: 'd-win', osType: 'windows' as const };
 const MAC = { id: 'd-mac', osType: 'macos' as const };
@@ -69,6 +69,30 @@ beforeEach(() => {
     version: { id: 'ver-1', catalogId: 'cat-1', version: '126.0.0', supportedOs: ['windows'] },
     catalogName: 'Chrome',
   }]]));
+});
+
+describe('normalizeAutomationActions — deploy_software', () => {
+  it('normalizes a deploy_software action with camelCase catalogId', () => {
+    const result = normalizeAutomationActions([{ type: 'deploy_software', catalogId: 'cat-abc' }]);
+    expect(result).toEqual([{ type: 'deploy_software', catalogId: 'cat-abc' }]);
+  });
+
+  it('normalizes a deploy_software action with snake_case catalog_id', () => {
+    const result = normalizeAutomationActions([{ type: 'deploy_software', catalog_id: 'cat-xyz' }]);
+    expect(result).toEqual([{ type: 'deploy_software', catalogId: 'cat-xyz' }]);
+  });
+
+  it('throws AutomationValidationError when catalogId is missing', () => {
+    expect(() => normalizeAutomationActions([{ type: 'deploy_software' }])).toThrow(
+      'actions[0] deploy_software requires catalogId',
+    );
+  });
+
+  it('throws AutomationValidationError for unknown action type', () => {
+    expect(() => normalizeAutomationActions([{ type: 'unknown_action' }])).toThrow(
+      'unsupported action type: unknown_action',
+    );
+  });
 });
 
 describe('executeDeploySoftwareActions', () => {
@@ -90,6 +114,38 @@ describe('executeDeploySoftwareActions', () => {
     });
     expect(createDeploymentMock).not.toHaveBeenCalled();
     expect(res.logs.some(l => /unsupported OS/i.test(l.message))).toBe(true);
+  });
+
+  it('deploys to all devices when supportedOs is null/empty (no OS restriction)', async () => {
+    latestMapMock.mockResolvedValueOnce(new Map([['cat-1', {
+      version: { id: 'ver-1', catalogId: 'cat-1', version: '1.0.0', supportedOs: null },
+      catalogName: 'SomeCrossplatformTool',
+    }]]));
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN, MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).toHaveBeenCalledTimes(1);
+    expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(
+      expect.arrayContaining(['d-win', 'd-mac']),
+    );
+    expect(res.failed).toBe(false);
+  });
+
+  it('deploys to all devices when supportedOs is an empty array', async () => {
+    latestMapMock.mockResolvedValueOnce(new Map([['cat-1', {
+      version: { id: 'ver-1', catalogId: 'cat-1', version: '1.0.0', supportedOs: [] },
+      catalogName: 'CrossplatformTool',
+    }]]));
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN, MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).toHaveBeenCalledTimes(1);
+    expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(
+      expect.arrayContaining(['d-win', 'd-mac']),
+    );
+    expect(res.failed).toBe(false);
   });
 
   it('skips a device that is already current', async () => {

--- a/apps/api/src/services/automationRuntime.deploySoftware.test.ts
+++ b/apps/api/src/services/automationRuntime.deploySoftware.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { createDeploymentMock, latestMapMock, isCurrentMock } = vi.hoisted(() => ({
+  createDeploymentMock: vi.fn(),
+  latestMapMock: vi.fn(),
+  isCurrentMock: vi.fn(),
+}));
+vi.mock('./softwareDeployment', () => ({ createSoftwareDeployment: createDeploymentMock }));
+vi.mock('./softwareCurrency', () => ({
+  resolveLatestVersionsByCatalogId: latestMapMock,
+  isDeviceSoftwareCurrent: isCurrentMock,
+}));
+
+// Mock all transitive dependencies that automationRuntime.ts loads
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  automationRuns: { id: 'id', automationId: 'automationId', status: 'status' },
+  configPolicyAutomations: { featureLinkId: 'featureLinkId' },
+  configPolicyFeatureLinks: { id: 'id', configPolicyId: 'configPolicyId' },
+  configurationPolicies: { id: 'id', orgId: 'orgId' },
+  devices: { id: 'id', hostname: 'hostname', osType: 'osType', status: 'status', displayName: 'displayName' },
+  scripts: { id: 'id', deletedAt: 'deletedAt' },
+  notificationChannels: { id: 'id', orgId: 'orgId' },
+  automations: { id: 'id', runCount: 'runCount', lastRunAt: 'lastRunAt', updatedAt: 'updatedAt' },
+  alerts: { id: 'id' },
+  alertRules: { id: 'id', orgId: 'orgId', name: 'name', targetType: 'targetType', targetId: 'targetId' },
+  alertTemplates: { id: 'id', orgId: 'orgId', name: 'name' },
+  deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./deploymentEngine', () => ({
+  resolveDeploymentTargets: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { SCRIPT: 'script' },
+  queueCommandForExecution: vi.fn().mockResolvedValue({ command: null, error: 'mocked' }),
+}));
+
+vi.mock('./notificationSenders', () => ({
+  getEmailRecipients: vi.fn().mockReturnValue([]),
+  sendEmailNotification: vi.fn().mockResolvedValue({ success: false }),
+  sendWebhookNotification: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+import { executeDeploySoftwareActions } from './automationRuntime';
+
+const WIN = { id: 'd-win', osType: 'windows' as const };
+const MAC = { id: 'd-mac', osType: 'macos' as const };
+
+beforeEach(() => {
+  createDeploymentMock.mockReset().mockResolvedValue({ deploymentId: 'dep-1', status: 'pending', dispatchedDeviceIds: ['d-win'] });
+  isCurrentMock.mockReset().mockResolvedValue(false);
+  latestMapMock.mockReset().mockResolvedValue(new Map([['cat-1', {
+    version: { id: 'ver-1', catalogId: 'cat-1', version: '126.0.0', supportedOs: ['windows'] },
+    catalogName: 'Chrome',
+  }]]));
+});
+
+describe('executeDeploySoftwareActions', () => {
+  it('deploys to an eligible Windows device and records a deployed log', async () => {
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).toHaveBeenCalledTimes(1);
+    expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(['d-win']);
+    expect(res.deployedDeviceIds.has('d-win')).toBe(true);
+    expect(res.failed).toBe(false);
+  });
+
+  it('skips a device whose OS is unsupported and does not create a deployment', async () => {
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).not.toHaveBeenCalled();
+    expect(res.logs.some(l => /unsupported OS/i.test(l.message))).toBe(true);
+  });
+
+  it('skips a device that is already current', async () => {
+    isCurrentMock.mockResolvedValue(true);
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).not.toHaveBeenCalled();
+    expect(res.logs.some(l => /already current/i.test(l.message))).toBe(true);
+  });
+
+  it('marks failed when the catalog has no latest version', async () => {
+    latestMapMock.mockResolvedValue(new Map());
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(res.failed).toBe(true);
+    expect(res.logs.some(l => /no latest version/i.test(l.message))).toBe(true);
+  });
+
+  it('marks failed when createSoftwareDeployment returns status "failed"', async () => {
+    // This exercises the same failed=true path that the executor wiring checks unconditionally,
+    // ensuring a dispatch failure propagates to devicesFailed regardless of onFailure setting.
+    createDeploymentMock.mockResolvedValue({ deploymentId: 'dep-err', status: 'failed', message: 'db error', dispatchedDeviceIds: [] });
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(res.failed).toBe(true);
+    expect(res.logs.some(l => /deploy_software failed/i.test(l.message))).toBe(true);
+    expect(res.deployedDeviceIds.size).toBe(0);
+  });
+});

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -23,6 +23,9 @@ import {
   sendEmailNotification,
   sendWebhookNotification,
 } from './notificationSenders';
+// softwareDeployment and softwareCurrency are imported lazily inside
+// executeDeploySoftwareActions to avoid pulling the agentWs→configurationPolicy
+// import chain into partial-mock test suites at module-load time.
 
 const ALERT_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
 
@@ -1166,6 +1169,106 @@ async function runWithConcurrency<T>(
   await Promise.all(workers);
 }
 
+/**
+ * Batched pass for `deploy_software` actions. Called ONCE per automation run
+ * after the per-device action loop. Creates one softwareDeployments row per
+ * action, filtering out devices whose OS is unsupported or whose installed
+ * version is already current.
+ */
+export async function executeDeploySoftwareActions(args: {
+  actions: AutomationAction[];
+  devices: Array<{ id: string; osType: 'windows' | 'macos' | 'linux' }>;
+  orgId: string;
+  createdBy: string | null;
+  runId: string;
+}): Promise<{ logs: AutomationLogEntry[]; deployedDeviceIds: Set<string>; failed: boolean }> {
+  const deployActions = args.actions.filter(
+    (a): a is DeploySoftwareAction => a.type === 'deploy_software',
+  );
+  const logs: AutomationLogEntry[] = [];
+  const deployedDeviceIds = new Set<string>();
+  let failed = false;
+  if (deployActions.length === 0) return { logs, deployedDeviceIds, failed };
+
+  // Lazy imports — avoid pulling the agentWs→configurationPolicy chain into
+  // partial-mock test suites at module-load time.
+  const { createSoftwareDeployment } = await import('./softwareDeployment');
+  const { resolveLatestVersionsByCatalogId, isDeviceSoftwareCurrent } = await import('./softwareCurrency');
+
+  const latest = await resolveLatestVersionsByCatalogId(
+    [...new Set(deployActions.map((a) => a.catalogId))],
+  );
+
+  for (const [actionIndex, action] of deployActions.entries()) {
+    const info = latest.get(action.catalogId);
+    if (!info) {
+      failed = true;
+      logs.push(logEntry('deploy_software has no latest version for catalog', 'error', {
+        actionType: action.type,
+        actionIndex,
+        details: { catalogId: action.catalogId },
+      }));
+      continue;
+    }
+    const supportedOs: string[] = Array.isArray(info.version.supportedOs)
+      ? (info.version.supportedOs as string[])
+      : [];
+    const eligible: string[] = [];
+    for (const device of args.devices) {
+      if (!supportedOs.includes(device.osType)) {
+        logs.push(logEntry(`Skipped ${info.catalogName}: unsupported OS`, 'info', {
+          actionType: action.type,
+          actionIndex,
+          deviceId: device.id,
+          details: { deviceOsType: device.osType, supportedOs },
+        }));
+        continue;
+      }
+      if (await isDeviceSoftwareCurrent(device.id, action.catalogId, info.version.version)) {
+        logs.push(logEntry(`Skipped ${info.catalogName}: already current`, 'info', {
+          actionType: action.type,
+          actionIndex,
+          deviceId: device.id,
+          details: { version: info.version.version },
+        }));
+        continue;
+      }
+      eligible.push(device.id);
+    }
+    if (eligible.length === 0) continue;
+
+    const result = await createSoftwareDeployment({
+      orgId: args.orgId,
+      softwareVersionId: info.version.id,
+      deploymentType: 'install',
+      deviceIds: eligible,
+      scheduleType: 'immediate',
+      createdBy: args.createdBy,
+      name: `Automation: deploy ${info.catalogName}`,
+    });
+    if (result.status === 'failed') {
+      failed = true;
+      logs.push(logEntry(`deploy_software failed: ${result.message ?? 'unknown error'}`, 'error', {
+        actionType: action.type,
+        actionIndex,
+        details: { catalogId: action.catalogId, deploymentId: result.deploymentId },
+      }));
+      continue;
+    }
+    for (const id of result.dispatchedDeviceIds) deployedDeviceIds.add(id);
+    logs.push(logEntry(
+      `Deploying ${info.catalogName} ${info.version.version} to ${eligible.length} device(s)`,
+      'info',
+      {
+        actionType: action.type,
+        actionIndex,
+        details: { deploymentId: result.deploymentId, deviceIds: eligible },
+      },
+    ));
+  }
+  return { logs, deployedDeviceIds, failed };
+}
+
 export async function createAutomationRunRecord(options: {
   automation: AutomationRow;
   triggeredBy: string;
@@ -1333,6 +1436,8 @@ export async function executeAutomationRun(
     let deviceFailed = false;
 
     for (const [actionIndex, action] of normalized.actions.entries()) {
+      // deploy_software is handled by the batched executeDeploySoftwareActions pass below
+      if (action.type === 'deploy_software') continue;
       const result = await executeAction(action, actionIndex, {
         automation,
         runId: run.id,
@@ -1372,6 +1477,20 @@ export async function executeAutomationRun(
       devicesSucceeded += 1;
     }
   });
+
+  // Batched deploy_software pass — runs once per automation run, after the per-device loop
+  const deployOutcome = await executeDeploySoftwareActions({
+    actions: normalized.actions,
+    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType })),
+    orgId: automation.orgId,
+    createdBy: automation.createdBy ?? null,
+    runId: run.id,
+  });
+  logs.push(...deployOutcome.logs);
+  // Per-device install status is tracked asynchronously in deploymentResults; the per-device loop above already counted each device once. A deploy-dispatch failure degrades the run status below.
+  if (deployOutcome.failed) {
+    devicesFailed += 1;
+  }
 
   const status: 'completed' | 'failed' | 'partial' =
     devicesFailed === 0
@@ -1790,6 +1909,8 @@ export async function executeConfigPolicyAutomationRun(
     let deviceFailed = false;
 
     for (const [actionIndex, action] of actions.entries()) {
+      // deploy_software is handled by the batched executeDeploySoftwareActions pass below
+      if (action.type === 'deploy_software') continue;
       const result = await executeAction(action, actionIndex, {
         automation: syntheticAutomation,
         runId: run.id,
@@ -1833,6 +1954,20 @@ export async function executeConfigPolicyAutomationRun(
       devicesSucceeded += 1;
     }
   });
+
+  // Batched deploy_software pass — runs once per config-policy automation run, after the per-device loop
+  const deployOutcome = await executeDeploySoftwareActions({
+    actions,
+    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType })),
+    orgId,
+    createdBy: null,
+    runId: run.id,
+  });
+  logs.push(...deployOutcome.logs);
+  // Per-device install status is tracked asynchronously in deploymentResults; the per-device loop above already counted each device once. A deploy-dispatch failure degrades the run status below.
+  if (deployOutcome.failed) {
+    devicesFailed += 1;
+  }
 
   const status: 'completed' | 'failed' | 'partial' =
     devicesFailed === 0

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -76,11 +76,17 @@ export type ExecuteCommandAction = {
   shell?: 'bash' | 'powershell' | 'cmd';
 };
 
+export type DeploySoftwareAction = {
+  type: 'deploy_software';
+  catalogId: string;
+};
+
 export type AutomationAction =
   | RunScriptAction
   | SendNotificationAction
   | CreateAlertAction
-  | ExecuteCommandAction;
+  | ExecuteCommandAction
+  | DeploySoftwareAction;
 
 export type NotificationTargets = {
   channelIds?: string[];

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -325,6 +325,15 @@ export function normalizeAutomationActions(input: unknown): AutomationAction[] {
       continue;
     }
 
+    if (type === 'deploy_software') {
+      const catalogId = asString(action.catalogId) ?? asString(action.catalog_id);
+      if (!catalogId) {
+        throw new AutomationValidationError(`actions[${index}] deploy_software requires catalogId`);
+      }
+      normalized.push({ type: 'deploy_software', catalogId });
+      continue;
+    }
+
     throw new AutomationValidationError(`unsupported action type: ${type}`);
   }
 
@@ -1215,7 +1224,7 @@ export async function executeDeploySoftwareActions(args: {
       : [];
     const eligible: string[] = [];
     for (const device of args.devices) {
-      if (!supportedOs.includes(device.osType)) {
+      if (supportedOs.length > 0 && !supportedOs.includes(device.osType)) {
         logs.push(logEntry(`Skipped ${info.catalogName}: unsupported OS`, 'info', {
           actionType: action.type,
           actionIndex,
@@ -1224,7 +1233,7 @@ export async function executeDeploySoftwareActions(args: {
         }));
         continue;
       }
-      if (await isDeviceSoftwareCurrent(device.id, action.catalogId, info.version.version)) {
+      if (await isDeviceSoftwareCurrent(device.id, action.catalogId, info.catalogName, info.version.version)) {
         logs.push(logEntry(`Skipped ${info.catalogName}: already current`, 'info', {
           actionType: action.type,
           actionIndex,

--- a/apps/api/src/services/softwareCurrency.test.ts
+++ b/apps/api/src/services/softwareCurrency.test.ts
@@ -93,24 +93,32 @@ describe('isDeviceSoftwareCurrent', () => {
   it('is true when an installed version is >= latest', async () => {
     dbMocks.selectResults.push([{ version: '126.0.1' }]);
 
-    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '126.0.0')).toBe(true);
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', 'Chrome', '126.0.0')).toBe(true);
   });
 
   it('is false when installed is older than latest', async () => {
     dbMocks.selectResults.push([{ version: '126.0.1' }]);
 
-    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '127.0.0')).toBe(false);
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', 'Chrome', '127.0.0')).toBe(false);
   });
 
   it('is false when no inventory row exists (deploy is the safe default)', async () => {
     dbMocks.selectResults.push([]);
 
-    expect(await isDeviceSoftwareCurrent('dev-2', 'cat-1', '1.0.0')).toBe(false);
+    expect(await isDeviceSoftwareCurrent('dev-2', 'cat-1', 'Chrome', '1.0.0')).toBe(false);
   });
 
   it('is false when the installed version is unparseable', async () => {
     dbMocks.selectResults.push([{ version: 'latest' }]);
 
-    expect(await isDeviceSoftwareCurrent('dev-3', 'cat-1', '1.0.0')).toBe(false);
+    expect(await isDeviceSoftwareCurrent('dev-3', 'cat-1', 'Chrome', '1.0.0')).toBe(false);
+  });
+
+  it('is true when a name-matched row (no catalogId) has version >= latest', async () => {
+    // Simulates an inventory row written without catalogId (the common case before
+    // backfill), matched by catalog name instead.
+    dbMocks.selectResults.push([{ version: '126.0.0' }]);
+
+    expect(await isDeviceSoftwareCurrent('dev-4', 'cat-1', 'Chrome', '126.0.0')).toBe(true);
   });
 });

--- a/apps/api/src/services/softwareCurrency.test.ts
+++ b/apps/api/src/services/softwareCurrency.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const selectResults: unknown[][] = [];
+  const chain = {
+    from: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    where: vi.fn(() => Promise.resolve(selectResults.shift() ?? [])),
+  };
+
+  return {
+    selectResults,
+    chain,
+    select: vi.fn(() => chain),
+  };
+});
+
+vi.mock('../db', () => ({
+  db: {
+    select: dbMocks.select,
+  },
+}));
+
+import {
+  compareVersions,
+  isDeviceSoftwareCurrent,
+  resolveLatestVersionsByCatalogId,
+} from './softwareCurrency';
+
+beforeEach(() => {
+  dbMocks.selectResults.length = 0;
+  dbMocks.select.mockClear();
+  dbMocks.chain.from.mockClear();
+  dbMocks.chain.innerJoin.mockClear();
+  dbMocks.chain.where.mockClear();
+});
+
+describe('compareVersions', () => {
+  it('orders dotted-numeric versions', () => {
+    expect(compareVersions('1.2.0', '1.10.0')).toBe(-1);
+    expect(compareVersions('2.0.0', '2.0.0')).toBe(0);
+    expect(compareVersions('126.0.1', '126.0.0')).toBe(1);
+  });
+
+  it('treats missing trailing segments as zero', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.3', '1.2.9')).toBe(1);
+  });
+
+  it('returns null when a version is unparseable', () => {
+    expect(compareVersions('latest', '1.0.0')).toBeNull();
+    expect(compareVersions('1.0.0', '')).toBeNull();
+  });
+});
+
+describe('resolveLatestVersionsByCatalogId', () => {
+  it('returns latest version info keyed by catalog id', async () => {
+    dbMocks.selectResults.push([
+      {
+        version: {
+          id: 'ver-1',
+          catalogId: 'cat-1',
+          version: '126.0.0',
+          isLatest: true,
+        },
+        catalogName: 'Chrome',
+      },
+    ]);
+
+    const result = await resolveLatestVersionsByCatalogId(['cat-1']);
+
+    expect(result.get('cat-1')).toEqual({
+      version: {
+        id: 'ver-1',
+        catalogId: 'cat-1',
+        version: '126.0.0',
+        isLatest: true,
+      },
+      catalogName: 'Chrome',
+    });
+    expect(dbMocks.chain.innerJoin).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty map without querying when no catalog ids are supplied', async () => {
+    const result = await resolveLatestVersionsByCatalogId([]);
+
+    expect(result.size).toBe(0);
+    expect(dbMocks.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('isDeviceSoftwareCurrent', () => {
+  it('is true when an installed version is >= latest', async () => {
+    dbMocks.selectResults.push([{ version: '126.0.1' }]);
+
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '126.0.0')).toBe(true);
+  });
+
+  it('is false when installed is older than latest', async () => {
+    dbMocks.selectResults.push([{ version: '126.0.1' }]);
+
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '127.0.0')).toBe(false);
+  });
+
+  it('is false when no inventory row exists (deploy is the safe default)', async () => {
+    dbMocks.selectResults.push([]);
+
+    expect(await isDeviceSoftwareCurrent('dev-2', 'cat-1', '1.0.0')).toBe(false);
+  });
+
+  it('is false when the installed version is unparseable', async () => {
+    dbMocks.selectResults.push([{ version: 'latest' }]);
+
+    expect(await isDeviceSoftwareCurrent('dev-3', 'cat-1', '1.0.0')).toBe(false);
+  });
+});

--- a/apps/api/src/services/softwareCurrency.ts
+++ b/apps/api/src/services/softwareCurrency.ts
@@ -1,0 +1,85 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { softwareCatalog, softwareInventory, softwareVersions } from '../db/schema';
+
+export interface LatestVersionInfo {
+  version: typeof softwareVersions.$inferSelect;
+  catalogName: string;
+}
+
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  const parse = (version: string): number[] | null => {
+    const trimmed = version.trim();
+    if (!trimmed || !/^\d+(\.\d+)*$/.test(trimmed)) {
+      return null;
+    }
+    return trimmed.split('.').map((segment) => Number(segment));
+  };
+
+  const parsedA = parse(a);
+  const parsedB = parse(b);
+  if (!parsedA || !parsedB) {
+    return null;
+  }
+
+  const length = Math.max(parsedA.length, parsedB.length);
+  for (let index = 0; index < length; index += 1) {
+    const left = parsedA[index] ?? 0;
+    const right = parsedB[index] ?? 0;
+    if (left < right) {
+      return -1;
+    }
+    if (left > right) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+export async function resolveLatestVersionsByCatalogId(
+  catalogIds: string[],
+): Promise<Map<string, LatestVersionInfo>> {
+  const latestByCatalogId = new Map<string, LatestVersionInfo>();
+  if (catalogIds.length === 0) {
+    return latestByCatalogId;
+  }
+
+  const rows = await db
+    .select({ version: softwareVersions, catalogName: softwareCatalog.name })
+    .from(softwareVersions)
+    .innerJoin(softwareCatalog, eq(softwareVersions.catalogId, softwareCatalog.id))
+    .where(and(inArray(softwareVersions.catalogId, catalogIds), eq(softwareVersions.isLatest, true)));
+
+  for (const row of rows) {
+    latestByCatalogId.set(row.version.catalogId, {
+      version: row.version,
+      catalogName: row.catalogName,
+    });
+  }
+
+  return latestByCatalogId;
+}
+
+export async function isDeviceSoftwareCurrent(
+  deviceId: string,
+  catalogId: string,
+  latestVersion: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ version: softwareInventory.version })
+    .from(softwareInventory)
+    .where(and(eq(softwareInventory.deviceId, deviceId), eq(softwareInventory.catalogId, catalogId)));
+
+  for (const row of rows) {
+    if (!row.version) {
+      continue;
+    }
+    const comparison = compareVersions(row.version, latestVersion);
+    if (comparison === 0 || comparison === 1) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/apps/api/src/services/softwareCurrency.ts
+++ b/apps/api/src/services/softwareCurrency.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { softwareCatalog, softwareInventory, softwareVersions } from '../db/schema';
 
@@ -64,12 +64,21 @@ export async function resolveLatestVersionsByCatalogId(
 export async function isDeviceSoftwareCurrent(
   deviceId: string,
   catalogId: string,
+  catalogName: string,
   latestVersion: string,
 ): Promise<boolean> {
   const rows = await db
     .select({ version: softwareInventory.version })
     .from(softwareInventory)
-    .where(and(eq(softwareInventory.deviceId, deviceId), eq(softwareInventory.catalogId, catalogId)));
+    .where(
+      and(
+        eq(softwareInventory.deviceId, deviceId),
+        or(
+          eq(softwareInventory.catalogId, catalogId),
+          sql`lower(${softwareInventory.name}) = lower(${catalogName})`,
+        ),
+      ),
+    );
 
   for (const row of rows) {
     if (!row.version) {

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted so the mock factory can reference sendCommandMock
+const { sendCommandMock } = vi.hoisted(() => ({ sendCommandMock: vi.fn() }));
+
+// Match the exact import paths used by routes/software.ts (and the service will mirror them)
+vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: sendCommandMock }));
+
+vi.mock('../services/s3Storage', () => ({
+  getPresignedUrl: vi.fn(async () => 'https://signed.example/pkg.exe'),
+  isS3Configured: () => true,
+  isS3NotFound: () => false,
+}));
+
+vi.mock('../services/edrInstallerResolver', () => ({
+  resolveEdrInstaller: vi.fn().mockResolvedValue({
+    downloadUrl: 'https://edr.example/pkg.exe',
+    silentInstallArgs: null,
+  }),
+}));
+
+// Drizzle db mock — capture calls and serve controlled per-test data.
+// Follows the chainable-mock pattern from apps/api/src/services/*.test.ts.
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  softwareCatalog: {
+    id: 'sc.id',
+    orgId: 'sc.orgId',
+    name: 'sc.name',
+    integrationProvider: 'sc.integrationProvider',
+  },
+  softwareVersions: { id: 'sv.id', catalogId: 'sv.catalogId' },
+  softwareDeployments: { id: 'sd.id', orgId: 'sd.orgId' },
+  deploymentResults: {
+    deploymentId: 'dr.deploymentId',
+    deviceId: 'dr.deviceId',
+    status: 'dr.status',
+  },
+  devices: { id: 'd.id', orgId: 'd.orgId', agentId: 'd.agentId' },
+}));
+
+import { createSoftwareDeployment } from './softwareDeployment';
+
+// ---------------------------------------------------------------------------
+// Mock builder helpers
+// ---------------------------------------------------------------------------
+
+/** Chainable select: db.select().from().where() → Promise<rows> */
+function sel(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+/** Insert with .returning() — for softwareDeployments */
+function insWithReturning(rows: unknown[]) {
+  return {
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+/** Insert without .returning() — for deploymentResults */
+function ins() {
+  return { values: vi.fn().mockResolvedValue([]) };
+}
+
+/** Update chain: db.update().set().where() → void */
+function upd() {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSoftwareDeployment', () => {
+  beforeEach(() => {
+    sendCommandMock.mockReset();
+    selectMock.mockReset();
+    insertMock.mockReset();
+    updateMock.mockReset();
+  });
+
+  it('creates a deployment + per-device results and dispatches software_install for immediate install', async () => {
+    const versionRecord = {
+      id: 'ver-1',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '1.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-1', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1' },
+      { id: 'dev-2', agentId: 'agent-2' },
+    ];
+
+    // 1st select: softwareVersions  2nd: softwareCatalog  3rd: devices
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+
+    // 1st insert: softwareDeployments (.returning())  2nd: deploymentResults (no .returning())
+    insertMock
+      .mockReturnValueOnce(insWithReturning([deployment]))
+      .mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-1',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2'],
+      scheduleType: 'immediate',
+      createdBy: 'system:automation',
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.deployment).toEqual(deployment);
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1', 'dev-2']);
+    expect(sendCommandMock).toHaveBeenCalledTimes(2);
+    expect(sendCommandMock.mock.calls[0]![1].type).toBe('software_install');
+  });
+
+  it('returns status "failed" with a message when no installer URL is available', async () => {
+    // Version has null s3Key AND null downloadUrl — no binary to dispatch
+    const versionRecord = {
+      id: 'ver-no-url',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: null,
+      fileType: null,
+      silentInstallArgs: null,
+      version: '1.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-no-url', orgId: 'org-1' };
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]));
+
+    insertMock
+      .mockReturnValueOnce(insWithReturning([deployment]))
+      .mockReturnValueOnce(ins());
+
+    updateMock.mockReturnValueOnce(upd());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-no-url',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toMatch(/No installer available/i);
+    expect(result.deployment).toEqual(deployment);
+    expect(sendCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('persists maintenanceWindowId in the insert when provided', async () => {
+    const versionRecord = {
+      id: 'ver-mw',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: null,
+      fileType: null,
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-mw', orgId: 'org-1', maintenanceWindowId: 'mw-test-id' };
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]));
+
+    // Use a captured values mock so we can assert what was inserted
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([deployment]),
+    });
+    insertMock
+      .mockReturnValueOnce({ values: valuesMock })   // softwareDeployments
+      .mockReturnValueOnce(ins());                    // deploymentResults (scheduleType=scheduled skips dispatch)
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-mw',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'scheduled', // not immediate — skips dispatch; focuses test on insert shape
+      createdBy: null,
+      maintenanceWindowId: 'mw-test-id',
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ maintenanceWindowId: 'mw-test-id' })
+    );
+    expect(result.deployment).toEqual(deployment);
+  });
+
+  it('stores a non-devices targetType as given and does not coerce to "devices"', async () => {
+    const versionRecord = {
+      id: 'ver-all',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: null,
+      fileType: null,
+      silentInstallArgs: null,
+      version: '3.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-all', orgId: 'org-1', targetType: 'all', targetIds: null };
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]));
+
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([deployment]),
+    });
+    insertMock
+      .mockReturnValueOnce({ values: valuesMock })
+      .mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-all',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2'],  // resolved device list used for dispatch
+      scheduleType: 'scheduled',
+      createdBy: null,
+      targetType: 'all',
+      targetIds: null,
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'all', targetIds: null })
+    );
+  });
+
+  it('defaults targetType to "devices" and targetIds to deviceIds when not provided (automation caller)', async () => {
+    const versionRecord = {
+      id: 'ver-auto',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: null,
+      fileType: null,
+      silentInstallArgs: null,
+      version: '4.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-auto', orgId: 'org-1' };
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]));
+
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([deployment]),
+    });
+    insertMock
+      .mockReturnValueOnce({ values: valuesMock })
+      .mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-auto',
+      deploymentType: 'install',
+      deviceIds: ['dev-a', 'dev-b'],
+      scheduleType: 'scheduled',
+      createdBy: 'system:automation',
+      // no targetType / targetIds / maintenanceWindowId
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: 'devices',
+        targetIds: ['dev-a', 'dev-b'],
+        maintenanceWindowId: null,
+      })
+    );
+  });
+});

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -1,0 +1,233 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  deploymentResults,
+  devices,
+  softwareCatalog,
+  softwareDeployments,
+  softwareVersions,
+} from '../db/schema';
+import { resolveEdrInstaller, type ResolvedInstaller } from './edrInstallerResolver';
+import { getPresignedUrl, isS3Configured, isS3NotFound } from './s3Storage';
+import { sendCommandToAgent, type AgentCommand } from '../routes/agentWs';
+
+export interface CreateSoftwareDeploymentInput {
+  orgId: string;
+  softwareVersionId: string;
+  deploymentType: 'install' | 'update' | 'uninstall';
+  deviceIds: string[];
+  scheduleType: 'immediate' | 'scheduled' | 'maintenance';
+  createdBy: string | null;
+  name?: string;
+  scheduledAt?: Date | null;
+  options?: Record<string, unknown>;
+  /** Preserved from the original route; omit for automation callers. Defaults to null. */
+  maintenanceWindowId?: string | null;
+  /**
+   * The original targetType from the HTTP payload. When provided the stored
+   * row reflects the user's intent (e.g. 'all', 'groups'). When omitted
+   * (automation callers that pass a pre-resolved deviceIds list) defaults to
+   * 'devices'. The dispatch always uses the resolved `deviceIds` either way.
+   */
+  targetType?: 'devices' | 'groups' | 'sites' | 'all' | 'filter';
+  /**
+   * The original targetIds from the HTTP payload. When provided the stored
+   * row reflects the user's raw selection. When omitted defaults to the
+   * resolved `deviceIds` list.
+   */
+  targetIds?: string[] | null;
+}
+
+export interface CreateSoftwareDeploymentResult {
+  deploymentId: string;
+  /** Full deployment row returned by the DB insert — pass through to the HTTP caller. */
+  deployment: typeof softwareDeployments.$inferSelect;
+  status: 'pending' | 'failed';
+  message?: string;
+  dispatchedDeviceIds: string[];
+}
+
+export async function createSoftwareDeployment(
+  input: CreateSoftwareDeploymentInput,
+): Promise<CreateSoftwareDeploymentResult> {
+  const {
+    orgId,
+    softwareVersionId,
+    deploymentType,
+    deviceIds,
+    scheduleType,
+    createdBy,
+    name,
+    scheduledAt,
+    options,
+    maintenanceWindowId,
+    targetType,
+    targetIds,
+  } = input;
+
+  // Look up version record
+  const [versionRecord] = await db
+    .select()
+    .from(softwareVersions)
+    .where(eq(softwareVersions.id, softwareVersionId));
+  if (!versionRecord) {
+    throw new Error(`Software version not found: ${softwareVersionId}`);
+  }
+
+  // Look up catalog item
+  const [catalogItem] = await db
+    .select({
+      id: softwareCatalog.id,
+      orgId: softwareCatalog.orgId,
+      name: softwareCatalog.name,
+      integrationProvider: softwareCatalog.integrationProvider,
+    })
+    .from(softwareCatalog)
+    .where(eq(softwareCatalog.id, versionRecord.catalogId));
+
+  if (!catalogItem) {
+    throw new Error(`Catalog item not found for version ${softwareVersionId}`);
+  }
+
+  // Insert deployment
+  const [deployment] = await db
+    .insert(softwareDeployments)
+    .values({
+      orgId,
+      name: name ?? 'Software Deployment',
+      softwareVersionId,
+      deploymentType,
+      targetType: targetType ?? 'devices',
+      targetIds: targetIds !== undefined ? targetIds : deviceIds,
+      scheduleType,
+      scheduledAt: scheduledAt ?? null,
+      maintenanceWindowId: maintenanceWindowId ?? null,
+      createdBy,
+      options: options ?? null,
+    })
+    .returning();
+
+  if (!deployment) {
+    throw new Error('Failed to create deployment record');
+  }
+
+  // Insert per-device results
+  if (deviceIds.length > 0) {
+    await db.insert(deploymentResults).values(
+      deviceIds.map((deviceId) => ({
+        deploymentId: deployment.id,
+        deviceId,
+        status: 'pending' as const,
+      })),
+    );
+  }
+
+  // For immediate installs, dispatch software_install commands to online agents
+  if (scheduleType === 'immediate' && deploymentType === 'install' && deviceIds.length > 0) {
+    // Get presigned URL for download
+    let downloadUrl: string | null = null;
+    if (versionRecord.s3Key && isS3Configured()) {
+      try {
+        downloadUrl = await getPresignedUrl(versionRecord.s3Key, 3600);
+      } catch (err) {
+        // Don't swallow: a transport/auth fault must be visible even though we
+        // still fall back to the stored downloadUrl below (#1808).
+        console[isS3NotFound(err) ? 'warn' : 'error'](
+          `[software-deploy] S3 presign failed for ${versionRecord.s3Key}, falling back to stored downloadUrl:`,
+          err,
+        );
+      }
+    }
+    downloadUrl = downloadUrl ?? versionRecord.downloadUrl;
+
+    // Built-in EDR packages: resolve per-org keys server-side BEFORE the dispatch
+    // gate. On resolution failure, mark every result failed and return — never
+    // dispatch and never silently no-op.
+    let resolvedInstaller: ResolvedInstaller | null = null;
+    if (
+      catalogItem.integrationProvider === 'huntress' ||
+      catalogItem.integrationProvider === 'sentinelone'
+    ) {
+      const resolved = await resolveEdrInstaller({
+        provider: catalogItem.integrationProvider,
+        orgId,
+        downloadUrlTemplate: versionRecord.downloadUrl,
+        silentInstallArgsTemplate: versionRecord.silentInstallArgs,
+      });
+      if ('error' in resolved) {
+        await db
+          .update(deploymentResults)
+          .set({ status: 'failed', errorMessage: resolved.error, completedAt: new Date() })
+          .where(eq(deploymentResults.deploymentId, deployment.id));
+        return {
+          deploymentId: deployment.id,
+          deployment,
+          status: 'failed',
+          message: resolved.error,
+          dispatchedDeviceIds: [],
+        };
+      }
+      resolvedInstaller = resolved;
+    }
+
+    const finalDownloadUrl = resolvedInstaller?.downloadUrl ?? downloadUrl;
+    const finalSilentInstallArgs =
+      resolvedInstaller?.silentInstallArgs ?? versionRecord.silentInstallArgs;
+
+    if (!finalDownloadUrl) {
+      // No installer binary/URL to dispatch — fail the results instead of leaving
+      // them 'pending' forever and reporting a false success to the caller.
+      await db
+        .update(deploymentResults)
+        .set({
+          status: 'failed',
+          errorMessage:
+            'No installer available for this version — upload an installer (or check storage configuration) before deploying.',
+          completedAt: new Date(),
+        })
+        .where(eq(deploymentResults.deploymentId, deployment.id));
+      return {
+        deploymentId: deployment.id,
+        deployment,
+        status: 'failed',
+        message: 'No installer available for this version',
+        dispatchedDeviceIds: [],
+      };
+    }
+
+    // Get agentIds for target devices
+    const targetDevices = await db
+      .select({ id: devices.id, agentId: devices.agentId })
+      .from(devices)
+      .where(
+        and(
+          eq(devices.orgId, orgId),
+          inArray(devices.id, deviceIds),
+        ),
+      );
+
+    const dispatchedDeviceIds: string[] = [];
+    for (const device of targetDevices) {
+      const command: AgentCommand = {
+        id: `sw-install-${deployment.id}-${device.id}`,
+        type: 'software_install',
+        payload: {
+          deploymentId: deployment.id,
+          downloadUrl: finalDownloadUrl,
+          checksum: versionRecord.checksum,
+          fileName:
+            versionRecord.originalFileName ?? `package.${versionRecord.fileType ?? 'exe'}`,
+          fileType: versionRecord.fileType ?? 'exe',
+          silentInstallArgs: finalSilentInstallArgs,
+          softwareName: catalogItem.name,
+          version: versionRecord.version,
+        },
+      };
+      sendCommandToAgent(device.agentId, command);
+      dispatchedDeviceIds.push(device.id);
+    }
+    return { deploymentId: deployment.id, deployment, status: 'pending', dispatchedDeviceIds };
+  }
+
+  return { deploymentId: deployment.id, deployment, status: 'pending', dispatchedDeviceIds: [] };
+}

--- a/apps/web/src/components/automations/AutomationEditPage.tsx
+++ b/apps/web/src/components/automations/AutomationEditPage.tsx
@@ -11,6 +11,7 @@ type Site = { id: string; name: string };
 type Group = { id: string; name: string };
 type Script = { id: string; name: string };
 type NotificationChannel = { id: string; name: string; type: string };
+type SoftwareCatalogItem = { id: string; name: string; vendor?: string };
 
 type AutomationEditPageProps = {
   automationId?: string;
@@ -51,6 +52,13 @@ function normalizeActionForForm(value: unknown): ActionFormValues {
     };
   }
 
+  if (type === 'deploy_software') {
+    return {
+      type,
+      catalogId: asString(action.catalogId) ?? asString(action.catalog_id)
+    };
+  }
+
   return {
     type: 'run_script',
     scriptId: asString(action.scriptId) ?? asString(action.script_id)
@@ -80,6 +88,13 @@ function buildActionPayload(action: ActionFormValues) {
     };
   }
 
+  if (action.type === 'deploy_software') {
+    return {
+      type: action.type,
+      catalogId: action.catalogId
+    };
+  }
+
   return {
     type: action.type,
     command: action.command
@@ -96,6 +111,7 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
   const [groups, setGroups] = useState<Group[]>([]);
   const [scripts, setScripts] = useState<Script[]>([]);
   const [notificationChannels, setNotificationChannels] = useState<NotificationChannel[]>([]);
+  const [softwareCatalog, setSoftwareCatalog] = useState<SoftwareCatalogItem[]>([]);
 
   const fetchAutomation = useCallback(async () => {
     if (!automationId || isNew) return;
@@ -211,13 +227,26 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
     }
   }, []);
 
+  const fetchSoftwareCatalog = useCallback(async () => {
+    try {
+      const response = await fetchWithAuth('/software/catalog');
+      if (response.ok) {
+        const data = await response.json();
+        setSoftwareCatalog(data.data ?? data.catalog ?? []);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
   useEffect(() => {
     fetchAutomation();
     fetchSites();
     fetchGroups();
     fetchScripts();
     fetchChannels();
-  }, [fetchAutomation, fetchSites, fetchGroups, fetchScripts, fetchChannels]);
+    fetchSoftwareCatalog();
+  }, [fetchAutomation, fetchSites, fetchGroups, fetchScripts, fetchChannels, fetchSoftwareCatalog]);
 
   const handleSubmit = async (values: AutomationFormValues) => {
     setSaving(true);
@@ -356,6 +385,7 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
         groups={groups}
         scripts={scripts}
         notificationChannels={notificationChannels}
+        softwareCatalog={softwareCatalog}
       />
     </div>
   );

--- a/apps/web/src/components/automations/AutomationForm.test.tsx
+++ b/apps/web/src/components/automations/AutomationForm.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AutomationForm from './AutomationForm';
+
+const CATALOG = [
+  { id: 'cat-1', name: 'Google Chrome', vendor: 'Google' },
+  { id: 'cat-2', name: 'Firefox', vendor: 'Mozilla' },
+];
+
+describe('AutomationForm — deploy_software action', () => {
+  it('renders a catalog picker + helper text and submits the chosen catalogId', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AutomationForm
+        onSubmit={onSubmit}
+        defaultValues={{ name: 'Deploy Chrome' }}
+        softwareCatalog={CATALOG}
+      />,
+    );
+
+    // Switch the default action to Deploy Software.
+    const actionTypeSelect = screen.getByDisplayValue('Run Script');
+    fireEvent.change(actionTypeSelect, { target: { value: 'deploy_software' } });
+
+    // Helper text + catalog picker appear.
+    expect(
+      screen.getByText(/Installs the latest version of the selected software/i),
+    ).toBeTruthy();
+    const catalogSelect = screen.getByDisplayValue('Select software...');
+    expect(catalogSelect).toBeTruthy();
+    // Populated from the software catalog list.
+    expect(screen.getByRole('option', { name: 'Google Chrome (Google)' })).toBeTruthy();
+
+    fireEvent.change(catalogSelect, { target: { value: 'cat-1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Save automation/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const values = onSubmit.mock.calls[0][0];
+    expect(values.actions[0].type).toBe('deploy_software');
+    expect(values.actions[0].catalogId).toBe('cat-1');
+  });
+});

--- a/apps/web/src/components/automations/AutomationForm.tsx
+++ b/apps/web/src/components/automations/AutomationForm.tsx
@@ -54,12 +54,13 @@ const conditionSchema = z.object({
 });
 
 const actionSchema = z.object({
-  type: z.enum(['run_script', 'send_notification', 'create_alert', 'execute_command']),
+  type: z.enum(['run_script', 'send_notification', 'create_alert', 'execute_command', 'deploy_software']),
   scriptId: z.string().optional(),
   notificationChannelId: z.string().optional(),
   alertSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']).optional(),
   alertMessage: z.string().optional(),
-  command: z.string().optional()
+  command: z.string().optional(),
+  catalogId: z.string().optional()
 });
 
 const automationSchema = z.object({
@@ -84,6 +85,7 @@ type Site = { id: string; name: string };
 type Group = { id: string; name: string };
 type Script = { id: string; name: string };
 type NotificationChannel = { id: string; name: string; type: string };
+type SoftwareCatalogItem = { id: string; name: string; vendor?: string };
 
 type AutomationFormProps = {
   onSubmit?: (values: AutomationFormValues) => void | Promise<void>;
@@ -96,6 +98,7 @@ type AutomationFormProps = {
   groups?: Group[];
   scripts?: Script[];
   notificationChannels?: NotificationChannel[];
+  softwareCatalog?: SoftwareCatalogItem[];
 };
 
 const triggerTypeOptions: { value: TriggerType; label: string; description: string; icon: typeof Clock }[] = [
@@ -159,7 +162,8 @@ const actionTypeOptions = [
   { value: 'run_script', label: 'Run Script' },
   { value: 'send_notification', label: 'Send Notification' },
   { value: 'create_alert', label: 'Create Alert' },
-  { value: 'execute_command', label: 'Execute Command' }
+  { value: 'execute_command', label: 'Execute Command' },
+  { value: 'deploy_software', label: 'Deploy Software' }
 ];
 
 const severityOptions = [
@@ -186,7 +190,8 @@ export default function AutomationForm({
   sites = [],
   groups = [],
   scripts = [],
-  notificationChannels = []
+  notificationChannels = [],
+  softwareCatalog = []
 }: AutomationFormProps) {
   const [conditionsExpanded, setConditionsExpanded] = useState(true);
   const [conditionMode, setConditionMode] = useState<'simple' | 'advanced'>(
@@ -685,6 +690,26 @@ export default function AutomationForm({
                           className="h-9 w-full rounded-md border bg-background px-3 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
                           {...register(`actions.${index}.command`)}
                         />
+                      </div>
+                    )}
+
+                    {watchActions?.[index]?.type === 'deploy_software' && (
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium text-muted-foreground">Software</label>
+                        <select
+                          className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                          {...register(`actions.${index}.catalogId`)}
+                        >
+                          <option value="">Select software...</option>
+                          {softwareCatalog.map(item => (
+                            <option key={item.id} value={item.id}>
+                              {item.vendor ? `${item.name} (${item.vendor})` : item.name}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="text-xs text-muted-foreground">
+                          Installs the latest version of the selected software; skips devices that already have it.
+                        </p>
                       </div>
                     )}
                   </div>

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AutomationTab from './AutomationTab';
+import { fetchWithAuth } from '../../../stores/auth';
+
+const saveMock = vi.fn();
+const removeMock = vi.fn();
+const clearErrorMock = vi.fn();
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: undefined,
+    clearError: clearErrorMock,
+  }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const CATALOG = [
+  { id: 'cat-1', name: 'Google Chrome', vendor: 'Google' },
+  { id: 'cat-2', name: 'Firefox', vendor: 'Mozilla' },
+];
+
+function renderTab() {
+  return render(
+    <AutomationTab
+      policyId="policy-1"
+      existingLink={undefined}
+      linkedPolicyId={null}
+      onLinkChanged={vi.fn()}
+    />,
+  );
+}
+
+describe('AutomationTab — deploy_software action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue(makeJsonResponse({ data: CATALOG }));
+  });
+
+  it('renders a catalog picker + helper text and emits { type:"deploy_software", catalogId }', async () => {
+    renderTab();
+
+    // Create + expand a new automation (the empty-state button auto-expands it).
+    // Both the header and empty-state share the "Add Automation" label; either works.
+    fireEvent.click(screen.getAllByRole('button', { name: /Add Automation/i })[0]);
+
+    // Switch the (single, default) action to Deploy Software.
+    const actionTypeSelect = screen.getByDisplayValue('Run Script');
+    fireEvent.change(actionTypeSelect, { target: { value: 'deploy_software' } });
+
+    // Helper text + catalog picker label appear.
+    expect(
+      screen.getByText(/Installs the latest version of the selected software/i),
+    ).toBeTruthy();
+    expect(screen.getByText('Software')).toBeTruthy();
+
+    // The catalog endpoint is the same one the Software Catalog page uses.
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith('/software/catalog?limit=100'),
+    );
+
+    // Open the picker dropdown and select an entry.
+    fireEvent.click(screen.getByText('Select software...'));
+    fireEvent.click(await screen.findByText('Google Chrome'));
+
+    // Persist and assert the emitted action shape.
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const payload = saveMock.mock.calls[0][1];
+    const action = payload.inlineSettings.items[0].actions[0];
+    expect(action).toEqual({ type: 'deploy_software', catalogId: 'cat-1' });
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
@@ -7,7 +7,7 @@ import FeatureTabShell from './FeatureTabShell';
 import InlineEntityPicker from './InlineEntityPicker';
 
 type TriggerType = 'schedule' | 'event' | 'manual';
-type ActionType = 'run_script' | 'send_notification' | 'create_alert' | 'execute_command';
+type ActionType = 'run_script' | 'send_notification' | 'create_alert' | 'execute_command' | 'deploy_software';
 type OnFailure = 'stop' | 'continue' | 'notify';
 
 type Action = {
@@ -17,6 +17,7 @@ type Action = {
   alertSeverity?: string;
   alertMessage?: string;
   notificationChannelId?: string;
+  catalogId?: string;
 };
 
 type AutomationItem = {
@@ -64,6 +65,7 @@ const actionTypeOptions: { value: ActionType; label: string }[] = [
   { value: 'send_notification', label: 'Send Notification' },
   { value: 'create_alert', label: 'Create Alert' },
   { value: 'execute_command', label: 'Execute Command' },
+  { value: 'deploy_software', label: 'Deploy Software' },
 ];
 
 const onFailureOptions: { value: OnFailure; label: string; description: string }[] = [
@@ -146,6 +148,18 @@ export default function AutomationTab({ policyId, existingLink, onLinkChanged, l
       prev.map((item, i) => {
         if (i !== itemIndex) return item;
         const actions = item.actions.map((a, ai) => (ai === actionIndex ? { ...a, ...patch } : a));
+        return { ...item, actions };
+      })
+    );
+  };
+
+  // Replace the action with a clean object that carries only the new type, so
+  // stale fields from a previously selected action type are not emitted.
+  const changeActionType = (itemIndex: number, actionIndex: number, type: ActionType) => {
+    setItems((prev) =>
+      prev.map((item, i) => {
+        if (i !== itemIndex) return item;
+        const actions = item.actions.map((a, ai) => (ai === actionIndex ? { type } : a));
         return { ...item, actions };
       })
     );
@@ -425,7 +439,7 @@ export default function AutomationTab({ policyId, existingLink, onLinkChanged, l
                                 <label className="text-xs font-medium text-muted-foreground">Action Type</label>
                                 <select
                                   value={action.type}
-                                  onChange={(e) => updateAction(index, ai, { type: e.target.value as ActionType })}
+                                  onChange={(e) => changeActionType(index, ai, e.target.value as ActionType)}
                                   className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-sm"
                                 >
                                   {actionTypeOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
@@ -502,6 +516,27 @@ export default function AutomationTab({ policyId, existingLink, onLinkChanged, l
                                     extra: ch.type,
                                   }))}
                                 />
+                              )}
+
+                              {action.type === 'deploy_software' && (
+                                <div className="space-y-1.5">
+                                  <InlineEntityPicker
+                                    value={action.catalogId ?? ''}
+                                    onChange={(id) => updateAction(index, ai, { catalogId: id })}
+                                    endpoint="/software/catalog?limit=100"
+                                    label="Software"
+                                    placeholder="Select software..."
+                                    compact
+                                    transform={(items) => items.map((s: any) => ({
+                                      id: s.id,
+                                      name: s.name || 'Unnamed Software',
+                                      extra: s.vendor || s.category,
+                                    }))}
+                                  />
+                                  <p className="text-xs text-muted-foreground">
+                                    Installs the latest version of the selected software; skips devices that already have it.
+                                  </p>
+                                </div>
                               )}
                             </div>
                             <button

--- a/docs/superpowers/plans/2026-06-27-deploy-software-automation-action.md
+++ b/docs/superpowers/plans/2026-06-27-deploy-software-automation-action.md
@@ -1,0 +1,629 @@
+# Software Deployment Automation Action — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `deploy_software` automation action that installs the latest catalog version of a chosen app on targeted devices, reusing Breeze's existing software-deployment subsystem.
+
+**Architecture:** A fifth automation action type referencing a `softwareCatalog` entry. The deployment create+dispatch logic currently inline in `POST /deployments` is extracted into a reusable `createSoftwareDeployment()` service that both the route and the automation executor call. Because a software deployment is one-to-many (one deployment, many devices) while the existing action loop is per-device, `deploy_software` runs as a **batched pass** over the run's devices — one `softwareDeployments` row per action — rather than inside the per-device action loop. Idempotency: skip devices whose installed version is already ≥ the catalog's latest (`software_inventory`); unknown/unparseable installed version → deploy (safe default).
+
+**Tech Stack:** Hono + TypeScript API, Drizzle ORM (PostgreSQL), BullMQ workers, Vitest, Zod (shared validators), React/Astro web.
+
+## Global Constraints
+
+- **Tenancy:** `automation_runs.config_policy_id` MUST be the resolved **policy** id (`configurationPolicies.id`), never the feature-link id (#1855 contract). `softwareDeployments.orgId` = the run's org. The automation worker runs under `withSystemDbAccessContext`.
+- **No new tables.** Reuse `softwareCatalog`, `softwareVersions`, `softwareDeployments`, `deploymentResults`, `software_inventory`.
+- **TDD:** every task writes the failing test first, watches it fail, then implements. Co-locate tests beside source (`foo.ts` → `foo.test.ts`).
+- **Version semantics:** always "latest of catalog entry," resolved from `softwareVersions.isLatest` at run time. No version pinning, no force-reinstall in this scope.
+- **Run API tests:** `cd apps/api && npx vitest run <path>`.
+
+---
+
+### Task 1: Extract `createSoftwareDeployment()` service from the deploy route
+
+**Files:**
+- Create: `apps/api/src/services/softwareDeployment.ts`
+- Create (test): `apps/api/src/services/softwareDeployment.test.ts`
+- Modify: `apps/api/src/routes/software.ts` (the `POST /deployments` handler, ~lines 1021–1189) to call the new service
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface CreateSoftwareDeploymentInput {
+    orgId: string;
+    softwareVersionId: string;
+    deploymentType: 'install' | 'update' | 'uninstall';
+    deviceIds: string[];
+    scheduleType: 'immediate' | 'scheduled' | 'maintenance';
+    createdBy: string | null;
+    name?: string;
+    scheduledAt?: Date | null;
+    options?: Record<string, unknown>;
+  }
+  export interface CreateSoftwareDeploymentResult {
+    deploymentId: string;
+    status: 'pending' | 'failed';
+    message?: string;
+    dispatchedDeviceIds: string[];
+  }
+  export async function createSoftwareDeployment(
+    input: CreateSoftwareDeploymentInput,
+  ): Promise<CreateSoftwareDeploymentResult>;
+  ```
+- Consumes: existing helpers already imported by `routes/software.ts` — `getPresignedUrl`, `isS3Configured`, `isS3NotFound`, `resolveEdrInstaller`, `sendCommandToAgent`, the `AgentCommand` type, and the `softwareVersions`/`softwareCatalog`/`softwareDeployments`/`deploymentResults`/`devices` Drizzle tables.
+
+- [ ] **Step 1: Read the current route handler.** Read `apps/api/src/routes/software.ts:1021-1189`. Identify the exact block that: looks up `versionRecord` + `catalogItem`, inserts the `softwareDeployments` row, inserts `deploymentResults` rows (status `pending`), and (for `scheduleType:'immediate' && deploymentType:'install'`) runs the S3 presign → EDR resolve → fallback → `sendCommandToAgent` dispatch (lines 1094–1175). This whole block becomes the service body.
+
+- [ ] **Step 2: Write the failing test.**
+
+`apps/api/src/services/softwareDeployment.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { sendCommandMock } = vi.hoisted(() => ({ sendCommandMock: vi.fn() }));
+vi.mock('../services/agentCommands', () => ({ sendCommandToAgent: sendCommandMock }));
+// Mock S3 + EDR helpers as no-ops/passthroughs so the dispatch path is exercised
+// without external calls. (Match the real import paths used by routes/software.ts.)
+vi.mock('../services/s3', () => ({
+  getPresignedUrl: vi.fn(async () => 'https://signed.example/pkg.exe'),
+  isS3Configured: () => true,
+  isS3NotFound: () => false,
+}));
+
+// Drizzle db mock: capture inserts, return a deployment id, and serve a version row.
+// Follow the existing db-mock pattern used in other services/*.test.ts in this repo.
+// (See apps/api/src/services/*.test.ts for the canonical chainable-mock shape.)
+
+import { createSoftwareDeployment } from './softwareDeployment';
+
+describe('createSoftwareDeployment', () => {
+  beforeEach(() => { sendCommandMock.mockReset(); });
+
+  it('creates a deployment + per-device results and dispatches software_install for immediate install', async () => {
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-1',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2'],
+      scheduleType: 'immediate',
+      createdBy: 'system:automation',
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1', 'dev-2']);
+    expect(sendCommandMock).toHaveBeenCalledTimes(2);
+    expect(sendCommandMock.mock.calls[0][1].type).toBe('software_install');
+  });
+
+  it('returns status "failed" with a message when no installer URL is available', async () => {
+    // Arrange the version mock to have null s3Key AND null downloadUrl.
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1', softwareVersionId: 'ver-no-url', deploymentType: 'install',
+      deviceIds: ['dev-1'], scheduleType: 'immediate', createdBy: null,
+    });
+    expect(result.status).toBe('failed');
+    expect(result.message).toMatch(/No installer available/i);
+    expect(sendCommandMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+> Note: match the exact mock import paths to whatever `routes/software.ts` imports (e.g. the S3 helper module, the EDR resolver module, the agent-command sender). Read the import block at the top of `routes/software.ts` and mirror those specifiers.
+
+- [ ] **Step 3: Run test to verify it fails.**
+
+Run: `cd apps/api && npx vitest run src/services/softwareDeployment.test.ts`
+Expected: FAIL — `createSoftwareDeployment is not a function` / module not found.
+
+- [ ] **Step 4: Implement the service.** Move the identified block from the route into `softwareDeployment.ts`, parameterized by `CreateSoftwareDeploymentInput`. Preserve behavior exactly:
+  - Look up `versionRecord` (softwareVersions) + `catalogItem` (softwareCatalog) by `softwareVersionId`.
+  - Insert one `softwareDeployments` row (`orgId`, `softwareVersionId`, `deploymentType`, `targetType:'devices'`, `targetIds: deviceIds`, `scheduleType`, `scheduledAt`, `createdBy`, `name`, `options`).
+  - Insert `deploymentResults` (one per device, status `pending`).
+  - If `scheduleType==='immediate' && deploymentType==='install'`: run the S3 presign → EDR resolve (`huntress`/`sentinelone`) → fallback URL logic exactly as in the route; on no-URL or EDR error, mark results `failed` and return `{ status:'failed', message, dispatchedDeviceIds: [] }`; otherwise look up `agentId` per device and `sendCommandToAgent` the `software_install` command (same payload shape as `routes/software.ts:1156-1171`), and return `{ status:'pending', dispatchedDeviceIds }`.
+  - For non-immediate or non-install: return `{ status:'pending', dispatchedDeviceIds: [] }`.
+
+- [ ] **Step 5: Rewire the route to call the service.** In `routes/software.ts`, replace the moved block so the handler resolves `targetDeviceIds` (existing `resolveSoftwareTargetDeviceIds`), then calls `createSoftwareDeployment({...})` and maps its result to the existing `c.json({ data: { id, status, message } }, 200)` response. Keep `writeRouteAudit` and validation in the route.
+
+- [ ] **Step 6: Run tests.**
+
+Run: `cd apps/api && npx vitest run src/services/softwareDeployment.test.ts src/routes/software`
+Expected: PASS. Then `npx tsc --noEmit -p tsconfig.json` shows no new errors in `software.ts`/`softwareDeployment.ts`.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add apps/api/src/services/softwareDeployment.ts apps/api/src/services/softwareDeployment.test.ts apps/api/src/routes/software.ts
+git commit -m "refactor(software): extract createSoftwareDeployment() service from deploy route (#1981)"
+```
+
+---
+
+### Task 2: Add the `deploy_software` action type + Zod validator
+
+**Files:**
+- Modify: `apps/api/src/services/automationRuntime.ts` (the `AutomationAction` union, ~lines 51–82)
+- Modify: `packages/shared/src/validators/index.ts` (automation action validator)
+- Test: `packages/shared/src/validators/automationActions.test.ts` (create if absent; otherwise add cases to the existing automation validator test)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type DeploySoftwareAction = {
+    type: 'deploy_software';
+    catalogId: string;
+  };
+  // AutomationAction union now includes | DeploySoftwareAction
+  ```
+
+- [ ] **Step 1: Find the existing automation action validator.** Search `packages/shared/src/validators/index.ts` for the discriminated union of automation actions (look for `'run_script'`, `'execute_command'`). Note its exact name (e.g. `automationActionSchema`).
+
+- [ ] **Step 2: Write the failing test.**
+
+`packages/shared/src/validators/automationActions.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { automationActionSchema } from './index'; // adjust to the real export name
+
+describe('automationActionSchema — deploy_software', () => {
+  it('accepts a valid deploy_software action', () => {
+    const parsed = automationActionSchema.safeParse({
+      type: 'deploy_software',
+      catalogId: '11111111-1111-1111-1111-111111111111',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects deploy_software without a uuid catalogId', () => {
+    const parsed = automationActionSchema.safeParse({ type: 'deploy_software', catalogId: 'not-a-uuid' });
+    expect(parsed.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails.**
+
+Run: `cd packages/shared && npx vitest run src/validators/automationActions.test.ts`
+Expected: FAIL — the union rejects `type:'deploy_software'`.
+
+- [ ] **Step 4: Implement.**
+  - In `packages/shared/src/validators/index.ts`, add a member to the automation action discriminated union:
+    ```ts
+    z.object({
+      type: z.literal('deploy_software'),
+      catalogId: z.string().uuid(),
+    }),
+    ```
+    (Use `.guid()` instead of `.uuid()` only if this repo's Zod is v4 — check neighboring members; match what they use.)
+  - In `automationRuntime.ts`, add `export type DeploySoftwareAction = { type: 'deploy_software'; catalogId: string };` and add `| DeploySoftwareAction` to the `AutomationAction` union.
+
+- [ ] **Step 5: Run tests.**
+
+Run: `cd packages/shared && npx vitest run src/validators/automationActions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/shared/src/validators/index.ts packages/shared/src/validators/automationActions.test.ts apps/api/src/services/automationRuntime.ts
+git commit -m "feat(automations): add deploy_software action type + validator (#1981)"
+```
+
+---
+
+### Task 3: Version-currency helpers (latest-version pre-fetch + skip-if-current)
+
+**Files:**
+- Create: `apps/api/src/services/softwareCurrency.ts`
+- Create (test): `apps/api/src/services/softwareCurrency.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // Best-effort dotted-numeric comparison: returns -1 | 0 | 1, or null if either is unparseable.
+  export function compareVersions(a: string, b: string): -1 | 0 | 1 | null;
+
+  // Latest isLatest=true softwareVersions row + catalog name, keyed by catalogId.
+  export interface LatestVersionInfo {
+    version: typeof import('../db/schema').softwareVersions.$inferSelect;
+    catalogName: string;
+  }
+  export async function resolveLatestVersionsByCatalogId(
+    catalogIds: string[],
+  ): Promise<Map<string, LatestVersionInfo>>;
+
+  // True if the device already has this catalog app at >= latestVersion. Unknown/unparseable → false.
+  export async function isDeviceSoftwareCurrent(
+    deviceId: string,
+    catalogId: string,
+    latestVersion: string,
+  ): Promise<boolean>;
+  ```
+
+- [ ] **Step 1: Check for an existing comparator.** Run `grep -rn "compareVersions\|semver" apps/api/src packages/shared/src`. If a suitable dotted-version comparator already exists, import and reuse it instead of adding `compareVersions` — adjust the test to target that export. Otherwise proceed.
+
+- [ ] **Step 2: Write the failing test.**
+
+`apps/api/src/services/softwareCurrency.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { compareVersions } from './softwareCurrency';
+
+describe('compareVersions', () => {
+  it('orders dotted-numeric versions', () => {
+    expect(compareVersions('1.2.0', '1.10.0')).toBe(-1);
+    expect(compareVersions('2.0.0', '2.0.0')).toBe(0);
+    expect(compareVersions('126.0.1', '126.0.0')).toBe(1);
+  });
+  it('treats missing trailing segments as zero', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.3', '1.2.9')).toBe(1);
+  });
+  it('returns null when a version is unparseable', () => {
+    expect(compareVersions('latest', '1.0.0')).toBeNull();
+    expect(compareVersions('1.0.0', '')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails.**
+
+Run: `cd apps/api && npx vitest run src/services/softwareCurrency.test.ts`
+Expected: FAIL — module/function not defined.
+
+- [ ] **Step 4: Implement `compareVersions`.**
+```ts
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  const parse = (v: string): number[] | null => {
+    if (!v || !/^\d+(\.\d+)*$/.test(v.trim())) return null;
+    return v.trim().split('.').map((n) => Number(n));
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return null;
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 5: Run the comparator test.**
+
+Run: `cd apps/api && npx vitest run src/services/softwareCurrency.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Add the DB helpers + their failing tests.** Add to the same test file:
+```ts
+import { resolveLatestVersionsByCatalogId, isDeviceSoftwareCurrent } from './softwareCurrency';
+
+describe('isDeviceSoftwareCurrent', () => {
+  // Mock the db so software_inventory returns a row with a given version.
+  it('is true when an installed version is >= latest', async () => {
+    // inventory row version '126.0.1', latest '126.0.0' → current
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '126.0.0')).toBe(true);
+  });
+  it('is false when installed is older than latest', async () => {
+    expect(await isDeviceSoftwareCurrent('dev-1', 'cat-1', '127.0.0')).toBe(false);
+  });
+  it('is false when no inventory row exists (deploy is the safe default)', async () => {
+    expect(await isDeviceSoftwareCurrent('dev-2', 'cat-1', '1.0.0')).toBe(false);
+  });
+  it('is false when the installed version is unparseable', async () => {
+    expect(await isDeviceSoftwareCurrent('dev-3', 'cat-1', '1.0.0')).toBe(false);
+  });
+});
+```
+Use the repo's standard Drizzle db-mock (see existing `apps/api/src/services/*.test.ts`). Drive each case by what the mocked `software_inventory` select returns.
+
+- [ ] **Step 7: Implement the DB helpers.**
+```ts
+import { db } from '../db';
+import { softwareVersions, softwareCatalog, softwareInventory } from '../db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+
+export async function resolveLatestVersionsByCatalogId(catalogIds: string[]) {
+  const map = new Map<string, LatestVersionInfo>();
+  if (catalogIds.length === 0) return map;
+  const rows = await db
+    .select({ version: softwareVersions, catalogName: softwareCatalog.name })
+    .from(softwareVersions)
+    .innerJoin(softwareCatalog, eq(softwareVersions.catalogId, softwareCatalog.id))
+    .where(and(inArray(softwareVersions.catalogId, catalogIds), eq(softwareVersions.isLatest, true)));
+  for (const r of rows) map.set(r.version.catalogId, { version: r.version, catalogName: r.catalogName });
+  return map;
+}
+
+export async function isDeviceSoftwareCurrent(deviceId: string, catalogId: string, latestVersion: string) {
+  const rows = await db
+    .select({ version: softwareInventory.version })
+    .from(softwareInventory)
+    .where(and(eq(softwareInventory.deviceId, deviceId), eq(softwareInventory.catalogId, catalogId)));
+  for (const r of rows) {
+    if (!r.version) continue;
+    const cmp = compareVersions(r.version, latestVersion);
+    if (cmp === 0 || cmp === 1) return true; // installed >= latest
+  }
+  return false; // absent or unparseable → not current → deploy
+}
+```
+
+- [ ] **Step 8: Run tests + commit.**
+
+Run: `cd apps/api && npx vitest run src/services/softwareCurrency.test.ts`
+Expected: PASS.
+```bash
+git add apps/api/src/services/softwareCurrency.ts apps/api/src/services/softwareCurrency.test.ts
+git commit -m "feat(software): version-currency helpers for deploy_software idempotency (#1981)"
+```
+
+---
+
+### Task 4: Batched `deploy_software` execution in the automation runner
+
+**Files:**
+- Modify: `apps/api/src/services/automationRuntime.ts` — add `executeDeploySoftwareActions()` batched pass and call it from BOTH run executors (the standalone path near lines 1280–1340 and the config-policy path near lines 1738–1829)
+- Test: `apps/api/src/services/automationRuntime.deploySoftware.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `createSoftwareDeployment` (Task 1), `resolveLatestVersionsByCatalogId` + `isDeviceSoftwareCurrent` (Task 3), `DeploySoftwareAction` (Task 2).
+- Produces:
+  ```ts
+  // Runs once per automation run, AFTER the per-device action loop. For each
+  // deploy_software action, filters eligible devices (OS-supported + not current),
+  // creates ONE softwareDeployments via createSoftwareDeployment, appends per-device
+  // log entries, and returns aggregate counts to fold into the run.
+  async function executeDeploySoftwareActions(args: {
+    actions: AutomationAction[];
+    devices: Array<{ id: string; osType: 'windows'|'macos'|'linux' }>;
+    orgId: string;
+    createdBy: string | null;
+    runId: string;
+  }): Promise<{ logs: AutomationLogEntry[]; deployedDeviceIds: Set<string>; failed: boolean }>;
+  ```
+
+- [ ] **Step 1: Write the failing test.**
+
+`apps/api/src/services/automationRuntime.deploySoftware.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { createDeploymentMock, latestMapMock, isCurrentMock } = vi.hoisted(() => ({
+  createDeploymentMock: vi.fn(),
+  latestMapMock: vi.fn(),
+  isCurrentMock: vi.fn(),
+}));
+vi.mock('./softwareDeployment', () => ({ createSoftwareDeployment: createDeploymentMock }));
+vi.mock('./softwareCurrency', () => ({
+  resolveLatestVersionsByCatalogId: latestMapMock,
+  isDeviceSoftwareCurrent: isCurrentMock,
+}));
+
+import { executeDeploySoftwareActions } from './automationRuntime';
+
+const WIN = { id: 'd-win', osType: 'windows' as const };
+const MAC = { id: 'd-mac', osType: 'macos' as const };
+
+beforeEach(() => {
+  createDeploymentMock.mockReset().mockResolvedValue({ deploymentId: 'dep-1', status: 'pending', dispatchedDeviceIds: ['d-win'] });
+  isCurrentMock.mockReset().mockResolvedValue(false);
+  latestMapMock.mockReset().mockResolvedValue(new Map([['cat-1', {
+    version: { id: 'ver-1', catalogId: 'cat-1', version: '126.0.0', supportedOs: ['windows'] },
+    catalogName: 'Chrome',
+  }]]));
+});
+
+describe('executeDeploySoftwareActions', () => {
+  it('deploys to an eligible Windows device and records a deployed log', async () => {
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).toHaveBeenCalledTimes(1);
+    expect(createDeploymentMock.mock.calls[0][0].deviceIds).toEqual(['d-win']);
+    expect(res.deployedDeviceIds.has('d-win')).toBe(true);
+    expect(res.failed).toBe(false);
+  });
+
+  it('skips a device whose OS is unsupported and does not create a deployment', async () => {
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).not.toHaveBeenCalled();
+    expect(res.logs.some(l => /unsupported OS/i.test(l.message))).toBe(true);
+  });
+
+  it('skips a device that is already current', async () => {
+    isCurrentMock.mockResolvedValue(true);
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).not.toHaveBeenCalled();
+    expect(res.logs.some(l => /already current/i.test(l.message))).toBe(true);
+  });
+
+  it('marks failed when the catalog has no latest version', async () => {
+    latestMapMock.mockResolvedValue(new Map());
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+    });
+    expect(res.failed).toBe(true);
+    expect(res.logs.some(l => /no latest version/i.test(l.message))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `cd apps/api && npx vitest run src/services/automationRuntime.deploySoftware.test.ts`
+Expected: FAIL — `executeDeploySoftwareActions` not exported.
+
+- [ ] **Step 3: Implement `executeDeploySoftwareActions`** (export it for testability). Use the existing `logEntry(...)` helper for log entries:
+```ts
+export async function executeDeploySoftwareActions(args: {
+  actions: AutomationAction[];
+  devices: Array<{ id: string; osType: 'windows' | 'macos' | 'linux' }>;
+  orgId: string;
+  createdBy: string | null;
+  runId: string;
+}): Promise<{ logs: AutomationLogEntry[]; deployedDeviceIds: Set<string>; failed: boolean }> {
+  const deployActions = args.actions.filter(
+    (a): a is DeploySoftwareAction => a.type === 'deploy_software',
+  );
+  const logs: AutomationLogEntry[] = [];
+  const deployedDeviceIds = new Set<string>();
+  let failed = false;
+  if (deployActions.length === 0) return { logs, deployedDeviceIds, failed };
+
+  const latest = await resolveLatestVersionsByCatalogId(
+    [...new Set(deployActions.map((a) => a.catalogId))],
+  );
+
+  for (const [actionIndex, action] of deployActions.entries()) {
+    const info = latest.get(action.catalogId);
+    if (!info) {
+      failed = true;
+      logs.push(logEntry('deploy_software has no latest version for catalog', 'error', {
+        actionType: action.type, actionIndex, details: { catalogId: action.catalogId },
+      }));
+      continue;
+    }
+    const supportedOs: string[] = Array.isArray(info.version.supportedOs) ? info.version.supportedOs : [];
+    const eligible: string[] = [];
+    for (const device of args.devices) {
+      if (!supportedOs.includes(device.osType)) {
+        logs.push(logEntry(`Skipped ${info.catalogName}: unsupported OS`, 'info', {
+          actionType: action.type, actionIndex, deviceId: device.id,
+          details: { deviceOsType: device.osType, supportedOs },
+        }));
+        continue;
+      }
+      if (await isDeviceSoftwareCurrent(device.id, action.catalogId, info.version.version)) {
+        logs.push(logEntry(`Skipped ${info.catalogName}: already current`, 'info', {
+          actionType: action.type, actionIndex, deviceId: device.id,
+          details: { version: info.version.version },
+        }));
+        continue;
+      }
+      eligible.push(device.id);
+    }
+    if (eligible.length === 0) continue;
+
+    const result = await createSoftwareDeployment({
+      orgId: args.orgId,
+      softwareVersionId: info.version.id,
+      deploymentType: 'install',
+      deviceIds: eligible,
+      scheduleType: 'immediate',
+      createdBy: args.createdBy,
+      name: `Automation: deploy ${info.catalogName}`,
+    });
+    if (result.status === 'failed') {
+      failed = true;
+      logs.push(logEntry(`deploy_software failed: ${result.message ?? 'unknown error'}`, 'error', {
+        actionType: action.type, actionIndex, details: { catalogId: action.catalogId, deploymentId: result.deploymentId },
+      }));
+      continue;
+    }
+    for (const id of result.dispatchedDeviceIds) deployedDeviceIds.add(id);
+    logs.push(logEntry(`Deploying ${info.catalogName} ${info.version.version} to ${eligible.length} device(s)`, 'info', {
+      actionType: action.type, actionIndex, details: { deploymentId: result.deploymentId, deviceIds: eligible },
+    }));
+  }
+  return { logs, deployedDeviceIds, failed };
+}
+```
+
+- [ ] **Step 4: Run the handler test.**
+
+Run: `cd apps/api && npx vitest run src/services/automationRuntime.deploySoftware.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into both run executors.** In `automationRuntime.ts`, after the existing per-device action loop completes in EACH executor (standalone run near ~1280–1340; config-policy run near ~1738–1829), call:
+```ts
+const deployOutcome = await executeDeploySoftwareActions({
+  actions,
+  devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType })),
+  orgId,                 // the run's org
+  createdBy: automation.createdBy ?? null,
+  runId,
+});
+// append deployOutcome.logs into the run's logs array;
+// fold deployOutcome.deployedDeviceIds into devicesSucceeded;
+// if deployOutcome.failed and onFailure === 'stop', mark the run 'failed'/'partial' per existing logic.
+```
+Important: in the `run_script`-style per-device dispatch, **exclude** `deploy_software` actions (they are handled by the batched pass) — add `if (action.type === 'deploy_software') continue;` in the per-device action loop, or filter them out of `actions` before that loop. Confirm `executeAction`'s switch does NOT also try to handle `deploy_software` (leave it out of `executeAction`).
+
+- [ ] **Step 6: Run the full affected suites.**
+
+Run: `cd apps/api && npx vitest run src/services/automationRuntime src/services/softwareDeployment src/services/softwareCurrency`
+Expected: PASS. Then `npx tsc --noEmit -p tsconfig.json` — no new errors.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add apps/api/src/services/automationRuntime.ts apps/api/src/services/automationRuntime.deploySoftware.test.ts
+git commit -m "feat(automations): execute deploy_software as a batched, idempotent deployment pass (#1981)"
+```
+
+---
+
+### Task 5: Frontend — "Deploy Software" action in the automation editor
+
+**Files:**
+- Modify: the automation action editor used by the config-policy automation feature tab and the standalone automation editor. Locate via: `grep -rn "run_script\|execute_command" apps/web/src` — the file rendering the action-type dropdown + per-type fields.
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/types.ts` only if an action-type list/enum lives there.
+- Test: co-located component test if the editor already has one; otherwise a focused render/validation test for the new action type.
+
+**Interfaces:**
+- Consumes: existing software catalog list endpoint. Find it via `grep -rn "softwareCatalog\|/software/catalog\|software-catalog" apps/web/src apps/api/src/routes/software.ts` — reuse the same fetch the Software Catalog page uses.
+
+- [ ] **Step 1: Locate the action editor + catalog fetch.** Run the greps above. Identify (a) where action types are listed for the dropdown, (b) the per-action field renderer (switch on `action.type`), and (c) the catalog list hook/endpoint.
+
+- [ ] **Step 2: Write the failing test.** Add a test asserting that selecting the "Deploy Software" action renders a catalog picker and produces an action object `{ type: 'deploy_software', catalogId }`. Follow the editor's existing test patterns (`apps/web/src/.../*.test.tsx`). If the editor has no test harness, write a minimal one rendering the editor with the new type selected and asserting the emitted action shape.
+
+- [ ] **Step 3: Run test to verify it fails.**
+
+Run: `cd apps/web && npx vitest run <path-to-new-test>`
+Expected: FAIL — "Deploy Software" option / catalog picker not present.
+
+- [ ] **Step 4: Implement.**
+  - Add `'deploy_software'` (label "Deploy Software") to the action-type options list.
+  - In the per-action field renderer, add a branch for `deploy_software` that renders a catalog `<select>` populated from the catalog list endpoint, bound to `action.catalogId`, plus helper text: `Installs the latest version of the selected software; skips devices that already have it.`
+  - Ensure the editor emits `{ type: 'deploy_software', catalogId }` with no extra fields.
+
+- [ ] **Step 5: Run test.**
+
+Run: `cd apps/web && npx vitest run <path-to-new-test>`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add apps/web/src
+git commit -m "feat(web): Deploy Software automation action editor with catalog picker (#1981)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Action shape (`deploy_software`, `catalogId`, no new tables) → Task 2. ✓
+- Latest-of-catalog at run time → Task 3 (`resolveLatestVersionsByCatalogId` on `isLatest`). ✓
+- Real deployment records + UI status → Task 1 (`createSoftwareDeployment` creates `softwareDeployments`+`deploymentResults`). ✓
+- Skip-if-current (unknown → deploy) → Task 3 (`isDeviceSoftwareCurrent`) + Task 4 (applied per device). ✓
+- OS gate → Task 4. ✓
+- One deployment row per action (batched pass) → Task 4. ✓
+- Targeted refactor of `POST /deployments` → Task 1. ✓
+- Tenancy (#1855 policy-id, system context, run org) → Global Constraints + Task 4 wiring (uses the run executors' existing run-recording, which already resolves the policy id post-#1855). ✓
+- Validation + frontend → Task 2 (Zod) + Task 5 (UI). ✓
+- Tests for handler/validator/comparator/currency → Tasks 2–4. ✓
+- Out-of-scope items (uninstall, pinned, force, pkg-manager) → not implemented, by design. ✓
+
+**Placeholder scan:** Concrete code/commands in every code step. The two intentional "locate via grep" steps (Tasks 1 mock paths, Task 5 editor location) are discovery instructions for repo-specific paths, each paired with the exact grep and the concrete change to make — not deferred work.
+
+**Type consistency:** `createSoftwareDeployment` input/result, `DeploySoftwareAction`, `LatestVersionInfo`, `compareVersions`, `isDeviceSoftwareCurrent`, and `executeDeploySoftwareActions` signatures are referenced consistently across Tasks 1→4. `dispatchedDeviceIds` (Task 1) is the field consumed in Task 4.
+
+**Note for executor:** Task 4's run-recording must not regress the #1855 tenant-key fix — verify `automation_runs.config_policy_id` is still the resolved policy id after wiring the deploy pass in. Add/keep a test asserting it if the config-policy executor's existing test doesn't already cover it.

--- a/docs/superpowers/specs/2026-06-27-deploy-software-automation-action-design.md
+++ b/docs/superpowers/specs/2026-06-27-deploy-software-automation-action-design.md
@@ -1,0 +1,114 @@
+# Software Deployment automation action — design
+
+**Issue:** [#1981](https://github.com/LanternOps/breeze/issues/1981) — `[Automations] Add "Software Deployment" as an automation action type`
+**Origin:** Feature request from @win-wxx on the #1854 Configuration Policy umbrella issue: *"could you please also consider adding Software Deployment as an automation action type? That would be incredibly useful for our MSP workflows."*
+**Date:** 2026-06-27
+
+## Problem
+
+Automations (Configuration Policy → automation feature, and standalone automations) support four action types today — `run_script`, `execute_command`, `send_notification`, `create_alert` — driven by `schedule` and `event` (e.g. device-online) triggers. There is no way to install software from an automation, even though Breeze already has a complete software-deployment subsystem. MSPs want "keep these apps current on these devices" as a scheduled automation.
+
+## Key finding: reuse, don't build
+
+Breeze already has the full deployment path:
+
+- `softwareCatalog` → `softwareVersions` (download URL, checksum, `silentInstallArgs`, `supportedOs`, `isLatest`) → `softwareDeployments` → `deploymentResults` (per-device status: pending/downloading/installing/completed/failed).
+- The agent already accepts a `software_install` command over WebSocket.
+- `POST /deployments` (`routes/software.ts`) resolves targets, creates records, and dispatches the command.
+- `software_inventory` (`deviceId`, `catalogId`, `version`) records what's installed per device.
+
+So this feature is **a new automation action that drives the existing deployment path** — not new deployment infrastructure.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Version semantics | **Latest of a catalog entry** — resolve `isLatest` at run time | Fits MSP "keep Chrome/Zoom current" scheduled workflow; pairs naturally with skip-if-current |
+| Result tracking | **Create real `softwareDeployments` + `deploymentResults` rows** | Appears in the existing Software Deployments UI with live status; reuses all read-back |
+| Idempotency | **Skip if already current** — deploy only to devices missing/older than latest | Safe to run nightly; no redundant reinstalls |
+
+## Action shape — no new tables
+
+A fifth action type in the automation `actions[]` JSONB, referencing a catalog entry the same way `run_script` references a `scriptId`:
+
+```ts
+{ type: 'deploy_software', catalogId: string }   // semantics: "ensure latest installed"
+```
+
+No `softwareVersionId` pinning, no force-reinstall flag — minimal by the decisions above. Reuses all existing software tables and the agent `software_install` command.
+
+## Execution flow
+
+Implemented in `apps/api/src/services/automationRuntime.ts`, alongside the existing action handlers and pre-fetch maps.
+
+**Pre-fetch (batch, mirrors `scriptsById`):** collect every `catalogId` referenced by `deploy_software` actions in the run; batch-resolve the current `isLatest` `softwareVersions` row plus catalog name into a `latestVersionByCatalogId` Map. Catalogs with no latest version are recorded as resolution failures.
+
+**Per device** (inside the existing `runWithConcurrency(deviceRows, 5, …)`), for each `deploy_software` action:
+
+1. **OS gate** — if `device.osType` ∉ `version.supportedOs`, log `unsupported OS` and skip the device for this action.
+2. **Skip-if-current** — look up `software_inventory` for `(deviceId, catalogId)`. If an installed `version >= latest`, log `already current` and skip. If no inventory row, or the installed version is unknown/unparseable, treat as **not current → deploy** (safe default: ensures latest gets installed).
+3. Otherwise the device is a deploy target for this action.
+
+**Create real records + dispatch:** for the deploy-target devices of each `deploy_software` action, call the new `createSoftwareDeployment()` service (see refactor below) once per action: it inserts one `softwareDeployments` row (`deploymentType:'install'`, `scheduleType:'immediate'`, `targetType:'devices'`, `targetIds` = resolved device ids, `createdBy` = system/automation marker), inserts `deploymentResults` per device (status `pending`), and dispatches the `software_install` command to each device's agent. Status read-back flows through the existing `deploymentResults` path and Software Deployments UI.
+
+**Run logging:** each device gets an `automation_runs.logs` entry per action — one of `deployed`, `already current`, `unsupported OS`, or `failed` (with reason). These roll into `devicesSucceeded` / `devicesFailed` on the run, consistent with the other action types. `onFailure` policy (`stop`/`continue`) is respected exactly as for other actions.
+
+## Targeted refactor
+
+The deployment-create + agent-dispatch logic is currently inline in the `POST /deployments` route handler (`apps/api/src/routes/software.ts`, ~lines 1021–1189). Extract it into a reusable service function:
+
+```ts
+// apps/api/src/services/softwareDeployment.ts (new or existing service module)
+createSoftwareDeployment(input: {
+  orgId, softwareVersionId, deploymentType, deviceIds,
+  scheduleType, createdBy, options?
+}): Promise<{ deploymentId: string; results: DeploymentResultRow[] }>
+```
+
+Both the route and the automation action call this single path, so checksum handling, `deploymentResults` creation, and `software_install` dispatch are not duplicated. This is the one piece of "improve the code we're touching" included in scope; no unrelated refactoring.
+
+## Tenancy / RLS
+
+- `softwareDeployments.orgId` = the run's org. Both standalone automations and config policies are org-scoped, so a single automation run targets devices in exactly one org — no cross-org grouping needed.
+- `automation_runs.config_policy_id` = the **resolved policy id**, never the feature-link id — the #1855 tenant-key contract. The worker runs under `withSystemDbAccessContext`, so writes succeed and org-scoped readers can still see the rows via the RLS EXISTS-join.
+- `software_inventory` reads are org-scoped; under system context in the worker they resolve correctly.
+
+## Validation + frontend
+
+- **Zod:** extend the automation action validator (`packages/shared/src/validators`) with the `deploy_software` variant: `{ type: 'deploy_software', catalogId: z.string().uuid() }`. Applies to both standalone automation actions and config-policy automation `inlineSettings`.
+- **Frontend:** in the automation feature tab's action editor (`apps/web/src/components/configurationPolicies/featureTabs/` and the standalone automation editor), add a "Deploy Software" action type with a **catalog picker** (reuse the existing `softwareCatalog` list endpoint) and helper text: *"Installs the latest version of the selected software; skips devices that already have it."*
+
+## Error handling / edge cases
+
+| Case | Behavior |
+|---|---|
+| Catalog entry has no `isLatest` version | Action fails for all devices with a clear log line; respects `onFailure` |
+| Device OS not in `supportedOs` | Skip device for that action, log `unsupported OS` (not a failure) |
+| Installed version unknown/unparseable | Treat as not-current → deploy (safe default) |
+| Device offline / no live agent | Same behavior as the manual `POST /deployments` path (deploymentResult stays `pending`; no special queueing added here) |
+| Version comparison | Prefer `catalogId`-matched inventory row; best-effort semantic version comparator; ties/unknown → deploy |
+
+## Testing
+
+- `automationRuntime` unit tests for the new handler: deploy path, skip-if-current, unsupported-OS skip, missing-latest failure, mixed-device run counts.
+- Validator test for the `deploy_software` action shape.
+- Run-recording test asserting `automation_runs.config_policy_id` is the policy id (not feature-link id) and `softwareDeployments`/`deploymentResults` rows are created with the right org.
+- Mirror existing `automationRuntime` test patterns (Drizzle mocks, pre-fetch maps).
+
+## Out of scope (YAGNI — note as future)
+
+- Uninstall / update-specific action variants (this action is install-or-update-to-latest).
+- Pinned exact-version mode and a force-reinstall toggle.
+- Package-manager-by-name installs (winget/choco direct) — bypasses catalog/checksum/inventory.
+- Offline-device install queueing beyond the existing manual-deploy behavior.
+
+## Files touched (anticipated)
+
+| File | Change |
+|---|---|
+| `apps/api/src/services/automationRuntime.ts` | New `deploy_software` handler + pre-fetch map + dispatch in `executeAction` |
+| `apps/api/src/services/softwareDeployment.ts` | New `createSoftwareDeployment()` service (extracted) |
+| `apps/api/src/routes/software.ts` | `POST /deployments` calls the extracted service |
+| `packages/shared/src/validators/index.ts` | `deploy_software` action validator |
+| `apps/web/src/components/configurationPolicies/featureTabs/` (+ standalone automation editor) | "Deploy Software" action UI with catalog picker |
+| Co-located `*.test.ts` | Handler, validator, and run-recording tests |

--- a/packages/shared/src/validators/automationActions.test.ts
+++ b/packages/shared/src/validators/automationActions.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { automationActionSchema, createAutomationSchema } from './index';
+
+const UUID = '11111111-1111-1111-1111-111111111111';
+
+describe('automationActionSchema - deploy_software', () => {
+  it('accepts a valid deploy_software action', () => {
+    const parsed = automationActionSchema.safeParse({
+      type: 'deploy_software',
+      catalogId: UUID,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects deploy_software without a uuid catalogId', () => {
+    const parsed = automationActionSchema.safeParse({
+      type: 'deploy_software',
+      catalogId: 'not-a-uuid',
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('createAutomationSchema.actions wiring', () => {
+  const base = { name: 'A', trigger: { type: 'schedule', cron: '0 0 * * *' } };
+
+  it('still accepts the pre-existing action shapes (backward compat)', () => {
+    const parsed = createAutomationSchema.safeParse({
+      ...base,
+      actions: [
+        { type: 'run_script', scriptId: UUID },
+        { type: 'send_notification', notificationChannelId: UUID, severity: 'critical' },
+        { type: 'create_alert', alertSeverity: 'high', alertMessage: 'x' },
+        { type: 'execute_command', command: 'echo hi', shell: 'bash' },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a deploy_software action through the real create path', () => {
+    const parsed = createAutomationSchema.safeParse({
+      ...base,
+      actions: [{ type: 'deploy_software', catalogId: UUID }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an action with an unknown type', () => {
+    const parsed = createAutomationSchema.safeParse({
+      ...base,
+      actions: [{ type: 'not_a_real_action' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -222,13 +222,44 @@ export const automationTriggerSchema = z.discriminatedUnion('type', [
   })
 ]);
 
+export const automationActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('run_script'),
+    scriptId: z.string().guid(),
+    parameters: z.record(z.string(), z.unknown()).optional(),
+    runAs: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('send_notification'),
+    notificationChannelId: z.string().guid(),
+    title: z.string().optional(),
+    message: z.string().optional(),
+    severity: z.enum(['critical', 'high', 'medium', 'low', 'info']).optional(),
+  }),
+  z.object({
+    type: z.literal('create_alert'),
+    alertSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+    alertMessage: z.string(),
+    alertTitle: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('execute_command'),
+    command: z.string(),
+    shell: z.enum(['bash', 'powershell', 'cmd']).optional(),
+  }),
+  z.object({
+    type: z.literal('deploy_software'),
+    catalogId: z.string().guid(),
+  }),
+]);
+
 export const createAutomationSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(2000).optional(),
   enabled: z.boolean().default(true),
   trigger: automationTriggerSchema,
   conditions: z.record(z.string(), z.unknown()).optional(),
-  actions: z.array(z.record(z.string(), z.unknown())).min(1),
+  actions: z.array(automationActionSchema).min(1),
   onFailure: z.enum(['stop', 'continue', 'notify']).default('stop'),
   notificationTargets: z.record(z.string(), z.unknown()).optional()
 });

--- a/packages/shared/src/validators/index_auth_automation.test.ts
+++ b/packages/shared/src/validators/index_auth_automation.test.ts
@@ -154,7 +154,7 @@ describe('createAutomationSchema', () => {
   const validAutomation = {
     name: 'Restart on failure',
     trigger: { type: 'event' as const, event: 'service.stopped' },
-    actions: [{ type: 'script', scriptId: VALID_UUID }],
+    actions: [{ type: 'run_script', scriptId: VALID_UUID }],
   };
 
   it('should accept valid automation', () => {


### PR DESCRIPTION
## What & why

Adds a **`deploy_software`** automation action — the feature @win-wxx requested on the #1854 Configuration Policy umbrella ("could you please also consider adding Software Deployment as an automation action type? That would be incredibly useful for our MSP workflows"). Automations can now install software on targeted devices on a schedule or device-online trigger, alongside the existing `run_script` / `execute_command` / `send_notification` / `create_alert` actions.

Spec: `docs/superpowers/specs/2026-06-27-deploy-software-automation-action-design.md`
Plan: `docs/superpowers/plans/2026-06-27-deploy-software-automation-action.md`

## Design decisions

- **Latest of a catalog entry** — the action references a `softwareCatalog` entry; the current `isLatest` version is resolved at run time ("keep these apps current"). No version pinning.
- **Real deployment records** — each run creates `softwareDeployments` + per-device `deploymentResults`, so it appears in the existing Software Deployments UI with live install status. Reuses the agent `software_install` command path (no new agent work).
- **Skip-if-current idempotency** — only deploys to devices missing/older than latest; safe to run nightly. Unknown installed version → deploy (safe default).

## How it works

- **`createSoftwareDeployment()` service** — extracted from `POST /deployments` so the route and the automation runner share one create+dispatch path (S3 presign / EDR key resolution / fallback all preserved; route still returns 201 + full deployment object).
- **`deploy_software` action** `{ type, catalogId }` — added to the runtime `AutomationAction` union and to `normalizeAutomationActions`, which is the actual runtime gate.
- **Version-currency helpers** — `resolveLatestVersionsByCatalogId` (isLatest), `isDeviceSoftwareCurrent` (skip-if-current), `compareVersions`.
- **Batched execution** — `executeDeploySoftwareActions` runs once per automation run (deploy is one-to-many, unlike the per-device action loop): resolves latest, gates by OS, skips already-current devices, creates one deployment per action. A deploy-dispatch failure can never yield a `completed` run. `deploy_software` is excluded from the per-device loop in both executors.
- **Frontend** — "Deploy Software" action in both the config-policy (`AutomationTab`) and standalone (`AutomationForm`) editors, with a catalog picker and helper text.

## Review findings fixed (whole-branch review)

- **Critical:** `normalizeAutomationActions` rejected `deploy_software` → the feature never ran. Added the case (+ end-to-end normalization tests).
- **Important:** `software_inventory.catalogId` is never populated by agent ingest, so skip-if-current matched zero rows (silent no-op). Now matches inventory by catalog **name** OR catalogId.
- **Important:** null/empty `supportedOs` made the OS gate skip every device. Empty `supportedOs` now means "no OS restriction."
- **Minor:** restored audit-on-success-only in `POST /deployments`.

## Known limitations / notes

- **Skip-if-current is best-effort by name** because `software_inventory.catalogId` isn't populated upstream; a catalog whose name differs from the OS-reported app name won't match and will deploy. A future inventory→catalog linker would tighten this.
- **`compareVersions`** handles dotted-numeric versions; non-numeric forms (e.g. `1.2.3-beta`) are treated as not-current → deploy.
- **Action-shape enforcement** is `normalizeAutomationActions` at runtime. A shared `automationActionSchema` is exported for reuse, but the automations create route still uses its own (freeform) schema — left as-is to avoid scope creep.

## Test plan

- API: `softwareDeployment`, `softwareCurrency`, `automationRuntime` (+ deploySoftware), `routes/software` — 173 passing locally; `tsc --noEmit` clean.
- Shared: `automationActionSchema` + backward-compat for existing action shapes — 779 validator tests passing.
- Web: `AutomationTab` + `AutomationForm` deploy-software editor tests passing.

Refs #1854. Closes #1981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)