### PR TITLE
feat(web): reset-columns button on device list + collapse-all in sidebar

### DIFF
--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -16,6 +16,7 @@ import {
   COLUMN_LABELS,
   readColumnOrder,
   readColumnVisibility,
+  resetColumns,
   writeColumnOrder,
   writeColumnVisibility,
   type ColumnId,
@@ -427,6 +428,13 @@ export default function DeviceList({
       writeColumnOrder(next);
       return next;
     });
+  };
+
+  // Restores both visibility and order to the catalog defaults.
+  const resetColumnsToDefault = () => {
+    const cols = resetColumns();
+    setColumnOrder(cols.map(c => c.id));
+    setVisibleColumns(new Set(cols.filter(c => c.visible).map(c => c.id)));
   };
 
   // Notify the parent that a freshly-created group has been handled. The group
@@ -1172,6 +1180,15 @@ export default function DeviceList({
                       <span>{COLUMN_LABELS[id]}</span>
                     </label>
                   ))}
+                  <hr className="my-1" />
+                  <button
+                    type="button"
+                    onClick={resetColumnsToDefault}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Reset to defaults
+                  </button>
                 </div>
               )}
             </div>

--- a/apps/web/src/components/devices/columnVisibility.test.ts
+++ b/apps/web/src/components/devices/columnVisibility.test.ts
@@ -6,6 +6,7 @@ import {
   isValidColumnId,
   readColumnOrder,
   readColumnVisibility,
+  resetColumns,
   writeColumnOrder,
   writeColumnVisibility,
 } from './columnVisibility';
@@ -218,6 +219,42 @@ describe('columnVisibility', () => {
         throw new DOMException('QuotaExceededError', 'QuotaExceededError');
       });
       expect(() => writeColumnOrder(['hostname'])).not.toThrow();
+    });
+  });
+
+  describe('resetColumns', () => {
+    it('overwrites a customized order + visibility back to catalog defaults', () => {
+      // Customize both hats: reversed order and a single visible column.
+      writeColumnOrder([...COLUMN_IDS].reverse());
+      writeColumnVisibility(['hostname']);
+
+      resetColumns();
+
+      // Persisted state round-trips to canonical order and default visibility.
+      expect(readColumnOrder()).toEqual([...COLUMN_IDS]);
+      const vis = readColumnVisibility();
+      expect(new Set(vis)).toEqual(new Set(DEFAULT_VISIBLE_COLUMNS));
+      expect(vis.size).toBe(DEFAULT_VISIBLE_COLUMNS.length);
+    });
+
+    it('returns the fresh ordered list so callers can sync without a re-read', () => {
+      writeColumnVisibility(['status']);
+      const cols = resetColumns();
+      // Return value is the contract the DeviceList handler syncs state from,
+      // so it must match what was persisted: full catalog in order, default vis.
+      expect(cols.map((c) => c.id)).toEqual([...COLUMN_IDS]);
+      const visibleIds = cols.filter((c) => c.visible).map((c) => c.id);
+      expect(new Set(visibleIds)).toEqual(new Set(DEFAULT_VISIBLE_COLUMNS));
+    });
+
+    it('still returns defaults when setItem throws (Safari private / quota)', () => {
+      vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+      const cols = resetColumns();
+      expect(cols.map((c) => c.id)).toEqual([...COLUMN_IDS]);
+      const visibleIds = cols.filter((c) => c.visible).map((c) => c.id);
+      expect(new Set(visibleIds)).toEqual(new Set(DEFAULT_VISIBLE_COLUMNS));
     });
   });
 

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -203,6 +203,15 @@ export function readColumnOrder(): ColumnId[] {
   return readColumns().map((c) => c.id);
 }
 
+// Clears any saved preference and returns the catalog defaults: every column
+// in catalog order at its default visibility. Returns the fresh ordered list
+// so callers can sync React state without a second read.
+export function resetColumns(): StoredColumn[] {
+  const cols = defaultColumns();
+  writeColumns(cols);
+  return cols;
+}
+
 // Updates only the order, preserving each column's current visibility flag.
 export function writeColumnOrder(order: Iterable<ColumnId>): void {
   const visById = new Map(readColumns().map((c) => [c.id, c.visible] as const));

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -203,9 +203,9 @@ export function readColumnOrder(): ColumnId[] {
   return readColumns().map((c) => c.id);
 }
 
-// Clears any saved preference and returns the catalog defaults: every column
-// in catalog order at its default visibility. Returns the fresh ordered list
-// so callers can sync React state without a second read.
+// Overwrites any saved preference with the catalog defaults: every column in
+// catalog order at its default visibility. Returns the fresh ordered list so
+// callers can sync React state without a second read.
 export function resetColumns(): StoredColumn[] {
   const cols = defaultColumns();
   writeColumns(cols);

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   ChevronDown,
   ChevronsLeft,
+  ChevronsDownUp,
   ShieldCheck,
   KeyRound,
   Package,
@@ -511,6 +512,18 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
     });
   }, [activeSectionId]);
 
