### PR TITLE
fix(web): render warranty (and other) feature cards on device Effective Config tab

### DIFF
--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.test.tsx
@@ -28,9 +28,44 @@ const mixedResponse = {
   ],
 };
 
+// Device whose real org policy enforces warranty (a feature type beyond the
+// original 8). Regression for the bug where the inheritance chain listed
+// 'warranty' but no warranty card rendered (the hardcoded card list dropped it).
+const warrantyResponse = {
+  deviceId: 'dev-3',
+  features: {
+    warranty: { featureType: 'warranty', featurePolicyId: null, inlineSettings: { enabled: true, warnDays: 90, criticalDays: 30 }, sourceLevel: 'organization', sourceTargetId: 'org-1', sourcePolicyId: 'pol-warr', sourcePolicyName: 'Windows Workstations', sourcePriority: 0 },
+    backup: { featureType: 'backup', featurePolicyId: null, inlineSettings: null, sourceLevel: 'default', sourceTargetId: 'breeze-defaults', sourcePolicyId: 'breeze-defaults', sourcePolicyName: 'Breeze Defaults', sourcePriority: 0 },
+  },
+  inheritanceChain: [
+    { level: 'organization', targetId: 'org-1', policyId: 'pol-warr', policyName: 'Windows Workstations', priority: 0, featureTypes: ['warranty'] },
+    { level: 'default', targetId: 'breeze-defaults', policyId: 'breeze-defaults', policyName: 'Breeze Defaults', priority: 0, featureTypes: ['backup'] },
+  ],
+};
+
+// Device where every resolved feature is enforced by a real policy and NOTHING
+// falls through to the baseline — the "Not enforced" strip must not render, and
+// the header must pluralize the enforced-feature count.
+const allEnforcedResponse = {
+  deviceId: 'dev-4',
+  features: {
+    patch: { featureType: 'patch', featurePolicyId: null, inlineSettings: null, sourceLevel: 'site', sourceTargetId: 'site-1', sourcePolicyId: 'pol-a', sourcePolicyName: 'Site Patch', sourcePriority: 0 },
+    warranty: { featureType: 'warranty', featurePolicyId: null, inlineSettings: { enabled: true }, sourceLevel: 'site', sourceTargetId: 'site-1', sourcePolicyId: 'pol-a', sourcePolicyName: 'Site Patch', sourcePriority: 0 },
+  },
+  inheritanceChain: [
+    { level: 'site', targetId: 'site-1', policyId: 'pol-a', policyName: 'Site Patch', priority: 0, featureTypes: ['patch', 'warranty'] },
+  ],
+};
+
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(async (url: string) => {
-    const body = url.includes('dev-2') ? mixedResponse : baselineOnlyResponse;
+    const body = url.includes('dev-4')
+      ? allEnforcedResponse
+      : url.includes('dev-3')
+        ? warrantyResponse
+        : url.includes('dev-2')
+          ? mixedResponse
+          : baselineOnlyResponse;
     return { ok: true, status: 200, statusText: 'OK', json: async () => body };
   }),
 }));
