### PR TITLE
fix(web): persist site address & contact on the Site Detail page (+ silent-write hardening)

### DIFF
--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -510,16 +510,22 @@ discoveryRoutes.patch(
       .where(eq(discoveryProfiles.id, profileId))
       .returning();
 
+    // 0-row write despite the prior access-checked SELECT => RLS rejection or a
+    // race. Surface it rather than returning 200 + null (a silent failure).
+    if (!updated) {
+      return c.json({ error: 'Failed to update discovery profile' }, 500);
+    }
+
     writeRouteAudit(c, {
-      orgId: updated?.orgId ?? orgResult.orgId,
+      orgId: updated.orgId,
       action: 'discovery.profile.update',
       resourceType: 'discovery_profile',
-      resourceId: updated?.id ?? profileId,
-      resourceName: updated?.name,
+      resourceId: updated.id,
+      resourceName: updated.name,
       details: { changedFields: Object.keys(updates) }
     });
 
-    return c.json(updated ? serializeDiscoveryProfile(updated) : updated);
+    return c.json(serializeDiscoveryProfile(updated));
   }
 );
 
@@ -1238,12 +1244,18 @@ discoveryRoutes.post(
       .where(eq(discoveredAssets.id, assetId))
       .returning();
 
+    // 0-row write despite the prior access-checked SELECT => RLS rejection or a
+    // race. Surface it rather than returning 200 + null (a silent failure).
+    if (!updated) {
+      return c.json({ error: 'Failed to link discovered asset' }, 500);
+    }
+
     writeRouteAudit(c, {
-      orgId: updated?.orgId ?? orgResult.orgId,
+      orgId: updated.orgId,
       action: 'discovery.asset.link',
       resourceType: 'discovered_asset',
-      resourceId: updated?.id ?? assetId,
-      resourceName: updated?.hostname ?? updated?.ipAddress ?? undefined,
+      resourceId: updated.id,
+      resourceName: updated.hostname ?? updated.ipAddress ?? undefined,
       details: { linkedDeviceId: body.deviceId }
     });
 

--- a/apps/api/src/routes/monitors.ts
+++ b/apps/api/src/routes/monitors.ts
@@ -628,15 +628,19 @@ monitorRoutes.delete(
     const [removed] = await db.delete(networkMonitors)
       .where(eq(networkMonitors.id, monitorId)).returning();
 
-    if (removed) {
-      writeRouteAudit(c, {
-        orgId: removed.orgId,
-        action: 'monitor.delete',
-        resourceType: 'network_monitor',
-        resourceId: removed.id,
-        resourceName: removed.name
-      });
+    // 0-row delete despite the prior requireMonitorAccess check => RLS rejection
+    // or a race. Surface it rather than returning 200 + { data: null }.
+    if (!removed) {
+      return c.json({ error: 'Failed to delete monitor' }, 500);
     }
+
+    writeRouteAudit(c, {
+      orgId: removed.orgId,
+      action: 'monitor.delete',
+      resourceType: 'network_monitor',
+      resourceId: removed.id,
+      resourceName: removed.name
+    });
 
     return c.json({ data: removed });
   }

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1432,6 +1432,13 @@ orgRoutes.patch('/sites/:id', requireScope('organization', 'partner', 'system'),
     .where(eq(sites.id, id))
     .returning();
 
+  // A 0-row write here means the RLS UPDATE policy rejected it even though the
+  // prior SELECT + ensureOrgAccess passed (RLS/app mismatch or a race). Surface
+  // it instead of returning 200 + null, which reads to the client as a success.
+  if (!updated) {
+    return c.json({ error: 'Failed to update site' }, 500);
+  }
+
   writeRouteAudit(c, {
     orgId: site.orgId,
     action: 'site.update',

--- a/apps/web/src/components/settings/SiteDetailPage.test.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SiteDetailPage from './SiteDetailPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const SITE_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const ORG_ID = '11111111-2222-4333-8444-555566667777';
+
+// The API stores address/contact as nested JSONB. Saving must round-trip that
+// shape — a flat payload gets silently stripped by the route's Zod validation,
+// which made the form appear to reset on save (the bug this test guards).
+const SITE_FROM_API = {
+  id: SITE_ID,
+  orgId: ORG_ID,
+  name: 'Main Office',
+  timezone: 'America/New_York',
+  status: 'active',
+  address: {
+    line1: '123 Market Street',
+    line2: 'Suite 500',
+    city: 'San Francisco',
+    state: 'CA',
+    postalCode: '94107',
+    country: 'United States'
+  },
+  contact: {
+    name: 'Alex Morgan',
+    email: 'alex@company.com',
+    phone: '+1 (555) 123-4567'
+  }
+};
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+function mockApi() {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method;
+
+    if (url === `/orgs/sites/${SITE_ID}` && method === 'PATCH') {
+      // Echo the request body back as the persisted row (it is already nested).
+      return makeJsonResponse(JSON.parse(String(init?.body)));
+    }
+    if (url === `/orgs/sites/${SITE_ID}`) {
+      return makeJsonResponse(SITE_FROM_API);
+    }
+    if (url === `/orgs/organizations/${ORG_ID}`) {
+      return makeJsonResponse({ id: ORG_ID, name: 'Acme Corp' });
+    }
+    // Policy assignments / available policies fired on mount.
+    return makeJsonResponse({ data: [] });
+  });
+}
+
+describe('SiteDetailPage — address/contact round-trip', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    window.location.hash = '';
+  });
+
+  it('populates the form from the nested address/contact the API returns', async () => {
+    mockApi();
+    render(<SiteDetailPage siteId={SITE_ID} />);
+
+    // If populateForm wrongly read flat keys, these would all be empty.
+    expect(await screen.findByPlaceholderText('123 Market Street')).toHaveValue('123 Market Street');
+    expect(screen.getByPlaceholderText('San Francisco')).toHaveValue('San Francisco');
+    expect(screen.getByPlaceholderText('CA')).toHaveValue('CA');
+    expect(screen.getByPlaceholderText('Alex Morgan')).toHaveValue('Alex Morgan');
+    expect(screen.getByPlaceholderText('alex@company.com')).toHaveValue('alex@company.com');
+  });
+
+  it('PATCHes a nested address/contact payload (not flat keys) on save', async () => {
+    mockApi();
+    render(<SiteDetailPage siteId={SITE_ID} />);
+
+    const cityInput = await screen.findByPlaceholderText('San Francisco');
+    fireEvent.change(cityInput, { target: { value: 'Oakland' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        ([url, init]) => String(url) === `/orgs/sites/${SITE_ID}` && init?.method === 'PATCH'
+      );
+      expect(patchCall).toBeTruthy();
+      const body = JSON.parse(String(patchCall![1]?.body));
+
+      // The route's Zod schema accepts nested `address`/`contact` and strips
+      // anything else — so the payload must be nested.
+      expect(body.address).toEqual({
+        line1: '123 Market Street',
+        line2: 'Suite 500',
+        city: 'Oakland',
+        state: 'CA',
+        postalCode: '94107',
+        country: 'United States'
+      });
+      expect(body.contact).toEqual({
+        name: 'Alex Morgan',
+        email: 'alex@company.com',
+        phone: '+1 (555) 123-4567'
+      });
+      // No flat keys that the API would silently drop.
+      expect(body).not.toHaveProperty('addressLine1');
+      expect(body).not.toHaveProperty('city');
+      expect(body).not.toHaveProperty('contactName');
+    });
+  });
+});