+  // Collapse every section except the one holding the active page, which stays
+  // open so the user never loses sight of where they are. Writes an explicit
+  // flag for every section so auto-expand can't silently re-open a sibling.
+  const collapseAllExceptActive = useCallback(() => {
+    const next: Record<string, boolean> = {};
+    for (const section of navSections) {
+      next[section.id] = section.id === activeSectionId;
+    }
+    setExpandedSections(next);
+    saveExpandedSections(next);
+  }, [activeSectionId]);
+
   // --- Sidebar mode cycling ------------------------------------------------
   const cycleMode = () => {
     const next: SidebarMode = mode === 'open' ? 'hover' : mode === 'hover' ? 'collapsed' : 'open';
@@ -675,16 +688,30 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
 
       <div className="flex h-16 items-center justify-between border-b px-4">
         <BrandHeader logoUrl={brandLogoUrl} name={brandName} showLabel={showLabels} />
-        {/* Only show mode toggle on non-tablet viewports */}
-        {!isTablet && (
-          <button
-            onClick={cycleMode}
-            title={toggleTitle}
-            className="rounded-md p-1.5 hover:bg-muted"
-          >
-            <ToggleIcon className="h-5 w-5" />
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {/* Collapse every section except the active one. Only meaningful when
+              section labels (and thus expandable groups) are shown. */}
+          {showLabels && (
+            <button
+              onClick={collapseAllExceptActive}
+              title="Collapse all sections"
+              aria-label="Collapse all sections"
+              className="rounded-md p-1.5 hover:bg-muted"
+            >
+              <ChevronsDownUp className="h-5 w-5" />
+            </button>
+          )}
+          {/* Only show mode toggle on non-tablet viewports */}
+          {!isTablet && (
+            <button
+              onClick={cycleMode}
+              title={toggleTitle}
+              className="rounded-md p-1.5 hover:bg-muted"
+            >
+              <ToggleIcon className="h-5 w-5" />
+            </button>
+          )}
+        </div>
       </div>
 
       <nav ref={navScrollRef} data-tour="sidebar-nav" className="sidebar-nav flex-1 min-h-0 space-y-1 overflow-y-auto p-2" style={{ scrollbarGutter: 'stable' }}>
@@ -722,13 +749,23 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
 
         <div className="flex h-16 items-center justify-between border-b px-4">
           <BrandHeader logoUrl={brandLogoUrl} name={brandName} showLabel />
-          <button
-            onClick={closeMobileMenu}
-            className="rounded-md p-1.5 hover:bg-muted"
-            title="Close menu"
-          >
-            <X className="h-5 w-5" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={collapseAllExceptActive}
+              title="Collapse all sections"
+              aria-label="Collapse all sections"
+              className="rounded-md p-1.5 hover:bg-muted"
+            >
+              <ChevronsDownUp className="h-5 w-5" />
+            </button>
+            <button
+              onClick={closeMobileMenu}
+              className="rounded-md p-1.5 hover:bg-muted"
+              title="Close menu"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
         </div>
 
         <nav className="sidebar-nav flex-1 min-h-0 space-y-1 overflow-y-auto p-2">


### PR DESCRIPTION
## Summary

Two small web UI quality-of-life additions:

1. **Device list — "Reset to defaults" for columns.** Adds a button at the bottom of the Columns dropdown that restores both column **visibility** and **order** to the catalog defaults. Backed by a new `resetColumns()` helper in `columnVisibility.ts` that clears the saved preference and returns the fresh ordered list so React state syncs without a second read.

2. **Sidebar — "Collapse all" button.** Adds a `ChevronsDownUp` button to the desktop and mobile nav headers that collapses every section **except the one containing the active page** (so you never lose your place). It writes an explicit collapsed flag for every section so the auto-expand-on-active-route logic can't silently re-open a sibling. The desktop button only renders when section labels are visible (hidden in icon-only collapsed mode, where there's nothing to collapse).

## Files changed
- `apps/web/src/components/devices/columnVisibility.ts` — new `resetColumns()` export
- `apps/web/src/components/devices/DeviceList.tsx` — handler + dropdown button
- `apps/web/src/components/layout/Sidebar.tsx` — `collapseAllExceptActive()` + header buttons (desktop + mobile)

## Verification
- `astro check` (1155 files): **0 errors**
- `eslint` on the three touched files: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)