### PR TITLE
Polishing quotes & invoices

### DIFF
--- a/apps/api/src/__tests__/integration/contractService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractService.integration.test.ts
@@ -19,7 +19,7 @@ import { eq, and } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { partners, organizations, sites, devices, users, organizationUsers, roles, contracts, contractBillingPeriods, contractLines, invoiceLines, invoices } from '../../db/schema';
 import {
-  createContract, getContract, addContractLineToContract, updateContract, listContracts,
+  createContract, getContract, addContractLineToContract, updateContractLine, updateContract, listContracts,
   activateContract, pauseContract, resumeContract, cancelContract, generateDueInvoice,
   type ContractActorT
 } from '../../services/contractService';
@@ -70,6 +70,28 @@ describe('contractService CRUD', () => {
     expect(got.lines.every((l) => l.orgId === orgId)).toBe(true);
     expect(got.lines.map((l) => l.sortOrder)).toEqual([0, 1]);
     expect(got.lines.find((l) => l.lineType === 'manual')!.manualQuantity).toBe('2');
+  });
+
+  it('updates a line in place (price + type change), preserving sortOrder', async () => {
+    const { actor, orgId } = await seedOrg();
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId, name: 'EditLine', billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01',
+      lines: [{ lineType: 'flat', description: 'Base fee', unitPrice: '500.00', taxable: false }],
+    }, actor));
+    const before = await withSystemDbAccessContext(() => getContract(c.id, actor));
+    const lineId = before.lines[0]!.id;
+    await withSystemDbAccessContext(() => updateContractLine(c.id, lineId, {
+      lineType: 'manual', description: 'Base fee (revised)', unitPrice: '650.00', manualQuantity: '3', taxable: true,
+    }, actor));
+    const after = await withSystemDbAccessContext(() => getContract(c.id, actor));
+    expect(after.lines).toHaveLength(1);
+    const l = after.lines[0]!;
+    expect(l.id).toBe(lineId);
+    expect(l.lineType).toBe('manual');
+    expect(l.unitPrice).toBe('650.00');
+    expect(l.manualQuantity).toBe('3');
+    expect(l.taxable).toBe(true);
+    expect(l.sortOrder).toBe(before.lines[0]!.sortOrder);
   });
 
   it('adds flat + per_device lines to a draft', async () => {

--- a/apps/api/src/__tests__/integration/contractService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractService.integration.test.ts
@@ -54,6 +54,24 @@ describe('contractService CRUD', () => {
     expect(got.lines).toHaveLength(0);
   });
 
+  it('creates a contract with lines atomically (single-screen create)', async () => {
+    const { actor, orgId } = await seedOrg();
+    const c = await withSystemDbAccessContext(() => createContract({
+      orgId, name: 'WithLines', billingTiming: 'advance', intervalMonths: 1, startDate: '2026-07-01',
+      lines: [
+        { lineType: 'flat', description: 'Base fee', unitPrice: '500.00', taxable: false },
+        { lineType: 'manual', description: 'Onboarding', unitPrice: '150.00', manualQuantity: '2', taxable: true },
+      ],
+    }, actor));
+    const got = await withSystemDbAccessContext(() => getContract(c.id, actor));
+    expect(got.lines).toHaveLength(2);
+    // Persisted in submitted order, with denormalized orgId and the manual qty.
+    expect(got.lines.map((l) => l.description)).toEqual(['Base fee', 'Onboarding']);
+    expect(got.lines.every((l) => l.orgId === orgId)).toBe(true);
+    expect(got.lines.map((l) => l.sortOrder)).toEqual([0, 1]);
+    expect(got.lines.find((l) => l.lineType === 'manual')!.manualQuantity).toBe('2');
+  });
+
   it('adds flat + per_device lines to a draft', async () => {
     const { actor, orgId } = await seedOrg();
     const c = await withSystemDbAccessContext(() => createContract({

--- a/apps/api/src/routes/contracts/contracts.test.ts
+++ b/apps/api/src/routes/contracts/contracts.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../services/contractService', () => ({
   updateContract: vi.fn(),
   deleteDraftContract: vi.fn(),
   addContractLineToContract: vi.fn(),
+  updateContractLine: vi.fn(),
   removeContractLine: vi.fn(),
   activateContract: vi.fn(),
   pauseContract: vi.fn(),
@@ -209,6 +210,29 @@ describe('contract line routes', () => {
     });
     expect(res.status).toBe(400);
     expect(svc.addContractLineToContract).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /:id/lines/:lineId updates a line in place', async () => {
+    (svc.updateContractLine as any).mockResolvedValue({ id: LINE_ID, unitPrice: '175.00' });
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineType: 'flat', description: 'Monthly fee', unitPrice: '175.00', taxable: true })
+    });
+    expect(res.status).toBe(200);
+    expect(svc.updateContractLine).toHaveBeenCalledWith(
+      CONTRACT_ID, LINE_ID, expect.objectContaining({ unitPrice: '175.00' }), expect.anything(),
+    );
+  });
+
+  it('PATCH /:id/lines/:lineId rejects an invalid body (missing description → 400, no service call)', async () => {
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineType: 'flat', unitPrice: '100.00', taxable: false })
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateContractLine).not.toHaveBeenCalled();
   });
 
   it('DELETE /:id/lines/:lineId removes a line', async () => {

--- a/apps/api/src/routes/contracts/contracts.test.ts
+++ b/apps/api/src/routes/contracts/contracts.test.ts
@@ -86,6 +86,39 @@ describe('contract crud routes', () => {
     expect(svc.createContract).not.toHaveBeenCalled();
   });
 
+  it('POST / forwards a lines[] array to the service (atomic single-screen create)', async () => {
+    (svc.createContract as any).mockResolvedValue({ id: CONTRACT_ID, status: 'draft' });
+    const lines = [
+      { lineType: 'flat', description: 'Base fee', unitPrice: '500.00', taxable: false },
+      { lineType: 'manual', description: 'Onboarding', unitPrice: '150.00', manualQuantity: '2', taxable: true },
+    ];
+    const res = await app().request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        orgId: ORG_ID, name: 'Managed Services', billingTiming: 'advance',
+        intervalMonths: 1, startDate: '2026-07-01', lines,
+      })
+    });
+    expect(res.status).toBe(200);
+    expect(svc.createContract).toHaveBeenCalledOnce();
+    expect((svc.createContract as any).mock.calls[0][0]).toMatchObject({ lines });
+  });
+
+  it('POST / rejects a create whose lines[] contains a malformed line (400, no service call)', async () => {
+    const res = await app().request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        orgId: ORG_ID, name: 'Managed Services', billingTiming: 'advance',
+        intervalMonths: 1, startDate: '2026-07-01',
+        lines: [{ lineType: 'manual', description: 'no qty', unitPrice: '10.00', taxable: false }],
+      })
+    });
+    expect(res.status).toBe(400);
+    expect(svc.createContract).not.toHaveBeenCalled();
+  });
+
   it('GET / lists contracts', async () => {
     (svc.listContracts as any).mockResolvedValue([{ id: CONTRACT_ID }]);
     const res = await app().request('/', { method: 'GET' });

--- a/apps/api/src/routes/contracts/lines.ts
+++ b/apps/api/src/routes/contracts/lines.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { contractLineInputSchema } from '@breeze/shared';
-import { addContractLineToContract, removeContractLine } from '../../services/contractService';
+import { addContractLineToContract, updateContractLine, removeContractLine } from '../../services/contractService';
 import { contractActorFrom, handleContractError } from './contracts';
 
 export const contractLineRoutes = new Hono();
@@ -15,6 +15,10 @@ const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() })
 
 contractLineRoutes.post('/:id/lines', scopes, writePerm, zValidator('param', idParam), zValidator('json', contractLineInputSchema), async (c) => {
   try { return c.json({ data: await addContractLineToContract(c.req.valid('param').id, c.req.valid('json'), contractActorFrom(c)) }); }
+  catch (err) { return handleContractError(c, err); }
+});
+contractLineRoutes.patch('/:id/lines/:lineId', scopes, writePerm, zValidator('param', lineParam), zValidator('json', contractLineInputSchema), async (c) => {
+  try { const p = c.req.valid('param'); return c.json({ data: await updateContractLine(p.id, p.lineId, c.req.valid('json'), contractActorFrom(c)) }); }
   catch (err) { return handleContractError(c, err); }
 });
 contractLineRoutes.delete('/:id/lines/:lineId', scopes, writePerm, zValidator('param', lineParam), async (c) => {

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -13,7 +13,9 @@ vi.mock('../../services/quoteService', () => ({
   addManualLine: vi.fn(),
   addCatalogLine: vi.fn(),
   updateLine: vi.fn(),
-  removeLine: vi.fn()
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
 }));
 
 // QuoteServiceError lives in quoteTypes; routes import the class from there.
@@ -230,6 +232,82 @@ describe('quote crud + lines routes', () => {
     });
     expect(res.status).toBe(403);
     expect(svc.createQuote).not.toHaveBeenCalled();
+  });
+
+  const LINE_ID = '44444444-4444-4444-4444-444444444444';
+
+  describe('PATCH /:id/blocks/reorder', () => {
+    it('returns 200 { ok: true } and calls reorderBlocks with blockIds + actor', async () => {
+      (svc.reorderBlocks as any).mockResolvedValue(undefined);
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [BLOCK_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ok).toBe(true);
+      expect(svc.reorderBlocks).toHaveBeenCalledWith(QUOTE_ID, [BLOCK_ID], expect.anything());
+    });
+
+    it('rejects empty blockIds array (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderBlocks).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-UUID in blockIds (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: ['not-a-uuid'] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderBlocks).not.toHaveBeenCalled();
+    });
+
+    it('maps REORDER_IDS_MISMATCH to 400', async () => {
+      (svc.reorderBlocks as any).mockRejectedValue(
+        new QuoteServiceError('Block IDs do not match quote blocks', 400, 'REORDER_IDS_MISMATCH')
+      );
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [BLOCK_ID] }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('REORDER_IDS_MISMATCH');
+    });
+  });
+
+  describe('PATCH /:id/blocks/:blockId/lines/reorder', () => {
+    it('returns 200 { ok: true } and calls reorderLines with blockId + lineIds + actor', async () => {
+      (svc.reorderLines as any).mockResolvedValue(undefined);
+      const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}/lines/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineIds: [LINE_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ok).toBe(true);
+      expect(svc.reorderLines).toHaveBeenCalledWith(QUOTE_ID, BLOCK_ID, [LINE_ID], expect.anything());
+    });
+
+    it('rejects non-UUID lineId (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}/lines/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineIds: ['not-a-uuid'] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderLines).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /:id/pdf', () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -28,7 +28,6 @@ const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIO
 const idParam = z.object({ id: z.string().guid() });
 const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
 const blockParam = z.object({ id: z.string().guid(), blockId: z.string().guid() });
-const blockLineReorderParam = z.object({ id: z.string().guid(), blockId: z.string().guid() });
 
 export function quoteActorFrom(c: { get: (k: string) => unknown }): QuoteActor {
   const auth = c.get('auth') as AuthContext;
@@ -77,7 +76,7 @@ quoteCrudRoutes.patch('/:id/blocks/:blockId', scopes, writePerm, zValidator('par
   try { const p = c.req.valid('param'); return c.json({ data: await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
-quoteCrudRoutes.patch('/:id/blocks/:blockId/lines/reorder', scopes, writePerm, zValidator('param', blockLineReorderParam), zValidator('json', reorderLinesSchema), async (c) => {
+quoteCrudRoutes.patch('/:id/blocks/:blockId/lines/reorder', scopes, writePerm, zValidator('param', blockParam), zValidator('json', reorderLinesSchema), async (c) => {
   try { const { id, blockId } = c.req.valid('param'); await reorderLines(id, blockId, c.req.valid('json').lineIds, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
   catch (err) { return handleServiceError(c, err); }
 });

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -7,10 +7,12 @@ import { PERMISSIONS } from '../../services/permissions';
 import {
   createQuoteSchema, updateQuoteSchema, quoteLineInputSchema, catalogQuoteLineSchema,
   updateQuoteLineSchema, quoteBlockInputSchema, listQuotesQuerySchema,
+  reorderBlocksSchema, reorderLinesSchema,
 } from '@breeze/shared';
 import {
   createQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
   addManualLine, addCatalogLine, updateLine, removeLine, addBlock, updateBlock, deleteBlock,
+  reorderBlocks, reorderLines,
 } from '../../services/quoteService';
 import { QuoteServiceError, type QuoteActor } from '../../services/quoteTypes';
 import { db } from '../../db';
@@ -26,6 +28,7 @@ const writePerm = requirePermission(PERMISSIONS.QUOTES_WRITE.resource, PERMISSIO
 const idParam = z.object({ id: z.string().guid() });
 const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
 const blockParam = z.object({ id: z.string().guid(), blockId: z.string().guid() });
+const blockLineReorderParam = z.object({ id: z.string().guid(), blockId: z.string().guid() });
 
 export function quoteActorFrom(c: { get: (k: string) => unknown }): QuoteActor {
   const auth = c.get('auth') as AuthContext;
@@ -66,8 +69,16 @@ quoteCrudRoutes.post('/:id/blocks', scopes, writePerm, zValidator('param', idPar
   try { return c.json({ data: await addBlock(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
+quoteCrudRoutes.patch('/:id/blocks/reorder', scopes, writePerm, zValidator('param', idParam), zValidator('json', reorderBlocksSchema), async (c) => {
+  try { const { id } = c.req.valid('param'); await reorderBlocks(id, c.req.valid('json').blockIds, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
+  catch (err) { return handleServiceError(c, err); }
+});
 quoteCrudRoutes.patch('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), zValidator('json', quoteBlockInputSchema), async (c) => {
   try { const p = c.req.valid('param'); return c.json({ data: await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+quoteCrudRoutes.patch('/:id/blocks/:blockId/lines/reorder', scopes, writePerm, zValidator('param', blockLineReorderParam), zValidator('json', reorderLinesSchema), async (c) => {
+  try { const { id, blockId } = c.req.valid('param'); await reorderLines(id, blockId, c.req.valid('json').lineIds, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.delete('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), async (c) => {

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -39,6 +39,7 @@ export async function createContract(input: {
   orgId: string; name: string; billingTiming: 'advance' | 'arrears'; intervalMonths: number;
   startDate: string; endDate?: string | null; autoIssue?: boolean; currencyCode?: string; notes?: string | null; terms?: string | null;
   autoRenew?: boolean; renewalTermMonths?: number | null; renewalNoticeDays?: number | null;
+  lines?: ContractLineInput[];
 }, actor: ContractActor) {
   requireOrgAccess(actor, input.orgId);
   if (actor.partnerId === null) throw new ContractServiceError('Partner scope required', 403, 'ORG_DENIED');
@@ -55,6 +56,21 @@ export async function createContract(input: {
     autoRenew: input.autoRenew ?? false, renewalTermMonths: input.renewalTermMonths ?? null,
     renewalNoticeDays: input.renewalNoticeDays ?? null,
   }).returning();
+  // Insert any supplied lines in the same (request-scoped) transaction so the
+  // whole create is atomic — a bad line rolls back the contract too. Mapping
+  // mirrors addContractLineToContract exactly (denormalized orgId for RLS).
+  if (input.lines?.length) {
+    await db.insert(contractLines).values(
+      input.lines.map((l, i) => ({
+        contractId: row!.id, orgId: row!.orgId,
+        lineType: l.lineType, description: l.description,
+        catalogItemId: l.catalogItemId ?? null, unitPrice: l.unitPrice,
+        manualQuantity: l.lineType === 'manual' ? (l.manualQuantity ?? '0') : null,
+        siteId: l.lineType === 'per_device' ? (l.siteId ?? null) : null,
+        taxable: l.taxable, sortOrder: l.sortOrder ?? i,
+      })),
+    );
+  }
   return row!;
 }
 

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -228,6 +228,22 @@ export async function addContractLineToContract(contractId: string, input: Contr
   return row!;
 }
 
+export async function updateContractLine(contractId: string, lineId: string, input: ContractLineInput, actor: ContractActor) {
+  const c = await getOwnedContractOr404(contractId, actor);
+  assertEditable(c);
+  // Full replace of the line's billing fields (mapping mirrors the insert path).
+  // sortOrder is preserved unless the caller supplies one.
+  const [row] = await db.update(contractLines).set({
+    lineType: input.lineType, description: input.description,
+    catalogItemId: input.catalogItemId ?? null, unitPrice: input.unitPrice,
+    manualQuantity: input.lineType === 'manual' ? (input.manualQuantity ?? '0') : null,
+    siteId: input.lineType === 'per_device' ? (input.siteId ?? null) : null,
+    taxable: input.taxable, ...(input.sortOrder !== undefined ? { sortOrder: input.sortOrder } : {}),
+  }).where(and(eq(contractLines.id, lineId), eq(contractLines.contractId, contractId))).returning();
+  if (!row) throw new ContractServiceError('Contract line not found', 404, 'CONTRACT_NOT_FOUND');
+  return row;
+}
+
 export async function removeContractLine(contractId: string, lineId: string, actor: ContractActor) {
   const c = await getOwnedContractOr404(contractId, actor);
   assertEditable(c);

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -55,6 +55,17 @@ function formatDate(value: string | Date | null | undefined): string {
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: '2-digit', timeZone: 'UTC' });
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays invoice.tax_total (authoritative), so the summed
+ *  column can differ by a rounding cent on many-line invoices. */
+function lineTax(lineTotal: string | number | null | undefined, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal ?? 0) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 interface BillToAddress {
   line1?: string | null; line2?: string | null; city?: string | null;
   region?: string | null; postalCode?: string | null; country?: string | null;
@@ -93,6 +104,10 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
     ? (branding.primaryColor.startsWith('#') ? branding.primaryColor : `#${branding.primaryColor}`)
     : '#2563eb';
   const groups = groupVisibleLinesByTicket(lines);
+  // Per-line Tax column appears only when this invoice carries tax (mirrors the
+  // header Tax row); otherwise it'd be a column of dashes.
+  const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+  const showTax = Number(invoice.taxTotal ?? 0) > 0;
   const billTo = addressLines(invoice.billToAddress as BillToAddress | null);
   const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
   const sellerLines = sellerAddressLines(seller);
@@ -103,14 +118,21 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
 
   const rowsHtml = groups.map((g) => {
     const header = g.ticketId
-      ? `<tr><td colspan="3" style="padding:10px 8px 4px;font-size:12px;font-weight:600;color:#6b7280;border-top:1px solid #e5e7eb;">Ticket work</td></tr>`
+      ? `<tr><td colspan="${showTax ? 4 : 3}" style="padding:10px 8px 4px;font-size:12px;font-weight:600;color:#6b7280;border-top:1px solid #e5e7eb;">Ticket work</td></tr>`
       : '';
-    const lineRows = g.lines.map((l) => `
+    const lineRows = g.lines.map((l) => {
+      const t = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+      const taxCell = showTax
+        ? `<td style="padding:6px 8px;font-size:13px;color:#6b7280;text-align:right;white-space:nowrap;">${t === null ? '&mdash;' : escapeHtml(formatMoney(t, currency))}</td>`
+        : '';
+      return `
       <tr>
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;">${escapeHtml(l.description)}</td>
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;text-align:right;white-space:nowrap;">${escapeHtml(String(Number(l.quantity)))}</td>
+        ${taxCell}
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;text-align:right;white-space:nowrap;">${escapeHtml(formatMoney(l.lineTotal, currency))}</td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
     return header + lineRows;
   }).join('');
 
@@ -151,6 +173,7 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
           <tr>
             <th style="padding:8px;text-align:left;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Description</th>
             <th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Qty</th>
+            ${showTax ? '<th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Tax</th>' : ''}
             <th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Amount</th>
           </tr>
         </thead>
@@ -193,6 +216,9 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
     try {
       const currency = invoice.currencyCode ?? branding.currencyCode ?? 'USD';
       const primary = hexToColor(branding.primaryColor, '#2563eb');
+      // Per-line Tax column only when this invoice carries tax (mirrors the header).
+      const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+      const showTax = Number(invoice.taxTotal ?? 0) > 0;
       const doc = new PDFDocument({ size: 'A4', margin: 50 });
       const chunks: Buffer[] = [];
       doc.on('data', (d: Buffer) => chunks.push(d));
@@ -235,12 +261,15 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       if (invoice.issueDate) { doc.text(`Issued: ${formatDate(invoice.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
       if (invoice.dueDate) { doc.text(`Due: ${formatDate(invoice.dueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
 
-      // Line table starts below the taller of the two columns.
+      // Line table starts below the taller of the two columns. When a Tax column
+      // is shown, the money columns narrow to 0.15 each to fit qty | tax | amount;
+      // otherwise the original two-column (qty | amount) layout is preserved.
       y = Math.max(fromY, billY) + 20;
-      const colQtyX = left + contentWidth * 0.62;
-      const colAmtX = left + contentWidth * 0.80;
-      const colDescW = contentWidth * 0.60;
-      const colNumW = contentWidth * 0.18;
+      const colNumW = contentWidth * (showTax ? 0.15 : 0.18);
+      const colQtyX = left + contentWidth * (showTax ? 0.52 : 0.62);
+      const colTaxX = left + contentWidth * 0.68;
+      const colAmtX = left + contentWidth * (showTax ? 0.83 : 0.80);
+      const colDescW = contentWidth * (showTax ? 0.50 : 0.60);
 
       doc.save();
       doc.rect(left - 6, y - 5, contentWidth + 12, 22).fill('#f8fafc');
@@ -248,6 +277,7 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
       doc.text('DESCRIPTION', left, y);
       doc.text('QTY', colQtyX, y, { width: colNumW, align: 'right' });
+      if (showTax) doc.text('TAX', colTaxX, y, { width: colNumW, align: 'right' });
       doc.text('AMOUNT', colAmtX, y, { width: colNumW, align: 'right' });
       y += 18;
       y += 6;
@@ -262,6 +292,11 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
           const descHeight = doc.heightOfString(l.description, { width: colDescW });
           doc.text(l.description, left, y, { width: colDescW });
           doc.text(String(Number(l.quantity)), colQtyX, y, { width: colNumW, align: 'right' });
+          if (showTax) {
+            const t = lineTax(l.lineTotal, l.taxable, taxRate);
+            doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), colTaxX, y, { width: colNumW, align: 'right' });
+            doc.fillColor('#1f2937');
+          }
           doc.text(formatMoney(l.lineTotal, currency), colAmtX, y, { width: colNumW, align: 'right' });
           y += Math.max(descHeight, 12) + 6;
         }

--- a/apps/api/src/services/quoteMath.ts
+++ b/apps/api/src/services/quoteMath.ts
@@ -1,63 +1,7 @@
-import { toCents, fromCents, computeLineTotal } from './invoiceMath';
-
-export interface QuoteLineForMath {
-  quantity: string;
-  unitPrice: string;
-  taxable: boolean;
-  customerVisible: boolean;
-  recurrence: 'one_time' | 'monthly' | 'annual';
-}
-
-export interface QuoteTotals {
-  subtotal: string;
-  taxTotal: string;
-  total: string;
-  oneTimeTotal: string;
-  monthlyRecurringTotal: string;
-  annualRecurringTotal: string;
-  /**
-   * The amount actually invoiced when the customer accepts the quote. Accept
-   * auto-issues a one-time-only invoice (recurring lines are deferred to the
-   * Phase 4 recurring contract — see quoteAcceptService.ts), so this is the
-   * one-time subtotal PLUS tax on just the taxable one-time lines. It mirrors
-   * quoteAcceptService's `computeInvoiceTotals(oneTimeLines, taxRate)` exactly,
-   * and is the figure the UI must advertise as "due on acceptance" — NOT
-   * `total`, which also rolls in the first monthly + annual period.
-   */
-  dueOnAcceptanceTotal: string;
-}
-
-export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
-  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
-  for (const l of lines) {
-    if (!l.customerVisible) continue;
-    // Route through the canonical billing helpers so quote per-line cents equal
-    // the persisted line_total (rounded to cents) and match invoices exactly:
-    // a single round-half-up at the cent boundary, never rounding unitPrice first.
-    const lineCents = toCents(computeLineTotal(l.quantity, l.unitPrice));
-    if (l.recurrence === 'monthly') monthly += lineCents;
-    else if (l.recurrence === 'annual') annual += lineCents;
-    else oneTime += lineCents;
-    if (l.taxable) {
-      taxableBasis += lineCents;
-      if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
-    }
-  }
-  // First-period basis: one-time + first monthly period + first annual period.
-  const subtotal = oneTime + monthly + annual;
-  // Match invoiceMath.computeInvoiceTotals' round-half-up; nullish so a 0 rate
-  // and null both yield 0 tax.
-  const rate = taxRate ?? 0;
-  const taxCents = Math.floor(taxableBasis * rate + 0.5);
-  // Tax on ONLY the one-time taxable lines — what accept actually invoices.
-  const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
-  return {
-    subtotal: fromCents(subtotal),
-    taxTotal: fromCents(taxCents),
-    total: fromCents(subtotal + taxCents),
-    oneTimeTotal: fromCents(oneTime),
-    monthlyRecurringTotal: fromCents(monthly),
-    annualRecurringTotal: fromCents(annual),
-    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
-  };
-}
+// Quote totals now live in @breeze/shared so the web editor's optimistic "Live
+// totals" rail computes from the exact same logic the API persists — they can
+// never settle to different figures. Re-exported here to keep the existing
+// `./quoteMath` import sites (quoteService, quotesPublic, portal/quotes) stable.
+// The quoteMath.test.ts beside this file exercises the shared implementation and
+// guards parity.
+export { computeQuoteTotals, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -41,6 +41,17 @@ function recurrenceSuffix(recurrence: string | null | undefined): string {
   return '';
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The summary Tax stays quote.tax_total (authoritative), so the summed
+ *  column can differ by a rounding cent on many-line quotes. */
+function lineTax(lineTotal: string | number | null | undefined, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal ?? 0) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 function hexToColor(value: string | null | undefined, fallback: string): string {
   if (!value) return fallback;
   const v = value.startsWith('#') ? value : `#${value}`;
@@ -117,6 +128,7 @@ interface QuoteLine {
   unitPrice: string | number;
   lineTotal?: string | number | null;
   recurrence?: string | null;
+  taxable?: boolean | null;
 }
 
 /** Loads a catalog item's product image bytes (or null). Injected so renderQuotePdf
@@ -130,21 +142,39 @@ type LoadCatalogImage = (catalogItemId: string) => Promise<{ data: Buffer } | nu
 
 interface Cols {
   left: number; right: number; contentWidth: number;
-  colQtyX: number; colDescW: number; colUnitX: number; colNumW: number; colAmtX: number;
+  colQtyX: number; colDescX: number; colDescW: number; colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number;
+  showTax: boolean;
 }
 
-function columnsFor(doc: PDFKit.PDFDocument): Cols {
+// When showTax is set the table carries a fifth column (qty | description | unit
+// | tax | total) and the money columns narrow to fit; otherwise the original
+// four-column layout (qty | description | unit | total) is preserved so existing
+// tax-free quotes render byte-identically. The summary uses the same colAmtX so
+// its amounts stay aligned under TOTAL.
+function columnsFor(doc: PDFKit.PDFDocument, showTax = false): Cols {
   const left = doc.page.margins.left;
   const right = doc.page.width - doc.page.margins.right;
   const contentWidth = right - left;
+  const colDescX = left + contentWidth * 0.12;
+  if (showTax) {
+    return {
+      left, right, contentWidth, showTax,
+      colQtyX: left,
+      colDescX,
+      colDescW: contentWidth * 0.36,
+      colUnitX: left + contentWidth * 0.50,
+      colTaxX: left + contentWidth * 0.67,
+      colAmtX: left + contentWidth * 0.84,
+      colNumW: contentWidth * 0.15,
+    };
+  }
   return {
-    left,
-    right,
-    contentWidth,
-    // qty | description | unit | total
+    left, right, contentWidth, showTax,
     colQtyX: left,
+    colDescX,
     colDescW: contentWidth * 0.46,
     colUnitX: left + contentWidth * 0.60,
+    colTaxX: left + contentWidth * 0.70, // unused when !showTax
     colAmtX: left + contentWidth * 0.80,
     colNumW: contentWidth * 0.18,
   };
@@ -171,8 +201,10 @@ async function renderLineTable(
   currency: string,
   startY: number,
   loadCatalogImage: LoadCatalogImage,
+  taxRate = 0,
+  showTax = false,
 ): Promise<number> {
-  const c = columnsFor(doc);
+  const c = columnsFor(doc, showTax);
   let y = ensureSpace(doc, startY, 60);
 
   // Pre-load product images (DB I/O) for catalog-sourced lines. A failed load
@@ -191,7 +223,7 @@ async function renderLineTable(
   // Reserve a thumbnail gutter only when at least one line has an image, so the
   // description column stays aligned across rows.
   const gutter = imageByLine.size > 0 ? THUMB + 8 : 0;
-  const descW = c.contentWidth * 0.46 - gutter;
+  const descW = c.colDescW - gutter;
 
   // Header row with a light fill bar.
   doc.save();
@@ -199,13 +231,14 @@ async function renderLineTable(
   doc.restore();
   doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
   doc.text('QTY', c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
-  doc.text('DESCRIPTION', c.colQtyX + c.contentWidth * 0.12, y, { width: c.contentWidth * 0.46, align: 'left' });
+  doc.text('DESCRIPTION', c.colDescX, y, { width: c.colDescW, align: 'left' });
   doc.text('UNIT', c.colUnitX, y, { width: c.colNumW, align: 'right' });
+  if (showTax) doc.text('TAX', c.colTaxX, y, { width: c.colNumW, align: 'right' });
   doc.text('TOTAL', c.colAmtX, y, { width: c.colNumW, align: 'right' });
   y += 18;
   y += 6;
 
-  const descX = c.colQtyX + c.contentWidth * 0.12;
+  const descX = c.colDescX;
   for (const l of lines) {
     y = ensureSpace(doc, y, Math.max(30, gutter));
     doc.fillColor('#1f2937').fontSize(10).font('Helvetica');
@@ -217,6 +250,11 @@ async function renderLineTable(
     }
     doc.text(l.description, descX + gutter, y, { width: descW });
     doc.text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
+    if (showTax) {
+      const t = lineTax(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), !!l.taxable, taxRate);
+      doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), c.colTaxX, y, { width: c.colNumW, align: 'right' });
+      doc.fillColor('#1f2937');
+    }
     const suffix = recurrenceSuffix(l.recurrence);
     doc.text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
     y += Math.max(descHeight, img ? THUMB : 12) + 6;
@@ -235,8 +273,8 @@ async function renderLineTable(
 // amount.
 // ---------------------------------------------------------------------------
 
-function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number): number {
-  const c = columnsFor(doc);
+function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number, showTax = false): number {
+  const c = columnsFor(doc, showTax);
   let y = ensureSpace(doc, startY + 6, 90);
 
   // Wider label column than the line table's so the emphasised "Due on
@@ -295,6 +333,9 @@ export async function renderQuotePdf(
   const currency = quote.currencyCode ?? branding.currencyCode ?? 'USD';
   const primary = hexToColor(branding.primaryColor, '#2563eb');
   const partnerName = branding.partnerName ?? 'Proposal';
+  // Per-line Tax column only when this quote carries tax (mirrors the summary).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
 
   const doc = new PDFDocument({ size: 'A4', margin: 50 });
   const chunks: Buffer[] = [];
@@ -407,17 +448,17 @@ export async function renderQuotePdf(
           doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
           y = doc.y + 6;
         }
-        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage);
+        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, taxRate, showTax);
       }
     }
   }
 
   // ---- Trailing default table for lines with no block ----------------------
   const orphanLines = lines.filter((l) => !l.blockId);
-  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage);
+  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage, taxRate, showTax);
 
   // ---- Recurring summary footer -------------------------------------------
-  y = renderRecurringSummary(doc, quote, currency, primary, y);
+  y = renderRecurringSummary(doc, quote, currency, primary, y, showTax);
 
   // ---- Terms & Conditions --------------------------------------------------
   if (quote.termsAndConditions) {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -352,7 +352,10 @@ export async function reorderBlocks(quoteId: string, blockIds: string[], actor: 
   await loadDraft(quoteId, actor);
   const existing = await db.select({ id: quoteBlocks.id }).from(quoteBlocks).where(eq(quoteBlocks.quoteId, quoteId));
   const existingSet = new Set(existing.map(r => r.id));
-  if (blockIds.length !== existing.length || !blockIds.every(id => existingSet.has(id))) {
+  // Use the deduped set size so a duplicated id (e.g. [A, A]) can't masquerade as
+  // a full permutation — that would renumber A twice and orphan another block's
+  // sort_order. (The zod schema also rejects duplicates; this is defense in depth.)
+  if (new Set(blockIds).size !== existing.length || !blockIds.every(id => existingSet.has(id))) {
     throw new QuoteServiceError('Block IDs do not match quote blocks', 400, 'REORDER_IDS_MISMATCH');
   }
   await db.transaction(async (tx) => {
@@ -371,7 +374,9 @@ export async function reorderLines(quoteId: string, blockId: string, lineIds: st
   const existing = await db.select({ id: quoteLines.id }).from(quoteLines)
     .where(and(eq(quoteLines.quoteId, quoteId), eq(quoteLines.blockId, blockId)));
   const existingSet = new Set(existing.map(r => r.id));
-  if (lineIds.length !== existing.length || !lineIds.every(id => existingSet.has(id))) {
+  // Deduped size guards against a duplicated id passing the permutation check
+  // (see reorderBlocks). The zod schema also rejects duplicates.
+  if (new Set(lineIds).size !== existing.length || !lineIds.every(id => existingSet.has(id))) {
     throw new QuoteServiceError('Line IDs do not match block lines', 400, 'REORDER_IDS_MISMATCH');
   }
   await db.transaction(async (tx) => {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -343,3 +343,40 @@ export async function removeLine(quoteId: string, lineId: string, actor: QuoteAc
   await db.delete(quoteLines).where(and(eq(quoteLines.id, lineId), eq(quoteLines.quoteId, quoteId)));
   await recomputeAndPersist(quoteId);
 }
+
+// ---------------------------------------------------------------------------
+// Reorder
+// ---------------------------------------------------------------------------
+
+export async function reorderBlocks(quoteId: string, blockIds: string[], actor: QuoteActor) {
+  await loadDraft(quoteId, actor);
+  const existing = await db.select({ id: quoteBlocks.id }).from(quoteBlocks).where(eq(quoteBlocks.quoteId, quoteId));
+  const existingSet = new Set(existing.map(r => r.id));
+  if (blockIds.length !== existing.length || !blockIds.every(id => existingSet.has(id))) {
+    throw new QuoteServiceError('Block IDs do not match quote blocks', 400, 'REORDER_IDS_MISMATCH');
+  }
+  await db.transaction(async (tx) => {
+    for (const [i, id] of blockIds.entries()) {
+      await tx.update(quoteBlocks).set({ sortOrder: i }).where(and(eq(quoteBlocks.id, id), eq(quoteBlocks.quoteId, quoteId)));
+    }
+  });
+}
+
+export async function reorderLines(quoteId: string, blockId: string, lineIds: string[], actor: QuoteActor) {
+  await loadDraft(quoteId, actor);
+  const [block] = await db.select({ id: quoteBlocks.id }).from(quoteBlocks)
+    .where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quoteId)))
+    .limit(1);
+  if (!block) throw new QuoteServiceError('Block not found', 404, 'BLOCK_NOT_FOUND');
+  const existing = await db.select({ id: quoteLines.id }).from(quoteLines)
+    .where(and(eq(quoteLines.quoteId, quoteId), eq(quoteLines.blockId, blockId)));
+  const existingSet = new Set(existing.map(r => r.id));
+  if (lineIds.length !== existing.length || !lineIds.every(id => existingSet.has(id))) {
+    throw new QuoteServiceError('Line IDs do not match block lines', 400, 'REORDER_IDS_MISMATCH');
+  }
+  await db.transaction(async (tx) => {
+    for (const [i, id] of lineIds.entries()) {
+      await tx.update(quoteLines).set({ sortOrder: i }).where(and(eq(quoteLines.id, id), eq(quoteLines.quoteId, quoteId), eq(quoteLines.blockId, blockId)));
+    }
+  });
+}

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -25,7 +25,8 @@ export type QuoteServiceErrorCode =
   | 'CATALOG_ITEM_NOT_FOUND'
   | 'INVALID_STATE'
   | 'QUOTE_EXPIRED'
-  | 'NOT_CONVERTED';
+  | 'NOT_CONVERTED'
+  | 'REORDER_IDS_MISMATCH';
 
 export class QuoteServiceError extends Error {
   constructor(

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -24,6 +24,16 @@ function money(value: string | number, currencyCode: string): string {
   }
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays invoice.taxTotal (authoritative). */
+function lineTax(lineTotal: string | number, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 function shortDate(value: string | null): string {
   if (!value) return '—';
   const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
@@ -89,6 +99,10 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
   const canPay = PAYABLE_STATUSES.has(invoice.status) && Number(invoice.balance) > 0;
+  // Per-line Tax column only when this invoice carries tax (mirrors the Tax row).
+  const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+  const showTax = Number(invoice.taxTotal) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   const seller = (invoice.sellerSnapshot ?? null) as DocSeller | null;
   const headerDates = [
@@ -218,18 +232,23 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
                   <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
                   <th className="px-2 py-2.5 text-right font-medium">Qty</th>
                   <th className="px-2 py-2.5 text-right font-medium">Price</th>
+                  {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
                   <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
                 </tr>
               </thead>
               <tbody>
-                {lines.map((l) => (
+                {lines.map((l) => {
+                  const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+                  return (
                   <tr key={l.id} className="border-b align-top last:border-0">
                     <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{l.quantity}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{money(l.unitPrice, currency)}</td>
+                    {showTax && <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : money(tax, currency)}</td>}
                     <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{money(l.lineTotal, currency)}</td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -238,7 +257,7 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
             <div className="flex justify-between text-sm"><span className="text-muted-foreground">Subtotal</span><span className="tabular-nums text-foreground">{money(invoice.subtotal, currency)}</span></div>
-            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Tax</span><span className="tabular-nums text-foreground">{money(invoice.taxTotal, currency)}</span></div>
+            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span><span className="tabular-nums text-foreground">{money(invoice.taxTotal, currency)}</span></div>
             <div className="flex justify-between border-t pt-2.5 text-sm"><span className="font-medium text-foreground">Total</span><span className="font-medium tabular-nums text-foreground">{money(invoice.total, currency)}</span></div>
             {Number(invoice.amountPaid) > 0 && (
               <div className="flex justify-between text-sm"><span className="text-muted-foreground">Paid</span><span className="tabular-nums text-foreground">−{money(invoice.amountPaid, currency)}</span></div>

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -38,6 +38,11 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   const open = status === 'sent' || status === 'viewed';
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Per-line Tax column + a Subtotal/Tax breakdown appear only when this quote
+  // carries tax (otherwise the totals stay focused on due-on-acceptance).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   const seller = (quote.sellerSnapshot ?? null) as DocSeller | null;
 
@@ -125,10 +130,24 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
           imageUrl={(imageId) =>
             buildPortalApiUrl(`/quotes/public/${encodeURIComponent(token)}/images/${imageId}`)
           }
+          taxRate={taxRate}
+          showTax={showTax}
         />
 
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
+            {showTax && (
+              <>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Subtotal</span>
+                  <span className="tabular-nums text-foreground">{money(quote.subtotal ?? 0, currency)}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span>
+                  <span className="tabular-nums text-foreground">{money(quote.taxTotal ?? 0, currency)}</span>
+                </div>
+              </>
+            )}
             {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Monthly recurring</span>

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -125,6 +125,11 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Per-line Tax column + a Subtotal/Tax breakdown appear only when this quote
+  // carries tax (otherwise the totals stay focused on due-on-acceptance).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   return (
     <div className="space-y-5" data-testid="quote-detail">
@@ -166,10 +171,24 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
           lines={lines}
           currency={currency}
           imageUrl={(imageId) => buildPortalApiUrl(`/portal/quotes/${quote.id}/images/${imageId}`)}
+          taxRate={taxRate}
+          showTax={showTax}
         />
 
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
+            {showTax && (
+              <>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Subtotal</span>
+                  <span className="tabular-nums text-foreground">{money(quote.subtotal ?? 0, currency)}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span>
+                  <span className="tabular-nums text-foreground">{money(quote.taxTotal ?? 0, currency)}</span>
+                </div>
+              </>
+            )}
             {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Monthly recurring</span>

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -18,6 +18,17 @@ export function money(value: string | number, currencyCode: string): string {
   }
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays the server's authoritative figure, so the summed
+ *  column can differ by a rounding cent on many-line quotes. */
+function lineTax(lineTotal: string | number, taxable: boolean | undefined, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 // rich_text blocks store author HTML. The portal has no HTML sanitizer
 // dependency, and rendering untrusted HTML on the *unauthenticated* public page
 // would be an XSS sink, so we strip all tags to plain text (matching the PDF's
@@ -55,11 +66,15 @@ function PricingTable({
   currency,
   label,
   testId,
+  taxRate,
+  showTax,
 }: {
   lines: QuoteLine[];
   currency: string;
   label?: string;
   testId: string;
+  taxRate: number;
+  showTax: boolean;
 }) {
   if (lines.length === 0) return null;
   // Preserve sortOrder within each recurrence group, in the canonical group order.
@@ -67,6 +82,7 @@ function PricingTable({
     ...g,
     rows: lines.filter((l) => (l.recurrence || 'one_time') === g.key),
   })).filter((g) => g.rows.length > 0);
+  const groupColSpan = showTax ? 5 : 4;
 
   return (
     <div className="overflow-hidden rounded-lg border bg-card" data-testid={testId}>
@@ -82,6 +98,7 @@ function PricingTable({
               <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
               <th className="px-2 py-2.5 text-right font-medium">Qty</th>
               <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
               <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
             </tr>
           </thead>
@@ -90,23 +107,31 @@ function PricingTable({
               <Fragment key={g.key}>
                 {grouped.length > 1 && (
                   <tr className="bg-muted/20">
-                    <td colSpan={4} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:px-5">
+                    <td colSpan={groupColSpan} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:px-5">
                       {g.label}
                     </td>
                   </tr>
                 )}
-                {g.rows.map((l) => (
+                {g.rows.map((l) => {
+                  const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+                  return (
                   <tr key={l.id} data-testid={`quote-line-${l.id}`} className="border-b align-top last:border-0">
                     <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{Number(l.quantity)}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
                       {money(l.unitPrice, currency)}{g.suffix && <span className="text-xs">{g.suffix}</span>}
                     </td>
+                    {showTax && (
+                      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                        {tax === null ? '—' : money(tax, currency)}
+                      </td>
+                    )}
                     <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
                       {money(l.lineTotal, currency)}{g.suffix && <span className="text-xs text-muted-foreground">{g.suffix}</span>}
                     </td>
                   </tr>
-                ))}
+                  );
+                })}
               </Fragment>
             ))}
           </tbody>
@@ -121,12 +146,18 @@ export function QuoteBlocks({
   lines,
   currency,
   imageUrl,
+  taxRate = 0,
+  showTax = false,
 }: {
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   currency: string;
   // Builds the (authed or token-scoped) URL to fetch a quote image by id.
   imageUrl: (imageId: string) => string;
+  /** Quote tax rate as a fraction (e.g. 0.085); used for the per-line Tax column. */
+  taxRate?: number;
+  /** Whether the quote carries tax — shows the per-line Tax column when true. */
+  showTax?: boolean;
 }) {
   const ordered = [...blocks].sort((a, b) => a.sortOrder - b.sortOrder);
   // Track lines already consumed by a line_items block so orphan lines render once.
@@ -192,6 +223,8 @@ export function QuoteBlocks({
           currency={currency}
           label={label}
           testId={`quote-lines-${block.id}`}
+          taxRate={taxRate}
+          showTax={showTax}
         />
       );
     }
@@ -207,7 +240,7 @@ export function QuoteBlocks({
     <div className="space-y-6">
       {rendered}
       {orphanLines.length > 0 && (
-        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" />
+        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" taxRate={taxRate} showTax={showTax} />
       )}
     </div>
   );

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -390,6 +390,7 @@ export interface QuoteLine {
   quantity: string;
   unitPrice: string;
   lineTotal: string;
+  taxable?: boolean;
   recurrence: string;
   customerVisible: boolean;
   sortOrder: number;
@@ -399,6 +400,7 @@ export interface QuoteHeader extends QuoteSummary {
   introNotes?: string | null;
   terms?: string | null;
   subtotal?: string;
+  taxRate?: string | null;
   taxTotal?: string;
   oneTimeTotal?: string;
   monthlyRecurringTotal?: string;

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -93,6 +93,10 @@ describe('InvoiceDetail', () => {
     fireEvent.change(screen.getByTestId('invoice-payment-method'), { target: { value: 'check' } });
     fireEvent.click(screen.getByTestId('invoice-payment-submit'));
 
+    // Confirm dialog must open before the POST fires.
+    await waitFor(() => expect(screen.getByTestId('invoice-payment-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('invoice-payment-confirm'));
+
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     const postCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/payments') && (c[1] as RequestInit)?.method === 'POST');
     expect(JSON.parse((postCall![1] as RequestInit).body as string)).toMatchObject({ amount: 50, method: 'check' });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -16,6 +16,8 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './invoiceTypes';
 
@@ -45,6 +47,9 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
 
   // Payment confirm dialog
   const [payConfirmOpen, setPayConfirmOpen] = useState(false);
+  // Reverse-a-payment confirm: reversing is a financial mutation, so it goes
+  // through a confirm step that names the specific payment.
+  const [reversePayment, setReversePayment] = useState<InvoicePayment | null>(null);
   // Void dialog
   const [voidOpen, setVoidOpen] = useState(false);
   // Delete dialog
@@ -83,6 +88,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     const cost = Number(l.costBasis) * Number(l.quantity);
     return formatMoney(revenue - cost, currency);
   };
+
+  // Per-line Tax column appears only when this invoice carries tax (mirrors the
+  // header Tax row), otherwise it'd be a column of dashes.
+  const showTax = Number(invoice.taxTotal) > 0;
 
   const canRecordPayment = invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
@@ -174,13 +183,14 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     try {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}/payments/${paymentId}`, { method: 'DELETE' }),
-        errorFallback: 'Could not void the payment.',
-        successMessage: 'Payment voided',
+        errorFallback: 'Could not reverse the payment.',
+        successMessage: 'Payment reversed',
         onUnauthorized: UNAUTHORIZED,
       });
+      setReversePayment(null);
       refresh();
     } catch (err) {
-      handleActionError(err, 'Could not void the payment.');
+      handleActionError(err, 'Could not reverse the payment.');
     } finally {
       setBusy(false);
     }
@@ -256,11 +266,14 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <th className="px-3 py-2 text-right font-medium">Price</th>
                   {accountingView && <th className="px-3 py-2 text-right font-medium">Cost</th>}
                   {accountingView && <th className="px-3 py-2 text-right font-medium">Margin</th>}
+                  {showTax && <th className="px-3 py-2 text-right font-medium">Tax</th>}
                   <th className="px-3 py-2 text-right font-medium">Total</th>
                 </tr>
               </thead>
               <tbody>
-                {visibleLines.map((l) => (
+                {visibleLines.map((l) => {
+                  const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, invoice.taxRate) : null;
+                  return (
                   <tr
                     key={l.id}
                     data-testid={`invoice-detail-line-${l.id}`}
@@ -274,9 +287,11 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                     <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, currency)}</td>
                     {accountingView && <td className="px-3 py-2 text-right">{l.costBasis == null ? '—' : formatMoney(l.costBasis, currency)}</td>}
                     {accountingView && <td className="px-3 py-2 text-right">{lineMargin(l)}</td>}
+                    {showTax && <td className="px-3 py-2 text-right text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>}
                     <td className="px-3 py-2 text-right">{formatMoney(l.lineTotal, currency)}</td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -293,8 +308,8 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
             </div>
             <dl className="space-y-1 text-sm tabular-nums">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd>{formatMoney(invoice.subtotal, currency)}</dd></div>
-              {Number(invoice.taxTotal) > 0 && (
-                <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
+              {showTax && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Tax{invoice.taxRate ? ` (${pctFromFraction(invoice.taxRate)}%)` : ''}</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
               )}
               <div className="flex min-w-0 justify-between gap-2 font-semibold"><dt>Total</dt><dd className="break-words">{formatMoney(invoice.total, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Paid</dt><dd>{formatMoney(invoice.amountPaid, currency)}</dd></div>
@@ -406,7 +421,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                       <span className="whitespace-nowrap text-[11px] text-muted-foreground">via Stripe</span>
                     ) : can('invoices', 'send') ? (
                       <button
-                        type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
+                        type="button" onClick={() => setReversePayment(p)} disabled={busy || invoice.status === 'void'}
                         aria-label={`Reverse payment of ${formatMoney(p.amount, currency)}`}
                         data-testid={`invoice-payment-void-${p.id}`}
                         className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
@@ -486,6 +501,18 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Reverse-a-payment confirm dialog */}
+      <ConfirmDialog
+        open={reversePayment !== null}
+        onClose={() => setReversePayment(null)}
+        onConfirm={() => { if (reversePayment) void voidPayment(reversePayment.id); }}
+        isLoading={busy}
+        title="Reverse this payment?"
+        message={reversePayment ? `This reverses the ${formatMoney(reversePayment.amount, currency)} ${PAYMENT_METHOD_LABELS[reversePayment.method]} payment and removes it from the invoice balance. This can't be undone.` : ''}
+        confirmLabel="Reverse payment"
+        confirmTestId="invoice-payment-reverse-confirm"
+      />
 
       {/* Record payment confirm dialog */}
       <ConfirmDialog

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -43,6 +43,8 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
   const [payRef, setPayRef] = useState('');
   const [payDate, setPayDate] = useState(() => new Date().toISOString().slice(0, 10));
 
+  // Payment confirm dialog
+  const [payConfirmOpen, setPayConfirmOpen] = useState(false);
   // Void dialog
   const [voidOpen, setVoidOpen] = useState(false);
   // Delete dialog
@@ -265,7 +267,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                     className={`border-t ${l.parentLineId ? 'bg-muted/20 text-xs text-muted-foreground' : ''}`}
                   >
                     <td className={`px-3 py-2 ${l.parentLineId ? 'pl-8' : ''}`}>
-                      {l.parentLineId ? '↳ ' : ''}{l.description}
+                      {l.parentLineId ? <span aria-hidden="true">↳ </span> : ''}{l.description}
                       {accountingView && !l.customerVisible ? ' (hidden)' : ''}
                     </td>
                     <td className="px-3 py-2 text-right">{l.quantity}</td>
@@ -284,22 +286,24 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="invoice-detail-summary">
             <div className="mb-3 flex items-center justify-between">
-              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status">
+              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status" aria-label={`Status: ${statusLabel(invoice)}`}>
                 {statusLabel(invoice)}
               </span>
               <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
             </div>
             <dl className="space-y-1 text-sm tabular-nums">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd>{formatMoney(invoice.subtotal, currency)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
-              <div className="flex justify-between font-semibold"><dt>Total</dt><dd>{formatMoney(invoice.total, currency)}</dd></div>
+              {Number(invoice.taxTotal) > 0 && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
+              )}
+              <div className="flex min-w-0 justify-between gap-2 font-semibold"><dt>Total</dt><dd className="break-words">{formatMoney(invoice.total, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Paid</dt><dd>{formatMoney(invoice.amountPaid, currency)}</dd></div>
             </dl>
             {/* Balance-due focal number */}
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Balance due</span>
+            <div className="mt-3 flex min-w-0 items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Balance due</span>
               <span
-                className={`text-2xl font-semibold tabular-nums ${Number(invoice.balance) > 0 && invoice.status !== 'void' ? '' : 'text-muted-foreground'}`}
+                className={`break-words text-2xl font-semibold tabular-nums ${Number(invoice.balance) > 0 && invoice.status !== 'void' ? '' : 'text-muted-foreground'}`}
                 data-testid="invoice-detail-balance"
               >
                 {formatMoney(invoice.balance, currency)}
@@ -466,7 +470,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   />
                 </div>
                 <button
-                  type="button" onClick={() => void recordPayment()} disabled={busy || !payAmount}
+                  type="button" onClick={() => setPayConfirmOpen(true)} disabled={busy || !payAmount}
                   title={!payAmount ? 'Enter a payment amount to record it' : undefined}
                   aria-describedby={!payAmount ? 'invoice-payment-submit-hint' : undefined}
                   data-testid="invoice-payment-submit"
@@ -482,6 +486,19 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Record payment confirm dialog */}
+      <ConfirmDialog
+        open={payConfirmOpen}
+        onClose={() => setPayConfirmOpen(false)}
+        onConfirm={() => { setPayConfirmOpen(false); void recordPayment(); }}
+        isLoading={busy}
+        variant="warning"
+        title="Record payment"
+        message={`Record a ${formatMoney(Number(payAmount), currency)} payment (${PAYMENT_METHOD_LABELS[payMethod]}) dated ${payDate}?`}
+        confirmLabel="Record payment"
+        confirmTestId="invoice-payment-confirm"
+      />
 
       {/* Delete draft dialog */}
       <ConfirmDialog

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -403,10 +403,11 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                     ) : can('invoices', 'send') ? (
                       <button
                         type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
+                        aria-label={`Reverse payment of ${formatMoney(p.amount, currency)}`}
                         data-testid={`invoice-payment-void-${p.id}`}
                         className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
                       >
-                        Void
+                        Reverse
                       </button>
                     ) : null}
                   </li>
@@ -436,11 +437,13 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <input
                     type="number" min="0" step="0.01" placeholder="Amount" value={payAmount}
                     onChange={(e) => setPayAmount(e.target.value)}
+                    aria-label="Amount"
                     data-testid="invoice-payment-amount"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                   <select
                     value={payMethod} onChange={(e) => setPayMethod(e.target.value as PaymentMethod)}
+                    aria-label="Payment method"
                     data-testid="invoice-payment-method"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   >
@@ -451,11 +454,13 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <input
                     type="text" placeholder="Reference (optional)" value={payRef}
                     onChange={(e) => setPayRef(e.target.value)}
+                    aria-label="Reference"
                     data-testid="invoice-payment-ref"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                   <input
                     type="date" value={payDate} onChange={(e) => setPayDate(e.target.value)}
+                    aria-label="Payment date"
                     data-testid="invoice-payment-date"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   />

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useState, type CSSProperties } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { handleActionError } from '../../lib/runAction';
+import { useOrgStore } from '../../stores/orgStore';
+import {
+  type InvoiceDetail as InvoiceDetailData,
+  type InvoiceLine,
+  STATUS_COLORS,
+  statusLabel,
+  formatDate,
+  formatMoney,
+  sellerLines,
+} from './invoiceTypes';
+
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+
+function LineRow({ line, currency }: { line: InvoiceLine; currency: string }) {
+  const child = !!line.parentLineId;
+  return (
+    <tr className="border-b align-top last:border-0">
+      <td className={`px-4 py-3 sm:px-5 ${child ? 'pl-8 text-muted-foreground' : 'text-foreground'}`}>
+        {child ? '↳ ' : ''}{line.description}
+      </td>
+      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{line.quantity}</td>
+      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{formatMoney(line.unitPrice, currency)}</td>
+      <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{formatMoney(line.lineTotal, currency)}</td>
+    </tr>
+  );
+}
+
+interface DocumentProps {
+  detail: InvoiceDetailData;
+  /** Resolved customer/bill-to name (parent looks it up against the org list). */
+  customerName: string;
+}
+
+/** Pure, presentational customer-facing invoice document. Renders the same
+ *  customer-visible lines and totals the customer receives on their invoice,
+ *  using the seller snapshot and the app accent. The sibling of QuoteDocument;
+ *  works for drafts without a portal round-trip. */
+export function InvoiceDocument({ detail, customerName }: DocumentProps) {
+  const { invoice, lines } = detail;
+  const currency = invoice.currencyCode;
+  const seller = invoice.sellerSnapshot;
+  // Invoices carry no per-partner branding payload (unlike quotes), so the
+  // document is anchored on the app's primary accent.
+  const accentStyle = { ['--doc-accent']: 'hsl(var(--primary))' } as CSSProperties;
+
+  // Customers only ever see customer-visible lines — cost/margin and hidden
+  // bundle components never reach the document.
+  const visibleLines = useMemo(
+    () => lines.filter((l) => l.customerVisible).sort((a, b) => a.sortOrder - b.sortOrder),
+    [lines],
+  );
+  const isEmpty = visibleLines.length === 0;
+  const amountPaid = Number(invoice.amountPaid);
+
+  return (
+    <div
+      style={accentStyle}
+      data-testid="invoice-document"
+      className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-sm"
+    >
+      {/* Accent top rule (mirrors QuoteDocument) */}
+      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
+
+      <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
+        {/* ── Header ─────────────────────────────────────────────── */}
+        <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            {seller?.name ? (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                {seller.name}
+              </p>
+            ) : (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                Invoice
+              </p>
+            )}
+            {seller && (
+              <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
+                {sellerLines(seller.address).map((line, i) => <p key={i}>{line}</p>)}
+                {seller.phone && <p>{seller.phone}</p>}
+                {seller.email && <p>{seller.email}</p>}
+                {seller.website && <p>{seller.website}</p>}
+              </address>
+            )}
+          </div>
+
+          <div className="space-y-2 sm:text-right">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>
+              Invoice
+            </p>
+            <p className="text-2xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-number">
+              {invoice.invoiceNumber ?? 'Draft'}
+            </p>
+            <span
+              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`}
+            >
+              {statusLabel(invoice)}
+            </span>
+            <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
+              {invoice.issueDate && (
+                <div className="flex gap-2"><dt>Issued</dt><dd className="font-medium text-foreground/80">{formatDate(invoice.issueDate)}</dd></div>
+              )}
+              {invoice.dueDate && (
+                <div className="flex gap-2"><dt>Due</dt><dd className="font-medium text-foreground/80">{formatDate(invoice.dueDate)}</dd></div>
+              )}
+            </dl>
+          </div>
+        </header>
+
+        {/* ── Bill to + notes ────────────────────────────────────── */}
+        <section className="space-y-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Bill to</p>
+            <p className="mt-1 text-base font-medium text-foreground" data-testid="invoice-document-customer">{customerName}</p>
+          </div>
+          {invoice.notes?.trim() && (
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">
+              {invoice.notes.trim()}
+            </p>
+          )}
+        </section>
+
+        {/* ── Lines ──────────────────────────────────────────────── */}
+        {isEmpty ? (
+          <div className="rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center text-sm text-muted-foreground">
+            This invoice doesn’t have any line items yet.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border bg-card">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[30rem] text-sm" data-testid="invoice-document-lines">
+                <thead>
+                  <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+                    <th className="px-2 py-2.5 text-right font-medium">Qty</th>
+                    <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+                    <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleLines.map((l) => <LineRow key={l.id} line={l} currency={currency} />)}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* ── Totals ─────────────────────────────────────────────── */}
+        {!isEmpty && (
+          <section className="flex justify-end">
+            <div className="w-full max-w-xs space-y-2.5">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span className="tabular-nums text-foreground">{formatMoney(invoice.subtotal, currency)}</span>
+              </div>
+              {Number(invoice.taxTotal) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax</span>
+                  <span className="tabular-nums text-foreground">{formatMoney(invoice.taxTotal, currency)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Total</span>
+                <span className="tabular-nums text-foreground">{formatMoney(invoice.total, currency)}</span>
+              </div>
+              {amountPaid > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Paid</span>
+                  <span className="tabular-nums text-foreground">{formatMoney(invoice.amountPaid, currency)}</span>
+                </div>
+              )}
+              <div
+                className="flex items-baseline justify-between border-t pt-3"
+                style={{ borderColor: 'var(--doc-accent)' }}
+              >
+                <span className="text-sm font-semibold text-foreground">Amount due</span>
+                <span
+                  className="text-2xl font-semibold tabular-nums"
+                  style={{ color: 'var(--doc-accent)' }}
+                  data-testid="invoice-document-due"
+                >
+                  {formatMoney(invoice.balance, currency)}
+                </span>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── Terms ──────────────────────────────────────────────── */}
+        {invoice.termsAndConditions?.trim() && (
+          <section className="space-y-2 border-t pt-6">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</h3>
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-xs leading-relaxed text-muted-foreground">
+              {invoice.termsAndConditions.trim()}
+            </p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Preview-tab wrapper: resolves the customer name from the loaded org list (same
+ *  source as InvoiceDetail), renders the document, and offers a PDF download. */
+export default function InvoiceDocumentPreview({ detail }: { detail: InvoiceDetailData }) {
+  const { invoice } = detail;
+  const organizations = useOrgStore((s) => s.organizations);
+  const [busy, setBusy] = useState(false);
+
+  const customerName = useMemo(() => {
+    const billTo = invoice.billToName?.trim();
+    if (billTo) return billTo;
+    const resolved = organizations.find((o) => o.id === invoice.orgId)?.name?.trim();
+    return resolved || invoice.orgId.slice(0, 8);
+  }, [invoice.billToName, invoice.orgId, organizations]);
+
+  const downloadPdf = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetchWithAuth(`/invoices/${invoice.id}/pdf`);
+      if (res.status === 401) return UNAUTHORIZED();
+      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the invoice PDF.'); return; }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      handleActionError(err, 'Could not download the invoice PDF.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, invoice.id, invoice.invoiceNumber]);
+
+  return (
+    <div className="space-y-4" data-testid="invoice-preview">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">This is what your customer sees on their invoice.</p>
+        <button
+          type="button"
+          onClick={() => void downloadPdf()}
+          disabled={busy}
+          data-testid="invoice-preview-download-pdf"
+          className="inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+        >
+          {busy ? 'Preparing…' : 'Download PDF'}
+        </button>
+      </div>
+      <div className="rounded-xl bg-muted/30 p-2 sm:p-8">
+        <InvoiceDocument detail={detail} customerName={customerName} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -20,7 +20,7 @@ function LineRow({ line, currency }: { line: InvoiceLine; currency: string }) {
   return (
     <tr className="border-b align-top last:border-0">
       <td className={`px-4 py-3 sm:px-5 ${child ? 'pl-8 text-muted-foreground' : 'text-foreground'}`}>
-        {child ? '↳ ' : ''}{line.description}
+        {child ? <span aria-hidden="true">↳ </span> : ''}{line.description}
       </td>
       <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{line.quantity}</td>
       <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{formatMoney(line.unitPrice, currency)}</td>
@@ -62,9 +62,6 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
       data-testid="invoice-document"
       className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-sm"
     >
-      {/* Accent top rule (mirrors QuoteDocument) */}
-      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
-
       <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
         {/* ── Header ─────────────────────────────────────────────── */}
         <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
@@ -78,6 +75,8 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
                 Invoice
               </p>
             )}
+            {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
+            <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
             {seller && (
               <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
                 {sellerLines(seller.address).map((line, i) => <p key={i}>{line}</p>)}
@@ -89,14 +88,13 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
           </div>
 
           <div className="space-y-2 sm:text-right">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>
-              Invoice
-            </p>
-            <p className="text-2xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-number">
+            <p className="text-[1.75rem] font-semibold leading-none tracking-tight text-foreground" data-testid="invoice-document-number">
               {invoice.invoiceNumber ?? 'Draft'}
             </p>
+            <p className="text-sm font-medium text-muted-foreground">Invoice</p>
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`}
+              aria-label={`Status: ${statusLabel(invoice)}`}
             >
               {statusLabel(invoice)}
             </span>

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -10,13 +10,16 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
-function LineRow({ line, currency }: { line: InvoiceLine; currency: string }) {
+function LineRow({ line, currency, taxRate, showTax }: { line: InvoiceLine; currency: string; taxRate: string | null; showTax: boolean }) {
   const child = !!line.parentLineId;
+  const tax = showTax ? lineTaxAmount(line.lineTotal, line.taxable, taxRate) : null;
   return (
     <tr className="border-b align-top last:border-0">
       <td className={`px-4 py-3 sm:px-5 ${child ? 'pl-8 text-muted-foreground' : 'text-foreground'}`}>
@@ -24,6 +27,9 @@ function LineRow({ line, currency }: { line: InvoiceLine; currency: string }) {
       </td>
       <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{line.quantity}</td>
       <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{formatMoney(line.unitPrice, currency)}</td>
+      {showTax && (
+        <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>
+      )}
       <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{formatMoney(line.lineTotal, currency)}</td>
     </tr>
   );
@@ -55,6 +61,9 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
   );
   const isEmpty = visibleLines.length === 0;
   const amountPaid = Number(invoice.amountPaid);
+  // Only surface the per-line Tax column when this invoice carries tax — mirrors
+  // the header Tax row's visibility (otherwise it's a column of dashes).
+  const showTax = Number(invoice.taxTotal) > 0;
 
   return (
     <div
@@ -136,11 +145,12 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
                     <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
                     <th className="px-2 py-2.5 text-right font-medium">Qty</th>
                     <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+                    {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
                     <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {visibleLines.map((l) => <LineRow key={l.id} line={l} currency={currency} />)}
+                  {visibleLines.map((l) => <LineRow key={l.id} line={l} currency={currency} taxRate={invoice.taxRate} showTax={showTax} />)}
                 </tbody>
               </table>
             </div>
@@ -155,9 +165,9 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
                 <span className="text-muted-foreground">Subtotal</span>
                 <span className="tabular-nums text-foreground">{formatMoney(invoice.subtotal, currency)}</span>
               </div>
-              {Number(invoice.taxTotal) > 0 && (
+              {showTax && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Tax</span>
+                  <span className="text-muted-foreground">Tax{invoice.taxRate ? ` (${pctFromFraction(invoice.taxRate)}%)` : ''}</span>
                   <span className="tabular-nums text-foreground">{formatMoney(invoice.taxTotal, currency)}</span>
                 </div>
               )}

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -139,6 +139,7 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Invoice issued and sent' }));
   });
@@ -177,6 +178,7 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
     // never a success "sent" claim when nothing went out

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -262,7 +262,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                   <th className="px-3 py-2 text-right font-medium">Qty</th>
                   <th className="px-3 py-2 text-right font-medium">Price</th>
                   <th className="px-3 py-2 text-center font-medium">Tax</th>
-                  <th className="px-3 py-2 text-center font-medium">Visible</th>
+                  <th className="px-3 py-2 text-center font-medium" title="Whether this line appears on the customer's invoice">Customer-visible</th>
                   <th className="px-3 py-2 text-right font-medium">Total</th>
                   <th className="px-3 py-2" />
                 </tr>

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -4,6 +4,8 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { UnsavedBadge } from './billingUi';
 import {
   type InvoiceDetail,
   type InvoiceLine,
@@ -32,6 +34,9 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   // an unambiguous in-flight label. Without it the disabled-but-still-"Issue"
   // button + still-"Draft" header during the POST reads as "done but stuck" (#1418).
   const [issuing, setIssuing] = useState(false);
+  // Issue-and-send emails the customer and can't be undone, so it goes through a
+  // confirm step (plain Issue stays direct — it's reversible via Void).
+  const [issueSendOpen, setIssueSendOpen] = useState(false);
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
   const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
@@ -235,6 +240,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       refresh();
       setIssuing(false);
       setBusy(false);
+      setIssueSendOpen(false);
     }
   }, [busy, invoice.id, refresh]);
 
@@ -244,7 +250,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
     <div className="space-y-6" data-testid="invoice-editor">
       {unapprovedCount > 0 && (
         <div
-          className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400"
+          className="rounded-md border border-warning/40 bg-warning/15 px-4 py-3 text-sm text-[hsl(36_92%_28%)] dark:text-warning"
           data-testid="invoice-unapproved-warning"
         >
           {unapprovedCount} line{unapprovedCount === 1 ? '' : 's'} reference unapproved time. Review before issuing.
@@ -398,7 +404,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-sm">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</h3>
+              <UnsavedBadge show={notesDirty} />
+            </div>
             <textarea
               value={notes}
               onChange={(e) => { setNotes(e.target.value); setNotesDirty(true); }}
@@ -409,13 +418,16 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-notes"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${notesDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Internal or customer notes…"
             />
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-sm">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <UnsavedBadge show={termsDirty} />
+            </div>
             <textarea
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
@@ -423,7 +435,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-terms"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
           </div>
@@ -443,7 +455,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             {can('invoices', 'send') && (
               <button
                 type="button"
-                onClick={() => void issue(true)}
+                onClick={() => setIssueSendOpen(true)}
                 disabled={busy || !hasVisibleLines}
                 data-testid="invoice-issue-send"
                 className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
@@ -459,6 +471,18 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={issueSendOpen}
+        onClose={() => setIssueSendOpen(false)}
+        onConfirm={() => void issue(true)}
+        isLoading={issuing}
+        variant="warning"
+        title="Issue and send this invoice?"
+        message={`This issues the invoice and emails it to ${invoice.billToName ?? 'the customer'} for ${formatMoney(invoice.total, currency)}. This can't be undone.`}
+        confirmLabel="Issue & Send"
+        confirmTestId="invoice-issue-send-confirm"
+      />
     </div>
   );
 }
@@ -531,7 +555,7 @@ function LineRow({
       </tr>
       {children.map((ch) => (
         <tr key={ch.id} className="border-t bg-muted/20 text-xs text-muted-foreground" data-testid={`invoice-line-child-${ch.id}`}>
-          <td className="px-3 py-1.5 pl-8">↳ {ch.description}{!ch.customerVisible ? ' (hidden)' : ''}</td>
+          <td className="px-3 py-1.5 pl-8"><span aria-hidden="true">↳ </span>{ch.description}{!ch.customerVisible ? ' (hidden)' : ''}</td>
           <td className="px-3 py-1.5 text-right">{ch.quantity}</td>
           <td className="px-3 py-1.5 text-right">{formatMoney(ch.unitPrice, currency)}</td>
           <td colSpan={4} />

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -318,19 +318,19 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             {addMode === 'manual' ? (
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_80px_100px_auto_auto]">
                 <input
-                  type="text" placeholder="Description" value={manualDesc}
+                  type="text" placeholder="Description" aria-label="Line description" value={manualDesc}
                   onChange={(e) => setManualDesc(e.target.value)}
                   data-testid="invoice-manual-desc"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder="Qty" value={manualQty}
+                  type="number" min="0" step="0.01" placeholder="Qty" aria-label="Quantity" value={manualQty}
                   onChange={(e) => setManualQty(e.target.value)}
                   data-testid="invoice-manual-qty"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder="Price" value={manualPrice}
+                  type="number" min="0" step="0.01" placeholder="Price" aria-label="Unit price" value={manualPrice}
                   onChange={(e) => setManualPrice(e.target.value)}
                   data-testid="invoice-manual-price"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -14,6 +14,13 @@ vi.mock('../../stores/auth', () => ({
     { getState: () => ({ tokens: null }) },
   ),
 }));
+// The Preview tab's InvoiceDocument reads the org list off orgStore; stub it so
+// the real module (which registers an org-id provider on the auth store at import
+// time) is never pulled into this partially-mocked auth setup.
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    selector({ organizations: [] }),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -3,18 +3,35 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import InvoiceEditor from './InvoiceEditor';
 import InvoiceDetail from './InvoiceDetail';
+import InvoiceDocumentPreview from './InvoiceDocument';
 import { type InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
+type Tab = 'editor' | 'preview' | 'detail';
+
+const TABS: { value: Tab; label: string }[] = [
+  { value: 'editor', label: 'Editor' },
+  { value: 'preview', label: 'Preview' },
+  { value: 'detail', label: 'Detail' },
+];
+
 interface Props {
   invoiceId?: string;
+}
+
+function readTab(isDraft: boolean): Tab {
+  if (typeof window === 'undefined') return isDraft ? 'editor' : 'detail';
+  const raw = window.location.hash.replace(/^#/, '');
+  if (TABS.some((t) => t.value === raw)) return raw as Tab;
+  return isDraft ? 'editor' : 'detail';
 }
 
 export default function InvoiceWorkspace({ invoiceId }: Props) {
   const [detail, setDetail] = useState<InvoiceDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [tab, setTab] = useState<Tab>('editor');
 
   const load = useCallback(async () => {
     if (!invoiceId) { setError('Missing invoice id'); setLoading(false); return; }
@@ -35,6 +52,25 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
   }, [invoiceId]);
 
   useEffect(() => { void load(); }, [load]);
+
+  // Initialise the active tab from the hash once we know whether it's a draft.
+  const isDraft = detail?.invoice.status === 'draft';
+  useEffect(() => {
+    if (!detail) return;
+    setTab(readTab(detail.invoice.status === 'draft'));
+  }, [detail]);
+
+  // React to back/forward hash changes.
+  useEffect(() => {
+    const onHash = () => setTab(readTab(detail?.invoice.status === 'draft'));
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, [detail]);
+
+  const selectTab = useCallback((next: Tab) => {
+    setTab(next);
+    if (typeof window !== 'undefined') window.location.hash = `#${next}`;
+  }, []);
 
   if (loading) {
     return (
@@ -57,8 +93,6 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     );
   }
 
-  const isDraft = detail.invoice.status === 'draft';
-
   return (
     <div className="space-y-4" data-testid="invoice-workspace">
       <div className="flex items-center justify-between">
@@ -69,11 +103,41 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
           </h1>
         </div>
       </div>
-      {isDraft ? (
-        <InvoiceEditor detail={detail} onChanged={() => void load()} />
-      ) : (
-        <InvoiceDetail detail={detail} onChanged={() => void load()} />
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b" role="tablist" data-testid="invoice-workspace-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.value}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.value}
+            onClick={() => selectTab(t.value)}
+            data-testid={`invoice-tab-${t.value}`}
+            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
+              tab === t.value
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'editor' && (
+        isDraft ? (
+          <InvoiceEditor detail={detail} onChanged={() => void load()} />
+        ) : (
+          <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="invoice-editor-locked">
+            This invoice is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
+          </div>
+        )
       )}
+
+      {tab === 'preview' && <InvoiceDocumentPreview detail={detail} />}
+
+      {tab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void load()} />}
     </div>
   );
 }

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -33,23 +33,32 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
 
-  const load = useCallback(async () => {
+  // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
+  // so the editor stays mounted — a full-page spinner would remount the form and
+  // discard the user's in-progress local state and cursor position. Only the
+  // initial load shows the spinner / replaces the view on error.
+  const fetchDetail = useCallback(async (quiet = false) => {
     if (!invoiceId) { setError('Missing invoice id'); setLoading(false); return; }
     try {
-      setLoading(true);
+      if (!quiet) setLoading(true);
       setError(undefined);
       const res = await fetchWithAuth(`/invoices/${invoiceId}`);
       if (res.status === 401) return UNAUTHORIZED();
-      if (res.status === 404) { setError('Invoice not found.'); return; }
+      if (res.status === 404) { if (!quiet) setError('Invoice not found.'); return; }
       if (!res.ok) throw new Error('Failed to load invoice');
       const body = (await res.json()) as { data: InvoiceDetailData };
       setDetail(body.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load invoice');
+      // A failed quiet reload leaves the editor intact; the inline action's own
+      // runAction toast already surfaced the failure.
+      if (!quiet) setError(err instanceof Error ? err.message : 'Failed to load invoice');
     } finally {
-      setLoading(false);
+      if (!quiet) setLoading(false);
     }
   }, [invoiceId]);
+
+  const load = useCallback(() => fetchDetail(false), [fetchDetail]);
+  const reload = useCallback(() => fetchDetail(true), [fetchDetail]);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -127,7 +136,7 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
 
       {tab === 'editor' && (
         isDraft ? (
-          <InvoiceEditor detail={detail} onChanged={() => void load()} />
+          <InvoiceEditor detail={detail} onChanged={() => void reload()} />
         ) : (
           <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="invoice-editor-locked">
             This invoice is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
@@ -137,7 +146,7 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
 
       {tab === 'preview' && <InvoiceDocumentPreview detail={detail} />}
 
-      {tab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void load()} />}
+      {tab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void reload()} />}
     </div>
   );
 }

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -102,6 +102,12 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     );
   }
 
+  // The Editor only applies to drafts, so it's hidden once an invoice is issued —
+  // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
+  // on a non-draft falls back to Detail.
+  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
+  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
+
   return (
     <div className="space-y-4" data-testid="invoice-workspace">
       <div className="flex items-center justify-between">
@@ -115,16 +121,16 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
 
       {/* Tabs */}
       <div className="flex gap-1 border-b" role="tablist" data-testid="invoice-workspace-tabs">
-        {TABS.map((t) => (
+        {visibleTabs.map((t) => (
           <button
             key={t.value}
             type="button"
             role="tab"
-            aria-selected={tab === t.value}
+            aria-selected={activeTab === t.value}
             onClick={() => selectTab(t.value)}
             data-testid={`invoice-tab-${t.value}`}
             className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
-              tab === t.value
+              activeTab === t.value
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
@@ -134,19 +140,11 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
         ))}
       </div>
 
-      {tab === 'editor' && (
-        isDraft ? (
-          <InvoiceEditor detail={detail} onChanged={() => void reload()} />
-        ) : (
-          <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="invoice-editor-locked">
-            This invoice is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
-          </div>
-        )
-      )}
+      {activeTab === 'editor' && isDraft && <InvoiceEditor detail={detail} onChanged={() => void reload()} />}
 
-      {tab === 'preview' && <InvoiceDocumentPreview detail={detail} />}
+      {activeTab === 'preview' && <InvoiceDocumentPreview detail={detail} />}
 
-      {tab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void reload()} />}
     </div>
   );
 }

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import InvoiceEditor from './InvoiceEditor';
@@ -81,6 +81,24 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     if (typeof window !== 'undefined') window.location.hash = `#${next}`;
   }, []);
 
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
+  // tab is both activated and focused.
+  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
+    const idx = tabs.findIndex((t) => t.value === current);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = tabs[nextIdx].value;
+    selectTab(next);
+    if (typeof document !== 'undefined') document.getElementById(`invoice-tab-${next}`)?.focus();
+  }, [selectTab]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16" data-testid="invoice-workspace-loading">
@@ -120,13 +138,21 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b" role="tablist" data-testid="invoice-workspace-tabs">
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        data-testid="invoice-workspace-tabs"
+        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
+      >
         {visibleTabs.map((t) => (
           <button
             key={t.value}
             type="button"
             role="tab"
+            id={`invoice-tab-${t.value}`}
             aria-selected={activeTab === t.value}
+            aria-controls={`invoice-tabpanel-${t.value}`}
+            tabIndex={activeTab === t.value ? 0 : -1}
             onClick={() => selectTab(t.value)}
             data-testid={`invoice-tab-${t.value}`}
             className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
@@ -140,11 +166,23 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
         ))}
       </div>
 
-      {activeTab === 'editor' && isDraft && <InvoiceEditor detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'editor' && isDraft && (
+        <div role="tabpanel" id="invoice-tabpanel-editor" aria-labelledby="invoice-tab-editor" tabIndex={0}>
+          <InvoiceEditor detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
 
-      {activeTab === 'preview' && <InvoiceDocumentPreview detail={detail} />}
+      {activeTab === 'preview' && (
+        <div role="tabpanel" id="invoice-tabpanel-preview" aria-labelledby="invoice-tab-preview" tabIndex={0}>
+          <InvoiceDocumentPreview detail={detail} />
+        </div>
+      )}
 
-      {activeTab === 'detail' && <InvoiceDetail detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'detail' && (
+        <div role="tabpanel" id="invoice-tabpanel-detail" aria-labelledby="invoice-tab-detail" tabIndex={0}>
+          <InvoiceDetail detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -69,7 +69,7 @@ describe('InvoicesPage', () => {
     // Overdue badge label + restrained overdue cue (red dot indicator + due tone),
     // replacing the old full-row red tint.
     expect(screen.getByTestId('invoices-status-inv-1')).toHaveTextContent('Overdue');
-    expect(row.querySelector('.bg-red-500')).not.toBeNull();
+    expect(row.querySelector('.bg-destructive')).not.toBeNull();
   });
 
   it('writes filter selections to the URL hash', async () => {

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
@@ -295,19 +296,34 @@ export function InvoicesPage() {
     return { outstanding, overdue, openCount: open.length, ccy };
   }, [invoices]);
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
-    <th className="px-3 py-3 text-right font-medium">
-      <button
-        type="button"
-        onClick={() => toggleSort(sortKey)}
-        className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-        data-testid={`invoices-sort-${sortKey}`}
-      >
-        {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
-      </button>
-    </th>
-  );
+  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
+    const active = sort?.key === sortKey;
+    const ariaLabel = active
+      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+      : `Sort by ${label}`;
+    return (
+      <th className="px-3 py-3 text-right font-medium">
+        <button
+          type="button"
+          onClick={() => toggleSort(sortKey)}
+          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
+          data-testid={`invoices-sort-${sortKey}`}
+          aria-label={ariaLabel}
+        >
+          {label}
+          {active ? (
+            sort!.dir === 'asc' ? (
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            )
+          ) : (
+            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </th>
+    );
+  };
 
   if (forbidden) {
     return (
@@ -720,6 +736,10 @@ export function InvoicesPage() {
 function SortHeaderLeft({
   label, sortKey, sort, onSort,
 }: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
+  const active = sort?.key === sortKey;
+  const ariaLabel = active
+    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
   return (
     <th className="px-3 py-3 font-medium">
       <button
@@ -727,9 +747,18 @@ function SortHeaderLeft({
         onClick={() => onSort(sortKey)}
         className="inline-flex items-center gap-1 hover:text-foreground"
         data-testid={`invoices-sort-${sortKey}`}
+        aria-label={ariaLabel}
       >
         {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+        {active ? (
+          sort!.dir === 'asc' ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
       </button>
     </th>
   );

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -302,7 +302,7 @@ export function InvoicesPage() {
       ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
       : `Sort by ${label}`;
     return (
-      <th className="px-3 py-3 text-right font-medium">
+      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
         <button
           type="button"
           onClick={() => toggleSort(sortKey)}
@@ -366,11 +366,11 @@ export function InvoicesPage() {
             <button
               type="button"
               onClick={() => applyFilter({ status: 'overdue' })}
-              className="rounded-lg border border-red-500/30 bg-red-500/5 px-4 py-3 text-left transition hover:bg-red-500/10"
+              className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-left transition hover:bg-destructive/10"
               data-testid="invoices-overdue-card"
             >
-              <div className="text-xs text-red-700 dark:text-red-400">Overdue</div>
-              <div className="mt-0.5 text-lg font-semibold tabular-nums text-red-700 dark:text-red-400">{summary.overdue}</div>
+              <div className="text-xs text-destructive">Overdue</div>
+              <div className="mt-0.5 text-lg font-semibold tabular-nums text-destructive">{summary.overdue}</div>
               <div className="text-xs text-muted-foreground">needs follow-up</div>
             </button>
           )}
@@ -521,7 +521,7 @@ export function InvoicesPage() {
                         </td>
                         <td className="px-3 py-3 font-medium">
                           <span className="flex items-center gap-2">
-                            <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-red-500' : 'bg-transparent'}`} aria-hidden="true" />
+                            <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-destructive' : 'bg-transparent'}`} aria-hidden="true" />
                             {inv.invoiceNumber ?? (
                               <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                                 Draft
@@ -531,7 +531,7 @@ export function InvoicesPage() {
                         </td>
                         <td className="px-3 py-3">{orgName(inv.orgId)}</td>
                         <td className="px-3 py-3 text-muted-foreground">{formatDate(inv.issueDate)}</td>
-                        <td className={`px-3 py-3 ${overdue ? 'font-medium text-red-700 dark:text-red-400' : 'text-muted-foreground'}`}>
+                        <td className={`px-3 py-3 ${overdue ? 'font-medium text-destructive' : 'text-muted-foreground'}`}>
                           {formatDate(inv.dueDate)}
                         </td>
                         <td className="px-3 py-3 text-right tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</td>
@@ -542,6 +542,7 @@ export function InvoicesPage() {
                           <span
                             className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
                             data-testid={`invoices-status-${inv.id}`}
+                            aria-label={`Status: ${statusLabel(inv)}`}
                           >
                             {statusLabel(inv)}
                           </span>
@@ -741,7 +742,7 @@ function SortHeaderLeft({
     ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
     : `Sort by ${label}`;
   return (
-    <th className="px-3 py-3 font-medium">
+    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
       <button
         type="button"
         onClick={() => onSort(sortKey)}

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -1,0 +1,36 @@
+// Shared presentational helpers for the quote + invoice billing UI, so copy and
+// affordances can't drift between the editor and detail/document surfaces.
+
+/**
+ * Inline "Unsaved" affordance for blur-saved fields (terms / notes). Shown while
+ * the field holds uncommitted edits; the field's onBlur save clears the dirty
+ * flag on success, so this also stays lit if a save FAILS — surfacing that the
+ * edit didn't persist instead of relying on a transient toast the user may miss.
+ */
+export function UnsavedBadge({ show }: { show: boolean }) {
+  if (!show) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-warning"
+      data-testid="unsaved-badge"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden="true" />
+      Unsaved
+    </span>
+  );
+}
+
+/**
+ * The recurring-billing explanation shown beneath quote totals. Single source so
+ * the editor and the detail view can't drift (the customer-facing QuoteDocument
+ * keeps its own shorter copy intentionally).
+ */
+export function RecurringBillingNote({ className, testId }: { className?: string; testId?: string }) {
+  return (
+    <p className={`text-xs leading-relaxed text-muted-foreground ${className ?? ''}`} data-testid={testId}>
+      Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their
+      own schedule via the contract. The first-period total combines the one-time charges with the first period of
+      each recurring cadence.
+    </p>
+  );
+}

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -181,6 +181,23 @@ export function pctFromFraction(frac: string | number | null): string {
   return String(Number((Number(frac) * 100).toFixed(3)));
 }
 
+/** Per-line tax amount for the line-table Tax column: taxable lines get
+ *  lineTotal × rate rounded to cents; non-taxable lines, a null/empty rate, or a
+ *  non-positive rate return null (rendered as '—'). The header Tax stays the
+ *  server's authoritative `taxTotal`, so a quote/invoice with many taxable lines
+ *  can differ from the summed column by a rounding cent. Mirrors quoteTypes. */
+export function lineTaxAmount(
+  lineTotal: string | number,
+  taxable: boolean,
+  taxRate: string | number | null,
+): number | null {
+  if (!taxable) return null;
+  const rate = taxRate === null || taxRate === '' ? 0 : Number(taxRate);
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
 export function formatDate(value: string | null | undefined): string {
   if (!value) return '—';

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -109,14 +109,37 @@ export const STATUS_LABELS: Record<InvoiceStatus, string> = {
   void: 'Void',
 };
 
-// Tailwind badge classes per status (mirrors the device/org status-pill style).
+/**
+ * Status-pill color roles, built from the app's semantic tokens (success /
+ * warning / info / destructive) rather than raw Tailwind palette hues. Shared by
+ * both the invoice and quote status pills (imported by quoteTypes) so the
+ * vocabulary can't drift between the two sibling surfaces.
+ *
+ * Five roles, not a per-status rainbow: meaning drives the hue (neutral = not
+ * sent, info = awaiting the customer, success = won/paid, warning = lapsing,
+ * danger = lost/overdue). The text label carries the finer distinction (Sent vs
+ * Viewed, Accepted vs Converted), so colour stays scannable.
+ *
+ * `info`/`success` base tokens are dark enough (L≈37-38%) to read on their own
+ * 10% tint; `warning`/`danger` base tokens (amber L50% / red L56%) fail WCAG as
+ * text on a light tint, so light mode uses a darker shade of the SAME token hue
+ * and dark mode (where the bg is dark) uses the token directly.
+ */
+export const STATUS_PILL = {
+  neutral: 'border-border bg-muted text-muted-foreground',
+  info: 'border-info/30 bg-info/10 text-info',
+  success: 'border-success/30 bg-success/10 text-success',
+  warning: 'border-warning/40 bg-warning/15 text-[hsl(36_92%_28%)] dark:text-warning',
+  danger: 'border-destructive/40 bg-destructive/10 text-[hsl(4_74%_42%)] dark:text-destructive',
+} as const;
+
 export const STATUS_COLORS: Record<InvoiceStatus, string> = {
-  draft: 'border-border bg-muted text-muted-foreground',
-  sent: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  partially_paid: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-  overdue: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
-  paid: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  void: 'border-border bg-muted text-muted-foreground line-through',
+  draft: STATUS_PILL.neutral,
+  sent: STATUS_PILL.info,
+  partially_paid: STATUS_PILL.warning,
+  overdue: STATUS_PILL.danger,
+  paid: STATUS_PILL.success,
+  void: `${STATUS_PILL.neutral} line-through`,
 };
 
 /** Display label for an invoice's status. The 'sent' lifecycle status means

--- a/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
+
+// Same auth-mock pattern as QuoteDetail.delete.test.tsx.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/quotes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/api/quotes')>();
+  return { ...actual, sendQuote: vi.fn() };
+});
+
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const line: QuoteLine = {
+  id: 'l-1', quoteId: 'q-1', blockId: null, orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: 'Onboarding', quantity: '1',
+  unitPrice: '500.00', taxable: false, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const emptyDraft: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', billToName: 'Acme', introNotes: null,
+    terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const filledDraft: QuoteDetailData = {
+  ...emptyDraft,
+  quote: { ...emptyDraft.quote, oneTimeTotal: '500.00', dueOnAcceptanceTotal: '500.00', subtotal: '500.00', total: '500.00' },
+  lines: [line],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'send' }];
+});
+
+describe('QuoteDetail — send proposal', () => {
+  it('disables Send and shows a hint when the quote has no content', async () => {
+    render(<QuoteDetail detail={emptyDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-send')).toBeDisabled();
+    expect(screen.getByTestId('quote-send-empty-hint')).toBeInTheDocument();
+  });
+
+  it('does not send on the first click — it opens a confirm step first', async () => {
+    const sendQuote = vi.mocked(quotesApi.sendQuote);
+    render(<QuoteDetail detail={filledDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+    // Critical: the irreversible email must NOT have fired from the first click.
+    expect(sendQuote).not.toHaveBeenCalled();
+  });
+
+  it('sends only after the confirm step and refreshes the quote', async () => {
+    const sendQuote = vi.mocked(quotesApi.sendQuote);
+    sendQuote.mockResolvedValue(resp({ data: null }));
+    const onChanged = vi.fn();
+
+    render(<QuoteDetail detail={filledDraft} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send-confirm'));
+    await waitFor(() => {
+      expect(sendQuote).toHaveBeenCalledWith('q-1');
+      expect(onChanged).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -36,9 +36,14 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
 
   const [busy, setBusy] = useState(false);
   const [sending, setSending] = useState(false);
+  const [sendOpen, setSendOpen] = useState(false);
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
+
+  // Sending emails the customer and is irreversible, so it goes through a
+  // confirm step — and an empty quote (no blocks, no lines) can't be sent at all.
+  const isEmpty = blocks.length === 0 && lines.length === 0;
 
   const send = useCallback(async () => {
     if (sending) return;
@@ -50,6 +55,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
         successMessage: 'Proposal sent',
         onUnauthorized: UNAUTHORIZED,
       });
+      setSendOpen(false);
       refresh();
     } catch (err) {
       handleActionError(err, 'Could not send the proposal.');
@@ -242,11 +248,37 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
             </div>
           )}
 
-          {/* Actions */}
+          {/* Actions — the primary action leads. On a draft that's "Send proposal"
+              (the irreversible money-moment); on an issued quote only "Download PDF"
+              remains, as a secondary affordance. */}
           <div className="space-y-2">
+            {/* Send a draft proposal: issues a number, emails the customer's billing
+                contact with the PDF + a public accept link, and flips draft→sent.
+                Gated on quotes:send. Only a draft can be sent — once sent, the
+                button drops out (the status pill above reflects the new state). The
+                click opens a confirm step; an empty quote can't be sent. */}
+            {can('quotes', 'send') && quote.status === 'draft' && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setSendOpen(true)}
+                  disabled={sending || isEmpty}
+                  title={isEmpty ? 'Add at least one item before sending.' : undefined}
+                  data-testid="quote-send"
+                  className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  {sending ? 'Sending…' : 'Send proposal'}
+                </button>
+                {isEmpty && (
+                  <p className="text-center text-xs text-muted-foreground" data-testid="quote-send-empty-hint">
+                    Add at least one item before sending.
+                  </p>
+                )}
+              </>
+            )}
             {/* PDF download is a read affordance — quotes has no dedicated export
                 action, so it's gated on quotes:read (visible to anyone who can view
-                the quote). */}
+                the quote). Secondary to the send action. */}
             {can('quotes', 'read') && (
               <button
                 type="button"
@@ -256,21 +288,6 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
               >
                 Download PDF
-              </button>
-            )}
-            {/* Send a draft proposal: issues a number, emails the customer's billing
-                contact with the PDF + a public accept link, and flips draft→sent.
-                Gated on quotes:send. Only a draft can be sent — once sent, the
-                button drops out (the status pill above reflects the new state). */}
-            {can('quotes', 'send') && quote.status === 'draft' && (
-              <button
-                type="button"
-                onClick={() => void send()}
-                disabled={sending}
-                data-testid="quote-send"
-                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
-              >
-                {sending ? 'Sending…' : 'Send proposal'}
               </button>
             )}
             {can('quotes', 'write') && quote.status === 'draft' && (
@@ -286,6 +303,17 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+      <ConfirmDialog
+        open={sendOpen}
+        onClose={() => setSendOpen(false)}
+        onConfirm={() => void send()}
+        isLoading={sending}
+        variant="warning"
+        title="Send this proposal?"
+        message={`We'll email this proposal to ${orgName} and mark it Sent — ${formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)} due on acceptance. This can't be undone.`}
+        confirmLabel="Send proposal"
+        confirmTestId="quote-send-confirm"
+      />
       <ConfirmDialog
         open={delOpen}
         onClose={() => setDelOpen(false)}

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -16,6 +16,8 @@ import {
   formatDate,
   formatMoney,
   formatRecurrence,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './quoteTypes';
 
@@ -126,6 +128,9 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
+  // Show the per-line Tax column only when this quote carries tax (mirrors the
+  // header Tax row); otherwise it'd be a column of dashes.
+  const showTax = Number(quote.taxTotal) > 0;
 
   // Customer label: prefer the explicit bill-to name; otherwise resolve the real
   // organization name from the client-side org list (same source the org switcher
@@ -169,12 +174,14 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 block={block}
                 lines={linesForBlock(block.id)}
                 currency={currency}
+                taxRate={quote.taxRate}
+                showTax={showTax}
               />
             ))
           )}
 
           {looseLines.length > 0 && (
-            <LineTable lines={looseLines} currency={currency} label="Other items" testId="quote-detail-loose-lines" />
+            <LineTable lines={looseLines} currency={currency} label="Other items" testId="quote-detail-loose-lines" taxRate={quote.taxRate} showTax={showTax} />
           )}
         </div>
 
@@ -209,8 +216,8 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               <div className="flex justify-between"><dt className="text-muted-foreground">One-time</dt><dd>{formatMoney(quote.oneTimeTotal, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Monthly</dt><dd>{formatMoney(quote.monthlyRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Annual</dt><dd>{formatMoney(quote.annualRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd></div>
-              {Number(quote.taxTotal) > 0 && (
-                <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(quote.taxTotal, currency)}</dd></div>
+              {showTax && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Tax{quote.taxRate ? ` (${pctFromFraction(quote.taxRate)}%)` : ''}</dt><dd>{formatMoney(quote.taxTotal, currency)}</dd></div>
               )}
             </dl>
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
@@ -340,7 +347,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
   );
 }
 
-function BlockView({ block, lines, currency }: { block: QuoteBlock; lines: QuoteLine[]; currency: string }) {
+function BlockView({ block, lines, currency, taxRate, showTax }: { block: QuoteBlock; lines: QuoteLine[]; currency: string; taxRate: string | null; showTax: boolean }) {
   const heading = (block.content?.text as string | undefined) ?? '';
   const html = (block.content?.html as string | undefined) ?? '';
   const tableLabel = (block.content?.label as string | undefined) ?? '';
@@ -364,12 +371,13 @@ function BlockView({ block, lines, currency }: { block: QuoteBlock; lines: Quote
   // line_items
   return (
     <div data-testid={`quote-detail-block-${block.id}`}>
-      <LineTable lines={lines} currency={currency} label={tableLabel || 'Pricing'} testId={`quote-detail-lines-${block.id}`} />
+      <LineTable lines={lines} currency={currency} label={tableLabel || 'Pricing'} testId={`quote-detail-lines-${block.id}`} taxRate={taxRate} showTax={showTax} />
     </div>
   );
 }
 
-function LineTable({ lines, currency, label, testId }: { lines: QuoteLine[]; currency: string; label: string; testId: string }) {
+function LineTable({ lines, currency, label, testId, taxRate, showTax }: { lines: QuoteLine[]; currency: string; label: string; testId: string; taxRate: string | null; showTax: boolean }) {
+  const colSpan = showTax ? 6 : 5;
   return (
     <div className="rounded-lg border bg-card shadow-sm">
       {label && (
@@ -382,28 +390,35 @@ function LineTable({ lines, currency, label, testId }: { lines: QuoteLine[]; cur
             <th className="px-3 py-2 text-right font-medium">Qty</th>
             <th className="px-3 py-2 text-right font-medium">Unit</th>
             <th className="px-3 py-2 font-medium">Recurrence</th>
+            {showTax && <th className="px-3 py-2 text-right font-medium">Tax</th>}
             <th className="px-3 py-2 text-right font-medium">Total</th>
           </tr>
         </thead>
         <tbody>
           {lines.length === 0 ? (
             <tr>
-              <td colSpan={5} className="px-3 py-6 text-center text-sm text-muted-foreground">No lines.</td>
+              <td colSpan={colSpan} className="px-3 py-6 text-center text-sm text-muted-foreground">No lines.</td>
             </tr>
           ) : (
-            lines.map((l) => (
-              <tr key={l.id} className="border-t" data-testid={`quote-detail-line-${l.id}`}>
-                <td className="px-3 py-2">{l.description}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{l.quantity}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
-                <td className="px-3 py-2">
-                  <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                    {formatRecurrence(l.recurrence)}
-                  </span>
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
-              </tr>
-            ))
+            lines.map((l) => {
+              const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, taxRate) : null;
+              return (
+                <tr key={l.id} className="border-t" data-testid={`quote-detail-line-${l.id}`}>
+                  <td className="px-3 py-2">{l.description}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{l.quantity}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
+                  <td className="px-3 py-2">
+                    <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {formatRecurrence(l.recurrence)}
+                    </span>
+                  </td>
+                  {showTax && (
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>
+                  )}
+                  <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
+                </tr>
+              );
+            })
           )}
         </tbody>
       </table>

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -184,7 +184,9 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
             <dl className="space-y-1 text-sm">
               <div className="flex justify-between"><dt className="text-muted-foreground">Customer</dt><dd className="text-right" data-testid="quote-detail-customer">{orgName}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Issued</dt><dd>{formatDate(quote.issueDate)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
+              {(!quote.issueDate || formatDate(quote.issueDate) !== formatDate(quote.createdAt)) && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
+              )}
             </dl>
           </div>
 

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -6,6 +6,7 @@ import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { deleteQuote, quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { RecurringBillingNote } from '../billingUi';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -148,8 +149,18 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
         {/* ── rendered blocks + lines ───────────────────────────────────── */}
         <div className="space-y-4">
           {sortedBlocks.length === 0 && looseLines.length === 0 ? (
-            <div className="rounded-lg border border-dashed bg-card p-8 text-center text-sm text-muted-foreground" data-testid="quote-detail-empty">
-              This quote has no content.
+            <div className="rounded-lg border border-dashed bg-card p-8 text-center" data-testid="quote-detail-empty">
+              <p className="text-sm text-muted-foreground">This quote has no content yet.</p>
+              {quote.status === 'draft' && can('quotes', 'write') && (
+                <button
+                  type="button"
+                  onClick={() => { if (typeof window !== 'undefined') window.location.hash = '#editor'; }}
+                  data-testid="quote-detail-empty-edit"
+                  className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                >
+                  Add content in the Editor
+                </button>
+              )}
             </div>
           ) : (
             sortedBlocks.map((block) => (
@@ -174,6 +185,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
                 data-testid="quote-detail-status"
+                aria-label={`Status: ${statusLabel(quote)}`}
               >
                 {statusLabel(quote)}
               </span>
@@ -201,9 +213,9 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(quote.taxTotal, currency)}</dd></div>
               )}
             </dl>
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-detail-due-on-acceptance">{formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}</span>
+            <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              <span className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums" data-testid="quote-detail-due-on-acceptance">{formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}</span>
             </div>
             {hasRecurring && (
               <>
@@ -211,9 +223,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                   <span className="text-muted-foreground">First-period total (incl. recurring)</span>
                   <span className="font-medium" data-testid="quote-detail-first-period">{formatMoney(quote.total, currency)}</span>
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
-                </p>
+                <RecurringBillingNote className="mt-2" />
               </>
             )}
           </div>

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -200,9 +200,6 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
       data-testid="quote-document"
       className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-sm"
     >
-      {/* Accent top rule */}
-      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
-
       <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
         {/* ── Header ─────────────────────────────────────────────── */}
         <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
@@ -214,6 +211,8 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
                 {branding?.partnerName ?? 'Proposal'}
               </p>
             )}
+            {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
+            <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
             {seller && (
               <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
                 {seller.name && <p className="font-medium text-foreground/80">{seller.name}</p>}
@@ -226,14 +225,13 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
           </div>
 
           <div className="space-y-2 sm:text-right">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>
-              Proposal
-            </p>
-            <p className="text-2xl font-semibold tracking-tight text-foreground" data-testid="quote-document-number">
+            <p className="text-[1.75rem] font-semibold leading-none tracking-tight text-foreground" data-testid="quote-document-number">
               {quote.quoteNumber ?? 'Draft'}
             </p>
+            <p className="text-sm font-medium text-muted-foreground">Proposal</p>
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
+              aria-label={`Status: ${statusLabel(quote)}`}
             >
               {statusLabel(quote)}
             </span>

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -12,6 +12,8 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './quoteTypes';
 
@@ -95,7 +97,7 @@ function DocImage({ quoteId, imageId, caption }: { quoteId: string; imageId: str
   );
 }
 
-function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency: string; label?: string }) {
+function PricingTable({ lines, currency, label, taxRate, showTax }: { lines: QuoteLine[]; currency: string; label?: string; taxRate: string | null; showTax: boolean }) {
   if (lines.length === 0) return null;
   const sorted = [...lines].sort((a, b) => a.sortOrder - b.sortOrder);
   return (
@@ -110,6 +112,7 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
               <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
               <th className="px-2 py-2.5 text-right font-medium">Qty</th>
               <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
               <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
             </tr>
           </thead>
@@ -117,6 +120,7 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
             {sorted.map((l) => {
               const suffix = RECURRENCE_SUFFIX[l.recurrence];
               const tag = RECURRENCE_LABEL[l.recurrence];
+              const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, taxRate) : null;
               return (
                 <tr key={l.id} className="border-b align-top last:border-0">
                   <td className="px-4 py-3 text-foreground sm:px-5">
@@ -131,6 +135,11 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
                   <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
                     {formatMoney(l.unitPrice, currency)}{suffix && <span className="text-xs">{suffix}</span>}
                   </td>
+                  {showTax && (
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                      {tax === null ? '—' : formatMoney(tax, currency)}
+                    </td>
+                  )}
                   <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
                     {formatMoney(l.lineTotal, currency)}{suffix && <span className="text-xs text-muted-foreground">{suffix}</span>}
                   </td>
@@ -144,7 +153,7 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
   );
 }
 
-function DocBlock({ block, lines, currency }: { block: QuoteBlock; lines: QuoteLine[]; currency: string }) {
+function DocBlock({ block, lines, currency, taxRate, showTax }: { block: QuoteBlock; lines: QuoteLine[]; currency: string; taxRate: string | null; showTax: boolean }) {
   if (block.blockType === 'heading') {
     const text = (block.content?.text as string | undefined)?.trim();
     if (!text) return null;
@@ -163,7 +172,7 @@ function DocBlock({ block, lines, currency }: { block: QuoteBlock; lines: QuoteL
   }
   // line_items
   const label = (block.content?.label as string | undefined)?.trim() || 'Pricing';
-  return <PricingTable lines={lines} currency={currency} label={label} />;
+  return <PricingTable lines={lines} currency={currency} label={label} taxRate={taxRate} showTax={showTax} />;
 }
 
 interface DocumentProps {
@@ -193,6 +202,9 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
   const dueOnAcceptance = quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
+  // Only surface the per-line Tax column when this quote actually carries tax —
+  // otherwise it's a column of dashes. Mirrors the header Tax row's visibility.
+  const showTax = Number(quote.taxTotal) > 0;
 
   return (
     <div
@@ -265,9 +277,9 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
         ) : (
           <div className="space-y-6">
             {sortedBlocks.map((block) => (
-              <DocBlock key={block.id} block={block} lines={linesForBlock(block.id)} currency={currency} />
+              <DocBlock key={block.id} block={block} lines={linesForBlock(block.id)} currency={currency} taxRate={quote.taxRate} showTax={showTax} />
             ))}
-            {looseLines.length > 0 && <PricingTable lines={looseLines} currency={currency} label="Additional items" />}
+            {looseLines.length > 0 && <PricingTable lines={looseLines} currency={currency} label="Additional items" taxRate={quote.taxRate} showTax={showTax} />}
           </div>
         )}
 
@@ -279,9 +291,11 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
                 <span className="text-muted-foreground">Subtotal</span>
                 <span className="tabular-nums text-foreground">{formatMoney(quote.subtotal, currency)}</span>
               </div>
-              {Number(quote.taxTotal) > 0 && (
+              {showTax && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Tax</span>
+                  <span className="text-muted-foreground">
+                    Tax{quote.taxRate ? ` (${pctFromFraction(quote.taxRate)}%)` : ''}
+                  </span>
                   <span className="tabular-nums text-foreground">{formatMoney(quote.taxTotal, currency)}</span>
                 </div>
               )}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -174,4 +174,53 @@ describe('QuoteEditor — inline line editing', () => {
     const manualDesc = screen.getByTestId('quote-manual-desc-blk-1');
     expect(manualDesc.tagName).toBe('TEXTAREA');
   });
+
+  it('re-adopts a server-normalized value after commit (no stuck-dirty row)', async () => {
+    // Enter a sub-cent price the server will round (9.999 → 10.00). Once the user
+    // stops editing, the refreshed prop must re-adopt the canonical server value
+    // rather than leaving the field/total pinned to the raw entry.
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    fireEvent.change(priceEl, { target: { value: '9.999' } });
+    fireEvent.blur(priceEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 9.999 }));
+
+    // The parent re-pulls; the server normalized the price to 10.00.
+    const normalized: QuoteDetailData = {
+      ...detail,
+      lines: [{ ...line, unitPrice: '10.00', lineTotal: '10.00' }],
+    };
+    rerender(<QuoteEditor detail={normalized} onChanged={vi.fn()} />);
+
+    await waitFor(() =>
+      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('10.00'),
+    );
+    // Row total reflects the authoritative server value, not the raw 9.999 entry.
+    expect(screen.getByTestId('quote-line-tax-line-1')).toBeInTheDocument();
+  });
+
+  it('keeps in-progress keystrokes when a stale refresh lands (no clobber)', async () => {
+    // "edit qty→5, blur, type 7": a refresh confirming 5 must not wipe the 7 the
+    // user has already typed into the still-focused field.
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qtyEl = screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement;
+    fireEvent.change(qtyEl, { target: { value: '5' } });
+    fireEvent.blur(qtyEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { quantity: 5 }));
+
+    // User immediately types 7 before the refresh GET (confirming 5) lands.
+    fireEvent.change(qtyEl, { target: { value: '7' } });
+    const confirmedFive: QuoteDetailData = {
+      ...detail,
+      lines: [{ ...line, quantity: '5.00', lineTotal: '250.00' }],
+    };
+    rerender(<QuoteEditor detail={confirmedFive} onChanged={vi.fn()} />);
+
+    // The 7 survives — the stale-but-changed prop did not clobber the edit.
+    expect((screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement).value).toBe('7');
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -90,6 +90,24 @@ describe('QuoteEditor — inline line editing', () => {
     expect(screen.getByTestId('quote-line-desc-line-1').tagName).toBe('TEXTAREA');
   });
 
+  it('renders a per-line Tax cell: "—" when not taxable, the computed amount when taxable', async () => {
+    // Non-taxable line + no rate → dash.
+    const { unmount } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-tax-line-1')).toHaveTextContent('—');
+    unmount();
+
+    // Taxable line ($50 line total) at 10% → $5.00 in the Tax cell.
+    const taxed: QuoteDetailData = {
+      ...detail,
+      quote: { ...detail.quote, taxRate: '0.1' },
+      lines: [{ ...line, taxable: true }],
+    };
+    render(<QuoteEditor detail={taxed} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-tax-line-1')).toHaveTextContent('$5.00');
+  });
+
   it('editing the description and blurring PATCHes the line, then refreshes', async () => {
     const onChanged = vi.fn();
     render(<QuoteEditor detail={detail} onChanged={onChanged} />);
@@ -102,7 +120,8 @@ describe('QuoteEditor — inline line editing', () => {
     await waitFor(() => {
       expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support' });
     });
-    expect(onChanged).toHaveBeenCalled();
+    // refresh() is coalesced (trailing), so onChanged fires shortly after the PATCH.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
     // Routine inline edits no longer fire a success toast (that was per-field
     // spam) — they flash a quiet "Saved" cue on the row instead.
     await waitFor(() => expect(screen.getByTestId('quote-line-saved-line-1')).toBeInTheDocument());

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -103,7 +103,10 @@ describe('QuoteEditor — inline line editing', () => {
       expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support' });
     });
     expect(onChanged).toHaveBeenCalled();
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Line updated' }));
+    // Routine inline edits no longer fire a success toast (that was per-field
+    // spam) — they flash a quiet "Saved" cue on the row instead.
+    await waitFor(() => expect(screen.getByTestId('quote-line-saved-line-1')).toBeInTheDocument());
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Line updated' }));
   });
 
   it('changing quantity sends a numeric quantity', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -230,6 +230,43 @@ describe('QuoteEditor — inline line editing', () => {
     expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$1.01');
   });
 
+  it('reflects a tax-rate edit optimistically in the rail (due on acceptance)', async () => {
+    // A $100 one-time taxable line, no rate yet. Typing a 10% rate must move the
+    // rail's "due on acceptance" to $110 immediately — before blur/save/refresh.
+    const taxableOneTime: QuoteDetailData = {
+      ...detail,
+      quote: {
+        ...detail.quote, taxRate: null, oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+        subtotal: '100.00', total: '100.00', dueOnAcceptanceTotal: '100.00',
+      },
+      lines: [{ ...line, recurrence: 'one_time', taxable: true, unitPrice: '100.00', quantity: '1.00', lineTotal: '100.00' }],
+    };
+    render(<QuoteEditor detail={taxableOneTime} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-total-due-on-acceptance')).toHaveTextContent('$100.00');
+
+    fireEvent.change(screen.getByTestId('quote-tax-rate'), { target: { value: '10' } });
+    await waitFor(() =>
+      expect(screen.getByTestId('quote-total-due-on-acceptance')).toHaveTextContent('$110.00'),
+    );
+  });
+
+  it('surfaces a cue (and reverts) when an invalid quantity is committed', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qtyEl = screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement;
+    fireEvent.change(qtyEl, { target: { value: '0' } });
+    fireEvent.blur(qtyEl);
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })),
+    );
+    // No PATCH for the rejected value, and the field snaps back to the persisted qty.
+    expect(updateLineMock).not.toHaveBeenCalled();
+    expect(qtyEl.value).toBe('1.00');
+  });
+
   it('keeps in-progress keystrokes when a stale refresh lands (no clobber)', async () => {
     // "edit qty→5, blur, type 7": a refresh confirming 5 must not wipe the 7 the
     // user has already typed into the still-focused field.

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -215,6 +215,21 @@ describe('QuoteEditor — inline line editing', () => {
     expect(updateLineMock).not.toHaveBeenCalled();
   });
 
+  it('row Total uses the shared cents math and agrees with the rail (sub-cent price)', async () => {
+    // 3 × 0.335 = 1.005 — naive float formatting can drift a cent from the
+    // server's round-half-up-at-the-cent-boundary. The row Total and the rail
+    // (both via the shared computeLineTotal) must land on the same $1.01.
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    fireEvent.change(screen.getByTestId('quote-line-price-line-1'), { target: { value: '0.335' } });
+
+    await waitFor(() => expect(screen.getByTestId('quote-line-total-line-1')).toHaveTextContent('$1.01'));
+    // The fixture line is monthly, so the rail's monthly figure mirrors it exactly.
+    expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$1.01');
+  });
+
   it('keeps in-progress keystrokes when a stale refresh lands (no clobber)', async () => {
     // "edit qty→5, blur, type 7": a refresh confirming 5 must not wipe the 7 the
     // user has already typed into the still-focused field.

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -201,6 +201,20 @@ describe('QuoteEditor — inline line editing', () => {
     expect(screen.getByTestId('quote-line-tax-line-1')).toBeInTheDocument();
   });
 
+  it('recomputes the right-rail totals optimistically while a line qty is mid-edit', async () => {
+    // The fixture line is a $50/mo recurring line, so the rail shows $50.00
+    // monthly. Bumping qty to 3 must move the rail to $150.00 immediately —
+    // before any blur/save/refresh — so the rail no longer lags the row.
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$50.00');
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    await waitFor(() => expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$150.00'));
+    // No PATCH yet — this is pure pre-commit optimism.
+    expect(updateLineMock).not.toHaveBeenCalled();
+  });
+
   it('keeps in-progress keystrokes when a stale refresh lands (no clobber)', async () => {
     // "edit qty→5, blur, type 7": a refresh confirming 5 must not wipe the 7 the
     // user has already typed into the still-focused field.

--- a/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteBlock, QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  removeLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const block: QuoteBlock = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Pricing' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const line: QuoteLine = {
+  id: 'l-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: 'Onboarding', quantity: '1',
+  unitPrice: '500.00', taxable: false, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '500.00', taxRate: null,
+    taxTotal: '0.00', total: '500.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [block],
+  lines: [line],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockImplementation(async () => json({ data: {} }));
+});
+
+describe('QuoteEditor — block removal', () => {
+  it('opens a confirm step naming the line count and does not delete on the first click', async () => {
+    const deleteBlock = vi.mocked(quotesApi.deleteBlock);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
+
+    const confirm = await screen.findByTestId('quote-block-remove-confirm');
+    expect(confirm).toBeInTheDocument();
+    // The cascade count must be surfaced to the user before they commit.
+    expect(screen.getByText(/1 line item/)).toBeInTheDocument();
+    // Nothing destroyed yet.
+    expect(deleteBlock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the block only after the confirm step', async () => {
+    const deleteBlock = vi.mocked(quotesApi.deleteBlock);
+    deleteBlock.mockResolvedValue(json({ data: null }));
+
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
+    fireEvent.click(await screen.findByTestId('quote-block-remove-confirm'));
+
+    await waitFor(() => expect(deleteBlock).toHaveBeenCalledWith('q-1', 'blk-1'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { reorderBlocks, reorderLines } from '../../../lib/api/quotes';
+
+// Writer permissions so the editor controls (incl. move buttons) render.
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/x/image'),
+}));
+
+const okResponse = () =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: { ok: true } }) } as unknown as Response);
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const tableBlock: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const headingBlock: QuoteDetailData['blocks'][number] = {
+  id: 'blk-2', quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+  content: { text: 'Summary', level: 2 }, sortOrder: 1, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const mkLine = (id: string, sortOrder: number): QuoteDetailData['lines'][number] => ({
+  id, quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: `Line ${id}`, quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'monthly', termMonths: null, billingFrequency: null, sortOrder,
+  createdAt: '2026-06-01T00:00:00Z',
+});
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '100.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [tableBlock, headingBlock],
+  lines: [mkLine('l-1', 0), mkLine('l-2', 1)],
+};
+
+const reorderBlocksMock = vi.mocked(reorderBlocks);
+const reorderLinesMock = vi.mocked(reorderLines);
+
+describe('QuoteEditor — reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reorderBlocksMock.mockResolvedValue(okResponse());
+    reorderLinesMock.mockResolvedValue(okResponse());
+  });
+
+  it('disables move-up on the first block and move-down on the last block', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-block-move-up-blk-1')).toBeDisabled();
+    expect(screen.getByTestId('quote-block-move-down-blk-2')).toBeDisabled();
+  });
+
+  it('moving the first block down sends the full reordered block id list', async () => {
+    const onChanged = vi.fn();
+    render(<QuoteEditor detail={detail} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-1'] }));
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('moving the second block up sends the same reordered list', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-up-blk-2'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-1'] }));
+  });
+
+  it('disables move-up on the first line and move-down on the last line', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-move-up-l-1')).toBeDisabled();
+    expect(screen.getByTestId('quote-line-move-down-l-2')).toBeDisabled();
+  });
+
+  it('moving the first line down sends the block id and reordered line list', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-line-move-down-l-1'));
+    await waitFor(() => expect(reorderLinesMock).toHaveBeenCalledWith('q-1', 'blk-1', { lineIds: ['l-2', 'l-1'] }));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
@@ -99,7 +99,8 @@ describe('QuoteEditor — reorder', () => {
 
     fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1'));
     await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-1'] }));
-    expect(onChanged).toHaveBeenCalled();
+    // refresh() is coalesced (trailing), so onChanged fires shortly after the PATCH.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
   });
 
   it('moving the second block up sends the same reordered list', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
@@ -125,4 +125,40 @@ describe('QuoteEditor — reorder', () => {
     fireEvent.click(screen.getByTestId('quote-line-move-down-l-1'));
     await waitFor(() => expect(reorderLinesMock).toHaveBeenCalledWith('q-1', 'blk-1', { lineIds: ['l-2', 'l-1'] }));
   });
+
+  it('accumulates rapid reorder clicks into a single PATCH with the final order', async () => {
+    // Three blocks so the first can be moved down twice. Two rapid clicks should
+    // stack on the optimistic order and coalesce into ONE PATCH carrying the final
+    // id list — not two competing requests (the central novel reorder behavior).
+    const thirdBlock: QuoteDetailData['blocks'][number] = {
+      id: 'blk-3', quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+      content: { text: 'Footer', level: 2 }, sortOrder: 2, createdAt: '2026-06-01T00:00:00Z',
+    };
+    const threeBlocks: QuoteDetailData = { ...detail, blocks: [tableBlock, headingBlock, thirdBlock] };
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1')); // [blk-2, blk-1, blk-3]
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1')); // [blk-2, blk-3, blk-1]
+
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledTimes(1));
+    expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-3', 'blk-1'] });
+  });
+
+  it('reverts the optimistic order and toasts when the reorder PATCH fails', async () => {
+    // A failed reorder must not leave the UI showing an order that never persisted.
+    reorderBlocksMock.mockResolvedValue(
+      { ok: false, status: 500, statusText: 'err', json: vi.fn().mockResolvedValue({ error: 'boom' }) } as unknown as Response,
+    );
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // blk-1 starts first (move-up disabled). Move it down (optimistically enables move-up).
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledTimes(1));
+
+    // Failure is surfaced and the optimistic order reverts (blk-1 back to first).
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await waitFor(() => expect(screen.getByTestId('quote-block-move-up-blk-1')).toBeDisabled());
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -84,7 +84,10 @@ describe('QuoteEditor', () => {
         termsAndConditions: 'Net 30',
       });
     });
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
+    // Blur-to-save fields now share the quiet "Saved" cue instead of a success
+    // toast (unified save-feedback model across the editor).
+    await waitFor(() => expect(screen.getByTestId('quote-terms-saved')).toBeInTheDocument());
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
   });
 
   it('renders the T&C textarea pre-filled with existing termsAndConditions', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1382,27 +1382,23 @@ function EditableLineRow({
   const [rec, setRec] = useState(line.recurrence);
   const [taxable, setTaxable] = useState(line.taxable);
 
-  // Resync the typed fields from the server only when the user hasn't diverged
-  // from what we last showed — mirroring the block-draft guard. A quiet refresh
-  // (now leading-edge, so it can land while a fast typer is still in the field)
-  // must not overwrite an in-progress edit: if the local value no longer matches
-  // the prop we last synced, the user has typed since — keep their text. Without
-  // this, "edit qty→5, blur, type 7" loses the 7 when the GET for 5 returns.
-  const lastDesc = useRef(line.description);
-  const lastQty = useRef(line.quantity);
-  const lastPrice = useRef(line.unitPrice);
-  useEffect(() => {
-    setDesc((cur) => (cur === lastDesc.current ? line.description : cur));
-    lastDesc.current = line.description;
-  }, [line.description]);
-  useEffect(() => {
-    setQty((cur) => (cur === lastQty.current ? line.quantity : cur));
-    lastQty.current = line.quantity;
-  }, [line.quantity]);
-  useEffect(() => {
-    setPrice((cur) => (cur === lastPrice.current ? line.unitPrice : cur));
-    lastPrice.current = line.unitPrice;
-  }, [line.unitPrice]);
+  // Resync the typed fields from the server, but never over an edit in progress.
+  // We track "has the user typed since the last commit?" rather than comparing
+  // values: local state holds a raw string ('9.999') while the prop is a
+  // formatted decimal ('10.00'), so a value comparison both (a) fails to re-adopt
+  // a server-normalized value — leaving the row stuck amber-dirty showing a wrong
+  // optimistic total when the server rounds — and (b) is fragile across formats.
+  // The flag is set on keystroke and cleared once a commit settles, so:
+  //   • a quiet/leading-edge refresh landing mid-type keeps the user's keystrokes
+  //     ("edit qty→5, blur, type 7" never loses the 7), and
+  //   • after the user stops editing, the next prop adopts the server's canonical
+  //     value (e.g. 9.999 → 10.00), clearing the dirty ring and the optimism.
+  const descEdited = useRef(false);
+  const qtyEdited = useRef(false);
+  const priceEdited = useRef(false);
+  useEffect(() => { if (!descEdited.current) setDesc(line.description); }, [line.description]);
+  useEffect(() => { if (!qtyEdited.current) setQty(line.quantity); }, [line.quantity]);
+  useEffect(() => { if (!priceEdited.current) setPrice(line.unitPrice); }, [line.unitPrice]);
   // recurrence/taxable are committed on change (the PATCH resolves before the
   // refresh GET fires), so a stale resync can't race them — a plain resync wins.
   useEffect(() => { setRec(line.recurrence); }, [line.recurrence]);
@@ -1433,26 +1429,33 @@ function EditableLineRow({
   // disagrees with itself (new qty, old total) until the debounced refresh lands.
   // When the row isn't dirty we defer to the authoritative server total so any
   // server-side normalization (e.g. clamped qty) still wins.
+  // Empty fields (mid-retype) aren't optimism inputs — Number('') is 0, which would
+  // flash Total/Tax to $0.00 while the user is clearing a field. Fall back to the
+  // server total until both fields hold a value.
   const qtyNum = Number(qty);
   const priceNum = Number(price);
   const displayTotal =
-    (qtyDirty || priceDirty) && Number.isFinite(qtyNum) && Number.isFinite(priceNum) && qtyNum >= 0 && priceNum >= 0
+    (qtyDirty || priceDirty) && qty.trim() !== '' && price.trim() !== ''
+    && Number.isFinite(qtyNum) && Number.isFinite(priceNum) && qtyNum >= 0 && priceNum >= 0
       ? qtyNum * priceNum
       : Number(line.lineTotal);
   const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
 
   const commitDesc = () => {
     const next = desc.trim();
+    descEdited.current = false; // committing — let the server value re-adopt next
     if (!next || next === line.description) { setDesc(line.description); return; }
     void edit({ description: next });
   };
   const commitQty = () => {
     const n = Number(qty);
+    qtyEdited.current = false;
     if (!Number.isFinite(n) || n <= 0 || n === Number(line.quantity)) { setQty(line.quantity); return; }
     void edit({ quantity: n });
   };
   const commitPrice = () => {
     const n = Number(price);
+    priceEdited.current = false;
     if (!Number.isFinite(n) || n < 0 || n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; }
     void edit({ unitPrice: n });
   };
@@ -1465,7 +1468,7 @@ function EditableLineRow({
           <textarea
             value={desc}
             aria-label="Line description"
-            onChange={(e) => setDesc(e.target.value)}
+            onChange={(e) => { setDesc(e.target.value); descEdited.current = true; }}
             onBlur={commitDesc}
             rows={2}
             disabled={busy}
@@ -1479,7 +1482,7 @@ function EditableLineRow({
           type="number" min="0" step="0.01"
           value={qty}
           aria-label="Quantity"
-          onChange={(e) => setQty(e.target.value)}
+          onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; }}
           onBlur={commitQty}
           disabled={busy}
           data-testid={`quote-line-qty-${line.id}`}
@@ -1491,7 +1494,7 @@ function EditableLineRow({
           type="number" min="0" step="0.01"
           value={price}
           aria-label="Unit price"
-          onChange={(e) => setPrice(e.target.value)}
+          onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; }}
           onBlur={commitPrice}
           disabled={busy}
           data-testid={`quote-line-price-${line.id}`}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -20,6 +20,7 @@ import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus } from 
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
 import CatalogEnrichButton from '../../catalog/CatalogEnrichButton';
 import DistributorLookup from './DistributorLookup';
+import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -218,6 +219,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       setBusy(false);
     }
   }, [busy, addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh]);
+
+  // Removing a line_items block cascades to every line under it (server-side), so
+  // the card's Remove button opens a confirm step instead of deleting outright.
+  const [pendingRemove, setPendingRemove] = useState<QuoteBlock | null>(null);
 
   // Real block delete: removes the block and (server-side) any lines attached to
   // it. Works for every block type — heading, rich_text, and line_items — so the
@@ -450,7 +455,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 onEditLine={editLine}
                 onEditBlock={editBlock}
                 onRemoveLine={deleteLine}
-                onRemoveBlock={removeBlock}
+                onRemoveBlock={setPendingRemove}
               />
             ))
           )}
@@ -604,6 +609,27 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        onClose={() => setPendingRemove(null)}
+        onConfirm={() => {
+          const block = pendingRemove;
+          setPendingRemove(null);
+          if (block) void removeBlock(block);
+        }}
+        isLoading={busy}
+        title="Remove block"
+        message={
+          pendingRemove?.blockType === 'line_items' && linesForBlock(pendingRemove.id).length > 0
+            ? `This removes the pricing table and its ${linesForBlock(pendingRemove.id).length} line item${
+                linesForBlock(pendingRemove.id).length === 1 ? '' : 's'
+              }. This can't be undone.`
+            : 'This removes this block. This can’t be undone.'
+        }
+        confirmLabel="Remove block"
+        confirmTestId="quote-block-remove-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { navigateTo } from '@/lib/navigation';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
@@ -21,6 +21,7 @@ import CatalogItemPicker from '../../catalog/CatalogItemPicker';
 import CatalogEnrichButton from '../../catalog/CatalogEnrichButton';
 import DistributorLookup from './DistributorLookup';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { UnsavedBadge, RecurringBillingNote } from '../billingUi';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -575,9 +576,9 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 </div>
               )}
             </dl>
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
+            <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              <span className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
                 {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
               </span>
             </div>
@@ -587,15 +588,16 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                   <span className="text-muted-foreground">First-period total (incl. recurring)</span>
                   <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(quote.total, currency)}</span>
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground" data-testid="quote-totals-recurring-hint">
-                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
-                </p>
+                <RecurringBillingNote className="mt-2" testId="quote-totals-recurring-hint" />
               </>
             )}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-sm">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <UnsavedBadge show={termsDirty} />
+            </div>
             <textarea
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
@@ -603,7 +605,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="quote-terms"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
           </div>
@@ -676,8 +678,20 @@ function BlockCard({
   // changes (e.g. after a refresh) so server normalization wins.
   const [headingDraft, setHeadingDraft] = useState(heading);
   const [richDraft, setRichDraft] = useState(html);
-  useEffect(() => { setHeadingDraft(heading); }, [heading]);
-  useEffect(() => { setRichDraft(html); }, [html]);
+  // Resync drafts from the server only when the user hasn't diverged from what we
+  // last showed. A quiet reload (fired by an unrelated inline edit elsewhere) must
+  // not clobber heading/rich text this user is mid-edit in: if the local draft no
+  // longer matches the prop we last synced, the user has typed — keep their text.
+  const lastHeading = useRef(heading);
+  const lastHtml = useRef(html);
+  useEffect(() => {
+    setHeadingDraft((cur) => (cur === lastHeading.current ? heading : cur));
+    lastHeading.current = heading;
+  }, [heading]);
+  useEffect(() => {
+    setRichDraft((cur) => (cur === lastHtml.current ? html : cur));
+    lastHtml.current = html;
+  }, [html]);
 
   const commitHeading = () => {
     const text = headingDraft.trim();
@@ -1016,7 +1030,7 @@ function EditableLineRow({
           <option value="monthly">Monthly</option>
           <option value="annual">Annual</option>
         </select>
-        <label className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
+        <label className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
           <input
             type="checkbox"
             checked={line.taxable}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -18,6 +18,7 @@ import {
   quoteImageUrl,
 } from '../../../lib/api/quotes';
 import type { QuoteBlockInput } from '@breeze/shared';
+import { computeQuoteTotals, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';
 import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
@@ -331,6 +332,56 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
     Object.values(lineReorderTimers.current).forEach(clearTimeout);
   }, []);
+
+  // Optimistic line drafts so the right-rail "Live totals" can recompute from
+  // in-progress edits instead of lagging behind the per-row optimistic totals.
+  // Each EditableLineRow reports its effective values while they diverge from the
+  // persisted line (and null once settled); the rail recomputes via the SAME
+  // computeQuoteTotals the server uses, so it can never settle to a different
+  // figure than the next GET returns.
+  const [lineDrafts, setLineDrafts] = useState<Record<string, QuoteLineForMath>>({});
+  const setLineDraft = useCallback((id: string, draft: QuoteLineForMath | null) => {
+    setLineDrafts((m) => {
+      if (!draft) {
+        if (!(id in m)) return m;
+        const n = { ...m }; delete n[id]; return n;
+      }
+      const prev = m[id];
+      if (prev && prev.quantity === draft.quantity && prev.unitPrice === draft.unitPrice
+        && prev.taxable === draft.taxable && prev.recurrence === draft.recurrence) return m;
+      return { ...m, [id]: draft };
+    });
+  }, []);
+  // Drop drafts for lines that no longer exist (removed) so a stale draft can't
+  // skew the rail after a delete.
+  useEffect(() => {
+    setLineDrafts((m) => {
+      const live = new Set(lines.map((l) => l.id));
+      const stale = Object.keys(m).filter((id) => !live.has(id));
+      if (stale.length === 0) return m;
+      const n = { ...m }; stale.forEach((id) => delete n[id]); return n;
+    });
+  }, [lines]);
+
+  // The figures the rail renders: optimistic recompute when any line is mid-edit,
+  // otherwise the authoritative server values verbatim.
+  const optimisticTotals = useMemo<QuoteTotals | null>(() => {
+    if (Object.keys(lineDrafts).length === 0) return null;
+    const merged: QuoteLineForMath[] = lines.map((l) => {
+      const d = lineDrafts[l.id];
+      return d ?? {
+        quantity: l.quantity, unitPrice: l.unitPrice, taxable: l.taxable,
+        customerVisible: l.customerVisible, recurrence: l.recurrence,
+      };
+    });
+    return computeQuoteTotals(merged, quote.taxRate ? parseFloat(quote.taxRate) : null);
+  }, [lineDrafts, lines, quote.taxRate]);
+  const railOneTime = optimisticTotals?.oneTimeTotal ?? quote.oneTimeTotal;
+  const railMonthly = optimisticTotals?.monthlyRecurringTotal ?? quote.monthlyRecurringTotal;
+  const railAnnual = optimisticTotals?.annualRecurringTotal ?? quote.annualRecurringTotal;
+  const railTax = optimisticTotals?.taxTotal ?? quote.taxTotal;
+  const railTotal = optimisticTotals?.total ?? quote.total;
+  const railDue = optimisticTotals?.dueOnAcceptanceTotal ?? quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
 
   // Apply an optimistic id ordering over a base list, but only if it's a clean
   // permutation (same membership) — otherwise fall back to the server order.
@@ -676,8 +727,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     }, 250);
   }, [linesForBlock, quote.id, refresh]);
 
-  const hasRecurring =
-    Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
+  const hasRecurring = Number(railMonthly) > 0 || Number(railAnnual) > 0;
 
   return (
     <div className="space-y-6" data-testid="quote-editor">
@@ -721,6 +771,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 onMoveLine={(line, dir) => moveLine(block.id, line, dir)}
                 onRemoveLine={setPendingLineRemove}
                 onRemoveBlock={setPendingRemove}
+                onLineDraft={setLineDraft}
               />
             ))
           )}
@@ -827,29 +878,29 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 recurring line (which doesn't move "due on acceptance") still tells
                 a screen-reader user the totals recomputed. */}
             <p className="sr-only" role="status" data-testid="quote-totals-sr">
-              {`Totals updated. One-time ${formatMoney(quote.oneTimeTotal, currency)}, `
-                + `monthly recurring ${formatMoney(quote.monthlyRecurringTotal, currency)}, `
-                + `annual recurring ${formatMoney(quote.annualRecurringTotal, currency)}`
-                + (Number(quote.taxTotal) > 0 ? `, tax ${formatMoney(quote.taxTotal, currency)}` : '')
-                + `, due on acceptance ${formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}.`}
+              {`Totals updated. One-time ${formatMoney(railOneTime, currency)}, `
+                + `monthly recurring ${formatMoney(railMonthly, currency)}, `
+                + `annual recurring ${formatMoney(railAnnual, currency)}`
+                + (Number(railTax) > 0 ? `, tax ${formatMoney(railTax, currency)}` : '')
+                + `, due on acceptance ${formatMoney(railDue, currency)}.`}
             </p>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">One-time</dt>
-                <dd data-testid="quote-total-onetime">{formatMoney(quote.oneTimeTotal, currency)}</dd>
+                <dd data-testid="quote-total-onetime">{formatMoney(railOneTime, currency)}</dd>
               </div>
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">Monthly recurring</dt>
-                <dd data-testid="quote-total-monthly">{formatMoney(quote.monthlyRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd>
+                <dd data-testid="quote-total-monthly">{formatMoney(railMonthly, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd>
               </div>
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">Annual recurring</dt>
-                <dd data-testid="quote-total-annual">{formatMoney(quote.annualRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd>
+                <dd data-testid="quote-total-annual">{formatMoney(railAnnual, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd>
               </div>
-              {Number(quote.taxTotal) > 0 && (
+              {Number(railTax) > 0 && (
                 <div className="flex items-baseline justify-between">
                   <dt className="text-muted-foreground">Tax</dt>
-                  <dd>{formatMoney(quote.taxTotal, currency)}</dd>
+                  <dd>{formatMoney(railTax, currency)}</dd>
                 </div>
               )}
             </dl>
@@ -898,14 +949,14 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums"
                 data-testid="quote-total-due-on-acceptance"
               >
-                {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
+                {formatMoney(railDue, currency)}
               </span>
             </div>
             {hasRecurring && (
               <>
                 <div className="mt-2 flex items-baseline justify-between text-sm tabular-nums">
                   <span className="text-muted-foreground">First-period total (incl. recurring)</span>
-                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(quote.total, currency)}</span>
+                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(railTotal, currency)}</span>
                 </div>
                 <RecurringBillingNote className="mt-2" testId="quote-totals-recurring-hint" />
               </>
@@ -991,7 +1042,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, taxRate, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, taxRate, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock, onLineDraft,
 }: {
   block: QuoteBlock;
   quoteId: string;
@@ -1016,6 +1067,7 @@ function BlockCard({
   onMoveLine: (line: QuoteLine, direction: 'up' | 'down') => void;
   onRemoveLine: (line: QuoteLine) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
+  onLineDraft: (lineId: string, draft: QuoteLineForMath | null) => void;
 }) {
   // Pending state scoped to this block: editing/removing this block, or adding a
   // line to it, never disables anything in a sibling block.
@@ -1207,6 +1259,7 @@ function BlockCard({
                         onEdit={onEditLine}
                         onMove={onMoveLine}
                         onRemove={onRemoveLine}
+                        onDraft={onLineDraft}
                       />
                     ) : (
                       <tr key={l.id} className="border-t" data-testid={`quote-line-${l.id}`}>
@@ -1361,7 +1414,7 @@ function BlockCard({
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 function EditableLineRow({
-  line, currency, taxRate, busy, isFirst, isLast, onEdit, onMove, onRemove,
+  line, currency, taxRate, busy, isFirst, isLast, onEdit, onMove, onRemove, onDraft,
 }: {
   line: QuoteLine;
   currency: string;
@@ -1372,6 +1425,7 @@ function EditableLineRow({
   onEdit: (lineId: string, body: LineUpdate) => Promise<boolean>;
   onMove: (line: QuoteLine, direction: 'up' | 'down') => void;
   onRemove: (line: QuoteLine) => void;
+  onDraft: (lineId: string, draft: QuoteLineForMath | null) => void;
 }) {
   const [desc, setDesc] = useState(line.description);
   const [qty, setQty] = useState(line.quantity);
@@ -1440,6 +1494,29 @@ function EditableLineRow({
       ? qtyNum * priceNum
       : Number(line.lineTotal);
   const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
+
+  // Report this row's effective values to the parent so the rail "Live totals"
+  // recompute matches the per-row optimistic Total/Tax. Mirror displayTotal's
+  // fallback: when a field is empty/invalid, use the persisted value (so a
+  // mid-clear field never zeroes the rail). Emit null once everything matches the
+  // persisted line, so the rail reverts to the authoritative server figures.
+  const qtyValid = qty.trim() !== '' && Number.isFinite(qtyNum) && qtyNum >= 0;
+  const priceValid = price.trim() !== '' && Number.isFinite(priceNum) && priceNum >= 0;
+  const effQty = qtyValid ? qty : line.quantity;
+  const effPrice = priceValid ? price : line.unitPrice;
+  const diverged =
+    Number(effQty) !== Number(line.quantity)
+    || Number(effPrice) !== Number(line.unitPrice)
+    || taxable !== line.taxable
+    || rec !== line.recurrence;
+  useEffect(() => {
+    onDraft(line.id, diverged
+      ? { quantity: String(effQty), unitPrice: String(effPrice), taxable, customerVisible: line.customerVisible, recurrence: rec }
+      : null);
+  }, [onDraft, line.id, line.customerVisible, diverged, effQty, effPrice, taxable, rec]);
+  // Clear this row's draft when it unmounts (e.g. removed) so the rail doesn't
+  // keep a phantom override.
+  useEffect(() => () => onDraft(line.id, null), [onDraft, line.id]);
 
   const commitDesc = () => {
     const next = desc.trim();

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -11,6 +11,8 @@ import {
   addCatalogLine,
   updateLine,
   removeLine,
+  reorderBlocks as reorderBlocksApi,
+  reorderLines as reorderLinesApi,
   uploadQuoteImage,
   quoteImageUrl,
 } from '../../../lib/api/quotes';
@@ -70,11 +72,38 @@ interface Props {
   onChanged: () => void;
 }
 
+// A quiet, transient "Saved" cue used consistently for every blur-to-save field
+// in the editor (terms, tax, block content, line fields). Returns the on-flag
+// and a trigger; clears its timer on unmount so a late fire can't setState a
+// gone node.
+function useSavedFlash(): [boolean, () => void] {
+  const [on, setOn] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const flash = useCallback(() => {
+    setOn(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setOn(false), 1500);
+  }, []);
+  return [on, flash];
+}
+
+// Visually-hidden polite live region — announces a transient message (e.g.
+// "Saved") to screen readers without taking visual space. Pairs with the visible
+// cue so sighted and SR users get the same feedback.
+function SrSaved({ show, label = 'Saved' }: { show: boolean; label?: string }) {
+  return <span role="status" aria-live="polite" className="sr-only">{show ? label : ''}</span>;
+}
+
 export default function QuoteEditor({ detail, onChanged }: Props) {
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
+  // Focus anchor: after a confirmed block/line removal the triggering button is
+  // gone, so we move focus here instead of letting it fall to <body> (which dumps
+  // a keyboard user to the top of the page).
+  const blocksColRef = useRef<HTMLDivElement>(null);
 
   // Per-item "saving" state, keyed so one in-flight mutation never freezes the
   // rest of the editor. Keys: 'terms', 'tax', 'add-block', `block:<id>`,
@@ -116,6 +145,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // Inline validation message for the tax field — an out-of-range/non-numeric
   // entry no longer silently reverts; we keep the bad value and explain why.
   const [taxError, setTaxError] = useState<string | null>(null);
+  // Quiet "Saved" cues for the right-rail blur-to-save fields, matching the
+  // per-line/per-block cue so the whole editor speaks one save language.
+  const [termsSaved, flashTermsSaved] = useSavedFlash();
+  const [taxSaved, flashTaxSaved] = useSavedFlash();
   const canCatalogWrite = can('catalog', 'write');
 
   // ---- add-block form ------------------------------------------------------
@@ -133,19 +166,19 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
   const saveTerms = useCallback(async () => {
     if (!termsDirty) return;
-    await runScoped('terms', async () => {
+    const ok = await runScoped('terms', async () => {
       await runAction({
         request: () => fetchWithAuth(`/quotes/${quote.id}`, {
           method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
         }),
         errorFallback: 'Could not save terms.',
-        successMessage: 'Terms saved',
         onUnauthorized: UNAUTHORIZED,
       });
       setTermsDirty(false);
       refresh();
     }, 'Could not save terms.');
-  }, [termsDirty, terms, quote.id, refresh, runScoped]);
+    if (ok) flashTermsSaved();
+  }, [termsDirty, terms, quote.id, refresh, runScoped, flashTermsSaved]);
 
   // Persist the tax rate as a fraction. Empty clears it (null); otherwise the
   // percent is clamped to 0–100 (fraction 0–1, matching updateQuoteSchema) and an
@@ -168,19 +201,19 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       fraction = Number((pct / 100).toFixed(5));
     }
     setTaxError(null);
-    await runScoped('tax', async () => {
+    const ok = await runScoped('tax', async () => {
       await runAction({
         request: () => fetchWithAuth(`/quotes/${quote.id}`, {
           method: 'PATCH', body: JSON.stringify({ taxRate: fraction }),
         }),
         errorFallback: 'Could not save the tax rate.',
-        successMessage: 'Tax rate saved',
         onUnauthorized: UNAUTHORIZED,
       });
       setTaxDirty(false);
       refresh();
     }, 'Could not save the tax rate.');
-  }, [taxDirty, taxPct, quote.id, refresh, runScoped]);
+    if (ok) flashTaxSaved();
+  }, [taxDirty, taxPct, quote.id, refresh, runScoped, flashTaxSaved]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -375,6 +408,13 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
       return Promise.resolve(false);
     }
+    // Guard the unit price too (parity with the inline edit path's commitPrice):
+    // a negative/NaN price shouldn't depend on the server to reject it.
+    const priceNum = Number(form.unitPrice);
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+      return Promise.resolve(false);
+    }
     return runScoped(`add-line:${blockId}`, async () => {
       await runAction({
         request: () => addManualLine(quote.id, {
@@ -382,7 +422,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           blockId,
           description: form.description.trim(),
           quantity: qtyNum,
-          unitPrice: Number(form.unitPrice),
+          unitPrice: priceNum,
           taxable: form.taxable,
           customerVisible: true,
           recurrence: form.recurrence,
@@ -403,7 +443,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
               : form.recurrence === 'annual'
                 ? 'annual'
                 : null,
-            unitPrice: Number(form.unitPrice),
+            unitPrice: priceNum,
             taxable: form.taxable,
           }),
           errorFallback: 'Line added, but saving it to the catalog failed.',
@@ -459,20 +499,61 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     }, 'Could not update the block.'),
   [quote.id, refresh, runScoped]);
 
+  // Reorder a block one slot up/down: compute the full new id order from a single
+  // swap and send it; the server renumbers sortOrder 0..n-1. Scoped pending keeps
+  // the rest of the editor live. refresh() re-pulls so sortedBlocks re-sorts.
+  const moveBlock = useCallback((block: QuoteBlock, direction: 'up' | 'down') =>
+    runScoped(`reorder-block:${block.id}`, async () => {
+      const ordered = [...sortedBlocks];
+      const idx = ordered.findIndex((b) => b.id === block.id);
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
+      [ordered[idx], ordered[swapIdx]] = [ordered[swapIdx], ordered[idx]];
+      await runAction({
+        request: () => reorderBlocksApi(quote.id, { blockIds: ordered.map((b) => b.id) }),
+        errorFallback: 'Could not reorder blocks.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    }, 'Could not reorder blocks.'),
+  [sortedBlocks, quote.id, refresh, runScoped]);
+
+  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') =>
+    runScoped(`reorder-line:${line.id}`, async () => {
+      const ordered = linesForBlock(blockId);
+      const idx = ordered.findIndex((l) => l.id === line.id);
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
+      const next = [...ordered];
+      [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
+      await runAction({
+        request: () => reorderLinesApi(quote.id, blockId, { lineIds: next.map((l) => l.id) }),
+        errorFallback: 'Could not reorder lines.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    }, 'Could not reorder lines.'),
+  [linesForBlock, quote.id, refresh, runScoped]);
+
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
 
   return (
     <div className="space-y-6" data-testid="quote-editor">
+      {canWrite && (
+        <p className="text-xs text-muted-foreground" data-testid="quote-editor-autosave-hint">
+          Changes save automatically as you edit.
+        </p>
+      )}
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         {/* ── blocks ─────────────────────────────────────────────────── */}
-        <div className="space-y-4">
+        <div className="space-y-4 focus:outline-none" ref={blocksColRef} tabIndex={-1}>
           {sortedBlocks.length === 0 ? (
             <div className="rounded-lg border border-dashed bg-card p-8 text-center text-sm text-muted-foreground" data-testid="quote-blocks-empty">
               No content yet. Add a heading, rich text, or a pricing table below.
             </div>
           ) : (
-            sortedBlocks.map((block) => (
+            sortedBlocks.map((block, idx) => (
               <BlockCard
                 key={block.id}
                 block={block}
@@ -483,11 +564,15 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 isPending={isPending}
                 canWrite={canWrite}
                 ecActive={ecActive}
+                isFirst={idx === 0}
+                isLast={idx === sortedBlocks.length - 1}
                 onAddCatalog={addCatalog}
                 onImportAddDistributor={importAndAddDistributor}
                 onAddManual={addManual}
                 onEditLine={editLine}
                 onEditBlock={editBlock}
+                onMoveBlock={moveBlock}
+                onMoveLine={(line, dir) => moveLine(block.id, line, dir)}
                 onRemoveLine={setPendingLineRemove}
                 onRemoveBlock={setPendingRemove}
               />
@@ -590,7 +675,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         {/* Sticky on lg so the totals you're building against stay visible while
             scrolling the blocks; on narrow widths this column stacks below. */}
         <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
-          <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals" aria-live="polite">
+          <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">
@@ -615,7 +700,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
             {canWrite && (
               <div className="mt-2 border-t pt-2">
                 <div className="flex items-center justify-between gap-2">
-                  <label htmlFor="quote-tax-rate" className="text-sm text-muted-foreground">Tax rate</label>
+                  <label htmlFor="quote-tax-rate" className="flex items-center gap-2 text-sm text-muted-foreground">
+                    Tax rate
+                    {taxSaved && <span className="text-xs font-medium text-success" data-testid="quote-tax-saved">Saved</span>}
+                  </label>
                   <div className="flex items-center gap-1">
                     <input
                       id="quote-tax-rate"
@@ -639,15 +727,22 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                   </div>
                 </div>
                 {taxError ? (
-                  <p className="mt-1 text-xs text-destructive" id="quote-tax-rate-error" data-testid="quote-tax-rate-error">{taxError}</p>
+                  <p className="mt-1 text-xs text-destructive" id="quote-tax-rate-error" role="alert" data-testid="quote-tax-rate-error">{taxError}</p>
                 ) : (
                   <p className="mt-1 text-xs text-muted-foreground">Applies to lines marked taxable.</p>
                 )}
+                <SrSaved show={taxSaved} />
               </div>
             )}
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              <span className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
+              {/* aria-live scoped to the headline figure so SR users hear the one
+                  number that matters recompute, not all four rows on every edit. */}
+              <span
+                className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums"
+                data-testid="quote-total-due-on-acceptance"
+                aria-live="polite"
+              >
                 {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
               </span>
             </div>
@@ -665,18 +760,22 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           <div className="rounded-lg border bg-card p-4 shadow-sm">
             <div className="mb-2 flex items-center justify-between gap-2">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
-              <UnsavedBadge show={termsDirty} />
+              <span className="flex items-center gap-2">
+                {termsSaved && <span className="text-xs font-medium text-success" data-testid="quote-terms-saved">Saved</span>}
+                <UnsavedBadge show={termsDirty} />
+              </span>
             </div>
             <textarea
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
               onBlur={() => { if (canWrite) void saveTerms(); }}
-              disabled={!canWrite}
+              disabled={!canWrite || isPending('terms')}
               data-testid="quote-terms"
               rows={3}
               className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
+            <SrSaved show={termsSaved} />
           </div>
         </div>
       </div>
@@ -686,8 +785,15 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onClose={() => setPendingRemove(null)}
         onConfirm={() => {
           const block = pendingRemove;
-          setPendingRemove(null);
-          if (block) void removeBlock(block);
+          if (!block) return;
+          // Keep the dialog open and awaiting (so isLoading shows "Processing…")
+          // until the delete resolves, then close and move focus to a stable
+          // anchor — the triggering Remove button is gone with the block.
+          void (async () => {
+            await removeBlock(block);
+            setPendingRemove(null);
+            blocksColRef.current?.focus();
+          })();
         }}
         isLoading={pendingRemove ? isPending(`block:${pendingRemove.id}`) : false}
         title="Remove block"
@@ -707,8 +813,12 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onClose={() => setPendingLineRemove(null)}
         onConfirm={() => {
           const line = pendingLineRemove;
-          setPendingLineRemove(null);
-          if (line) void deleteLine(line.id);
+          if (!line) return;
+          void (async () => {
+            await deleteLine(line.id);
+            setPendingLineRemove(null);
+            blocksColRef.current?.focus();
+          })();
         }}
         isLoading={pendingLineRemove ? isPending(`line:${pendingLineRemove.id}`) : false}
         title="Remove line"
@@ -726,7 +836,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, catalog, isPending, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock,
 }: {
   block: QuoteBlock;
   quoteId: string;
@@ -736,6 +846,8 @@ function BlockCard({
   isPending: (key: string) => boolean;
   canWrite: boolean;
   ecActive: boolean;
+  isFirst: boolean;
+  isLast: boolean;
   onAddCatalog: (blockId: string, item: CatalogItem) => void;
   onImportAddDistributor: (blockId: string, product: EcProduct, sellPrice: number) => void;
   onAddManual: (
@@ -744,9 +856,12 @@ function BlockCard({
   ) => Promise<boolean>;
   onEditLine: (lineId: string, body: LineUpdate) => Promise<boolean>;
   onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => Promise<boolean>;
+  onMoveBlock: (block: QuoteBlock, direction: 'up' | 'down') => void;
+  onMoveLine: (line: QuoteLine, direction: 'up' | 'down') => void;
   onRemoveLine: (line: QuoteLine) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
 }) {
+  const reorderBusy = isPending(`reorder-block:${block.id}`);
   // Pending state scoped to this block: editing/removing this block, or adding a
   // line to it, never disables anything in a sibling block.
   const blockBusy = isPending(`block:${block.id}`);
@@ -823,17 +938,40 @@ function BlockCard({
           {blockSaved && (
             <span className="font-medium normal-case tracking-normal text-success" data-testid={`quote-block-saved-${block.id}`}>Saved</span>
           )}
+          <SrSaved show={blockSaved} />
         </span>
         {canWrite && (
-          <button
-            type="button"
-            onClick={() => onRemoveBlock(block)}
-            disabled={blockBusy}
-            data-testid={`quote-block-remove-${block.id}`}
-            className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-          >
-            Remove
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => onMoveBlock(block, 'up')}
+              disabled={reorderBusy || isFirst}
+              aria-label="Move block up"
+              data-testid={`quote-block-move-up-${block.id}`}
+              className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => onMoveBlock(block, 'down')}
+              disabled={reorderBusy || isLast}
+              aria-label="Move block down"
+              data-testid={`quote-block-move-down-${block.id}`}
+              className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              onClick={() => onRemoveBlock(block)}
+              disabled={blockBusy}
+              data-testid={`quote-block-remove-${block.id}`}
+              className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+            >
+              Remove
+            </button>
+          </div>
         )}
       </div>
 
@@ -847,7 +985,7 @@ function BlockCard({
               onBlur={() => void commitHeading()}
               disabled={blockBusy}
               data-testid={`quote-block-heading-input-${block.id}`}
-              className="w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold disabled:opacity-60 ${headingDraft.trim() !== heading ? 'ring-1 ring-warning' : ''}`}
             />
           ) : (
             <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
@@ -863,7 +1001,7 @@ function BlockCard({
               disabled={blockBusy}
               rows={4}
               data-testid={`quote-block-rich-input-${block.id}`}
-              className="w-full resize-y rounded-md border bg-background px-2 py-1 text-sm disabled:opacity-60"
+              className={`w-full resize-y rounded-md border bg-background px-2 py-1 text-sm disabled:opacity-60 ${richDraft !== html ? 'ring-1 ring-warning' : ''}`}
             />
           ) : (
             <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
@@ -901,14 +1039,18 @@ function BlockCard({
                     </td>
                   </tr>
                 ) : (
-                  lines.map((l) =>
+                  lines.map((l, idx) =>
                     canWrite ? (
                       <EditableLineRow
                         key={l.id}
                         line={l}
                         currency={currency}
                         busy={isPending(`line:${l.id}`)}
+                        reorderBusy={isPending(`reorder-line:${l.id}`)}
+                        isFirst={idx === 0}
+                        isLast={idx === lines.length - 1}
                         onEdit={onEditLine}
+                        onMove={onMoveLine}
                         onRemove={onRemoveLine}
                       />
                     ) : (
@@ -1060,22 +1202,33 @@ function BlockCard({
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 function EditableLineRow({
-  line, currency, busy, onEdit, onRemove,
+  line, currency, busy, reorderBusy, isFirst, isLast, onEdit, onMove, onRemove,
 }: {
   line: QuoteLine;
   currency: string;
   busy: boolean;
+  reorderBusy: boolean;
+  isFirst: boolean;
+  isLast: boolean;
   onEdit: (lineId: string, body: LineUpdate) => Promise<boolean>;
+  onMove: (line: QuoteLine, direction: 'up' | 'down') => void;
   onRemove: (line: QuoteLine) => void;
 }) {
   const [desc, setDesc] = useState(line.description);
   const [qty, setQty] = useState(line.quantity);
   const [price, setPrice] = useState(line.unitPrice);
+  // recurrence/taxable are committed on change (not blur); keep them in local
+  // state so the control updates instantly rather than lagging until the
+  // refresh() round-trip lands, and revert if the save fails.
+  const [rec, setRec] = useState(line.recurrence);
+  const [taxable, setTaxable] = useState(line.taxable);
 
   // Resync when the persisted line changes (after a refresh()).
   useEffect(() => { setDesc(line.description); }, [line.description]);
   useEffect(() => { setQty(line.quantity); }, [line.quantity]);
   useEffect(() => { setPrice(line.unitPrice); }, [line.unitPrice]);
+  useEffect(() => { setRec(line.recurrence); }, [line.recurrence]);
+  useEffect(() => { setTaxable(line.taxable); }, [line.taxable]);
 
   // Quiet "Saved" flash in place of the old per-field success toast.
   const [saved, setSaved] = useState(false);
@@ -1086,7 +1239,16 @@ function EditableLineRow({
     if (savedTimer.current) clearTimeout(savedTimer.current);
     savedTimer.current = setTimeout(() => setSaved(false), 1500);
   }, []);
-  const edit = useCallback(async (body: LineUpdate) => { if (await onEdit(line.id, body)) flashSaved(); }, [onEdit, line.id, flashSaved]);
+  const edit = useCallback(async (body: LineUpdate): Promise<boolean> => {
+    const ok = await onEdit(line.id, body);
+    if (ok) flashSaved();
+    return ok;
+  }, [onEdit, line.id, flashSaved]);
+  // Per-field dirty cue (mirrors the terms/tax ring) so every editable surface
+  // signals unsaved state the same way.
+  const descDirty = desc.trim() !== line.description;
+  const qtyDirty = Number(qty) !== Number(line.quantity);
+  const priceDirty = Number(price) !== Number(line.unitPrice);
 
   const commitDesc = () => {
     const next = desc.trim();
@@ -1117,7 +1279,7 @@ function EditableLineRow({
             rows={2}
             disabled={busy}
             data-testid={`quote-line-desc-${line.id}`}
-            className="min-h-[2.25rem] w-full resize-y rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+            className={`min-h-[2.25rem] w-full resize-y rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${descDirty ? 'ring-1 ring-warning' : ''}`}
           />
         </div>
       </td>
@@ -1130,7 +1292,7 @@ function EditableLineRow({
           onBlur={commitQty}
           disabled={busy}
           data-testid={`quote-line-qty-${line.id}`}
-          className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+          className={`h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${qtyDirty ? 'ring-1 ring-warning' : ''}`}
         />
       </td>
       <td className="px-2 py-2 text-right">
@@ -1142,14 +1304,18 @@ function EditableLineRow({
           onBlur={commitPrice}
           disabled={busy}
           data-testid={`quote-line-price-${line.id}`}
-          className="h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+          className={`h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${priceDirty ? 'ring-1 ring-warning' : ''}`}
         />
       </td>
       <td className="px-2 py-2">
         <select
-          value={line.recurrence}
+          value={rec}
           aria-label="Billing frequency"
-          onChange={(e) => void edit({ recurrence: e.target.value as QuoteLineRecurrence })}
+          onChange={(e) => {
+            const next = e.target.value as QuoteLineRecurrence;
+            setRec(next); // optimistic — revert if the save fails
+            void edit({ recurrence: next }).then((ok) => { if (!ok) setRec(line.recurrence); });
+          }}
           disabled={busy}
           data-testid={`quote-line-recurrence-${line.id}`}
           className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
@@ -1161,9 +1327,13 @@ function EditableLineRow({
         <label className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
           <input
             type="checkbox"
-            checked={line.taxable}
+            checked={taxable}
             aria-label="Taxable"
-            onChange={(e) => void edit({ taxable: e.target.checked })}
+            onChange={(e) => {
+              const next = e.target.checked;
+              setTaxable(next); // optimistic — revert if the save fails
+              void edit({ taxable: next }).then((ok) => { if (!ok) setTaxable(line.taxable); });
+            }}
             disabled={busy}
             data-testid={`quote-line-taxable-${line.id}`}
           />
@@ -1173,17 +1343,40 @@ function EditableLineRow({
       <td className="px-2 py-2 text-right tabular-nums">
         {formatMoney(line.lineTotal, currency)}
         {saved && <span className="ml-1 text-xs font-medium text-success" data-testid={`quote-line-saved-${line.id}`}>Saved</span>}
+        <SrSaved show={saved} />
       </td>
       <td className="px-2 py-2 text-right">
-        <button
-          type="button"
-          onClick={() => onRemove(line)}
-          disabled={busy}
-          data-testid={`quote-line-remove-${line.id}`}
-          className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-        >
-          Remove
-        </button>
+        <div className="flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={() => onMove(line, 'up')}
+            disabled={reorderBusy || isFirst}
+            aria-label="Move line up"
+            data-testid={`quote-line-move-up-${line.id}`}
+            className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            onClick={() => onMove(line, 'down')}
+            disabled={reorderBusy || isLast}
+            aria-label="Move line down"
+            data-testid={`quote-line-move-down-${line.id}`}
+            className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+          >
+            ↓
+          </button>
+          <button
+            type="button"
+            onClick={() => onRemove(line)}
+            disabled={busy}
+            data-testid={`quote-line-remove-${line.id}`}
+            className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+          >
+            Remove
+          </button>
+        </div>
       </td>
     </tr>
   );

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import { navigateTo } from '@/lib/navigation';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
@@ -32,6 +33,7 @@ import {
   formatMoney,
   formatRecurrence,
   pctFromFraction,
+  lineTaxAmount,
 } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -93,6 +95,47 @@ function useSavedFlash(): [boolean, () => void] {
 // cue so sighted and SR users get the same feedback.
 function SrSaved({ show, label = 'Saved' }: { show: boolean; label?: string }) {
   return <span role="status" aria-live="polite" className="sr-only">{show ? label : ''}</span>;
+}
+
+// Up/down reorder controls: lucide chevrons in 28px targets (clears the WCAG
+// 2.5.8 24×24 minimum) instead of raw glyphs, disabled only at the list ends.
+// When the pressed direction hits an end and self-disables, focus hops to the
+// still-enabled sibling so a keyboard user never drops to <body>.
+function MoveControls({
+  disabledUp, disabledDown, onUp, onDown, labelUp, labelDown, testIdUp, testIdDown,
+}: {
+  disabledUp: boolean;
+  disabledDown: boolean;
+  onUp: () => void;
+  onDown: () => void;
+  labelUp: string;
+  labelDown: string;
+  testIdUp: string;
+  testIdDown: string;
+}) {
+  const upRef = useRef<HTMLButtonElement>(null);
+  const downRef = useRef<HTMLButtonElement>(null);
+  const move = (dir: 'up' | 'down') => {
+    (dir === 'up' ? onUp : onDown)();
+    if (typeof requestAnimationFrame === 'undefined') return;
+    requestAnimationFrame(() => {
+      const pressed = dir === 'up' ? upRef.current : downRef.current;
+      const other = dir === 'up' ? downRef.current : upRef.current;
+      if (pressed && !pressed.disabled) pressed.focus();
+      else other?.focus();
+    });
+  };
+  const cls = 'inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-30';
+  return (
+    <>
+      <button ref={upRef} type="button" onClick={() => move('up')} disabled={disabledUp} aria-label={labelUp} data-testid={testIdUp} className={cls}>
+        <ChevronUp className="h-4 w-4" aria-hidden />
+      </button>
+      <button ref={downRef} type="button" onClick={() => move('down')} disabled={disabledDown} aria-label={labelDown} data-testid={testIdDown} className={cls}>
+        <ChevronDown className="h-4 w-4" aria-hidden />
+      </button>
+    </>
+  );
 }
 
 export default function QuoteEditor({ detail, onChanged }: Props) {
@@ -162,7 +205,18 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
   useEffect(() => { setTaxPct(pctFromFraction(quote.taxRate)); setTaxDirty(false); }, [quote.taxRate]);
 
-  const refresh = useCallback(() => onChanged(), [onChanged]);
+  // Coalesce re-pulls: each mutation calls refresh(), but tab-through editing
+  // would otherwise fire one full GET /quotes/:id per field. A short trailing
+  // delay collapses a burst of edits into a single refetch — the inline cues
+  // ("Saved", optimistic field/reorder state) already give immediate feedback,
+  // so only the server-recomputed totals wait. Guards against the documented US
+  // DB connection pressure from refetch storms.
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (refreshTimer.current) clearTimeout(refreshTimer.current); }, []);
+  const refresh = useCallback(() => {
+    if (refreshTimer.current) clearTimeout(refreshTimer.current);
+    refreshTimer.current = setTimeout(() => onChanged(), 300);
+  }, [onChanged]);
 
   const saveTerms = useCallback(async () => {
     if (!termsDirty) return;
@@ -236,17 +290,36 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
   useEffect(() => { void loadEcStatus(); }, [loadEcStatus]);
 
+  // Optimistic order overrides so a reorder reflects instantly instead of waiting
+  // for the round-trip + (coalesced) refetch. Each is cleared the moment fresh
+  // server data arrives (the prop array identity changes on refresh), so the
+  // server order always wins once it lands; a failed reorder reverts immediately.
+  const [blockOrder, setBlockOrder] = useState<string[] | null>(null);
+  const [lineOrder, setLineOrder] = useState<Record<string, string[]>>({});
+  useEffect(() => { setBlockOrder(null); }, [blocks]);
+  useEffect(() => { setLineOrder({}); }, [lines]);
+
+  // Apply an optimistic id ordering over a base list, but only if it's a clean
+  // permutation (same membership) — otherwise fall back to the server order.
+  const applyOrder = <T extends { id: string }>(base: T[], order: string[] | undefined): T[] => {
+    if (!order) return base;
+    const byId = new Map(base.map((x) => [x.id, x]));
+    const ordered = order.map((id) => byId.get(id)).filter((x): x is T => x !== undefined);
+    return ordered.length === base.length ? ordered : base;
+  };
+
   const sortedBlocks = useMemo(
-    () => [...blocks].sort((a, b) => a.sortOrder - b.sortOrder),
-    [blocks],
+    () => applyOrder([...blocks].sort((a, b) => a.sortOrder - b.sortOrder), blockOrder ?? undefined),
+    [blocks, blockOrder],
   );
 
   const linesForBlock = useCallback(
     (blockId: string) =>
-      lines
-        .filter((l) => l.blockId === blockId)
-        .sort((a, b) => a.sortOrder - b.sortOrder),
-    [lines],
+      applyOrder(
+        lines.filter((l) => l.blockId === blockId).sort((a, b) => a.sortOrder - b.sortOrder),
+        lineOrder[blockId],
+      ),
+    [lines, lineOrder],
   );
 
   // ---- add block -----------------------------------------------------------
@@ -502,38 +575,54 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // Reorder a block one slot up/down: compute the full new id order from a single
   // swap and send it; the server renumbers sortOrder 0..n-1. Scoped pending keeps
   // the rest of the editor live. refresh() re-pulls so sortedBlocks re-sorts.
-  const moveBlock = useCallback((block: QuoteBlock, direction: 'up' | 'down') =>
-    runScoped(`reorder-block:${block.id}`, async () => {
-      const ordered = [...sortedBlocks];
-      const idx = ordered.findIndex((b) => b.id === block.id);
-      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-      if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
-      [ordered[idx], ordered[swapIdx]] = [ordered[swapIdx], ordered[idx]];
+  // Reorder a block one slot: apply the new order optimistically so the card
+  // moves instantly (the buttons disable while the PATCH is in flight, so no
+  // double-fire), send the full id list, and revert the override on failure.
+  const moveBlock = useCallback((block: QuoteBlock, direction: 'up' | 'down') => {
+    // Drop a repeat click while this block's reorder is still in flight, so we
+    // never set an optimistic order the in-flight guard would then revert.
+    if (isPending(`reorder-block:${block.id}`)) return Promise.resolve(false);
+    const ordered = [...sortedBlocks];
+    const idx = ordered.findIndex((b) => b.id === block.id);
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return Promise.resolve(false);
+    [ordered[idx], ordered[swapIdx]] = [ordered[swapIdx], ordered[idx]];
+    const ids = ordered.map((b) => b.id);
+    const prev = blockOrder;
+    setBlockOrder(ids);
+    return runScoped(`reorder-block:${block.id}`, async () => {
       await runAction({
-        request: () => reorderBlocksApi(quote.id, { blockIds: ordered.map((b) => b.id) }),
+        request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
         errorFallback: 'Could not reorder blocks.',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    }, 'Could not reorder blocks.'),
-  [sortedBlocks, quote.id, refresh, runScoped]);
+    }, 'Could not reorder blocks.').then((ok) => { if (!ok) setBlockOrder(prev); return ok; });
+  }, [sortedBlocks, blockOrder, quote.id, refresh, runScoped, isPending]);
 
-  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') =>
-    runScoped(`reorder-line:${line.id}`, async () => {
-      const ordered = linesForBlock(blockId);
-      const idx = ordered.findIndex((l) => l.id === line.id);
-      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-      if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
-      const next = [...ordered];
-      [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
+  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
+    if (isPending(`reorder-line:${line.id}`)) return Promise.resolve(false);
+    const ordered = linesForBlock(blockId);
+    const idx = ordered.findIndex((l) => l.id === line.id);
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return Promise.resolve(false);
+    const next = [...ordered];
+    [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
+    const ids = next.map((l) => l.id);
+    const prev = lineOrder[blockId];
+    setLineOrder((m) => ({ ...m, [blockId]: ids }));
+    return runScoped(`reorder-line:${line.id}`, async () => {
       await runAction({
-        request: () => reorderLinesApi(quote.id, blockId, { lineIds: next.map((l) => l.id) }),
+        request: () => reorderLinesApi(quote.id, blockId, { lineIds: ids }),
         errorFallback: 'Could not reorder lines.',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    }, 'Could not reorder lines.'),
-  [linesForBlock, quote.id, refresh, runScoped]);
+    }, 'Could not reorder lines.').then((ok) => {
+      if (!ok) setLineOrder((m) => ({ ...m, [blockId]: prev as string[] }));
+      return ok;
+    });
+  }, [linesForBlock, lineOrder, quote.id, refresh, runScoped, isPending]);
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
@@ -547,7 +636,11 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       )}
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         {/* ── blocks ─────────────────────────────────────────────────── */}
-        <div className="space-y-4 focus:outline-none" ref={blocksColRef} tabIndex={-1}>
+        <div
+          className="space-y-4 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          ref={blocksColRef}
+          tabIndex={-1}
+        >
           {sortedBlocks.length === 0 ? (
             <div className="rounded-lg border border-dashed bg-card p-8 text-center text-sm text-muted-foreground" data-testid="quote-blocks-empty">
               No content yet. Add a heading, rich text, or a pricing table below.
@@ -560,6 +653,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 quoteId={quote.id}
                 lines={linesForBlock(block.id)}
                 currency={currency}
+                taxRate={quote.taxRate}
                 catalog={catalog}
                 isPending={isPending}
                 canWrite={canWrite}
@@ -677,6 +771,16 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
+            {/* One concise SR announcement covering every figure, so editing a
+                recurring line (which doesn't move "due on acceptance") still tells
+                a screen-reader user the totals recomputed. */}
+            <p className="sr-only" role="status" aria-live="polite" data-testid="quote-totals-sr">
+              {`Totals updated. One-time ${formatMoney(quote.oneTimeTotal, currency)}, `
+                + `monthly recurring ${formatMoney(quote.monthlyRecurringTotal, currency)}, `
+                + `annual recurring ${formatMoney(quote.annualRecurringTotal, currency)}`
+                + (Number(quote.taxTotal) > 0 ? `, tax ${formatMoney(quote.taxTotal, currency)}` : '')
+                + `, due on acceptance ${formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}.`}
+            </p>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">One-time</dt>
@@ -736,12 +840,11 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
             )}
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              {/* aria-live scoped to the headline figure so SR users hear the one
-                  number that matters recompute, not all four rows on every edit. */}
+              {/* Visual figure only; the SR-only summary node above announces the
+                  full set of totals on any change. */}
               <span
                 className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums"
                 data-testid="quote-total-due-on-acceptance"
-                aria-live="polite"
               >
                 {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
               </span>
@@ -836,12 +939,13 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, taxRate, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock,
 }: {
   block: QuoteBlock;
   quoteId: string;
   lines: QuoteLine[];
   currency: string;
+  taxRate: string | null;
   catalog: CatalogItem[];
   isPending: (key: string) => boolean;
   canWrite: boolean;
@@ -861,7 +965,6 @@ function BlockCard({
   onRemoveLine: (line: QuoteLine) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
 }) {
-  const reorderBusy = isPending(`reorder-block:${block.id}`);
   // Pending state scoped to this block: editing/removing this block, or adding a
   // line to it, never disables anything in a sibling block.
   const blockBusy = isPending(`block:${block.id}`);
@@ -942,26 +1045,16 @@ function BlockCard({
         </span>
         {canWrite && (
           <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => onMoveBlock(block, 'up')}
-              disabled={reorderBusy || isFirst}
-              aria-label="Move block up"
-              data-testid={`quote-block-move-up-${block.id}`}
-              className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
-            >
-              ↑
-            </button>
-            <button
-              type="button"
-              onClick={() => onMoveBlock(block, 'down')}
-              disabled={reorderBusy || isLast}
-              aria-label="Move block down"
-              data-testid={`quote-block-move-down-${block.id}`}
-              className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
-            >
-              ↓
-            </button>
+            <MoveControls
+              disabledUp={isFirst}
+              disabledDown={isLast}
+              onUp={() => onMoveBlock(block, 'up')}
+              onDown={() => onMoveBlock(block, 'down')}
+              labelUp="Move block up"
+              labelDown="Move block down"
+              testIdUp={`quote-block-move-up-${block.id}`}
+              testIdDown={`quote-block-move-down-${block.id}`}
+            />
             <button
               type="button"
               onClick={() => onRemoveBlock(block)}
@@ -1027,6 +1120,7 @@ function BlockCard({
                   <th className="px-2 py-2 text-right font-medium">Qty</th>
                   <th className="px-2 py-2 text-right font-medium">Unit</th>
                   <th className="px-2 py-2 font-medium">Recurrence</th>
+                  <th className="px-2 py-2 text-right font-medium">Tax</th>
                   <th className="px-2 py-2 text-right font-medium">Total</th>
                   <th className="px-2 py-2" />
                 </tr>
@@ -1034,7 +1128,7 @@ function BlockCard({
               <tbody>
                 {lines.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-2 py-6 text-center text-sm text-muted-foreground">
+                    <td colSpan={7} className="px-2 py-6 text-center text-sm text-muted-foreground">
                       No lines yet. Add a catalog item or a manual line below.
                     </td>
                   </tr>
@@ -1045,8 +1139,8 @@ function BlockCard({
                         key={l.id}
                         line={l}
                         currency={currency}
+                        taxRate={taxRate}
                         busy={isPending(`line:${l.id}`)}
-                        reorderBusy={isPending(`reorder-line:${l.id}`)}
                         isFirst={idx === 0}
                         isLast={idx === lines.length - 1}
                         onEdit={onEditLine}
@@ -1067,6 +1161,9 @@ function BlockCard({
                           <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                             {formatRecurrence(l.recurrence)}
                           </span>
+                        </td>
+                        <td className="px-2 py-2 text-right tabular-nums text-muted-foreground">
+                          {lineTaxAmount(l.lineTotal, l.taxable, taxRate) === null ? '—' : formatMoney(lineTaxAmount(l.lineTotal, l.taxable, taxRate)!, currency)}
                         </td>
                         <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
                         <td className="px-2 py-2 text-right" />
@@ -1202,12 +1299,12 @@ function BlockCard({
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 function EditableLineRow({
-  line, currency, busy, reorderBusy, isFirst, isLast, onEdit, onMove, onRemove,
+  line, currency, taxRate, busy, isFirst, isLast, onEdit, onMove, onRemove,
 }: {
   line: QuoteLine;
   currency: string;
+  taxRate: string | null;
   busy: boolean;
-  reorderBusy: boolean;
   isFirst: boolean;
   isLast: boolean;
   onEdit: (lineId: string, body: LineUpdate) => Promise<boolean>;
@@ -1324,7 +1421,9 @@ function EditableLineRow({
           <option value="monthly">Monthly</option>
           <option value="annual">Annual</option>
         </select>
-        <label className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+      </td>
+      <td className="px-2 py-2 text-right">
+        <label className="flex items-center justify-end gap-1.5 text-xs text-muted-foreground">
           <input
             type="checkbox"
             checked={taxable}
@@ -1337,7 +1436,12 @@ function EditableLineRow({
             disabled={busy}
             data-testid={`quote-line-taxable-${line.id}`}
           />
-          Taxable
+          <span className="tabular-nums" data-testid={`quote-line-tax-${line.id}`}>
+            {(() => {
+              const tax = lineTaxAmount(line.lineTotal, taxable, taxRate);
+              return tax === null ? '—' : formatMoney(tax, currency);
+            })()}
+          </span>
         </label>
       </td>
       <td className="px-2 py-2 text-right tabular-nums">
@@ -1347,26 +1451,16 @@ function EditableLineRow({
       </td>
       <td className="px-2 py-2 text-right">
         <div className="flex items-center justify-end gap-1">
-          <button
-            type="button"
-            onClick={() => onMove(line, 'up')}
-            disabled={reorderBusy || isFirst}
-            aria-label="Move line up"
-            data-testid={`quote-line-move-up-${line.id}`}
-            className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
-          >
-            ↑
-          </button>
-          <button
-            type="button"
-            onClick={() => onMove(line, 'down')}
-            disabled={reorderBusy || isLast}
-            aria-label="Move line down"
-            data-testid={`quote-line-move-down-${line.id}`}
-            className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
-          >
-            ↓
-          </button>
+          <MoveControls
+            disabledUp={isFirst}
+            disabledDown={isLast}
+            onUp={() => onMove(line, 'up')}
+            onDown={() => onMove(line, 'down')}
+            labelUp="Move line up"
+            labelDown="Move line down"
+            testIdUp={`quote-line-move-up-${line.id}`}
+            testIdDown={`quote-line-move-down-${line.id}`}
+          />
           <button
             type="button"
             onClick={() => onRemove(line)}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -29,6 +29,7 @@ import {
   type QuoteLineRecurrence,
   formatMoney,
   formatRecurrence,
+  pctFromFraction,
 } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -80,6 +81,9 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const [ecActive, setEcActive] = useState(false);
   const [terms, setTerms] = useState(quote.termsAndConditions ?? '');
   const [termsDirty, setTermsDirty] = useState(false);
+  // Tax rate is stored as a fraction ('0.07'); the input edits it as a percent ('7').
+  const [taxPct, setTaxPct] = useState(pctFromFraction(quote.taxRate));
+  const [taxDirty, setTaxDirty] = useState(false);
   const canCatalogWrite = can('catalog', 'write');
 
   // ---- add-block form ------------------------------------------------------
@@ -91,6 +95,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const [imageCaption, setImageCaption] = useState('');
 
   useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
+  useEffect(() => { setTaxPct(pctFromFraction(quote.taxRate)); setTaxDirty(false); }, [quote.taxRate]);
 
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
@@ -114,6 +119,44 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       setBusy(false);
     }
   }, [busy, termsDirty, terms, quote.id, refresh]);
+
+  // Persist the tax rate as a fraction. Empty clears it (null); otherwise the
+  // percent is clamped to 0–100 (fraction 0–1, matching updateQuoteSchema) and an
+  // out-of-range/non-numeric entry resets to the persisted value rather than
+  // saving garbage. The server recomputes taxTotal/total, so refresh() re-pulls.
+  const saveTaxRate = useCallback(async () => {
+    if (busy || !taxDirty) return;
+    const trimmed = taxPct.trim();
+    let fraction: number | null;
+    if (trimmed === '') {
+      fraction = null;
+    } else {
+      const pct = Number(trimmed);
+      if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+        setTaxPct(pctFromFraction(quote.taxRate));
+        setTaxDirty(false);
+        return;
+      }
+      fraction = Number((pct / 100).toFixed(5));
+    }
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/quotes/${quote.id}`, {
+          method: 'PATCH', body: JSON.stringify({ taxRate: fraction }),
+        }),
+        errorFallback: 'Could not save the tax rate.',
+        successMessage: 'Tax rate saved',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setTaxDirty(false);
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not save the tax rate.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, taxDirty, taxPct, quote.id, quote.taxRate, refresh]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -576,6 +619,31 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 </div>
               )}
             </dl>
+            {canWrite && (
+              <div className="mt-2 border-t pt-2">
+                <div className="flex items-center justify-between gap-2">
+                  <label htmlFor="quote-tax-rate" className="text-sm text-muted-foreground">Tax rate</label>
+                  <div className="flex items-center gap-1">
+                    <input
+                      id="quote-tax-rate"
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.001"
+                      value={taxPct}
+                      onChange={(e) => { setTaxPct(e.target.value); setTaxDirty(true); }}
+                      onBlur={() => void saveTaxRate()}
+                      disabled={busy}
+                      placeholder="0"
+                      data-testid="quote-tax-rate"
+                      className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${taxDirty ? 'ring-1 ring-warning' : ''}`}
+                    />
+                    <span className="text-sm text-muted-foreground">%</span>
+                  </div>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">Applies to lines marked taxable.</p>
+              </div>
+            )}
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
               <span className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
@@ -877,26 +945,27 @@ function BlockCard({
                   />
                   <div className="grid grid-cols-1 items-start gap-2 sm:grid-cols-[1fr_70px_90px_110px]">
                     <textarea
-                      placeholder="Description" value={desc}
+                      placeholder="Description" aria-label="Line description" value={desc}
                       onChange={(e) => setDesc(e.target.value)}
                       rows={2}
                       data-testid={`quote-manual-desc-${block.id}`}
                       className="min-h-[2.25rem] resize-y rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     <input
-                      type="number" min="0" step="0.01" placeholder="Qty" value={qty}
+                      type="number" min="0" step="0.01" placeholder="Qty" aria-label="Quantity" value={qty}
                       onChange={(e) => setQty(e.target.value)}
                       data-testid={`quote-manual-qty-${block.id}`}
                       className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     <input
-                      type="number" min="0" step="0.01" placeholder="Unit price" value={price}
+                      type="number" min="0" step="0.01" placeholder="Unit price" aria-label="Unit price" value={price}
                       onChange={(e) => setPrice(e.target.value)}
                       data-testid={`quote-manual-price-${block.id}`}
                       className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     <select
                       value={recurrence}
+                      aria-label="Billing frequency"
                       onChange={(e) => setRecurrence(e.target.value as QuoteLineRecurrence)}
                       data-testid={`quote-manual-recurrence-${block.id}`}
                       className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -76,7 +76,36 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
 
-  const [busy, setBusy] = useState(false);
+  // Per-item "saving" state, keyed so one in-flight mutation never freezes the
+  // rest of the editor. Keys: 'terms', 'tax', 'add-block', `block:<id>`,
+  // `add-line:<blockId>`, `line:<id>`. `pending` drives disabled styling;
+  // `inFlight` is the synchronous double-submit guard (state updates are async).
+  const inFlight = useRef<Set<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
+  const isPending = useCallback((key: string) => pending.has(key), [pending]);
+
+  // Run a scoped mutation: mark the key pending, run, surface failures via the
+  // standard handleActionError path, and always clear the key. Returns whether
+  // the mutation succeeded so callers can flash a quiet "Saved" cue.
+  const runScoped = useCallback(
+    async (key: string, fn: () => Promise<void>, errMsg: string): Promise<boolean> => {
+      if (inFlight.current.has(key)) return false;
+      inFlight.current.add(key);
+      setPending((s) => { const n = new Set(s); n.add(key); return n; });
+      try {
+        await fn();
+        return true;
+      } catch (err) {
+        handleActionError(err, errMsg);
+        return false;
+      } finally {
+        inFlight.current.delete(key);
+        setPending((s) => { const n = new Set(s); n.delete(key); return n; });
+      }
+    },
+    [],
+  );
+
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
   const [ecActive, setEcActive] = useState(false);
   const [terms, setTerms] = useState(quote.termsAndConditions ?? '');
@@ -84,6 +113,9 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // Tax rate is stored as a fraction ('0.07'); the input edits it as a percent ('7').
   const [taxPct, setTaxPct] = useState(pctFromFraction(quote.taxRate));
   const [taxDirty, setTaxDirty] = useState(false);
+  // Inline validation message for the tax field — an out-of-range/non-numeric
+  // entry no longer silently reverts; we keep the bad value and explain why.
+  const [taxError, setTaxError] = useState<string | null>(null);
   const canCatalogWrite = can('catalog', 'write');
 
   // ---- add-block form ------------------------------------------------------
@@ -100,9 +132,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
   const saveTerms = useCallback(async () => {
-    if (busy || !termsDirty) return;
-    setBusy(true);
-    try {
+    if (!termsDirty) return;
+    await runScoped('terms', async () => {
       await runAction({
         request: () => fetchWithAuth(`/quotes/${quote.id}`, {
           method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
@@ -113,19 +144,15 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       });
       setTermsDirty(false);
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save terms.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, termsDirty, terms, quote.id, refresh]);
+    }, 'Could not save terms.');
+  }, [termsDirty, terms, quote.id, refresh, runScoped]);
 
   // Persist the tax rate as a fraction. Empty clears it (null); otherwise the
   // percent is clamped to 0–100 (fraction 0–1, matching updateQuoteSchema) and an
   // out-of-range/non-numeric entry resets to the persisted value rather than
   // saving garbage. The server recomputes taxTotal/total, so refresh() re-pulls.
   const saveTaxRate = useCallback(async () => {
-    if (busy || !taxDirty) return;
+    if (!taxDirty) return;
     const trimmed = taxPct.trim();
     let fraction: number | null;
     if (trimmed === '') {
@@ -133,14 +160,15 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     } else {
       const pct = Number(trimmed);
       if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
-        setTaxPct(pctFromFraction(quote.taxRate));
-        setTaxDirty(false);
+        // Keep the user's entry (don't snap it away) and explain the constraint
+        // inline instead of swallowing it.
+        setTaxError('Enter a rate from 0 to 100.');
         return;
       }
       fraction = Number((pct / 100).toFixed(5));
     }
-    setBusy(true);
-    try {
+    setTaxError(null);
+    await runScoped('tax', async () => {
       await runAction({
         request: () => fetchWithAuth(`/quotes/${quote.id}`, {
           method: 'PATCH', body: JSON.stringify({ taxRate: fraction }),
@@ -151,12 +179,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       });
       setTaxDirty(false);
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save the tax rate.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, taxDirty, taxPct, quote.id, quote.taxRate, refresh]);
+    }, 'Could not save the tax rate.');
+  }, [taxDirty, taxPct, quote.id, refresh, runScoped]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -194,8 +218,6 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
   // ---- add block -----------------------------------------------------------
   const submitBlock = useCallback(async () => {
-    if (busy) return;
-
     // Image blocks have no block-update endpoint, so the file must exist before
     // the block: upload it (POST /:id/images → { data: { imageId } }), then add
     // an image block with that imageId already in its content. Both steps go
@@ -203,8 +225,13 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     if (addType === 'image') {
       const file = imageFile;
       if (!file) return;
-      setBusy(true);
-      try {
+      // Honor the "up to 5 MB" promise client-side so the user gets an immediate,
+      // specific message instead of a generic server-side upload failure.
+      if (file.size > 5 * 1024 * 1024) {
+        handleActionError(new Error('image too large'), 'Image must be 5 MB or smaller.');
+        return;
+      }
+      await runScoped('add-block', async () => {
         const uploaded = await runAction<{ imageId: string }>({
           request: () => uploadQuoteImage(quote.id, file),
           errorFallback: 'Could not upload the image.',
@@ -226,11 +253,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         });
         setImageFile(null); setImageCaption('');
         refresh();
-      } catch (err) {
-        handleActionError(err, 'Could not add the image block.');
-      } finally {
-        setBusy(false);
-      }
+      }, 'Could not add the image block.');
       return;
     }
 
@@ -247,8 +270,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         content: tableLabel.trim() ? { label: tableLabel.trim() } : {},
       };
     }
-    setBusy(true);
-    try {
+    await runScoped('add-block', async () => {
       await runAction({
         request: () => addBlock(quote.id, body),
         errorFallback: 'Could not add the block.',
@@ -257,24 +279,21 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       });
       setHeadingText(''); setRichText(''); setTableLabel('');
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not add the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh]);
+    }, 'Could not add the block.');
+  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh, runScoped]);
 
   // Removing a line_items block cascades to every line under it (server-side), so
   // the card's Remove button opens a confirm step instead of deleting outright.
   const [pendingRemove, setPendingRemove] = useState<QuoteBlock | null>(null);
+  // Line removal is equally irreversible, so it gets the same confirm step the
+  // block remove has (rather than deleting on a single click).
+  const [pendingLineRemove, setPendingLineRemove] = useState<QuoteLine | null>(null);
 
   // Real block delete: removes the block and (server-side) any lines attached to
   // it. Works for every block type — heading, rich_text, and line_items — so the
   // "Remove" button is no longer a silent no-op for heading/rich_text blocks.
-  const removeBlock = useCallback(async (block: QuoteBlock) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const removeBlock = useCallback((block: QuoteBlock) =>
+    runScoped(`block:${block.id}`, async () => {
       await runAction({
         request: () => deleteBlock(quote.id, block.id),
         errorFallback: 'Could not remove the block.',
@@ -282,12 +301,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not remove the block.'),
+  [quote.id, refresh, runScoped]);
 
   // ---- line mutations (scoped to a line_items block) ----------------------
   const doAddCatalog = useCallback(async (blockId: string, item: CatalogItem) => {
@@ -300,13 +315,9 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     refresh();
   }, [quote.id, refresh]);
 
-  const addCatalog = useCallback(async (blockId: string, item: CatalogItem) => {
-    if (busy) return;
-    setBusy(true);
-    try { await doAddCatalog(blockId, item); }
-    catch (err) { handleActionError(err, 'Could not add the catalog item.'); }
-    finally { setBusy(false); }
-  }, [busy, doAddCatalog]);
+  const addCatalog = useCallback((blockId: string, item: CatalogItem) =>
+    runScoped(`add-line:${blockId}`, () => doAddCatalog(blockId, item), 'Could not add the catalog item.'),
+  [doAddCatalog, runScoped]);
 
   const resolveCatalogBySku = useCallback(async (sku: string): Promise<CatalogItem | null> => {
     const fromState = catalog.find((i) => i.sku === sku);
@@ -321,10 +332,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     return (body?.data ?? []).find((i) => i.sku === sku) ?? null;
   }, [catalog]);
 
-  const importAndAddDistributor = useCallback(async (blockId: string, product: EcProduct, sellPrice: number) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const importAndAddDistributor = useCallback((blockId: string, product: EcProduct, sellPrice: number) =>
+    runScoped(`add-line:${blockId}`, async () => {
       // Check the catalog first: if this SKU is already imported, add the existing
       // item directly. This avoids the duplicate-SKU error toast (runAction toasts
       // the failure before throwing) firing on the common "already in catalog" path,
@@ -351,26 +360,28 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       }
       await doAddCatalog(blockId, item);
       void loadCatalog(); // surface a newly-imported item in the catalog picker too
-    } catch (err) {
-      handleActionError(err, 'Could not add the distributor item.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, doAddCatalog, resolveCatalogBySku, loadCatalog]);
+    }, 'Could not add the distributor item.'),
+  [doAddCatalog, resolveCatalogBySku, loadCatalog, runScoped]);
 
-  const addManual = useCallback(async (
+  const addManual = useCallback((
     blockId: string,
     form: { description: string; quantity: string; unitPrice: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean },
   ) => {
-    if (busy || !form.description.trim()) return;
-    setBusy(true);
-    try {
+    if (!form.description.trim()) return Promise.resolve(false);
+    // Guard qty 0 / non-numeric here too — the inline edit path already does, and
+    // a silent $0-quantity line is a real footgun on the add path.
+    const qtyNum = Number(form.quantity);
+    if (!Number.isFinite(qtyNum) || qtyNum <= 0) {
+      handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+      return Promise.resolve(false);
+    }
+    return runScoped(`add-line:${blockId}`, async () => {
       await runAction({
         request: () => addManualLine(quote.id, {
           sourceType: 'manual',
           blockId,
           description: form.description.trim(),
-          quantity: Number(form.quantity),
+          quantity: qtyNum,
           unitPrice: Number(form.unitPrice),
           taxable: form.taxable,
           customerVisible: true,
@@ -402,17 +413,11 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         void loadCatalog();
       }
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not add the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh, loadCatalog]);
+    }, 'Could not add the line.');
+  }, [quote.id, refresh, loadCatalog, runScoped]);
 
-  const deleteLine = useCallback(async (lineId: string) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const deleteLine = useCallback((lineId: string) =>
+    runScoped(`line:${lineId}`, async () => {
       await runAction({
         request: () => removeLine(quote.id, lineId),
         errorFallback: 'Could not remove the line.',
@@ -420,54 +425,39 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not remove the line.'),
+  [quote.id, refresh, runScoped]);
 
   // Inline edit of an existing line. `body` carries only the changed fields
-  // (matches updateQuoteLineSchema). Routed through runAction so success/failure
-  // is surfaced, then refresh() re-pulls the quote so totals recompute.
-  const editLine = useCallback(async (lineId: string, body: LineUpdate) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  // (matches updateQuoteLineSchema). Routed through runAction so failures are
+  // surfaced, then refresh() re-pulls the quote so totals recompute. Returns
+  // whether it succeeded so the row can flash a quiet "Saved" cue — routine
+  // inline edits no longer fire a success toast (that was per-field spam).
+  const editLine = useCallback((lineId: string, body: LineUpdate) =>
+    runScoped(`line:${lineId}`, async () => {
       await runAction({
         request: () => updateLine(quote.id, lineId, body),
         errorFallback: 'Could not update the line.',
-        successMessage: 'Line updated',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not update the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not update the line.'),
+  [quote.id, refresh, runScoped]);
 
   // Inline edit of a block's content (heading text/level, rich-text html). The
   // block type is restated so the server validates the content shape; it is
-  // immutable and never changes here.
-  const editBlock = useCallback(async (block: QuoteBlock, content: Record<string, unknown>) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  // immutable and never changes here. Like editLine, success is quiet (the row
+  // flashes "Saved"); only failures toast.
+  const editBlock = useCallback((block: QuoteBlock, content: Record<string, unknown>) =>
+    runScoped(`block:${block.id}`, async () => {
       await runAction({
         request: () => updateBlock(quote.id, block.id, { blockType: block.blockType, content } as QuoteBlockInput),
         errorFallback: 'Could not update the block.',
-        successMessage: 'Block updated',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not update the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not update the block.'),
+  [quote.id, refresh, runScoped]);
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
@@ -490,7 +480,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 lines={linesForBlock(block.id)}
                 currency={currency}
                 catalog={catalog}
-                busy={busy}
+                isPending={isPending}
                 canWrite={canWrite}
                 ecActive={ecActive}
                 onAddCatalog={addCatalog}
@@ -498,7 +488,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 onAddManual={addManual}
                 onEditLine={editLine}
                 onEditBlock={editBlock}
-                onRemoveLine={deleteLine}
+                onRemoveLine={setPendingLineRemove}
                 onRemoveBlock={setPendingRemove}
               />
             ))
@@ -513,6 +503,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 <button
                   key={o.value}
                   type="button"
+                  aria-pressed={addType === o.value}
                   onClick={() => setAddType(o.value)}
                   data-testid={`quote-add-block-type-${o.value}`}
                   className={`rounded-md border px-3 py-1.5 text-xs font-medium ${
@@ -580,7 +571,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 type="button"
                 onClick={() => void submitBlock()}
                 disabled={
-                  busy ||
+                  isPending('add-block') ||
                   (addType === 'heading' && !headingText.trim()) ||
                   (addType === 'rich_text' && !richText.trim()) ||
                   (addType === 'image' && !imageFile)
@@ -596,8 +587,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         </div>
 
         {/* ── live totals + terms ────────────────────────────────────── */}
-        <div className="space-y-4">
-          <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals">
+        {/* Sticky on lg so the totals you're building against stay visible while
+            scrolling the blocks; on narrow widths this column stacks below. */}
+        <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+          <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="quote-live-totals" aria-live="polite">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">
@@ -631,17 +624,25 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                       max="100"
                       step="0.001"
                       value={taxPct}
-                      onChange={(e) => { setTaxPct(e.target.value); setTaxDirty(true); }}
+                      onChange={(e) => { setTaxPct(e.target.value); setTaxDirty(true); if (taxError) setTaxError(null); }}
                       onBlur={() => void saveTaxRate()}
-                      disabled={busy}
+                      disabled={isPending('tax')}
                       placeholder="0"
+                      aria-invalid={taxError !== null}
+                      aria-describedby={taxError ? 'quote-tax-rate-error' : undefined}
                       data-testid="quote-tax-rate"
-                      className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${taxDirty ? 'ring-1 ring-warning' : ''}`}
+                      className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60 ${
+                        taxError ? 'border-destructive ring-1 ring-destructive' : taxDirty ? 'ring-1 ring-warning' : ''
+                      }`}
                     />
                     <span className="text-sm text-muted-foreground">%</span>
                   </div>
                 </div>
-                <p className="mt-1 text-xs text-muted-foreground">Applies to lines marked taxable.</p>
+                {taxError ? (
+                  <p className="mt-1 text-xs text-destructive" id="quote-tax-rate-error" data-testid="quote-tax-rate-error">{taxError}</p>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">Applies to lines marked taxable.</p>
+                )}
               </div>
             )}
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
@@ -688,7 +689,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           setPendingRemove(null);
           if (block) void removeBlock(block);
         }}
-        isLoading={busy}
+        isLoading={pendingRemove ? isPending(`block:${pendingRemove.id}`) : false}
         title="Remove block"
         message={
           pendingRemove?.blockType === 'line_items' && linesForBlock(pendingRemove.id).length > 0
@@ -700,20 +701,39 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         confirmLabel="Remove block"
         confirmTestId="quote-block-remove-confirm"
       />
+
+      <ConfirmDialog
+        open={pendingLineRemove !== null}
+        onClose={() => setPendingLineRemove(null)}
+        onConfirm={() => {
+          const line = pendingLineRemove;
+          setPendingLineRemove(null);
+          if (line) void deleteLine(line.id);
+        }}
+        isLoading={pendingLineRemove ? isPending(`line:${pendingLineRemove.id}`) : false}
+        title="Remove line"
+        message={
+          pendingLineRemove
+            ? `This removes "${pendingLineRemove.description || 'this line'}" from the quote. This can’t be undone.`
+            : ''
+        }
+        confirmLabel="Remove line"
+        confirmTestId="quote-line-remove-confirm"
+      />
     </div>
   );
 }
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, catalog, busy, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, catalog, isPending, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onRemoveLine, onRemoveBlock,
 }: {
   block: QuoteBlock;
   quoteId: string;
   lines: QuoteLine[];
   currency: string;
   catalog: CatalogItem[];
-  busy: boolean;
+  isPending: (key: string) => boolean;
   canWrite: boolean;
   ecActive: boolean;
   onAddCatalog: (blockId: string, item: CatalogItem) => void;
@@ -721,12 +741,17 @@ function BlockCard({
   onAddManual: (
     blockId: string,
     form: { description: string; quantity: string; unitPrice: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean },
-  ) => void;
-  onEditLine: (lineId: string, body: LineUpdate) => void;
-  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => void;
-  onRemoveLine: (lineId: string) => void;
+  ) => Promise<boolean>;
+  onEditLine: (lineId: string, body: LineUpdate) => Promise<boolean>;
+  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => Promise<boolean>;
+  onRemoveLine: (line: QuoteLine) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
 }) {
+  // Pending state scoped to this block: editing/removing this block, or adding a
+  // line to it, never disables anything in a sibling block.
+  const blockBusy = isPending(`block:${block.id}`);
+  const addLineBusy = isPending(`add-line:${block.id}`);
+
   const [mode, setMode] = useState<'catalog' | 'manual' | 'distributor'>('catalog');
   const [desc, setDesc] = useState('');
   const [qty, setQty] = useState('1');
@@ -761,33 +786,49 @@ function BlockCard({
     lastHtml.current = html;
   }, [html]);
 
-  const commitHeading = () => {
+  // Quiet "Saved" flash for inline content edits (replaces the old per-edit
+  // success toast). Cleared on unmount so a late timer can't setState a gone row.
+  const [blockSaved, setBlockSaved] = useState(false);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedTimer.current) clearTimeout(savedTimer.current); }, []);
+  const flashSaved = useCallback(() => {
+    setBlockSaved(true);
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+    savedTimer.current = setTimeout(() => setBlockSaved(false), 1500);
+  }, []);
+
+  const commitHeading = async () => {
     const text = headingDraft.trim();
     if (!text || text === heading) { setHeadingDraft(heading); return; }
-    onEditBlock(block, { text, level: (block.content?.level as number | undefined) ?? 2 });
+    if (await onEditBlock(block, { text, level: (block.content?.level as number | undefined) ?? 2 })) flashSaved();
   };
-  const commitRich = () => {
+  const commitRich = async () => {
     if (richDraft === html) return;
-    onEditBlock(block, { html: richDraft });
+    if (await onEditBlock(block, { html: richDraft })) flashSaved();
   };
 
-  const submitManual = () => {
-    onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
-    setDesc(''); setQty('1'); setPrice('0.00'); setTaxable(false); setRecurrence('one_time'); setSaveToCatalog(false);
+  const submitManual = async () => {
+    const ok = await onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
+    // Only clear the form on success, so a rejected add (e.g. qty 0) keeps the
+    // user's input to correct rather than wiping it.
+    if (ok) { setDesc(''); setQty('1'); setPrice('0.00'); setTaxable(false); setRecurrence('one_time'); setSaveToCatalog(false); }
   };
 
   return (
     <div className="rounded-lg border bg-card shadow-sm" data-testid={`quote-block-${block.id}`}>
       <div className="flex items-center justify-between border-b px-4 py-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {BLOCK_TYPE_LABELS[block.blockType] ?? block.blockType}
           {isTable && tableLabel ? ` · ${tableLabel}` : ''}
+          {blockSaved && (
+            <span className="font-medium normal-case tracking-normal text-success" data-testid={`quote-block-saved-${block.id}`}>Saved</span>
+          )}
         </span>
         {canWrite && (
           <button
             type="button"
             onClick={() => onRemoveBlock(block)}
-            disabled={busy}
+            disabled={blockBusy}
             data-testid={`quote-block-remove-${block.id}`}
             className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
           >
@@ -801,11 +842,12 @@ function BlockCard({
           canWrite ? (
             <input
               value={headingDraft}
+              aria-label="Heading text"
               onChange={(e) => setHeadingDraft(e.target.value)}
-              onBlur={commitHeading}
-              disabled={busy}
+              onBlur={() => void commitHeading()}
+              disabled={blockBusy}
               data-testid={`quote-block-heading-input-${block.id}`}
-              className="w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold"
+              className="w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold disabled:opacity-60"
             />
           ) : (
             <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
@@ -815,12 +857,13 @@ function BlockCard({
           canWrite ? (
             <textarea
               value={richDraft}
+              aria-label="Rich text content"
               onChange={(e) => setRichDraft(e.target.value)}
-              onBlur={commitRich}
-              disabled={busy}
+              onBlur={() => void commitRich()}
+              disabled={blockBusy}
               rows={4}
               data-testid={`quote-block-rich-input-${block.id}`}
-              className="w-full resize-y rounded-md border bg-background px-2 py-1 text-sm"
+              className="w-full resize-y rounded-md border bg-background px-2 py-1 text-sm disabled:opacity-60"
             />
           ) : (
             <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
@@ -864,7 +907,7 @@ function BlockCard({
                         key={l.id}
                         line={l}
                         currency={currency}
-                        busy={busy}
+                        busy={isPending(`line:${l.id}`)}
                         onEdit={onEditLine}
                         onRemove={onRemoveLine}
                       />
@@ -879,7 +922,7 @@ function BlockCard({
                         <td className="px-2 py-2 text-right tabular-nums">{l.quantity}</td>
                         <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
                         <td className="px-2 py-2">
-                          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                             {formatRecurrence(l.recurrence)}
                           </span>
                         </td>
@@ -900,6 +943,7 @@ function BlockCard({
                   <button
                     key={m}
                     type="button"
+                    aria-pressed={mode === m}
                     onClick={() => setMode(m)}
                     data-testid={`quote-line-mode-${block.id}-${m}`}
                     className={`rounded-md border px-3 py-1 text-xs font-medium ${
@@ -914,7 +958,7 @@ function BlockCard({
               {mode === 'distributor' ? (
                 <DistributorLookup
                   blockId={block.id}
-                  busy={busy}
+                  busy={addLineBusy}
                   onImportAdd={(product, sellPrice) => onImportAddDistributor(block.id, product, sellPrice)}
                 />
               ) : mode === 'catalog' ? (
@@ -930,7 +974,7 @@ function BlockCard({
                     onSelect={(it) => onAddCatalog(block.id, it)}
                     testId={`quote-catalog-picker-${block.id}`}
                     placeholder="Search catalog by name or SKU"
-                    disabled={busy}
+                    disabled={addLineBusy}
                   />
                 )
               ) : (
@@ -988,8 +1032,8 @@ function BlockCard({
                     </div>
                     <button
                       type="button"
-                      onClick={submitManual}
-                      disabled={busy || !desc.trim()}
+                      onClick={() => void submitManual()}
+                      disabled={addLineBusy || !desc.trim()}
                       data-testid={`quote-manual-add-${block.id}`}
                       className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                     >
@@ -1021,8 +1065,8 @@ function EditableLineRow({
   line: QuoteLine;
   currency: string;
   busy: boolean;
-  onEdit: (lineId: string, body: LineUpdate) => void;
-  onRemove: (lineId: string) => void;
+  onEdit: (lineId: string, body: LineUpdate) => Promise<boolean>;
+  onRemove: (line: QuoteLine) => void;
 }) {
   const [desc, setDesc] = useState(line.description);
   const [qty, setQty] = useState(line.quantity);
@@ -1033,20 +1077,31 @@ function EditableLineRow({
   useEffect(() => { setQty(line.quantity); }, [line.quantity]);
   useEffect(() => { setPrice(line.unitPrice); }, [line.unitPrice]);
 
+  // Quiet "Saved" flash in place of the old per-field success toast.
+  const [saved, setSaved] = useState(false);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedTimer.current) clearTimeout(savedTimer.current); }, []);
+  const flashSaved = useCallback(() => {
+    setSaved(true);
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+    savedTimer.current = setTimeout(() => setSaved(false), 1500);
+  }, []);
+  const edit = useCallback(async (body: LineUpdate) => { if (await onEdit(line.id, body)) flashSaved(); }, [onEdit, line.id, flashSaved]);
+
   const commitDesc = () => {
     const next = desc.trim();
     if (!next || next === line.description) { setDesc(line.description); return; }
-    onEdit(line.id, { description: next });
+    void edit({ description: next });
   };
   const commitQty = () => {
     const n = Number(qty);
     if (!Number.isFinite(n) || n <= 0 || n === Number(line.quantity)) { setQty(line.quantity); return; }
-    onEdit(line.id, { quantity: n });
+    void edit({ quantity: n });
   };
   const commitPrice = () => {
     const n = Number(price);
     if (!Number.isFinite(n) || n < 0 || n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; }
-    onEdit(line.id, { unitPrice: n });
+    void edit({ unitPrice: n });
   };
 
   return (
@@ -1056,6 +1111,7 @@ function EditableLineRow({
           {line.catalogItemId && <CatalogLineThumb catalogItemId={line.catalogItemId} />}
           <textarea
             value={desc}
+            aria-label="Line description"
             onChange={(e) => setDesc(e.target.value)}
             onBlur={commitDesc}
             rows={2}
@@ -1069,6 +1125,7 @@ function EditableLineRow({
         <input
           type="number" min="0" step="0.01"
           value={qty}
+          aria-label="Quantity"
           onChange={(e) => setQty(e.target.value)}
           onBlur={commitQty}
           disabled={busy}
@@ -1080,6 +1137,7 @@ function EditableLineRow({
         <input
           type="number" min="0" step="0.01"
           value={price}
+          aria-label="Unit price"
           onChange={(e) => setPrice(e.target.value)}
           onBlur={commitPrice}
           disabled={busy}
@@ -1090,7 +1148,8 @@ function EditableLineRow({
       <td className="px-2 py-2">
         <select
           value={line.recurrence}
-          onChange={(e) => onEdit(line.id, { recurrence: e.target.value as QuoteLineRecurrence })}
+          aria-label="Billing frequency"
+          onChange={(e) => void edit({ recurrence: e.target.value as QuoteLineRecurrence })}
           disabled={busy}
           data-testid={`quote-line-recurrence-${line.id}`}
           className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
@@ -1103,18 +1162,22 @@ function EditableLineRow({
           <input
             type="checkbox"
             checked={line.taxable}
-            onChange={(e) => onEdit(line.id, { taxable: e.target.checked })}
+            aria-label="Taxable"
+            onChange={(e) => void edit({ taxable: e.target.checked })}
             disabled={busy}
             data-testid={`quote-line-taxable-${line.id}`}
           />
           Taxable
         </label>
       </td>
-      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(line.lineTotal, currency)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        {formatMoney(line.lineTotal, currency)}
+        {saved && <span className="ml-1 text-xs font-medium text-success" data-testid={`quote-line-saved-${line.id}`}>Saved</span>}
+      </td>
       <td className="px-2 py-2 text-right">
         <button
           type="button"
-          onClick={() => onRemove(line.id)}
+          onClick={() => onRemove(line)}
           disabled={busy}
           data-testid={`quote-line-remove-${line.id}`}
           className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -363,10 +363,25 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     });
   }, [lines]);
 
-  // The figures the rail renders: optimistic recompute when any line is mid-edit,
-  // otherwise the authoritative server values verbatim.
+  // The effective tax rate the rail should reflect: the committed server rate
+  // normally, but the live tax-field value while it's mid-edit (and valid). An
+  // out-of-range/non-numeric entry isn't applied — it falls back to the committed
+  // rate, matching saveTaxRate's own clamp — so the rail never previews garbage.
+  const committedRate = quote.taxRate ? parseFloat(quote.taxRate) : null;
+  const effectiveRate = useMemo<number | null>(() => {
+    if (!taxDirty) return committedRate;
+    const trimmed = taxPct.trim();
+    if (trimmed === '') return null;
+    const pct = Number(trimmed);
+    if (!Number.isFinite(pct) || pct < 0 || pct > 100) return committedRate;
+    return Number((pct / 100).toFixed(5));
+  }, [taxDirty, taxPct, committedRate]);
+  const rateChanged = effectiveRate !== committedRate;
+
+  // The figures the rail renders: optimistic recompute when any line is mid-edit
+  // OR the tax rate is mid-edit, otherwise the authoritative server values.
   const optimisticTotals = useMemo<QuoteTotals | null>(() => {
-    if (Object.keys(lineDrafts).length === 0) return null;
+    if (Object.keys(lineDrafts).length === 0 && !rateChanged) return null;
     const merged: QuoteLineForMath[] = lines.map((l) => {
       const d = lineDrafts[l.id];
       return d ?? {
@@ -374,8 +389,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         customerVisible: l.customerVisible, recurrence: l.recurrence,
       };
     });
-    return computeQuoteTotals(merged, quote.taxRate ? parseFloat(quote.taxRate) : null);
-  }, [lineDrafts, lines, quote.taxRate]);
+    return computeQuoteTotals(merged, effectiveRate);
+  }, [lineDrafts, lines, effectiveRate, rateChanged]);
   const railOneTime = optimisticTotals?.oneTimeTotal ?? quote.oneTimeTotal;
   const railMonthly = optimisticTotals?.monthlyRecurringTotal ?? quote.monthlyRecurringTotal;
   const railAnnual = optimisticTotals?.annualRecurringTotal ?? quote.annualRecurringTotal;
@@ -1521,13 +1536,25 @@ function EditableLineRow({
   const commitQty = () => {
     const n = Number(qty);
     qtyEdited.current = false;
-    if (!Number.isFinite(n) || n <= 0 || n === Number(line.quantity)) { setQty(line.quantity); return; }
+    if (n === Number(line.quantity)) { setQty(line.quantity); return; } // unchanged — silent
+    // A rejected entry no longer snaps back silently: tell the user why (parity
+    // with the tax field and the manual-add path) before reverting.
+    if (!Number.isFinite(n) || n <= 0) {
+      handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+      setQty(line.quantity);
+      return;
+    }
     void edit({ quantity: n });
   };
   const commitPrice = () => {
     const n = Number(price);
     priceEdited.current = false;
-    if (!Number.isFinite(n) || n < 0 || n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; }
+    if (n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; } // unchanged — silent
+    if (!Number.isFinite(n) || n < 0) {
+      handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+      setPrice(line.unitPrice);
+      return;
+    }
     void edit({ unitPrice: n });
   };
 

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -18,7 +18,7 @@ import {
   quoteImageUrl,
 } from '../../../lib/api/quotes';
 import type { QuoteBlockInput } from '@breeze/shared';
-import { computeQuoteTotals, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';
+import { computeQuoteTotals, computeLineTotal, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';
 import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
@@ -1478,37 +1478,31 @@ function EditableLineRow({
   const qtyDirty = Number(qty) !== Number(line.quantity);
   const priceDirty = Number(price) !== Number(line.unitPrice);
 
-  // While qty/price are mid-edit, the row's Total and Tax cells must reflect the
-  // local values, not the server's stale `lineTotal` — otherwise the row visibly
-  // disagrees with itself (new qty, old total) until the debounced refresh lands.
-  // When the row isn't dirty we defer to the authoritative server total so any
-  // server-side normalization (e.g. clamped qty) still wins.
-  // Empty fields (mid-retype) aren't optimism inputs — Number('') is 0, which would
-  // flash Total/Tax to $0.00 while the user is clearing a field. Fall back to the
-  // server total until both fields hold a value.
+  // Effective qty/price for the optimistic Total/Tax and the rail draft. A blank
+  // or non-positive qty / negative price isn't an optimism input — it would flash
+  // the line to $0 while the user is mid-retype (and `commitQty` rejects qty ≤ 0
+  // anyway), so fall back to the persisted value until the field holds a real one.
   const qtyNum = Number(qty);
   const priceNum = Number(price);
-  const displayTotal =
-    (qtyDirty || priceDirty) && qty.trim() !== '' && price.trim() !== ''
-    && Number.isFinite(qtyNum) && Number.isFinite(priceNum) && qtyNum >= 0 && priceNum >= 0
-      ? qtyNum * priceNum
-      : Number(line.lineTotal);
-  const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
-
-  // Report this row's effective values to the parent so the rail "Live totals"
-  // recompute matches the per-row optimistic Total/Tax. Mirror displayTotal's
-  // fallback: when a field is empty/invalid, use the persisted value (so a
-  // mid-clear field never zeroes the rail). Emit null once everything matches the
-  // persisted line, so the rail reverts to the authoritative server figures.
-  const qtyValid = qty.trim() !== '' && Number.isFinite(qtyNum) && qtyNum >= 0;
+  const qtyValid = qty.trim() !== '' && Number.isFinite(qtyNum) && qtyNum > 0;
   const priceValid = price.trim() !== '' && Number.isFinite(priceNum) && priceNum >= 0;
   const effQty = qtyValid ? qty : line.quantity;
   const effPrice = priceValid ? price : line.unitPrice;
-  const diverged =
-    Number(effQty) !== Number(line.quantity)
-    || Number(effPrice) !== Number(line.unitPrice)
-    || taxable !== line.taxable
-    || rec !== line.recurrence;
+  const totalDiverged = Number(effQty) !== Number(line.quantity) || Number(effPrice) !== Number(line.unitPrice);
+
+  // The row's Total/Tax use the SAME shared cents math as the rail
+  // (computeLineTotal — round-half-up at the cent boundary), so a sub-cent unit
+  // price can't make the row Total and the rail contribution disagree by a cent
+  // while typing. When qty/price are unchanged we defer to the authoritative
+  // persisted lineTotal so server normalization still wins on settle.
+  const displayTotal = totalDiverged ? computeLineTotal(effQty, effPrice) : line.lineTotal;
+  const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
+
+  // Report this row's effective values to the parent so the rail "Live totals"
+  // recompute uses the same inputs. Emit null once nothing diverges, so the rail
+  // reverts to the authoritative server figures; cleanup on unmount avoids a
+  // phantom draft skewing the rail after a delete.
+  const diverged = totalDiverged || taxable !== line.taxable || rec !== line.recurrence;
   useEffect(() => {
     onDraft(line.id, diverged
       ? { quantity: String(effQty), unitPrice: String(effPrice), taxable, customerVisible: line.customerVisible, recurrence: rec }
@@ -1616,7 +1610,7 @@ function EditableLineRow({
         </label>
       </td>
       <td className="px-2 py-2 text-right tabular-nums">
-        {formatMoney(displayTotal, currency)}
+        <span data-testid={`quote-line-total-${line.id}`}>{formatMoney(displayTotal, currency)}</span>
         {saved && <span className="ml-1 text-xs font-medium text-success" data-testid={`quote-line-saved-${line.id}`}>Saved</span>}
         <SrSaved show={saved} />
       </td>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -94,7 +94,8 @@ function useSavedFlash(): [boolean, () => void] {
 // "Saved") to screen readers without taking visual space. Pairs with the visible
 // cue so sighted and SR users get the same feedback.
 function SrSaved({ show, label = 'Saved' }: { show: boolean; label?: string }) {
-  return <span role="status" aria-live="polite" className="sr-only">{show ? label : ''}</span>;
+  // role="status" already implies aria-live="polite" — don't double it.
+  return <span role="status" className="sr-only">{show ? label : ''}</span>;
 }
 
 // Up/down reorder controls: lucide chevrons in 28px targets (clears the WCAG
@@ -206,16 +207,34 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   useEffect(() => { setTaxPct(pctFromFraction(quote.taxRate)); setTaxDirty(false); }, [quote.taxRate]);
 
   // Coalesce re-pulls: each mutation calls refresh(), but tab-through editing
-  // would otherwise fire one full GET /quotes/:id per field. A short trailing
-  // delay collapses a burst of edits into a single refetch — the inline cues
-  // ("Saved", optimistic field/reorder state) already give immediate feedback,
-  // so only the server-recomputed totals wait. Guards against the documented US
-  // DB connection pressure from refetch storms.
+  // would otherwise fire one full GET /quotes/:id per field. This is a LEADING +
+  // trailing throttle, not a pure trailing debounce: the first edit of a burst
+  // refetches immediately (so the server-recomputed rail totals update at once),
+  // then further edits within the window collapse into a single trailing refetch
+  // that captures the final state. This caps requests at ~1 / window (guarding
+  // the documented US DB connection pressure) while never leaving the "Live
+  // totals" frozen mid-burst — a pure trailing debounce did exactly that.
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshTrailing = useRef(false);
   useEffect(() => () => { if (refreshTimer.current) clearTimeout(refreshTimer.current); }, []);
   const refresh = useCallback(() => {
-    if (refreshTimer.current) clearTimeout(refreshTimer.current);
-    refreshTimer.current = setTimeout(() => onChanged(), 300);
+    if (refreshTimer.current) {
+      // Inside the cooldown window — remember to fire once more when it closes.
+      refreshTrailing.current = true;
+      return;
+    }
+    onChanged(); // leading edge: refetch now
+    const openWindow = () => {
+      refreshTimer.current = setTimeout(function close() {
+        refreshTimer.current = null;
+        if (refreshTrailing.current) {
+          refreshTrailing.current = false;
+          onChanged();
+          openWindow(); // reopen so a fresh burst keeps coalescing
+        }
+      }, 300);
+    };
+    openWindow();
   }, [onChanged]);
 
   const saveTerms = useCallback(async () => {
@@ -296,8 +315,22 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // server order always wins once it lands; a failed reorder reverts immediately.
   const [blockOrder, setBlockOrder] = useState<string[] | null>(null);
   const [lineOrder, setLineOrder] = useState<Record<string, string[]>>({});
-  useEffect(() => { setBlockOrder(null); }, [blocks]);
-  useEffect(() => { setLineOrder({}); }, [lines]);
+  // Debounced reorder commit: repeat chevron clicks accumulate into the optimistic
+  // order instantly (no click is dropped while a PATCH is "in flight"); a single
+  // trailing PATCH per axis sends the final full id list. The server renumbers
+  // 0..n-1 from that list, so a coalesced final order is always correct. The
+  // `*Base` refs hold the latest optimistic id order so successive clicks within
+  // one tick stack on each other rather than re-reading a stale render.
+  const blockReorderTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const blockReorderBase = useRef<string[] | null>(null);
+  const lineReorderTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const lineReorderBase = useRef<Record<string, string[]>>({});
+  useEffect(() => { setBlockOrder(null); blockReorderBase.current = null; }, [blocks]);
+  useEffect(() => { setLineOrder({}); lineReorderBase.current = {}; }, [lines]);
+  useEffect(() => () => {
+    if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
+    Object.values(lineReorderTimers.current).forEach(clearTimeout);
+  }, []);
 
   // Apply an optimistic id ordering over a base list, but only if it's a clean
   // permutation (same membership) — otherwise fall back to the server order.
@@ -572,57 +605,76 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     }, 'Could not update the block.'),
   [quote.id, refresh, runScoped]);
 
-  // Reorder a block one slot up/down: compute the full new id order from a single
-  // swap and send it; the server renumbers sortOrder 0..n-1. Scoped pending keeps
-  // the rest of the editor live. refresh() re-pulls so sortedBlocks re-sorts.
-  // Reorder a block one slot: apply the new order optimistically so the card
-  // moves instantly (the buttons disable while the PATCH is in flight, so no
-  // double-fire), send the full id list, and revert the override on failure.
+  // Reorder a block one slot up/down. The optimistic order updates instantly on
+  // every click (clicks accumulate — none are dropped while a PATCH is pending),
+  // and a single trailing PATCH per burst sends the final full id list, which the
+  // server renumbers 0..n-1. Each click stacks on `blockReorderBase` so a flurry
+  // of clicks moves an item several slots before one request goes out. A failed
+  // reorder clears the override and re-pulls the authoritative server order.
   const moveBlock = useCallback((block: QuoteBlock, direction: 'up' | 'down') => {
-    // Drop a repeat click while this block's reorder is still in flight, so we
-    // never set an optimistic order the in-flight guard would then revert.
-    if (isPending(`reorder-block:${block.id}`)) return Promise.resolve(false);
-    const ordered = [...sortedBlocks];
-    const idx = ordered.findIndex((b) => b.id === block.id);
+    const currentIds = blockReorderBase.current ?? sortedBlocks.map((b) => b.id);
+    const idx = currentIds.indexOf(block.id);
     const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-    if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return Promise.resolve(false);
-    [ordered[idx], ordered[swapIdx]] = [ordered[swapIdx], ordered[idx]];
-    const ids = ordered.map((b) => b.id);
-    const prev = blockOrder;
-    setBlockOrder(ids);
-    return runScoped(`reorder-block:${block.id}`, async () => {
-      await runAction({
-        request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
-        errorFallback: 'Could not reorder blocks.',
-        onUnauthorized: UNAUTHORIZED,
-      });
-      refresh();
-    }, 'Could not reorder blocks.').then((ok) => { if (!ok) setBlockOrder(prev); return ok; });
-  }, [sortedBlocks, blockOrder, quote.id, refresh, runScoped, isPending]);
+    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
+    const ids = [...currentIds];
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    blockReorderBase.current = ids;
+    setBlockOrder(ids); // optimistic, instant
+    // Debounce the PATCH (not runScoped — its shared key would drop a second
+    // reorder that fires while the first is still in flight; the debounce already
+    // coalesces a burst). runAction surfaces failures; on failure we drop the
+    // override and re-pull the authoritative order.
+    if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
+    blockReorderTimer.current = setTimeout(() => {
+      blockReorderTimer.current = null;
+      void (async () => {
+        try {
+          await runAction({
+            request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
+            errorFallback: 'Could not reorder blocks.',
+            onUnauthorized: UNAUTHORIZED,
+          });
+          refresh();
+        } catch (err) {
+          handleActionError(err, 'Could not reorder blocks.');
+          setBlockOrder(null);
+          blockReorderBase.current = null;
+          refresh();
+        }
+      })();
+    }, 250);
+  }, [sortedBlocks, quote.id, refresh]);
 
   const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
-    if (isPending(`reorder-line:${line.id}`)) return Promise.resolve(false);
-    const ordered = linesForBlock(blockId);
-    const idx = ordered.findIndex((l) => l.id === line.id);
+    const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
+    const idx = currentIds.indexOf(line.id);
     const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-    if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return Promise.resolve(false);
-    const next = [...ordered];
-    [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
-    const ids = next.map((l) => l.id);
-    const prev = lineOrder[blockId];
-    setLineOrder((m) => ({ ...m, [blockId]: ids }));
-    return runScoped(`reorder-line:${line.id}`, async () => {
-      await runAction({
-        request: () => reorderLinesApi(quote.id, blockId, { lineIds: ids }),
-        errorFallback: 'Could not reorder lines.',
-        onUnauthorized: UNAUTHORIZED,
-      });
-      refresh();
-    }, 'Could not reorder lines.').then((ok) => {
-      if (!ok) setLineOrder((m) => ({ ...m, [blockId]: prev as string[] }));
-      return ok;
-    });
-  }, [linesForBlock, lineOrder, quote.id, refresh, runScoped, isPending]);
+    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
+    const ids = [...currentIds];
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    lineReorderBase.current = { ...lineReorderBase.current, [blockId]: ids };
+    setLineOrder((m) => ({ ...m, [blockId]: ids })); // optimistic, instant
+    const existing = lineReorderTimers.current[blockId];
+    if (existing) clearTimeout(existing);
+    lineReorderTimers.current[blockId] = setTimeout(() => {
+      delete lineReorderTimers.current[blockId];
+      void (async () => {
+        try {
+          await runAction({
+            request: () => reorderLinesApi(quote.id, blockId, { lineIds: ids }),
+            errorFallback: 'Could not reorder lines.',
+            onUnauthorized: UNAUTHORIZED,
+          });
+          refresh();
+        } catch (err) {
+          handleActionError(err, 'Could not reorder lines.');
+          setLineOrder((m) => { const n = { ...m }; delete n[blockId]; return n; });
+          delete lineReorderBase.current[blockId];
+          refresh();
+        }
+      })();
+    }, 250);
+  }, [linesForBlock, quote.id, refresh]);
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
@@ -631,7 +683,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     <div className="space-y-6" data-testid="quote-editor">
       {canWrite && (
         <p className="text-xs text-muted-foreground" data-testid="quote-editor-autosave-hint">
-          Changes save automatically as you edit.
+          Changes save automatically as you edit. An amber outline marks an edit that hasn’t saved yet.
         </p>
       )}
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
@@ -774,7 +826,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
             {/* One concise SR announcement covering every figure, so editing a
                 recurring line (which doesn't move "due on acceptance") still tells
                 a screen-reader user the totals recomputed. */}
-            <p className="sr-only" role="status" aria-live="polite" data-testid="quote-totals-sr">
+            <p className="sr-only" role="status" data-testid="quote-totals-sr">
               {`Totals updated. One-time ${formatMoney(quote.oneTimeTotal, currency)}, `
                 + `monthly recurring ${formatMoney(quote.monthlyRecurringTotal, currency)}, `
                 + `annual recurring ${formatMoney(quote.annualRecurringTotal, currency)}`
@@ -1113,14 +1165,23 @@ function BlockCard({
 
         {isTable && (
           <div className="space-y-3">
-            <table className="w-full text-sm" data-testid={`quote-block-lines-${block.id}`}>
+            {/* The 7-column row (description + 4 inline controls + total + actions)
+                can't compress gracefully on a tablet, so the table keeps a sensible
+                min width and the wrapper scrolls horizontally below that. */}
+            <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-2 py-2 font-medium">Description</th>
                   <th className="px-2 py-2 text-right font-medium">Qty</th>
                   <th className="px-2 py-2 text-right font-medium">Unit</th>
                   <th className="px-2 py-2 font-medium">Recurrence</th>
-                  <th className="px-2 py-2 text-right font-medium">Tax</th>
+                  <th
+                    className="px-2 py-2 text-right font-medium"
+                    title="Per-line tax. The header Tax total is authoritative and may differ by a rounding cent."
+                  >
+                    Tax
+                  </th>
                   <th className="px-2 py-2 text-right font-medium">Total</th>
                   <th className="px-2 py-2" />
                 </tr>
@@ -1173,6 +1234,7 @@ function BlockCard({
                 )}
               </tbody>
             </table>
+            </div>
 
             {/* Add line to this pricing table */}
             {canWrite && (
@@ -1320,10 +1382,29 @@ function EditableLineRow({
   const [rec, setRec] = useState(line.recurrence);
   const [taxable, setTaxable] = useState(line.taxable);
 
-  // Resync when the persisted line changes (after a refresh()).
-  useEffect(() => { setDesc(line.description); }, [line.description]);
-  useEffect(() => { setQty(line.quantity); }, [line.quantity]);
-  useEffect(() => { setPrice(line.unitPrice); }, [line.unitPrice]);
+  // Resync the typed fields from the server only when the user hasn't diverged
+  // from what we last showed — mirroring the block-draft guard. A quiet refresh
+  // (now leading-edge, so it can land while a fast typer is still in the field)
+  // must not overwrite an in-progress edit: if the local value no longer matches
+  // the prop we last synced, the user has typed since — keep their text. Without
+  // this, "edit qty→5, blur, type 7" loses the 7 when the GET for 5 returns.
+  const lastDesc = useRef(line.description);
+  const lastQty = useRef(line.quantity);
+  const lastPrice = useRef(line.unitPrice);
+  useEffect(() => {
+    setDesc((cur) => (cur === lastDesc.current ? line.description : cur));
+    lastDesc.current = line.description;
+  }, [line.description]);
+  useEffect(() => {
+    setQty((cur) => (cur === lastQty.current ? line.quantity : cur));
+    lastQty.current = line.quantity;
+  }, [line.quantity]);
+  useEffect(() => {
+    setPrice((cur) => (cur === lastPrice.current ? line.unitPrice : cur));
+    lastPrice.current = line.unitPrice;
+  }, [line.unitPrice]);
+  // recurrence/taxable are committed on change (the PATCH resolves before the
+  // refresh GET fires), so a stale resync can't race them — a plain resync wins.
   useEffect(() => { setRec(line.recurrence); }, [line.recurrence]);
   useEffect(() => { setTaxable(line.taxable); }, [line.taxable]);
 
@@ -1346,6 +1427,19 @@ function EditableLineRow({
   const descDirty = desc.trim() !== line.description;
   const qtyDirty = Number(qty) !== Number(line.quantity);
   const priceDirty = Number(price) !== Number(line.unitPrice);
+
+  // While qty/price are mid-edit, the row's Total and Tax cells must reflect the
+  // local values, not the server's stale `lineTotal` — otherwise the row visibly
+  // disagrees with itself (new qty, old total) until the debounced refresh lands.
+  // When the row isn't dirty we defer to the authoritative server total so any
+  // server-side normalization (e.g. clamped qty) still wins.
+  const qtyNum = Number(qty);
+  const priceNum = Number(price);
+  const displayTotal =
+    (qtyDirty || priceDirty) && Number.isFinite(qtyNum) && Number.isFinite(priceNum) && qtyNum >= 0 && priceNum >= 0
+      ? qtyNum * priceNum
+      : Number(line.lineTotal);
+  const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
 
   const commitDesc = () => {
     const next = desc.trim();
@@ -1437,15 +1531,12 @@ function EditableLineRow({
             data-testid={`quote-line-taxable-${line.id}`}
           />
           <span className="tabular-nums" data-testid={`quote-line-tax-${line.id}`}>
-            {(() => {
-              const tax = lineTaxAmount(line.lineTotal, taxable, taxRate);
-              return tax === null ? '—' : formatMoney(tax, currency);
-            })()}
+            {displayTax === null ? '—' : formatMoney(displayTax, currency)}
           </span>
         </label>
       </td>
       <td className="px-2 py-2 text-right tabular-nums">
-        {formatMoney(line.lineTotal, currency)}
+        {formatMoney(displayTotal, currency)}
         {saved && <span className="ml-1 text-xs font-medium text-success" data-testid={`quote-line-saved-${line.id}`}>Saved</span>}
         <SrSaved show={saved} />
       </td>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -75,10 +75,10 @@ interface Props {
   onChanged: () => void;
 }
 
-// A quiet, transient "Saved" cue used consistently for every blur-to-save field
-// in the editor (terms, tax, block content, line fields). Returns the on-flag
-// and a trigger; clears its timer on unmount so a late fire can't setState a
-// gone node.
+// A quiet, transient "Saved" cue for the right-rail blur-to-save fields (terms,
+// tax). BlockCard and EditableLineRow replicate this same pattern inline rather
+// than calling the hook. Returns the on-flag and a trigger; clears its timer on
+// unmount so a late fire can't setState a gone node.
 function useSavedFlash(): [boolean, () => void] {
   const [on, setOn] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -255,9 +255,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   }, [termsDirty, terms, quote.id, refresh, runScoped, flashTermsSaved]);
 
   // Persist the tax rate as a fraction. Empty clears it (null); otherwise the
-  // percent is clamped to 0–100 (fraction 0–1, matching updateQuoteSchema) and an
-  // out-of-range/non-numeric entry resets to the persisted value rather than
-  // saving garbage. The server recomputes taxTotal/total, so refresh() re-pulls.
+  // percent is validated against 0–100 (fraction 0–1, matching updateQuoteSchema).
+  // An out-of-range/non-numeric entry is kept in the field with an inline error
+  // rather than saved or silently reverted. The server recomputes taxTotal/total,
+  // so refresh() re-pulls.
   const saveTaxRate = useCallback(async () => {
     if (!taxDirty) return;
     const trimmed = taxPct.trim();
@@ -366,7 +367,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   // The effective tax rate the rail should reflect: the committed server rate
   // normally, but the live tax-field value while it's mid-edit (and valid). An
   // out-of-range/non-numeric entry isn't applied — it falls back to the committed
-  // rate, matching saveTaxRate's own clamp — so the rail never previews garbage.
+  // rate, matching saveTaxRate's own rejection of out-of-range values — so the
+  // rail never previews garbage.
   const committedRate = quote.taxRate ? parseFloat(quote.taxRate) : null;
   const effectiveRate = useMemo<number | null>(() => {
     if (!taxDirty) return committedRate;
@@ -1008,10 +1010,12 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
           const block = pendingRemove;
           if (!block) return;
           // Keep the dialog open and awaiting (so isLoading shows "Processing…")
-          // until the delete resolves, then close and move focus to a stable
-          // anchor — the triggering Remove button is gone with the block.
+          // until the delete resolves. On failure (already toasted by runAction)
+          // leave the dialog open so the user can retry or cancel — don't close as
+          // if it worked while the block is still there. On success, close and move
+          // focus to a stable anchor — the triggering Remove button is gone.
           void (async () => {
-            await removeBlock(block);
+            if (!(await removeBlock(block))) return;
             setPendingRemove(null);
             blocksColRef.current?.focus();
           })();
@@ -1035,8 +1039,10 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onConfirm={() => {
           const line = pendingLineRemove;
           if (!line) return;
+          // Leave the dialog open on failure (already toasted) so the user can
+          // retry; only close + restore focus once the line is actually gone.
           void (async () => {
-            await deleteLine(line.id);
+            if (!(await deleteLine(line.id))) return;
             setPendingLineRemove(null);
             blocksColRef.current?.focus();
           })();
@@ -1457,7 +1463,7 @@ function EditableLineRow({
   // formatted decimal ('10.00'), so a value comparison both (a) fails to re-adopt
   // a server-normalized value — leaving the row stuck amber-dirty showing a wrong
   // optimistic total when the server rounds — and (b) is fragile across formats.
-  // The flag is set on keystroke and cleared once a commit settles, so:
+  // The flag is set on keystroke and cleared when a commit is initiated (on blur), so:
   //   • a quiet/leading-edge refresh landing mid-type keeps the user's keystrokes
   //     ("edit qty→5, blur, type 7" never loses the 7), and
   //   • after the user stops editing, the next prop adopts the server's canonical

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import QuoteEditor from './QuoteEditor';
@@ -81,6 +81,24 @@ export default function QuoteWorkspace({ id }: Props) {
     if (typeof window !== 'undefined') window.location.hash = `#${next}`;
   }, []);
 
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
+  // tab is both activated and focused.
+  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
+    const idx = tabs.findIndex((t) => t.value === current);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = tabs[nextIdx].value;
+    selectTab(next);
+    if (typeof document !== 'undefined') document.getElementById(`quote-tab-${next}`)?.focus();
+  }, [selectTab]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16" data-testid="quote-workspace-loading">
@@ -120,13 +138,21 @@ export default function QuoteWorkspace({ id }: Props) {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b" role="tablist" data-testid="quote-workspace-tabs">
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        data-testid="quote-workspace-tabs"
+        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
+      >
         {visibleTabs.map((t) => (
           <button
             key={t.value}
             type="button"
             role="tab"
+            id={`quote-tab-${t.value}`}
             aria-selected={activeTab === t.value}
+            aria-controls={`quote-tabpanel-${t.value}`}
+            tabIndex={activeTab === t.value ? 0 : -1}
             onClick={() => selectTab(t.value)}
             data-testid={`quote-tab-${t.value}`}
             className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
@@ -140,11 +166,23 @@ export default function QuoteWorkspace({ id }: Props) {
         ))}
       </div>
 
-      {activeTab === 'editor' && isDraft && <QuoteEditor detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'editor' && isDraft && (
+        <div role="tabpanel" id="quote-tabpanel-editor" aria-labelledby="quote-tab-editor" tabIndex={0}>
+          <QuoteEditor detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
 
-      {activeTab === 'preview' && <QuoteDocumentPreview detail={detail} />}
+      {activeTab === 'preview' && (
+        <div role="tabpanel" id="quote-tabpanel-preview" aria-labelledby="quote-tab-preview" tabIndex={0}>
+          <QuoteDocumentPreview detail={detail} />
+        </div>
+      )}
 
-      {activeTab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'detail' && (
+        <div role="tabpanel" id="quote-tabpanel-detail" aria-labelledby="quote-tab-detail" tabIndex={0}>
+          <QuoteDetail detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -102,6 +102,12 @@ export default function QuoteWorkspace({ id }: Props) {
     );
   }
 
+  // The Editor only applies to drafts, so it's hidden once a quote is issued —
+  // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
+  // on a non-draft falls back to Detail.
+  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
+  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
+
   return (
     <div className="space-y-4" data-testid="quote-workspace">
       <div className="flex items-center justify-between">
@@ -115,16 +121,16 @@ export default function QuoteWorkspace({ id }: Props) {
 
       {/* Tabs */}
       <div className="flex gap-1 border-b" role="tablist" data-testid="quote-workspace-tabs">
-        {TABS.map((t) => (
+        {visibleTabs.map((t) => (
           <button
             key={t.value}
             type="button"
             role="tab"
-            aria-selected={tab === t.value}
+            aria-selected={activeTab === t.value}
             onClick={() => selectTab(t.value)}
             data-testid={`quote-tab-${t.value}`}
             className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
-              tab === t.value
+              activeTab === t.value
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
@@ -134,19 +140,11 @@ export default function QuoteWorkspace({ id }: Props) {
         ))}
       </div>
 
-      {tab === 'editor' && (
-        isDraft ? (
-          <QuoteEditor detail={detail} onChanged={() => void reload()} />
-        ) : (
-          <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="quote-editor-locked">
-            This quote is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
-          </div>
-        )
-      )}
+      {activeTab === 'editor' && isDraft && <QuoteEditor detail={detail} onChanged={() => void reload()} />}
 
-      {tab === 'preview' && <QuoteDocumentPreview detail={detail} />}
+      {activeTab === 'preview' && <QuoteDocumentPreview detail={detail} />}
 
-      {tab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void reload()} />}
+      {activeTab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void reload()} />}
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -33,23 +33,32 @@ export default function QuoteWorkspace({ id }: Props) {
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
 
-  const load = useCallback(async () => {
+  // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
+  // so the editor stays mounted — a full-page spinner would remount the form and
+  // discard the user's in-progress local state and cursor position. Only the
+  // initial load shows the spinner / replaces the view on error.
+  const fetchDetail = useCallback(async (quiet = false) => {
     if (!id) { setError('Missing quote id'); setLoading(false); return; }
     try {
-      setLoading(true);
+      if (!quiet) setLoading(true);
       setError(undefined);
       const res = await fetchWithAuth(`/quotes/${id}`);
       if (res.status === 401) return UNAUTHORIZED();
-      if (res.status === 404) { setError('Quote not found.'); return; }
+      if (res.status === 404) { if (!quiet) setError('Quote not found.'); return; }
       if (!res.ok) throw new Error('Failed to load quote');
       const body = (await res.json()) as { data: QuoteDetailData };
       setDetail(body.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load quote');
+      // A failed quiet reload leaves the editor intact; the inline action's own
+      // runAction toast already surfaced the failure.
+      if (!quiet) setError(err instanceof Error ? err.message : 'Failed to load quote');
     } finally {
-      setLoading(false);
+      if (!quiet) setLoading(false);
     }
   }, [id]);
+
+  const load = useCallback(() => fetchDetail(false), [fetchDetail]);
+  const reload = useCallback(() => fetchDetail(true), [fetchDetail]);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -127,7 +136,7 @@ export default function QuoteWorkspace({ id }: Props) {
 
       {tab === 'editor' && (
         isDraft ? (
-          <QuoteEditor detail={detail} onChanged={() => void load()} />
+          <QuoteEditor detail={detail} onChanged={() => void reload()} />
         ) : (
           <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="quote-editor-locked">
             This quote is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
@@ -137,7 +146,7 @@ export default function QuoteWorkspace({ id }: Props) {
 
       {tab === 'preview' && <QuoteDocumentPreview detail={detail} />}
 
-      {tab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void load()} />}
+      {tab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void reload()} />}
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
@@ -245,19 +246,34 @@ export function QuotesPage() {
     [bulk, loadQuotes, filters],
   );
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
-    <th className="px-3 py-3 text-right font-medium">
-      <button
-        type="button"
-        onClick={() => toggleSort(sortKey)}
-        className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-        data-testid={`quotes-sort-${sortKey}`}
-      >
-        {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
-      </button>
-    </th>
-  );
+  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
+    const active = sort?.key === sortKey;
+    const ariaLabel = active
+      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+      : `Sort by ${label}`;
+    return (
+      <th className="px-3 py-3 text-right font-medium">
+        <button
+          type="button"
+          onClick={() => toggleSort(sortKey)}
+          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
+          data-testid={`quotes-sort-${sortKey}`}
+          aria-label={ariaLabel}
+        >
+          {label}
+          {active ? (
+            sort!.dir === 'asc' ? (
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            )
+          ) : (
+            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </th>
+    );
+  };
 
   return (
     <div className="space-y-5" data-testid="quotes-page">
@@ -522,6 +538,10 @@ export function QuotesPage() {
 function SortHeaderLeft({
   label, sortKey, sort, onSort,
 }: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
+  const active = sort?.key === sortKey;
+  const ariaLabel = active
+    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
   return (
     <th className="px-3 py-3 font-medium">
       <button
@@ -529,9 +549,18 @@ function SortHeaderLeft({
         onClick={() => onSort(sortKey)}
         className="inline-flex items-center gap-1 hover:text-foreground"
         data-testid={`quotes-sort-${sortKey}`}
+        aria-label={ariaLabel}
       >
         {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+        {active ? (
+          sort!.dir === 'asc' ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
       </button>
     </th>
   );

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -86,6 +86,7 @@ export function QuotesPage() {
   const [sort, setSort] = useState<Sort | null>(null);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [sendOpen, setSendOpen] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
 
   // New-quote dialog state
@@ -192,6 +193,16 @@ export function QuotesPage() {
   const toggleSort = (key: SortKey) =>
     setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' }));
 
+  // Aggregate value awaiting the customer's signature (sent + viewed), mirroring
+  // the invoice list's Outstanding strip. Single-currency partners are the norm;
+  // label with the first quote's currency.
+  const summary = useMemo(() => {
+    const awaiting = quotes.filter((qt) => qt.status === 'sent' || qt.status === 'viewed');
+    const outForSignature = awaiting.reduce((sum, qt) => sum + num(qt.total), 0);
+    const ccy = quotes[0]?.currencyCode || 'USD';
+    return { outForSignature, awaitingCount: awaiting.length, ccy };
+  }, [quotes]);
+
   // ---- derived rows: search filter (client) then optional sort ------------
   const rows = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -252,7 +263,7 @@ export function QuotesPage() {
       ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
       : `Sort by ${label}`;
     return (
-      <th className="px-3 py-3 text-right font-medium">
+      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
         <button
           type="button"
           onClick={() => toggleSort(sortKey)}
@@ -295,6 +306,17 @@ export function QuotesPage() {
           </button>
         )}
       </div>
+
+      {/* Out-for-signature summary */}
+      {!loading && !error && summary.awaitingCount > 0 && (
+        <div className="flex flex-wrap gap-3" data-testid="quotes-outstanding-strip">
+          <div className="rounded-lg border bg-card px-4 py-3">
+            <div className="text-xs text-muted-foreground">Out for signature</div>
+            <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outForSignature, summary.ccy)}</div>
+            <div className="text-xs text-muted-foreground">{summary.awaitingCount} awaiting</div>
+          </div>
+        </div>
+      )}
 
       {/* Toolbar: search + filters */}
       <div className="flex flex-wrap items-end gap-2" data-testid="quotes-filters">
@@ -429,6 +451,7 @@ export function QuotesPage() {
                         <span
                           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[qt.status]}`}
                           data-testid={`quotes-status-${qt.id}`}
+                          aria-label={`Status: ${statusLabel(qt)}`}
                         >
                           {statusLabel(qt)}
                         </span>
@@ -445,13 +468,24 @@ export function QuotesPage() {
               onClear={bulk.clear}
               testIdPrefix="quotes"
               actions={[
-                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', disabled: bulkBusy, onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
+                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', disabled: bulkBusy, onClick: () => setSendOpen(true) }] : []),
                 ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setDeleteOpen(true) }] : []),
               ]}
             />
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={sendOpen}
+        onClose={() => setSendOpen(false)}
+        onConfirm={() => { setSendOpen(false); void runBulkQuotes('/quotes/bulk-send', 'sent'); }}
+        title="Send quotes"
+        message={`Email ${bulk.size} selected proposal(s) to their customers? This can't be undone.`}
+        variant="warning"
+        confirmLabel="Send"
+        confirmTestId="quotes-bulk-send-confirm"
+      />
 
       <ConfirmDialog
         open={deleteOpen}
@@ -543,7 +577,7 @@ function SortHeaderLeft({
     ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
     : `Sort by ${label}`;
   return (
-    <th className="px-3 py-3 font-medium">
+    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
       <button
         type="button"
         onClick={() => onSort(sortKey)}

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -5,6 +5,7 @@
 import type { SellerSnapshot } from '../invoiceTypes';
 export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
+import { STATUS_PILL } from '../invoiceTypes';
 
 export type QuoteStatus =
   | 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'expired' | 'converted';
@@ -118,14 +119,20 @@ export const STATUS_LABELS: Record<QuoteStatus, string> = {
 };
 
 // Tailwind badge classes per status (mirrors the invoice/contract status-pill style).
+// Five semantic roles shared with the invoice pills (see STATUS_PILL): the
+// colour reads the lifecycle (neutral → info while it's with the customer →
+// success when won → warning when lapsing → danger when lost), and the label
+// carries the finer distinction. sent/viewed share info; accepted/converted
+// share success — collapsing the old blue/indigo/violet/emerald rainbow that
+// was hard to tell apart at pill scale.
 export const STATUS_COLORS: Record<QuoteStatus, string> = {
-  draft: 'border-border bg-muted text-muted-foreground',
-  sent: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  viewed: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-400',
-  accepted: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  declined: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
-  expired: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-  converted: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-400',
+  draft: STATUS_PILL.neutral,
+  sent: STATUS_PILL.info,
+  viewed: STATUS_PILL.info,
+  accepted: STATUS_PILL.success,
+  declined: STATUS_PILL.danger,
+  expired: STATUS_PILL.warning,
+  converted: STATUS_PILL.success,
 };
 
 /** Display label for a quote's status. The 'sent' lifecycle status only reads as

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -163,6 +163,23 @@ export function pctFromFraction(frac: string | number | null): string {
   return String(Number((Number(frac) * 100).toFixed(3)));
 }
 
+/** Per-line tax amount for the pricing-table Tax column: taxable lines get
+ *  lineTotal × rate rounded to cents; non-taxable lines, a null/empty rate, or a
+ *  non-positive rate return null (rendered as '—'). The document/detail header
+ *  Tax stays the server's authoritative `taxTotal`, so a quote with many taxable
+ *  lines can differ from the summed column by a rounding cent. */
+export function lineTaxAmount(
+  lineTotal: string | number,
+  taxable: boolean,
+  taxRate: string | number | null,
+): number | null {
+  if (!taxable) return null;
+  const rate = taxRate === null || taxRate === '' ? 0 : Number(taxRate);
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
 export function formatDate(value: string | null | undefined): string {
   if (!value) return '—';

--- a/apps/web/src/components/catalog/CatalogItemPicker.tsx
+++ b/apps/web/src/components/catalog/CatalogItemPicker.tsx
@@ -74,6 +74,7 @@ export default function CatalogItemPicker({
         aria-expanded={open}
         aria-controls={listId}
         aria-autocomplete="list"
+        aria-activedescendant={open && results.length > 0 ? `${listId}-opt-${active}` : undefined}
         value={query}
         disabled={disabled}
         placeholder={placeholder}
@@ -91,7 +92,7 @@ export default function CatalogItemPicker({
           data-testid={`${testId}-list`}
         >
           {results.map((item, idx) => (
-            <li key={item.id} role="option" aria-selected={idx === active}>
+            <li key={item.id} id={`${listId}-opt-${idx}`} role="option" aria-selected={idx === active}>
               <button
                 type="button"
                 onMouseEnter={() => setActive(idx)}

--- a/apps/web/src/components/contracts/ContractDetail.delete.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.delete.test.tsx
@@ -99,3 +99,28 @@ describe('ContractDetail — delete action', () => {
     });
   });
 });
+
+describe('ContractDetail — generate invoice action', () => {
+  it('gates "Generate invoice now" behind a confirm before billing the client', async () => {
+    state.permissions = [{ resource: 'contracts', action: 'manage' }];
+    const generate = vi.mocked(contractsApi.generateContractInvoice);
+    generate.mockResolvedValue(resp({ data: { invoiceId: 'inv-1' } }));
+
+    const { navigateTo } = await import('@/lib/navigation');
+    const navigateMock = vi.mocked(navigateTo);
+
+    render(<ContractDetail detail={activeDetail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('contract-detail')).toBeInTheDocument());
+
+    // Clicking the button opens a confirm — it must NOT generate immediately.
+    fireEvent.click(screen.getByTestId('generate-now-btn'));
+    await waitFor(() => expect(screen.getByTestId('contract-generate-confirm')).toBeInTheDocument());
+    expect(generate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('contract-generate-confirm'));
+    await waitFor(() => {
+      expect(generate).toHaveBeenCalledWith('ct-1');
+      expect(navigateMock).toHaveBeenCalledWith('/billing/invoices/inv-1');
+    });
+  });
+});

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+import Spinner from '../shared/Spinner';
 import {
   contractTransition,
   deleteContract,
@@ -62,8 +63,12 @@ export default function ContractDetail({ detail, onChanged }: Props) {
   const { contract, lines, periods } = detail;
   const currency = contract.currencyCode;
 
-  const [busy, setBusy] = useState(false);
+  // Which action is in flight, so the active button shows a spinner + verb
+  // (matches ContractEditor's pattern). `busy` is derived for the disable guards.
+  const [pending, setPending] = useState<null | ContractTransition | 'generate' | 'delete'>(null);
+  const busy = pending !== null;
   const [delOpen, setDelOpen] = useState(false);
+  const [genOpen, setGenOpen] = useState(false);
   const [estimate, setEstimate] = useState<ContractEstimate | null>(null);
 
   useEffect(() => {
@@ -80,7 +85,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
 
   const transition = useCallback(async (verb: ContractTransition) => {
     if (busy) return;
-    setBusy(true);
+    setPending(verb);
     try {
       await runAction({
         request: () => contractTransition(contract.id, verb),
@@ -92,13 +97,13 @@ export default function ContractDetail({ detail, onChanged }: Props) {
     } catch (err) {
       handleActionError(err, `Could not ${verb} the contract.`);
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract.id, refresh]);
 
   const generateNow = useCallback(async () => {
     if (busy) return;
-    setBusy(true);
+    setPending('generate');
     try {
       const result = await runAction<{ data?: { invoiceId?: string } }>({
         request: () => generateContractInvoice(contract.id),
@@ -106,6 +111,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
         successMessage: 'Invoice generated',
         onUnauthorized: UNAUTHORIZED,
       });
+      setGenOpen(false);
       const invoiceId = result?.data?.invoiceId;
       if (invoiceId) {
         void navigateTo(`/billing/invoices/${invoiceId}`);
@@ -115,13 +121,13 @@ export default function ContractDetail({ detail, onChanged }: Props) {
     } catch (err) {
       handleActionError(err, 'Could not generate an invoice.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract.id, refresh]);
 
   const remove = useCallback(async () => {
     if (busy) return;
-    setBusy(true);
+    setPending('delete');
     try {
       await runAction({
         request: () => deleteContract(contract.id),
@@ -134,7 +140,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
     } catch (err) {
       handleActionError(err, 'Could not delete the draft.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract.id]);
 
@@ -204,8 +210,8 @@ export default function ContractDetail({ detail, onChanged }: Props) {
           </div>
 
           {/* Lines (read-only) */}
-          <div className="rounded-lg border bg-card shadow-sm">
-            <table className="w-full text-sm" data-testid="contract-detail-lines">
+          <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
+            <table className="w-full min-w-[30rem] text-sm" data-testid="contract-detail-lines">
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-3 py-2 font-medium">Type</th>
@@ -233,7 +239,10 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                           ? <span className="text-muted-foreground">auto</span>
                           : (l.lineType === 'manual' ? (l.manualQuantity ?? '0') : '1')}
                       </td>
-                      <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
+                      <td className="px-3 py-2 text-center">
+                        <span aria-hidden="true">{l.taxable ? '✓' : '—'}</span>
+                        <span className="sr-only">{l.taxable ? 'Taxable' : 'Not taxable'}</span>
+                      </td>
                     </tr>
                   ))
                 )}
@@ -246,7 +255,8 @@ export default function ContractDetail({ detail, onChanged }: Props) {
             <h3 className="border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Billing history
             </h3>
-            <table className="w-full text-sm" data-testid="contract-periods">
+            <div className="overflow-x-auto">
+            <table className="w-full min-w-[28rem] text-sm" data-testid="contract-periods">
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-3 py-2 font-medium">Period</th>
@@ -284,6 +294,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                 )}
               </tbody>
             </table>
+            </div>
           </div>
         </div>
 
@@ -318,7 +329,7 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                     onClick={() => void transition(verb)}
                     disabled={busy}
                     data-testid={`contract-${verb}-btn`}
-                    className={`inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50 ${
+                    className={`inline-flex w-full items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50 ${
                       destructive
                         ? 'border border-destructive/40 text-destructive hover:bg-destructive/10'
                         : verb === 'activate' || verb === 'resume'
@@ -326,23 +337,25 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                           : 'border hover:bg-muted'
                     }`}
                   >
-                    {TRANSITION_LABELS[verb]}
+                    {pending === verb && <Spinner />}
+                    {pending === verb ? `${TRANSITION_LABELS[verb]}…` : TRANSITION_LABELS[verb]}
                   </button>
                 );
               })}
             </div>
           )}
 
-          {/* Generate now */}
+          {/* Generate now (gated by a confirm — it bills the client immediately) */}
           {can('contracts', 'manage') && canGenerate && (
             <button
               type="button"
-              onClick={() => void generateNow()}
+              onClick={() => setGenOpen(true)}
               disabled={busy}
               data-testid="generate-now-btn"
-              className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
             >
-              Generate invoice now
+              {pending === 'generate' && <Spinner />}
+              {pending === 'generate' ? 'Generating…' : 'Generate invoice now'}
             </button>
           )}
 
@@ -361,10 +374,26 @@ export default function ContractDetail({ detail, onChanged }: Props) {
       </div>
 
       <ConfirmDialog
+        open={genOpen}
+        onClose={() => setGenOpen(false)}
+        onConfirm={() => void generateNow()}
+        isLoading={pending === 'generate'}
+        variant="warning"
+        title="Generate invoice now"
+        message={
+          `This bills ${contract.name} for the current period right away` +
+          `${estimate ? ` — about ${formatMoney(estimate.periodTotal, currency)}` : ''}` +
+          `${contract.autoIssue ? ', issued immediately.' : ' as a draft you can review.'}`
+        }
+        confirmLabel="Generate invoice"
+        confirmTestId="contract-generate-confirm"
+      />
+
+      <ConfirmDialog
         open={delOpen}
         onClose={() => setDelOpen(false)}
         onConfirm={() => void remove()}
-        isLoading={busy}
+        isLoading={pending === 'delete'}
         title="Delete draft contract"
         message="This permanently deletes the draft contract. This cannot be undone."
         confirmLabel="Delete draft"

--- a/apps/web/src/components/contracts/ContractEditor.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../lib/api/contracts', async (importOriginal) => {
     createContract: vi.fn(),
     updateContract: vi.fn(),
     addContractLine: vi.fn(),
+    updateContractLine: vi.fn(),
     removeContractLine: vi.fn(),
     contractTransition: vi.fn(),
     getContractEstimate: vi.fn(),
@@ -99,6 +100,34 @@ describe('ContractEditor (create)', () => {
     await waitFor(() => expect(api.createContract).toHaveBeenCalled());
     expect((api.createContract as any).mock.calls[0][0].lines).toEqual([
       { lineType: 'flat', description: 'Workstation mgmt', unitPrice: '40.00', taxable: false },
+    ]);
+  });
+
+  it('edits a staged line in place before create (no separate API call)', async () => {
+    render(<ContractEditor />);
+    const orgInput = await screen.findByTestId('contract-form-org-input');
+    fireEvent.focus(orgInput);
+    fireEvent.change(orgInput, { target: { value: 'Acme' } });
+    fireEvent.click(await screen.findByTestId('contract-form-org-option-org-1'));
+    fireEvent.change(screen.getByTestId('contract-form-name'), { target: { value: 'Acme MSA' } });
+
+    // Stage, then edit the line in place via the same form.
+    fireEvent.change(screen.getByTestId('contract-line-desc'), { target: { value: 'Workstation mgmt' } });
+    fireEvent.change(screen.getByTestId('contract-line-price'), { target: { value: '40.00' } });
+    fireEvent.click(screen.getByTestId('add-line-btn'));
+    expect(await screen.findByText('Workstation mgmt')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('line-edit-0'));
+    expect(screen.getByTestId('contract-line-form-title')).toHaveTextContent('Edit line');
+    fireEvent.change(screen.getByTestId('contract-line-price'), { target: { value: '55.00' } });
+    fireEvent.click(screen.getByTestId('add-line-btn')); // now "Save line"
+
+    fireEvent.click(screen.getByTestId('save-contract-btn'));
+    await waitFor(() => expect(api.createContract).toHaveBeenCalled());
+    // Staged edit is local — no PATCH — and the new price is in the create payload.
+    expect(api.updateContractLine).not.toHaveBeenCalled();
+    expect((api.createContract as any).mock.calls[0][0].lines).toEqual([
+      { lineType: 'flat', description: 'Workstation mgmt', unitPrice: '55.00', taxable: false },
     ]);
   });
 });

--- a/apps/web/src/components/contracts/ContractEditor.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ContractEditor from './ContractEditor';
@@ -53,14 +53,14 @@ describe('ContractEditor (create)', () => {
 
   it('includes the Terms field in the create payload', async () => {
     render(<ContractEditor />);
-    const orgSelect = await screen.findByTestId('contract-form-org');
-    // The <option>s populate only after the async /orgs/organizations fetch
-    // resolves. Wait for the option before selecting it — otherwise the
-    // controlled <select> rejects a value with no matching option, orgId stays
-    // empty, canSaveHeader is false, and the save no-ops (flaky under CI load).
-    await within(orgSelect).findByRole('option', { name: 'Acme' });
-
-    fireEvent.change(orgSelect, { target: { value: 'org-1' } });
+    // The org picker is a searchable combobox: focus to open, type to filter,
+    // then click the matching option. The option only renders after the async
+    // /orgs/organizations fetch resolves, so findByTestId waits it out —
+    // otherwise orgId stays empty, canSaveHeader is false, and save no-ops.
+    const orgInput = await screen.findByTestId('contract-form-org-input');
+    fireEvent.focus(orgInput);
+    fireEvent.change(orgInput, { target: { value: 'Acme' } });
+    fireEvent.click(await screen.findByTestId('contract-form-org-option-org-1'));
     fireEvent.change(screen.getByTestId('contract-form-name'), { target: { value: 'Acme MSA' } });
     fireEvent.change(screen.getByTestId('contract-form-terms'), { target: { value: 'Net 30. Auto-renews.' } });
     fireEvent.click(screen.getByTestId('save-contract-btn'));
@@ -69,5 +69,36 @@ describe('ContractEditor (create)', () => {
     expect((api.createContract as any).mock.calls[0][0]).toMatchObject({
       orgId: 'org-1', name: 'Acme MSA', terms: 'Net 30. Auto-renews.',
     });
+  });
+
+  it('explains why the create button is disabled until requirements are met', async () => {
+    render(<ContractEditor />);
+    // No org selected yet → the save button is disabled with a reason shown.
+    const hint = await screen.findByTestId('contract-save-hint');
+    expect(hint).toHaveTextContent('Select an organization to save.');
+    expect(screen.getByTestId('save-contract-btn')).toBeDisabled();
+  });
+
+  it('stages lines locally and sends them in the atomic create payload', async () => {
+    render(<ContractEditor />);
+    const orgInput = await screen.findByTestId('contract-form-org-input');
+    fireEvent.focus(orgInput);
+    fireEvent.change(orgInput, { target: { value: 'Acme' } });
+    fireEvent.click(await screen.findByTestId('contract-form-org-option-org-1'));
+    fireEvent.change(screen.getByTestId('contract-form-name'), { target: { value: 'Acme MSA' } });
+
+    // The lines table + add-line form are available in create mode (no save-first
+    // step). Staging a line is local — it must NOT hit the line API.
+    fireEvent.change(screen.getByTestId('contract-line-desc'), { target: { value: 'Workstation mgmt' } });
+    fireEvent.change(screen.getByTestId('contract-line-price'), { target: { value: '40.00' } });
+    fireEvent.click(screen.getByTestId('add-line-btn'));
+    expect(await screen.findByText('Workstation mgmt')).toBeInTheDocument();
+    expect(api.addContractLine).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('save-contract-btn'));
+    await waitFor(() => expect(api.createContract).toHaveBeenCalled());
+    expect((api.createContract as any).mock.calls[0][0].lines).toEqual([
+      { lineType: 'flat', description: 'Workstation mgmt', unitPrice: '40.00', taxable: false },
+    ]);
   });
 });

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -7,6 +7,7 @@ import {
   createContract,
   updateContract,
   addContractLine,
+  updateContractLine,
   removeContractLine,
   contractTransition,
   getContractEstimate,
@@ -69,7 +70,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   // Which mutation is in flight, so the active button (not all of them) shows a
   // spinner + verb. null = idle; `busy` is derived for the existing disable
   // guards so every in-flight path still blocks concurrent mutations.
-  const [pending, setPending] = useState<null | 'create' | 'save' | 'addLine' | 'removeLine' | 'activate'>(null);
+  const [pending, setPending] = useState<null | 'create' | 'save' | 'addLine' | 'editLine' | 'removeLine' | 'activate'>(null);
   const busy = pending !== null;
 
   // Confirmation gates for the two irreversible money-moments: removing a
@@ -111,6 +112,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [lineTaxable, setLineTaxable] = useState(false);
   const [lineSiteId, setLineSiteId] = useState('');
   const [lineCatalogId, setLineCatalogId] = useState('');
+  // Set while editing an existing line in place; the add-line form becomes the
+  // editor (Save line / Cancel) instead of adding a new row.
+  const [editingLineId, setEditingLineId] = useState<string | null>(null);
 
   // Lines staged locally in create mode (no contract id yet); committed
   // atomically with the contract on save. Edit mode reads persisted lines.
@@ -165,7 +169,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   useEffect(() => { if (!isCreate) void loadEstimate(); }, [isCreate, loadEstimate]);
 
   const intervalIsValid = intervalMonths >= 1 && intervalMonths <= 60;
-  const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalIsValid;
+  // ISO yyyy-mm-dd compares lexicographically === chronologically.
+  const dateRangeValid = !endDate || endDate > startDate;
+  const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalIsValid && dateRangeValid;
 
   // First unmet requirement, surfaced under the disabled save button so the user
   // never has to guess why it's greyed out.
@@ -177,7 +183,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
         ? 'Set a start date to save.'
         : !intervalIsValid
           ? 'Enter a billing interval of 1–60 months.'
-          : null;
+          : !dateRangeValid
+            ? 'End date must be after the start date.'
+            : null;
 
   // ---- live "Estimated this period" ----------------------------------------
   // flat/manual contribute qty×price; per_device/per_seat are resolved by the
@@ -230,6 +238,77 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const removeDraftLine = useCallback((id: string) => {
     setDraftLines((prev) => prev.filter((l) => l.id !== id));
   }, []);
+
+  const resetLineForm = useCallback(() => {
+    setLineType('flat'); setLineDesc(''); setLinePrice('0.00'); setLineQty('1');
+    setLineTaxable(false); setLineSiteId(''); setLineCatalogId('');
+  }, []);
+
+  // Load an existing line into the add-line form, turning it into an editor.
+  const startEditLine = useCallback((l: LineView) => {
+    setLineType(l.lineType);
+    setLineDesc(l.description);
+    setLinePrice(l.unitPrice);
+    setLineQty(l.manualQuantity ?? '1');
+    setLineSiteId(l.siteId ?? '');
+    setLineCatalogId(l.catalogItemId ?? '');
+    setLineTaxable(l.taxable);
+    setEditingLineId(l.id);
+  }, []);
+
+  const cancelEditLine = useCallback(() => {
+    resetLineForm();
+    setEditingLineId(null);
+  }, [resetLineForm]);
+
+  // The current add-line form values as a LineView body (sans id).
+  const currentLineFields = useCallback((): Omit<LineView, 'id'> => ({
+    lineType,
+    description: lineDesc.trim(),
+    unitPrice: linePrice,
+    manualQuantity: lineType === 'manual' ? lineQty : null,
+    siteId: lineType === 'per_device' ? (lineSiteId || null) : null,
+    catalogItemId: lineCatalogId || null,
+    taxable: lineTaxable,
+  }), [lineType, lineDesc, linePrice, lineQty, lineSiteId, lineCatalogId, lineTaxable]);
+
+  // The same values shaped for the line API (omit absent optionals).
+  const currentLineInput = useCallback(() => ({
+    lineType,
+    description: lineDesc.trim(),
+    unitPrice: linePrice,
+    taxable: lineTaxable,
+    ...(lineType === 'manual' ? { manualQuantity: lineQty } : {}),
+    ...(lineType === 'per_device' && lineSiteId ? { siteId: lineSiteId } : {}),
+    ...(lineCatalogId ? { catalogItemId: lineCatalogId } : {}),
+  }), [lineType, lineDesc, linePrice, lineQty, lineSiteId, lineCatalogId, lineTaxable]);
+
+  // Save an in-place edit: local for staged (create) lines, PATCH for persisted.
+  const saveEditLine = useCallback(async () => {
+    if (!editingLineId || !lineDesc.trim()) return;
+    if (isCreate) {
+      const fields = currentLineFields();
+      setDraftLines((prev) => prev.map((dl) => dl.id === editingLineId ? { id: dl.id, ...fields } : dl));
+      cancelEditLine();
+      return;
+    }
+    if (busy || !contract) return;
+    setPending('editLine');
+    try {
+      await runAction({
+        request: () => updateContractLine(contract.id, editingLineId, currentLineInput()),
+        errorFallback: 'Could not update the line.',
+        successMessage: 'Line updated',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      cancelEditLine();
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not update the line.');
+    } finally {
+      setPending(null);
+    }
+  }, [editingLineId, lineDesc, isCreate, busy, contract, currentLineFields, currentLineInput, cancelEditLine, refresh]);
 
   /** Map staged lines to the contractLineInputSchema shape (omit absent
    *  optionals rather than sending null, which the string schema rejects). */
@@ -607,13 +686,23 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                           </td>
                           <td className="px-3 py-2 text-right">
                             {can('contracts', 'write') && (
-                              <button
-                                type="button" onClick={() => isCreate ? removeDraftLine(l.id) : setRemoveTarget(l)} disabled={busy}
-                                data-testid={`line-remove-${idx}`}
-                                className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                              >
-                                Remove
-                              </button>
+                              <div className="flex justify-end gap-1">
+                                <button
+                                  type="button" onClick={() => startEditLine(l)} disabled={busy}
+                                  data-testid={`line-edit-${idx}`}
+                                  aria-current={editingLineId === l.id ? 'true' : undefined}
+                                  className={`rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50 ${editingLineId === l.id ? 'border-primary text-primary' : ''}`}
+                                >
+                                  Edit
+                                </button>
+                                <button
+                                  type="button" onClick={() => isCreate ? removeDraftLine(l.id) : setRemoveTarget(l)} disabled={busy}
+                                  data-testid={`line-remove-${idx}`}
+                                  className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                >
+                                  Remove
+                                </button>
+                              </div>
                             )}
                           </td>
                         </tr>
@@ -623,9 +712,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 </table>
               </div>
 
-              {/* Add line */}
+              {/* Add / edit line */}
               <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="contract-add-line">
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground" data-testid="contract-line-form-title">
+                  {editingLineId ? 'Edit line' : 'Add a line'}
+                </h4>
+                {/* What's being billed */}
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                     Line type
                     <select
@@ -648,41 +741,8 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                   </label>
-                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
-                    Unit price
-                    <input
-                      type="number" min="0" step="0.01" value={linePrice}
-                      onChange={(e) => setLinePrice(e.target.value)}
-                      data-testid="contract-line-price"
-                      className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                  </label>
-                  {lineType === 'manual' && (
-                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
-                      Quantity
-                      <input
-                        type="number" min="0" step="0.01" value={lineQty}
-                        onChange={(e) => setLineQty(e.target.value)}
-                        data-testid="contract-line-qty"
-                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                      />
-                    </label>
-                  )}
-                  {lineType === 'per_device' && (
-                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
-                      Site (optional — scopes the device count)
-                      <select
-                        value={lineSiteId} onChange={(e) => setLineSiteId(e.target.value)}
-                        data-testid="contract-line-site"
-                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        <option value="">All sites</option>
-                        {sites.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
-                      </select>
-                    </label>
-                  )}
                   {catalogItems.length > 0 && (
-                    <div className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    <div className="flex flex-col gap-1 text-xs font-medium text-foreground/85 sm:col-span-2">
                       Link catalog item (optional)
                       {lineCatalogId ? (
                         <div className="flex flex-col gap-1" data-testid="contract-line-catalog-picked">
@@ -720,7 +780,41 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       )}
                     </div>
                   )}
-                  <label className="flex items-center gap-2 text-sm">
+                  {/* How much it costs */}
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Unit price
+                    <input
+                      type="number" min="0" step="0.01" value={linePrice}
+                      onChange={(e) => setLinePrice(e.target.value)}
+                      data-testid="contract-line-price"
+                      className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </label>
+                  {lineType === 'manual' && (
+                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                      Quantity
+                      <input
+                        type="number" min="0" step="0.01" value={lineQty}
+                        onChange={(e) => setLineQty(e.target.value)}
+                        data-testid="contract-line-qty"
+                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </label>
+                  )}
+                  {lineType === 'per_device' && (
+                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                      Site (optional — scopes the device count)
+                      <select
+                        value={lineSiteId} onChange={(e) => setLineSiteId(e.target.value)}
+                        data-testid="contract-line-site"
+                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value="">All sites</option>
+                        {sites.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                      </select>
+                    </label>
+                  )}
+                  <label className="flex items-center gap-2 text-sm sm:col-span-2">
                     <input
                       type="checkbox" checked={lineTaxable} onChange={(e) => setLineTaxable(e.target.checked)}
                       data-testid="contract-line-taxable"
@@ -728,21 +822,36 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     Taxable
                   </label>
                 </div>
-                <div className="mt-3 flex items-center justify-between">
+                <div className="mt-3 flex items-center justify-between gap-2">
                   <span className="text-xs text-muted-foreground">
                     {newLineEstimate === null
                       ? 'Quantity resolved automatically at billing time.'
                       : `Line total: ${formatMoney(newLineEstimate, contract?.currencyCode)}`}
                   </span>
                   {can('contracts', 'write') && (
-                    <button
-                      type="button" onClick={() => isCreate ? addDraftLine() : void addLine()} disabled={busy || !lineDesc.trim()}
-                      data-testid="add-line-btn"
-                      className="inline-flex h-9 items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
-                    >
-                      {pending === 'addLine' && <Spinner />}
-                      {pending === 'addLine' ? 'Adding…' : 'Add line'}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      {editingLineId && (
+                        <button
+                          type="button" onClick={cancelEditLine} disabled={busy}
+                          data-testid="cancel-line-btn"
+                          className="inline-flex h-9 items-center justify-center rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => editingLineId ? void saveEditLine() : (isCreate ? addDraftLine() : void addLine())}
+                        disabled={busy || !lineDesc.trim()}
+                        data-testid="add-line-btn"
+                        className="inline-flex h-9 items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                      >
+                        {(pending === 'addLine' || pending === 'editLine') && <Spinner />}
+                        {editingLineId
+                          ? (pending === 'editLine' ? 'Saving…' : 'Save line')
+                          : (pending === 'addLine' ? 'Adding…' : 'Add line')}
+                      </button>
+                    </div>
                   )}
                 </div>
               </div>
@@ -754,7 +863,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           <div className="rounded-lg border border-primary/30 bg-primary/[0.03] p-4 shadow-sm" data-testid="contract-estimate">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Estimated this period</h3>
             {isCreate && lines.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Add a line below to see the estimated total.</p>
+              <p className="text-sm text-muted-foreground">Add a line to see the estimated total.</p>
             ) : (
               <>
                 <p className="text-2xl font-semibold tabular-nums" data-testid="contract-estimate-total">
@@ -768,6 +877,11 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 {liveEstimate && liveEstimate.lines.some((l) => l.live) && (
                   <p className="mt-1 text-xs text-muted-foreground">
                     Includes live device / seat counts as of today.
+                  </p>
+                )}
+                {!liveEstimate && !estimateFailed && estimate.hasAuto && (
+                  <p className="mt-1 text-xs text-muted-foreground" data-testid="contract-estimate-auto-note">
+                    Per-device / seat lines bill on live counts and aren&rsquo;t in this total.
                   </p>
                 )}
                 {!liveEstimate && estimateFailed && (

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -10,6 +10,7 @@ import {
   removeContractLine,
   contractTransition,
   getContractEstimate,
+  formatCadenceAdverb,
   type ContractBillingTiming,
   type ContractDetail,
   type ContractLine,
@@ -17,12 +18,20 @@ import {
   type ContractEstimate,
 } from '../../lib/api/contracts';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
+import SearchableSelect from '../shared/SearchableSelect';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import Spinner from '../shared/Spinner';
 import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
 import { formatMoney } from '../billing/invoiceTypes';
 import { usePermissions } from '../../lib/permissions';
 
 interface Organization { id: string; name: string }
 interface Site { id: string; name: string }
+
+/** The subset the lines table + estimate read. In edit mode these are persisted
+ *  ContractLines; in create mode they're lines staged locally before the
+ *  contract exists, committed atomically with the create. */
+type LineView = Pick<ContractLine, 'id' | 'lineType' | 'description' | 'unitPrice' | 'manualQuantity' | 'siteId' | 'taxable' | 'catalogItemId'>;
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -57,7 +66,16 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const isCreate = !detail;
   const contract = detail?.contract;
 
-  const [busy, setBusy] = useState(false);
+  // Which mutation is in flight, so the active button (not all of them) shows a
+  // spinner + verb. null = idle; `busy` is derived for the existing disable
+  // guards so every in-flight path still blocks concurrent mutations.
+  const [pending, setPending] = useState<null | 'create' | 'save' | 'addLine' | 'removeLine' | 'activate'>(null);
+  const busy = pending !== null;
+
+  // Confirmation gates for the two irreversible money-moments: removing a
+  // billing line and activating (which starts real invoice generation).
+  const [removeTarget, setRemoveTarget] = useState<LineView | null>(null);
+  const [confirmActivate, setConfirmActivate] = useState(false);
 
   // ---- header form ---------------------------------------------------------
   const [orgId, setOrgId] = useState(contract?.orgId ?? presetOrgId ?? '');
@@ -94,7 +112,10 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [lineSiteId, setLineSiteId] = useState('');
   const [lineCatalogId, setLineCatalogId] = useState('');
 
-  const lines: ContractLine[] = detail?.lines ?? [];
+  // Lines staged locally in create mode (no contract id yet); committed
+  // atomically with the contract on save. Edit mode reads persisted lines.
+  const [draftLines, setDraftLines] = useState<LineView[]>([]);
+  const lines: LineView[] = isCreate ? draftLines : (detail?.lines ?? []);
 
   const loadOrgs = useCallback(async () => {
     const res = await fetchWithAuth('/orgs/organizations');
@@ -146,6 +167,18 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const intervalIsValid = intervalMonths >= 1 && intervalMonths <= 60;
   const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalIsValid;
 
+  // First unmet requirement, surfaced under the disabled save button so the user
+  // never has to guess why it's greyed out.
+  const missingHint = !orgId
+    ? 'Select an organization to save.'
+    : name.trim().length === 0
+      ? 'Add a contract name to save.'
+      : !startDate
+        ? 'Set a start date to save.'
+        : !intervalIsValid
+          ? 'Enter a billing interval of 1–60 months.'
+          : null;
+
   // ---- live "Estimated this period" ----------------------------------------
   // flat/manual contribute qty×price; per_device/per_seat are resolved by the
   // generator from live counts, so we surface them as "auto" without a number.
@@ -175,10 +208,45 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
 
   const refresh = useCallback(() => { onChanged?.(); void loadEstimate(); }, [onChanged, loadEstimate]);
 
+  // ---- create-mode line staging (local; committed with the create) ----------
+  const addDraftLine = useCallback(() => {
+    if (!lineDesc.trim()) return;
+    setDraftLines((prev) => [...prev, {
+      id: crypto.randomUUID(),
+      lineType,
+      description: lineDesc.trim(),
+      unitPrice: linePrice,
+      manualQuantity: lineType === 'manual' ? lineQty : null,
+      siteId: lineType === 'per_device' ? (lineSiteId || null) : null,
+      catalogItemId: lineCatalogId || null,
+      taxable: lineTaxable,
+    }]);
+    setLineDesc(''); setLinePrice('0.00'); setLineQty('1');
+    setLineTaxable(false); setLineSiteId(''); setLineCatalogId('');
+  }, [lineType, lineDesc, linePrice, lineQty, lineSiteId, lineCatalogId, lineTaxable]);
+
+  // Staged lines aren't persisted yet, so removal is instant (no confirm —
+  // unlike edit mode, where Remove deletes a real billing line).
+  const removeDraftLine = useCallback((id: string) => {
+    setDraftLines((prev) => prev.filter((l) => l.id !== id));
+  }, []);
+
+  /** Map staged lines to the contractLineInputSchema shape (omit absent
+   *  optionals rather than sending null, which the string schema rejects). */
+  const draftLinePayload = useCallback(() => draftLines.map((l) => ({
+    lineType: l.lineType,
+    description: l.description,
+    unitPrice: l.unitPrice,
+    taxable: l.taxable,
+    ...(l.lineType === 'manual' ? { manualQuantity: l.manualQuantity ?? '0' } : {}),
+    ...(l.lineType === 'per_device' && l.siteId ? { siteId: l.siteId } : {}),
+    ...(l.catalogItemId ? { catalogItemId: l.catalogItemId } : {}),
+  })), [draftLines]);
+
   // ---- create flow ---------------------------------------------------------
   const saveCreate = useCallback(async () => {
     if (busy || !canSaveHeader) return;
-    setBusy(true);
+    setPending('create');
     try {
       if (autoRenew && !renewalTermMonths) {
         showToast({ type: 'error', message: 'Enter a renewal term (months) before saving.' });
@@ -198,6 +266,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           renewalNoticeDays: autoRenew ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
           notes: notes.trim() || null,
           terms: terms.trim() || null,
+          // Commit staged lines atomically with the contract; on failure nothing
+          // persists and the staged lines stay in the form for a retry.
+          lines: draftLinePayload(),
         }),
         errorFallback: 'Could not create the contract.',
         successMessage: 'Contract created',
@@ -208,14 +279,14 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } catch (err) {
       handleActionError(err, 'Could not create the contract.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
-  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms]);
+  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms, draftLinePayload]);
 
   // ---- edit flow -----------------------------------------------------------
   const saveHeader = useCallback(async () => {
     if (busy || !contract || !canSaveHeader) return;
-    setBusy(true);
+    setPending('save');
     try {
       if (autoRenew && !renewalTermMonths) {
         showToast({ type: 'error', message: 'Enter a renewal term (months) before saving.' });
@@ -243,13 +314,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } catch (err) {
       handleActionError(err, 'Could not save the contract.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms, refresh]);
 
   const addLine = useCallback(async () => {
     if (busy || !contract || !lineDesc.trim()) return;
-    setBusy(true);
+    setPending('addLine');
     try {
       await runAction({
         request: () => addContractLine(contract.id, {
@@ -274,13 +345,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } catch (err) {
       handleActionError(err, 'Could not add the line.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract, lineType, lineDesc, linePrice, lineQty, lineSiteId, lineCatalogId, lineTaxable, refresh]);
 
   const removeLine = useCallback(async (lineId: string) => {
     if (busy || !contract) return;
-    setBusy(true);
+    setPending('removeLine');
     try {
       await runAction({
         request: () => removeContractLine(contract.id, lineId),
@@ -292,13 +363,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } catch (err) {
       handleActionError(err, 'Could not remove the line.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract, refresh]);
 
   const activate = useCallback(async () => {
     if (busy || !contract) return;
-    setBusy(true);
+    setPending('activate');
     try {
       await runAction({
         request: () => contractTransition(contract.id, 'activate'),
@@ -310,7 +381,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } catch (err) {
       handleActionError(err, 'Could not activate the contract.');
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   }, [busy, contract, refresh]);
 
@@ -319,154 +390,182 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     [sites],
   );
 
+  // Linked catalog item (if any) and whether the entered unit price diverges
+  // from it, so we can warn instead of silently letting the two disagree.
+  const linkedCatalogItem = useMemo(
+    () => catalogItems.find((i) => i.id === lineCatalogId) ?? null,
+    [catalogItems, lineCatalogId],
+  );
+  const catalogPriceMismatch =
+    linkedCatalogItem != null && Number(linkedCatalogItem.unitPrice) !== Number(linePrice || '0');
+
   return (
     <div className="space-y-6" data-testid="contract-editor">
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         {/* ── header form + lines ─────────────────────────────────────── */}
         <div className="space-y-6">
           <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="contract-header-form">
-            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Contract</h3>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {isCreate && (
-                <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                  Organization
-                  <select
-                    value={orgId}
-                    onChange={(e) => setOrgId(e.target.value)}
-                    data-testid="contract-form-org"
-                    className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="">Select an organization…</option>
-                    {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
-                  </select>
-                </label>
-              )}
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Name
-                <input
-                  type="text" value={name} onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. Managed Services — Acme Co"
-                  data-testid="contract-form-name"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Billing timing
-                <select
-                  value={billingTiming} onChange={(e) => setBillingTiming(e.target.value as ContractBillingTiming)}
-                  data-testid="contract-form-timing"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  <option value="advance">In advance</option>
-                  <option value="arrears">In arrears</option>
-                </select>
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Billing cadence
-                <select
-                  value={intervalCustom ? 'custom' : String(intervalMonths)}
-                  onChange={(e) => {
-                    if (e.target.value === 'custom') { setIntervalCustom(true); return; }
-                    setIntervalCustom(false);
-                    setIntervalMonths(Number(e.target.value));
-                  }}
-                  data-testid="contract-form-interval"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  {INTERVAL_PRESETS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
-                  <option value="custom">Custom…</option>
-                </select>
-              </label>
-              {intervalCustom && (
-                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                  Interval (months)
-                  <input
-                    type="number" min="1" max="60" value={intervalMonths}
-                    onChange={(e) => setIntervalMonths(Number(e.target.value))}
-                    data-testid="contract-form-interval-custom"
-                    className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                  />
-                </label>
-              )}
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Start date
-                <input
-                  type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)}
-                  data-testid="contract-form-start"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                End date (optional)
-                <input
-                  type="date" value={endDate} onChange={(e) => { setEndDate(e.target.value); if (!e.target.value) setAutoRenew(false); }}
-                  data-testid="contract-form-end"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex items-center gap-2 text-sm sm:col-span-2">
-                <input
-                  type="checkbox" checked={autoIssue} onChange={(e) => setAutoIssue(e.target.checked)}
-                  data-testid="contract-form-auto-issue"
-                />
-                Auto-issue generated invoices (otherwise they land as drafts)
-              </label>
-              <div className="sm:col-span-2">
-                <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
-                  <input
-                    type="checkbox" checked={autoRenew} disabled={!endDate}
-                    onChange={(e) => setAutoRenew(e.target.checked)}
-                  />
-                  <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
-                </label>
-                {autoRenew && (
-                  <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                      Renewal term (months)
-                      <input
-                        type="number" min={1} max={120} value={renewalTermMonths}
-                        onChange={(e) => setRenewalTermMonths(e.target.value)}
-                        data-testid="contract-renewal-term"
-                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                      />
-                    </label>
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                      Advance notice (days)
-                      <input
-                        type="number" min={0} max={365} value={renewalNoticeDays}
-                        onChange={(e) => setRenewalNoticeDays(e.target.value)}
-                        data-testid="contract-renewal-notice-days"
-                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                      />
-                    </label>
+            <div className="space-y-5">
+              {/* Identity */}
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {isCreate && (
+                  <div className="flex flex-col gap-1 text-xs font-medium text-foreground/85 sm:col-span-2">
+                    Organization
+                    <SearchableSelect
+                      options={orgs}
+                      value={orgId}
+                      onChange={setOrgId}
+                      placeholder="Search organizations…"
+                      ariaLabel="Organization"
+                      testId="contract-form-org"
+                    />
                   </div>
                 )}
+                <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85 sm:col-span-2">
+                  Name
+                  <input
+                    type="text" value={name} onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g. Managed Services — Acme Co"
+                    data-testid="contract-form-name"
+                    className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </label>
               </div>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Notes (optional)
-                <textarea
-                  value={notes} onChange={(e) => setNotes(e.target.value)} rows={2}
-                  data-testid="contract-form-notes"
-                  className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Terms (optional, shown on the invoice)
-                <textarea
-                  value={terms} onChange={(e) => setTerms(e.target.value)} rows={2}
-                  data-testid="contract-form-terms"
-                  placeholder="e.g. Net 30. Auto-renews unless cancelled 30 days prior."
-                  className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </label>
+
+              {/* Billing schedule */}
+              <fieldset className="m-0 space-y-3 border-0 p-0">
+                <legend className="mb-1 p-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Billing schedule</legend>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Billing timing
+                    <select
+                      value={billingTiming} onChange={(e) => setBillingTiming(e.target.value as ContractBillingTiming)}
+                      data-testid="contract-form-timing"
+                      className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="advance">In advance</option>
+                      <option value="arrears">In arrears</option>
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Billing cadence
+                    <select
+                      value={intervalCustom ? 'custom' : String(intervalMonths)}
+                      onChange={(e) => {
+                        if (e.target.value === 'custom') { setIntervalCustom(true); return; }
+                        setIntervalCustom(false);
+                        setIntervalMonths(Number(e.target.value));
+                      }}
+                      data-testid="contract-form-interval"
+                      className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      {INTERVAL_PRESETS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                      <option value="custom">Custom…</option>
+                    </select>
+                  </label>
+                  {intervalCustom && (
+                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                      Interval (months)
+                      <input
+                        type="number" min="1" max="60" value={intervalMonths}
+                        onChange={(e) => setIntervalMonths(Number(e.target.value))}
+                        data-testid="contract-form-interval-custom"
+                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </label>
+                  )}
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Start date
+                    <input
+                      type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)}
+                      data-testid="contract-form-start"
+                      className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    End date (optional)
+                    <input
+                      type="date" value={endDate} onChange={(e) => { setEndDate(e.target.value); if (!e.target.value) setAutoRenew(false); }}
+                      data-testid="contract-form-end"
+                      className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </label>
+                </div>
+              </fieldset>
+
+              {/* Renewal & issuing */}
+              <fieldset className="m-0 space-y-3 border-0 p-0">
+                <legend className="mb-1 p-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Renewal &amp; issuing</legend>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox" checked={autoIssue} onChange={(e) => setAutoIssue(e.target.checked)}
+                    data-testid="contract-form-auto-issue"
+                  />
+                  Auto-issue generated invoices (otherwise they land as drafts)
+                </label>
+                <div>
+                  <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
+                    <input
+                      type="checkbox" checked={autoRenew} disabled={!endDate}
+                      onChange={(e) => setAutoRenew(e.target.checked)}
+                    />
+                    <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
+                  </label>
+                  {autoRenew && (
+                    <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
+                      <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                        Renewal term (months)
+                        <input
+                          type="number" min={1} max={120} value={renewalTermMonths}
+                          onChange={(e) => setRenewalTermMonths(e.target.value)}
+                          data-testid="contract-renewal-term"
+                          className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                        Advance notice (days)
+                        <input
+                          type="number" min={0} max={365} value={renewalNoticeDays}
+                          onChange={(e) => setRenewalNoticeDays(e.target.value)}
+                          data-testid="contract-renewal-notice-days"
+                          className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                        />
+                      </label>
+                    </div>
+                  )}
+                </div>
+              </fieldset>
+
+              {/* Invoice text */}
+              <fieldset className="m-0 space-y-3 border-0 p-0">
+                <legend className="mb-1 p-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Invoice text</legend>
+                <div className="grid grid-cols-1 gap-3">
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Notes (optional)
+                    <textarea
+                      value={notes} onChange={(e) => setNotes(e.target.value)} rows={2}
+                      data-testid="contract-form-notes"
+                      className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
+                    Terms (optional, shown on the invoice)
+                    <textarea
+                      value={terms} onChange={(e) => setTerms(e.target.value)} rows={2}
+                      data-testid="contract-form-terms"
+                      placeholder="e.g. Net 30. Auto-renews unless cancelled 30 days prior."
+                      className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </label>
+                </div>
+              </fieldset>
             </div>
           </div>
 
-          {/* Lines (edit mode only — a contract needs an id before lines attach) */}
-          {!isCreate && (
-            <div className="space-y-4">
-              <div className="rounded-lg border bg-card shadow-sm">
-                <table className="w-full text-sm" data-testid="contract-editor-lines">
+          {/* Lines — staged locally in create mode, persisted in edit mode */}
+          <div className="space-y-4">
+              <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
+                <table className="w-full min-w-[34rem] text-sm" data-testid="contract-editor-lines">
                   <thead>
                     <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                       <th className="px-3 py-2 font-medium">Type</th>
@@ -474,7 +573,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       <th className="px-3 py-2 text-right font-medium">Unit price</th>
                       <th className="px-3 py-2 text-right font-medium">Qty</th>
                       <th className="px-3 py-2 text-center font-medium">Tax</th>
-                      <th className="px-3 py-2" />
+                      <th className="px-3 py-2"><span className="sr-only">Actions</span></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -502,11 +601,14 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                                   : <span className="text-muted-foreground">auto</span>)
                               : (l.lineType === 'manual' ? (l.manualQuantity ?? '0') : '1')}
                           </td>
-                          <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
+                          <td className="px-3 py-2 text-center">
+                            <span aria-hidden="true">{l.taxable ? '✓' : '—'}</span>
+                            <span className="sr-only">{l.taxable ? 'Taxable' : 'Not taxable'}</span>
+                          </td>
                           <td className="px-3 py-2 text-right">
                             {can('contracts', 'write') && (
                               <button
-                                type="button" onClick={() => void removeLine(l.id)} disabled={busy}
+                                type="button" onClick={() => isCreate ? removeDraftLine(l.id) : setRemoveTarget(l)} disabled={busy}
                                 data-testid={`line-remove-${idx}`}
                                 className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
                               >
@@ -524,7 +626,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
               {/* Add line */}
               <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="contract-add-line">
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                     Line type
                     <select
                       value={lineType}
@@ -537,7 +639,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       ))}
                     </select>
                   </label>
-                  <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                     Description
                     <input
                       type="text" value={lineDesc} onChange={(e) => setLineDesc(e.target.value)}
@@ -546,7 +648,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                   </label>
-                  <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                     Unit price
                     <input
                       type="number" min="0" step="0.01" value={linePrice}
@@ -556,7 +658,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     />
                   </label>
                   {lineType === 'manual' && (
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                       Quantity
                       <input
                         type="number" min="0" step="0.01" value={lineQty}
@@ -567,7 +669,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     </label>
                   )}
                   {lineType === 'per_device' && (
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                    <label className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                       Site (optional — scopes the device count)
                       <select
                         value={lineSiteId} onChange={(e) => setLineSiteId(e.target.value)}
@@ -580,13 +682,26 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     </label>
                   )}
                   {catalogItems.length > 0 && (
-                    <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                    <div className="flex flex-col gap-1 text-xs font-medium text-foreground/85">
                       Link catalog item (optional)
                       {lineCatalogId ? (
-                        <span className="inline-flex h-9 items-center gap-1.5 self-start rounded-md border bg-muted/40 px-2.5 text-sm text-foreground" data-testid="contract-line-catalog-picked">
-                          <span className="font-medium">{catalogItems.find((i) => i.id === lineCatalogId)?.name ?? 'Item'}</span>
-                          <button type="button" onClick={() => setLineCatalogId('')} aria-label="Clear catalog link" className="ml-1 text-muted-foreground hover:text-foreground">×</button>
-                        </span>
+                        <div className="flex flex-col gap-1" data-testid="contract-line-catalog-picked">
+                          <span className="inline-flex h-9 items-center gap-1 self-start rounded-md border bg-muted/40 pl-2.5 pr-1 text-sm text-foreground">
+                            <span className="font-medium">{linkedCatalogItem?.name ?? 'Item'}</span>
+                            <button
+                              type="button" onClick={() => setLineCatalogId('')}
+                              aria-label="Clear catalog link"
+                              className="inline-flex h-6 w-6 items-center justify-center rounded text-base leading-none text-muted-foreground hover:bg-muted hover:text-foreground"
+                            >
+                              ×
+                            </button>
+                          </span>
+                          {catalogPriceMismatch && linkedCatalogItem && (
+                            <span className="text-[11px] font-normal text-amber-600 dark:text-amber-500" data-testid="contract-line-catalog-price-note">
+                              Catalog lists {formatMoney(linkedCatalogItem.unitPrice, contract?.currencyCode)} — keeping your entered price.
+                            </span>
+                          )}
+                        </div>
                       ) : (
                         <CatalogItemPicker
                           items={catalogItems}
@@ -594,7 +709,10 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                           onSelect={(it) => {
                             setLineCatalogId(it.id);
                             if (!lineDesc.trim()) setLineDesc(it.name);
-                            setLinePrice(it.unitPrice);
+                            // Don't clobber a price the user already typed (e.g. a
+                            // negotiated rate); only fill from the catalog when the
+                            // field is still at its default.
+                            if (linePrice === '' || Number(linePrice) === 0) setLinePrice(it.unitPrice);
                           }}
                           testId="contract-line-catalog-picker"
                           placeholder="Search catalog…"
@@ -618,25 +736,25 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                   </span>
                   {can('contracts', 'write') && (
                     <button
-                      type="button" onClick={() => void addLine()} disabled={busy || !lineDesc.trim()}
+                      type="button" onClick={() => isCreate ? addDraftLine() : void addLine()} disabled={busy || !lineDesc.trim()}
                       data-testid="add-line-btn"
-                      className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                      className="inline-flex h-9 items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"
                     >
-                      Add line
+                      {pending === 'addLine' && <Spinner />}
+                      {pending === 'addLine' ? 'Adding…' : 'Add line'}
                     </button>
                   )}
                 </div>
               </div>
-            </div>
-          )}
+          </div>
         </div>
 
         {/* ── summary + actions ───────────────────────────────────────── */}
         <div className="space-y-4">
-          <div className="rounded-lg border bg-card p-4 shadow-sm" data-testid="contract-estimate">
+          <div className="rounded-lg border border-primary/30 bg-primary/[0.03] p-4 shadow-sm" data-testid="contract-estimate">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Estimated this period</h3>
-            {isCreate ? (
-              <p className="text-sm text-muted-foreground">Save the contract, then add lines to see an estimate.</p>
+            {isCreate && lines.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Add a line below to see the estimated total.</p>
             ) : (
               <>
                 <p className="text-2xl font-semibold tabular-nums" data-testid="contract-estimate-total">
@@ -665,32 +783,45 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           <div className="space-y-2">
             {isCreate ? (
               can('contracts', 'write') && (
-                <button
-                  type="button" onClick={() => void saveCreate()} disabled={busy || !canSaveHeader}
-                  data-testid="save-contract-btn"
-                  className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                >
-                  Create contract
-                </button>
+                <>
+                  <button
+                    type="button" onClick={() => void saveCreate()} disabled={busy || !canSaveHeader}
+                    data-testid="save-contract-btn"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                  >
+                    {pending === 'create' && <Spinner />}
+                    {pending === 'create' ? 'Creating…' : 'Create contract'}
+                  </button>
+                  {!canSaveHeader && missingHint && (
+                    <p className="text-center text-xs text-muted-foreground" data-testid="contract-save-hint">{missingHint}</p>
+                  )}
+                </>
               )
             ) : (
               <>
                 {can('contracts', 'write') && (
-                  <button
-                    type="button" onClick={() => void saveHeader()} disabled={busy || !canSaveHeader}
-                    data-testid="save-contract-btn"
-                    className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-                  >
-                    Save changes
-                  </button>
+                  <>
+                    <button
+                      type="button" onClick={() => void saveHeader()} disabled={busy || !canSaveHeader}
+                      data-testid="save-contract-btn"
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                      {pending === 'save' && <Spinner />}
+                      {pending === 'save' ? 'Saving…' : 'Save changes'}
+                    </button>
+                    {!canSaveHeader && missingHint && (
+                      <p className="text-center text-xs text-muted-foreground" data-testid="contract-save-hint">{missingHint}</p>
+                    )}
+                  </>
                 )}
                 {can('contracts', 'manage') && contract?.status === 'draft' && (
                   <button
-                    type="button" onClick={() => void activate()} disabled={busy || lines.length === 0}
+                    type="button" onClick={() => setConfirmActivate(true)} disabled={busy || lines.length === 0}
                     data-testid="activate-contract-btn"
-                    className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/15 disabled:opacity-50"
                   >
-                    Activate contract
+                    {pending === 'activate' && <Spinner />}
+                    {pending === 'activate' ? 'Activating…' : 'Activate contract'}
                   </button>
                 )}
                 {contract?.status === 'draft' && lines.length === 0 && (
@@ -703,6 +834,40 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={removeTarget !== null}
+        onClose={() => setRemoveTarget(null)}
+        onConfirm={() => { const id = removeTarget?.id; setRemoveTarget(null); if (id) void removeLine(id); }}
+        isLoading={busy}
+        variant="destructive"
+        title="Remove contract line"
+        message={
+          removeTarget
+            ? `Remove "${removeTarget.description}" from this contract? This changes what the client is billed each period.`
+            : ''
+        }
+        confirmLabel="Remove line"
+        confirmTestId="contract-line-remove-confirm"
+      />
+
+      <ConfirmDialog
+        open={confirmActivate}
+        onClose={() => setConfirmActivate(false)}
+        onConfirm={() => { setConfirmActivate(false); void activate(); }}
+        isLoading={busy}
+        variant="warning"
+        title="Activate contract"
+        message={
+          `Activating starts billing for "${name.trim() || 'this contract'}". It will generate ` +
+          `${liveEstimate ? formatMoney(liveEstimate.periodTotal, contract?.currencyCode) : formatMoney(estimate.known, contract?.currencyCode)}` +
+          `${!liveEstimate && estimate.hasAuto ? ' plus auto-counted device/seat lines' : ''} ` +
+          `${formatCadenceAdverb(intervalMonths)}, starting ${startDate ? new Date(`${startDate}T00:00:00`).toLocaleDateString() : 'the start date'}. ` +
+          `${autoIssue ? 'Invoices are issued automatically.' : 'Invoices land as drafts for review.'}`
+        }
+        confirmLabel="Activate contract"
+        confirmTestId="contract-activate-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -62,6 +62,10 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
 
   const { can } = usePermissions();
   const canWrite = can('catalog', 'write');
+  // A user who can't write opens this drawer to *read* an item (e.g. a manager
+  // browsing the catalog, or the row-click "see details" path). Render the fields
+  // as a clean read-only view instead of an editable-looking form with no Save.
+  const readOnly = !canWrite;
   // Per-org overrides are a partner surface (an MSP pricing a customer). Detect
   // partner scope from the JWT claims — useOrgStore().partners is only populated
   // from a system-scope-only endpoint, so a real partner-scope user gets an empty
@@ -430,7 +434,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
 
   if (!open || typeof document === 'undefined') return null;
 
-  const fieldCls = 'w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
+  const fieldCls = 'w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring read-only:cursor-default read-only:bg-muted/40 read-only:focus:ring-0';
 
   return createPortal(
     <div
@@ -453,7 +457,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
         {/* Header */}
         <div className="flex items-center justify-between border-b px-5 py-4">
           <h2 id={titleId} className="text-base font-semibold">
-            {editId ? 'Edit item' : 'New item'}
+            {editId ? (readOnly ? 'Item details' : 'Edit item') : 'New item'}
           </h2>
           <button
             type="button"
@@ -486,9 +490,10 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                   key={t}
                   type="button"
                   onClick={() => setItemType(t)}
+                  disabled={readOnly}
                   aria-pressed={itemType === t}
-                  className={`rounded px-2 py-1.5 text-sm font-medium transition ${
-                    itemType === t ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+                  className={`rounded px-2 py-1.5 text-sm font-medium transition disabled:cursor-default ${
+                    itemType === t ? 'bg-card text-foreground shadow-sm' : `text-muted-foreground ${readOnly ? '' : 'hover:text-foreground'}`
                   }`}
                   data-testid={`catalog-form-type-${t}`}
                 >
@@ -504,6 +509,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
               id="catalog-form-name-input"
               value={name}
               onChange={(e) => setName(e.target.value)}
+              readOnly={readOnly}
               className={fieldCls}
               placeholder="e.g. Managed Workstation"
               data-testid="catalog-form-name"
@@ -516,6 +522,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
               id="catalog-form-sku-input"
               value={sku}
               onChange={(e) => setSku(e.target.value)}
+              readOnly={readOnly}
               className={`${fieldCls} font-mono`}
               placeholder="SKU-001"
               data-testid="catalog-form-sku"
@@ -530,6 +537,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                 value={unitPrice}
                 onChange={(e) => setUnitPrice(e.target.value)}
                 inputMode="decimal"
+                readOnly={readOnly}
                 className={`${fieldCls} text-right tabular-nums`}
                 placeholder="0.00"
                 data-testid="catalog-form-price"
@@ -542,6 +550,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                 value={costBasis}
                 onChange={(e) => setCostBasis(e.target.value)}
                 inputMode="decimal"
+                readOnly={readOnly}
                 className={`${fieldCls} text-right tabular-nums`}
                 placeholder="0.00"
                 data-testid="catalog-form-cost"
@@ -620,6 +629,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
               type="checkbox"
               checked={isBundle}
               onChange={(e) => setIsBundle(e.target.checked)}
+              disabled={readOnly}
               className="h-4 w-4"
               data-testid="catalog-form-bundle"
             />
@@ -670,7 +680,8 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                           <select
                             value={c.componentItemId}
                             onChange={(e) => patchComponent(idx, { componentItemId: e.target.value })}
-                            className="h-9 flex-1 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                            disabled={readOnly}
+                            className="h-9 flex-1 rounded-md border bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-default disabled:bg-muted/40"
                             data-testid={`catalog-bundle-item-${idx}`}
                           >
                             <option value="">Select item…</option>
@@ -686,7 +697,8 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                             onChange={(e) => patchComponent(idx, { quantity: e.target.value })}
                             inputMode="decimal"
                             aria-label="Quantity"
-                            className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+                            readOnly={readOnly}
+                            className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring read-only:cursor-default read-only:bg-muted/40"
                             data-testid={`catalog-bundle-qty-${idx}`}
                           />
                           {canWrite && (
@@ -708,6 +720,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                             type="checkbox"
                             checked={c.showOnInvoice}
                             onChange={(e) => patchComponent(idx, { showOnInvoice: e.target.checked })}
+                            disabled={readOnly}
                             data-testid={`catalog-bundle-showoninvoice-${idx}`}
                           />
                           Show this line on the invoice
@@ -806,7 +819,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
             className="rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
             data-testid="catalog-form-cancel"
           >
-            Cancel
+            {readOnly ? 'Close' : 'Cancel'}
           </button>
           {canWrite && (
             <button

--- a/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.permissions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import CatalogItemsTab from './CatalogItemsTab';
@@ -68,6 +68,23 @@ describe('CatalogItemsTab — permission gating', () => {
     expect(screen.queryByTestId('catalog-add-item')).not.toBeInTheDocument();
     // RowActions has nothing actionable → it renders no kebab trigger at all.
     expect(screen.queryByTestId('catalog-actions-l1')).not.toBeInTheDocument();
+  });
+
+  it('read-only row-click opens the item as a read-only "details" view', async () => {
+    state.permissions = [{ resource: 'catalog', action: 'read' }];
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+
+    // No write grant → the row-click "see details" path must not present an
+    // editable-looking form with no Save. Header reads "Item details", fields
+    // are read-only, and there's no Save button.
+    fireEvent.click(screen.getByTestId('catalog-item-row-l1'));
+    const drawer = await screen.findByTestId('catalog-item-editor');
+
+    expect(within(drawer).getByText('Item details')).toBeInTheDocument();
+    expect(within(drawer).queryByText('Edit item')).not.toBeInTheDocument();
+    expect(within(drawer).getByTestId('catalog-form-name')).toHaveAttribute('readonly');
+    expect(within(drawer).queryByTestId('catalog-form-save')).not.toBeInTheDocument();
   });
 
   it('write-without-delete shows Add item and Edit but NOT Archive', async () => {

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -146,6 +146,35 @@ describe('CatalogItemsTab', () => {
     expect(screen.queryByTestId('catalog-item-editor')).not.toBeInTheDocument();
   });
 
+  it('clicking a bundle row expands its inline detail instead of opening the editor', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Starter Bundle');
+
+    // Bundles own a richer inline detail (components + economics); the row-click
+    // surfaces that rather than the edit drawer, so the row has one predictable
+    // "details" action. Editing a bundle stays on the kebab menu.
+    fireEvent.click(screen.getByTestId('catalog-item-row-b1'));
+
+    await screen.findByTestId('catalog-bundle-detail-b1');
+    expect(screen.queryByTestId('catalog-item-editor')).not.toBeInTheDocument();
+  });
+
+  it('does not open a row when the click ends a text selection (SKU copy)', async () => {
+    const getSelectionSpy = vi
+      .spyOn(window, 'getSelection')
+      .mockReturnValue({ toString: () => 'WID-1' } as unknown as Selection);
+    try {
+      render(<CatalogItemsTab />);
+      await screen.findByText('Widget Service');
+
+      fireEvent.click(screen.getByTestId('catalog-item-row-w1'));
+
+      expect(screen.queryByTestId('catalog-item-editor')).not.toBeInTheDocument();
+    } finally {
+      getSelectionSpy.mockRestore();
+    }
+  });
+
   it('creates a bundle and PUTs components including showOnInvoice', async () => {
     render(<CatalogItemsTab />);
     await screen.findByText('Widget Service');

--- a/apps/web/src/components/settings/CatalogItemsTab.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.test.tsx
@@ -115,6 +115,37 @@ describe('CatalogItemsTab', () => {
     });
   });
 
+  it('opens the editor drawer with the item when its row is clicked', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Widget Service');
+
+    fireEvent.click(screen.getByTestId('catalog-item-row-w1'));
+
+    const drawer = await screen.findByTestId('catalog-item-editor');
+    expect(within(drawer).getByText('Edit item')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('catalog-form-name')).toHaveValue('Widget Service');
+  });
+
+  it('opens the editor when the item name is clicked (keyboard-focusable affordance)', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Laptop');
+
+    fireEvent.click(screen.getByTestId('catalog-item-name-l1'));
+
+    const drawer = await screen.findByTestId('catalog-item-editor');
+    expect(within(drawer).getByTestId('catalog-form-name')).toHaveValue('Laptop');
+  });
+
+  it('does not open the editor when the bundle toggle is clicked', async () => {
+    render(<CatalogItemsTab />);
+    await screen.findByText('Starter Bundle');
+
+    fireEvent.click(screen.getByTestId('catalog-bundle-toggle-b1'));
+
+    await screen.findByTestId('catalog-bundle-detail-b1');
+    expect(screen.queryByTestId('catalog-item-editor')).not.toBeInTheDocument();
+  });
+
   it('creates a bundle and PUTs components including showOnInvoice', async () => {
     render(<CatalogItemsTab />);
     await screen.findByText('Widget Service');

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -333,7 +333,17 @@ export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number 
                   const isOpen = !!exp;
                   return (
                     <FragmentRow key={it.id}>
-                      <tr className="border-t transition hover:bg-muted/40" data-testid={`catalog-item-row-${it.id}`}>
+                      <tr
+                        className="cursor-pointer border-t transition hover:bg-muted/40"
+                        data-testid={`catalog-item-row-${it.id}`}
+                        onClick={(e) => {
+                          // Open the details drawer when the row body is clicked, but
+                          // let the inline controls (bundle toggle, row-actions menu,
+                          // the name button) handle their own clicks.
+                          if ((e.target as HTMLElement).closest('button,a,input,select,[role="menu"]')) return;
+                          openEdit(it);
+                        }}
+                      >
                         <td className="px-3 py-3 font-medium">
                           <span className="flex items-center gap-1.5">
                             {it.isBundle ? (
@@ -352,7 +362,14 @@ export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number 
                             ) : (
                               <span className="inline-block w-[18px]" />
                             )}
-                            {it.name}
+                            <button
+                              type="button"
+                              onClick={() => openEdit(it)}
+                              className="rounded text-left hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                              data-testid={`catalog-item-name-${it.id}`}
+                            >
+                              {it.name}
+                            </button>
                             {it.isBundle && (
                               <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                                 Bundle

--- a/apps/web/src/components/settings/CatalogItemsTab.tsx
+++ b/apps/web/src/components/settings/CatalogItemsTab.tsx
@@ -334,14 +334,21 @@ export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number 
                   return (
                     <FragmentRow key={it.id}>
                       <tr
-                        className="cursor-pointer border-t transition hover:bg-muted/40"
+                        className="group cursor-pointer border-t transition hover:bg-muted/40"
                         data-testid={`catalog-item-row-${it.id}`}
                         onClick={(e) => {
-                          // Open the details drawer when the row body is clicked, but
-                          // let the inline controls (bundle toggle, row-actions menu,
-                          // the name button) handle their own clicks.
+                          // Don't hijack a text selection — techs copy SKUs, and a click
+                          // that ends a drag-select must not also open the row.
+                          if (window.getSelection()?.toString()) return;
+                          // Let the inline controls (bundle toggle, row-actions menu, the
+                          // name button) handle their own clicks.
                           if ((e.target as HTMLElement).closest('button,a,input,select,[role="menu"]')) return;
-                          openEdit(it);
+                          // A bundle already has a richer inline detail (components +
+                          // economics) behind the chevron — toggle that instead of the
+                          // editor so the row has one predictable "details" action.
+                          // Editing a bundle stays on the kebab menu.
+                          if (it.isBundle) toggleExpand(it);
+                          else openEdit(it);
                         }}
                       >
                         <td className="px-3 py-3 font-medium">
@@ -364,7 +371,8 @@ export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number 
                             )}
                             <button
                               type="button"
-                              onClick={() => openEdit(it)}
+                              onClick={() => (it.isBundle ? toggleExpand(it) : openEdit(it))}
+                              aria-expanded={it.isBundle ? isOpen : undefined}
                               className="rounded text-left hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                               data-testid={`catalog-item-name-${it.id}`}
                             >
@@ -389,15 +397,28 @@ export default function CatalogItemsTab({ reloadKey = 0 }: { reloadKey?: number 
                           {formatMargin(margin)}
                         </td>
                         <td className="px-3 py-3 text-right">
-                          <RowActions
-                            item={it}
-                            view={view}
-                            busy={archivingId === it.id}
-                            disabled={archivingId !== null}
-                            onEdit={() => openEdit(it)}
-                            onArchive={() => setPendingArchive(it)}
-                            onRestore={() => void restore(it.id)}
-                          />
+                          <div className="flex items-center justify-end gap-1.5">
+                            {/* Hover-only disclosure cue: signals the row opens the
+                                details drawer. Bundles use their leading chevron instead. */}
+                            {!it.isBundle && (
+                              <svg
+                                aria-hidden="true"
+                                className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-60"
+                                viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+                              >
+                                <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            )}
+                            <RowActions
+                              item={it}
+                              view={view}
+                              busy={archivingId === it.id}
+                              disabled={archivingId !== null}
+                              onEdit={() => openEdit(it)}
+                              onArchive={() => setPendingArchive(it)}
+                              onRestore={() => void restore(it.id)}
+                            />
+                          </div>
                         </td>
                       </tr>
                       {isOpen && (

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertOctagon, AlertTriangle } from 'lucide-react';
 import { Dialog } from './Dialog';
 
 export interface ConfirmDialogProps {
@@ -25,6 +25,11 @@ export function ConfirmDialog({
   isLoading = false,
   confirmTestId,
 }: ConfirmDialogProps) {
+  // Encode severity by SHAPE, not color alone: a stop-octagon for destructive
+  // (irreversible removal) vs a caution-triangle for warning (a guarded but
+  // non-destructive action like activate/generate). Colorblind users and a
+  // glance-read both get the distinction without relying on red-vs-amber.
+  const Icon = variant === 'destructive' ? AlertOctagon : AlertTriangle;
   return (
     <Dialog open={open} onClose={onClose} title={title} maxWidth="md" className="p-6">
       <div className="flex gap-4">
@@ -33,10 +38,11 @@ export function ConfirmDialog({
             variant === 'destructive' ? 'bg-destructive/10' : 'bg-warning/10'
           }`}
         >
-          <AlertTriangle
+          <Icon
             className={`h-5 w-5 ${
               variant === 'destructive' ? 'text-destructive' : 'text-warning'
             }`}
+            aria-hidden="true"
           />
         </div>
         <div className="flex-1">

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -64,7 +64,7 @@ export function ConfirmDialog({
               : 'bg-warning text-warning-foreground hover:bg-warning/90'
           }`}
         >
-          {isLoading ? 'Processing...' : confirmLabel}
+          {isLoading ? 'Processing…' : confirmLabel}
         </button>
       </div>
     </Dialog>

--- a/apps/web/src/components/shared/SearchableSelect.test.tsx
+++ b/apps/web/src/components/shared/SearchableSelect.test.tsx
@@ -44,6 +44,14 @@ describe('SearchableSelect', () => {
     expect(onChange).toHaveBeenCalledWith('org-2');
   });
 
+  it('shows a "Showing N of M" hint when matches exceed the cap', () => {
+    const many: SelectOption[] = Array.from({ length: 12 }, (_, i) => ({ id: `o-${i}`, name: `Org ${i}` }));
+    const onChange = vi.fn();
+    render(<SearchableSelect options={many} value="" onChange={onChange} testId="ss" maxResults={8} />);
+    fireEvent.focus(screen.getByTestId('ss-input'));
+    expect(screen.getByTestId('ss-truncated')).toHaveTextContent('Showing 8 of 12');
+  });
+
   it('shows a no-matches hint when the query matches nothing', () => {
     const { input } = setup();
     fireEvent.focus(input);

--- a/apps/web/src/components/shared/SearchableSelect.test.tsx
+++ b/apps/web/src/components/shared/SearchableSelect.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import SearchableSelect, { type SelectOption } from './SearchableSelect';
+
+const OPTIONS: SelectOption[] = [
+  { id: 'org-1', name: 'Acme Corp' },
+  { id: 'org-2', name: 'Globex' },
+  { id: 'org-3', name: 'Initech' },
+];
+
+function setup(value = '') {
+  const onChange = vi.fn();
+  render(<SearchableSelect options={OPTIONS} value={value} onChange={onChange} testId="ss" />);
+  return { onChange, input: screen.getByTestId('ss-input') as HTMLInputElement };
+}
+
+describe('SearchableSelect', () => {
+  it('opens on focus and filters by name substring', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    expect(screen.getByTestId('ss-list')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'glo' } });
+    expect(screen.getByTestId('ss-option-org-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('ss-option-org-1')).not.toBeInTheDocument();
+  });
+
+  it('selects an option on click and reports its id', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByTestId('ss-option-org-3'));
+    expect(onChange).toHaveBeenCalledWith('org-3');
+    // List closes after a pick.
+    expect(screen.queryByTestId('ss-list')).not.toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation (ArrowDown + Enter)', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    // active starts at 0 (Acme); one ArrowDown moves to Globex.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('org-2');
+  });
+
+  it('shows a no-matches hint when the query matches nothing', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    expect(screen.getByTestId('ss-noresults')).toBeInTheDocument();
+  });
+
+  it('displays the selected option name when closed', () => {
+    const { input } = setup('org-1');
+    expect(input.value).toBe('Acme Corp');
+  });
+
+  it('points aria-activedescendant at the highlighted option for screen readers', () => {
+    const { input } = setup();
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    fireEvent.focus(input);
+    const active = input.getAttribute('aria-activedescendant');
+    expect(active).toBeTruthy();
+    // The id must resolve to a rendered option element.
+    expect(document.getElementById(active as string)).toHaveAttribute('role', 'option');
+  });
+});

--- a/apps/web/src/components/shared/SearchableSelect.tsx
+++ b/apps/web/src/components/shared/SearchableSelect.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+
+export interface SelectOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  /** Options to search; the picker filters by name (case-insensitive substring). */
+  options: SelectOption[];
+  /** Currently-selected option id ('' when none). */
+  value: string;
+  /** Called with the chosen option id. */
+  onChange: (id: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  testId?: string;
+  /** Accessible label when no visible <label> is wired to the input. */
+  ariaLabel?: string;
+  /** Cap the visible result rows. */
+  maxResults?: number;
+}
+
+/**
+ * Generic searchable single-select (combobox). Mirrors CatalogItemPicker's
+ * keyboard + ARIA behaviour but keeps the current selection visible instead of
+ * clearing after a pick — use it anywhere a native <select> would force a
+ * scroll-hunt through many options (e.g. the org picker on long tenant lists).
+ * The dropdown is absolutely positioned within a relative wrapper, so place it
+ * in form areas that are not overflow-clipped.
+ */
+export default function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = 'Search…',
+  disabled,
+  testId = 'searchable-select',
+  ariaLabel,
+  maxResults = 8,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+
+  const selected = useMemo(() => options.find((o) => o.id === value) ?? null, [options, value]);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return options.filter((o) => !q || o.name.toLowerCase().includes(q)).slice(0, maxResults);
+  }, [options, query, maxResults]);
+
+  useEffect(() => { setActive(0); }, [query, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) { setOpen(false); setQuery(''); }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const choose = (opt: SelectOption) => {
+    onChange(opt.id);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') { setOpen(false); setQuery(''); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true); setActive((a) => Math.min(a + 1, results.length - 1)); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => Math.max(a - 1, 0)); return; }
+    if (e.key === 'Enter' && open && results[active]) { e.preventDefault(); choose(results[active]); }
+  };
+
+  // Closed: show the selected name. Open: show what the user is typing.
+  const display = open ? query : (selected?.name ?? '');
+
+  return (
+    <div ref={wrapRef} className="relative" data-testid={testId}>
+      <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={open && results.length > 0 ? `${listId}-opt-${active}` : undefined}
+        aria-label={ariaLabel}
+        value={display}
+        disabled={disabled}
+        placeholder={selected ? selected.name : placeholder}
+        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        className="h-10 w-full rounded-md border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+        data-testid={`${testId}-input`}
+      />
+      {open && results.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute z-30 mt-1 max-h-64 w-full overflow-auto rounded-md border bg-card py-1 shadow-lg"
+          data-testid={`${testId}-list`}
+        >
+          {results.map((opt, idx) => (
+            <li key={opt.id} id={`${listId}-opt-${idx}`} role="option" aria-selected={idx === active}>
+              <button
+                type="button"
+                onMouseEnter={() => setActive(idx)}
+                onClick={() => choose(opt)}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${idx === active ? 'bg-muted' : ''} ${opt.id === value ? 'font-medium' : ''}`}
+                data-testid={`${testId}-option-${opt.id}`}
+              >
+                <span className="flex-1 truncate">{opt.name}</span>
+                {opt.id === value && <span className="text-primary" aria-hidden="true">✓</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && query.trim() !== '' && results.length === 0 && (
+        <div
+          className="absolute z-30 mt-1 w-full rounded-md border bg-card px-3 py-2 text-xs text-muted-foreground shadow-lg"
+          data-testid={`${testId}-noresults`}
+        >
+          No matches.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/SearchableSelect.tsx
+++ b/apps/web/src/components/shared/SearchableSelect.tsx
@@ -47,10 +47,12 @@ export default function SearchableSelect({
 
   const selected = useMemo(() => options.find((o) => o.id === value) ?? null, [options, value]);
 
-  const results = useMemo(() => {
+  const matches = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return options.filter((o) => !q || o.name.toLowerCase().includes(q)).slice(0, maxResults);
-  }, [options, query, maxResults]);
+    return options.filter((o) => !q || o.name.toLowerCase().includes(q));
+  }, [options, query]);
+  const results = useMemo(() => matches.slice(0, maxResults), [matches, maxResults]);
+  const truncated = matches.length > results.length;
 
   useEffect(() => { setActive(0); }, [query, open]);
 
@@ -119,6 +121,15 @@ export default function SearchableSelect({
               </button>
             </li>
           ))}
+          {truncated && (
+            <li
+              className="border-t px-3 py-1.5 text-[11px] text-muted-foreground"
+              role="presentation"
+              data-testid={`${testId}-truncated`}
+            >
+              Showing {results.length} of {matches.length} — keep typing to narrow.
+            </li>
+          )}
         </ul>
       )}
       {open && query.trim() !== '' && results.length === 0 && (

--- a/apps/web/src/components/shared/Spinner.tsx
+++ b/apps/web/src/components/shared/Spinner.tsx
@@ -1,0 +1,9 @@
+/** Inline button spinner; static (no spin) under prefers-reduced-motion. */
+export default function Spinner({ className = 'h-3.5 w-3.5' }: { className?: string }) {
+  return (
+    <span
+      className={`inline-block animate-spin rounded-full border-2 border-current border-t-transparent motion-reduce:animate-none ${className}`}
+      aria-hidden="true"
+    />
+  );
+}

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -146,6 +146,14 @@ export function addContractLine(id: string, body: unknown): Promise<Response> {
   });
 }
 
+export function updateContractLine(id: string, lineId: string, body: unknown): Promise<Response> {
+  return fetchWithAuth(`/contracts/${id}/lines/${lineId}`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
 export function removeContractLine(id: string, lineId: string): Promise<Response> {
   return fetchWithAuth(`/contracts/${id}/lines/${lineId}`, { method: 'DELETE' });
 }

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -193,6 +193,20 @@ export function formatCadence(intervalMonths: number): string {
   }
 }
 
+/** Adverb form for inline prose ("bills monthly", "renews annually"). */
+export function formatCadenceAdverb(intervalMonths: number): string {
+  switch (intervalMonths) {
+    case 1:
+      return 'monthly';
+    case 3:
+      return 'quarterly';
+    case 12:
+      return 'annually';
+    default:
+      return `every ${intervalMonths} months`;
+  }
+}
+
 /** Normalize a per-period value to an estimated monthly figure (annual ÷ 12,
  *  quarterly ÷ 3) for an "Est. monthly recurring" rollup. */
 export function monthlyValue(periodValue: string | number | null | undefined, intervalMonths: number): number {

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -136,6 +136,26 @@ export function removeLine(id: string, lineId: string): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}/lines/${lineId}`, { method: 'DELETE' });
 }
 
+/** Reorder a quote's blocks. Body is the full ordered id list; the server
+ *  renumbers sortOrder 0..n-1 (PATCH /quotes/:id/blocks/reorder). */
+export function reorderBlocks(id: string, body: { blockIds: string[] }): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/blocks/reorder`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+/** Reorder the lines within a pricing-table block. Full ordered id list; the
+ *  server renumbers sortOrder 0..n-1 (PATCH /quotes/:id/blocks/:blockId/lines/reorder). */
+export function reorderLines(id: string, blockId: string, body: { lineIds: string[] }): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/blocks/${blockId}/lines/reorder`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
 /** Absolute API path for the quote PDF (`GET /api/v1/quotes/:id/pdf`). The route
  *  streams `application/pdf` inline; callers fetch it via `fetchWithAuth` (to
  *  attach the auth header) the same way InvoiceDetail downloads its PDF. */

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './semverCompare';
 export * from './timezone';
 export * from './assuranceLevel';
 export * from './ticketTemplate';
+export * from './quoteMath';

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { computeQuoteTotals, computeLineTotal, toCents, fromCents, type QuoteLineForMath } from './quoteMath';
+
+const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
+  quantity: '1', unitPrice: '0', taxable: false, recurrence: 'one_time', customerVisible: true, ...over,
+});
+
+describe('quoteMath (shared)', () => {
+  it('buckets one-time vs monthly vs annual and taxes only taxable lines', () => {
+    const r = computeQuoteTotals([
+      line({ quantity: '2', unitPrice: '500', recurrence: 'one_time', taxable: true }),
+      line({ quantity: '10', unitPrice: '22', recurrence: 'monthly', taxable: true }),
+      line({ quantity: '1', unitPrice: '1200', recurrence: 'annual', taxable: false }),
+    ], 0.1);
+    expect(r.oneTimeTotal).toBe('1000.00');
+    expect(r.monthlyRecurringTotal).toBe('220.00');
+    expect(r.annualRecurringTotal).toBe('1200.00');
+    expect(r.subtotal).toBe('2420.00');
+    expect(r.taxTotal).toBe('122.00'); // (1000 + 220) * 0.1
+    expect(r.total).toBe('2542.00');
+  });
+
+  it('dueOnAcceptanceTotal is the one-time subtotal + tax on one-time lines only', () => {
+    const r = computeQuoteTotals([
+      line({ quantity: '1', unitPrice: '500', recurrence: 'one_time', taxable: true }),
+      line({ quantity: '1', unitPrice: '1000', recurrence: 'monthly', taxable: true }),
+    ], 0.1);
+    expect(r.taxTotal).toBe('150.00');             // whole-quote tax incl. monthly
+    expect(r.dueOnAcceptanceTotal).toBe('550.00'); // one-time 500 + its 50 tax
+    expect(r.dueOnAcceptanceTotal).not.toBe(r.total);
+  });
+
+  it('excludes non-customer-visible lines and treats null taxRate as zero', () => {
+    expect(computeQuoteTotals([line({ unitPrice: '100', customerVisible: false })], 0).subtotal).toBe('0.00');
+    const r = computeQuoteTotals([line({ unitPrice: '100', taxable: true })], null);
+    expect(r.taxTotal).toBe('0.00');
+    expect(r.total).toBe('100.00');
+  });
+
+  it('rounds at the cent boundary without rounding unitPrice first', () => {
+    // 0.05 * 0.70 = 0.035 → 3.4999.. cents → floor(+0.5) = 3 → 0.03 (not 0.04).
+    expect(computeLineTotal('0.05', '0.70')).toBe('0.03');
+    expect(computeQuoteTotals([line({ quantity: '0.05', unitPrice: '0.70' })], null).subtotal).toBe('0.03');
+    // sub-cent unit prices survive: 3 * 0.335 = 1.005 → round half-up → 1.01.
+    expect(computeLineTotal('3', '0.335')).toBe('1.01');
+  });
+
+  it('cents helpers round-trip and treat blank as zero', () => {
+    expect(toCents('12.34')).toBe(1234);
+    expect(toCents('')).toBe(0);
+    expect(toCents(null)).toBe(0);
+    expect(fromCents(1234)).toBe('12.34');
+  });
+});

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -1,0 +1,91 @@
+// Single source of truth for quote totals, shared by the API (authoritative
+// recompute on every mutation) and the web editor (optimistic "Live totals" rail
+// while the user is mid-edit). Keeping one implementation here means the
+// optimistic rail can never settle to a different figure than the server returns.
+//
+// The cents discipline mirrors invoiceMath/catalogPricing exactly: integer cents
+// with a single round-half-up at the cent boundary, never rounding unitPrice
+// first. These helpers are intentionally self-contained (no invoice-status / DB
+// coupling) so the module is safe to import into the browser bundle.
+
+/** Money string/number → integer cents (round-half-to-even via Math.round on
+ *  the ×100 product). Null/empty → 0. */
+export function toCents(v: string | number | null | undefined): number {
+  if (v === null || v === undefined || v === '') return 0;
+  return Math.round(Number(v) * 100);
+}
+
+/** Integer cents → 2-decimal money string. */
+export function fromCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/** Round-half-up of a fractional-cent amount. */
+function roundHalfUp(n: number): number {
+  return Math.floor(n + 0.5);
+}
+
+/** quantity × unitPrice in full precision, then a single round-half-up at the
+ *  cent boundary. (Rounding unitPrice to cents first would lose sub-cent unit
+ *  prices like 0.335 — 3 × 0.335 = 1.005 must round half-up to 1.01.) */
+export function computeLineTotal(quantity: string | number, unitPrice: string | number): string {
+  const fractionalCents = Number(quantity) * Number(unitPrice) * 100;
+  return fromCents(roundHalfUp(fractionalCents));
+}
+
+export interface QuoteLineForMath {
+  quantity: string;
+  unitPrice: string;
+  taxable: boolean;
+  customerVisible: boolean;
+  recurrence: 'one_time' | 'monthly' | 'annual';
+}
+
+export interface QuoteTotals {
+  subtotal: string;
+  taxTotal: string;
+  total: string;
+  oneTimeTotal: string;
+  monthlyRecurringTotal: string;
+  annualRecurringTotal: string;
+  /**
+   * The amount actually invoiced when the customer accepts the quote. Accept
+   * auto-issues a one-time-only invoice (recurring lines defer to the recurring
+   * contract), so this is the one-time subtotal PLUS tax on just the taxable
+   * one-time lines. NOT `total`, which also rolls in the first monthly + annual
+   * period. Must equal quoteAcceptService's invoice math.
+   */
+  dueOnAcceptanceTotal: string;
+}
+
+export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
+  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
+  for (const l of lines) {
+    if (!l.customerVisible) continue;
+    // Route per-line cents through computeLineTotal so they equal the persisted
+    // line_total (rounded to cents) and match invoices exactly.
+    const lineCents = toCents(computeLineTotal(l.quantity, l.unitPrice));
+    if (l.recurrence === 'monthly') monthly += lineCents;
+    else if (l.recurrence === 'annual') annual += lineCents;
+    else oneTime += lineCents;
+    if (l.taxable) {
+      taxableBasis += lineCents;
+      if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
+    }
+  }
+  // First-period basis: one-time + first monthly period + first annual period.
+  const subtotal = oneTime + monthly + annual;
+  const rate = taxRate ?? 0;
+  const taxCents = Math.floor(taxableBasis * rate + 0.5);
+  // Tax on ONLY the one-time taxable lines — what accept actually invoices.
+  const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
+  return {
+    subtotal: fromCents(subtotal),
+    taxTotal: fromCents(taxCents),
+    total: fromCents(subtotal + taxCents),
+    oneTimeTotal: fromCents(oneTime),
+    monthlyRecurringTotal: fromCents(monthly),
+    annualRecurringTotal: fromCents(annual),
+    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
+  };
+}

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -8,11 +8,14 @@
 // first. These helpers are intentionally self-contained (no invoice-status / DB
 // coupling) so the module is safe to import into the browser bundle.
 
-/** Money string/number → integer cents (round-half-to-even via Math.round on
- *  the ×100 product). Null/empty → 0. */
+/** Money string/number → integer cents (round-half-up — `Math.round` ties toward
+ *  +∞ — on the ×100 product). Null/empty/non-finite → 0, so a stray NaN can't
+ *  propagate to a literal "NaN" on the totals rail (this module is browser-safe
+ *  and shared, so it can't assume every caller pre-validates). */
 export function toCents(v: string | number | null | undefined): number {
   if (v === null || v === undefined || v === '') return 0;
-  return Math.round(Number(v) * 100);
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
 }
 
 /** Integer cents → 2-decimal money string. */

--- a/packages/shared/src/validators/contracts.test.ts
+++ b/packages/shared/src/validators/contracts.test.ts
@@ -31,6 +31,27 @@ describe('createContractSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+  // Single-screen create: lines are committed atomically with the contract.
+  it('accepts an optional lines[] array of valid lines', () => {
+    const r = createContractSchema.safeParse({
+      orgId: '11111111-1111-1111-1111-111111111111', name: 'Acme MSP', billingTiming: 'advance',
+      intervalMonths: 1, startDate: '2026-07-01',
+      lines: [
+        { lineType: 'flat', description: 'Base fee', unitPrice: '500.00', taxable: false },
+        { lineType: 'manual', description: 'Onboarding', unitPrice: '150.00', manualQuantity: '2', taxable: true },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects a create whose lines[] contains a malformed line (whole create fails)', () => {
+    const r = createContractSchema.safeParse({
+      orgId: '11111111-1111-1111-1111-111111111111', name: 'Acme MSP', billingTiming: 'advance',
+      intervalMonths: 1, startDate: '2026-07-01',
+      // manual line missing required manualQuantity → the line schema's refine fails
+      lines: [{ lineType: 'manual', description: 'Bad', unitPrice: '10.00', taxable: false }],
+    });
+    expect(r.success).toBe(false);
+  });
 });
 
 describe('auto-renew fields', () => {

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -37,6 +37,10 @@ export const createContractSchema = z.object({
   autoRenew: z.boolean().optional(),
   renewalTermMonths: z.number().int().min(1).max(120).nullable().optional(),
   renewalNoticeDays: z.number().int().min(0).max(365).nullable().optional(),
+  // Optional lines to create atomically with the contract (single-screen create).
+  // Each line is validated by the same schema the per-line POST endpoint uses, so
+  // a malformed line rejects the whole create (the request runs in one transaction).
+  lines: z.array(contractLineInputSchema).max(200).optional(),
 }).refine(
   (c) => c.endDate == null || c.endDate > c.startDate,
   { message: 'endDate must be after startDate', path: ['endDate'] }

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
   acceptQuoteSchema, declineQuoteSchema,
-  updateQuoteSchema,
+  updateQuoteSchema, reorderBlocksSchema, reorderLinesSchema,
 } from './quotes';
 
 describe('quote validators', () => {
@@ -48,6 +48,27 @@ describe('declineQuoteSchema', () => {
   });
 });
 
+
+describe('reorder schemas', () => {
+  const A = '11111111-1111-1111-1111-111111111111';
+  const B = '22222222-2222-2222-2222-222222222222';
+  it('accepts a non-empty list of unique guids', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: [A, B] }).success).toBe(true);
+    expect(reorderLinesSchema.safeParse({ lineIds: [A, B] }).success).toBe(true);
+  });
+  it('rejects an empty list', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: [] }).success).toBe(false);
+  });
+  it('rejects duplicate ids (would corrupt sort_order)', () => {
+    // [A, A] for blocks [A, B] would otherwise pass a length+membership check,
+    // renumber A twice, and orphan B's sort_order.
+    expect(reorderBlocksSchema.safeParse({ blockIds: [A, A] }).success).toBe(false);
+    expect(reorderLinesSchema.safeParse({ lineIds: [A, A] }).success).toBe(false);
+  });
+  it('rejects non-guid ids', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: ['not-a-guid'] }).success).toBe(false);
+  });
+});
 
 describe('quote T&C field', () => {
   it('create accepts termsAndConditions', () => {

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -75,8 +75,17 @@ export const updateQuoteSchema = z.object({
   billToName: z.string().max(255).nullable().optional(),
 });
 
-export const reorderBlocksSchema = z.object({ blockIds: z.array(z.string().guid()).min(1) });
-export const reorderLinesSchema = z.object({ lineIds: z.array(z.string().guid()).min(1) });
+// A reorder payload must be a clean permutation of the existing ids, so the id
+// list has to be unique — without this, a duplicated id (e.g. [A, A] for blocks
+// [A, B]) passes a length+membership check, renumbers A twice, never touches B,
+// and corrupts sort_order. Uniqueness is enforced here so both routes are
+// covered; the service re-checks as defense in depth.
+const uniqueReorderIds = z
+  .array(z.string().guid())
+  .min(1)
+  .refine((ids) => new Set(ids).size === ids.length, { message: 'ids must be unique' });
+export const reorderBlocksSchema = z.object({ blockIds: uniqueReorderIds });
+export const reorderLinesSchema = z.object({ lineIds: uniqueReorderIds });
 export type ReorderLinesInput = z.infer<typeof reorderLinesSchema>;
 export type ReorderBlocksInput = z.infer<typeof reorderBlocksSchema>;
 

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -76,6 +76,9 @@ export const updateQuoteSchema = z.object({
 });
 
 export const reorderBlocksSchema = z.object({ blockIds: z.array(z.string().guid()).min(1) });
+export const reorderLinesSchema = z.object({ lineIds: z.array(z.string().guid()).min(1) });
+export type ReorderLinesInput = z.infer<typeof reorderLinesSchema>;
+export type ReorderBlocksInput = z.infer<typeof reorderBlocksSchema>;
 
 export const acceptQuoteSchema = z.object({
   signerName: z.string().min(1).max(255),


### PR DESCRIPTION
## Polishing quotes & invoices

This branch carries two related billing workstreams against `main`.

### Quote-builder polish (primary)

A multi-pass UX/correctness hardening of the quote editor (`apps/web/src/components/billing/quotes/QuoteEditor.tsx`), driven by six design-critique rounds (score 26 → **35/40**, ending with zero P0/P1).

**Save model & feedback.** Per-item scoped pending state (one in-flight mutation never freezes the editor), a single save language across every blur/change surface — amber dirty ring → transient "Saved" cue → visually-hidden `SrSaved` live region → `runAction` failure toast. Routine inline edits no longer fire per-field success-toast spam.

**Optimistic, internally-consistent totals.** Each line row computes its own Total/Tax optimistically while mid-edit, and the right-rail "Live totals" recompute from in-progress edits (lines *and* tax rate) so the rail never lags the rows. Crucially, the row, the rail, and the server now share **one** implementation of the money math: `computeQuoteTotals` was extracted to `packages/shared/src/utils/quoteMath.ts` (round-half-up at the cent boundary, never rounding unitPrice first); the API re-exports it (`apps/api/src/services/quoteMath.ts`, import sites unchanged, existing `quoteMath.test.ts` now a parity guard) and the web imports the same function — so an optimistic figure provably can't settle to something the next GET contradicts.

**Edit-race correctness.** A leading+trailing throttled `refresh()` keeps the rail fresh without refetch storms (guards the documented US DB connection pressure). The line row tracks "edited since last commit" so a refresh landing mid-type never clobbers in-progress keystrokes, yet still re-adopts a server-normalized value once the user stops (e.g. `9.999` → `10.00`, no stuck-dirty row). Rejected qty/price now toast a reason before reverting instead of snapping back silently.

**Reorder & a11y.** Block/line reorder is optimistic and accumulates rapid clicks into a single debounced PATCH per axis (full id list; server renumbers 0..n-1). `MoveControls` clear the WCAG 24×24 target floor, disable only at list ends, and hop focus to the live sibling on self-disable; deletes return focus to a stable anchor. Per-line Tax column, a single consolidated SR totals announcement, an autosave hint that legends the amber dirty ring, and a responsive (overflow-x-auto) line table.

**Tests.** Quote-builder unit coverage extended (reorder, inline-edit, remove-block, optimistic rail, sub-cent row/rail parity, clobber-guard, server-normalize re-adoption); shared `quoteMath` unit test added. `pnpm` web billing suite green locally (110 tests); API `quoteMath` parity test green; tsc clean across the quote-builder + shared changes.

### Contract & catalog workstream (bundled)

Also included on this branch: single-screen atomic contract create + builder polish (`aa9a7c347`), and inline line editing + density/a11y polish on the contract builder (`e6e8b0247`) — `ContractEditor`/`ContractDetail`, a shared `SearchableSelect`, and catalog settings updates.

> Note: this is a combined branch. If CI flags the contract/catalog files, those belong to the second workstream above, not the quote-builder changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
