### PR TITLE
fix(mcp): resolve owning partner for org-scoped keys + honor public base URL in SSE endpoint

### DIFF
--- a/apps/api/src/routes/mcpServer.orgKeyPartnerRole.test.ts
+++ b/apps/api/src/routes/mcpServer.orgKeyPartnerRole.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { z as zod } from 'zod';
+
+// Regression coverage for the MCP RBAC bug on self-hosted deployments:
+// a Partner Admin with NO organization_users row creates a normal (manual)
+// org-scoped API key. apiKeyAuth gates partner-axis resolution to
+// mcp_provisioning keys, so such a key reaches the MCP dispatch with
+// partnerId: null. buildAuthFromApiKey must resolve the OWNING org's partner
+// for ROLE resolution, otherwise getUserPermissions (org-membership-first,
+// partner only when partnerId is set) returns null and every tools/call dies
+// with "Insufficient permissions: no role assigned" — even though tools/list
+// (ungated) works. See buildAuthFromApiKey in ./mcpServer.
+
+const mocks = vi.hoisted(() => ({
+  // Owning-org → partner resolver. Per test we set its return to model an org
+  // that belongs to a partner (the fix) vs. an org with no usable partner.
+  getActiveOrgTenant: vi.fn(async (_orgId: string): Promise<{ orgId: string; partnerId: string } | null> => null),
+  // Spy so we can assert the partnerId buildAuthFromApiKey threads into role
+  // resolution. Returns a benign org-perms object (its shape is irrelevant to
+  // these assertions; checkToolPermission is stubbed below).
+  getUserPermissions: vi.fn(async (_userId: string, _ctx: { partnerId?: string; orgId?: string }) => ({
+    permissions: [],
+    partnerId: null,
+    orgId: 'org-1',
+    roleId: 'role-1',
+    scope: 'organization' as const,
+    allowedSiteIds: undefined,
+  })),
+  // Capturing stub: the real gate reads auth.partnerId (3rd arg) to resolve the
+  // caller's role. We assert on the captured auth instead of modeling the
+  // permissions DB. Returns null = allow, so dispatch completes.
+  checkToolPermission: vi.fn(async (_toolName: string, _input: unknown, _auth: { partnerId: string | null }) => null),
+  executeTool: vi.fn(async () => JSON.stringify({ ok: true })),
+}));
+
+vi.mock('../services/tenantStatus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tenantStatus')>();
+  return { ...actual, getActiveOrgTenant: mocks.getActiveOrgTenant };
+});
+
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return { ...actual, getUserPermissions: mocks.getUserPermissions };
+});
+
+vi.mock('../services/aiGuardrails', () => ({
+  checkGuardrails: () => ({ allowed: true, tier: 1 }),
+  checkToolPermission: mocks.checkToolPermission,
+  checkToolRateLimit: async () => null,
+}));
+
+vi.mock('../services/aiTools', () => ({
+  getToolDefinitions: () => [
+    { name: 'list_devices', description: 'list', inputSchema: zod.object({}).passthrough() },
+  ],
+  executeTool: mocks.executeTool,
+  getToolTier: () => 1,
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withDbAccessContext: vi.fn((_ctx: any, fn: any) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: any) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: {}, alerts: {}, scripts: {}, automations: {},
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+  partners: { id: 'partners.id', billingEmail: 'partners.billingEmail' },
+  partnerUsers: {}, apiKeys: {},
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+vi.mock('../services/redis', () => ({ getRedis: () => null }));
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60000) })),
+}));
+vi.mock('../middleware/bearerTokenAuth', () => ({
+  bearerTokenAuthMiddleware: async () => { throw new Error('should not be called without a Bearer header'); },
+  resolvePartnerAccessibleOrgIds: async () => [],
+}));
+vi.mock('./mcpExecutionOrg', () => ({ resolveMcpExecutionOrgId: () => 'org-1' }));
+vi.mock('../services/mcpToolExecutionLedger', () => ({
+  beginMcpToolExecutionLedger: async () => ({ id: 'ledger-1' }),
+  completeMcpToolExecutionLedger: async () => undefined,
+}));
+
+// `partnerId: null` models the manual (user-created) key the Partner Admin
+// minted: apiKeyAuth left the partner axis unresolved. `createdBy` is the
+// partner-admin user who has no organization_users row.
+function mockApiKey(partnerId: string | null) {
+  vi.doMock('../middleware/apiKeyAuth', () => ({
+    apiKeyAuthMiddleware: async (c: any, next: any) => {
+      c.set('apiKey', {
+        id: 'key-1',
+        orgId: 'org-1',
+        partnerId,
+        name: 'test',
+        keyPrefix: 'brz_test',
+        scopes: ['ai:read'],
+        rateLimit: 1000,
+        createdBy: 'partner-admin-user',
+      });
+      c.set('apiKeyOrgId', 'org-1');
+      await next();
+    },
+    requireApiKeyScope: () => async (_c: any, next: any) => next(),
+  }));
+}
+
+async function callListDevices(partnerId: string | null) {
+  mockApiKey(partnerId);
+  const mod = await import('./mcpServer');
+  return mod.mcpServerRoutes.request('/message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'list_devices', arguments: {} },
+    }),
+  });
+}
+
+const ORIG_HOSTED = process.env.IS_HOSTED;
+
+describe('MCP org-scoped key resolves owning partner for role lookup', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getActiveOrgTenant.mockClear();
+    mocks.getUserPermissions.mockClear();
+    mocks.checkToolPermission.mockClear();
+    mocks.executeTool.mockClear();
+    delete process.env.IS_HOSTED;
+  });
+
+  afterEach(() => {
+    if (ORIG_HOSTED === undefined) delete process.env.IS_HOSTED;
+    else process.env.IS_HOSTED = ORIG_HOSTED;
+    vi.doUnmock('../middleware/apiKeyAuth');
+  });
+
+  it('manual key (partnerId: null) resolves the org\'s partner so the partner-admin role is found', async () => {
+    mocks.getActiveOrgTenant.mockResolvedValueOnce({ orgId: 'org-1', partnerId: 'partner-1' });
+
+    const res = await callListDevices(null);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBeUndefined();
+
+    // The owning org was consulted to recover the partner the manual key lacked.
+    expect(mocks.getActiveOrgTenant).toHaveBeenCalledWith('org-1');
+
+    // buildAuthFromApiKey threads the resolved partner into role resolution
+    // (instead of the null the key carried).
+    expect(mocks.getUserPermissions).toHaveBeenCalledWith(
+      'partner-admin-user',
+      expect.objectContaining({ partnerId: 'partner-1', orgId: 'org-1' }),
+    );
+
+    // The auth handed to the RBAC gate carries the resolved partner — this is
+    // the value aiGuardrails uses to find the caller's role. Without the fix it
+    // was null and the gate returned "no role assigned".
+    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [string, unknown, { partnerId: string | null }];
+    expect(auth.partnerId).toBe('partner-1');
+  });
+
+  it('falls back to null (no crash) when the owning org has no usable partner', async () => {
+    mocks.getActiveOrgTenant.mockResolvedValueOnce(null);
+
+    const res = await callListDevices(null);
+    expect(res.status).toBe(200);
+
+    expect(mocks.getActiveOrgTenant).toHaveBeenCalledWith('org-1');
+    expect(mocks.getUserPermissions).toHaveBeenCalledWith(
+      'partner-admin-user',
+      expect.objectContaining({ partnerId: undefined, orgId: 'org-1' }),
+    );
+    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [string, unknown, { partnerId: string | null }];
+    expect(auth.partnerId).toBeNull();
+  });
+
+  it('already-resolved key (mcp_provisioning) keeps its partner and skips the org lookup', async () => {
+    const res = await callListDevices('partner-9');
+    expect(res.status).toBe(200);
+
+    // partnerId was already present, so the `??` short-circuits — no extra DB hit.
+    expect(mocks.getActiveOrgTenant).not.toHaveBeenCalled();
+    expect(mocks.getUserPermissions).toHaveBeenCalledWith(
+      'partner-admin-user',
+      expect.objectContaining({ partnerId: 'partner-9', orgId: 'org-1' }),
+    );
+    const [, , auth] = mocks.checkToolPermission.mock.calls[0] as [string, unknown, { partnerId: string | null }];
+    expect(auth.partnerId).toBe('partner-9');
+  });
+});

