### PR TITLE
Polishing quotes & invoices (rebased onto Tailwind 4)

### DIFF
--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -13,7 +13,9 @@ vi.mock('../../services/quoteService', () => ({
   addManualLine: vi.fn(),
   addCatalogLine: vi.fn(),
   updateLine: vi.fn(),
-  removeLine: vi.fn()
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
 }));
 
 // QuoteServiceError lives in quoteTypes; routes import the class from there.
@@ -230,6 +232,82 @@ describe('quote crud + lines routes', () => {
     });
     expect(res.status).toBe(403);
     expect(svc.createQuote).not.toHaveBeenCalled();
+  });
+
+  const LINE_ID = '44444444-4444-4444-4444-444444444444';
+
+  describe('PATCH /:id/blocks/reorder', () => {
+    it('returns 200 { ok: true } and calls reorderBlocks with blockIds + actor', async () => {
+      (svc.reorderBlocks as any).mockResolvedValue(undefined);
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [BLOCK_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ok).toBe(true);
+      expect(svc.reorderBlocks).toHaveBeenCalledWith(QUOTE_ID, [BLOCK_ID], expect.anything());
+    });
+
+    it('rejects empty blockIds array (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderBlocks).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-UUID in blockIds (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: ['not-a-uuid'] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderBlocks).not.toHaveBeenCalled();
+    });
+
+    it('maps REORDER_IDS_MISMATCH to 400', async () => {
+      (svc.reorderBlocks as any).mockRejectedValue(
+        new QuoteServiceError('Block IDs do not match quote blocks', 400, 'REORDER_IDS_MISMATCH')
+      );
+      const res = await app().request(`/${QUOTE_ID}/blocks/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ blockIds: [BLOCK_ID] }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('REORDER_IDS_MISMATCH');
+    });
+  });
+
+  describe('PATCH /:id/blocks/:blockId/lines/reorder', () => {
+    it('returns 200 { ok: true } and calls reorderLines with blockId + lineIds + actor', async () => {
+      (svc.reorderLines as any).mockResolvedValue(undefined);
+      const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}/lines/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineIds: [LINE_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ok).toBe(true);
+      expect(svc.reorderLines).toHaveBeenCalledWith(QUOTE_ID, BLOCK_ID, [LINE_ID], expect.anything());
+    });
+
+    it('rejects non-UUID lineId (400, service not called)', async () => {
+      const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}/lines/reorder`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineIds: ['not-a-uuid'] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.reorderLines).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /:id/pdf', () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -7,10 +7,12 @@ import { PERMISSIONS } from '../../services/permissions';
 import {
   createQuoteSchema, updateQuoteSchema, quoteLineInputSchema, catalogQuoteLineSchema,
   updateQuoteLineSchema, quoteBlockInputSchema, listQuotesQuerySchema,
+  reorderBlocksSchema, reorderLinesSchema,
 } from '@breeze/shared';
 import {
   createQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
   addManualLine, addCatalogLine, updateLine, removeLine, addBlock, updateBlock, deleteBlock,
+  reorderBlocks, reorderLines,
 } from '../../services/quoteService';
 import { QuoteServiceError, type QuoteActor } from '../../services/quoteTypes';
 import { db } from '../../db';
@@ -66,8 +68,16 @@ quoteCrudRoutes.post('/:id/blocks', scopes, writePerm, zValidator('param', idPar
   try { return c.json({ data: await addBlock(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
+quoteCrudRoutes.patch('/:id/blocks/reorder', scopes, writePerm, zValidator('param', idParam), zValidator('json', reorderBlocksSchema), async (c) => {
+  try { const { id } = c.req.valid('param'); await reorderBlocks(id, c.req.valid('json').blockIds, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
+  catch (err) { return handleServiceError(c, err); }
+});
 quoteCrudRoutes.patch('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), zValidator('json', quoteBlockInputSchema), async (c) => {
   try { const p = c.req.valid('param'); return c.json({ data: await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c)) }); }
+  catch (err) { return handleServiceError(c, err); }
+});
+quoteCrudRoutes.patch('/:id/blocks/:blockId/lines/reorder', scopes, writePerm, zValidator('param', blockParam), zValidator('json', reorderLinesSchema), async (c) => {
+  try { const { id, blockId } = c.req.valid('param'); await reorderLines(id, blockId, c.req.valid('json').lineIds, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.delete('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), async (c) => {

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -55,6 +55,17 @@ function formatDate(value: string | Date | null | undefined): string {
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: '2-digit', timeZone: 'UTC' });
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays invoice.tax_total (authoritative), so the summed
+ *  column can differ by a rounding cent on many-line invoices. */
+function lineTax(lineTotal: string | number | null | undefined, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal ?? 0) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 interface BillToAddress {
   line1?: string | null; line2?: string | null; city?: string | null;
   region?: string | null; postalCode?: string | null; country?: string | null;
@@ -93,6 +104,10 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
     ? (branding.primaryColor.startsWith('#') ? branding.primaryColor : `#${branding.primaryColor}`)
     : '#2563eb';
   const groups = groupVisibleLinesByTicket(lines);
+  // Per-line Tax column appears only when this invoice carries tax (mirrors the
+  // header Tax row); otherwise it'd be a column of dashes.
+  const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+  const showTax = Number(invoice.taxTotal ?? 0) > 0;
   const billTo = addressLines(invoice.billToAddress as BillToAddress | null);
   const seller = (invoice.sellerSnapshot as SellerSnapshot | null) ?? null;
   const sellerLines = sellerAddressLines(seller);
@@ -103,14 +118,21 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
 
   const rowsHtml = groups.map((g) => {
     const header = g.ticketId
-      ? `<tr><td colspan="3" style="padding:10px 8px 4px;font-size:12px;font-weight:600;color:#6b7280;border-top:1px solid #e5e7eb;">Ticket work</td></tr>`
+      ? `<tr><td colspan="${showTax ? 4 : 3}" style="padding:10px 8px 4px;font-size:12px;font-weight:600;color:#6b7280;border-top:1px solid #e5e7eb;">Ticket work</td></tr>`
       : '';
-    const lineRows = g.lines.map((l) => `
+    const lineRows = g.lines.map((l) => {
+      const t = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+      const taxCell = showTax
+        ? `<td style="padding:6px 8px;font-size:13px;color:#6b7280;text-align:right;white-space:nowrap;">${t === null ? '&mdash;' : escapeHtml(formatMoney(t, currency))}</td>`
+        : '';
+      return `
       <tr>
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;">${escapeHtml(l.description)}</td>
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;text-align:right;white-space:nowrap;">${escapeHtml(String(Number(l.quantity)))}</td>
+        ${taxCell}
         <td style="padding:6px 8px;font-size:13px;color:#1f2937;text-align:right;white-space:nowrap;">${escapeHtml(formatMoney(l.lineTotal, currency))}</td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
     return header + lineRows;
   }).join('');
 
@@ -151,6 +173,7 @@ export function renderInvoiceHtml(invoice: InvoiceRow, lines: InvoiceLineRow[], 
           <tr>
             <th style="padding:8px;text-align:left;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Description</th>
             <th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Qty</th>
+            ${showTax ? '<th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Tax</th>' : ''}
             <th style="padding:8px;text-align:right;font-size:11px;font-weight:600;letter-spacing:0.5px;color:#9ca3af;text-transform:uppercase;border-bottom:2px solid #e5e7eb;">Amount</th>
           </tr>
         </thead>
@@ -193,6 +216,9 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
     try {
       const currency = invoice.currencyCode ?? branding.currencyCode ?? 'USD';
       const primary = hexToColor(branding.primaryColor, '#2563eb');
+      // Per-line Tax column only when this invoice carries tax (mirrors the header).
+      const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+      const showTax = Number(invoice.taxTotal ?? 0) > 0;
       const doc = new PDFDocument({ size: 'A4', margin: 50 });
       const chunks: Buffer[] = [];
       doc.on('data', (d: Buffer) => chunks.push(d));
@@ -235,12 +261,15 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       if (invoice.issueDate) { doc.text(`Issued: ${formatDate(invoice.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
       if (invoice.dueDate) { doc.text(`Due: ${formatDate(invoice.dueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
 
-      // Line table starts below the taller of the two columns.
+      // Line table starts below the taller of the two columns. When a Tax column
+      // is shown, the money columns narrow to 0.15 each to fit qty | tax | amount;
+      // otherwise the original two-column (qty | amount) layout is preserved.
       y = Math.max(fromY, billY) + 20;
-      const colQtyX = left + contentWidth * 0.62;
-      const colAmtX = left + contentWidth * 0.80;
-      const colDescW = contentWidth * 0.60;
-      const colNumW = contentWidth * 0.18;
+      const colNumW = contentWidth * (showTax ? 0.15 : 0.18);
+      const colQtyX = left + contentWidth * (showTax ? 0.52 : 0.62);
+      const colTaxX = left + contentWidth * 0.68;
+      const colAmtX = left + contentWidth * (showTax ? 0.83 : 0.80);
+      const colDescW = contentWidth * (showTax ? 0.50 : 0.60);
 
       doc.save();
       doc.rect(left - 6, y - 5, contentWidth + 12, 22).fill('#f8fafc');
@@ -248,6 +277,7 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
       doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
       doc.text('DESCRIPTION', left, y);
       doc.text('QTY', colQtyX, y, { width: colNumW, align: 'right' });
+      if (showTax) doc.text('TAX', colTaxX, y, { width: colNumW, align: 'right' });
       doc.text('AMOUNT', colAmtX, y, { width: colNumW, align: 'right' });
       y += 18;
       y += 6;
@@ -262,6 +292,11 @@ export function renderInvoicePdfBuffer(invoice: InvoiceRow, lines: InvoiceLineRo
           const descHeight = doc.heightOfString(l.description, { width: colDescW });
           doc.text(l.description, left, y, { width: colDescW });
           doc.text(String(Number(l.quantity)), colQtyX, y, { width: colNumW, align: 'right' });
+          if (showTax) {
+            const t = lineTax(l.lineTotal, l.taxable, taxRate);
+            doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), colTaxX, y, { width: colNumW, align: 'right' });
+            doc.fillColor('#1f2937');
+          }
           doc.text(formatMoney(l.lineTotal, currency), colAmtX, y, { width: colNumW, align: 'right' });
           y += Math.max(descHeight, 12) + 6;
         }

--- a/apps/api/src/services/quoteMath.ts
+++ b/apps/api/src/services/quoteMath.ts
@@ -1,63 +1,7 @@
-import { toCents, fromCents, computeLineTotal } from './invoiceMath';
-
-export interface QuoteLineForMath {
-  quantity: string;
-  unitPrice: string;
-  taxable: boolean;
-  customerVisible: boolean;
-  recurrence: 'one_time' | 'monthly' | 'annual';
-}
-
-export interface QuoteTotals {
-  subtotal: string;
-  taxTotal: string;
-  total: string;
-  oneTimeTotal: string;
-  monthlyRecurringTotal: string;
-  annualRecurringTotal: string;
-  /**
-   * The amount actually invoiced when the customer accepts the quote. Accept
-   * auto-issues a one-time-only invoice (recurring lines are deferred to the
-   * Phase 4 recurring contract — see quoteAcceptService.ts), so this is the
-   * one-time subtotal PLUS tax on just the taxable one-time lines. It mirrors
-   * quoteAcceptService's `computeInvoiceTotals(oneTimeLines, taxRate)` exactly,
-   * and is the figure the UI must advertise as "due on acceptance" — NOT
-   * `total`, which also rolls in the first monthly + annual period.
-   */
-  dueOnAcceptanceTotal: string;
-}
-
-export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
-  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
-  for (const l of lines) {
-    if (!l.customerVisible) continue;
-    // Route through the canonical billing helpers so quote per-line cents equal
-    // the persisted line_total (rounded to cents) and match invoices exactly:
-    // a single round-half-up at the cent boundary, never rounding unitPrice first.
-    const lineCents = toCents(computeLineTotal(l.quantity, l.unitPrice));
-    if (l.recurrence === 'monthly') monthly += lineCents;
-    else if (l.recurrence === 'annual') annual += lineCents;
-    else oneTime += lineCents;
-    if (l.taxable) {
-      taxableBasis += lineCents;
-      if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
-    }
-  }
-  // First-period basis: one-time + first monthly period + first annual period.
-  const subtotal = oneTime + monthly + annual;
-  // Match invoiceMath.computeInvoiceTotals' round-half-up; nullish so a 0 rate
-  // and null both yield 0 tax.
-  const rate = taxRate ?? 0;
-  const taxCents = Math.floor(taxableBasis * rate + 0.5);
-  // Tax on ONLY the one-time taxable lines — what accept actually invoices.
-  const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
-  return {
-    subtotal: fromCents(subtotal),
-    taxTotal: fromCents(taxCents),
-    total: fromCents(subtotal + taxCents),
-    oneTimeTotal: fromCents(oneTime),
-    monthlyRecurringTotal: fromCents(monthly),
-    annualRecurringTotal: fromCents(annual),
-    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
-  };
-}
+// Quote totals now live in @breeze/shared so the web editor's optimistic "Live
+// totals" rail computes from the exact same logic the API persists — they can
+// never settle to different figures. Re-exported here to keep the existing
+// `./quoteMath` import sites (quoteService, quotesPublic, portal/quotes) stable.
+// The quoteMath.test.ts beside this file exercises the shared implementation and
+// guards parity.
+export { computeQuoteTotals, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -41,6 +41,17 @@ function recurrenceSuffix(recurrence: string | null | undefined): string {
   return '';
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The summary Tax stays quote.tax_total (authoritative), so the summed
+ *  column can differ by a rounding cent on many-line quotes. */
+function lineTax(lineTotal: string | number | null | undefined, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal ?? 0) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 function hexToColor(value: string | null | undefined, fallback: string): string {
   if (!value) return fallback;
   const v = value.startsWith('#') ? value : `#${value}`;
@@ -117,6 +128,7 @@ interface QuoteLine {
   unitPrice: string | number;
   lineTotal?: string | number | null;
   recurrence?: string | null;
+  taxable?: boolean | null;
 }
 
 /** Loads a catalog item's product image bytes (or null). Injected so renderQuotePdf
@@ -130,21 +142,39 @@ type LoadCatalogImage = (catalogItemId: string) => Promise<{ data: Buffer } | nu
 
 interface Cols {
   left: number; right: number; contentWidth: number;
-  colQtyX: number; colDescW: number; colUnitX: number; colNumW: number; colAmtX: number;
+  colQtyX: number; colDescX: number; colDescW: number; colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number;
+  showTax: boolean;
 }
 
-function columnsFor(doc: PDFKit.PDFDocument): Cols {
+// When showTax is set the table carries a fifth column (qty | description | unit
+// | tax | total) and the money columns narrow to fit; otherwise the original
+// four-column layout (qty | description | unit | total) is preserved so existing
+// tax-free quotes render byte-identically. The summary uses the same colAmtX so
+// its amounts stay aligned under TOTAL.
+function columnsFor(doc: PDFKit.PDFDocument, showTax = false): Cols {
   const left = doc.page.margins.left;
   const right = doc.page.width - doc.page.margins.right;
   const contentWidth = right - left;
+  const colDescX = left + contentWidth * 0.12;
+  if (showTax) {
+    return {
+      left, right, contentWidth, showTax,
+      colQtyX: left,
+      colDescX,
+      colDescW: contentWidth * 0.36,
+      colUnitX: left + contentWidth * 0.50,
+      colTaxX: left + contentWidth * 0.67,
+      colAmtX: left + contentWidth * 0.84,
+      colNumW: contentWidth * 0.15,
+    };
+  }
   return {
-    left,
-    right,
-    contentWidth,
-    // qty | description | unit | total
+    left, right, contentWidth, showTax,
     colQtyX: left,
+    colDescX,
     colDescW: contentWidth * 0.46,
     colUnitX: left + contentWidth * 0.60,
+    colTaxX: left + contentWidth * 0.70, // unused when !showTax
     colAmtX: left + contentWidth * 0.80,
     colNumW: contentWidth * 0.18,
   };
@@ -171,8 +201,10 @@ async function renderLineTable(
   currency: string,
   startY: number,
   loadCatalogImage: LoadCatalogImage,
+  taxRate = 0,
+  showTax = false,
 ): Promise<number> {
-  const c = columnsFor(doc);
+  const c = columnsFor(doc, showTax);
   let y = ensureSpace(doc, startY, 60);
 
   // Pre-load product images (DB I/O) for catalog-sourced lines. A failed load
@@ -191,7 +223,7 @@ async function renderLineTable(
   // Reserve a thumbnail gutter only when at least one line has an image, so the
   // description column stays aligned across rows.
   const gutter = imageByLine.size > 0 ? THUMB + 8 : 0;
-  const descW = c.contentWidth * 0.46 - gutter;
+  const descW = c.colDescW - gutter;
 
   // Header row with a light fill bar.
   doc.save();
@@ -199,13 +231,14 @@ async function renderLineTable(
   doc.restore();
   doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
   doc.text('QTY', c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
-  doc.text('DESCRIPTION', c.colQtyX + c.contentWidth * 0.12, y, { width: c.contentWidth * 0.46, align: 'left' });
+  doc.text('DESCRIPTION', c.colDescX, y, { width: c.colDescW, align: 'left' });
   doc.text('UNIT', c.colUnitX, y, { width: c.colNumW, align: 'right' });
+  if (showTax) doc.text('TAX', c.colTaxX, y, { width: c.colNumW, align: 'right' });
   doc.text('TOTAL', c.colAmtX, y, { width: c.colNumW, align: 'right' });
   y += 18;
   y += 6;
 
-  const descX = c.colQtyX + c.contentWidth * 0.12;
+  const descX = c.colDescX;
   for (const l of lines) {
     y = ensureSpace(doc, y, Math.max(30, gutter));
     doc.fillColor('#1f2937').fontSize(10).font('Helvetica');
@@ -217,6 +250,11 @@ async function renderLineTable(
     }
     doc.text(l.description, descX + gutter, y, { width: descW });
     doc.text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
+    if (showTax) {
+      const t = lineTax(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), !!l.taxable, taxRate);
+      doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), c.colTaxX, y, { width: c.colNumW, align: 'right' });
+      doc.fillColor('#1f2937');
+    }
     const suffix = recurrenceSuffix(l.recurrence);
     doc.text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
     y += Math.max(descHeight, img ? THUMB : 12) + 6;
@@ -235,8 +273,8 @@ async function renderLineTable(
 // amount.
 // ---------------------------------------------------------------------------
 
-function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number): number {
-  const c = columnsFor(doc);
+function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number, showTax = false): number {
+  const c = columnsFor(doc, showTax);
   let y = ensureSpace(doc, startY + 6, 90);
 
   // Wider label column than the line table's so the emphasised "Due on
@@ -295,6 +333,9 @@ export async function renderQuotePdf(
   const currency = quote.currencyCode ?? branding.currencyCode ?? 'USD';
   const primary = hexToColor(branding.primaryColor, '#2563eb');
   const partnerName = branding.partnerName ?? 'Proposal';
+  // Per-line Tax column only when this quote carries tax (mirrors the summary).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
 
   const doc = new PDFDocument({ size: 'A4', margin: 50 });
   const chunks: Buffer[] = [];
@@ -407,17 +448,17 @@ export async function renderQuotePdf(
           doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
           y = doc.y + 6;
         }
-        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage);
+        y = await renderLineTable(doc, blockLines, currency, y, loadCatalogImage, taxRate, showTax);
       }
     }
   }
 
   // ---- Trailing default table for lines with no block ----------------------
   const orphanLines = lines.filter((l) => !l.blockId);
-  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage);
+  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage, taxRate, showTax);
 
   // ---- Recurring summary footer -------------------------------------------
-  y = renderRecurringSummary(doc, quote, currency, primary, y);
+  y = renderRecurringSummary(doc, quote, currency, primary, y, showTax);
 
   // ---- Terms & Conditions --------------------------------------------------
   if (quote.termsAndConditions) {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -343,3 +343,45 @@ export async function removeLine(quoteId: string, lineId: string, actor: QuoteAc
   await db.delete(quoteLines).where(and(eq(quoteLines.id, lineId), eq(quoteLines.quoteId, quoteId)));
   await recomputeAndPersist(quoteId);
 }
+
+// ---------------------------------------------------------------------------
+// Reorder
+// ---------------------------------------------------------------------------
+
+export async function reorderBlocks(quoteId: string, blockIds: string[], actor: QuoteActor) {
+  await loadDraft(quoteId, actor);
+  const existing = await db.select({ id: quoteBlocks.id }).from(quoteBlocks).where(eq(quoteBlocks.quoteId, quoteId));
+  const existingSet = new Set(existing.map(r => r.id));
+  // Use the deduped set size so a duplicated id (e.g. [A, A]) can't masquerade as
+  // a full permutation — that would renumber A twice and orphan another block's
+  // sort_order. (The zod schema also rejects duplicates; this is defense in depth.)
+  if (new Set(blockIds).size !== existing.length || !blockIds.every(id => existingSet.has(id))) {
+    throw new QuoteServiceError('Block IDs do not match quote blocks', 400, 'REORDER_IDS_MISMATCH');
+  }
+  await db.transaction(async (tx) => {
+    for (const [i, id] of blockIds.entries()) {
+      await tx.update(quoteBlocks).set({ sortOrder: i }).where(and(eq(quoteBlocks.id, id), eq(quoteBlocks.quoteId, quoteId)));
+    }
+  });
+}
+
+export async function reorderLines(quoteId: string, blockId: string, lineIds: string[], actor: QuoteActor) {
+  await loadDraft(quoteId, actor);
+  const [block] = await db.select({ id: quoteBlocks.id }).from(quoteBlocks)
+    .where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quoteId)))
+    .limit(1);
+  if (!block) throw new QuoteServiceError('Block not found', 404, 'BLOCK_NOT_FOUND');
+  const existing = await db.select({ id: quoteLines.id }).from(quoteLines)
+    .where(and(eq(quoteLines.quoteId, quoteId), eq(quoteLines.blockId, blockId)));
+  const existingSet = new Set(existing.map(r => r.id));
+  // Deduped size guards against a duplicated id passing the permutation check
+  // (see reorderBlocks). The zod schema also rejects duplicates.
+  if (new Set(lineIds).size !== existing.length || !lineIds.every(id => existingSet.has(id))) {
+    throw new QuoteServiceError('Line IDs do not match block lines', 400, 'REORDER_IDS_MISMATCH');
+  }
+  await db.transaction(async (tx) => {
+    for (const [i, id] of lineIds.entries()) {
+      await tx.update(quoteLines).set({ sortOrder: i }).where(and(eq(quoteLines.id, id), eq(quoteLines.quoteId, quoteId), eq(quoteLines.blockId, blockId)));
+    }
+  });
+}

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -25,7 +25,8 @@ export type QuoteServiceErrorCode =
   | 'CATALOG_ITEM_NOT_FOUND'
   | 'INVALID_STATE'
   | 'QUOTE_EXPIRED'
-  | 'NOT_CONVERTED';
+  | 'NOT_CONVERTED'
+  | 'REORDER_IDS_MISMATCH';
 
 export class QuoteServiceError extends Error {
   constructor(

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -24,6 +24,16 @@ function money(value: string | number, currencyCode: string): string {
   }
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays invoice.taxTotal (authoritative). */
+function lineTax(lineTotal: string | number, taxable: boolean, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 function shortDate(value: string | null): string {
   if (!value) return '—';
   const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
@@ -89,6 +99,10 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
   const canPay = PAYABLE_STATUSES.has(invoice.status) && Number(invoice.balance) > 0;
+  // Per-line Tax column only when this invoice carries tax (mirrors the Tax row).
+  const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+  const showTax = Number(invoice.taxTotal) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   const seller = (invoice.sellerSnapshot ?? null) as DocSeller | null;
   const headerDates = [
@@ -212,24 +226,29 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
 
         <div className="overflow-hidden rounded-lg border bg-card">
           <div className="overflow-x-auto">
-            <table className="w-full min-w-md text-sm">
+            <table className="w-full min-w-[28rem] text-sm">
               <thead>
                 <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
                   <th className="px-2 py-2.5 text-right font-medium">Qty</th>
                   <th className="px-2 py-2.5 text-right font-medium">Price</th>
+                  {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
                   <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
                 </tr>
               </thead>
               <tbody>
-                {lines.map((l) => (
+                {lines.map((l) => {
+                  const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+                  return (
                   <tr key={l.id} className="border-b align-top last:border-0">
                     <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{l.quantity}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{money(l.unitPrice, currency)}</td>
+                    {showTax && <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : money(tax, currency)}</td>}
                     <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{money(l.lineTotal, currency)}</td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -238,7 +257,7 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
             <div className="flex justify-between text-sm"><span className="text-muted-foreground">Subtotal</span><span className="tabular-nums text-foreground">{money(invoice.subtotal, currency)}</span></div>
-            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Tax</span><span className="tabular-nums text-foreground">{money(invoice.taxTotal, currency)}</span></div>
+            <div className="flex justify-between text-sm"><span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span><span className="tabular-nums text-foreground">{money(invoice.taxTotal, currency)}</span></div>
             <div className="flex justify-between border-t pt-2.5 text-sm"><span className="font-medium text-foreground">Total</span><span className="font-medium tabular-nums text-foreground">{money(invoice.total, currency)}</span></div>
             {Number(invoice.amountPaid) > 0 && (
               <div className="flex justify-between text-sm"><span className="text-muted-foreground">Paid</span><span className="tabular-nums text-foreground">−{money(invoice.amountPaid, currency)}</span></div>

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -38,6 +38,11 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   const open = status === 'sent' || status === 'viewed';
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Per-line Tax column + a Subtotal/Tax breakdown appear only when this quote
+  // carries tax (otherwise the totals stay focused on due-on-acceptance).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   const seller = (quote.sellerSnapshot ?? null) as DocSeller | null;
 
@@ -125,10 +130,24 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
           imageUrl={(imageId) =>
             buildPortalApiUrl(`/quotes/public/${encodeURIComponent(token)}/images/${imageId}`)
           }
+          taxRate={taxRate}
+          showTax={showTax}
         />
 
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
+            {showTax && (
+              <>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Subtotal</span>
+                  <span className="tabular-nums text-foreground">{money(quote.subtotal ?? 0, currency)}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span>
+                  <span className="tabular-nums text-foreground">{money(quote.taxTotal ?? 0, currency)}</span>
+                </div>
+              </>
+            )}
             {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Monthly recurring</span>

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -125,6 +125,11 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Per-line Tax column + a Subtotal/Tax breakdown appear only when this quote
+  // carries tax (otherwise the totals stay focused on due-on-acceptance).
+  const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
+  const showTax = Number(quote.taxTotal ?? 0) > 0;
+  const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
 
   return (
     <div className="space-y-5" data-testid="quote-detail">
@@ -166,10 +171,24 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
           lines={lines}
           currency={currency}
           imageUrl={(imageId) => buildPortalApiUrl(`/portal/quotes/${quote.id}/images/${imageId}`)}
+          taxRate={taxRate}
+          showTax={showTax}
         />
 
         <section className="flex justify-end">
           <div className="w-full max-w-xs space-y-2.5">
+            {showTax && (
+              <>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Subtotal</span>
+                  <span className="tabular-nums text-foreground">{money(quote.subtotal ?? 0, currency)}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax{taxPct ? ` (${taxPct}%)` : ''}</span>
+                  <span className="tabular-nums text-foreground">{money(quote.taxTotal ?? 0, currency)}</span>
+                </div>
+              </>
+            )}
             {hasRecurring && Number(quote.monthlyRecurringTotal ?? 0) > 0 && (
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Monthly recurring</span>

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -18,6 +18,17 @@ export function money(value: string | number, currencyCode: string): string {
   }
 }
 
+/** Per-line tax amount for the Tax column: taxable lines get lineTotal × rate
+ *  rounded to cents; non-taxable lines / a non-positive rate return null (shown
+ *  as '—'). The header Tax stays the server's authoritative figure, so the summed
+ *  column can differ by a rounding cent on many-line quotes. */
+function lineTax(lineTotal: string | number, taxable: boolean | undefined, rate: number): number | null {
+  if (!taxable || !(rate > 0)) return null;
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
+}
+
 // rich_text blocks store author HTML. The portal has no HTML sanitizer
 // dependency, and rendering untrusted HTML on the *unauthenticated* public page
 // would be an XSS sink, so we strip all tags to plain text (matching the PDF's
@@ -55,11 +66,15 @@ function PricingTable({
   currency,
   label,
   testId,
+  taxRate,
+  showTax,
 }: {
   lines: QuoteLine[];
   currency: string;
   label?: string;
   testId: string;
+  taxRate: number;
+  showTax: boolean;
 }) {
   if (lines.length === 0) return null;
   // Preserve sortOrder within each recurrence group, in the canonical group order.
@@ -67,6 +82,7 @@ function PricingTable({
     ...g,
     rows: lines.filter((l) => (l.recurrence || 'one_time') === g.key),
   })).filter((g) => g.rows.length > 0);
+  const groupColSpan = showTax ? 5 : 4;
 
   return (
     <div className="overflow-hidden rounded-lg border bg-card" data-testid={testId}>
@@ -76,12 +92,13 @@ function PricingTable({
         </div>
       )}
       <div className="overflow-x-auto">
-        <table className="w-full min-w-120 text-sm">
+        <table className="w-full min-w-[30rem] text-sm">
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
               <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
               <th className="px-2 py-2.5 text-right font-medium">Qty</th>
               <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
               <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
             </tr>
           </thead>
@@ -90,23 +107,31 @@ function PricingTable({
               <Fragment key={g.key}>
                 {grouped.length > 1 && (
                   <tr className="bg-muted/20">
-                    <td colSpan={4} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:px-5">
+                    <td colSpan={groupColSpan} className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:px-5">
                       {g.label}
                     </td>
                   </tr>
                 )}
-                {g.rows.map((l) => (
+                {g.rows.map((l) => {
+                  const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+                  return (
                   <tr key={l.id} data-testid={`quote-line-${l.id}`} className="border-b align-top last:border-0">
                     <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{Number(l.quantity)}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
                       {money(l.unitPrice, currency)}{g.suffix && <span className="text-xs">{g.suffix}</span>}
                     </td>
+                    {showTax && (
+                      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                        {tax === null ? '—' : money(tax, currency)}
+                      </td>
+                    )}
                     <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
                       {money(l.lineTotal, currency)}{g.suffix && <span className="text-xs text-muted-foreground">{g.suffix}</span>}
                     </td>
                   </tr>
-                ))}
+                  );
+                })}
               </Fragment>
             ))}
           </tbody>
@@ -121,12 +146,18 @@ export function QuoteBlocks({
   lines,
   currency,
   imageUrl,
+  taxRate = 0,
+  showTax = false,
 }: {
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   currency: string;
   // Builds the (authed or token-scoped) URL to fetch a quote image by id.
   imageUrl: (imageId: string) => string;
+  /** Quote tax rate as a fraction (e.g. 0.085); used for the per-line Tax column. */
+  taxRate?: number;
+  /** Whether the quote carries tax — shows the per-line Tax column when true. */
+  showTax?: boolean;
 }) {
   const ordered = [...blocks].sort((a, b) => a.sortOrder - b.sortOrder);
   // Track lines already consumed by a line_items block so orphan lines render once.
@@ -192,6 +223,8 @@ export function QuoteBlocks({
           currency={currency}
           label={label}
           testId={`quote-lines-${block.id}`}
+          taxRate={taxRate}
+          showTax={showTax}
         />
       );
     }
@@ -207,7 +240,7 @@ export function QuoteBlocks({
     <div className="space-y-6">
       {rendered}
       {orphanLines.length > 0 && (
-        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" />
+        <PricingTable lines={orphanLines} currency={currency} label="Pricing" testId="quote-lines-default" taxRate={taxRate} showTax={showTax} />
       )}
     </div>
   );

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -390,6 +390,7 @@ export interface QuoteLine {
   quantity: string;
   unitPrice: string;
   lineTotal: string;
+  taxable?: boolean;
   recurrence: string;
   customerVisible: boolean;
   sortOrder: number;
@@ -399,6 +400,7 @@ export interface QuoteHeader extends QuoteSummary {
   introNotes?: string | null;
   terms?: string | null;
   subtotal?: string;
+  taxRate?: string | null;
   taxTotal?: string;
   oneTimeTotal?: string;
   monthlyRecurringTotal?: string;

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -93,6 +93,10 @@ describe('InvoiceDetail', () => {
     fireEvent.change(screen.getByTestId('invoice-payment-method'), { target: { value: 'check' } });
     fireEvent.click(screen.getByTestId('invoice-payment-submit'));
 
+    // Confirm dialog must open before the POST fires.
+    await waitFor(() => expect(screen.getByTestId('invoice-payment-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('invoice-payment-confirm'));
+
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     const postCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/payments') && (c[1] as RequestInit)?.method === 'POST');
     expect(JSON.parse((postCall![1] as RequestInit).body as string)).toMatchObject({ amount: 50, method: 'check' });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -16,6 +16,8 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './invoiceTypes';
 
@@ -43,6 +45,11 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
   const [payRef, setPayRef] = useState('');
   const [payDate, setPayDate] = useState(() => new Date().toISOString().slice(0, 10));
 
+  // Payment confirm dialog
+  const [payConfirmOpen, setPayConfirmOpen] = useState(false);
+  // Reverse-a-payment confirm: reversing is a financial mutation, so it goes
+  // through a confirm step that names the specific payment.
+  const [reversePayment, setReversePayment] = useState<InvoicePayment | null>(null);
   // Void dialog
   const [voidOpen, setVoidOpen] = useState(false);
   // Delete dialog
@@ -81,6 +88,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     const cost = Number(l.costBasis) * Number(l.quantity);
     return formatMoney(revenue - cost, currency);
   };
+
+  // Per-line Tax column appears only when this invoice carries tax (mirrors the
+  // header Tax row), otherwise it'd be a column of dashes.
+  const showTax = Number(invoice.taxTotal) > 0;
 
   const canRecordPayment = invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
@@ -172,13 +183,14 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     try {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}/payments/${paymentId}`, { method: 'DELETE' }),
-        errorFallback: 'Could not void the payment.',
-        successMessage: 'Payment voided',
+        errorFallback: 'Could not reverse the payment.',
+        successMessage: 'Payment reversed',
         onUnauthorized: UNAUTHORIZED,
       });
+      setReversePayment(null);
       refresh();
     } catch (err) {
-      handleActionError(err, 'Could not void the payment.');
+      handleActionError(err, 'Could not reverse the payment.');
     } finally {
       setBusy(false);
     }
@@ -254,27 +266,32 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <th className="px-3 py-2 text-right font-medium">Price</th>
                   {accountingView && <th className="px-3 py-2 text-right font-medium">Cost</th>}
                   {accountingView && <th className="px-3 py-2 text-right font-medium">Margin</th>}
+                  {showTax && <th className="px-3 py-2 text-right font-medium">Tax</th>}
                   <th className="px-3 py-2 text-right font-medium">Total</th>
                 </tr>
               </thead>
               <tbody>
-                {visibleLines.map((l) => (
+                {visibleLines.map((l) => {
+                  const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, invoice.taxRate) : null;
+                  return (
                   <tr
                     key={l.id}
                     data-testid={`invoice-detail-line-${l.id}`}
                     className={`border-t ${l.parentLineId ? 'bg-muted/20 text-xs text-muted-foreground' : ''}`}
                   >
                     <td className={`px-3 py-2 ${l.parentLineId ? 'pl-8' : ''}`}>
-                      {l.parentLineId ? '↳ ' : ''}{l.description}
+                      {l.parentLineId ? <span aria-hidden="true">↳ </span> : ''}{l.description}
                       {accountingView && !l.customerVisible ? ' (hidden)' : ''}
                     </td>
                     <td className="px-3 py-2 text-right">{l.quantity}</td>
                     <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, currency)}</td>
                     {accountingView && <td className="px-3 py-2 text-right">{l.costBasis == null ? '—' : formatMoney(l.costBasis, currency)}</td>}
                     {accountingView && <td className="px-3 py-2 text-right">{lineMargin(l)}</td>}
+                    {showTax && <td className="px-3 py-2 text-right text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>}
                     <td className="px-3 py-2 text-right">{formatMoney(l.lineTotal, currency)}</td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -284,22 +301,24 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-detail-summary">
             <div className="mb-3 flex items-center justify-between">
-              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status">
+              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status" aria-label={`Status: ${statusLabel(invoice)}`}>
                 {statusLabel(invoice)}
               </span>
               <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
             </div>
             <dl className="space-y-1 text-sm tabular-nums">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd>{formatMoney(invoice.subtotal, currency)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
-              <div className="flex justify-between font-semibold"><dt>Total</dt><dd>{formatMoney(invoice.total, currency)}</dd></div>
+              {showTax && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Tax{invoice.taxRate ? ` (${pctFromFraction(invoice.taxRate)}%)` : ''}</dt><dd>{formatMoney(invoice.taxTotal, currency)}</dd></div>
+              )}
+              <div className="flex min-w-0 justify-between gap-2 font-semibold"><dt>Total</dt><dd className="break-words">{formatMoney(invoice.total, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Paid</dt><dd>{formatMoney(invoice.amountPaid, currency)}</dd></div>
             </dl>
             {/* Balance-due focal number */}
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Balance due</span>
+            <div className="mt-3 flex min-w-0 items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Balance due</span>
               <span
-                className={`text-2xl font-semibold tabular-nums ${Number(invoice.balance) > 0 && invoice.status !== 'void' ? '' : 'text-muted-foreground'}`}
+                className={`break-words text-2xl font-semibold tabular-nums ${Number(invoice.balance) > 0 && invoice.status !== 'void' ? '' : 'text-muted-foreground'}`}
                 data-testid="invoice-detail-balance"
               >
                 {formatMoney(invoice.balance, currency)}
@@ -399,14 +418,15 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                     </span>
                     {/* Stripe payments are refunded through Stripe, never hand-voided. */}
                     {p.source === 'stripe' ? (
-                      <span className="whitespace-nowrap chart-legend-xs text-muted-foreground">via Stripe</span>
+                      <span className="whitespace-nowrap text-[11px] text-muted-foreground">via Stripe</span>
                     ) : can('invoices', 'send') ? (
                       <button
-                        type="button" onClick={() => void voidPayment(p.id)} disabled={busy || invoice.status === 'void'}
+                        type="button" onClick={() => setReversePayment(p)} disabled={busy || invoice.status === 'void'}
+                        aria-label={`Reverse payment of ${formatMoney(p.amount, currency)}`}
                         data-testid={`invoice-payment-void-${p.id}`}
                         className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
                       >
-                        Void
+                        Reverse
                       </button>
                     ) : null}
                   </li>
@@ -436,11 +456,13 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <input
                     type="number" min="0" step="0.01" placeholder="Amount" value={payAmount}
                     onChange={(e) => setPayAmount(e.target.value)}
+                    aria-label="Amount"
                     data-testid="invoice-payment-amount"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                   />
                   <select
                     value={payMethod} onChange={(e) => setPayMethod(e.target.value as PaymentMethod)}
+                    aria-label="Payment method"
                     data-testid="invoice-payment-method"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                   >
@@ -451,17 +473,19 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                   <input
                     type="text" placeholder="Reference (optional)" value={payRef}
                     onChange={(e) => setPayRef(e.target.value)}
+                    aria-label="Reference"
                     data-testid="invoice-payment-ref"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                   />
                   <input
                     type="date" value={payDate} onChange={(e) => setPayDate(e.target.value)}
+                    aria-label="Payment date"
                     data-testid="invoice-payment-date"
                     className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                   />
                 </div>
                 <button
-                  type="button" onClick={() => void recordPayment()} disabled={busy || !payAmount}
+                  type="button" onClick={() => setPayConfirmOpen(true)} disabled={busy || !payAmount}
                   title={!payAmount ? 'Enter a payment amount to record it' : undefined}
                   aria-describedby={!payAmount ? 'invoice-payment-submit-hint' : undefined}
                   data-testid="invoice-payment-submit"
@@ -477,6 +501,31 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Reverse-a-payment confirm dialog */}
+      <ConfirmDialog
+        open={reversePayment !== null}
+        onClose={() => setReversePayment(null)}
+        onConfirm={() => { if (reversePayment) void voidPayment(reversePayment.id); }}
+        isLoading={busy}
+        title="Reverse this payment?"
+        message={reversePayment ? `This reverses the ${formatMoney(reversePayment.amount, currency)} ${PAYMENT_METHOD_LABELS[reversePayment.method]} payment and removes it from the invoice balance. This can't be undone.` : ''}
+        confirmLabel="Reverse payment"
+        confirmTestId="invoice-payment-reverse-confirm"
+      />
+
+      {/* Record payment confirm dialog */}
+      <ConfirmDialog
+        open={payConfirmOpen}
+        onClose={() => setPayConfirmOpen(false)}
+        onConfirm={() => { setPayConfirmOpen(false); void recordPayment(); }}
+        isLoading={busy}
+        variant="warning"
+        title="Record payment"
+        message={`Record a ${formatMoney(Number(payAmount), currency)} payment (${PAYMENT_METHOD_LABELS[payMethod]}) dated ${payDate}?`}
+        confirmLabel="Record payment"
+        confirmTestId="invoice-payment-confirm"
+      />
 
       {/* Delete draft dialog */}
       <ConfirmDialog

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -1,0 +1,271 @@
+import { useCallback, useMemo, useState, type CSSProperties } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { handleActionError } from '../../lib/runAction';
+import { useOrgStore } from '../../stores/orgStore';
+import {
+  type InvoiceDetail as InvoiceDetailData,
+  type InvoiceLine,
+  STATUS_COLORS,
+  statusLabel,
+  formatDate,
+  formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
+  sellerLines,
+} from './invoiceTypes';
+
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+
+function LineRow({ line, currency, taxRate, showTax }: { line: InvoiceLine; currency: string; taxRate: string | null; showTax: boolean }) {
+  const child = !!line.parentLineId;
+  const tax = showTax ? lineTaxAmount(line.lineTotal, line.taxable, taxRate) : null;
+  return (
+    <tr className="border-b align-top last:border-0">
+      <td className={`px-4 py-3 sm:px-5 ${child ? 'pl-8 text-muted-foreground' : 'text-foreground'}`}>
+        {child ? <span aria-hidden="true">↳ </span> : ''}{line.description}
+      </td>
+      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{line.quantity}</td>
+      <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{formatMoney(line.unitPrice, currency)}</td>
+      {showTax && (
+        <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>
+      )}
+      <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">{formatMoney(line.lineTotal, currency)}</td>
+    </tr>
+  );
+}
+
+interface DocumentProps {
+  detail: InvoiceDetailData;
+  /** Resolved customer/bill-to name (parent looks it up against the org list). */
+  customerName: string;
+}
+
+/** Pure, presentational customer-facing invoice document. Renders the same
+ *  customer-visible lines and totals the customer receives on their invoice,
+ *  using the seller snapshot and the app accent. The sibling of QuoteDocument;
+ *  works for drafts without a portal round-trip. */
+export function InvoiceDocument({ detail, customerName }: DocumentProps) {
+  const { invoice, lines } = detail;
+  const currency = invoice.currencyCode;
+  const seller = invoice.sellerSnapshot;
+  // Invoices carry no per-partner branding payload (unlike quotes), so the
+  // document is anchored on the app's primary accent.
+  const accentStyle = { ['--doc-accent']: 'hsl(var(--primary))' } as CSSProperties;
+
+  // Customers only ever see customer-visible lines — cost/margin and hidden
+  // bundle components never reach the document.
+  const visibleLines = useMemo(
+    () => lines.filter((l) => l.customerVisible).sort((a, b) => a.sortOrder - b.sortOrder),
+    [lines],
+  );
+  const isEmpty = visibleLines.length === 0;
+  const amountPaid = Number(invoice.amountPaid);
+  // Only surface the per-line Tax column when this invoice carries tax — mirrors
+  // the header Tax row's visibility (otherwise it's a column of dashes).
+  const showTax = Number(invoice.taxTotal) > 0;
+
+  return (
+    <div
+      style={accentStyle}
+      data-testid="invoice-document"
+      className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-xs"
+    >
+      <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
+        {/* ── Header ─────────────────────────────────────────────── */}
+        <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            {seller?.name ? (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                {seller.name}
+              </p>
+            ) : (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                Invoice
+              </p>
+            )}
+            {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
+            <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
+            {seller && (
+              <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
+                {sellerLines(seller.address).map((line, i) => <p key={i}>{line}</p>)}
+                {seller.phone && <p>{seller.phone}</p>}
+                {seller.email && <p>{seller.email}</p>}
+                {seller.website && <p>{seller.website}</p>}
+              </address>
+            )}
+          </div>
+
+          <div className="space-y-2 sm:text-right">
+            <p className="text-[1.75rem] font-semibold leading-none tracking-tight text-foreground" data-testid="invoice-document-number">
+              {invoice.invoiceNumber ?? 'Draft'}
+            </p>
+            <p className="text-sm font-medium text-muted-foreground">Invoice</p>
+            <span
+              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`}
+              aria-label={`Status: ${statusLabel(invoice)}`}
+            >
+              {statusLabel(invoice)}
+            </span>
+            <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
+              {invoice.issueDate && (
+                <div className="flex gap-2"><dt>Issued</dt><dd className="font-medium text-foreground/80">{formatDate(invoice.issueDate)}</dd></div>
+              )}
+              {invoice.dueDate && (
+                <div className="flex gap-2"><dt>Due</dt><dd className="font-medium text-foreground/80">{formatDate(invoice.dueDate)}</dd></div>
+              )}
+            </dl>
+          </div>
+        </header>
+
+        {/* ── Bill to + notes ────────────────────────────────────── */}
+        <section className="space-y-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Bill to</p>
+            <p className="mt-1 text-base font-medium text-foreground" data-testid="invoice-document-customer">{customerName}</p>
+          </div>
+          {invoice.notes?.trim() && (
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-sm leading-relaxed text-foreground/90">
+              {invoice.notes.trim()}
+            </p>
+          )}
+        </section>
+
+        {/* ── Lines ──────────────────────────────────────────────── */}
+        {isEmpty ? (
+          <div className="rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center text-sm text-muted-foreground">
+            This invoice doesn’t have any line items yet.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border bg-card">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[30rem] text-sm" data-testid="invoice-document-lines">
+                <thead>
+                  <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+                    <th className="px-2 py-2.5 text-right font-medium">Qty</th>
+                    <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+                    {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
+                    <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleLines.map((l) => <LineRow key={l.id} line={l} currency={currency} taxRate={invoice.taxRate} showTax={showTax} />)}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* ── Totals ─────────────────────────────────────────────── */}
+        {!isEmpty && (
+          <section className="flex justify-end">
+            <div className="w-full max-w-xs space-y-2.5">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span className="tabular-nums text-foreground">{formatMoney(invoice.subtotal, currency)}</span>
+              </div>
+              {showTax && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Tax{invoice.taxRate ? ` (${pctFromFraction(invoice.taxRate)}%)` : ''}</span>
+                  <span className="tabular-nums text-foreground">{formatMoney(invoice.taxTotal, currency)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Total</span>
+                <span className="tabular-nums text-foreground">{formatMoney(invoice.total, currency)}</span>
+              </div>
+              {amountPaid > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Paid</span>
+                  <span className="tabular-nums text-foreground">{formatMoney(invoice.amountPaid, currency)}</span>
+                </div>
+              )}
+              <div
+                className="flex items-baseline justify-between border-t pt-3"
+                style={{ borderColor: 'var(--doc-accent)' }}
+              >
+                <span className="text-sm font-semibold text-foreground">Amount due</span>
+                <span
+                  className="text-2xl font-semibold tabular-nums"
+                  style={{ color: 'var(--doc-accent)' }}
+                  data-testid="invoice-document-due"
+                >
+                  {formatMoney(invoice.balance, currency)}
+                </span>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── Terms ──────────────────────────────────────────────── */}
+        {invoice.termsAndConditions?.trim() && (
+          <section className="space-y-2 border-t pt-6">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms &amp; Conditions</h3>
+            <p className="max-w-prose whitespace-pre-wrap text-pretty text-xs leading-relaxed text-muted-foreground">
+              {invoice.termsAndConditions.trim()}
+            </p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Preview-tab wrapper: resolves the customer name from the loaded org list (same
+ *  source as InvoiceDetail), renders the document, and offers a PDF download. */
+export default function InvoiceDocumentPreview({ detail }: { detail: InvoiceDetailData }) {
+  const { invoice } = detail;
+  const organizations = useOrgStore((s) => s.organizations);
+  const [busy, setBusy] = useState(false);
+
+  const customerName = useMemo(() => {
+    const billTo = invoice.billToName?.trim();
+    if (billTo) return billTo;
+    const resolved = organizations.find((o) => o.id === invoice.orgId)?.name?.trim();
+    return resolved || invoice.orgId.slice(0, 8);
+  }, [invoice.billToName, invoice.orgId, organizations]);
+
+  const downloadPdf = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetchWithAuth(`/invoices/${invoice.id}/pdf`);
+      if (res.status === 401) return UNAUTHORIZED();
+      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the invoice PDF.'); return; }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      handleActionError(err, 'Could not download the invoice PDF.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, invoice.id, invoice.invoiceNumber]);
+
+  return (
+    <div className="space-y-4" data-testid="invoice-preview">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">This is what your customer sees on their invoice.</p>
+        <button
+          type="button"
+          onClick={() => void downloadPdf()}
+          disabled={busy}
+          data-testid="invoice-preview-download-pdf"
+          className="inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+        >
+          {busy ? 'Preparing…' : 'Download PDF'}
+        </button>
+      </div>
+      <div className="rounded-xl bg-muted/30 p-2 sm:p-8">
+        <InvoiceDocument detail={detail} customerName={customerName} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -139,6 +139,7 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Invoice issued and sent' }));
   });
@@ -177,6 +178,7 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
     // never a success "sent" claim when nothing went out

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -4,6 +4,8 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { UnsavedBadge } from './billingUi';
 import {
   type InvoiceDetail,
   type InvoiceLine,
@@ -32,6 +34,9 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   // an unambiguous in-flight label. Without it the disabled-but-still-"Issue"
   // button + still-"Draft" header during the POST reads as "done but stuck" (#1418).
   const [issuing, setIssuing] = useState(false);
+  // Issue-and-send emails the customer and can't be undone, so it goes through a
+  // confirm step (plain Issue stays direct — it's reversible via Void).
+  const [issueSendOpen, setIssueSendOpen] = useState(false);
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
   const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
@@ -235,6 +240,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       refresh();
       setIssuing(false);
       setBusy(false);
+      setIssueSendOpen(false);
     }
   }, [busy, invoice.id, refresh]);
 
@@ -244,7 +250,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
     <div className="space-y-6" data-testid="invoice-editor">
       {unapprovedCount > 0 && (
         <div
-          className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400"
+          className="rounded-md border border-warning/40 bg-warning/15 px-4 py-3 text-sm text-[hsl(36_92%_28%)] dark:text-warning"
           data-testid="invoice-unapproved-warning"
         >
           {unapprovedCount} line{unapprovedCount === 1 ? '' : 's'} reference unapproved time. Review before issuing.
@@ -262,7 +268,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                   <th className="px-3 py-2 text-right font-medium">Qty</th>
                   <th className="px-3 py-2 text-right font-medium">Price</th>
                   <th className="px-3 py-2 text-center font-medium">Tax</th>
-                  <th className="px-3 py-2 text-center font-medium">Visible</th>
+                  <th className="px-3 py-2 text-center font-medium" title="Whether this line appears on the customer's invoice">Customer-visible</th>
                   <th className="px-3 py-2 text-right font-medium">Total</th>
                   <th className="px-3 py-2" />
                 </tr>
@@ -312,19 +318,19 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             {addMode === 'manual' ? (
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_80px_100px_auto_auto]">
                 <input
-                  type="text" placeholder="Description" value={manualDesc}
+                  type="text" placeholder="Description" aria-label="Line description" value={manualDesc}
                   onChange={(e) => setManualDesc(e.target.value)}
                   data-testid="invoice-manual-desc"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder="Qty" value={manualQty}
+                  type="number" min="0" step="0.01" placeholder="Qty" aria-label="Quantity" value={manualQty}
                   onChange={(e) => setManualQty(e.target.value)}
                   data-testid="invoice-manual-qty"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder="Price" value={manualPrice}
+                  type="number" min="0" step="0.01" placeholder="Price" aria-label="Unit price" value={manualPrice}
                   onChange={(e) => setManualPrice(e.target.value)}
                   data-testid="invoice-manual-price"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
@@ -398,7 +404,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</h3>
+              <UnsavedBadge show={notesDirty} />
+            </div>
             <textarea
               value={notes}
               onChange={(e) => { setNotes(e.target.value); setNotesDirty(true); }}
@@ -409,13 +418,16 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-notes"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${notesDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Internal or customer notes…"
             />
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <UnsavedBadge show={termsDirty} />
+            </div>
             <textarea
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
@@ -423,7 +435,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-terms"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
           </div>
@@ -443,7 +455,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             {can('invoices', 'send') && (
               <button
                 type="button"
-                onClick={() => void issue(true)}
+                onClick={() => setIssueSendOpen(true)}
                 disabled={busy || !hasVisibleLines}
                 data-testid="invoice-issue-send"
                 className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
@@ -459,6 +471,18 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={issueSendOpen}
+        onClose={() => setIssueSendOpen(false)}
+        onConfirm={() => void issue(true)}
+        isLoading={issuing}
+        variant="warning"
+        title="Issue and send this invoice?"
+        message={`This issues the invoice and emails it to ${invoice.billToName ?? 'the customer'} for ${formatMoney(invoice.total, currency)}. This can't be undone.`}
+        confirmLabel="Issue & Send"
+        confirmTestId="invoice-issue-send-confirm"
+      />
     </div>
   );
 }
@@ -531,7 +555,7 @@ function LineRow({
       </tr>
       {children.map((ch) => (
         <tr key={ch.id} className="border-t bg-muted/20 text-xs text-muted-foreground" data-testid={`invoice-line-child-${ch.id}`}>
-          <td className="px-3 py-1.5 pl-8">↳ {ch.description}{!ch.customerVisible ? ' (hidden)' : ''}</td>
+          <td className="px-3 py-1.5 pl-8"><span aria-hidden="true">↳ </span>{ch.description}{!ch.customerVisible ? ' (hidden)' : ''}</td>
           <td className="px-3 py-1.5 text-right">{ch.quantity}</td>
           <td className="px-3 py-1.5 text-right">{formatMoney(ch.unitPrice, currency)}</td>
           <td colSpan={4} />

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -14,6 +14,13 @@ vi.mock('../../stores/auth', () => ({
     { getState: () => ({ tokens: null }) },
   ),
 }));
+// The Preview tab's InvoiceDocument reads the org list off orgStore; stub it so
+// the real module (which registers an org-id provider on the auth store at import
+// time) is never pulled into this partially-mocked auth setup.
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    selector({ organizations: [] }),
+}));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -1,40 +1,103 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import InvoiceEditor from './InvoiceEditor';
 import InvoiceDetail from './InvoiceDetail';
+import InvoiceDocumentPreview from './InvoiceDocument';
 import { type InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
+type Tab = 'editor' | 'preview' | 'detail';
+
+const TABS: { value: Tab; label: string }[] = [
+  { value: 'editor', label: 'Editor' },
+  { value: 'preview', label: 'Preview' },
+  { value: 'detail', label: 'Detail' },
+];
+
 interface Props {
   invoiceId?: string;
+}
+
+function readTab(isDraft: boolean): Tab {
+  if (typeof window === 'undefined') return isDraft ? 'editor' : 'detail';
+  const raw = window.location.hash.replace(/^#/, '');
+  if (TABS.some((t) => t.value === raw)) return raw as Tab;
+  return isDraft ? 'editor' : 'detail';
 }
 
 export default function InvoiceWorkspace({ invoiceId }: Props) {
   const [detail, setDetail] = useState<InvoiceDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const [tab, setTab] = useState<Tab>('editor');
 
-  const load = useCallback(async () => {
+  // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
+  // so the editor stays mounted — a full-page spinner would remount the form and
+  // discard the user's in-progress local state and cursor position. Only the
+  // initial load shows the spinner / replaces the view on error.
+  const fetchDetail = useCallback(async (quiet = false) => {
     if (!invoiceId) { setError('Missing invoice id'); setLoading(false); return; }
     try {
-      setLoading(true);
+      if (!quiet) setLoading(true);
       setError(undefined);
       const res = await fetchWithAuth(`/invoices/${invoiceId}`);
       if (res.status === 401) return UNAUTHORIZED();
-      if (res.status === 404) { setError('Invoice not found.'); return; }
+      if (res.status === 404) { if (!quiet) setError('Invoice not found.'); return; }
       if (!res.ok) throw new Error('Failed to load invoice');
       const body = (await res.json()) as { data: InvoiceDetailData };
       setDetail(body.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load invoice');
+      // A failed quiet reload leaves the editor intact; the inline action's own
+      // runAction toast already surfaced the failure.
+      if (!quiet) setError(err instanceof Error ? err.message : 'Failed to load invoice');
     } finally {
-      setLoading(false);
+      if (!quiet) setLoading(false);
     }
   }, [invoiceId]);
 
+  const load = useCallback(() => fetchDetail(false), [fetchDetail]);
+  const reload = useCallback(() => fetchDetail(true), [fetchDetail]);
+
   useEffect(() => { void load(); }, [load]);
+
+  // Initialise the active tab from the hash once we know whether it's a draft.
+  const isDraft = detail?.invoice.status === 'draft';
+  useEffect(() => {
+    if (!detail) return;
+    setTab(readTab(detail.invoice.status === 'draft'));
+  }, [detail]);
+
+  // React to back/forward hash changes.
+  useEffect(() => {
+    const onHash = () => setTab(readTab(detail?.invoice.status === 'draft'));
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, [detail]);
+
+  const selectTab = useCallback((next: Tab) => {
+    setTab(next);
+    if (typeof window !== 'undefined') window.location.hash = `#${next}`;
+  }, []);
+
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
+  // tab is both activated and focused.
+  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
+    const idx = tabs.findIndex((t) => t.value === current);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = tabs[nextIdx].value;
+    selectTab(next);
+    if (typeof document !== 'undefined') document.getElementById(`invoice-tab-${next}`)?.focus();
+  }, [selectTab]);
 
   if (loading) {
     return (
@@ -57,7 +120,11 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     );
   }
 
-  const isDraft = detail.invoice.status === 'draft';
+  // The Editor only applies to drafts, so it's hidden once an invoice is issued —
+  // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
+  // on a non-draft falls back to Detail.
+  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
+  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
 
   return (
     <div className="space-y-4" data-testid="invoice-workspace">
@@ -69,10 +136,52 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
           </h1>
         </div>
       </div>
-      {isDraft ? (
-        <InvoiceEditor detail={detail} onChanged={() => void load()} />
-      ) : (
-        <InvoiceDetail detail={detail} onChanged={() => void load()} />
+
+      {/* Tabs */}
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        data-testid="invoice-workspace-tabs"
+        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
+      >
+        {visibleTabs.map((t) => (
+          <button
+            key={t.value}
+            type="button"
+            role="tab"
+            id={`invoice-tab-${t.value}`}
+            aria-selected={activeTab === t.value}
+            aria-controls={`invoice-tabpanel-${t.value}`}
+            tabIndex={activeTab === t.value ? 0 : -1}
+            onClick={() => selectTab(t.value)}
+            data-testid={`invoice-tab-${t.value}`}
+            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
+              activeTab === t.value
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'editor' && isDraft && (
+        <div role="tabpanel" id="invoice-tabpanel-editor" aria-labelledby="invoice-tab-editor" tabIndex={0}>
+          <InvoiceEditor detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
+
+      {activeTab === 'preview' && (
+        <div role="tabpanel" id="invoice-tabpanel-preview" aria-labelledby="invoice-tab-preview" tabIndex={0}>
+          <InvoiceDocumentPreview detail={detail} />
+        </div>
+      )}
+
+      {activeTab === 'detail' && (
+        <div role="tabpanel" id="invoice-tabpanel-detail" aria-labelledby="invoice-tab-detail" tabIndex={0}>
+          <InvoiceDetail detail={detail} onChanged={() => void reload()} />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -69,7 +69,7 @@ describe('InvoicesPage', () => {
     // Overdue badge label + restrained overdue cue (red dot indicator + due tone),
     // replacing the old full-row red tint.
     expect(screen.getByTestId('invoices-status-inv-1')).toHaveTextContent('Overdue');
-    expect(row.querySelector('.bg-red-500')).not.toBeNull();
+    expect(row.querySelector('.bg-destructive')).not.toBeNull();
   });
 
   it('writes filter selections to the URL hash', async () => {

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
@@ -295,19 +296,34 @@ export function InvoicesPage() {
     return { outstanding, overdue, openCount: open.length, ccy };
   }, [invoices]);
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
-    <th className="px-3 py-3 text-right font-medium">
-      <button
-        type="button"
-        onClick={() => toggleSort(sortKey)}
-        className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-        data-testid={`invoices-sort-${sortKey}`}
-      >
-        {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
-      </button>
-    </th>
-  );
+  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
+    const active = sort?.key === sortKey;
+    const ariaLabel = active
+      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+      : `Sort by ${label}`;
+    return (
+      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+        <button
+          type="button"
+          onClick={() => toggleSort(sortKey)}
+          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
+          data-testid={`invoices-sort-${sortKey}`}
+          aria-label={ariaLabel}
+        >
+          {label}
+          {active ? (
+            sort!.dir === 'asc' ? (
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            )
+          ) : (
+            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </th>
+    );
+  };
 
   if (forbidden) {
     return (
@@ -350,11 +366,11 @@ export function InvoicesPage() {
             <button
               type="button"
               onClick={() => applyFilter({ status: 'overdue' })}
-              className="rounded-lg border border-red-500/30 bg-red-500/5 px-4 py-3 text-left transition hover:bg-red-500/10"
+              className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-left transition hover:bg-destructive/10"
               data-testid="invoices-overdue-card"
             >
-              <div className="text-xs text-red-700 dark:text-red-400">Overdue</div>
-              <div className="mt-0.5 text-lg font-semibold tabular-nums text-red-700 dark:text-red-400">{summary.overdue}</div>
+              <div className="text-xs text-destructive">Overdue</div>
+              <div className="mt-0.5 text-lg font-semibold tabular-nums text-destructive">{summary.overdue}</div>
               <div className="text-xs text-muted-foreground">needs follow-up</div>
             </button>
           )}
@@ -368,7 +384,7 @@ export function InvoicesPage() {
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search number or org"
           aria-label="Search invoices"
-          className="h-10 min-w-48 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+          className="h-10 min-w-[12rem] flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
           data-testid="invoices-search"
         />
         <select
@@ -505,7 +521,7 @@ export function InvoicesPage() {
                         </td>
                         <td className="px-3 py-3 font-medium">
                           <span className="flex items-center gap-2">
-                            <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-red-500' : 'bg-transparent'}`} aria-hidden="true" />
+                            <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-destructive' : 'bg-transparent'}`} aria-hidden="true" />
                             {inv.invoiceNumber ?? (
                               <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                                 Draft
@@ -515,7 +531,7 @@ export function InvoicesPage() {
                         </td>
                         <td className="px-3 py-3">{orgName(inv.orgId)}</td>
                         <td className="px-3 py-3 text-muted-foreground">{formatDate(inv.issueDate)}</td>
-                        <td className={`px-3 py-3 ${overdue ? 'font-medium text-red-700 dark:text-red-400' : 'text-muted-foreground'}`}>
+                        <td className={`px-3 py-3 ${overdue ? 'font-medium text-destructive' : 'text-muted-foreground'}`}>
                           {formatDate(inv.dueDate)}
                         </td>
                         <td className="px-3 py-3 text-right tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</td>
@@ -526,6 +542,7 @@ export function InvoicesPage() {
                           <span
                             className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
                             data-testid={`invoices-status-${inv.id}`}
+                            aria-label={`Status: ${statusLabel(inv)}`}
                           >
                             {statusLabel(inv)}
                           </span>
@@ -720,16 +737,29 @@ export function InvoicesPage() {
 function SortHeaderLeft({
   label, sortKey, sort, onSort,
 }: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
+  const active = sort?.key === sortKey;
+  const ariaLabel = active
+    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
   return (
-    <th className="px-3 py-3 font-medium">
+    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
       <button
         type="button"
         onClick={() => onSort(sortKey)}
         className="inline-flex items-center gap-1 hover:text-foreground"
         data-testid={`invoices-sort-${sortKey}`}
+        aria-label={ariaLabel}
       >
         {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+        {active ? (
+          sort!.dir === 'asc' ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
       </button>
     </th>
   );

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -1,0 +1,36 @@
+// Shared presentational helpers for the quote + invoice billing UI, so copy and
+// affordances can't drift between the editor and detail/document surfaces.
+
+/**
+ * Inline "Unsaved" affordance for blur-saved fields (terms / notes). Shown while
+ * the field holds uncommitted edits; the field's onBlur save clears the dirty
+ * flag on success, so this also stays lit if a save FAILS — surfacing that the
+ * edit didn't persist instead of relying on a transient toast the user may miss.
+ */
+export function UnsavedBadge({ show }: { show: boolean }) {
+  if (!show) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-warning"
+      data-testid="unsaved-badge"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden="true" />
+      Unsaved
+    </span>
+  );
+}
+
+/**
+ * The recurring-billing explanation shown beneath quote totals. Single source so
+ * the editor and the detail view can't drift (the customer-facing QuoteDocument
+ * keeps its own shorter copy intentionally).
+ */
+export function RecurringBillingNote({ className, testId }: { className?: string; testId?: string }) {
+  return (
+    <p className={`text-xs leading-relaxed text-muted-foreground ${className ?? ''}`} data-testid={testId}>
+      Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their
+      own schedule via the contract. The first-period total combines the one-time charges with the first period of
+      each recurring cadence.
+    </p>
+  );
+}

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -109,14 +109,37 @@ export const STATUS_LABELS: Record<InvoiceStatus, string> = {
   void: 'Void',
 };
 
-// Tailwind badge classes per status (mirrors the device/org status-pill style).
+/**
+ * Status-pill color roles, built from the app's semantic tokens (success /
+ * warning / info / destructive) rather than raw Tailwind palette hues. Shared by
+ * both the invoice and quote status pills (imported by quoteTypes) so the
+ * vocabulary can't drift between the two sibling surfaces.
+ *
+ * Five roles, not a per-status rainbow: meaning drives the hue (neutral = not
+ * sent, info = awaiting the customer, success = won/paid, warning = lapsing,
+ * danger = lost/overdue). The text label carries the finer distinction (Sent vs
+ * Viewed, Accepted vs Converted), so colour stays scannable.
+ *
+ * `info`/`success` base tokens are dark enough (L≈37-38%) to read on their own
+ * 10% tint; `warning`/`danger` base tokens (amber L50% / red L56%) fail WCAG as
+ * text on a light tint, so light mode uses a darker shade of the SAME token hue
+ * and dark mode (where the bg is dark) uses the token directly.
+ */
+export const STATUS_PILL = {
+  neutral: 'border-border bg-muted text-muted-foreground',
+  info: 'border-info/30 bg-info/10 text-info',
+  success: 'border-success/30 bg-success/10 text-success',
+  warning: 'border-warning/40 bg-warning/15 text-[hsl(36_92%_28%)] dark:text-warning',
+  danger: 'border-destructive/40 bg-destructive/10 text-[hsl(4_74%_42%)] dark:text-destructive',
+} as const;
+
 export const STATUS_COLORS: Record<InvoiceStatus, string> = {
-  draft: 'border-border bg-muted text-muted-foreground',
-  sent: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  partially_paid: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-  overdue: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
-  paid: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  void: 'border-border bg-muted text-muted-foreground line-through',
+  draft: STATUS_PILL.neutral,
+  sent: STATUS_PILL.info,
+  partially_paid: STATUS_PILL.warning,
+  overdue: STATUS_PILL.danger,
+  paid: STATUS_PILL.success,
+  void: `${STATUS_PILL.neutral} line-through`,
 };
 
 /** Display label for an invoice's status. The 'sent' lifecycle status means
@@ -156,6 +179,23 @@ export function formatMoney(value: string | number | null | undefined, currencyC
 export function pctFromFraction(frac: string | number | null): string {
   if (frac === null || frac === '') return '';
   return String(Number((Number(frac) * 100).toFixed(3)));
+}
+
+/** Per-line tax amount for the line-table Tax column: taxable lines get
+ *  lineTotal × rate rounded to cents; non-taxable lines, a null/empty rate, or a
+ *  non-positive rate return null (rendered as '—'). The header Tax stays the
+ *  server's authoritative `taxTotal`, so a quote/invoice with many taxable lines
+ *  can differ from the summed column by a rounding cent. Mirrors quoteTypes. */
+export function lineTaxAmount(
+  lineTotal: string | number,
+  taxable: boolean,
+  taxRate: string | number | null,
+): number | null {
+  if (!taxable) return null;
+  const rate = taxRate === null || taxRate === '' ? 0 : Number(taxRate);
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
 }
 
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */

--- a/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
+
+// Same auth-mock pattern as QuoteDetail.delete.test.tsx.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/quotes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/api/quotes')>();
+  return { ...actual, sendQuote: vi.fn() };
+});
+
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const line: QuoteLine = {
+  id: 'l-1', quoteId: 'q-1', blockId: null, orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: 'Onboarding', quantity: '1',
+  unitPrice: '500.00', taxable: false, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const emptyDraft: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', billToName: 'Acme', introNotes: null,
+    terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const filledDraft: QuoteDetailData = {
+  ...emptyDraft,
+  quote: { ...emptyDraft.quote, oneTimeTotal: '500.00', dueOnAcceptanceTotal: '500.00', subtotal: '500.00', total: '500.00' },
+  lines: [line],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'send' }];
+});
+
+describe('QuoteDetail — send proposal', () => {
+  it('disables Send and shows a hint when the quote has no content', async () => {
+    render(<QuoteDetail detail={emptyDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-send')).toBeDisabled();
+    expect(screen.getByTestId('quote-send-empty-hint')).toBeInTheDocument();
+  });
+
+  it('does not send on the first click — it opens a confirm step first', async () => {
+    const sendQuote = vi.mocked(quotesApi.sendQuote);
+    render(<QuoteDetail detail={filledDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+    // Critical: the irreversible email must NOT have fired from the first click.
+    expect(sendQuote).not.toHaveBeenCalled();
+  });
+
+  it('sends only after the confirm step and refreshes the quote', async () => {
+    const sendQuote = vi.mocked(quotesApi.sendQuote);
+    sendQuote.mockResolvedValue(resp({ data: null }));
+    const onChanged = vi.fn();
+
+    render(<QuoteDetail detail={filledDraft} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send-confirm'));
+    await waitFor(() => {
+      expect(sendQuote).toHaveBeenCalledWith('q-1');
+      expect(onChanged).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -6,6 +6,7 @@ import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { deleteQuote, quotePdfUrl, sendQuote } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { RecurringBillingNote } from '../billingUi';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -15,6 +16,8 @@ import {
   formatDate,
   formatMoney,
   formatRecurrence,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './quoteTypes';
 
@@ -36,9 +39,14 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
 
   const [busy, setBusy] = useState(false);
   const [sending, setSending] = useState(false);
+  const [sendOpen, setSendOpen] = useState(false);
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
+
+  // Sending emails the customer and is irreversible, so it goes through a
+  // confirm step — and an empty quote (no blocks, no lines) can't be sent at all.
+  const isEmpty = blocks.length === 0 && lines.length === 0;
 
   const send = useCallback(async () => {
     if (sending) return;
@@ -50,6 +58,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
         successMessage: 'Proposal sent',
         onUnauthorized: UNAUTHORIZED,
       });
+      setSendOpen(false);
       refresh();
     } catch (err) {
       handleActionError(err, 'Could not send the proposal.');
@@ -119,6 +128,9 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
 
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
+  // Show the per-line Tax column only when this quote carries tax (mirrors the
+  // header Tax row); otherwise it'd be a column of dashes.
+  const showTax = Number(quote.taxTotal) > 0;
 
   // Customer label: prefer the explicit bill-to name; otherwise resolve the real
   // organization name from the client-side org list (same source the org switcher
@@ -142,8 +154,18 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
         {/* ── rendered blocks + lines ───────────────────────────────────── */}
         <div className="space-y-4">
           {sortedBlocks.length === 0 && looseLines.length === 0 ? (
-            <div className="rounded-lg border border-dashed bg-card p-8 text-center text-sm text-muted-foreground" data-testid="quote-detail-empty">
-              This quote has no content.
+            <div className="rounded-lg border border-dashed bg-card p-8 text-center" data-testid="quote-detail-empty">
+              <p className="text-sm text-muted-foreground">This quote has no content yet.</p>
+              {quote.status === 'draft' && can('quotes', 'write') && (
+                <button
+                  type="button"
+                  onClick={() => { if (typeof window !== 'undefined') window.location.hash = '#editor'; }}
+                  data-testid="quote-detail-empty-edit"
+                  className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                >
+                  Add content in the Editor
+                </button>
+              )}
             </div>
           ) : (
             sortedBlocks.map((block) => (
@@ -152,12 +174,14 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 block={block}
                 lines={linesForBlock(block.id)}
                 currency={currency}
+                taxRate={quote.taxRate}
+                showTax={showTax}
               />
             ))
           )}
 
           {looseLines.length > 0 && (
-            <LineTable lines={looseLines} currency={currency} label="Other items" testId="quote-detail-loose-lines" />
+            <LineTable lines={looseLines} currency={currency} label="Other items" testId="quote-detail-loose-lines" taxRate={quote.taxRate} showTax={showTax} />
           )}
         </div>
 
@@ -168,6 +192,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
                 data-testid="quote-detail-status"
+                aria-label={`Status: ${statusLabel(quote)}`}
               >
                 {statusLabel(quote)}
               </span>
@@ -178,7 +203,9 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
             <dl className="space-y-1 text-sm">
               <div className="flex justify-between"><dt className="text-muted-foreground">Customer</dt><dd className="text-right" data-testid="quote-detail-customer">{orgName}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Issued</dt><dd>{formatDate(quote.issueDate)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
+              {(!quote.issueDate || formatDate(quote.issueDate) !== formatDate(quote.createdAt)) && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
+              )}
             </dl>
           </div>
 
@@ -189,13 +216,13 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
               <div className="flex justify-between"><dt className="text-muted-foreground">One-time</dt><dd>{formatMoney(quote.oneTimeTotal, currency)}</dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Monthly</dt><dd>{formatMoney(quote.monthlyRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd></div>
               <div className="flex justify-between"><dt className="text-muted-foreground">Annual</dt><dd>{formatMoney(quote.annualRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd></div>
-              {Number(quote.taxTotal) > 0 && (
-                <div className="flex justify-between"><dt className="text-muted-foreground">Tax</dt><dd>{formatMoney(quote.taxTotal, currency)}</dd></div>
+              {showTax && (
+                <div className="flex justify-between"><dt className="text-muted-foreground">Tax{quote.taxRate ? ` (${pctFromFraction(quote.taxRate)}%)` : ''}</dt><dd>{formatMoney(quote.taxTotal, currency)}</dd></div>
               )}
             </dl>
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-detail-due-on-acceptance">{formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}</span>
+            <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              <span className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums" data-testid="quote-detail-due-on-acceptance">{formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}</span>
             </div>
             {hasRecurring && (
               <>
@@ -203,9 +230,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                   <span className="text-muted-foreground">First-period total (incl. recurring)</span>
                   <span className="font-medium" data-testid="quote-detail-first-period">{formatMoney(quote.total, currency)}</span>
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
-                </p>
+                <RecurringBillingNote className="mt-2" />
               </>
             )}
           </div>
@@ -242,11 +267,37 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
             </div>
           )}
 
-          {/* Actions */}
+          {/* Actions — the primary action leads. On a draft that's "Send proposal"
+              (the irreversible money-moment); on an issued quote only "Download PDF"
+              remains, as a secondary affordance. */}
           <div className="space-y-2">
+            {/* Send a draft proposal: issues a number, emails the customer's billing
+                contact with the PDF + a public accept link, and flips draft→sent.
+                Gated on quotes:send. Only a draft can be sent — once sent, the
+                button drops out (the status pill above reflects the new state). The
+                click opens a confirm step; an empty quote can't be sent. */}
+            {can('quotes', 'send') && quote.status === 'draft' && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setSendOpen(true)}
+                  disabled={sending || isEmpty}
+                  title={isEmpty ? 'Add at least one item before sending.' : undefined}
+                  data-testid="quote-send"
+                  className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  {sending ? 'Sending…' : 'Send proposal'}
+                </button>
+                {isEmpty && (
+                  <p className="text-center text-xs text-muted-foreground" data-testid="quote-send-empty-hint">
+                    Add at least one item before sending.
+                  </p>
+                )}
+              </>
+            )}
             {/* PDF download is a read affordance — quotes has no dedicated export
                 action, so it's gated on quotes:read (visible to anyone who can view
-                the quote). */}
+                the quote). Secondary to the send action. */}
             {can('quotes', 'read') && (
               <button
                 type="button"
@@ -256,21 +307,6 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
                 className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
               >
                 Download PDF
-              </button>
-            )}
-            {/* Send a draft proposal: issues a number, emails the customer's billing
-                contact with the PDF + a public accept link, and flips draft→sent.
-                Gated on quotes:send. Only a draft can be sent — once sent, the
-                button drops out (the status pill above reflects the new state). */}
-            {can('quotes', 'send') && quote.status === 'draft' && (
-              <button
-                type="button"
-                onClick={() => void send()}
-                disabled={sending}
-                data-testid="quote-send"
-                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
-              >
-                {sending ? 'Sending…' : 'Send proposal'}
               </button>
             )}
             {can('quotes', 'write') && quote.status === 'draft' && (
@@ -287,6 +323,17 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
         </div>
       </div>
       <ConfirmDialog
+        open={sendOpen}
+        onClose={() => setSendOpen(false)}
+        onConfirm={() => void send()}
+        isLoading={sending}
+        variant="warning"
+        title="Send this proposal?"
+        message={`We'll email this proposal to ${orgName} and mark it Sent — ${formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)} due on acceptance. This can't be undone.`}
+        confirmLabel="Send proposal"
+        confirmTestId="quote-send-confirm"
+      />
+      <ConfirmDialog
         open={delOpen}
         onClose={() => setDelOpen(false)}
         onConfirm={() => void remove()}
@@ -300,7 +347,7 @@ export default function QuoteDetail({ detail, onChanged }: Props) {
   );
 }
 
-function BlockView({ block, lines, currency }: { block: QuoteBlock; lines: QuoteLine[]; currency: string }) {
+function BlockView({ block, lines, currency, taxRate, showTax }: { block: QuoteBlock; lines: QuoteLine[]; currency: string; taxRate: string | null; showTax: boolean }) {
   const heading = (block.content?.text as string | undefined) ?? '';
   const html = (block.content?.html as string | undefined) ?? '';
   const tableLabel = (block.content?.label as string | undefined) ?? '';
@@ -324,12 +371,13 @@ function BlockView({ block, lines, currency }: { block: QuoteBlock; lines: Quote
   // line_items
   return (
     <div data-testid={`quote-detail-block-${block.id}`}>
-      <LineTable lines={lines} currency={currency} label={tableLabel || 'Pricing'} testId={`quote-detail-lines-${block.id}`} />
+      <LineTable lines={lines} currency={currency} label={tableLabel || 'Pricing'} testId={`quote-detail-lines-${block.id}`} taxRate={taxRate} showTax={showTax} />
     </div>
   );
 }
 
-function LineTable({ lines, currency, label, testId }: { lines: QuoteLine[]; currency: string; label: string; testId: string }) {
+function LineTable({ lines, currency, label, testId, taxRate, showTax }: { lines: QuoteLine[]; currency: string; label: string; testId: string; taxRate: string | null; showTax: boolean }) {
+  const colSpan = showTax ? 6 : 5;
   return (
     <div className="rounded-lg border bg-card shadow-xs">
       {label && (
@@ -342,28 +390,35 @@ function LineTable({ lines, currency, label, testId }: { lines: QuoteLine[]; cur
             <th className="px-3 py-2 text-right font-medium">Qty</th>
             <th className="px-3 py-2 text-right font-medium">Unit</th>
             <th className="px-3 py-2 font-medium">Recurrence</th>
+            {showTax && <th className="px-3 py-2 text-right font-medium">Tax</th>}
             <th className="px-3 py-2 text-right font-medium">Total</th>
           </tr>
         </thead>
         <tbody>
           {lines.length === 0 ? (
             <tr>
-              <td colSpan={5} className="px-3 py-6 text-center text-sm text-muted-foreground">No lines.</td>
+              <td colSpan={colSpan} className="px-3 py-6 text-center text-sm text-muted-foreground">No lines.</td>
             </tr>
           ) : (
-            lines.map((l) => (
-              <tr key={l.id} className="border-t" data-testid={`quote-detail-line-${l.id}`}>
-                <td className="px-3 py-2">{l.description}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{l.quantity}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
-                <td className="px-3 py-2">
-                  <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                    {formatRecurrence(l.recurrence)}
-                  </span>
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
-              </tr>
-            ))
+            lines.map((l) => {
+              const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, taxRate) : null;
+              return (
+                <tr key={l.id} className="border-t" data-testid={`quote-detail-line-${l.id}`}>
+                  <td className="px-3 py-2">{l.description}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{l.quantity}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
+                  <td className="px-3 py-2">
+                    <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {formatRecurrence(l.recurrence)}
+                    </span>
+                  </td>
+                  {showTax && (
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>
+                  )}
+                  <td className="px-3 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
+                </tr>
+              );
+            })
           )}
         </tbody>
       </table>

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -12,6 +12,8 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  lineTaxAmount,
+  pctFromFraction,
   sellerLines,
 } from './quoteTypes';
 
@@ -95,7 +97,7 @@ function DocImage({ quoteId, imageId, caption }: { quoteId: string; imageId: str
   );
 }
 
-function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency: string; label?: string }) {
+function PricingTable({ lines, currency, label, taxRate, showTax }: { lines: QuoteLine[]; currency: string; label?: string; taxRate: string | null; showTax: boolean }) {
   if (lines.length === 0) return null;
   const sorted = [...lines].sort((a, b) => a.sortOrder - b.sortOrder);
   return (
@@ -104,12 +106,13 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
         <div className="border-b bg-muted/40 px-4 py-2.5 text-sm font-semibold text-foreground sm:px-5">{label}</div>
       )}
       <div className="overflow-x-auto">
-        <table className="w-full min-w-120 text-sm">
+        <table className="w-full min-w-[30rem] text-sm">
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
               <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
               <th className="px-2 py-2.5 text-right font-medium">Qty</th>
               <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
+              {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
               <th className="px-4 py-2.5 text-right font-medium sm:px-5">Amount</th>
             </tr>
           </thead>
@@ -117,6 +120,7 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
             {sorted.map((l) => {
               const suffix = RECURRENCE_SUFFIX[l.recurrence];
               const tag = RECURRENCE_LABEL[l.recurrence];
+              const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, taxRate) : null;
               return (
                 <tr key={l.id} className="border-b align-top last:border-0">
                   <td className="px-4 py-3 text-foreground sm:px-5">
@@ -131,6 +135,11 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
                   <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
                     {formatMoney(l.unitPrice, currency)}{suffix && <span className="text-xs">{suffix}</span>}
                   </td>
+                  {showTax && (
+                    <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">
+                      {tax === null ? '—' : formatMoney(tax, currency)}
+                    </td>
+                  )}
                   <td className="whitespace-nowrap px-4 py-3 text-right font-medium tabular-nums text-foreground sm:px-5">
                     {formatMoney(l.lineTotal, currency)}{suffix && <span className="text-xs text-muted-foreground">{suffix}</span>}
                   </td>
@@ -144,7 +153,7 @@ function PricingTable({ lines, currency, label }: { lines: QuoteLine[]; currency
   );
 }
 
-function DocBlock({ block, lines, currency }: { block: QuoteBlock; lines: QuoteLine[]; currency: string }) {
+function DocBlock({ block, lines, currency, taxRate, showTax }: { block: QuoteBlock; lines: QuoteLine[]; currency: string; taxRate: string | null; showTax: boolean }) {
   if (block.blockType === 'heading') {
     const text = (block.content?.text as string | undefined)?.trim();
     if (!text) return null;
@@ -163,7 +172,7 @@ function DocBlock({ block, lines, currency }: { block: QuoteBlock; lines: QuoteL
   }
   // line_items
   const label = (block.content?.label as string | undefined)?.trim() || 'Pricing';
-  return <PricingTable lines={lines} currency={currency} label={label} />;
+  return <PricingTable lines={lines} currency={currency} label={label} taxRate={taxRate} showTax={showTax} />;
 }
 
 interface DocumentProps {
@@ -193,6 +202,9 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
   const hasRecurring =
     Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
   const dueOnAcceptance = quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
+  // Only surface the per-line Tax column when this quote actually carries tax —
+  // otherwise it's a column of dashes. Mirrors the header Tax row's visibility.
+  const showTax = Number(quote.taxTotal) > 0;
 
   return (
     <div
@@ -200,9 +212,6 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
       data-testid="quote-document"
       className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-xs"
     >
-      {/* Accent top rule */}
-      <div className="h-1.5 w-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
-
       <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">
         {/* ── Header ─────────────────────────────────────────────── */}
         <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
@@ -214,6 +223,8 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
                 {branding?.partnerName ?? 'Proposal'}
               </p>
             )}
+            {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
+            <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
             {seller && (
               <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
                 {seller.name && <p className="font-medium text-foreground/80">{seller.name}</p>}
@@ -226,14 +237,13 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
           </div>
 
           <div className="space-y-2 sm:text-right">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: 'var(--doc-accent)' }}>
-              Proposal
-            </p>
-            <p className="text-2xl font-semibold tracking-tight text-foreground" data-testid="quote-document-number">
+            <p className="text-[1.75rem] font-semibold leading-none tracking-tight text-foreground" data-testid="quote-document-number">
               {quote.quoteNumber ?? 'Draft'}
             </p>
+            <p className="text-sm font-medium text-muted-foreground">Proposal</p>
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
+              aria-label={`Status: ${statusLabel(quote)}`}
             >
               {statusLabel(quote)}
             </span>
@@ -267,9 +277,9 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
         ) : (
           <div className="space-y-6">
             {sortedBlocks.map((block) => (
-              <DocBlock key={block.id} block={block} lines={linesForBlock(block.id)} currency={currency} />
+              <DocBlock key={block.id} block={block} lines={linesForBlock(block.id)} currency={currency} taxRate={quote.taxRate} showTax={showTax} />
             ))}
-            {looseLines.length > 0 && <PricingTable lines={looseLines} currency={currency} label="Additional items" />}
+            {looseLines.length > 0 && <PricingTable lines={looseLines} currency={currency} label="Additional items" taxRate={quote.taxRate} showTax={showTax} />}
           </div>
         )}
 
@@ -281,9 +291,11 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
                 <span className="text-muted-foreground">Subtotal</span>
                 <span className="tabular-nums text-foreground">{formatMoney(quote.subtotal, currency)}</span>
               </div>
-              {Number(quote.taxTotal) > 0 && (
+              {showTax && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Tax</span>
+                  <span className="text-muted-foreground">
+                    Tax{quote.taxRate ? ` (${pctFromFraction(quote.taxRate)}%)` : ''}
+                  </span>
                   <span className="tabular-nums text-foreground">{formatMoney(quote.taxTotal, currency)}</span>
                 </div>
               )}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.editline.test.tsx
@@ -90,6 +90,24 @@ describe('QuoteEditor — inline line editing', () => {
     expect(screen.getByTestId('quote-line-desc-line-1').tagName).toBe('TEXTAREA');
   });
 
+  it('renders a per-line Tax cell: "—" when not taxable, the computed amount when taxable', async () => {
+    // Non-taxable line + no rate → dash.
+    const { unmount } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-tax-line-1')).toHaveTextContent('—');
+    unmount();
+
+    // Taxable line ($50 line total) at 10% → $5.00 in the Tax cell.
+    const taxed: QuoteDetailData = {
+      ...detail,
+      quote: { ...detail.quote, taxRate: '0.1' },
+      lines: [{ ...line, taxable: true }],
+    };
+    render(<QuoteEditor detail={taxed} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-tax-line-1')).toHaveTextContent('$5.00');
+  });
+
   it('editing the description and blurring PATCHes the line, then refreshes', async () => {
     const onChanged = vi.fn();
     render(<QuoteEditor detail={detail} onChanged={onChanged} />);
@@ -102,8 +120,12 @@ describe('QuoteEditor — inline line editing', () => {
     await waitFor(() => {
       expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { description: 'Premium managed support' });
     });
-    expect(onChanged).toHaveBeenCalled();
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Line updated' }));
+    // refresh() is coalesced (trailing), so onChanged fires shortly after the PATCH.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    // Routine inline edits no longer fire a success toast (that was per-field
+    // spam) — they flash a quiet "Saved" cue on the row instead.
+    await waitFor(() => expect(screen.getByTestId('quote-line-saved-line-1')).toBeInTheDocument());
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Line updated' }));
   });
 
   it('changing quantity sends a numeric quantity', async () => {
@@ -151,5 +173,120 @@ describe('QuoteEditor — inline line editing', () => {
     fireEvent.click(screen.getByTestId('quote-line-mode-blk-1-manual'));
     const manualDesc = screen.getByTestId('quote-manual-desc-blk-1');
     expect(manualDesc.tagName).toBe('TEXTAREA');
+  });
+
+  it('re-adopts a server-normalized value after commit (no stuck-dirty row)', async () => {
+    // Enter a sub-cent price the server will round (9.999 → 10.00). Once the user
+    // stops editing, the refreshed prop must re-adopt the canonical server value
+    // rather than leaving the field/total pinned to the raw entry.
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const priceEl = screen.getByTestId('quote-line-price-line-1') as HTMLInputElement;
+    fireEvent.change(priceEl, { target: { value: '9.999' } });
+    fireEvent.blur(priceEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { unitPrice: 9.999 }));
+
+    // The parent re-pulls; the server normalized the price to 10.00.
+    const normalized: QuoteDetailData = {
+      ...detail,
+      lines: [{ ...line, unitPrice: '10.00', lineTotal: '10.00' }],
+    };
+    rerender(<QuoteEditor detail={normalized} onChanged={vi.fn()} />);
+
+    await waitFor(() =>
+      expect((screen.getByTestId('quote-line-price-line-1') as HTMLInputElement).value).toBe('10.00'),
+    );
+    // Row total reflects the authoritative server value, not the raw 9.999 entry.
+    expect(screen.getByTestId('quote-line-tax-line-1')).toBeInTheDocument();
+  });
+
+  it('recomputes the right-rail totals optimistically while a line qty is mid-edit', async () => {
+    // The fixture line is a $50/mo recurring line, so the rail shows $50.00
+    // monthly. Bumping qty to 3 must move the rail to $150.00 immediately —
+    // before any blur/save/refresh — so the rail no longer lags the row.
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$50.00');
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    await waitFor(() => expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$150.00'));
+    // No PATCH yet — this is pure pre-commit optimism.
+    expect(updateLineMock).not.toHaveBeenCalled();
+  });
+
+  it('row Total uses the shared cents math and agrees with the rail (sub-cent price)', async () => {
+    // 3 × 0.335 = 1.005 — naive float formatting can drift a cent from the
+    // server's round-half-up-at-the-cent-boundary. The row Total and the rail
+    // (both via the shared computeLineTotal) must land on the same $1.01.
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    fireEvent.change(screen.getByTestId('quote-line-price-line-1'), { target: { value: '0.335' } });
+
+    await waitFor(() => expect(screen.getByTestId('quote-line-total-line-1')).toHaveTextContent('$1.01'));
+    // The fixture line is monthly, so the rail's monthly figure mirrors it exactly.
+    expect(screen.getByTestId('quote-total-monthly')).toHaveTextContent('$1.01');
+  });
+
+  it('reflects a tax-rate edit optimistically in the rail (due on acceptance)', async () => {
+    // A $100 one-time taxable line, no rate yet. Typing a 10% rate must move the
+    // rail's "due on acceptance" to $110 immediately — before blur/save/refresh.
+    const taxableOneTime: QuoteDetailData = {
+      ...detail,
+      quote: {
+        ...detail.quote, taxRate: null, oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+        subtotal: '100.00', total: '100.00', dueOnAcceptanceTotal: '100.00',
+      },
+      lines: [{ ...line, recurrence: 'one_time', taxable: true, unitPrice: '100.00', quantity: '1.00', lineTotal: '100.00' }],
+    };
+    render(<QuoteEditor detail={taxableOneTime} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-total-due-on-acceptance')).toHaveTextContent('$100.00');
+
+    fireEvent.change(screen.getByTestId('quote-tax-rate'), { target: { value: '10' } });
+    await waitFor(() =>
+      expect(screen.getByTestId('quote-total-due-on-acceptance')).toHaveTextContent('$110.00'),
+    );
+  });
+
+  it('surfaces a cue (and reverts) when an invalid quantity is committed', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qtyEl = screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement;
+    fireEvent.change(qtyEl, { target: { value: '0' } });
+    fireEvent.blur(qtyEl);
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })),
+    );
+    // No PATCH for the rejected value, and the field snaps back to the persisted qty.
+    expect(updateLineMock).not.toHaveBeenCalled();
+    expect(qtyEl.value).toBe('1.00');
+  });
+
+  it('keeps in-progress keystrokes when a stale refresh lands (no clobber)', async () => {
+    // "edit qty→5, blur, type 7": a refresh confirming 5 must not wipe the 7 the
+    // user has already typed into the still-focused field.
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const qtyEl = screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement;
+    fireEvent.change(qtyEl, { target: { value: '5' } });
+    fireEvent.blur(qtyEl);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { quantity: 5 }));
+
+    // User immediately types 7 before the refresh GET (confirming 5) lands.
+    fireEvent.change(qtyEl, { target: { value: '7' } });
+    const confirmedFive: QuoteDetailData = {
+      ...detail,
+      lines: [{ ...line, quantity: '5.00', lineTotal: '250.00' }],
+    };
+    rerender(<QuoteEditor detail={confirmedFive} onChanged={vi.fn()} />);
+
+    // The 7 survives — the stale-but-changed prop did not clobber the edit.
+    expect((screen.getByTestId('quote-line-qty-line-1') as HTMLInputElement).value).toBe('7');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.removeblock.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteBlock, QuoteDetail as QuoteDetailData, QuoteLine } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  removeLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const block: QuoteBlock = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Pricing' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const line: QuoteLine = {
+  id: 'l-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: 'Onboarding', quantity: '1',
+  unitPrice: '500.00', taxable: false, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '500.00', taxRate: null,
+    taxTotal: '0.00', total: '500.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [block],
+  lines: [line],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockImplementation(async () => json({ data: {} }));
+});
+
+describe('QuoteEditor — block removal', () => {
+  it('opens a confirm step naming the line count and does not delete on the first click', async () => {
+    const deleteBlock = vi.mocked(quotesApi.deleteBlock);
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
+
+    const confirm = await screen.findByTestId('quote-block-remove-confirm');
+    expect(confirm).toBeInTheDocument();
+    // The cascade count must be surfaced to the user before they commit.
+    expect(screen.getByText(/1 line item/)).toBeInTheDocument();
+    // Nothing destroyed yet.
+    expect(deleteBlock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the block only after the confirm step', async () => {
+    const deleteBlock = vi.mocked(quotesApi.deleteBlock);
+    deleteBlock.mockResolvedValue(json({ data: null }));
+
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-remove-blk-1'));
+    fireEvent.click(await screen.findByTestId('quote-block-remove-confirm'));
+
+    await waitFor(() => expect(deleteBlock).toHaveBeenCalledWith('q-1', 'blk-1'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.reorder.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { reorderBlocks, reorderLines } from '../../../lib/api/quotes';
+
+// Writer permissions so the editor controls (incl. move buttons) render.
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/x/image'),
+}));
+
+const okResponse = () =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: { ok: true } }) } as unknown as Response);
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const tableBlock: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const headingBlock: QuoteDetailData['blocks'][number] = {
+  id: 'blk-2', quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+  content: { text: 'Summary', level: 2 }, sortOrder: 1, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const mkLine = (id: string, sortOrder: number): QuoteDetailData['lines'][number] => ({
+  id, quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, description: `Line ${id}`, quantity: '1.00',
+  unitPrice: '50.00', taxable: false, customerVisible: true, lineTotal: '50.00',
+  recurrence: 'monthly', termMonths: null, billingFrequency: null, sortOrder,
+  createdAt: '2026-06-01T00:00:00Z',
+});
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '100.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [tableBlock, headingBlock],
+  lines: [mkLine('l-1', 0), mkLine('l-2', 1)],
+};
+
+const reorderBlocksMock = vi.mocked(reorderBlocks);
+const reorderLinesMock = vi.mocked(reorderLines);
+
+describe('QuoteEditor — reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reorderBlocksMock.mockResolvedValue(okResponse());
+    reorderLinesMock.mockResolvedValue(okResponse());
+  });
+
+  it('disables move-up on the first block and move-down on the last block', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-block-move-up-blk-1')).toBeDisabled();
+    expect(screen.getByTestId('quote-block-move-down-blk-2')).toBeDisabled();
+  });
+
+  it('moving the first block down sends the full reordered block id list', async () => {
+    const onChanged = vi.fn();
+    render(<QuoteEditor detail={detail} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-1'] }));
+    // refresh() is coalesced (trailing), so onChanged fires shortly after the PATCH.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('moving the second block up sends the same reordered list', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-up-blk-2'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-1'] }));
+  });
+
+  it('disables move-up on the first line and move-down on the last line', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-line-move-up-l-1')).toBeDisabled();
+    expect(screen.getByTestId('quote-line-move-down-l-2')).toBeDisabled();
+  });
+
+  it('moving the first line down sends the block id and reordered line list', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-line-move-down-l-1'));
+    await waitFor(() => expect(reorderLinesMock).toHaveBeenCalledWith('q-1', 'blk-1', { lineIds: ['l-2', 'l-1'] }));
+  });
+
+  it('accumulates rapid reorder clicks into a single PATCH with the final order', async () => {
+    // Three blocks so the first can be moved down twice. Two rapid clicks should
+    // stack on the optimistic order and coalesce into ONE PATCH carrying the final
+    // id list — not two competing requests (the central novel reorder behavior).
+    const thirdBlock: QuoteDetailData['blocks'][number] = {
+      id: 'blk-3', quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+      content: { text: 'Footer', level: 2 }, sortOrder: 2, createdAt: '2026-06-01T00:00:00Z',
+    };
+    const threeBlocks: QuoteDetailData = { ...detail, blocks: [tableBlock, headingBlock, thirdBlock] };
+    render(<QuoteEditor detail={threeBlocks} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1')); // [blk-2, blk-1, blk-3]
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1')); // [blk-2, blk-3, blk-1]
+
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledTimes(1));
+    expect(reorderBlocksMock).toHaveBeenCalledWith('q-1', { blockIds: ['blk-2', 'blk-3', 'blk-1'] });
+  });
+
+  it('reverts the optimistic order and toasts when the reorder PATCH fails', async () => {
+    // A failed reorder must not leave the UI showing an order that never persisted.
+    reorderBlocksMock.mockResolvedValue(
+      { ok: false, status: 500, statusText: 'err', json: vi.fn().mockResolvedValue({ error: 'boom' }) } as unknown as Response,
+    );
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    // blk-1 starts first (move-up disabled). Move it down (optimistically enables move-up).
+    fireEvent.click(screen.getByTestId('quote-block-move-down-blk-1'));
+    await waitFor(() => expect(reorderBlocksMock).toHaveBeenCalledTimes(1));
+
+    // Failure is surfaced and the optimistic order reverts (blk-1 back to first).
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await waitFor(() => expect(screen.getByTestId('quote-block-move-up-blk-1')).toBeDisabled());
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -84,7 +84,10 @@ describe('QuoteEditor', () => {
         termsAndConditions: 'Net 30',
       });
     });
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
+    // Blur-to-save fields now share the quiet "Saved" cue instead of a success
+    // toast (unified save-feedback model across the editor).
+    await waitFor(() => expect(screen.getByTestId('quote-terms-saved')).toBeInTheDocument());
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
   });
 
   it('renders the T&C textarea pre-filled with existing termsAndConditions', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import { navigateTo } from '@/lib/navigation';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError } from '../../../lib/runAction';
@@ -11,15 +12,20 @@ import {
   addCatalogLine,
   updateLine,
   removeLine,
+  reorderBlocks as reorderBlocksApi,
+  reorderLines as reorderLinesApi,
   uploadQuoteImage,
   quoteImageUrl,
 } from '../../../lib/api/quotes';
 import type { QuoteBlockInput } from '@breeze/shared';
+import { computeQuoteTotals, computeLineTotal, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';
 import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
 import CatalogEnrichButton from '../../catalog/CatalogEnrichButton';
 import DistributorLookup from './DistributorLookup';
+import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { UnsavedBadge, RecurringBillingNote } from '../billingUi';
 import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
@@ -27,6 +33,8 @@ import {
   type QuoteLineRecurrence,
   formatMoney,
   formatRecurrence,
+  pctFromFraction,
+  lineTaxAmount,
 } from './quoteTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -67,17 +75,125 @@ interface Props {
   onChanged: () => void;
 }
 
+// A quiet, transient "Saved" cue for the right-rail blur-to-save fields (terms,
+// tax). BlockCard and EditableLineRow replicate this same pattern inline rather
+// than calling the hook. Returns the on-flag and a trigger; clears its timer on
+// unmount so a late fire can't setState a gone node.
+function useSavedFlash(): [boolean, () => void] {
+  const [on, setOn] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const flash = useCallback(() => {
+    setOn(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setOn(false), 1500);
+  }, []);
+  return [on, flash];
+}
+
+// Visually-hidden polite live region — announces a transient message (e.g.
+// "Saved") to screen readers without taking visual space. Pairs with the visible
+// cue so sighted and SR users get the same feedback.
+function SrSaved({ show, label = 'Saved' }: { show: boolean; label?: string }) {
+  // role="status" already implies aria-live="polite" — don't double it.
+  return <span role="status" className="sr-only">{show ? label : ''}</span>;
+}
+
+// Up/down reorder controls: lucide chevrons in 28px targets (clears the WCAG
+// 2.5.8 24×24 minimum) instead of raw glyphs, disabled only at the list ends.
+// When the pressed direction hits an end and self-disables, focus hops to the
+// still-enabled sibling so a keyboard user never drops to <body>.
+function MoveControls({
+  disabledUp, disabledDown, onUp, onDown, labelUp, labelDown, testIdUp, testIdDown,
+}: {
+  disabledUp: boolean;
+  disabledDown: boolean;
+  onUp: () => void;
+  onDown: () => void;
+  labelUp: string;
+  labelDown: string;
+  testIdUp: string;
+  testIdDown: string;
+}) {
+  const upRef = useRef<HTMLButtonElement>(null);
+  const downRef = useRef<HTMLButtonElement>(null);
+  const move = (dir: 'up' | 'down') => {
+    (dir === 'up' ? onUp : onDown)();
+    if (typeof requestAnimationFrame === 'undefined') return;
+    requestAnimationFrame(() => {
+      const pressed = dir === 'up' ? upRef.current : downRef.current;
+      const other = dir === 'up' ? downRef.current : upRef.current;
+      if (pressed && !pressed.disabled) pressed.focus();
+      else other?.focus();
+    });
+  };
+  const cls = 'inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-30';
+  return (
+    <>
+      <button ref={upRef} type="button" onClick={() => move('up')} disabled={disabledUp} aria-label={labelUp} data-testid={testIdUp} className={cls}>
+        <ChevronUp className="h-4 w-4" aria-hidden />
+      </button>
+      <button ref={downRef} type="button" onClick={() => move('down')} disabled={disabledDown} aria-label={labelDown} data-testid={testIdDown} className={cls}>
+        <ChevronDown className="h-4 w-4" aria-hidden />
+      </button>
+    </>
+  );
+}
+
 export default function QuoteEditor({ detail, onChanged }: Props) {
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
+  // Focus anchor: after a confirmed block/line removal the triggering button is
+  // gone, so we move focus here instead of letting it fall to <body> (which dumps
+  // a keyboard user to the top of the page).
+  const blocksColRef = useRef<HTMLDivElement>(null);
 
-  const [busy, setBusy] = useState(false);
+  // Per-item "saving" state, keyed so one in-flight mutation never freezes the
+  // rest of the editor. Keys: 'terms', 'tax', 'add-block', `block:<id>`,
+  // `add-line:<blockId>`, `line:<id>`. `pending` drives disabled styling;
+  // `inFlight` is the synchronous double-submit guard (state updates are async).
+  const inFlight = useRef<Set<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
+  const isPending = useCallback((key: string) => pending.has(key), [pending]);
+
+  // Run a scoped mutation: mark the key pending, run, surface failures via the
+  // standard handleActionError path, and always clear the key. Returns whether
+  // the mutation succeeded so callers can flash a quiet "Saved" cue.
+  const runScoped = useCallback(
+    async (key: string, fn: () => Promise<void>, errMsg: string): Promise<boolean> => {
+      if (inFlight.current.has(key)) return false;
+      inFlight.current.add(key);
+      setPending((s) => { const n = new Set(s); n.add(key); return n; });
+      try {
+        await fn();
+        return true;
+      } catch (err) {
+        handleActionError(err, errMsg);
+        return false;
+      } finally {
+        inFlight.current.delete(key);
+        setPending((s) => { const n = new Set(s); n.delete(key); return n; });
+      }
+    },
+    [],
+  );
+
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
   const [ecActive, setEcActive] = useState(false);
   const [terms, setTerms] = useState(quote.termsAndConditions ?? '');
   const [termsDirty, setTermsDirty] = useState(false);
+  // Tax rate is stored as a fraction ('0.07'); the input edits it as a percent ('7').
+  const [taxPct, setTaxPct] = useState(pctFromFraction(quote.taxRate));
+  const [taxDirty, setTaxDirty] = useState(false);
+  // Inline validation message for the tax field — an out-of-range/non-numeric
+  // entry no longer silently reverts; we keep the bad value and explain why.
+  const [taxError, setTaxError] = useState<string | null>(null);
+  // Quiet "Saved" cues for the right-rail blur-to-save fields, matching the
+  // per-line/per-block cue so the whole editor speaks one save language.
+  const [termsSaved, flashTermsSaved] = useSavedFlash();
+  const [taxSaved, flashTaxSaved] = useSavedFlash();
   const canCatalogWrite = can('catalog', 'write');
 
   // ---- add-block form ------------------------------------------------------
@@ -89,29 +205,90 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const [imageCaption, setImageCaption] = useState('');
 
   useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
+  useEffect(() => { setTaxPct(pctFromFraction(quote.taxRate)); setTaxDirty(false); }, [quote.taxRate]);
 
-  const refresh = useCallback(() => onChanged(), [onChanged]);
+  // Coalesce re-pulls: each mutation calls refresh(), but tab-through editing
+  // would otherwise fire one full GET /quotes/:id per field. This is a LEADING +
+  // trailing throttle, not a pure trailing debounce: the first edit of a burst
+  // refetches immediately (so the server-recomputed rail totals update at once),
+  // then further edits within the window collapse into a single trailing refetch
+  // that captures the final state. This caps requests at ~1 / window (guarding
+  // the documented US DB connection pressure) while never leaving the "Live
+  // totals" frozen mid-burst — a pure trailing debounce did exactly that.
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshTrailing = useRef(false);
+  useEffect(() => () => { if (refreshTimer.current) clearTimeout(refreshTimer.current); }, []);
+  const refresh = useCallback(() => {
+    if (refreshTimer.current) {
+      // Inside the cooldown window — remember to fire once more when it closes.
+      refreshTrailing.current = true;
+      return;
+    }
+    onChanged(); // leading edge: refetch now
+    const openWindow = () => {
+      refreshTimer.current = setTimeout(function close() {
+        refreshTimer.current = null;
+        if (refreshTrailing.current) {
+          refreshTrailing.current = false;
+          onChanged();
+          openWindow(); // reopen so a fresh burst keeps coalescing
+        }
+      }, 300);
+    };
+    openWindow();
+  }, [onChanged]);
 
   const saveTerms = useCallback(async () => {
-    if (busy || !termsDirty) return;
-    setBusy(true);
-    try {
+    if (!termsDirty) return;
+    const ok = await runScoped('terms', async () => {
       await runAction({
         request: () => fetchWithAuth(`/quotes/${quote.id}`, {
           method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
         }),
         errorFallback: 'Could not save terms.',
-        successMessage: 'Terms saved',
         onUnauthorized: UNAUTHORIZED,
       });
       setTermsDirty(false);
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save terms.');
-    } finally {
-      setBusy(false);
+    }, 'Could not save terms.');
+    if (ok) flashTermsSaved();
+  }, [termsDirty, terms, quote.id, refresh, runScoped, flashTermsSaved]);
+
+  // Persist the tax rate as a fraction. Empty clears it (null); otherwise the
+  // percent is validated against 0–100 (fraction 0–1, matching updateQuoteSchema).
+  // An out-of-range/non-numeric entry is kept in the field with an inline error
+  // rather than saved or silently reverted. The server recomputes taxTotal/total,
+  // so refresh() re-pulls.
+  const saveTaxRate = useCallback(async () => {
+    if (!taxDirty) return;
+    const trimmed = taxPct.trim();
+    let fraction: number | null;
+    if (trimmed === '') {
+      fraction = null;
+    } else {
+      const pct = Number(trimmed);
+      if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+        // Keep the user's entry (don't snap it away) and explain the constraint
+        // inline instead of swallowing it.
+        setTaxError('Enter a rate from 0 to 100.');
+        return;
+      }
+      fraction = Number((pct / 100).toFixed(5));
     }
-  }, [busy, termsDirty, terms, quote.id, refresh]);
+    setTaxError(null);
+    const ok = await runScoped('tax', async () => {
+      await runAction({
+        request: () => fetchWithAuth(`/quotes/${quote.id}`, {
+          method: 'PATCH', body: JSON.stringify({ taxRate: fraction }),
+        }),
+        errorFallback: 'Could not save the tax rate.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setTaxDirty(false);
+      refresh();
+    }, 'Could not save the tax rate.');
+    if (ok) flashTaxSaved();
+  }, [taxDirty, taxPct, quote.id, refresh, runScoped, flashTaxSaved]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -134,23 +311,120 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
 
   useEffect(() => { void loadEcStatus(); }, [loadEcStatus]);
 
+  // Optimistic order overrides so a reorder reflects instantly instead of waiting
+  // for the round-trip + (coalesced) refetch. Each is cleared the moment fresh
+  // server data arrives (the prop array identity changes on refresh), so the
+  // server order always wins once it lands; a failed reorder reverts immediately.
+  const [blockOrder, setBlockOrder] = useState<string[] | null>(null);
+  const [lineOrder, setLineOrder] = useState<Record<string, string[]>>({});
+  // Debounced reorder commit: repeat chevron clicks accumulate into the optimistic
+  // order instantly (no click is dropped while a PATCH is "in flight"); a single
+  // trailing PATCH per axis sends the final full id list. The server renumbers
+  // 0..n-1 from that list, so a coalesced final order is always correct. The
+  // `*Base` refs hold the latest optimistic id order so successive clicks within
+  // one tick stack on each other rather than re-reading a stale render.
+  const blockReorderTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const blockReorderBase = useRef<string[] | null>(null);
+  const lineReorderTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const lineReorderBase = useRef<Record<string, string[]>>({});
+  useEffect(() => { setBlockOrder(null); blockReorderBase.current = null; }, [blocks]);
+  useEffect(() => { setLineOrder({}); lineReorderBase.current = {}; }, [lines]);
+  useEffect(() => () => {
+    if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
+    Object.values(lineReorderTimers.current).forEach(clearTimeout);
+  }, []);
+
+  // Optimistic line drafts so the right-rail "Live totals" can recompute from
+  // in-progress edits instead of lagging behind the per-row optimistic totals.
+  // Each EditableLineRow reports its effective values while they diverge from the
+  // persisted line (and null once settled); the rail recomputes via the SAME
+  // computeQuoteTotals the server uses, so it can never settle to a different
+  // figure than the next GET returns.
+  const [lineDrafts, setLineDrafts] = useState<Record<string, QuoteLineForMath>>({});
+  const setLineDraft = useCallback((id: string, draft: QuoteLineForMath | null) => {
+    setLineDrafts((m) => {
+      if (!draft) {
+        if (!(id in m)) return m;
+        const n = { ...m }; delete n[id]; return n;
+      }
+      const prev = m[id];
+      if (prev && prev.quantity === draft.quantity && prev.unitPrice === draft.unitPrice
+        && prev.taxable === draft.taxable && prev.recurrence === draft.recurrence) return m;
+      return { ...m, [id]: draft };
+    });
+  }, []);
+  // Drop drafts for lines that no longer exist (removed) so a stale draft can't
+  // skew the rail after a delete.
+  useEffect(() => {
+    setLineDrafts((m) => {
+      const live = new Set(lines.map((l) => l.id));
+      const stale = Object.keys(m).filter((id) => !live.has(id));
+      if (stale.length === 0) return m;
+      const n = { ...m }; stale.forEach((id) => delete n[id]); return n;
+    });
+  }, [lines]);
+
+  // The effective tax rate the rail should reflect: the committed server rate
+  // normally, but the live tax-field value while it's mid-edit (and valid). An
+  // out-of-range/non-numeric entry isn't applied — it falls back to the committed
+  // rate, matching saveTaxRate's own rejection of out-of-range values — so the
+  // rail never previews garbage.
+  const committedRate = quote.taxRate ? parseFloat(quote.taxRate) : null;
+  const effectiveRate = useMemo<number | null>(() => {
+    if (!taxDirty) return committedRate;
+    const trimmed = taxPct.trim();
+    if (trimmed === '') return null;
+    const pct = Number(trimmed);
+    if (!Number.isFinite(pct) || pct < 0 || pct > 100) return committedRate;
+    return Number((pct / 100).toFixed(5));
+  }, [taxDirty, taxPct, committedRate]);
+  const rateChanged = effectiveRate !== committedRate;
+
+  // The figures the rail renders: optimistic recompute when any line is mid-edit
+  // OR the tax rate is mid-edit, otherwise the authoritative server values.
+  const optimisticTotals = useMemo<QuoteTotals | null>(() => {
+    if (Object.keys(lineDrafts).length === 0 && !rateChanged) return null;
+    const merged: QuoteLineForMath[] = lines.map((l) => {
+      const d = lineDrafts[l.id];
+      return d ?? {
+        quantity: l.quantity, unitPrice: l.unitPrice, taxable: l.taxable,
+        customerVisible: l.customerVisible, recurrence: l.recurrence,
+      };
+    });
+    return computeQuoteTotals(merged, effectiveRate);
+  }, [lineDrafts, lines, effectiveRate, rateChanged]);
+  const railOneTime = optimisticTotals?.oneTimeTotal ?? quote.oneTimeTotal;
+  const railMonthly = optimisticTotals?.monthlyRecurringTotal ?? quote.monthlyRecurringTotal;
+  const railAnnual = optimisticTotals?.annualRecurringTotal ?? quote.annualRecurringTotal;
+  const railTax = optimisticTotals?.taxTotal ?? quote.taxTotal;
+  const railTotal = optimisticTotals?.total ?? quote.total;
+  const railDue = optimisticTotals?.dueOnAcceptanceTotal ?? quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
+
+  // Apply an optimistic id ordering over a base list, but only if it's a clean
+  // permutation (same membership) — otherwise fall back to the server order.
+  const applyOrder = <T extends { id: string }>(base: T[], order: string[] | undefined): T[] => {
+    if (!order) return base;
+    const byId = new Map(base.map((x) => [x.id, x]));
+    const ordered = order.map((id) => byId.get(id)).filter((x): x is T => x !== undefined);
+    return ordered.length === base.length ? ordered : base;
+  };
+
   const sortedBlocks = useMemo(
-    () => [...blocks].sort((a, b) => a.sortOrder - b.sortOrder),
-    [blocks],
+    () => applyOrder([...blocks].sort((a, b) => a.sortOrder - b.sortOrder), blockOrder ?? undefined),
+    [blocks, blockOrder],
   );
 
   const linesForBlock = useCallback(
     (blockId: string) =>
-      lines
-        .filter((l) => l.blockId === blockId)
-        .sort((a, b) => a.sortOrder - b.sortOrder),
-    [lines],
+      applyOrder(
+        lines.filter((l) => l.blockId === blockId).sort((a, b) => a.sortOrder - b.sortOrder),
+        lineOrder[blockId],
+      ),
+    [lines, lineOrder],
   );
 
   // ---- add block -----------------------------------------------------------
   const submitBlock = useCallback(async () => {
-    if (busy) return;
-
     // Image blocks have no block-update endpoint, so the file must exist before
     // the block: upload it (POST /:id/images → { data: { imageId } }), then add
     // an image block with that imageId already in its content. Both steps go
@@ -158,8 +432,13 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     if (addType === 'image') {
       const file = imageFile;
       if (!file) return;
-      setBusy(true);
-      try {
+      // Honor the "up to 5 MB" promise client-side so the user gets an immediate,
+      // specific message instead of a generic server-side upload failure.
+      if (file.size > 5 * 1024 * 1024) {
+        handleActionError(new Error('image too large'), 'Image must be 5 MB or smaller.');
+        return;
+      }
+      await runScoped('add-block', async () => {
         const uploaded = await runAction<{ imageId: string }>({
           request: () => uploadQuoteImage(quote.id, file),
           errorFallback: 'Could not upload the image.',
@@ -181,11 +460,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         });
         setImageFile(null); setImageCaption('');
         refresh();
-      } catch (err) {
-        handleActionError(err, 'Could not add the image block.');
-      } finally {
-        setBusy(false);
-      }
+      }, 'Could not add the image block.');
       return;
     }
 
@@ -202,8 +477,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         content: tableLabel.trim() ? { label: tableLabel.trim() } : {},
       };
     }
-    setBusy(true);
-    try {
+    await runScoped('add-block', async () => {
       await runAction({
         request: () => addBlock(quote.id, body),
         errorFallback: 'Could not add the block.',
@@ -212,20 +486,21 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       });
       setHeadingText(''); setRichText(''); setTableLabel('');
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not add the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh]);
+    }, 'Could not add the block.');
+  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, quote.id, refresh, runScoped]);
+
+  // Removing a line_items block cascades to every line under it (server-side), so
+  // the card's Remove button opens a confirm step instead of deleting outright.
+  const [pendingRemove, setPendingRemove] = useState<QuoteBlock | null>(null);
+  // Line removal is equally irreversible, so it gets the same confirm step the
+  // block remove has (rather than deleting on a single click).
+  const [pendingLineRemove, setPendingLineRemove] = useState<QuoteLine | null>(null);
 
   // Real block delete: removes the block and (server-side) any lines attached to
   // it. Works for every block type — heading, rich_text, and line_items — so the
   // "Remove" button is no longer a silent no-op for heading/rich_text blocks.
-  const removeBlock = useCallback(async (block: QuoteBlock) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const removeBlock = useCallback((block: QuoteBlock) =>
+    runScoped(`block:${block.id}`, async () => {
       await runAction({
         request: () => deleteBlock(quote.id, block.id),
         errorFallback: 'Could not remove the block.',
@@ -233,12 +508,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not remove the block.'),
+  [quote.id, refresh, runScoped]);
 
   // ---- line mutations (scoped to a line_items block) ----------------------
   const doAddCatalog = useCallback(async (blockId: string, item: CatalogItem) => {
@@ -251,13 +522,9 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     refresh();
   }, [quote.id, refresh]);
 
-  const addCatalog = useCallback(async (blockId: string, item: CatalogItem) => {
-    if (busy) return;
-    setBusy(true);
-    try { await doAddCatalog(blockId, item); }
-    catch (err) { handleActionError(err, 'Could not add the catalog item.'); }
-    finally { setBusy(false); }
-  }, [busy, doAddCatalog]);
+  const addCatalog = useCallback((blockId: string, item: CatalogItem) =>
+    runScoped(`add-line:${blockId}`, () => doAddCatalog(blockId, item), 'Could not add the catalog item.'),
+  [doAddCatalog, runScoped]);
 
   const resolveCatalogBySku = useCallback(async (sku: string): Promise<CatalogItem | null> => {
     const fromState = catalog.find((i) => i.sku === sku);
@@ -272,10 +539,8 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
     return (body?.data ?? []).find((i) => i.sku === sku) ?? null;
   }, [catalog]);
 
-  const importAndAddDistributor = useCallback(async (blockId: string, product: EcProduct, sellPrice: number) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const importAndAddDistributor = useCallback((blockId: string, product: EcProduct, sellPrice: number) =>
+    runScoped(`add-line:${blockId}`, async () => {
       // Check the catalog first: if this SKU is already imported, add the existing
       // item directly. This avoids the duplicate-SKU error toast (runAction toasts
       // the failure before throwing) firing on the common "already in catalog" path,
@@ -302,27 +567,36 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
       }
       await doAddCatalog(blockId, item);
       void loadCatalog(); // surface a newly-imported item in the catalog picker too
-    } catch (err) {
-      handleActionError(err, 'Could not add the distributor item.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, doAddCatalog, resolveCatalogBySku, loadCatalog]);
+    }, 'Could not add the distributor item.'),
+  [doAddCatalog, resolveCatalogBySku, loadCatalog, runScoped]);
 
-  const addManual = useCallback(async (
+  const addManual = useCallback((
     blockId: string,
     form: { description: string; quantity: string; unitPrice: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean },
   ) => {
-    if (busy || !form.description.trim()) return;
-    setBusy(true);
-    try {
+    if (!form.description.trim()) return Promise.resolve(false);
+    // Guard qty 0 / non-numeric here too — the inline edit path already does, and
+    // a silent $0-quantity line is a real footgun on the add path.
+    const qtyNum = Number(form.quantity);
+    if (!Number.isFinite(qtyNum) || qtyNum <= 0) {
+      handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+      return Promise.resolve(false);
+    }
+    // Guard the unit price too (parity with the inline edit path's commitPrice):
+    // a negative/NaN price shouldn't depend on the server to reject it.
+    const priceNum = Number(form.unitPrice);
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+      return Promise.resolve(false);
+    }
+    return runScoped(`add-line:${blockId}`, async () => {
       await runAction({
         request: () => addManualLine(quote.id, {
           sourceType: 'manual',
           blockId,
           description: form.description.trim(),
-          quantity: Number(form.quantity),
-          unitPrice: Number(form.unitPrice),
+          quantity: qtyNum,
+          unitPrice: priceNum,
           taxable: form.taxable,
           customerVisible: true,
           recurrence: form.recurrence,
@@ -343,7 +617,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
               : form.recurrence === 'annual'
                 ? 'annual'
                 : null,
-            unitPrice: Number(form.unitPrice),
+            unitPrice: priceNum,
             taxable: form.taxable,
           }),
           errorFallback: 'Line added, but saving it to the catalog failed.',
@@ -353,17 +627,11 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         void loadCatalog();
       }
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not add the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh, loadCatalog]);
+    }, 'Could not add the line.');
+  }, [quote.id, refresh, loadCatalog, runScoped]);
 
-  const deleteLine = useCallback(async (lineId: string) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const deleteLine = useCallback((lineId: string) =>
+    runScoped(`line:${lineId}`, async () => {
       await runAction({
         request: () => removeLine(quote.id, lineId),
         errorFallback: 'Could not remove the line.',
@@ -371,86 +639,156 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not remove the line.'),
+  [quote.id, refresh, runScoped]);
 
   // Inline edit of an existing line. `body` carries only the changed fields
-  // (matches updateQuoteLineSchema). Routed through runAction so success/failure
-  // is surfaced, then refresh() re-pulls the quote so totals recompute.
-  const editLine = useCallback(async (lineId: string, body: LineUpdate) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  // (matches updateQuoteLineSchema). Routed through runAction so failures are
+  // surfaced, then refresh() re-pulls the quote so totals recompute. Returns
+  // whether it succeeded so the row can flash a quiet "Saved" cue — routine
+  // inline edits no longer fire a success toast (that was per-field spam).
+  const editLine = useCallback((lineId: string, body: LineUpdate) =>
+    runScoped(`line:${lineId}`, async () => {
       await runAction({
         request: () => updateLine(quote.id, lineId, body),
         errorFallback: 'Could not update the line.',
-        successMessage: 'Line updated',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not update the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not update the line.'),
+  [quote.id, refresh, runScoped]);
 
   // Inline edit of a block's content (heading text/level, rich-text html). The
   // block type is restated so the server validates the content shape; it is
-  // immutable and never changes here.
-  const editBlock = useCallback(async (block: QuoteBlock, content: Record<string, unknown>) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  // immutable and never changes here. Like editLine, success is quiet (the row
+  // flashes "Saved"); only failures toast.
+  const editBlock = useCallback((block: QuoteBlock, content: Record<string, unknown>) =>
+    runScoped(`block:${block.id}`, async () => {
       await runAction({
         request: () => updateBlock(quote.id, block.id, { blockType: block.blockType, content } as QuoteBlockInput),
         errorFallback: 'Could not update the block.',
-        successMessage: 'Block updated',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not update the block.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, refresh]);
+    }, 'Could not update the block.'),
+  [quote.id, refresh, runScoped]);
 
-  const hasRecurring =
-    Number(quote.monthlyRecurringTotal) > 0 || Number(quote.annualRecurringTotal) > 0;
+  // Reorder a block one slot up/down. The optimistic order updates instantly on
+  // every click (clicks accumulate — none are dropped while a PATCH is pending),
+  // and a single trailing PATCH per burst sends the final full id list, which the
+  // server renumbers 0..n-1. Each click stacks on `blockReorderBase` so a flurry
+  // of clicks moves an item several slots before one request goes out. A failed
+  // reorder clears the override and re-pulls the authoritative server order.
+  const moveBlock = useCallback((block: QuoteBlock, direction: 'up' | 'down') => {
+    const currentIds = blockReorderBase.current ?? sortedBlocks.map((b) => b.id);
+    const idx = currentIds.indexOf(block.id);
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
+    const ids = [...currentIds];
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    blockReorderBase.current = ids;
+    setBlockOrder(ids); // optimistic, instant
+    // Debounce the PATCH (not runScoped — its shared key would drop a second
+    // reorder that fires while the first is still in flight; the debounce already
+    // coalesces a burst). runAction surfaces failures; on failure we drop the
+    // override and re-pull the authoritative order.
+    if (blockReorderTimer.current) clearTimeout(blockReorderTimer.current);
+    blockReorderTimer.current = setTimeout(() => {
+      blockReorderTimer.current = null;
+      void (async () => {
+        try {
+          await runAction({
+            request: () => reorderBlocksApi(quote.id, { blockIds: ids }),
+            errorFallback: 'Could not reorder blocks.',
+            onUnauthorized: UNAUTHORIZED,
+          });
+          refresh();
+        } catch (err) {
+          handleActionError(err, 'Could not reorder blocks.');
+          setBlockOrder(null);
+          blockReorderBase.current = null;
+          refresh();
+        }
+      })();
+    }, 250);
+  }, [sortedBlocks, quote.id, refresh]);
+
+  const moveLine = useCallback((blockId: string, line: QuoteLine, direction: 'up' | 'down') => {
+    const currentIds = lineReorderBase.current[blockId] ?? linesForBlock(blockId).map((l) => l.id);
+    const idx = currentIds.indexOf(line.id);
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= currentIds.length) return;
+    const ids = [...currentIds];
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    lineReorderBase.current = { ...lineReorderBase.current, [blockId]: ids };
+    setLineOrder((m) => ({ ...m, [blockId]: ids })); // optimistic, instant
+    const existing = lineReorderTimers.current[blockId];
+    if (existing) clearTimeout(existing);
+    lineReorderTimers.current[blockId] = setTimeout(() => {
+      delete lineReorderTimers.current[blockId];
+      void (async () => {
+        try {
+          await runAction({
+            request: () => reorderLinesApi(quote.id, blockId, { lineIds: ids }),
+            errorFallback: 'Could not reorder lines.',
+            onUnauthorized: UNAUTHORIZED,
+          });
+          refresh();
+        } catch (err) {
+          handleActionError(err, 'Could not reorder lines.');
+          setLineOrder((m) => { const n = { ...m }; delete n[blockId]; return n; });
+          delete lineReorderBase.current[blockId];
+          refresh();
+        }
+      })();
+    }, 250);
+  }, [linesForBlock, quote.id, refresh]);
+
+  const hasRecurring = Number(railMonthly) > 0 || Number(railAnnual) > 0;
 
   return (
     <div className="space-y-6" data-testid="quote-editor">
+      {canWrite && (
+        <p className="text-xs text-muted-foreground" data-testid="quote-editor-autosave-hint">
+          Changes save automatically as you edit. An amber outline marks an edit that hasn’t saved yet.
+        </p>
+      )}
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         {/* ── blocks ─────────────────────────────────────────────────── */}
-        <div className="space-y-4">
+        <div
+          className="space-y-4 rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          ref={blocksColRef}
+          tabIndex={-1}
+        >
           {sortedBlocks.length === 0 ? (
             <div className="rounded-lg border border-dashed bg-card p-8 text-center text-sm text-muted-foreground" data-testid="quote-blocks-empty">
               No content yet. Add a heading, rich text, or a pricing table below.
             </div>
           ) : (
-            sortedBlocks.map((block) => (
+            sortedBlocks.map((block, idx) => (
               <BlockCard
                 key={block.id}
                 block={block}
                 quoteId={quote.id}
                 lines={linesForBlock(block.id)}
                 currency={currency}
+                taxRate={quote.taxRate}
                 catalog={catalog}
-                busy={busy}
+                isPending={isPending}
                 canWrite={canWrite}
                 ecActive={ecActive}
+                isFirst={idx === 0}
+                isLast={idx === sortedBlocks.length - 1}
                 onAddCatalog={addCatalog}
                 onImportAddDistributor={importAndAddDistributor}
                 onAddManual={addManual}
                 onEditLine={editLine}
                 onEditBlock={editBlock}
-                onRemoveLine={deleteLine}
-                onRemoveBlock={removeBlock}
+                onMoveBlock={moveBlock}
+                onMoveLine={(line, dir) => moveLine(block.id, line, dir)}
+                onRemoveLine={setPendingLineRemove}
+                onRemoveBlock={setPendingRemove}
+                onLineDraft={setLineDraft}
               />
             ))
           )}
@@ -464,6 +802,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 <button
                   key={o.value}
                   type="button"
+                  aria-pressed={addType === o.value}
                   onClick={() => setAddType(o.value)}
                   data-testid={`quote-add-block-type-${o.value}`}
                   className={`rounded-md border px-3 py-1.5 text-xs font-medium ${
@@ -531,7 +870,7 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
                 type="button"
                 onClick={() => void submitBlock()}
                 disabled={
-                  busy ||
+                  isPending('add-block') ||
                   (addType === 'heading' && !headingText.trim()) ||
                   (addType === 'rich_text' && !richText.trim()) ||
                   (addType === 'image' && !imageFile)
@@ -547,90 +886,215 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
         </div>
 
         {/* ── live totals + terms ────────────────────────────────────── */}
-        <div className="space-y-4">
+        {/* Sticky on lg so the totals you're building against stay visible while
+            scrolling the blocks; on narrow widths this column stacks below. */}
+        <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="quote-live-totals">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
+            {/* One concise SR announcement covering every figure, so editing a
+                recurring line (which doesn't move "due on acceptance") still tells
+                a screen-reader user the totals recomputed. */}
+            <p className="sr-only" role="status" data-testid="quote-totals-sr">
+              {`Totals updated. One-time ${formatMoney(railOneTime, currency)}, `
+                + `monthly recurring ${formatMoney(railMonthly, currency)}, `
+                + `annual recurring ${formatMoney(railAnnual, currency)}`
+                + (Number(railTax) > 0 ? `, tax ${formatMoney(railTax, currency)}` : '')
+                + `, due on acceptance ${formatMoney(railDue, currency)}.`}
+            </p>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">One-time</dt>
-                <dd data-testid="quote-total-onetime">{formatMoney(quote.oneTimeTotal, currency)}</dd>
+                <dd data-testid="quote-total-onetime">{formatMoney(railOneTime, currency)}</dd>
               </div>
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">Monthly recurring</dt>
-                <dd data-testid="quote-total-monthly">{formatMoney(quote.monthlyRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd>
+                <dd data-testid="quote-total-monthly">{formatMoney(railMonthly, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd>
               </div>
               <div className="flex items-baseline justify-between">
                 <dt className="text-muted-foreground">Annual recurring</dt>
-                <dd data-testid="quote-total-annual">{formatMoney(quote.annualRecurringTotal, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd>
+                <dd data-testid="quote-total-annual">{formatMoney(railAnnual, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd>
               </div>
-              {Number(quote.taxTotal) > 0 && (
+              {Number(railTax) > 0 && (
                 <div className="flex items-baseline justify-between">
                   <dt className="text-muted-foreground">Tax</dt>
-                  <dd>{formatMoney(quote.taxTotal, currency)}</dd>
+                  <dd>{formatMoney(railTax, currency)}</dd>
                 </div>
               )}
             </dl>
-            <div className="mt-3 flex items-end justify-between border-t pt-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
-              <span className="text-2xl font-semibold tabular-nums" data-testid="quote-total-due-on-acceptance">
-                {formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency)}
+            {canWrite && (
+              <div className="mt-2 border-t pt-2">
+                <div className="flex items-center justify-between gap-2">
+                  <label htmlFor="quote-tax-rate" className="flex items-center gap-2 text-sm text-muted-foreground">
+                    Tax rate
+                    {taxSaved && <span className="text-xs font-medium text-success" data-testid="quote-tax-saved">Saved</span>}
+                  </label>
+                  <div className="flex items-center gap-1">
+                    <input
+                      id="quote-tax-rate"
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.001"
+                      value={taxPct}
+                      onChange={(e) => { setTaxPct(e.target.value); setTaxDirty(true); if (taxError) setTaxError(null); }}
+                      onBlur={() => void saveTaxRate()}
+                      disabled={isPending('tax')}
+                      placeholder="0"
+                      aria-invalid={taxError !== null}
+                      aria-describedby={taxError ? 'quote-tax-rate-error' : undefined}
+                      data-testid="quote-tax-rate"
+                      className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${
+                        taxError ? 'border-destructive ring-1 ring-destructive' : taxDirty ? 'ring-1 ring-warning' : ''
+                      }`}
+                    />
+                    <span className="text-sm text-muted-foreground">%</span>
+                  </div>
+                </div>
+                {taxError ? (
+                  <p className="mt-1 text-xs text-destructive" id="quote-tax-rate-error" role="alert" data-testid="quote-tax-rate-error">{taxError}</p>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">Applies to lines marked taxable.</p>
+                )}
+                <SrSaved show={taxSaved} />
+              </div>
+            )}
+            <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
+              {/* Visual figure only; the SR-only summary node above announces the
+                  full set of totals on any change. */}
+              <span
+                className="min-w-0 break-words text-right text-2xl font-semibold tabular-nums"
+                data-testid="quote-total-due-on-acceptance"
+              >
+                {formatMoney(railDue, currency)}
               </span>
             </div>
             {hasRecurring && (
               <>
                 <div className="mt-2 flex items-baseline justify-between text-sm tabular-nums">
                   <span className="text-muted-foreground">First-period total (incl. recurring)</span>
-                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(quote.total, currency)}</span>
+                  <span className="font-medium" data-testid="quote-total-first-period">{formatMoney(railTotal, currency)}</span>
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground" data-testid="quote-totals-recurring-hint">
-                  Accepting this quote invoices only the one-time charges now. Recurring lines (monthly + annual) bill on their own schedule via the contract. The first-period total combines the one-time charges with the first period of each recurring cadence.
-                </p>
+                <RecurringBillingNote className="mt-2" testId="quote-totals-recurring-hint" />
               </>
             )}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Terms & Conditions</h3>
+              <span className="flex items-center gap-2">
+                {termsSaved && <span className="text-xs font-medium text-success" data-testid="quote-terms-saved">Saved</span>}
+                <UnsavedBadge show={termsDirty} />
+              </span>
+            </div>
             <textarea
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
               onBlur={() => { if (canWrite) void saveTerms(); }}
-              disabled={!canWrite}
+              disabled={!canWrite || isPending('terms')}
               data-testid="quote-terms"
               rows={3}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
+            <SrSaved show={termsSaved} />
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        onClose={() => setPendingRemove(null)}
+        onConfirm={() => {
+          const block = pendingRemove;
+          if (!block) return;
+          // Keep the dialog open and awaiting (so isLoading shows "Processing…")
+          // until the delete resolves. On failure (already toasted by runAction)
+          // leave the dialog open so the user can retry or cancel — don't close as
+          // if it worked while the block is still there. On success, close and move
+          // focus to a stable anchor — the triggering Remove button is gone.
+          void (async () => {
+            if (!(await removeBlock(block))) return;
+            setPendingRemove(null);
+            blocksColRef.current?.focus();
+          })();
+        }}
+        isLoading={pendingRemove ? isPending(`block:${pendingRemove.id}`) : false}
+        title="Remove block"
+        message={
+          pendingRemove?.blockType === 'line_items' && linesForBlock(pendingRemove.id).length > 0
+            ? `This removes the pricing table and its ${linesForBlock(pendingRemove.id).length} line item${
+                linesForBlock(pendingRemove.id).length === 1 ? '' : 's'
+              }. This can't be undone.`
+            : 'This removes this block. This can’t be undone.'
+        }
+        confirmLabel="Remove block"
+        confirmTestId="quote-block-remove-confirm"
+      />
+
+      <ConfirmDialog
+        open={pendingLineRemove !== null}
+        onClose={() => setPendingLineRemove(null)}
+        onConfirm={() => {
+          const line = pendingLineRemove;
+          if (!line) return;
+          // Leave the dialog open on failure (already toasted) so the user can
+          // retry; only close + restore focus once the line is actually gone.
+          void (async () => {
+            if (!(await deleteLine(line.id))) return;
+            setPendingLineRemove(null);
+            blocksColRef.current?.focus();
+          })();
+        }}
+        isLoading={pendingLineRemove ? isPending(`line:${pendingLineRemove.id}`) : false}
+        title="Remove line"
+        message={
+          pendingLineRemove
+            ? `This removes "${pendingLineRemove.description || 'this line'}" from the quote. This can’t be undone.`
+            : ''
+        }
+        confirmLabel="Remove line"
+        confirmTestId="quote-line-remove-confirm"
+      />
     </div>
   );
 }
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, catalog, busy, canWrite, ecActive, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onRemoveLine, onRemoveBlock,
+  block, quoteId, lines, currency, taxRate, catalog, isPending, canWrite, ecActive, isFirst, isLast, onAddCatalog, onImportAddDistributor, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock, onLineDraft,
 }: {
   block: QuoteBlock;
   quoteId: string;
   lines: QuoteLine[];
   currency: string;
+  taxRate: string | null;
   catalog: CatalogItem[];
-  busy: boolean;
+  isPending: (key: string) => boolean;
   canWrite: boolean;
   ecActive: boolean;
+  isFirst: boolean;
+  isLast: boolean;
   onAddCatalog: (blockId: string, item: CatalogItem) => void;
   onImportAddDistributor: (blockId: string, product: EcProduct, sellPrice: number) => void;
   onAddManual: (
     blockId: string,
     form: { description: string; quantity: string; unitPrice: string; taxable: boolean; recurrence: QuoteLineRecurrence; saveToCatalog: boolean },
-  ) => void;
-  onEditLine: (lineId: string, body: LineUpdate) => void;
-  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => void;
-  onRemoveLine: (lineId: string) => void;
+  ) => Promise<boolean>;
+  onEditLine: (lineId: string, body: LineUpdate) => Promise<boolean>;
+  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => Promise<boolean>;
+  onMoveBlock: (block: QuoteBlock, direction: 'up' | 'down') => void;
+  onMoveLine: (line: QuoteLine, direction: 'up' | 'down') => void;
+  onRemoveLine: (line: QuoteLine) => void;
   onRemoveBlock: (block: QuoteBlock) => void;
+  onLineDraft: (lineId: string, draft: QuoteLineForMath | null) => void;
 }) {
+  // Pending state scoped to this block: editing/removing this block, or adding a
+  // line to it, never disables anything in a sibling block.
+  const blockBusy = isPending(`block:${block.id}`);
+  const addLineBusy = isPending(`add-line:${block.id}`);
+
   const [mode, setMode] = useState<'catalog' | 'manual' | 'distributor'>('catalog');
   const [desc, setDesc] = useState('');
   const [qty, setQty] = useState('1');
@@ -650,41 +1114,82 @@ function BlockCard({
   // changes (e.g. after a refresh) so server normalization wins.
   const [headingDraft, setHeadingDraft] = useState(heading);
   const [richDraft, setRichDraft] = useState(html);
-  useEffect(() => { setHeadingDraft(heading); }, [heading]);
-  useEffect(() => { setRichDraft(html); }, [html]);
+  // Resync drafts from the server only when the user hasn't diverged from what we
+  // last showed. A quiet reload (fired by an unrelated inline edit elsewhere) must
+  // not clobber heading/rich text this user is mid-edit in: if the local draft no
+  // longer matches the prop we last synced, the user has typed — keep their text.
+  const lastHeading = useRef(heading);
+  const lastHtml = useRef(html);
+  useEffect(() => {
+    setHeadingDraft((cur) => (cur === lastHeading.current ? heading : cur));
+    lastHeading.current = heading;
+  }, [heading]);
+  useEffect(() => {
+    setRichDraft((cur) => (cur === lastHtml.current ? html : cur));
+    lastHtml.current = html;
+  }, [html]);
 
-  const commitHeading = () => {
+  // Quiet "Saved" flash for inline content edits (replaces the old per-edit
+  // success toast). Cleared on unmount so a late timer can't setState a gone row.
+  const [blockSaved, setBlockSaved] = useState(false);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedTimer.current) clearTimeout(savedTimer.current); }, []);
+  const flashSaved = useCallback(() => {
+    setBlockSaved(true);
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+    savedTimer.current = setTimeout(() => setBlockSaved(false), 1500);
+  }, []);
+
+  const commitHeading = async () => {
     const text = headingDraft.trim();
     if (!text || text === heading) { setHeadingDraft(heading); return; }
-    onEditBlock(block, { text, level: (block.content?.level as number | undefined) ?? 2 });
+    if (await onEditBlock(block, { text, level: (block.content?.level as number | undefined) ?? 2 })) flashSaved();
   };
-  const commitRich = () => {
+  const commitRich = async () => {
     if (richDraft === html) return;
-    onEditBlock(block, { html: richDraft });
+    if (await onEditBlock(block, { html: richDraft })) flashSaved();
   };
 
-  const submitManual = () => {
-    onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
-    setDesc(''); setQty('1'); setPrice('0.00'); setTaxable(false); setRecurrence('one_time'); setSaveToCatalog(false);
+  const submitManual = async () => {
+    const ok = await onAddManual(block.id, { description: desc, quantity: qty, unitPrice: price, taxable, recurrence, saveToCatalog });
+    // Only clear the form on success, so a rejected add (e.g. qty 0) keeps the
+    // user's input to correct rather than wiping it.
+    if (ok) { setDesc(''); setQty('1'); setPrice('0.00'); setTaxable(false); setRecurrence('one_time'); setSaveToCatalog(false); }
   };
 
   return (
     <div className="rounded-lg border bg-card shadow-xs" data-testid={`quote-block-${block.id}`}>
       <div className="flex items-center justify-between border-b px-4 py-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {BLOCK_TYPE_LABELS[block.blockType] ?? block.blockType}
           {isTable && tableLabel ? ` · ${tableLabel}` : ''}
+          {blockSaved && (
+            <span className="font-medium normal-case tracking-normal text-success" data-testid={`quote-block-saved-${block.id}`}>Saved</span>
+          )}
+          <SrSaved show={blockSaved} />
         </span>
         {canWrite && (
-          <button
-            type="button"
-            onClick={() => onRemoveBlock(block)}
-            disabled={busy}
-            data-testid={`quote-block-remove-${block.id}`}
-            className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-          >
-            Remove
-          </button>
+          <div className="flex items-center gap-1">
+            <MoveControls
+              disabledUp={isFirst}
+              disabledDown={isLast}
+              onUp={() => onMoveBlock(block, 'up')}
+              onDown={() => onMoveBlock(block, 'down')}
+              labelUp="Move block up"
+              labelDown="Move block down"
+              testIdUp={`quote-block-move-up-${block.id}`}
+              testIdDown={`quote-block-move-down-${block.id}`}
+            />
+            <button
+              type="button"
+              onClick={() => onRemoveBlock(block)}
+              disabled={blockBusy}
+              data-testid={`quote-block-remove-${block.id}`}
+              className="rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+            >
+              Remove
+            </button>
+          </div>
         )}
       </div>
 
@@ -693,11 +1198,12 @@ function BlockCard({
           canWrite ? (
             <input
               value={headingDraft}
+              aria-label="Heading text"
               onChange={(e) => setHeadingDraft(e.target.value)}
-              onBlur={commitHeading}
-              disabled={busy}
+              onBlur={() => void commitHeading()}
+              disabled={blockBusy}
               data-testid={`quote-block-heading-input-${block.id}`}
-              className="w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold"
+              className={`w-full rounded-md border bg-background px-2 py-1 text-lg font-semibold disabled:opacity-60 ${headingDraft.trim() !== heading ? 'ring-1 ring-warning' : ''}`}
             />
           ) : (
             <p className="text-lg font-semibold" data-testid={`quote-block-heading-content-${block.id}`}>{heading}</p>
@@ -707,12 +1213,13 @@ function BlockCard({
           canWrite ? (
             <textarea
               value={richDraft}
+              aria-label="Rich text content"
               onChange={(e) => setRichDraft(e.target.value)}
-              onBlur={commitRich}
-              disabled={busy}
+              onBlur={() => void commitRich()}
+              disabled={blockBusy}
               rows={4}
               data-testid={`quote-block-rich-input-${block.id}`}
-              className="w-full resize-y rounded-md border bg-background px-2 py-1 text-sm"
+              className={`w-full resize-y rounded-md border bg-background px-2 py-1 text-sm disabled:opacity-60 ${richDraft !== html ? 'ring-1 ring-warning' : ''}`}
             />
           ) : (
             <p className="whitespace-pre-wrap text-sm text-foreground" data-testid={`quote-block-rich-content-${block.id}`}>{html}</p>
@@ -731,13 +1238,23 @@ function BlockCard({
 
         {isTable && (
           <div className="space-y-3">
-            <table className="w-full text-sm" data-testid={`quote-block-lines-${block.id}`}>
+            {/* The 7-column row (description + 4 inline controls + total + actions)
+                can't compress gracefully on a tablet, so the table keeps a sensible
+                min width and the wrapper scrolls horizontally below that. */}
+            <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-2 py-2 font-medium">Description</th>
                   <th className="px-2 py-2 text-right font-medium">Qty</th>
                   <th className="px-2 py-2 text-right font-medium">Unit</th>
                   <th className="px-2 py-2 font-medium">Recurrence</th>
+                  <th
+                    className="px-2 py-2 text-right font-medium"
+                    title="Per-line tax. The header Tax total is authoritative and may differ by a rounding cent."
+                  >
+                    Tax
+                  </th>
                   <th className="px-2 py-2 text-right font-medium">Total</th>
                   <th className="px-2 py-2" />
                 </tr>
@@ -745,20 +1262,25 @@ function BlockCard({
               <tbody>
                 {lines.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-2 py-6 text-center text-sm text-muted-foreground">
+                    <td colSpan={7} className="px-2 py-6 text-center text-sm text-muted-foreground">
                       No lines yet. Add a catalog item or a manual line below.
                     </td>
                   </tr>
                 ) : (
-                  lines.map((l) =>
+                  lines.map((l, idx) =>
                     canWrite ? (
                       <EditableLineRow
                         key={l.id}
                         line={l}
                         currency={currency}
-                        busy={busy}
+                        taxRate={taxRate}
+                        busy={isPending(`line:${l.id}`)}
+                        isFirst={idx === 0}
+                        isLast={idx === lines.length - 1}
                         onEdit={onEditLine}
+                        onMove={onMoveLine}
                         onRemove={onRemoveLine}
+                        onDraft={onLineDraft}
                       />
                     ) : (
                       <tr key={l.id} className="border-t" data-testid={`quote-line-${l.id}`}>
@@ -771,9 +1293,12 @@ function BlockCard({
                         <td className="px-2 py-2 text-right tabular-nums">{l.quantity}</td>
                         <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.unitPrice, currency)}</td>
                         <td className="px-2 py-2">
-                          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                             {formatRecurrence(l.recurrence)}
                           </span>
+                        </td>
+                        <td className="px-2 py-2 text-right tabular-nums text-muted-foreground">
+                          {lineTaxAmount(l.lineTotal, l.taxable, taxRate) === null ? '—' : formatMoney(lineTaxAmount(l.lineTotal, l.taxable, taxRate)!, currency)}
                         </td>
                         <td className="px-2 py-2 text-right tabular-nums">{formatMoney(l.lineTotal, currency)}</td>
                         <td className="px-2 py-2 text-right" />
@@ -783,6 +1308,7 @@ function BlockCard({
                 )}
               </tbody>
             </table>
+            </div>
 
             {/* Add line to this pricing table */}
             {canWrite && (
@@ -792,6 +1318,7 @@ function BlockCard({
                   <button
                     key={m}
                     type="button"
+                    aria-pressed={mode === m}
                     onClick={() => setMode(m)}
                     data-testid={`quote-line-mode-${block.id}-${m}`}
                     className={`rounded-md border px-3 py-1 text-xs font-medium ${
@@ -806,7 +1333,7 @@ function BlockCard({
               {mode === 'distributor' ? (
                 <DistributorLookup
                   blockId={block.id}
-                  busy={busy}
+                  busy={addLineBusy}
                   onImportAdd={(product, sellPrice) => onImportAddDistributor(block.id, product, sellPrice)}
                 />
               ) : mode === 'catalog' ? (
@@ -822,7 +1349,7 @@ function BlockCard({
                     onSelect={(it) => onAddCatalog(block.id, it)}
                     testId={`quote-catalog-picker-${block.id}`}
                     placeholder="Search catalog by name or SKU"
-                    disabled={busy}
+                    disabled={addLineBusy}
                   />
                 )
               ) : (
@@ -837,26 +1364,27 @@ function BlockCard({
                   />
                   <div className="grid grid-cols-1 items-start gap-2 sm:grid-cols-[1fr_70px_90px_110px]">
                     <textarea
-                      placeholder="Description" value={desc}
+                      placeholder="Description" aria-label="Line description" value={desc}
                       onChange={(e) => setDesc(e.target.value)}
                       rows={2}
                       data-testid={`quote-manual-desc-${block.id}`}
                       className="min-h-9 resize-y rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                     />
                     <input
-                      type="number" min="0" step="0.01" placeholder="Qty" value={qty}
+                      type="number" min="0" step="0.01" placeholder="Qty" aria-label="Quantity" value={qty}
                       onChange={(e) => setQty(e.target.value)}
                       data-testid={`quote-manual-qty-${block.id}`}
                       className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                     />
                     <input
-                      type="number" min="0" step="0.01" placeholder="Unit price" value={price}
+                      type="number" min="0" step="0.01" placeholder="Unit price" aria-label="Unit price" value={price}
                       onChange={(e) => setPrice(e.target.value)}
                       data-testid={`quote-manual-price-${block.id}`}
                       className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                     />
                     <select
                       value={recurrence}
+                      aria-label="Billing frequency"
                       onChange={(e) => setRecurrence(e.target.value as QuoteLineRecurrence)}
                       data-testid={`quote-manual-recurrence-${block.id}`}
                       className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
@@ -879,8 +1407,8 @@ function BlockCard({
                     </div>
                     <button
                       type="button"
-                      onClick={submitManual}
-                      disabled={busy || !desc.trim()}
+                      onClick={() => void submitManual()}
+                      disabled={addLineBusy || !desc.trim()}
                       data-testid={`quote-manual-add-${block.id}`}
                       className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                     >
@@ -907,37 +1435,133 @@ function BlockCard({
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 function EditableLineRow({
-  line, currency, busy, onEdit, onRemove,
+  line, currency, taxRate, busy, isFirst, isLast, onEdit, onMove, onRemove, onDraft,
 }: {
   line: QuoteLine;
   currency: string;
+  taxRate: string | null;
   busy: boolean;
-  onEdit: (lineId: string, body: LineUpdate) => void;
-  onRemove: (lineId: string) => void;
+  isFirst: boolean;
+  isLast: boolean;
+  onEdit: (lineId: string, body: LineUpdate) => Promise<boolean>;
+  onMove: (line: QuoteLine, direction: 'up' | 'down') => void;
+  onRemove: (line: QuoteLine) => void;
+  onDraft: (lineId: string, draft: QuoteLineForMath | null) => void;
 }) {
   const [desc, setDesc] = useState(line.description);
   const [qty, setQty] = useState(line.quantity);
   const [price, setPrice] = useState(line.unitPrice);
+  // recurrence/taxable are committed on change (not blur); keep them in local
+  // state so the control updates instantly rather than lagging until the
+  // refresh() round-trip lands, and revert if the save fails.
+  const [rec, setRec] = useState(line.recurrence);
+  const [taxable, setTaxable] = useState(line.taxable);
 
-  // Resync when the persisted line changes (after a refresh()).
-  useEffect(() => { setDesc(line.description); }, [line.description]);
-  useEffect(() => { setQty(line.quantity); }, [line.quantity]);
-  useEffect(() => { setPrice(line.unitPrice); }, [line.unitPrice]);
+  // Resync the typed fields from the server, but never over an edit in progress.
+  // We track "has the user typed since the last commit?" rather than comparing
+  // values: local state holds a raw string ('9.999') while the prop is a
+  // formatted decimal ('10.00'), so a value comparison both (a) fails to re-adopt
+  // a server-normalized value — leaving the row stuck amber-dirty showing a wrong
+  // optimistic total when the server rounds — and (b) is fragile across formats.
+  // The flag is set on keystroke and cleared when a commit is initiated (on blur), so:
+  //   • a quiet/leading-edge refresh landing mid-type keeps the user's keystrokes
+  //     ("edit qty→5, blur, type 7" never loses the 7), and
+  //   • after the user stops editing, the next prop adopts the server's canonical
+  //     value (e.g. 9.999 → 10.00), clearing the dirty ring and the optimism.
+  const descEdited = useRef(false);
+  const qtyEdited = useRef(false);
+  const priceEdited = useRef(false);
+  useEffect(() => { if (!descEdited.current) setDesc(line.description); }, [line.description]);
+  useEffect(() => { if (!qtyEdited.current) setQty(line.quantity); }, [line.quantity]);
+  useEffect(() => { if (!priceEdited.current) setPrice(line.unitPrice); }, [line.unitPrice]);
+  // recurrence/taxable are committed on change (the PATCH resolves before the
+  // refresh GET fires), so a stale resync can't race them — a plain resync wins.
+  useEffect(() => { setRec(line.recurrence); }, [line.recurrence]);
+  useEffect(() => { setTaxable(line.taxable); }, [line.taxable]);
+
+  // Quiet "Saved" flash in place of the old per-field success toast.
+  const [saved, setSaved] = useState(false);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedTimer.current) clearTimeout(savedTimer.current); }, []);
+  const flashSaved = useCallback(() => {
+    setSaved(true);
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+    savedTimer.current = setTimeout(() => setSaved(false), 1500);
+  }, []);
+  const edit = useCallback(async (body: LineUpdate): Promise<boolean> => {
+    const ok = await onEdit(line.id, body);
+    if (ok) flashSaved();
+    return ok;
+  }, [onEdit, line.id, flashSaved]);
+  // Per-field dirty cue (mirrors the terms/tax ring) so every editable surface
+  // signals unsaved state the same way.
+  const descDirty = desc.trim() !== line.description;
+  const qtyDirty = Number(qty) !== Number(line.quantity);
+  const priceDirty = Number(price) !== Number(line.unitPrice);
+
+  // Effective qty/price for the optimistic Total/Tax and the rail draft. A blank
+  // or non-positive qty / negative price isn't an optimism input — it would flash
+  // the line to $0 while the user is mid-retype (and `commitQty` rejects qty ≤ 0
+  // anyway), so fall back to the persisted value until the field holds a real one.
+  const qtyNum = Number(qty);
+  const priceNum = Number(price);
+  const qtyValid = qty.trim() !== '' && Number.isFinite(qtyNum) && qtyNum > 0;
+  const priceValid = price.trim() !== '' && Number.isFinite(priceNum) && priceNum >= 0;
+  const effQty = qtyValid ? qty : line.quantity;
+  const effPrice = priceValid ? price : line.unitPrice;
+  const totalDiverged = Number(effQty) !== Number(line.quantity) || Number(effPrice) !== Number(line.unitPrice);
+
+  // The row's Total/Tax use the SAME shared cents math as the rail
+  // (computeLineTotal — round-half-up at the cent boundary), so a sub-cent unit
+  // price can't make the row Total and the rail contribution disagree by a cent
+  // while typing. When qty/price are unchanged we defer to the authoritative
+  // persisted lineTotal so server normalization still wins on settle.
+  const displayTotal = totalDiverged ? computeLineTotal(effQty, effPrice) : line.lineTotal;
+  const displayTax = lineTaxAmount(displayTotal, taxable, taxRate);
+
+  // Report this row's effective values to the parent so the rail "Live totals"
+  // recompute uses the same inputs. Emit null once nothing diverges, so the rail
+  // reverts to the authoritative server figures; cleanup on unmount avoids a
+  // phantom draft skewing the rail after a delete.
+  const diverged = totalDiverged || taxable !== line.taxable || rec !== line.recurrence;
+  useEffect(() => {
+    onDraft(line.id, diverged
+      ? { quantity: String(effQty), unitPrice: String(effPrice), taxable, customerVisible: line.customerVisible, recurrence: rec }
+      : null);
+  }, [onDraft, line.id, line.customerVisible, diverged, effQty, effPrice, taxable, rec]);
+  // Clear this row's draft when it unmounts (e.g. removed) so the rail doesn't
+  // keep a phantom override.
+  useEffect(() => () => onDraft(line.id, null), [onDraft, line.id]);
 
   const commitDesc = () => {
     const next = desc.trim();
+    descEdited.current = false; // committing — let the server value re-adopt next
     if (!next || next === line.description) { setDesc(line.description); return; }
-    onEdit(line.id, { description: next });
+    void edit({ description: next });
   };
   const commitQty = () => {
     const n = Number(qty);
-    if (!Number.isFinite(n) || n <= 0 || n === Number(line.quantity)) { setQty(line.quantity); return; }
-    onEdit(line.id, { quantity: n });
+    qtyEdited.current = false;
+    if (n === Number(line.quantity)) { setQty(line.quantity); return; } // unchanged — silent
+    // A rejected entry no longer snaps back silently: tell the user why (parity
+    // with the tax field and the manual-add path) before reverting.
+    if (!Number.isFinite(n) || n <= 0) {
+      handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+      setQty(line.quantity);
+      return;
+    }
+    void edit({ quantity: n });
   };
   const commitPrice = () => {
     const n = Number(price);
-    if (!Number.isFinite(n) || n < 0 || n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; }
-    onEdit(line.id, { unitPrice: n });
+    priceEdited.current = false;
+    if (n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; } // unchanged — silent
+    if (!Number.isFinite(n) || n < 0) {
+      handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+      setPrice(line.unitPrice);
+      return;
+    }
+    void edit({ unitPrice: n });
   };
 
   return (
@@ -947,12 +1571,13 @@ function EditableLineRow({
           {line.catalogItemId && <CatalogLineThumb catalogItemId={line.catalogItemId} />}
           <textarea
             value={desc}
-            onChange={(e) => setDesc(e.target.value)}
+            aria-label="Line description"
+            onChange={(e) => { setDesc(e.target.value); descEdited.current = true; }}
             onBlur={commitDesc}
             rows={2}
             disabled={busy}
             data-testid={`quote-line-desc-${line.id}`}
-            className="min-h-9 w-full resize-y rounded-md border bg-background px-2 py-1 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            className={`min-h-9 w-full resize-y rounded-md border bg-background px-2 py-1 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${descDirty ? 'ring-1 ring-warning' : ''}`}
           />
         </div>
       </td>
@@ -960,28 +1585,35 @@ function EditableLineRow({
         <input
           type="number" min="0" step="0.01"
           value={qty}
-          onChange={(e) => setQty(e.target.value)}
+          aria-label="Quantity"
+          onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; }}
           onBlur={commitQty}
           disabled={busy}
           data-testid={`quote-line-qty-${line.id}`}
-          className="h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          className={`h-9 w-16 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${qtyDirty ? 'ring-1 ring-warning' : ''}`}
         />
       </td>
       <td className="px-2 py-2 text-right">
         <input
           type="number" min="0" step="0.01"
           value={price}
-          onChange={(e) => setPrice(e.target.value)}
+          aria-label="Unit price"
+          onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; }}
           onBlur={commitPrice}
           disabled={busy}
           data-testid={`quote-line-price-${line.id}`}
-          className="h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          className={`h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${priceDirty ? 'ring-1 ring-warning' : ''}`}
         />
       </td>
       <td className="px-2 py-2">
         <select
-          value={line.recurrence}
-          onChange={(e) => onEdit(line.id, { recurrence: e.target.value as QuoteLineRecurrence })}
+          value={rec}
+          aria-label="Billing frequency"
+          onChange={(e) => {
+            const next = e.target.value as QuoteLineRecurrence;
+            setRec(next); // optimistic — revert if the save fails
+            void edit({ recurrence: next }).then((ok) => { if (!ok) setRec(line.recurrence); });
+          }}
           disabled={busy}
           data-testid={`quote-line-recurrence-${line.id}`}
           className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
@@ -990,28 +1622,53 @@ function EditableLineRow({
           <option value="monthly">Monthly</option>
           <option value="annual">Annual</option>
         </select>
-        <label className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
+      </td>
+      <td className="px-2 py-2 text-right">
+        <label className="flex items-center justify-end gap-1.5 text-xs text-muted-foreground">
           <input
             type="checkbox"
-            checked={line.taxable}
-            onChange={(e) => onEdit(line.id, { taxable: e.target.checked })}
+            checked={taxable}
+            aria-label="Taxable"
+            onChange={(e) => {
+              const next = e.target.checked;
+              setTaxable(next); // optimistic — revert if the save fails
+              void edit({ taxable: next }).then((ok) => { if (!ok) setTaxable(line.taxable); });
+            }}
             disabled={busy}
             data-testid={`quote-line-taxable-${line.id}`}
           />
-          Taxable
+          <span className="tabular-nums" data-testid={`quote-line-tax-${line.id}`}>
+            {displayTax === null ? '—' : formatMoney(displayTax, currency)}
+          </span>
         </label>
       </td>
-      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(line.lineTotal, currency)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        <span data-testid={`quote-line-total-${line.id}`}>{formatMoney(displayTotal, currency)}</span>
+        {saved && <span className="ml-1 text-xs font-medium text-success" data-testid={`quote-line-saved-${line.id}`}>Saved</span>}
+        <SrSaved show={saved} />
+      </td>
       <td className="px-2 py-2 text-right">
-        <button
-          type="button"
-          onClick={() => onRemove(line.id)}
-          disabled={busy}
-          data-testid={`quote-line-remove-${line.id}`}
-          className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-        >
-          Remove
-        </button>
+        <div className="flex items-center justify-end gap-1">
+          <MoveControls
+            disabledUp={isFirst}
+            disabledDown={isLast}
+            onUp={() => onMove(line, 'up')}
+            onDown={() => onMove(line, 'down')}
+            labelUp="Move line up"
+            labelDown="Move line down"
+            testIdUp={`quote-line-move-up-${line.id}`}
+            testIdDown={`quote-line-move-down-${line.id}`}
+          />
+          <button
+            type="button"
+            onClick={() => onRemove(line)}
+            disabled={busy}
+            data-testid={`quote-line-remove-${line.id}`}
+            className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+          >
+            Remove
+          </button>
+        </div>
       </td>
     </tr>
   );

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import QuoteEditor from './QuoteEditor';
@@ -33,23 +33,32 @@ export default function QuoteWorkspace({ id }: Props) {
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
 
-  const load = useCallback(async () => {
+  // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
+  // so the editor stays mounted — a full-page spinner would remount the form and
+  // discard the user's in-progress local state and cursor position. Only the
+  // initial load shows the spinner / replaces the view on error.
+  const fetchDetail = useCallback(async (quiet = false) => {
     if (!id) { setError('Missing quote id'); setLoading(false); return; }
     try {
-      setLoading(true);
+      if (!quiet) setLoading(true);
       setError(undefined);
       const res = await fetchWithAuth(`/quotes/${id}`);
       if (res.status === 401) return UNAUTHORIZED();
-      if (res.status === 404) { setError('Quote not found.'); return; }
+      if (res.status === 404) { if (!quiet) setError('Quote not found.'); return; }
       if (!res.ok) throw new Error('Failed to load quote');
       const body = (await res.json()) as { data: QuoteDetailData };
       setDetail(body.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load quote');
+      // A failed quiet reload leaves the editor intact; the inline action's own
+      // runAction toast already surfaced the failure.
+      if (!quiet) setError(err instanceof Error ? err.message : 'Failed to load quote');
     } finally {
-      setLoading(false);
+      if (!quiet) setLoading(false);
     }
   }, [id]);
+
+  const load = useCallback(() => fetchDetail(false), [fetchDetail]);
+  const reload = useCallback(() => fetchDetail(true), [fetchDetail]);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -72,6 +81,24 @@ export default function QuoteWorkspace({ id }: Props) {
     if (typeof window !== 'undefined') window.location.hash = `#${next}`;
   }, []);
 
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
+  // tab is both activated and focused.
+  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
+    const idx = tabs.findIndex((t) => t.value === current);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = tabs[nextIdx].value;
+    selectTab(next);
+    if (typeof document !== 'undefined') document.getElementById(`quote-tab-${next}`)?.focus();
+  }, [selectTab]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16" data-testid="quote-workspace-loading">
@@ -93,6 +120,12 @@ export default function QuoteWorkspace({ id }: Props) {
     );
   }
 
+  // The Editor only applies to drafts, so it's hidden once a quote is issued —
+  // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
+  // on a non-draft falls back to Detail.
+  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
+  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
+
   return (
     <div className="space-y-4" data-testid="quote-workspace">
       <div className="flex items-center justify-between">
@@ -105,17 +138,25 @@ export default function QuoteWorkspace({ id }: Props) {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b" role="tablist" data-testid="quote-workspace-tabs">
-        {TABS.map((t) => (
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        data-testid="quote-workspace-tabs"
+        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
+      >
+        {visibleTabs.map((t) => (
           <button
             key={t.value}
             type="button"
             role="tab"
-            aria-selected={tab === t.value}
+            id={`quote-tab-${t.value}`}
+            aria-selected={activeTab === t.value}
+            aria-controls={`quote-tabpanel-${t.value}`}
+            tabIndex={activeTab === t.value ? 0 : -1}
             onClick={() => selectTab(t.value)}
             data-testid={`quote-tab-${t.value}`}
             className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
-              tab === t.value
+              activeTab === t.value
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
@@ -125,19 +166,23 @@ export default function QuoteWorkspace({ id }: Props) {
         ))}
       </div>
 
-      {tab === 'editor' && (
-        isDraft ? (
-          <QuoteEditor detail={detail} onChanged={() => void load()} />
-        ) : (
-          <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground" data-testid="quote-editor-locked">
-            This quote is no longer a draft and can no longer be edited. Switch to the Detail tab to review it.
-          </div>
-        )
+      {activeTab === 'editor' && isDraft && (
+        <div role="tabpanel" id="quote-tabpanel-editor" aria-labelledby="quote-tab-editor" tabIndex={0}>
+          <QuoteEditor detail={detail} onChanged={() => void reload()} />
+        </div>
       )}
 
-      {tab === 'preview' && <QuoteDocumentPreview detail={detail} />}
+      {activeTab === 'preview' && (
+        <div role="tabpanel" id="quote-tabpanel-preview" aria-labelledby="quote-tab-preview" tabIndex={0}>
+          <QuoteDocumentPreview detail={detail} />
+        </div>
+      )}
 
-      {tab === 'detail' && <QuoteDetail detail={detail} onChanged={() => void load()} />}
+      {activeTab === 'detail' && (
+        <div role="tabpanel" id="quote-tabpanel-detail" aria-labelledby="quote-tab-detail" tabIndex={0}>
+          <QuoteDetail detail={detail} onChanged={() => void reload()} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
@@ -85,6 +86,7 @@ export function QuotesPage() {
   const [sort, setSort] = useState<Sort | null>(null);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [sendOpen, setSendOpen] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
 
   // New-quote dialog state
@@ -191,6 +193,16 @@ export function QuotesPage() {
   const toggleSort = (key: SortKey) =>
     setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' }));
 
+  // Aggregate value awaiting the customer's signature (sent + viewed), mirroring
+  // the invoice list's Outstanding strip. Single-currency partners are the norm;
+  // label with the first quote's currency.
+  const summary = useMemo(() => {
+    const awaiting = quotes.filter((qt) => qt.status === 'sent' || qt.status === 'viewed');
+    const outForSignature = awaiting.reduce((sum, qt) => sum + num(qt.total), 0);
+    const ccy = quotes[0]?.currencyCode || 'USD';
+    return { outForSignature, awaitingCount: awaiting.length, ccy };
+  }, [quotes]);
+
   // ---- derived rows: search filter (client) then optional sort ------------
   const rows = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -245,19 +257,34 @@ export function QuotesPage() {
     [bulk, loadQuotes, filters],
   );
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => (
-    <th className="px-3 py-3 text-right font-medium">
-      <button
-        type="button"
-        onClick={() => toggleSort(sortKey)}
-        className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-        data-testid={`quotes-sort-${sortKey}`}
-      >
-        {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
-      </button>
-    </th>
-  );
+  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
+    const active = sort?.key === sortKey;
+    const ariaLabel = active
+      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+      : `Sort by ${label}`;
+    return (
+      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+        <button
+          type="button"
+          onClick={() => toggleSort(sortKey)}
+          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
+          data-testid={`quotes-sort-${sortKey}`}
+          aria-label={ariaLabel}
+        >
+          {label}
+          {active ? (
+            sort!.dir === 'asc' ? (
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            )
+          ) : (
+            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </th>
+    );
+  };
 
   return (
     <div className="space-y-5" data-testid="quotes-page">
@@ -280,6 +307,17 @@ export function QuotesPage() {
         )}
       </div>
 
+      {/* Out-for-signature summary */}
+      {!loading && !error && summary.awaitingCount > 0 && (
+        <div className="flex flex-wrap gap-3" data-testid="quotes-outstanding-strip">
+          <div className="rounded-lg border bg-card px-4 py-3">
+            <div className="text-xs text-muted-foreground">Out for signature</div>
+            <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outForSignature, summary.ccy)}</div>
+            <div className="text-xs text-muted-foreground">{summary.awaitingCount} awaiting</div>
+          </div>
+        </div>
+      )}
+
       {/* Toolbar: search + filters */}
       <div className="flex flex-wrap items-end gap-2" data-testid="quotes-filters">
         <input
@@ -287,7 +325,7 @@ export function QuotesPage() {
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search number or org"
           aria-label="Search quotes"
-          className="h-10 min-w-48 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+          className="h-10 min-w-[12rem] flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
           data-testid="quotes-search"
         />
         <select
@@ -413,6 +451,7 @@ export function QuotesPage() {
                         <span
                           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[qt.status]}`}
                           data-testid={`quotes-status-${qt.id}`}
+                          aria-label={`Status: ${statusLabel(qt)}`}
                         >
                           {statusLabel(qt)}
                         </span>
@@ -429,13 +468,24 @@ export function QuotesPage() {
               onClear={bulk.clear}
               testIdPrefix="quotes"
               actions={[
-                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', disabled: bulkBusy, onClick: () => void runBulkQuotes('/quotes/bulk-send', 'sent') }] : []),
+                ...(can('quotes', 'send') ? [{ key: 'send', label: 'Send', disabled: bulkBusy, onClick: () => setSendOpen(true) }] : []),
                 ...(can('quotes', 'write') ? [{ key: 'delete', label: 'Delete drafts', variant: 'destructive' as const, disabled: bulkBusy, onClick: () => setDeleteOpen(true) }] : []),
               ]}
             />
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={sendOpen}
+        onClose={() => setSendOpen(false)}
+        onConfirm={() => { setSendOpen(false); void runBulkQuotes('/quotes/bulk-send', 'sent'); }}
+        title="Send quotes"
+        message={`Email ${bulk.size} selected proposal(s) to their customers? This can't be undone.`}
+        variant="warning"
+        confirmLabel="Send"
+        confirmTestId="quotes-bulk-send-confirm"
+      />
 
       <ConfirmDialog
         open={deleteOpen}
@@ -522,16 +572,29 @@ export function QuotesPage() {
 function SortHeaderLeft({
   label, sortKey, sort, onSort,
 }: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
+  const active = sort?.key === sortKey;
+  const ariaLabel = active
+    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
   return (
-    <th className="px-3 py-3 font-medium">
+    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
       <button
         type="button"
         onClick={() => onSort(sortKey)}
         className="inline-flex items-center gap-1 hover:text-foreground"
         data-testid={`quotes-sort-${sortKey}`}
+        aria-label={ariaLabel}
       >
         {label}
-        <span className="text-[10px] leading-none">{sort?.key === sortKey ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+        {active ? (
+          sort!.dir === 'asc' ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
       </button>
     </th>
   );

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -5,6 +5,7 @@
 import type { SellerSnapshot } from '../invoiceTypes';
 export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
+import { STATUS_PILL } from '../invoiceTypes';
 
 export type QuoteStatus =
   | 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'expired' | 'converted';
@@ -118,14 +119,20 @@ export const STATUS_LABELS: Record<QuoteStatus, string> = {
 };
 
 // Tailwind badge classes per status (mirrors the invoice/contract status-pill style).
+// Five semantic roles shared with the invoice pills (see STATUS_PILL): the
+// colour reads the lifecycle (neutral → info while it's with the customer →
+// success when won → warning when lapsing → danger when lost), and the label
+// carries the finer distinction. sent/viewed share info; accepted/converted
+// share success — collapsing the old blue/indigo/violet/emerald rainbow that
+// was hard to tell apart at pill scale.
 export const STATUS_COLORS: Record<QuoteStatus, string> = {
-  draft: 'border-border bg-muted text-muted-foreground',
-  sent: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  viewed: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-400',
-  accepted: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  declined: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
-  expired: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-  converted: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-400',
+  draft: STATUS_PILL.neutral,
+  sent: STATUS_PILL.info,
+  viewed: STATUS_PILL.info,
+  accepted: STATUS_PILL.success,
+  declined: STATUS_PILL.danger,
+  expired: STATUS_PILL.warning,
+  converted: STATUS_PILL.success,
 };
 
 /** Display label for a quote's status. The 'sent' lifecycle status only reads as
@@ -154,6 +161,23 @@ export function formatMoney(value: string | number | null | undefined, currencyC
 export function pctFromFraction(frac: string | number | null): string {
   if (frac === null || frac === '') return '';
   return String(Number((Number(frac) * 100).toFixed(3)));
+}
+
+/** Per-line tax amount for the pricing-table Tax column: taxable lines get
+ *  lineTotal × rate rounded to cents; non-taxable lines, a null/empty rate, or a
+ *  non-positive rate return null (rendered as '—'). The document/detail header
+ *  Tax stays the server's authoritative `taxTotal`, so a quote with many taxable
+ *  lines can differ from the summed column by a rounding cent. */
+export function lineTaxAmount(
+  lineTotal: string | number,
+  taxable: boolean,
+  taxRate: string | number | null,
+): number | null {
+  if (!taxable) return null;
+  const rate = taxRate === null || taxRate === '' ? 0 : Number(taxRate);
+  const cents = Math.round(Number(lineTotal) * 100);
+  if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
+  return Math.round(cents * rate) / 100;
 }
 
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertOctagon, AlertTriangle } from 'lucide-react';
 import { Dialog } from './Dialog';
 
 export interface ConfirmDialogProps {
@@ -25,6 +25,11 @@ export function ConfirmDialog({
   isLoading = false,
   confirmTestId,
 }: ConfirmDialogProps) {
+  // Encode severity by SHAPE, not color alone: a stop-octagon for destructive
+  // (irreversible removal) vs a caution-triangle for warning (a guarded but
+  // non-destructive action like activate/generate). Colorblind users and a
+  // glance-read both get the distinction without relying on red-vs-amber.
+  const Icon = variant === 'destructive' ? AlertOctagon : AlertTriangle;
   return (
     <Dialog open={open} onClose={onClose} title={title} maxWidth="md" className="p-6">
       <div className="flex gap-4">
@@ -33,10 +38,11 @@ export function ConfirmDialog({
             variant === 'destructive' ? 'bg-destructive/10' : 'bg-warning/10'
           }`}
         >
-          <AlertTriangle
+          <Icon
             className={`h-5 w-5 ${
               variant === 'destructive' ? 'text-destructive' : 'text-warning'
             }`}
+            aria-hidden="true"
           />
         </div>
         <div className="flex-1">
@@ -64,7 +70,7 @@ export function ConfirmDialog({
               : 'bg-warning text-warning-foreground hover:bg-warning/90'
           }`}
         >
-          {isLoading ? 'Processing...' : confirmLabel}
+          {isLoading ? 'Processing…' : confirmLabel}
         </button>
       </div>
     </Dialog>

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -136,6 +136,26 @@ export function removeLine(id: string, lineId: string): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}/lines/${lineId}`, { method: 'DELETE' });
 }
 
+/** Reorder a quote's blocks. Body is the full ordered id list; the server
+ *  renumbers sortOrder 0..n-1 (PATCH /quotes/:id/blocks/reorder). */
+export function reorderBlocks(id: string, body: { blockIds: string[] }): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/blocks/reorder`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+/** Reorder the lines within a pricing-table block. Full ordered id list; the
+ *  server renumbers sortOrder 0..n-1 (PATCH /quotes/:id/blocks/:blockId/lines/reorder). */
+export function reorderLines(id: string, blockId: string, body: { lineIds: string[] }): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/blocks/${blockId}/lines/reorder`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
 /** Absolute API path for the quote PDF (`GET /api/v1/quotes/:id/pdf`). The route
  *  streams `application/pdf` inline; callers fetch it via `fetchWithAuth` (to
  *  attach the auth header) the same way InvoiceDetail downloads its PDF. */

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './semverCompare';
 export * from './timezone';
 export * from './assuranceLevel';
 export * from './ticketTemplate';
+export * from './quoteMath';

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { computeQuoteTotals, computeLineTotal, toCents, fromCents, type QuoteLineForMath } from './quoteMath';
+
+const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
+  quantity: '1', unitPrice: '0', taxable: false, recurrence: 'one_time', customerVisible: true, ...over,
+});
+
+describe('quoteMath (shared)', () => {
+  it('buckets one-time vs monthly vs annual and taxes only taxable lines', () => {
+    const r = computeQuoteTotals([
+      line({ quantity: '2', unitPrice: '500', recurrence: 'one_time', taxable: true }),
+      line({ quantity: '10', unitPrice: '22', recurrence: 'monthly', taxable: true }),
+      line({ quantity: '1', unitPrice: '1200', recurrence: 'annual', taxable: false }),
+    ], 0.1);
+    expect(r.oneTimeTotal).toBe('1000.00');
+    expect(r.monthlyRecurringTotal).toBe('220.00');
+    expect(r.annualRecurringTotal).toBe('1200.00');
+    expect(r.subtotal).toBe('2420.00');
+    expect(r.taxTotal).toBe('122.00'); // (1000 + 220) * 0.1
+    expect(r.total).toBe('2542.00');
+  });
+
+  it('dueOnAcceptanceTotal is the one-time subtotal + tax on one-time lines only', () => {
+    const r = computeQuoteTotals([
+      line({ quantity: '1', unitPrice: '500', recurrence: 'one_time', taxable: true }),
+      line({ quantity: '1', unitPrice: '1000', recurrence: 'monthly', taxable: true }),
+    ], 0.1);
+    expect(r.taxTotal).toBe('150.00');             // whole-quote tax incl. monthly
+    expect(r.dueOnAcceptanceTotal).toBe('550.00'); // one-time 500 + its 50 tax
+    expect(r.dueOnAcceptanceTotal).not.toBe(r.total);
+  });
+
+  it('excludes non-customer-visible lines and treats null taxRate as zero', () => {
+    expect(computeQuoteTotals([line({ unitPrice: '100', customerVisible: false })], 0).subtotal).toBe('0.00');
+    const r = computeQuoteTotals([line({ unitPrice: '100', taxable: true })], null);
+    expect(r.taxTotal).toBe('0.00');
+    expect(r.total).toBe('100.00');
+  });
+
+  it('rounds at the cent boundary without rounding unitPrice first', () => {
+    // 0.05 * 0.70 = 0.035 → 3.4999.. cents → floor(+0.5) = 3 → 0.03 (not 0.04).
+    expect(computeLineTotal('0.05', '0.70')).toBe('0.03');
+    expect(computeQuoteTotals([line({ quantity: '0.05', unitPrice: '0.70' })], null).subtotal).toBe('0.03');
+    // sub-cent unit prices survive: 3 * 0.335 = 1.005 → round half-up → 1.01.
+    expect(computeLineTotal('3', '0.335')).toBe('1.01');
+  });
+
+  it('cents helpers round-trip and treat blank as zero', () => {
+    expect(toCents('12.34')).toBe(1234);
+    expect(toCents('')).toBe(0);
+    expect(toCents(null)).toBe(0);
+    expect(fromCents(1234)).toBe('12.34');
+  });
+});

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -1,0 +1,94 @@
+// Single source of truth for quote totals, shared by the API (authoritative
+// recompute on every mutation) and the web editor (optimistic "Live totals" rail
+// while the user is mid-edit). Keeping one implementation here means the
+// optimistic rail can never settle to a different figure than the server returns.
+//
+// The cents discipline mirrors invoiceMath/catalogPricing exactly: integer cents
+// with a single round-half-up at the cent boundary, never rounding unitPrice
+// first. These helpers are intentionally self-contained (no invoice-status / DB
+// coupling) so the module is safe to import into the browser bundle.
+
+/** Money string/number → integer cents (round-half-up — `Math.round` ties toward
+ *  +∞ — on the ×100 product). Null/empty/non-finite → 0, so a stray NaN can't
+ *  propagate to a literal "NaN" on the totals rail (this module is browser-safe
+ *  and shared, so it can't assume every caller pre-validates). */
+export function toCents(v: string | number | null | undefined): number {
+  if (v === null || v === undefined || v === '') return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}
+
+/** Integer cents → 2-decimal money string. */
+export function fromCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/** Round-half-up of a fractional-cent amount. */
+function roundHalfUp(n: number): number {
+  return Math.floor(n + 0.5);
+}
+
+/** quantity × unitPrice in full precision, then a single round-half-up at the
+ *  cent boundary. (Rounding unitPrice to cents first would lose sub-cent unit
+ *  prices like 0.335 — 3 × 0.335 = 1.005 must round half-up to 1.01.) */
+export function computeLineTotal(quantity: string | number, unitPrice: string | number): string {
+  const fractionalCents = Number(quantity) * Number(unitPrice) * 100;
+  return fromCents(roundHalfUp(fractionalCents));
+}
+
+export interface QuoteLineForMath {
+  quantity: string;
+  unitPrice: string;
+  taxable: boolean;
+  customerVisible: boolean;
+  recurrence: 'one_time' | 'monthly' | 'annual';
+}
+
+export interface QuoteTotals {
+  subtotal: string;
+  taxTotal: string;
+  total: string;
+  oneTimeTotal: string;
+  monthlyRecurringTotal: string;
+  annualRecurringTotal: string;
+  /**
+   * The amount actually invoiced when the customer accepts the quote. Accept
+   * auto-issues a one-time-only invoice (recurring lines defer to the recurring
+   * contract), so this is the one-time subtotal PLUS tax on just the taxable
+   * one-time lines. NOT `total`, which also rolls in the first monthly + annual
+   * period. Must equal quoteAcceptService's invoice math.
+   */
+  dueOnAcceptanceTotal: string;
+}
+
+export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
+  let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
+  for (const l of lines) {
+    if (!l.customerVisible) continue;
+    // Route per-line cents through computeLineTotal so they equal the persisted
+    // line_total (rounded to cents) and match invoices exactly.
+    const lineCents = toCents(computeLineTotal(l.quantity, l.unitPrice));
+    if (l.recurrence === 'monthly') monthly += lineCents;
+    else if (l.recurrence === 'annual') annual += lineCents;
+    else oneTime += lineCents;
+    if (l.taxable) {
+      taxableBasis += lineCents;
+      if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
+    }
+  }
+  // First-period basis: one-time + first monthly period + first annual period.
+  const subtotal = oneTime + monthly + annual;
+  const rate = taxRate ?? 0;
+  const taxCents = Math.floor(taxableBasis * rate + 0.5);
+  // Tax on ONLY the one-time taxable lines — what accept actually invoices.
+  const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
+  return {
+    subtotal: fromCents(subtotal),
+    taxTotal: fromCents(taxCents),
+    total: fromCents(subtotal + taxCents),
+    oneTimeTotal: fromCents(oneTime),
+    monthlyRecurringTotal: fromCents(monthly),
+    annualRecurringTotal: fromCents(annual),
+    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
+  };
+}

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createQuoteSchema, quoteLineInputSchema, quoteBlockInputSchema, listQuotesQuerySchema,
   acceptQuoteSchema, declineQuoteSchema,
-  updateQuoteSchema,
+  updateQuoteSchema, reorderBlocksSchema, reorderLinesSchema,
 } from './quotes';
 
 describe('quote validators', () => {
@@ -48,6 +48,27 @@ describe('declineQuoteSchema', () => {
   });
 });
 
+
+describe('reorder schemas', () => {
+  const A = '11111111-1111-1111-1111-111111111111';
+  const B = '22222222-2222-2222-2222-222222222222';
+  it('accepts a non-empty list of unique guids', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: [A, B] }).success).toBe(true);
+    expect(reorderLinesSchema.safeParse({ lineIds: [A, B] }).success).toBe(true);
+  });
+  it('rejects an empty list', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: [] }).success).toBe(false);
+  });
+  it('rejects duplicate ids (would corrupt sort_order)', () => {
+    // [A, A] for blocks [A, B] would otherwise pass a length+membership check,
+    // renumber A twice, and orphan B's sort_order.
+    expect(reorderBlocksSchema.safeParse({ blockIds: [A, A] }).success).toBe(false);
+    expect(reorderLinesSchema.safeParse({ lineIds: [A, A] }).success).toBe(false);
+  });
+  it('rejects non-guid ids', () => {
+    expect(reorderBlocksSchema.safeParse({ blockIds: ['not-a-guid'] }).success).toBe(false);
+  });
+});
 
 describe('quote T&C field', () => {
   it('create accepts termsAndConditions', () => {

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -75,7 +75,19 @@ export const updateQuoteSchema = z.object({
   billToName: z.string().max(255).nullable().optional(),
 });
 
-export const reorderBlocksSchema = z.object({ blockIds: z.array(z.string().guid()).min(1) });
+// A reorder payload must be a clean permutation of the existing ids, so the id
+// list has to be unique — without this, a duplicated id (e.g. [A, A] for blocks
+// [A, B]) passes a length+membership check, renumbers A twice, never touches B,
+// and corrupts sort_order. Uniqueness is enforced here so both routes are
+// covered; the service re-checks as defense in depth.
+const uniqueReorderIds = z
+  .array(z.string().guid())
+  .min(1)
+  .refine((ids) => new Set(ids).size === ids.length, { message: 'ids must be unique' });
+export const reorderBlocksSchema = z.object({ blockIds: uniqueReorderIds });
+export const reorderLinesSchema = z.object({ lineIds: uniqueReorderIds });
+export type ReorderLinesInput = z.infer<typeof reorderLinesSchema>;
+export type ReorderBlocksInput = z.infer<typeof reorderBlocksSchema>;
 
 export const acceptQuoteSchema = z.object({
   signerName: z.string().min(1).max(255),


### PR DESCRIPTION
## Polishing quotes & invoices (isolated, rebased onto Tailwind 4 / Astro 7)

Focused quote-builder + invoice polish, **rebased onto current `main`** (Astro 7 / Tailwind 4 / Vite 8). This supersedes the quote/invoice portion of #2010, which was a combined branch that conflicted with main and bundled an unrelated contract/catalog workstream. That workstream is **intentionally excluded** here — every file in this PR is in the quotes / invoices / shared-quote-math domain.

### Tailwind 4 reconcile
Main's framework upgrade touched only component `className` strings, never logic — so the shared/API/validator files reconciled with zero conflict. The components were migrated to the TW4 utility renames (`outline-none`→`outline-hidden`, `shadow-sm`→`shadow-xs`, `shadow`→`shadow-sm`, `min-h-[2.25rem]`→`min-h-9`); the shadcn semantic CSS-var tokens are unchanged.

**Verified on the TW4 base:** web billing suite (112), shared (18), API quote tests (27) all green; `astro build` (prod) succeeds; `tsc` clean across web/api/shared.

### What's in it

**Single source of truth for quote totals.** `computeQuoteTotals` lives in `packages/shared/src/utils/quoteMath.ts` (round-half-up at the cent boundary, never rounding unitPrice first); the API re-exports it and the web imports the same function, so the optimistic UI can never settle to a figure the next GET contradicts. The existing API `quoteMath.test.ts` cross-checks parity against `invoiceMath.computeLineTotal`.

**Optimistic, internally-consistent totals.** Each line row computes Total/Tax from local values while editing, and the right-rail "Live totals" recompute from in-progress edits (lines *and* tax rate) via that same shared math — row and rail can't disagree, even at sub-cent rounding. A leading+trailing throttled `refresh()` caps refetches at ~1/window (guards the documented US DB connection pressure) without freezing the rail mid-burst. An "edited-since-last-commit" flag re-adopts server normalization (e.g. `9.999`→`10.00`) without clobbering in-progress keystrokes.

**Block/line reorder.** Optimistic, with rapid clicks accumulated into a single debounced PATCH carrying the final id list (server renumbers `0..n-1`). A uniqueness guard on the reorder schemas + a deduped-size service check reject duplicate-id payloads that would otherwise corrupt `sort_order`.

**Save model & a11y.** One save language across every surface (amber dirty ring → "Saved" cue → `SrSaved` live region → `runAction` failure toast); `MoveControls` focus management (WCAG target size + focus-hop on self-disable); consolidated SR totals announcement; dirty-ring legend; shape-encoded `ConfirmDialog` severity; ConfirmDialog stays open on a failed removal.

### Review
This branch carries the same code reviewed in #2010 (five-agent pass: code, silent-failure, tests, comments, type-design), including the fixes that came out of it — most notably the duplicate-id reorder guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