--- a/apps/web/src/components/settings/SiteDetailPage.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.tsx
@@ -17,21 +17,34 @@ import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 // --- Types ---
 
+// The API stores `address` and `contact` as nested JSONB objects (see the
+// `sites` table + `siteContactSchema` in apps/api/src/routes/orgs.ts). The
+// form fields below are flat, so populateForm/handleSaveDetails map between
+// the two shapes. Sending flat keys would have them silently stripped by the
+// route's Zod validation — the bug that made saves appear to reset.
+type SiteAddress = {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+};
+
+type SiteContact = {
+  name?: string;
+  email?: string;
+  phone?: string;
+};
+
 type SiteDetails = {
   id: string;
   name: string;
   orgId: string;
   timezone: string;
   status: string;
-  addressLine1?: string;
-  addressLine2?: string;
-  city?: string;
-  state?: string;
-  postalCode?: string;
-  country?: string;
-  contactName?: string;
-  contactEmail?: string;
-  contactPhone?: string;
+  address?: SiteAddress | null;
+  contact?: SiteContact | null;
   deviceCount?: number;
 };
 
@@ -152,15 +165,15 @@ export default function SiteDetailPage({ siteId }: { siteId: string }) {
   const populateForm = useCallback((s: SiteDetails) => {
     setFormName(s.name ?? '');
     setFormTimezone(s.timezone ?? 'UTC');
-    setFormAddressLine1(s.addressLine1 ?? '');
-    setFormAddressLine2(s.addressLine2 ?? '');
-    setFormCity(s.city ?? '');
-    setFormState(s.state ?? '');
-    setFormPostalCode(s.postalCode ?? '');
-    setFormCountry(s.country ?? '');
-    setFormContactName(s.contactName ?? '');
-    setFormContactEmail(s.contactEmail ?? '');
-    setFormContactPhone(s.contactPhone ?? '');
+    setFormAddressLine1(s.address?.line1 ?? '');
+    setFormAddressLine2(s.address?.line2 ?? '');
+    setFormCity(s.address?.city ?? '');
+    setFormState(s.address?.state ?? '');
+    setFormPostalCode(s.address?.postalCode ?? '');
+    setFormCountry(s.address?.country ?? '');
+    setFormContactName(s.contact?.name ?? '');
+    setFormContactEmail(s.contact?.email ?? '');
+    setFormContactPhone(s.contact?.phone ?? '');
   }, []);
 
   const fetchSite = useCallback(async () => {
@@ -251,15 +264,19 @@ export default function SiteDetailPage({ siteId }: { siteId: string }) {
         body: JSON.stringify({
           name: formName,
           timezone: formTimezone,
-          addressLine1: formAddressLine1,
-          addressLine2: formAddressLine2 || undefined,
-          city: formCity,
-          state: formState,
-          postalCode: formPostalCode,
-          country: formCountry,
-          contactName: formContactName,
-          contactEmail: formContactEmail,
-          contactPhone: formContactPhone,
+          address: {
+            line1: formAddressLine1,
+            line2: formAddressLine2 || undefined,
+            city: formCity,
+            state: formState,
+            postalCode: formPostalCode,
+            country: formCountry,
+          },
+          contact: {
+            name: formContactName,
+            email: formContactEmail,
+            phone: formContactPhone,
+          },
         }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Problem

Editing a customer **Site** (Settings → Organizations → site → Details) and clicking **Save** would reset the form — the address/contact info entered just vanished and was never persisted.

## Root cause

The Site Detail page spoke a **flat** address/contact contract (`addressLine1`, `city`, `contactName`, …) while the `sites` API stores and returns those as **nested JSONB** objects (`address: {line1, …}`, `contact: {name, …}`):

- On **save**, the route's Zod validation silently stripped the unknown flat keys — only `name`/`timezone` persisted.
- The handler returned the real (nested) row, which the flat-field form then read as `undefined` → the form "reset" to empty.

This was masked for months: the site-update endpoint was originally an **echo-only stub** that returned the request body verbatim, so the flat round-trip *looked* like it worked. When the endpoint became a real DB write (commit `b40defc7c`), the mismatch surfaced as the visible reset. So this is a latent bug exposed by replacing a mock with a real endpoint — not a regression of previously-working code.

## Fix

- **`SiteDetailPage.tsx`** — map flat form fields ↔ nested `address`/`contact` in both `populateForm` (read) and the PATCH body (write), matching the already-correct OrganizationsPage/`SiteForm` modal. Co-located test round-trips the nested shape and asserts no flat keys are sent (verified to fail against the pre-fix code).

### Defense-in-depth: silent 0-row writes

While here, a sweep found the same silent-failure shape that hid this bug — update/delete handlers returning `200 + null` on a 0-row write (RLS rejection or a race after the access-checked SELECT), which reads to the client as success. Added explicit `if (!x) return 500` guards (matching the existing monitors/snmp/discovery convention) to:

- `PATCH /orgs/sites/:id` (sites)
- `PATCH /discovery/profiles/:id` (discoveryProfiles)
- `POST /discovery/assets/:id/link` (discoveredAssets)
- `DELETE /monitors/:id` (networkMonitors)

These tables have RLS forced, so cross-tenant writes were already prevented — this only changes a silent fake-success into a real error.

## Testing

- New web test passes; confirmed non-vacuous (fails against pre-fix code).
- API typechecks clean; 242 route tests pass across orgs / discovery / monitors suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)