--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -1120,6 +1120,57 @@ describe('MCP bootstrap carve-out', () => {
     delete process.env.MCP_MAX_SSE_SESSIONS_PER_KEY;
   });
 
+  it('SSE endpoint event uses the configured public base URL scheme/host, not the raw request URL', async () => {
+    // Regression: behind a reverse proxy (Caddy) the inbound hop is plain http,
+    // so deriving the message endpoint from c.req.url emitted an http:// URL on
+    // an https deployment. The endpoint must come from resolveServerUrl
+    // (BREEZE_SERVER || PUBLIC_API_URL) so it honors the external scheme/host.
+    delete process.env.IS_HOSTED;
+    const savedPublic = process.env.PUBLIC_API_URL;
+    const savedServer = process.env.BREEZE_SERVER;
+    delete process.env.BREEZE_SERVER;
+    process.env.PUBLIC_API_URL = 'https://mcp.example.com';
+
+    vi.doMock('../middleware/apiKeyAuth', () => ({
+      apiKeyAuthMiddleware: async (c: any, next: any) => {
+        c.set('apiKey', {
+          id: 'key-sse-scheme', orgId: 'org-1', partnerId: 'partner-1',
+          name: 'test', keyPrefix: 'brz_test', scopes: ['ai:read'],
+          rateLimit: 1000, createdBy: 'user-1',
+        });
+        c.set('apiKeyOrgId', 'org-1');
+        await next();
+      },
+      requireApiKeyScope: () => async (_c: any, next: any) => next(),
+    }));
+    vi.doMock('../services/redis', () => ({ getRedis: () => null }));
+
+    try {
+      const { mcpServerRoutes } = await import('./mcpServer');
+      const res = await mcpServerRoutes.request('/sse', {
+        method: 'GET',
+        headers: { 'X-API-Key': 'whatever' },
+      });
+      expect(res.status).toBe(200);
+
+      // The endpoint event is the first thing written; read one chunk then
+      // cancel so the handler's poll loop doesn't hang the test.
+      const reader = res.body!.getReader();
+      const { value } = await reader.read();
+      await reader.cancel();
+      const chunk = new TextDecoder().decode(value);
+
+      expect(chunk).toContain('event: endpoint');
+      expect(chunk).toMatch(/data: https:\/\/mcp\.example\.com\/message\?sessionId=/);
+      expect(chunk).not.toContain('data: http://');
+    } finally {
+      if (savedPublic === undefined) delete process.env.PUBLIC_API_URL;
+      else process.env.PUBLIC_API_URL = savedPublic;
+      if (savedServer === undefined) delete process.env.BREEZE_SERVER;
+      else process.env.BREEZE_SERVER = savedServer;
+    }
+  });
+
   // ===========================================================================
   // MED-1: Mcp-Session-Id is server-minted and bound to the calling principal
   // ===========================================================================

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -31,6 +31,8 @@ import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
 import { getUserPermissions } from '../services/permissions';
