### PR TITLE
fix(compose): drop non-existent postcss.config.mjs bind mount from dev stacks

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,7 +139,6 @@ services:
       - ./apps/web/tsconfig.json:/app/apps/web/tsconfig.json:ro
       - ./apps/web/astro.config.mjs:/app/apps/web/astro.config.mjs:ro
       - ./apps/web/tailwind.config.mjs:/app/apps/web/tailwind.config.mjs:ro
-      - ./apps/web/postcss.config.mjs:/app/apps/web/postcss.config.mjs:ro
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
       - ./packages/shared/tsconfig.json:/app/packages/shared/tsconfig.json:ro
       # Exclude node_modules (use container's)

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -94,7 +94,6 @@ services:
       - ./apps/web/tsconfig.json:/app/apps/web/tsconfig.json:ro
       - ./apps/web/astro.config.mjs:/app/apps/web/astro.config.mjs:ro
       - ./apps/web/tailwind.config.mjs:/app/apps/web/tailwind.config.mjs:ro
-      - ./apps/web/postcss.config.mjs:/app/apps/web/postcss.config.mjs:ro
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
       - ./packages/shared/tsconfig.json:/app/packages/shared/tsconfig.json:ro
       # Exclude node_modules (use container's)


### PR DESCRIPTION
## Summary

The dev compose files bind-mounted `./apps/web/postcss.config.mjs` into the web container, but **that file has never existed in the repo**. The web app configures Tailwind/PostCSS through the `@astrojs/tailwind` integration in `apps/web/astro.config.mjs`, not a standalone `postcss.config.mjs` — the path is absent from the repo tree, the `breeze-web:dev` image, and git history alike.

## Why it bites

Docker auto-creates a missing bind-mount **source** as an empty *directory* on the host. So the first `docker compose -f docker-compose.yml -f docker-compose.override.yml.dev up` silently creates `apps/web/postcss.config.mjs/` (a directory) and mounts it. On a clean checkout where that artifact doesn't exist yet — or once someone cleans it — the mount can fail outright (`mounting … not a directory`), and the stray empty dir is a confusing untracked artifact in the working tree.

Hit this while bringing up a fresh code-mounted dev stack: the web container failed to start until the line + stale empty dir were removed.

## Fix

Remove the spurious mount from both dev compose files:
- `docker-compose.override.yml.dev` (the line has been there since #166)
- `docker-compose.dev.yml`

Astro resolves its PostCSS config via the integration, so nothing reads the mounted path; web/portal come up cleanly without it. **No functional change to the app** — purely removes a dead bind mount.

## Test

- `grep -rn postcss.config.mjs docker-compose*` → no matches after the change.
- Brought up the code-mounted dev stack (`docker-compose.override.yml.dev`) with the line removed: `api/web/portal/caddy/postgres/redis` all healthy, `/health` 200, web hot-reload (`pnpm dev`) serving with `apps/web/src` live-mounted.

Reported by: internal Playwright UI QA sweep, 2026-06-27 (evidence in `docs/testing/FEATURE_TEST_LOG.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)