### PR TITLE
fix(reliability): finish #1967 de-junk — macOS/Linux classifier + server-side hardware gate + weak app-crash signal

### DIFF
--- a/agent/internal/collectors/eventlogs_darwin.go
+++ b/agent/internal/collectors/eventlogs_darwin.go
@@ -3,6 +3,7 @@
 package collectors
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -209,14 +210,13 @@ func (c *EventLogCollector) collectCrashReports(since time.Time) ([]EventLogEntr
 				continue
 			}
 
-			// Label real kernel panics distinctly so the reliability classifier
-			// counts them as system crashes, while per-app crash reports and
-			// JetsamEvent (memory-pressure) reports stay "Application crash: …"
-			// and are deliberately NOT counted toward the crash factor.
-			kind := "Application crash"
-			if strings.Contains(strings.ToLower(name), "panic") || strings.EqualFold(crashData.processName, "kernel") {
-				kind = "Kernel panic"
-			}
+			// Classify from the authoritative .ips bug_type (filename/procName are
+			// fallbacks). Real kernel panics are labelled "Kernel panic" so the
+			// reliability classifier counts them as a full device crash; per-app
+			// reports become "Application crash" (the classifier counts those as a
+			// weak, downweighted app_crash); JetsamEvent memory-pressure reports
+			// are labelled distinctly and dropped by the classifier.
+			kind := crashReportKind(name, crashData.bugType, crashData.processName)
 
 			results = append(results, EventLogEntry{
 				Timestamp: info.ModTime().UTC().Format(time.RFC3339),
@@ -242,6 +242,7 @@ type crashInfo struct {
 	processName   string
 	exceptionType string
 	version       string
+	bugType       string // .ips "bug_type": 210 = kernel panic, 298 = JetsamEvent
 }
 
 func parseCrashReport(path string) (*crashInfo, error) {
@@ -260,7 +261,21 @@ func parseCrashReport(path string) (*crashInfo, error) {
 
 	info := &crashInfo{processName: "Unknown"}
 
-	// Try JSON (.ips format)
+	// A modern .ips report is a one-line JSON header (carrying "bug_type")
+	// followed by a separate JSON body (procName / exception). A whole-file
+	// Unmarshal fails on the two values, so peel off the header line first; the
+	// remainder is the body parsed below.
+	if nl := bytes.IndexByte(data, '\n'); nl > 0 {
+		var header struct {
+			BugType string `json:"bug_type"`
+		}
+		if json.Unmarshal(data[:nl], &header) == nil && header.BugType != "" {
+			info.bugType = truncateCollectorString(header.BugType)
+			data = data[nl+1:]
+		}
+	}
+
+	// Try JSON (.ips body, or older single-object format)
 	var ipsData map[string]any
 	if err := json.Unmarshal(data, &ipsData); err == nil {
 		if name, ok := ipsData["procName"].(string); ok {

--- a/agent/internal/collectors/eventlogs_darwin.go
+++ b/agent/internal/collectors/eventlogs_darwin.go
@@ -209,13 +209,22 @@ func (c *EventLogCollector) collectCrashReports(since time.Time) ([]EventLogEntr
 				continue
 			}
 
+			// Label real kernel panics distinctly so the reliability classifier
+			// counts them as system crashes, while per-app crash reports and
+			// JetsamEvent (memory-pressure) reports stay "Application crash: …"
+			// and are deliberately NOT counted toward the crash factor.
+			kind := "Application crash"
+			if strings.Contains(strings.ToLower(name), "panic") || strings.EqualFold(crashData.processName, "kernel") {
+				kind = "Kernel panic"
+			}
+
 			results = append(results, EventLogEntry{
 				Timestamp: info.ModTime().UTC().Format(time.RFC3339),
 				Level:     "error",
 				Category:  "application",
 				Source:    crashData.processName,
 				EventID:   fmt.Sprintf("crash:%s", name),
-				Message:   fmt.Sprintf("Application crash: %s (%s)", crashData.processName, crashData.exceptionType),
+				Message:   fmt.Sprintf("%s: %s (%s)", kind, crashData.processName, crashData.exceptionType),
 				Details: map[string]any{
 					"file":          name,
 					"processName":   crashData.processName,

--- a/agent/internal/collectors/reliability.go
+++ b/agent/internal/collectors/reliability.go
@@ -120,6 +120,11 @@ func classifyHardwareType(message, source string, numericID int) string {
 	switch {
 	case strings.Contains(src, "whea"), strings.Contains(msg, "machine check"), strings.Contains(msg, "mce"):
 		return "mce"
+	case strings.Contains(msg, "thermal"):
+		// macOS thermal-pressure / SMC thermal faults. Stamped as a real type so
+		// the API's genuine-hardware gate recognises it by type, not by hoping the
+		// substring "thermal" appears in the source.
+		return "thermal"
 	case strings.Contains(msg, "memory"), strings.Contains(msg, "edac"),
 		numericID == 13 || numericID == 50 || numericID == 51:
 		return "memory"

--- a/agent/internal/collectors/reliability_darwin.go
+++ b/agent/internal/collectors/reliability_darwin.go
@@ -2,11 +2,9 @@
 
 package collectors
 
-import (
-	"strings"
-)
-
 // Collect gathers reliability metrics from uptime + macOS crash/log telemetry.
+// Classification lives in classifyDarwinEventLogEntry (reliability_unix.go) so it
+// is unit-testable on Linux CI.
 func (c *ReliabilityCollector) Collect() (*ReliabilityMetrics, error) {
 	metrics, err := c.collectBase()
 	if err != nil {
@@ -19,43 +17,7 @@ func (c *ReliabilityCollector) Collect() (*ReliabilityMetrics, error) {
 	}
 
 	for _, entry := range events {
-		ts := normalizeEventTimestamp(entry.Timestamp)
-		msg := strings.ToLower(entry.Message)
-		src := strings.ToLower(entry.Source)
-		level := strings.ToLower(entry.Level)
-
-		classified := true
-		switch {
-		case strings.Contains(msg, "kernel panic"), strings.Contains(msg, "panic("):
-			appendCrash(metrics, "kernel_panic", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-
-		case strings.Contains(msg, "application crash"), strings.Contains(msg, "crashed"):
-			appendCrash(metrics, "system_crash", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-
-		case strings.Contains(msg, "hang"), strings.Contains(msg, "not responding"):
-			appendHang(metrics, entry.Source, ts)
-
-		case strings.Contains(src, "launchd") && (strings.Contains(msg, "exited") || strings.Contains(msg, "failed")):
-			appendServiceFailure(metrics, entry.Source, ts, entry.EventID)
-
-		case level == "critical" && entry.Category == "system" && strings.Contains(msg, "shutdown"):
-			appendCrash(metrics, "system_crash", ts, map[string]any{
-				"source": entry.Source,
-			})
-
-		default:
-			classified = false
-		}
-
-		if !classified && (entry.Category == "hardware" || strings.Contains(msg, "i/o error") || strings.Contains(msg, "memory")) {
-			appendHardwareError(metrics, entry, ts)
-		}
+		classifyDarwinEventLogEntry(metrics, entry)
 	}
 
 	return metrics, nil

--- a/agent/internal/collectors/reliability_linux.go
+++ b/agent/internal/collectors/reliability_linux.go
@@ -2,11 +2,9 @@
 
 package collectors
 
-import (
-	"strings"
-)
-
 // Collect gathers reliability metrics from uptime + Linux journal/syslog signals.
+// Classification lives in classifyLinuxEventLogEntry (reliability_unix.go) so it
+// is unit-testable on CI.
 func (c *ReliabilityCollector) Collect() (*ReliabilityMetrics, error) {
 	metrics, err := c.collectBase()
 	if err != nil {
@@ -19,38 +17,7 @@ func (c *ReliabilityCollector) Collect() (*ReliabilityMetrics, error) {
 	}
 
 	for _, entry := range events {
-		ts := normalizeEventTimestamp(entry.Timestamp)
-		msg := strings.ToLower(entry.Message)
-		src := strings.ToLower(entry.Source)
-
-		classified := true
-		switch {
-		case strings.Contains(msg, "kernel panic"), strings.Contains(msg, "oops"), strings.Contains(msg, "segfault"):
-			appendCrash(metrics, "kernel_panic", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-
-		case strings.Contains(msg, "oom"), strings.Contains(msg, "out of memory"):
-			appendCrash(metrics, "oom_kill", ts, map[string]any{
-				"source":  entry.Source,
-				"eventId": entry.EventID,
-			})
-
-		case strings.Contains(msg, "service") && (strings.Contains(msg, "failed") || strings.Contains(msg, "failure")),
-			strings.Contains(src, "systemd") && strings.Contains(msg, "failed"):
-			appendServiceFailure(metrics, entry.Source, ts, entry.EventID)
-
-		case strings.Contains(msg, "hang"), strings.Contains(msg, "not responding"), strings.Contains(msg, "blocked for more than"):
-			appendHang(metrics, entry.Source, ts)
-
-		default:
-			classified = false
-		}
-
-		if !classified && (entry.Category == "hardware" || strings.Contains(msg, "i/o error") || strings.Contains(msg, "edac") || strings.Contains(msg, "mce")) {
-			appendHardwareError(metrics, entry, ts)
-		}
+		classifyLinuxEventLogEntry(metrics, entry)
 	}
 
 	return metrics, nil

--- a/agent/internal/collectors/reliability_test.go
+++ b/agent/internal/collectors/reliability_test.go
@@ -545,3 +545,149 @@ func TestClassifyEventLogEntry(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyDarwinEventLogEntry covers the macOS junk that drowned scores
+// (#1907 follow-up): IOKit plugin chatter wrongly counted as hardware, and
+// per-app / JetsamEvent DiagnosticReports wrongly counted as system crashes.
+func TestClassifyDarwinEventLogEntry(t *testing.T) {
+	ts := "2026-01-15T10:00:00Z"
+
+	tests := []struct {
+		name          string
+		entry         EventLogEntry
+		wantCrashes   int
+		wantServices  int
+		wantHangs     int
+		wantHardware  int
+		wantCrashType string
+	}{
+		{
+			name:  "com.apple.iokit.cfplugin error is NOT hardware",
+			entry: EventLogEntry{Timestamp: ts, Level: "error", Category: "hardware", Source: "com.apple.iokit.cfplugin", EventID: "com.apple.iokit.cfplugin:89", Message: "plugin failed to load"},
+		},
+		{
+			name:  "App Store foundation error is NOT hardware",
+			entry: EventLogEntry{Timestamp: ts, Level: "error", Category: "hardware", Source: "com.apple.appstorefoundation", EventID: "com.apple.appstorefoundation:15257", Message: "request failed"},
+		},
+		{
+			name:          "Per-app crash counts as weak app_crash",
+			entry:         EventLogEntry{Timestamp: ts, Level: "error", Category: "application", Source: "wdavdaemon", EventID: "crash:wdavdaemon-2026.ips", Message: "Application crash: wdavdaemon (EXC_CRASH)"},
+			wantCrashes:   1,
+			wantCrashType: "app_crash",
+		},
+		{
+			name:  "JetsamEvent memory-pressure report is dropped entirely",
+			entry: EventLogEntry{Timestamp: ts, Level: "error", Category: "application", Source: "Unknown", EventID: "crash:JetsamEvent-2026.ips", Message: "Application crash: Unknown ()"},
+		},
+		{
+			name:          "Kernel panic IS a full device crash",
+			entry:         EventLogEntry{Timestamp: ts, Level: "critical", Category: "hardware", Source: "kernel", EventID: "kernel:0", Message: "Kernel panic: kernel ()"},
+			wantCrashes:   1,
+			wantCrashType: "kernel_panic",
+		},
+		{
+			name:         "Real disk I/O error IS hardware",
+			entry:        EventLogEntry{Timestamp: ts, Level: "error", Category: "hardware", Source: "com.apple.iokit.IOStorageFamily", EventID: "x:1", Message: "disk0s2: I/O error"},
+			wantHardware: 1,
+		},
+		{
+			name:         "Thermal event IS hardware",
+			entry:        EventLogEntry{Timestamp: ts, Level: "critical", Category: "hardware", Source: "com.apple.iokit.thermal", EventID: "x:2", Message: "thermal pressure level critical"},
+			wantHardware: 1,
+		},
+		{
+			name:         "launchd service failure IS a service failure",
+			entry:        EventLogEntry{Timestamp: ts, Level: "error", Category: "application", Source: "com.apple.launchd", EventID: "x:3", Message: "service com.foo exited with code 1"},
+			wantServices: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newMetrics()
+			classifyDarwinEventLogEntry(m, tc.entry)
+			if len(m.CrashEvents) != tc.wantCrashes {
+				t.Errorf("crashes: got %d, want %d", len(m.CrashEvents), tc.wantCrashes)
+			}
+			if len(m.ServiceFailures) != tc.wantServices {
+				t.Errorf("services: got %d, want %d", len(m.ServiceFailures), tc.wantServices)
+			}
+			if len(m.AppHangs) != tc.wantHangs {
+				t.Errorf("hangs: got %d, want %d", len(m.AppHangs), tc.wantHangs)
+			}
+			if len(m.HardwareErrors) != tc.wantHardware {
+				t.Errorf("hardware: got %d, want %d", len(m.HardwareErrors), tc.wantHardware)
+			}
+			if tc.wantCrashType != "" {
+				if len(m.CrashEvents) == 0 || m.CrashEvents[0].Type != tc.wantCrashType {
+					t.Errorf("crash type: got %v, want %q", m.CrashEvents, tc.wantCrashType)
+				}
+			}
+			if total := totalFactors(m); total > 1 {
+				t.Errorf("double-counted: total=%d", total)
+			}
+		})
+	}
+}
+
+// TestClassifyLinuxEventLogEntry covers the Linux hardware catch-all: routine
+// kernel chatter hard-tagged Category="hardware" must not count as a fault.
+func TestClassifyLinuxEventLogEntry(t *testing.T) {
+	ts := "2026-01-15T10:00:00Z"
+
+	tests := []struct {
+		name         string
+		entry        EventLogEntry
+		wantCrashes  int
+		wantServices int
+		wantHangs    int
+		wantHardware int
+	}{
+		{
+			name:  "Routine kernel USB notice is NOT hardware",
+			entry: EventLogEntry{Timestamp: ts, Level: "warning", Category: "hardware", Source: "kernel", EventID: "kernel:0", Message: "usb 1-1: USB disconnect, device number 5"},
+		},
+		{
+			name:         "Disk I/O error IS hardware",
+			entry:        EventLogEntry{Timestamp: ts, Level: "error", Category: "hardware", Source: "kernel", EventID: "kernel:0", Message: "blk_update_request: I/O error, dev sda"},
+			wantHardware: 1,
+		},
+		{
+			name:         "EDAC memory error IS hardware",
+			entry:        EventLogEntry{Timestamp: ts, Level: "error", Category: "hardware", Source: "kernel", EventID: "kernel:0", Message: "EDAC MC0: 1 CE memory read error"},
+			wantHardware: 1,
+		},
+		{
+			name:        "OOM kill IS a crash",
+			entry:       EventLogEntry{Timestamp: ts, Level: "critical", Category: "hardware", Source: "kernel", EventID: "kernel:0", Message: "Out of memory: Killed process 1234"},
+			wantCrashes: 1,
+		},
+		{
+			name:         "systemd unit failure IS a service failure",
+			entry:        EventLogEntry{Timestamp: ts, Level: "error", Category: "application", Source: "systemd", EventID: "systemd:1", Message: "nginx.service: Failed with result 'exit-code'"},
+			wantServices: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newMetrics()
+			classifyLinuxEventLogEntry(m, tc.entry)
+			if len(m.CrashEvents) != tc.wantCrashes {
+				t.Errorf("crashes: got %d, want %d", len(m.CrashEvents), tc.wantCrashes)
+			}
+			if len(m.ServiceFailures) != tc.wantServices {
+				t.Errorf("services: got %d, want %d", len(m.ServiceFailures), tc.wantServices)
+			}
+			if len(m.AppHangs) != tc.wantHangs {
+				t.Errorf("hangs: got %d, want %d", len(m.AppHangs), tc.wantHangs)
+			}
+			if len(m.HardwareErrors) != tc.wantHardware {
+				t.Errorf("hardware: got %d, want %d", len(m.HardwareErrors), tc.wantHardware)
+			}
+			if total := totalFactors(m); total > 1 {
+				t.Errorf("double-counted: total=%d", total)
+			}
+		})
+	}
+}

--- a/agent/internal/collectors/reliability_test.go
+++ b/agent/internal/collectors/reliability_test.go
@@ -691,3 +691,27 @@ func TestClassifyLinuxEventLogEntry(t *testing.T) {
 		})
 	}
 }
+
+func TestCrashReportKind(t *testing.T) {
+	cases := []struct {
+		name     string
+		bugType  string
+		procName string
+		want     string
+	}{
+		// bug_type is authoritative even when the filename/procName say otherwise.
+		{"Kernel-2026-06-27.ips", "210", "Unknown", "Kernel panic"},
+		{"JetsamEvent-2026-06-27.ips", "298", "Unknown", "JetsamEvent"},
+		{"wdavdaemon-2026-06-27.ips", "309", "wdavdaemon", "Application crash"},
+		// Fallbacks when bug_type is absent (legacy reports).
+		{"panic-full-2026.ips", "", "Unknown", "Kernel panic"},
+		{"weird.ips", "", "kernel", "Kernel panic"},
+		{"JetsamEvent-legacy.ips", "", "Unknown", "JetsamEvent"},
+		{"Chrome-2026-06-27.ips", "", "Chrome", "Application crash"},
+	}
+	for _, tc := range cases {
+		if got := crashReportKind(tc.name, tc.bugType, tc.procName); got != tc.want {
+			t.Errorf("crashReportKind(%q,%q,%q) = %q, want %q", tc.name, tc.bugType, tc.procName, got, tc.want)
+		}
+	}
+}

--- a/agent/internal/collectors/reliability_unix.go
+++ b/agent/internal/collectors/reliability_unix.go
@@ -2,6 +2,29 @@ package collectors
 
 import "strings"
 
+// crashReportKind classifies a macOS DiagnosticReport for the reliability
+// pipeline. bug_type is authoritative when present (210 = kernel panic,
+// 298 = JetsamEvent); filename / process name are fallbacks for legacy reports
+// whose header is missing or unparsable. Platform-neutral so it is CI-testable.
+// Returns the message prefix used downstream: "Kernel panic" (→ full device
+// crash), "JetsamEvent" (→ dropped), or "Application crash" (→ weak app_crash).
+func crashReportKind(name, bugType, procName string) string {
+	switch strings.TrimSpace(bugType) {
+	case "210":
+		return "Kernel panic"
+	case "298":
+		return "JetsamEvent"
+	}
+	lname := strings.ToLower(name)
+	if strings.Contains(lname, "jetsam") {
+		return "JetsamEvent"
+	}
+	if strings.Contains(lname, "panic") || strings.EqualFold(procName, "kernel") {
+		return "Kernel panic"
+	}
+	return "Application crash"
+}
+
 // classifyDarwinEventLogEntry routes a single macOS event-log entry into exactly
 // one reliability factor (crash / hang / service-failure / hardware-error) or
 // none. It is platform-neutral (no build tag) so it can be unit-tested on Linux
@@ -60,9 +83,11 @@ func classifyDarwinEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntr
 	}
 
 	// Hardware: genuine hardware faults only. classifyHardwareType matches
-	// MCE / memory / disk-I/O signals; thermal is macOS-specific. Benign IOKit
-	// plugin/appstore errors return "unknown" and are dropped.
-	if classifyHardwareType(entry.Message, entry.Source, nid) != "unknown" || strings.Contains(msg, "thermal") {
+	// MCE / memory / disk-I/O / thermal signals and stamps a real Type; benign
+	// IOKit plugin/appstore errors return "unknown" and are dropped. Gating on
+	// the classified type (never entry.Category) keeps the agent and the API's
+	// genuine-hardware gate in agreement.
+	if classifyHardwareType(entry.Message, entry.Source, nid) != "unknown" {
 		appendHardwareError(metrics, entry, ts)
 	}
 }

--- a/agent/internal/collectors/reliability_unix.go
+++ b/agent/internal/collectors/reliability_unix.go
@@ -1,0 +1,113 @@
+package collectors
+
+import "strings"
+
+// classifyDarwinEventLogEntry routes a single macOS event-log entry into exactly
+// one reliability factor (crash / hang / service-failure / hardware-error) or
+// none. It is platform-neutral (no build tag) so it can be unit-tested on Linux
+// CI; reliability_darwin.go calls it from the darwin-only Collect loop.
+//
+// Junk that previously drowned macOS scores is handled here:
+//   - JetsamEvent (memory-pressure) reports are not crashes by any measure and
+//     are dropped entirely.
+//   - Per-app crash reports count, but as a weak "app_crash" type — the API
+//     downweights them relative to a kernel panic / BSOD, since an app crashing
+//     is app instability, not whole-device failure.
+//   - Generic com.apple.iokit.* error/fault chatter (cfplugin, appstore, …) is
+//     hard-tagged Category="hardware" by collectHardwareErrors; counting it
+//     drowned scores in benign noise. Hardware now gates on a genuine fault
+//     signal (thermal / disk-I/O / memory / MCE), never on entry.Category.
+func classifyDarwinEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
+	ts := normalizeEventTimestamp(entry.Timestamp)
+	msg := strings.ToLower(entry.Message)
+	src := strings.ToLower(entry.Source)
+	level := strings.ToLower(entry.Level)
+	nid := numericEventID(entry)
+
+	// JetsamEvent reports are memory-pressure notices, not crashes — never count.
+	if strings.Contains(strings.ToLower(entry.EventID), "jetsam") || strings.Contains(src, "jetsam") {
+		return
+	}
+
+	switch {
+	case strings.Contains(msg, "kernel panic"), strings.Contains(msg, "panic("):
+		appendCrash(metrics, "kernel_panic", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+		})
+		return
+
+	case strings.Contains(msg, "application crash"), strings.Contains(msg, "crashed"):
+		appendCrash(metrics, "app_crash", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+		})
+		return
+
+	case strings.Contains(msg, "hang"), strings.Contains(msg, "not responding"):
+		appendHang(metrics, entry.Source, ts)
+		return
+
+	case strings.Contains(src, "launchd") && (strings.Contains(msg, "exited") || strings.Contains(msg, "failed")):
+		appendServiceFailure(metrics, entry.Source, ts, entry.EventID)
+		return
+
+	case level == "critical" && entry.Category == "system" && strings.Contains(msg, "shutdown"):
+		appendCrash(metrics, "system_crash", ts, map[string]any{
+			"source": entry.Source,
+		})
+		return
+	}
+
+	// Hardware: genuine hardware faults only. classifyHardwareType matches
+	// MCE / memory / disk-I/O signals; thermal is macOS-specific. Benign IOKit
+	// plugin/appstore errors return "unknown" and are dropped.
+	if classifyHardwareType(entry.Message, entry.Source, nid) != "unknown" || strings.Contains(msg, "thermal") {
+		appendHardwareError(metrics, entry, ts)
+	}
+}
+
+// classifyLinuxEventLogEntry routes a single Linux journal entry into exactly one
+// reliability factor or none. Platform-neutral for CI testing; reliability_linux.go
+// calls it from the linux-only Collect loop.
+//
+// collectKernelErrors hard-tags EVERY kernel-priority message Category="hardware",
+// so the prior catch-all counted routine kernel chatter (USB resets, ACPI notices,
+// rate-limit warnings) as hardware errors. Hardware now gates on a genuine fault
+// signal (I/O error / MCE / EDAC-memory) via classifyHardwareType.
+func classifyLinuxEventLogEntry(metrics *ReliabilityMetrics, entry EventLogEntry) {
+	ts := normalizeEventTimestamp(entry.Timestamp)
+	msg := strings.ToLower(entry.Message)
+	src := strings.ToLower(entry.Source)
+	nid := numericEventID(entry)
+
+	switch {
+	case strings.Contains(msg, "kernel panic"), strings.Contains(msg, "oops"), strings.Contains(msg, "segfault"):
+		appendCrash(metrics, "kernel_panic", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+		})
+		return
+
+	case strings.Contains(msg, "oom"), strings.Contains(msg, "out of memory"):
+		appendCrash(metrics, "oom_kill", ts, map[string]any{
+			"source":  entry.Source,
+			"eventId": entry.EventID,
+		})
+		return
+
+	case strings.Contains(msg, "service") && (strings.Contains(msg, "failed") || strings.Contains(msg, "failure")),
+		strings.Contains(src, "systemd") && strings.Contains(msg, "failed"):
+		appendServiceFailure(metrics, entry.Source, ts, entry.EventID)
+		return
+
+	case strings.Contains(msg, "hang"), strings.Contains(msg, "not responding"), strings.Contains(msg, "blocked for more than"):
+		appendHang(metrics, entry.Source, ts)
+		return
+	}
+
+	// Hardware: genuine faults only (I/O / MCE / EDAC-memory), never entry.Category.
+	if classifyHardwareType(entry.Message, entry.Source, nid) != "unknown" {
+		appendHardwareError(metrics, entry, ts)
+	}
+}

--- a/apps/api/src/db/schema/reliability.ts
+++ b/apps/api/src/db/schema/reliability.ts
@@ -25,7 +25,7 @@ export type ReliabilityServiceFailure = {
 };
 
 export type ReliabilityHardwareError = {
-  type: 'mce' | 'disk' | 'memory' | 'unknown';
+  type: 'mce' | 'disk' | 'memory' | 'thermal' | 'unknown';
   severity: 'critical' | 'error' | 'warning';
   timestamp: string;
   source: string;

--- a/apps/api/src/db/schema/reliability.ts
+++ b/apps/api/src/db/schema/reliability.ts
@@ -3,7 +3,9 @@ import { devices } from './devices';
 import { organizations } from './orgs';
 
 export type ReliabilityCrashEvent = {
-  type: 'bsod' | 'kernel_panic' | 'system_crash' | 'oom_kill' | 'unknown';
+  // app_crash = a per-app crash report (macOS), counted toward the crash factor
+  // at reduced weight vs. a whole-device crash (bsod / kernel_panic).
+  type: 'bsod' | 'kernel_panic' | 'system_crash' | 'oom_kill' | 'app_crash' | 'unknown';
   timestamp: string;
   details?: Record<string, unknown>;
 };

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -15,6 +15,7 @@ function makeBucket(overrides: Record<string, unknown>) {
     sampleCount: 1,
     uptimeSecondsMax: 3600,
     crashCount: 0,
+    appCrashCount: 0,
     hangCount: 0,
     unresolvedHangCount: 0,
     serviceFailureCount: 0,
@@ -56,7 +57,7 @@ describe('reliabilityScoringInternals', () => {
         uptimeSeconds: 1200,
         crashEvents: [{ timestamp: '2026-02-20T12:01:00.000Z' }],
         serviceFailures: [{ timestamp: '2026-02-20T12:05:00.000Z', recovered: true }],
-        hardwareErrors: [{ timestamp: '2026-02-20T12:10:00.000Z', severity: 'critical' }],
+        hardwareErrors: [{ timestamp: '2026-02-20T12:10:00.000Z', severity: 'critical', type: 'disk', source: 'disk' }],
       }),
     ] as any[];
 
@@ -322,13 +323,14 @@ describe('mergeRowsIntoDailyBuckets event dedup (#1904)', () => {
   });
 
   it('keeps two distinct events with all-empty structured keys separate via JSON fallback', () => {
-    // No type/source/eventId/serviceName/timestamp — only distinguishable by a
-    // non-keyed field. JSON fallback must keep them as two events.
+    // No type/timestamp — only distinguishable by a non-keyed field. JSON
+    // fallback must keep them as two events. Uses crashEvents because the
+    // hardware factor now drops events with no genuine fault source/type.
     const rows = [
       makeHistoryRow({
-        hardwareErrors: [
-          { severity: 'error', source: '', details: { a: 1 } },
-          { severity: 'error', source: '', details: { a: 2 } },
+        crashEvents: [
+          { type: '', details: { a: 1 } },
+          { type: '', details: { a: 2 } },
         ],
       }),
     ] as any[];
@@ -336,7 +338,57 @@ describe('mergeRowsIntoDailyBuckets event dedup (#1904)', () => {
     const map = new Map<string, any>();
     mergeRowsIntoDailyBuckets(map, rows as any);
 
-    expect(totalCount(map, (b) => b.hardwareErrorCount)).toBe(2);
+    expect(totalCount(map, (b) => b.crashCount)).toBe(2);
+  });
+
+  it('drops hardware events that are not genuine hardware faults (old-agent junk)', () => {
+    // v0.84.0 and earlier mis-tagged SCM / DCOM / IOKit-plugin events as
+    // hardware. They carry no fault type and a non-hardware source, so the
+    // server-side gate must exclude them while keeping real faults.
+    const rows = [
+      makeHistoryRow({
+        hardwareErrors: [
+          { type: 'unknown', severity: 'error', source: 'service control manager', eventId: '7000', timestamp: '2026-02-20T10:00:00.000Z' },
+          { type: 'unknown', severity: 'error', source: 'microsoft-windows-distributedcom', eventId: '10010', timestamp: '2026-02-20T10:01:00.000Z' },
+          { type: 'unknown', severity: 'error', source: 'com.apple.iokit.cfplugin', eventId: 'x', timestamp: '2026-02-20T10:02:00.000Z' },
+          { type: 'disk', severity: 'critical', source: 'nvme', eventId: '7', timestamp: '2026-02-20T10:03:00.000Z' },
+        ],
+      }),
+    ] as any[];
+
+    const map = new Map<string, any>();
+    mergeRowsIntoDailyBuckets(map, rows as any);
+
+    // Only the genuine nvme/disk fault survives.
+    expect(totalCount(map, (b) => b.hardwareErrorCount)).toBe(1);
+    expect(totalCount(map, (b) => b.hardwareCriticalCount)).toBe(1);
+  });
+
+  it('tracks app_crash as a downweighted subset of crashCount', () => {
+    const rows = [
+      makeHistoryRow({
+        crashEvents: [
+          { type: 'app_crash', timestamp: '2026-02-20T10:00:00.000Z' },
+          { type: 'app_crash', timestamp: '2026-02-20T11:00:00.000Z' },
+          { type: 'bsod', timestamp: '2026-02-20T12:00:00.000Z' },
+        ],
+      }),
+    ] as any[];
+
+    const map = new Map<string, any>();
+    mergeRowsIntoDailyBuckets(map, rows as any);
+
+    // All three show in the raw crash count (headline tile); two are app crashes.
+    expect(totalCount(map, (b) => b.crashCount)).toBe(3);
+    expect(totalCount(map, (b) => b.appCrashCount)).toBe(2);
+
+    // The effective crash load downweights the two app crashes to 0.25 each:
+    // 3 - 2*(1-0.25) = 1.5, strictly less than the raw 3.
+    const { effectiveCrashLoad, RELIABILITY_APP_CRASH_WEIGHT } = reliabilityScoringInternals;
+    expect(effectiveCrashLoad(3, 2)).toBeCloseTo(3 - 2 * (1 - RELIABILITY_APP_CRASH_WEIGHT));
+    expect(effectiveCrashLoad(3, 2)).toBeLessThan(3);
+    // A real device crash (BSOD) is never downweighted.
+    expect(effectiveCrashLoad(1, 0)).toBe(1);
   });
 
   it('matches a count(DISTINCT ...) over a window with heavy overlap (inflation guard)', () => {

--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -364,6 +364,17 @@ describe('mergeRowsIntoDailyBuckets event dedup (#1904)', () => {
     expect(totalCount(map, (b) => b.hardwareCriticalCount)).toBe(1);
   });
 
+  it('isGenuineHardwareError: only real fault types or known hardware sources pass', () => {
+    const { isGenuineHardwareError } = reliabilityScoringInternals;
+    // Empty / no-type / non-hardware-source events are dropped.
+    expect(isGenuineHardwareError({} as any)).toBe(false);
+    expect(isGenuineHardwareError({ source: '', type: '' } as any)).toBe(false);
+    expect(isGenuineHardwareError({ source: 'service control manager', type: 'unknown' } as any)).toBe(false);
+    // Genuine: a known hardware source, or a real fault subtype (incl. thermal).
+    expect(isGenuineHardwareError({ source: 'nvme', type: 'unknown' } as any)).toBe(true);
+    expect(isGenuineHardwareError({ source: 'com.apple.kernel', type: 'thermal' } as any)).toBe(true);
+  });
+
   it('tracks app_crash as a downweighted subset of crashCount', () => {
     const rows = [
       makeHistoryRow({
@@ -899,6 +910,16 @@ describe('scoreDailyBucket', () => {
     const mixed = scoreDailyBucket(emptyBucket({ crashCount: 1, serviceFailureCount: 2, hardwareCriticalCount: 1 }));
     expect(mixed).toBeLessThan(oneCrash);
   });
+
+  it('downweights app crashes vs. real device crashes (app_crash weighting)', () => {
+    // 4 per-app crashes dent the score far less than 4 BSODs. At weight 0.25 the
+    // effective load of 4 app crashes is 4×0.25 = 1.0, ≈ a single real crash.
+    const fourApp = scoreDailyBucket(emptyBucket({ crashCount: 4, appCrashCount: 4 }));
+    const fourReal = scoreDailyBucket(emptyBucket({ crashCount: 4, appCrashCount: 0 }));
+    const oneReal = scoreDailyBucket(emptyBucket({ crashCount: 1, appCrashCount: 0 }));
+    expect(fourApp).toBeGreaterThan(fourReal);
+    expect(fourApp).toBeCloseTo(oneReal);
+  });
 });
 
 describe('scoreBand', () => {
@@ -1293,6 +1314,25 @@ describe('aggregateReliabilityOffenders', () => {
 
     // critical reported first must not be downgraded by a later warning / unknown severity.
     expect(result.hardware[0]).toMatchObject({ key: 'disk0', count: 3, detail: 'critical' });
+  });
+
+  it('excludes non-genuine hardware (old-agent SCM/DCOM/IOKit junk) from the drill-down', () => {
+    const rows = [
+      makeHistoryRow({
+        hardwareErrors: [
+          { type: 'unknown', severity: 'error', source: 'service control manager', eventId: '7000', timestamp: '2026-02-20T10:00:00.000Z' },
+          { type: 'unknown', severity: 'error', source: 'com.apple.iokit.cfplugin', eventId: 'x', timestamp: '2026-02-20T10:01:00.000Z' },
+          { type: 'disk', severity: 'critical', source: 'nvme', eventId: '7', timestamp: '2026-02-20T10:02:00.000Z' },
+        ],
+      }),
+    ];
+
+    const result = aggregateReliabilityOffenders(rows);
+
+    // The two junk sources must not appear; only the genuine nvme fault does.
+    expect(result.hardware).toEqual([
+      { key: 'nvme', label: 'nvme', count: 1, lastOccurrence: '2026-02-20T10:02:00.000Z', detail: 'critical' },
+    ]);
   });
 
   it('breaks count ties by most-recent occurrence', () => {

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -738,11 +738,19 @@ function hardwareErrorKey(event: HistoryRow['hardwareErrors'][number]): string {
 // Bluetooth and macOS IOKit-plugin chatter into `hardwareErrors`. The v0.85.0+
 // agent gates correctly, but historical rows AND devices still on the old binary
 // keep emitting that junk. This server-side gate mirrors the agent's hardware
-// classifier (agent/internal/collectors/reliability.go) so old/straggler data
-// can't depress the hardware factor: an event counts only when it carries a real
-// fault subtype OR comes from a known hardware/driver provider. A genuine
-// v0.85.0 hardware error always satisfies one of these, so no real signal is lost.
-const HARDWARE_FAULT_TYPES = new Set(['mce', 'memory', 'disk']);
+// classifiers (Windows reliability.go:classifyEventLogEntry, macOS/Linux
+// reliability_unix.go) so old/straggler data can't depress the hardware factor:
+// an event counts only when it carries a real fault subtype OR comes from a known
+// hardware/driver provider.
+//
+// Parity: HARDWARE_FAULT_TYPES must equal the non-"unknown" returns of the agent's
+// classifyHardwareType (mce/memory/disk/thermal), and HARDWARE_SOURCE_KEYWORDS must
+// be a superset of the agent's knownHardwareSources. A genuine v0.85.0 hardware
+// error always carries one of those fault subtypes (the agent now stamps thermal as
+// a type, not a message-only signal), so no real v0.85.0 signal is lost. (Pre-0.85
+// thermal events stamped type="unknown" survive only if their source contains
+// "thermal" — acceptable, as that junk-era data ages out of the 30-day window.)
+const HARDWARE_FAULT_TYPES = new Set(['mce', 'memory', 'disk', 'thermal']);
 const HARDWARE_SOURCE_KEYWORDS = [
   'whea', 'disk', 'ntfs', 'volmgr', 'storahci', 'stornvme', 'nvme',
   'iastor', 'msahci', 'nvlddmkm', 'amdkmdag', 'igfx', 'thermal', 'edac',

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -101,6 +101,7 @@ type DailyAggregateBucket = {
   sampleCount: number;
   uptimeSecondsMax: number;
   crashCount: number;
+  appCrashCount: number;
   hangCount: number;
   unresolvedHangCount: number;
   serviceFailureCount: number;
@@ -445,6 +446,17 @@ function scoreUptime(uptimePercent: number): number {
   return clampScore(((uptimePercent - 90) / 10) * 100);
 }
 
+// macOS per-app crash reports (Chrome, Outlook, security agents) are genuine but
+// far weaker reliability signals than a BSOD / kernel panic, so they count toward
+// the crash SCORE at reduced weight. Raw crash counts (headline tiles) are
+// unchanged — only the score is downweighted. appCrashCount is a subset of
+// crashCount; agents emit crash type "app_crash" (kernel panics / BSOD stay full).
+const RELIABILITY_APP_CRASH_WEIGHT = 0.25;
+
+function effectiveCrashLoad(crashCount: number, appCrashCount: number): number {
+  return Math.max(0, crashCount - appCrashCount * (1 - RELIABILITY_APP_CRASH_WEIGHT));
+}
+
 function scoreCrashes(
   crashCount7d: number,
   crashCount30d: number,
@@ -567,6 +579,7 @@ function createEmptyBucket(date: string): DailyAggregateBucket {
     sampleCount: 0,
     uptimeSecondsMax: 0,
     crashCount: 0,
+    appCrashCount: 0,
     hangCount: 0,
     unresolvedHangCount: 0,
     serviceFailureCount: 0,
@@ -599,6 +612,7 @@ function normalizeBucketRecord(raw: unknown, dateOverride?: string): DailyAggreg
     sampleCount: coerceCount(obj.sampleCount),
     uptimeSecondsMax: coerceCount(obj.uptimeSecondsMax),
     crashCount: coerceCount(obj.crashCount),
+    appCrashCount: coerceCount(obj.appCrashCount),
     hangCount: coerceCount(obj.hangCount),
     unresolvedHangCount: coerceCount(obj.unresolvedHangCount),
     serviceFailureCount: coerceCount(obj.serviceFailureCount),
@@ -656,6 +670,7 @@ function serializeDailyBuckets(dailyBuckets: DailyAggregateBucket[]): DailyAggre
     sampleCount: bucket.sampleCount,
     uptimeSecondsMax: bucket.uptimeSecondsMax,
     crashCount: bucket.crashCount,
+    appCrashCount: bucket.appCrashCount,
     hangCount: bucket.hangCount,
     unresolvedHangCount: bucket.unresolvedHangCount,
     serviceFailureCount: bucket.serviceFailureCount,
@@ -718,6 +733,27 @@ function hardwareErrorKey(event: HistoryRow['hardwareErrors'][number]): string {
   return eventKeyOrJson('hardware', [event.source, event.eventId, event.timestamp, event.type], event);
 }
 
+// Issue #1967 follow-up: agents at v0.84.0 and earlier hard-tagged the entire
+// System log Category="hardware", sweeping Service Control Manager, DCOM,
+// Bluetooth and macOS IOKit-plugin chatter into `hardwareErrors`. The v0.85.0+
+// agent gates correctly, but historical rows AND devices still on the old binary
+// keep emitting that junk. This server-side gate mirrors the agent's hardware
+// classifier (agent/internal/collectors/reliability.go) so old/straggler data
+// can't depress the hardware factor: an event counts only when it carries a real
+// fault subtype OR comes from a known hardware/driver provider. A genuine
+// v0.85.0 hardware error always satisfies one of these, so no real signal is lost.
+const HARDWARE_FAULT_TYPES = new Set(['mce', 'memory', 'disk']);
+const HARDWARE_SOURCE_KEYWORDS = [
+  'whea', 'disk', 'ntfs', 'volmgr', 'storahci', 'stornvme', 'nvme',
+  'iastor', 'msahci', 'nvlddmkm', 'amdkmdag', 'igfx', 'thermal', 'edac',
+];
+
+function isGenuineHardwareError(event: HistoryRow['hardwareErrors'][number]): boolean {
+  if (HARDWARE_FAULT_TYPES.has((event.type ?? '').toLowerCase())) return true;
+  const source = (event.source ?? '').toLowerCase();
+  return HARDWARE_SOURCE_KEYWORDS.some((keyword) => source.includes(keyword));
+}
+
 // The day bucket an event belongs to is the day of the EVENT's own timestamp,
 // not the row's collectedAt. An event near midnight can be re-reported in rows
 // on either side of a day boundary; anchoring on the event timestamp keeps the
@@ -763,6 +799,9 @@ function mergeRowsIntoDailyBuckets(
       if (!isNewEvent(crashEventKey(event))) continue;
       const bucket = upsertBucket(map, eventDayKey(event.timestamp, row.collectedAt));
       bucket.crashCount += 1;
+      // app_crash is a subset of crashCount, tracked separately so the score can
+      // downweight per-app crashes while the headline tile still shows them all.
+      if (event.type === 'app_crash') bucket.appCrashCount += 1;
       bucket.lastCrashAt = maxTimestamp([bucket.lastCrashAt, event.timestamp ?? fallbackTimestamp]);
     }
 
@@ -783,6 +822,7 @@ function mergeRowsIntoDailyBuckets(
     }
 
     for (const event of row.hardwareErrors) {
+      if (!isGenuineHardwareError(event)) continue;
       if (!isNewEvent(hardwareErrorKey(event))) continue;
       const bucket = upsertBucket(map, eventDayKey(event.timestamp, row.collectedAt));
       bucket.hardwareErrorCount += 1;
@@ -851,7 +891,7 @@ function scoreDailyBucket(bucket: DailyAggregateBucket): number {
   // across factors. Uptime is intentionally absent: not a per-day-bucket quantity.
   const lost = (score: number): number => 100 - score;
   const lostPoints =
-    lost(saturatingScore(bucket.crashCount, K_CRASHES))
+    lost(saturatingScore(effectiveCrashLoad(bucket.crashCount, bucket.appCrashCount), K_CRASHES))
     + lost(saturatingScore(bucket.hangCount + bucket.unresolvedHangCount, K_HANGS))
     + lost(saturatingScore(
       Math.max(0, bucket.serviceFailureCount - bucket.recoveredServiceCount * 0.5),
@@ -1201,6 +1241,8 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   const crashCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.crashCount);
   const crashCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.crashCount);
   const crashCount90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.crashCount);
+  const appCrashCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.appCrashCount);
+  const appCrashCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.appCrashCount);
 
   const hangCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.hangCount);
   const hangCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.hangCount);
@@ -1217,7 +1259,11 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   const warningHardwareCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.hardwareWarningCount);
 
   const uptimeScore = scoreUptime(uptime90d);
-  const crashScore = scoreCrashes(crashCount7d, crashCount30d, observedUpDays30);
+  const crashScore = scoreCrashes(
+    effectiveCrashLoad(crashCount7d, appCrashCount7d),
+    effectiveCrashLoad(crashCount30d, appCrashCount30d),
+    observedUpDays30
+  );
   const hangScore = scoreHangs(hangCount30d, unresolvedHangCount30d, observedUpDays30);
   const serviceFailureScore = scoreServiceFailures(
     serviceFailureCount30d,
@@ -1812,6 +1858,7 @@ function aggregateReliabilityOffenders(
     }
 
     for (const event of row.hardwareErrors) {
+      if (!isGenuineHardwareError(event)) continue;
       if (!inWindow(event.timestamp, row.collectedAt)) continue;
       if (!isNewEvent(hardwareErrorKey(event))) continue;
       const entry = upsertOffender(hardware, event.source?.trim() || 'Unknown component');
@@ -1965,4 +2012,7 @@ export const reliabilityScoringInternals = {
   countObservedUpDaysInWindow,
   RELIABILITY_RATE_REFERENCE_DAYS,
   RELIABILITY_RATE_MIN_DAYS,
+  isGenuineHardwareError,
+  effectiveCrashLoad,
+  RELIABILITY_APP_CRASH_WEIGHT,
 };

--- a/packages/shared/src/validators/reliability.test.ts
+++ b/packages/shared/src/validators/reliability.test.ts
@@ -19,7 +19,9 @@ describe('reliabilityCrashEventSchema', () => {
   });
 
   it('should accept all crash event types', () => {
-    const types = ['bsod', 'kernel_panic', 'system_crash', 'oom_kill', 'unknown'] as const;
+    // Must include every type the agent emits — a macOS app_crash that fails here
+    // would 400 the entire reliability upload (see agent reliability_unix.go).
+    const types = ['bsod', 'kernel_panic', 'system_crash', 'oom_kill', 'app_crash', 'unknown'] as const;
     for (const type of types) {
       const result = reliabilityCrashEventSchema.safeParse({
         type,
@@ -239,7 +241,7 @@ describe('reliabilityHardwareErrorSchema', () => {
   });
 
   it('should accept all hardware error types', () => {
-    const types = ['mce', 'disk', 'memory', 'unknown'] as const;
+    const types = ['mce', 'disk', 'memory', 'thermal', 'unknown'] as const;
     for (const type of types) {
       const result = reliabilityHardwareErrorSchema.safeParse({
         type,

--- a/packages/shared/src/validators/reliability.ts
+++ b/packages/shared/src/validators/reliability.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const reliabilityCrashEventSchema = z.object({
-  type: z.enum(['bsod', 'kernel_panic', 'system_crash', 'oom_kill', 'unknown']),
+  // app_crash = macOS per-app crash report (downweighted vs. whole-device crashes).
+  // Keep in sync with ReliabilityCrashEvent (apps/api/src/db/schema/reliability.ts)
+  // and the agent emitter (agent/internal/collectors/reliability_unix.go).
+  type: z.enum(['bsod', 'kernel_panic', 'system_crash', 'oom_kill', 'app_crash', 'unknown']),
   timestamp: z.string().datetime(),
   details: z.record(z.string(), z.unknown()).optional(),
 });
@@ -21,7 +24,10 @@ export const reliabilityServiceFailureSchema = z.object({
 });
 
 export const reliabilityHardwareErrorSchema = z.object({
-  type: z.enum(['mce', 'disk', 'memory', 'unknown']),
+  // 'thermal' is macOS-sourced; classified by type (not source) so the API's
+  // genuine-hardware gate recognises it. Keep in sync with ReliabilityHardwareError
+  // and the agent's classifyHardwareType (agent/internal/collectors/reliability.go).
+  type: z.enum(['mce', 'disk', 'memory', 'thermal', 'unknown']),
   severity: z.enum(['critical', 'error', 'warning']),
   timestamp: z.string().datetime(),
   source: z.string().min(1).max(255),


### PR DESCRIPTION
## Why

The agent event-classification fix (#1967, v0.85.0) only covered **Windows**. Looking at real production data (OliveTech, US) the worst reliability scores were almost all driven by **misclassified junk**, not real problems:

- **macOS** "hardware errors" were `com.apple.iokit.cfplugin` / App Store chatter; "crashes" were per-app DiagnosticReports (`ninjarmm-macagent`, `wdavdaemon`) and even `JetsamEvent` memory-pressure reports.
- **Linux** counted routine kernel chatter (USB resets, ACPI) as hardware faults via a `Category=="hardware"` catch-all.
- Old/straggler agents keep emitting the same junk regardless of the Windows fix, so a one-time data purge wouldn't hold.

## What

**Agent (Go)**
- Extract `classifyDarwinEventLogEntry` / `classifyLinuxEventLogEntry` into the no-build-tag `reliability_unix.go` so the platform classifiers are **unit-testable on CI** (the old inline switches were build-tagged and never exercised).
- Hardware gates on a genuine fault signal (`classifyHardwareType` + thermal/EDAC), **never `entry.Category`** — drops the IOKit/AppStore/Bluetooth/kernel-chatter junk.
- macOS crashes: `JetsamEvent` dropped; kernel panics labelled distinctly and count fully; per-app crashes count as a **weak `app_crash` type** (per product decision: app instability ≠ whole-device failure, but still counts).

**API (scoring)**
- `isGenuineHardwareError` gate at the score-aggregation **and** offenders chokepoints mirrors the agent allowlist, so junk from history **and** devices still on old binaries can't depress the hardware factor.
- `app_crash` is a **downweighted subset** of `crashCount` (`RELIABILITY_APP_CRASH_WEIGHT = 0.25`): headline crash tiles still show every crash, but the crash *score* weights per-app crashes well below a BSOD/panic.

## Recovery (no destructive purge)
Scores self-heal via existing automation: every agent post enqueues a device recompute (`routes/agents/reliability.ts`) and the nightly `scan-orgs` cron recomputes the fleet. With the server-side gate deployed, scores recover within hours — no SQL purge required.

## Tests
- 18 new Go classifier cases; all platforms cross-compile, `-race` green.
- API scoring + offenders coverage for the hardware gate and app-crash weighting; **164 reliability tests green**, `tsc` clean.

## Known minor follow-up
The org-summary "worst device" heuristic still counts `crashEvents.length` (incl. app crashes) at full weight — coarse ranking only, not the headline score. Left as-is to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)