+import { getActiveOrgTenant } from '../services/tenantStatus';
+import { resolveServerUrl } from '../services/recoveryBootstrap';
 import { resolveSiteAllowedDeviceIds, deviceSiteDenied } from '../services/aiToolsSiteScope';
 import { writeAuditEvent } from '../services/auditEvents';
 import { sanitizeAuditPayload, summarizePayload, summarizeToolResult } from '../services/auditPayloadSanitizer';
@@ -368,9 +370,19 @@ mcpServerRoutes.get(
     sseSessionQueues.set(sessionId, { queue: [], principalKey, createdAt: Date.now() });
 
     return streamSSE(c, async (stream) => {
-      // Send endpoint event so client knows where to POST messages
-      const baseUrl = new URL(c.req.url);
-      const messageUrl = `${baseUrl.protocol}//${baseUrl.host}${baseUrl.pathname.replace('/sse', '/message')}?sessionId=${sessionId}`;
+      // Send endpoint event so client knows where to POST messages.
+      //
+      // The scheme/host come from the configured public base URL
+      // (BREEZE_SERVER / PUBLIC_API_URL), NOT the raw request URL. Behind a
+      // reverse proxy (e.g. Caddy) the inbound hop is plain http://, so deriving
+      // the scheme from c.req.url emitted an http:// endpoint even on an https
+      // deployment. We deliberately do NOT trust X-Forwarded-Proto/Host here —
+      // matching the rest of the codebase's URL-emitting routes — to avoid host-
+      // header injection. Self-hosters set PUBLIC_API_URL to their external URL.
+      // The path is taken from the actual request so the /sse → /message mapping
+      // stays correct regardless of mount point.
+      const requestPath = new URL(c.req.url).pathname.replace('/sse', '/message');
+      const messageUrl = `${resolveServerUrl(c.req.url)}${requestPath}?sessionId=${sessionId}`;
 
       await stream.writeSSE({
         event: 'endpoint',
@@ -1565,15 +1577,28 @@ async function buildAuthFromApiKey(apiKey: {
     // restriction — it can never be broader than the user who minted it. Load
     // the creator's allowedSiteIds for this org so the site gate (verifyDeviceAccess)
     // applies to MCP/API-key callers exactly as it does to the JWT request path.
+    //
+    // The creator may be a Partner Admin with NO organization_users row for this
+    // org — their role lives in partner_users. getUserPermissions only consults
+    // the partner axis when given a partnerId, but manual (user-created) keys
+    // carry partnerId: null because apiKeyAuth deliberately gates partner-axis
+    // RLS visibility (accessiblePartnerIds) to mcp_provisioning keys. Resolve the
+    // owning org's partner here purely for ROLE resolution so a partner-admin-
+    // minted key can pass checkToolPermission. This does NOT widen the key's RLS
+    // partner visibility: the middleware still established this request's DB
+    // context with an empty accessiblePartnerIds, so partner-scoped tables stay
+    // unreadable. The key remains org-scoped (orgCondition pins to this org).
+    const partnerId =
+      apiKey.partnerId ?? (await getActiveOrgTenant(apiKey.orgId))?.partnerId ?? null;
     const creatorPerms = await getUserPermissions(apiKey.createdBy, {
-      partnerId: apiKey.partnerId || undefined,
+      partnerId: partnerId || undefined,
       orgId: apiKey.orgId,
     });
     const allowedSiteIds = creatorPerms?.allowedSiteIds;
     return {
       user,
       token: {} as AuthContext['token'],
-      partnerId: apiKey.partnerId,
+      partnerId,
       orgId: apiKey.orgId,
       scope: 'organization',
       accessibleOrgIds: [apiKey.orgId],


### PR DESCRIPTION
Investigated from a self-hoster report (SemoTech): Cursor → `https://domain.com/api/v1/mcp/sse` with an `X-API-Key`, behind Caddy (LAN-only, long SSE timeouts, `X-Forwarded-Proto: https`). SSE connect / `initialize` / `tools/list` (102 tools) all work, but **every `tools/call` fails with `Insufficient permissions: no role assigned`**. The reporter also flagged that the SSE `endpoint` event advertises an `http://` URL.

Both are real. The reporter's RBAC diagnosis was correct.

## 1. RBAC `no role assigned` on `tools/call`

**Root cause.** A Partner Admin with **no `organization_users` row** mints a normal (manual) org-scoped API key. `apiKeyAuth` deliberately resolves the owning org's `partnerId` **only** for `source='mcp_provisioning'` keys (`apiKeyAuth.ts:198-199`), so a manual key reaches MCP dispatch with `partnerId: null`. `getUserPermissions` (`permissions.ts:121-165`) checks org membership first and consults the **partner axis only when `partnerId` is set** — so the creator's partner role is never found, and `checkToolPermission` (`aiGuardrails.ts:663`) returns `Insufficient permissions: no role assigned`. `tools/list` works because it has no RBAC gate; only `tools/call` does.

**Fix.** `buildAuthFromApiKey` now resolves the owning org's partner (`getActiveOrgTenant`) **purely for role resolution** when the key carries no `partnerId`. This is contained to the MCP path and does **not** widen the key's RLS partner visibility — `apiKeyAuth` still establishes the request DB context with an **empty `accessiblePartnerIds`**, so partner-scoped tables stay unreadable (defense-in-depth preserved). The key stays org-scoped: `orgCondition` still pins to its single org, and IP-allowlist enforcement only runs for `scope === 'partner'`. `mcp_provisioning` keys already carry a `partnerId`, so the `??` short-circuits and skips the extra lookup.

## 2. SSE `endpoint` event emits `http://` behind `https`

The `GET /sse` handler built the message URL from the **raw request URL** (`mcpServer.ts`), whose scheme is the plain-http inbound hop behind Caddy — so it advertised `http://…/message` on an https deployment. It now uses the canonical `resolveServerUrl` (`BREEZE_SERVER || PUBLIC_API_URL`), matching every other URL-emitting route. It deliberately does **not** trust `X-Forwarded-Proto`/`Host` (host-header injection — same reasoning as `enrollmentKeys.ts:952`). Self-hosters set `PUBLIC_API_URL` to their external URL. The request path is preserved so the `/sse → /message` mapping stays correct regardless of mount point.

## Tests
- New `mcpServer.orgKeyPartnerRole.test.ts`: manual-key resolves the owning partner into role resolution (happy path), graceful `null` fallback when the org has no usable partner, and the unchanged `mcp_provisioning` path (no extra DB hit).
- `mcpServer.test.ts`: new assertion that the SSE `endpoint` event uses the configured public base URL scheme/host, not `http://`.
- All 73 MCP unit tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)