@@ -65,6 +100,35 @@ describe('DeviceEffectiveConfigTab baseline labeling', () => {
       expect(screen.getByText(/1 assigned/i)).toBeInTheDocument(),
     );
     expect(screen.queryByText(/2 assigned/i)).not.toBeInTheDocument();
+  });
+
+  it('renders an enforced card for a warranty policy and collapses baseline features into the Not-enforced strip', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-3" />);
+    // Warranty is enforced by a real org policy → it must render as a full card
+    // (the original bug dropped it because it was outside the hardcoded card list).
+    // The card renders the label as an <h4> heading; the inheritance chain renders
+    // the same word only as a <span> chip. Targeting the heading role pins the
+    // CARD specifically, so this can't pass on the chain alone (the original bug).
+    await screen.findByRole('heading', { level: 4, name: 'Warranty' });
+    // Inline settings are summarized on the card so the enabled state is visible.
+    expect(screen.getByText(/enabled: yes/i)).toBeInTheDocument();
+    // The header counts only the enforced feature, not the baseline fall-through.
+    expect(screen.getByText(/1 enforced feature/i)).toBeInTheDocument();
+    // Baseline fall-through (backup) is collapsed into the compact strip, not a card.
+    expect(screen.getByText('Not enforced')).toBeInTheDocument();
+    expect(screen.getAllByText('Backup').length).toBeGreaterThan(0);
+  });
+
+  it('omits the Not-enforced strip and pluralizes the count when every feature is enforced', async () => {
+    render(<DeviceEffectiveConfigTab deviceId="dev-4" />);
+    // Both enforced features render as cards...
+    await screen.findByRole('heading', { level: 4, name: 'Patch Management' });
+    expect(screen.getByRole('heading', { level: 4, name: 'Warranty' })).toBeInTheDocument();
+    // ...the header pluralizes (regression guard for the `!== 1 ? 's'` branch)...
+    expect(screen.getByText(/2 enforced features/i)).toBeInTheDocument();
+    // ...and with nothing falling through to default, the strip must NOT render —
+    // otherwise the UI would falsely claim defaults apply when none do.
+    expect(screen.queryByText('Not enforced')).not.toBeInTheDocument();
   });
 
   it('omits the synthetic default node from the inheritance-chain table (no dead link)', async () => {

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
@@ -1,16 +1,23 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   Bell,
+  Boxes,
   ClipboardCheck,
+  Cloud,
+  FileSearch,
   HardDrive,
   Layers,
-  Monitor,
+  LifeBuoy,
   PackageCheck,
   RefreshCw,
+  ScrollText,
   Shield,
+  ShieldCheck,
   Activity,
+  Usb,
   Wrench,
   Zap,
+  type LucideIcon,
 } from 'lucide-react';
 
 import { friendlyFetchError } from '../../lib/utils';
@@ -26,7 +33,14 @@ type FeatureType =
   | 'monitoring'
   | 'maintenance'
   | 'compliance'
-  | 'automation';
+  | 'automation'
+  | 'warranty'
+  | 'helper'
+  | 'event_log'
+  | 'software_policy'
+  | 'sensitive_data'
+  | 'peripheral_control'
+  | 'onedrive_helper';
 
 type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device' | 'default';
 
@@ -58,27 +72,45 @@ type EffectiveConfiguration = {
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const ALL_FEATURE_TYPES: FeatureType[] = [
-  'patch',
-  'alert_rule',
-  'automation',
-  'maintenance',
-  'compliance',
-  'security',
-  'backup',
-  'monitoring',
-];
-
-const FEATURE_META: Record<FeatureType, { label: string; icon: React.ReactNode }> = {
-  patch:        { label: 'Patch Management',    icon: <PackageCheck className="h-5 w-5" /> },
-  alert_rule:   { label: 'Alert Rules',         icon: <Bell className="h-5 w-5" /> },
-  automation:   { label: 'Automation',           icon: <Zap className="h-5 w-5" /> },
-  maintenance:  { label: 'Maintenance Windows', icon: <Wrench className="h-5 w-5" /> },
-  compliance:   { label: 'Compliance',           icon: <ClipboardCheck className="h-5 w-5" /> },
-  security:     { label: 'Security',             icon: <Shield className="h-5 w-5" /> },
-  backup:       { label: 'Backup',               icon: <HardDrive className="h-5 w-5" /> },
-  monitoring:   { label: 'Monitoring',           icon: <Activity className="h-5 w-5" /> },
+// Single source of truth for which config-policy feature types this tab renders.
+// It is exhaustive over FeatureType (tsc fails if a union member lacks an entry),
+// and ALL_FEATURE_TYPES below is derived from its keys, so a type can never be
+// silently dropped from the grid — the original bug, where a resolved `warranty`
+// feature rendered no card because it was absent from a hand-maintained list.
+//
+// remote_access and pam are deliberately absent from FeatureType (and so from
+// this map): they are the two baselines that actively *apply* a value to an
+// unassigned device (`applied: true` in policyBaselineDefaults.ts — remote_access
+// defaults ON, pam is present but uacInterceptionEnabled:false). For them a
+// 'default' source still means something is in effect, so the "Not enforced"
+// labeling below would mislabel them. Every type present here is a "not enforced
+// when unassigned" baseline, so that labeling is safe.
+//
+// NOTE: parity with the canonical CONFIG_FEATURE_TYPES
+// (apps/api/src/services/configFeatureTypes.ts) minus those two is maintained by
+// hand — no test enforces it. A new canonical feature type must be added here too
+// or it won't render on this tab.
+const FEATURE_META: Record<FeatureType, { label: string; Icon: LucideIcon }> = {
+  patch:              { label: 'Patch Management',    Icon: PackageCheck },
+  alert_rule:         { label: 'Alert Rules',         Icon: Bell },
+  automation:         { label: 'Automation',          Icon: Zap },
+  maintenance:        { label: 'Maintenance Windows', Icon: Wrench },
+  compliance:         { label: 'Compliance',          Icon: ClipboardCheck },
+  security:           { label: 'Security',            Icon: Shield },
+  backup:             { label: 'Backup',              Icon: HardDrive },
+  monitoring:         { label: 'Monitoring',          Icon: Activity },
+  warranty:           { label: 'Warranty',            Icon: ShieldCheck },
+  software_policy:    { label: 'Software Policy',     Icon: Boxes },
+  sensitive_data:     { label: 'Data Discovery',      Icon: FileSearch },
+  peripheral_control: { label: 'Peripheral Control',  Icon: Usb },
+  event_log:          { label: 'Event Logs',          Icon: ScrollText },
+  helper:             { label: 'Breeze Assist',       Icon: LifeBuoy },
+  onedrive_helper:    { label: 'OneDrive Helper',     Icon: Cloud },
 };
+
+// Display order = FEATURE_META insertion order. Derived (not hand-listed) so the
+// grid stays in lockstep with FEATURE_META and can't silently omit a type.
+const ALL_FEATURE_TYPES = Object.keys(FEATURE_META) as FeatureType[];
 
 const LEVEL_LABELS: Record<AssignmentLevel, string> = {
   partner: 'Partner',
@@ -208,11 +240,16 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
   const { features, inheritanceChain } = data;
   // The synthetic "Breeze Defaults" layer (level 'default') is excluded from the
   // assigned-policy count AND the inheritance-chain table below — it is not a real
-  // assigned policy, has no policy page to link to, and lists feature types this
-  // tab does not render. Baseline coverage is surfaced per-card ("Not enforced —
-  // Breeze Defaults") and on the dedicated /configuration-policies/defaults page.
+  // assigned policy and has no policy page to link to. Its feature types instead
+  // collapse into the "Not enforced — using Breeze Defaults" strip, and the
+  // dedicated /configuration-policies/defaults page covers them in full.
   const assignedChain = inheritanceChain.filter((e) => e.level !== 'default');
   const configuredTypes = ALL_FEATURE_TYPES.filter((ft) => features[ft]);
+  // Split enforced (a real assigned policy wins) from baseline fall-through.
+  // Every type in ALL_FEATURE_TYPES is "not enforced when unassigned", so a
+  // 'default' source unambiguously means baseline here (see the constant's note).
+  const enforcedTypes = configuredTypes.filter((ft) => features[ft]!.sourceLevel !== 'default');
+  const baselineTypes = configuredTypes.filter((ft) => features[ft]!.sourceLevel === 'default');
 
   return (
     <div className="space-y-6">
@@ -222,8 +259,8 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
           <h3 className="text-lg font-semibold">Effective Configuration</h3>
           <p className="text-sm text-muted-foreground">
             Resolved configuration from {assignedChain.length} assigned{' '}
-            {assignedChain.length === 1 ? 'policy' : 'policies'} across{' '}
-            {configuredTypes.length} feature{configuredTypes.length !== 1 ? 's' : ''}
+            {assignedChain.length === 1 ? 'policy' : 'policies'} ·{' '}
+            {enforcedTypes.length} enforced feature{enforcedTypes.length !== 1 ? 's' : ''}
           </p>
         </div>
         <button
@@ -236,70 +273,80 @@ export default function DeviceEffectiveConfigTab({ deviceId }: DeviceEffectiveCo
         </button>
       </div>
 
-      {/* Configured feature cards */}
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {configuredTypes.map((ft) => {
-          const feature = features[ft]!;
-          const meta = FEATURE_META[ft];
-          const settings = summarizeSettings(
-            feature.inlineSettings as Record<string, unknown> | null
-          );
-          // Safe ONLY while ALL_FEATURE_TYPES excludes remote_access/pam (the two
-          // applied baselines). For every type this tab tracks, a baseline source
-          // ('default') means "not enforced", so we label it as such instead of
-          // letting it read as actively "configured". If remote_access/pam are
-          // ever added to this tab, gate this on the feature being non-applied
-          // rather than on sourceLevel alone, or an applied default (e.g. Remote
-          // Desktop ON) would be mislabeled "Not enforced".
-          const isBaseline = feature.sourceLevel === 'default';
+      {/* Enforced feature cards — only features a real assigned policy wins. */}
+      {enforcedTypes.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {enforcedTypes.map((ft) => {
+            const feature = features[ft]!;
+            const { label, Icon } = FEATURE_META[ft];
+            const settings = summarizeSettings(feature.inlineSettings);
 
-          return (
-            <div key={ft} className="rounded-lg border bg-card p-5 shadow-sm">
-              <div className="flex items-start gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  {meta.icon}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <h4 className="font-semibold">{meta.label}</h4>
-                    {isBaseline && (
-                      <span className="inline-flex items-center rounded-full border bg-muted/50 px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
-                        Not enforced
-                      </span>
-                    )}
+            return (
+              <div key={ft} className="rounded-lg border bg-card p-5 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Icon className="h-5 w-5" />
                   </div>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    From: <span className="font-medium text-foreground">{feature.sourcePolicyName}</span>
-                    {' '}
-                    <span className="inline-flex items-center rounded-full border bg-muted/50 px-1.5 py-0.5 text-xs text-muted-foreground">
-                      {LEVEL_LABELS[feature.sourceLevel]}
-                    </span>
+                  <div className="min-w-0 flex-1">
+                    <h4 className="font-semibold">{label}</h4>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      From: <span className="font-medium text-foreground">{feature.sourcePolicyName}</span>
+                      {' '}
+                      <span className="inline-flex items-center rounded-full border bg-muted/50 px-1.5 py-0.5 text-xs text-muted-foreground">
+                        {LEVEL_LABELS[feature.sourceLevel]}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+
+                {/* Settings summary */}
+                {settings.length > 0 && (
+                  <div className="mt-3 rounded-md border bg-muted/30 px-3 py-2">
+                    <ul className="space-y-0.5 text-xs text-muted-foreground">
+                      {settings.map((s) => (
+                        <li key={s} className="capitalize">{s}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Feature policy reference */}
+                {feature.featurePolicyId && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Linked policy:{' '}
+                    <span className="font-mono text-xs">{feature.featurePolicyId.slice(0, 8)}...</span>
                   </p>
-                </div>
+                )}
               </div>
+            );
+          })}
+        </div>
+      )}
 
-              {/* Settings summary */}
-              {settings.length > 0 && (
-                <div className="mt-3 rounded-md border bg-muted/30 px-3 py-2">
-                  <ul className="space-y-0.5 text-xs text-muted-foreground">
-                    {settings.map((s) => (
-                      <li key={s} className="capitalize">{s}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {/* Feature policy reference */}
-              {feature.featurePolicyId && (
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Linked policy:{' '}
-                  <span className="font-mono text-xs">{feature.featurePolicyId.slice(0, 8)}...</span>
-                </p>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {/* Not-enforced baseline features — collapsed into one compact strip so the
+          page highlights what's actually applied instead of a wall of grey cards. */}
+      {baselineTypes.length > 0 && (
+        <div className="rounded-lg border bg-card p-5 shadow-sm">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-semibold text-muted-foreground">Not enforced</h4>
+            <span className="text-xs text-muted-foreground">— using Breeze Defaults</span>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {baselineTypes.map((ft) => {
+              const { label, Icon } = FEATURE_META[ft];
+              return (
+                <span
+                  key={ft}
+                  className="inline-flex items-center gap-1.5 rounded-full border bg-muted/30 px-2.5 py-1 text-xs text-muted-foreground"
+                >
+                  <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />
+                  {label}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Inheritance chain — real assigned policies only (the synthetic
           "Breeze Defaults" node is excluded; see assignedChain above). */}


### PR DESCRIPTION
## Problem

The device **Effective Configuration** tab rendered a hardcoded list of 8 config-policy feature types and silently dropped any others the API resolved. A device with a `warranty` policy showed warranty in the inheritance chain but had **no warranty card** — so the enabled state (the source of unexpected warranty alerts) was invisible on the device page.

## Fix

- **Render the missing types.** Added `warranty` + the other "not enforced when unassigned" baseline types (`software_policy`, `sensitive_data`, `peripheral_control`, `event_log`, `helper`, `onedrive_helper`). `remote_access`/`pam` stay excluded — they are *applied* baselines (`applied: true` in `policyBaselineDefaults.ts`), so a `'default'` source for them is in effect and would be mislabeled "Not enforced".
- **Kill the drift class.** `ALL_FEATURE_TYPES` now derives from `FEATURE_META` keys, and `FEATURE_META` is `Record<FeatureType, …>` (compiler-exhaustive). The grid can no longer silently omit a type that has display metadata — which is the exact mechanism of the original bug.
- **De-clutter the layout.** Full cards render only for **enforced** features (a real policy wins); baseline fall-through collapses into one compact **"Not enforced — using Breeze Defaults"** chip strip instead of a wall of grey cards. Header counts enforced features only.
- **Icon refactor.** `FEATURE_META` stores the `LucideIcon` component (not a pre-rendered node) so cards (20px) and chips (14px) size independently.

## Tests

- Regression for the dropped warranty card — pinned via the card's `<h4>` heading role so it can't pass on the inheritance-chain text alone.
- New all-enforced/no-baseline case covering the strip-absent guard and the plural count branch.
- 6/6 pass; `tsc --noEmit` on the web app clean.

## Review

Ran the multi-agent PR review (code, tests, types, comments, simplify) on the change before pushing and applied all findings: fixed a factual comment error (`pam` is `applied` but defaults OFF, not ON), derived the type list to prevent drift, hardened the regression test, and dropped a redundant cast.

## Follow-ups (not in this PR)

1. `featureTabs/types.ts` is already **missing `onedrive_helper`** (16 vs canonical 17) — same drift class, separate fix.
2. Permanent fix: derive the web `FeatureType` from a shared registry or add a parity test against `CONFIG_FEATURE_TYPES` so a new canonical feature can't silently fail to render. Needs a web↔api/shared-package decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)