### PR TITLE
fix(api): public Windows short-link installer 500s on null-creator child key

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -492,6 +492,63 @@ describe("GET /s/:code", () => {
     issueSpy.mockRestore();
   });
 
+  it("passes createdByUserId: null (never \"\") for the null-creator child key", async () => {
+    // Regression: the /s/:code route spawns the child download key with
+    // createdBy: null (it has no authenticated user). serveInstaller's Windows
+    // branch previously coerced that to "" via `?? ""`, and the empty string
+    // failed the uuid cast on insert into installer_bootstrap_tokens.created_by
+    // (`invalid input syntax for type uuid: ""`) — every Windows short link 500'd.
+    // Match the real route: the child row carries createdBy: null.
+    const shortLinkRow = makeKeyRow({
+      shortCode: "nullcreator",
+      installerPlatform: "windows",
+    });
+    const childRow = makeChildKeyRow({
+      installerPlatform: "windows",
+      createdBy: null,
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-2",
+        token: "NULLCREAT0",
+        expiresAt: new Date(Date.now() + 3_600_000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request("/s/nullcreator");
+
+    expect(res.status).toBe(200);
+    expect(issueSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ createdByUserId: null }),
+    );
+    // The "" that broke the uuid insert must never be passed.
+    expect(issueSpy.mock.calls[0]?.[0]?.createdByUserId).not.toBe("");
+
+    issueSpy.mockRestore();
+  });
+
   it("returns 404 for unknown code", async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1691,7 +1691,10 @@ async function serveInstaller(
     try {
       issued = await issueBootstrapTokenForKey({
         parentEnrollmentKeyId: keyRow.id,
-        createdByUserId: keyRow.createdBy ?? "",
+        // created_by is a nullable uuid FK; a key created by an unauthenticated
+        // path has no creator. Pass null — `?? ""` made Postgres reject the
+        // insert with `invalid input syntax for type uuid: ""` (500 on /s/:code).
+        createdByUserId: keyRow.createdBy ?? null,
         maxUsage: 1,
         installerPlatform: "windows",
       });

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -9,7 +9,14 @@ import {
 
 export interface IssueBootstrapTokenInput {
   parentEnrollmentKeyId: string;
-  createdByUserId: string;
+  /**
+   * Creator user id, or null when the token is issued by an unauthenticated
+   * path (e.g. the public /s/:code short-link installer download) whose parent
+   * enrollment key may itself have no recorded creator. The created_by column
+   * is a nullable uuid FK — pass null, never an empty string (an empty string
+   * fails the uuid cast: `invalid input syntax for type uuid: ""`).
+   */
+  createdByUserId: string | null;
   maxUsage?: number;
   installerPlatform?: "windows" | "macos";
 }


### PR DESCRIPTION
## Summary

Public Windows installer **short links** (`/s/<code>`) returned `{"error":"Internal Server Error"}` (HTTP 500) on self-hosted v0.85.0. Dashboard **Direct Download** worked.

## Root cause

The `/s/:code` route spawns a single-use child enrollment key with `createdBy: null` (there is no authenticated user on the public path), then hands it to the shared `serveInstaller` helper. `serveInstaller`'s Windows branch did:

```ts
createdByUserId: keyRow.createdBy ?? "",
```

`installer_bootstrap_tokens.created_by` is a **nullable `uuid` FK**. The empty string is not a valid uuid, so Postgres rejected the insert:

```
DrizzleQueryError: invalid input syntax for type uuid: ""
  at issueBootstrapTokenForKey
```

Because the child key's `createdBy` is *always* null on this path, **every** Windows short link 500'd. Direct Download was unaffected because it sources a real user UUID.

## Fix

- `enrollmentKeys.ts` — pass `keyRow.createdBy ?? null` (one char).
- `installerBootstrapTokenIssuance.ts` — widen `IssueBootstrapTokenInput.createdByUserId` to `string | null` so null flows cleanly into the nullable column. The `?? ""` only existed to satisfy the over-narrow `string` type.

No migration. macOS short links were never affected (they don't route `keyRow.createdBy` through this helper).

## Why it escaped tests

The existing `/s/:code` unit test mocked `issueBootstrapTokenForKey`, so the failing DB insert never ran, and its child-row fixture carried a **non-null** `createdBy`, diverging from the real route (`createdBy: null`). Added a regression test that mirrors the real route (`createdBy: null`) and asserts the helper receives `createdByUserId: null`, never `""`. Verified red→green: with the bug reintroduced the test catches `createdByUserId: ""`.

## Test plan

- [x] `vitest run enrollmentKeys.test.ts enrollmentKeys_installer.test.ts` — 67 passed
- [x] Regression test fails with the bug reintroduced, passes with the fix
- [x] `tsc --noEmit` clean

Reported by SemoTech (self-hosted v0.85.0) with an exact root-cause analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)