### PR TITLE
Polish invoices + internal margin summary panel

### DIFF
--- a/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
@@ -83,6 +83,8 @@ describe('InvoiceDetail — permission gating', () => {
     expect(screen.queryByTestId('invoice-payment-void-p1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-payment-submit')).not.toBeInTheDocument();
+    // But cost/margin IS a read affordance — invoices:read sees the margin panel.
+    expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
   });
 
   it('invoices:write WITHOUT invoices:send still hides every send-gated control', async () => {
@@ -98,6 +100,8 @@ describe('InvoiceDetail — permission gating', () => {
     expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
     // write does not grant export either.
     expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+    // Margin gates on invoices:read specifically — write without read does not see it.
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
   });
 
   it('invoices:export reveals Download PDF but NOT the send-gated controls', async () => {

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -102,6 +102,21 @@ describe('InvoiceDetail', () => {
     expect(JSON.parse((postCall![1] as RequestInit).body as string)).toMatchObject({ amount: 50, method: 'check' });
   });
 
+  it('blocks payment recording on a draft and explains why', async () => {
+    const draft: InvoiceDetailData = {
+      ...issued,
+      invoice: { ...issued.invoice, status: 'draft', invoiceNumber: null },
+    };
+    render(<InvoiceDetail detail={draft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    // The payment form / pay-link must not be offered before an invoice is issued.
+    expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-payment-submit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+    // Instead the operator is told what unlocks it.
+    expect(screen.getByTestId('invoice-payments-draft-hint')).toHaveTextContent('Issue this invoice to record payments.');
+  });
+
   it('shows the void action for an issued invoice and opens the dialog', async () => {
     render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -60,14 +60,44 @@ describe('InvoiceDetail', () => {
     render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
 
-    // Customer view: hidden bundle child not rendered, no cost column.
+    // Customer view: hidden bundle child not rendered, no per-line cost/margin
+    // columns. (Scoped to the table headers — the internal margin summary panel
+    // carries its own "Cost" label and is always visible to readers.)
     expect(screen.queryByTestId('invoice-detail-line-l2')).not.toBeInTheDocument();
-    expect(screen.queryByText('Cost')).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Cost' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Margin' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('invoice-accounting-toggle'));
     expect(screen.getByTestId('invoice-detail-line-l2')).toBeInTheDocument();
-    expect(screen.getByText('Cost')).toBeInTheDocument();
-    expect(screen.getByText('Margin')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Cost' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Margin' })).toBeInTheDocument();
+  });
+
+  it('renders the internal margin summary (billed-only, one-time, excludes tax)', async () => {
+    render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+
+    // l1 is the only billed line: revenue 120 − cost (80×1) = 40. The hidden bundle
+    // child l2 is not customer-visible, so it's excluded (matches the quote math).
+    expect(screen.getByTestId('invoice-margin-cost')).toHaveTextContent('$80.00');
+    expect(screen.getByTestId('invoice-margin-net-onetime')).toHaveTextContent('$40.00');
+    // Invoices are one-time → the recurring profit rows never appear.
+    expect(screen.queryByTestId('invoice-margin-net-monthly')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-margin-net-annual')).not.toBeInTheDocument();
+    // Every billed line has a cost → no "estimate incomplete" warning.
+    expect(screen.queryByTestId('invoice-margin-missing-cost')).not.toBeInTheDocument();
+  });
+
+  it('warns in the margin summary when a billed line has no cost', async () => {
+    const noCost: InvoiceDetailData = {
+      ...issued,
+      lines: [{ ...lines[0], costBasis: null }],
+    };
+    render(<InvoiceDetail detail={noCost} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-margin-missing-cost')).toHaveTextContent('1 line missing a cost');
+    // The line is excluded from the net, so profit reads as $0.00 (not negative).
+    expect(screen.getByTestId('invoice-margin-net-onetime')).toHaveTextContent('$0.00');
   });
 
   it('records a payment via the form', async () => {

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -77,14 +77,36 @@ describe('InvoiceDetail', () => {
     render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
 
-    // l1 is the only billed line: revenue 120 − cost (80×1) = 40. The hidden bundle
-    // child l2 is not customer-visible, so it's excluded (matches the quote math).
+    // l1 is the only top-level line: revenue 120 − cost (80×1) = 40. l2 is a bundle
+    // child (parentLineId 'l1'), so it's excluded from the summary regardless of
+    // visibility — its cost is already rolled into the parent.
     expect(screen.getByTestId('invoice-margin-cost')).toHaveTextContent('$80.00');
     expect(screen.getByTestId('invoice-margin-net-onetime')).toHaveTextContent('$40.00');
     // Invoices are one-time → the recurring profit rows never appear.
     expect(screen.queryByTestId('invoice-margin-net-monthly')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-margin-net-annual')).not.toBeInTheDocument();
-    // Every billed line has a cost → no "estimate incomplete" warning.
+    // Every counted line has a cost → no "estimate incomplete" warning.
+    expect(screen.queryByTestId('invoice-margin-missing-cost')).not.toBeInTheDocument();
+  });
+
+  it('counts a bundle once — a VISIBLE component is not double-counted', async () => {
+    // A bundle persists as a parent rollup line whose costBasis is the full bundle
+    // cost (Σ component costs) PLUS child component lines that each carry their own
+    // costBasis. Here the parent (p1) rolls up cost 80 / revenue 120, and a VISIBLE
+    // component child (c1) carries its own cost 10. Summing every line would give
+    // cost 90 / net 30; folding over top-level lines only gives the correct
+    // cost 80 / net 40 — the parent already includes the component's cost.
+    const bundle: InvoiceDetailData = {
+      ...issued,
+      lines: [
+        { ...lines[0], id: 'p1', parentLineId: null, costBasis: '80.00', revenueAllocation: '120.00', customerVisible: true, quantity: '1.00', unitPrice: '120.00', lineTotal: '120.00' },
+        { ...lines[1], id: 'c1', parentLineId: 'p1', costBasis: '10.00', revenueAllocation: '40.00', customerVisible: true, quantity: '1.00', unitPrice: '0.00', lineTotal: '0.00' },
+      ],
+    };
+    render(<InvoiceDetail detail={bundle} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-margin-cost')).toHaveTextContent('$80.00');
+    expect(screen.getByTestId('invoice-margin-net-onetime')).toHaveTextContent('$40.00');
     expect(screen.queryByTestId('invoice-margin-missing-cost')).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -87,9 +87,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
   );
 
   // Cost/margin is an internal read affordance, visible to anyone who can read
-  // the invoice (mirrors the always-on Accounting view toggle and the quote
-  // rails' `quotes:read` gate). Same shared cents math as quotes so an invoice
-  // margin can't drift from the quote it was issued from.
+  // the invoice (the same read-level gate the quote rails use for `quotes:read`;
+  // cost is a read affordance, not a write one). Independent of the per-line
+  // Accounting view toggle below, which defaults off. Uses the shared cents math
+  // so the figure is rounded + labelled identically to a quote's.
   const canSeeMargin = can('invoices', 'read');
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -95,7 +95,11 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
   // header Tax row), otherwise it'd be a column of dashes.
   const showTax = Number(invoice.taxTotal) > 0;
 
-  const canRecordPayment = invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
+  // Payments only attach to a live invoice: a draft has no number and isn't owed
+  // yet, so taking money against it would book a payment to an invoice that was
+  // never issued. Gate on a non-draft, unpaid, still-owing status.
+  const canRecordPayment =
+    invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
 
   const downloadPdf = useCallback(async () => {
@@ -439,6 +443,12 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
               </ul>
             )}
 
+            {invoice.status === 'draft' && (
+              <p className="mt-3 text-xs text-muted-foreground" data-testid="invoice-payments-draft-hint">
+                Issue this invoice to record payments.
+              </p>
+            )}
+
             {canRecordPayment && stripeConnected && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => void sendPayLink()} disabled={busy}
@@ -527,7 +537,7 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
         isLoading={busy}
         variant="warning"
         title="Record payment"
-        message={`Record a ${formatMoney(Number(payAmount), currency)} payment (${PAYMENT_METHOD_LABELS[payMethod]}) dated ${payDate}?`}
+        message={`Record a ${formatMoney(Number(payAmount), currency)} payment (${PAYMENT_METHOD_LABELS[payMethod]}) dated ${formatDate(payDate)}?`}
         confirmLabel="Record payment"
         confirmTestId="invoice-payment-confirm"
       />
@@ -545,10 +555,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
       />
 
       {/* Void dialog */}
-      <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoice" maxWidth="md" className="p-6">
+      <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoice" labelledBy="invoice-void-title" maxWidth="md" className="p-6">
         <div className="space-y-4" data-testid="invoice-void-dialog">
           <div>
-            <h2 className="text-lg font-semibold">Void invoice</h2>
+            <h2 id="invoice-void-title" className="text-lg font-semibold">Void invoice</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               Voiding releases billed work so it can be re-invoiced. This cannot be undone.
             </p>

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -21,7 +21,9 @@ import {
   lineBlurb,
   pctFromFraction,
   sellerLines,
+  computeInvoiceProfit,
 } from './invoiceTypes';
+import { MarginPanel } from './billingUi';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -83,6 +85,13 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     () => (accountingView ? lines : lines.filter((l) => l.customerVisible)),
     [accountingView, lines],
   );
+
+  // Cost/margin is an internal read affordance, visible to anyone who can read
+  // the invoice (mirrors the always-on Accounting view toggle and the quote
+  // rails' `quotes:read` gate). Same shared cents math as quotes so an invoice
+  // margin can't drift from the quote it was issued from.
+  const canSeeMargin = can('invoices', 'read');
+  const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
   const lineMargin = (l: InvoiceLine): string => {
     if (l.costBasis == null) return '—';
@@ -333,6 +342,10 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
                 {formatMoney(invoice.balance, currency)}
               </span>
             </div>
+            {/* Internal margin summary — profitability stays visible after the
+                invoice is issued and the Editor tab disappears (same reason
+                QuoteDetail renders it). Never reaches the customer document. */}
+            {canSeeMargin && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
           </div>
 
           {/* Seller From block */}

--- a/apps/web/src/components/billing/InvoiceDocument.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InvoiceDocument } from './InvoiceDocument';
+import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+
+// InvoiceDocument is presentational, but its module imports the auth/org stores
+// and navigation (used by the PDF-download affordance). Mock them so the unit
+// renders without real store initialization or network.
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { organizations: { id: string; name: string }[] }) => unknown) =>
+    selector({ organizations: [{ id: 'org-1', name: 'Acme Industries' }] }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// A billed line carrying a cost, plus a hidden bundle child that also carries a
+// cost — neither the cost nor the hidden component may surface on the customer
+// document.
+const detail: InvoiceDetailData = {
+  invoice: {
+    id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
+    currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '120.00',
+    taxRate: '0.000', taxTotal: '0.00', total: '120.00', amountPaid: '0.00', balance: '120.00',
+    billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [
+    {
+      id: 'l1', invoiceId: 'inv-1', sourceType: 'catalog', parentLineId: null, catalogItemId: 'c1',
+      name: null, description: 'Widget', quantity: '1.00', unitPrice: '120.00', costBasis: '80.00', revenueAllocation: '120.00',
+      taxable: true, customerVisible: true, lineTotal: '120.00', isUnapprovedTime: false, sortOrder: 0,
+    },
+    {
+      id: 'l2', invoiceId: 'inv-1', sourceType: 'bundle', parentLineId: 'l1', catalogItemId: 'c2',
+      name: null, description: 'Secret component', quantity: '1.00', unitPrice: '0.00', costBasis: '10.00', revenueAllocation: null,
+      taxable: false, customerVisible: false, lineTotal: '0.00', isUnapprovedTime: false, sortOrder: 1,
+    },
+  ],
+};
+
+describe('InvoiceDocument — customer-facing, no internal cost', () => {
+  it('renders billed lines but never the cost, margin, or hidden components', () => {
+    render(<InvoiceDocument detail={detail} customerName="Acme Industries" />);
+    expect(screen.getByTestId('invoice-document')).toBeInTheDocument();
+
+    // The customer DOES see the line and its price/total.
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+    expect(screen.getAllByText('$120.00').length).toBeGreaterThan(0);
+
+    // Internal cost figures must NOT leak: neither the per-unit cost ($80.00 /
+    // $10.00) nor a margin/cost label, nor the hidden bundle child.
+    expect(screen.queryByText('$80.00')).not.toBeInTheDocument();
+    expect(screen.queryByText('$10.00')).not.toBeInTheDocument();
+    expect(screen.queryByText(/margin/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Cost$/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Secret component')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -78,17 +78,18 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
         {/* ── Header ─────────────────────────────────────────────── */}
         <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-3">
-            {seller?.name ? (
-              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
-                {seller.name}
-              </p>
-            ) : (
-              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
-                Invoice
-              </p>
+            {/* Seller wordmark + letterhead rule only when the seller is named. An
+                unbranded invoice lets the right-hand "Invoice" meta carry identity
+                rather than repeating the word "Invoice" on both sides of the header. */}
+            {seller?.name && (
+              <>
+                <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                  {seller.name}
+                </p>
+                {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
+                <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
+              </>
             )}
-            {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
-            <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
             {seller && (
               <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">
                 {sellerLines(seller.address).map((line, i) => <p key={i}>{line}</p>)}
@@ -101,9 +102,11 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
 
           <div className="space-y-2 sm:text-right">
             <p className="text-[1.75rem] font-semibold leading-none tracking-tight text-foreground" data-testid="invoice-document-number">
-              {invoice.invoiceNumber ?? 'Draft'}
+              {invoice.invoiceNumber ?? 'Invoice'}
             </p>
-            <p className="text-sm font-medium text-muted-foreground">Invoice</p>
+            {/* The "Invoice" type label is redundant on an unnumbered draft, where the
+                heading above already reads "Invoice" and the status pill reads "Draft". */}
+            {invoice.invoiceNumber && <p className="text-sm font-medium text-muted-foreground">Invoice</p>}
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`}
               aria-label={`Status: ${statusLabel(invoice)}`}

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -68,6 +68,8 @@ describe('InvoiceEditor — permission gating', () => {
     expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
     // Notes entry is disabled (gated on write) rather than removed.
     expect(screen.getByTestId('invoice-notes')).toBeDisabled();
+    // Cost/margin is a read affordance — invoices:read sees the margin panel.
+    expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
   });
 
   it('invoices:write reveals editing controls but still hides Issue / Issue & Send', async () => {
@@ -83,6 +85,8 @@ describe('InvoiceEditor — permission gating', () => {
     // send-gated:
     expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
+    // Margin gates on invoices:read specifically — write without read does not see it.
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
   });
 
   it('invoices:send reveals Issue / Issue & Send but NOT the editing controls', async () => {

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -67,6 +67,17 @@ describe('InvoiceEditor', () => {
     expect(screen.getByTestId('invoice-line-line-1')).toHaveTextContent('Consulting');
   });
 
+  it('warns when a line is taxable but no tax rate is configured', async () => {
+    const taxable = { ...manualLine, taxable: true };
+    const { rerender } = render(<InvoiceEditor detail={draft([taxable])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-tax-rate-hint')).toHaveTextContent('no tax rate is set');
+
+    // Once a real rate exists the hint disappears (and the Tax row shows the percent).
+    rerender(<InvoiceEditor detail={draft([taxable], { taxRate: '0.07', taxTotal: '7.00' })} onChanged={vi.fn()} />);
+    expect(screen.queryByTestId('invoice-tax-rate-hint')).not.toBeInTheDocument();
+  });
+
   it('adds a manual line and triggers a reload (onChanged)', async () => {
     const onChanged = vi.fn();
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -132,6 +132,24 @@ describe('InvoiceEditor', () => {
     });
   });
 
+  it('renders the internal margin summary from line costs', async () => {
+    const costedLine = { ...manualLine, id: 'line-c', costBasis: '30.00', quantity: '2.00', unitPrice: '50.00', lineTotal: '100.00' };
+    render(<InvoiceEditor detail={draft([costedLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+    // revenue 100 − cost (30×2 = 60) = 40 net.
+    expect(screen.getByTestId('invoice-margin-cost')).toHaveTextContent('$60.00');
+    expect(screen.getByTestId('invoice-margin-net-onetime')).toHaveTextContent('$40.00');
+    expect(screen.queryByTestId('invoice-margin-net-monthly')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-margin-missing-cost')).not.toBeInTheDocument();
+  });
+
+  it('flags a missing cost in the margin summary', async () => {
+    // manualLine has costBasis null → excluded from net and counted as missing.
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-margin-missing-cost')).toHaveTextContent('1 line missing a cost');
+  });
+
   it('flags unapproved-time lines with a warning banner', async () => {
     const unapproved = { ...manualLine, id: 'line-u', isUnapprovedTime: true };
     render(<InvoiceEditor detail={draft([unapproved])} onChanged={vi.fn()} />);

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -5,13 +5,14 @@ import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
-import { UnsavedBadge } from './billingUi';
+import { UnsavedBadge, MarginPanel } from './billingUi';
 import {
   type InvoiceDetail,
   type InvoiceLine,
   formatMoney,
   lineTitle,
   lineBlurb,
+  computeInvoiceProfit,
 } from './invoiceTypes';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
 import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
@@ -28,8 +29,12 @@ type AddMode = 'catalog' | 'manual';
 export default function InvoiceEditor({ detail, onChanged }: Props) {
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
+  // Cost/margin is a read affordance (mirrors InvoiceDetail + the quote rails'
+  // `quotes:read` gate) — anyone who can read the invoice sees it.
+  const canSeeMargin = can('invoices', 'read');
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
+  const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
   const [busy, setBusy] = useState(false);
   // Distinct from `busy` (which any line edit sets) so the Issue buttons can show
@@ -423,6 +428,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                 <a href="/settings/billing" className="underline hover:text-foreground">Set one in Billing settings</a>.
               </p>
             )}
+            {/* Internal margin summary — at-a-glance profitability while building the
+                invoice (the per-line cost/margin breakdown lives in InvoiceDetail's
+                Accounting view). Reuses the shared quote math; never customer-facing. */}
+            {canSeeMargin && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-bill-to">

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -250,6 +250,11 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   }, [busy, invoice.id, refresh]);
 
   const hasVisibleLines = lines.some((l) => l.customerVisible);
+  // Tax rate is inherited from partner Billing settings, not set per invoice. When
+  // a line is marked taxable but no rate is configured, the Tax row reads $0.00
+  // with no obvious cause — point the operator at where the rate actually lives.
+  const hasTaxableLine = lines.some((l) => l.taxable);
+  const noTaxRate = !invoice.taxRate || Number(invoice.taxRate) <= 0;
 
   return (
     <div className="space-y-6" data-testid="invoice-editor">
@@ -305,15 +310,18 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           {/* Add line */}
           {canWrite && (
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-add-line">
-            <div className="mb-3 flex gap-2">
+            {/* Segmented control — same vocabulary as the New-invoice source toggle
+                so "pick one mode" looks identical everywhere in the invoice flow. */}
+            <div className="mb-3 inline-flex gap-1 rounded-md border bg-muted/40 p-1" role="group" aria-label="Add line source">
               {(['catalog', 'manual'] as AddMode[]).map((m) => (
                 <button
                   key={m}
                   type="button"
                   onClick={() => setAddMode(m)}
+                  aria-pressed={addMode === m}
                   data-testid={`invoice-add-mode-${m}`}
-                  className={`rounded-md border px-3 py-1.5 text-xs font-medium ${
-                    addMode === m ? 'border-primary bg-primary/10 text-primary' : 'hover:bg-muted'
+                  className={`rounded px-3 py-1.5 text-xs font-medium transition ${
+                    addMode === m ? 'bg-card text-foreground shadow-xs' : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {m === 'catalog' ? 'Catalog item' : 'Manual line'}
@@ -406,14 +414,27 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Summary</h3>
             <dl className="space-y-1 text-sm">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd data-testid="invoice-subtotal">{formatMoney(invoice.subtotal, currency)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">Tax{invoice.taxRate ? ` (${(Number(invoice.taxRate) * 100).toFixed(2)}%)` : ''}</dt><dd data-testid="invoice-tax">{formatMoney(invoice.taxTotal, currency)}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted-foreground">Tax{!noTaxRate ? ` (${(Number(invoice.taxRate) * 100).toFixed(2)}%)` : ''}</dt><dd data-testid="invoice-tax">{formatMoney(invoice.taxTotal, currency)}</dd></div>
               <div className="flex justify-between border-t pt-1 font-semibold"><dt>Total</dt><dd data-testid="invoice-total">{formatMoney(invoice.total, currency)}</dd></div>
             </dl>
+            {hasTaxableLine && noTaxRate && (
+              <p className="mt-3 text-xs text-muted-foreground" data-testid="invoice-tax-rate-hint">
+                Lines are marked taxable, but no tax rate is set.{' '}
+                <a href="/settings/billing" className="underline hover:text-foreground">Set one in Billing settings</a>.
+              </p>
+            )}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-bill-to">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Bill to</h3>
-            <p className="text-sm">{invoice.billToName ?? 'Set on the organization billing settings.'}</p>
+            {invoice.billToName ? (
+              <p className="text-sm">{invoice.billToName}</p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No billing contact set.{' '}
+                <a href="/settings/organizations" className="underline hover:text-foreground">Add one in Organization settings</a>.
+              </p>
+            )}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs">

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -84,6 +84,40 @@ describe('InvoicesPage', () => {
     expect(window.location.hash).toContain('orgId=org-1');
   });
 
+  it('surfaces a Drafts shortcut that filters to drafts', async () => {
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+    const drafts = screen.getByTestId('invoices-drafts-card');
+    expect(drafts).toHaveTextContent('Drafts');
+    fireEvent.click(drafts);
+    expect(window.location.hash).toContain('status=draft');
+  });
+
+  it('hides the filter toolbar on a genuinely empty list', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/invoices')) return json({ data: [] });
+      return json({}, false, 404);
+    });
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-empty')).toBeInTheDocument());
+    // Controls with nothing to act on are hidden in the true empty state.
+    expect(screen.queryByTestId('invoices-filters')).not.toBeInTheDocument();
+  });
+
+  it('shows a Clear control once a filter is active and resets all filters', async () => {
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+    // No clear affordance until something is filtering.
+    expect(screen.queryByTestId('invoices-filters-clear')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('invoices-filter-status'), { target: { value: 'overdue' } });
+    fireEvent.click(screen.getByTestId('invoices-filters-clear'));
+    expect(window.location.hash).toBe('');
+    expect(screen.getByTestId('invoices-filter-status')).toHaveValue('');
+  });
+
   it('navigates to a row on click', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from './bulk/useBulkSelection';
 import { BulkActionBar } from './bulk/BulkActionBar';
+import { DataCard, CardField } from '../shared/ResponsiveTable';
 import AccessDenied from '../shared/AccessDenied';
 import {
   type InvoiceStatus,
@@ -166,6 +167,12 @@ export function InvoicesPage() {
     });
   }, []);
 
+  const clearFilters = useCallback(() => {
+    setFilters(EMPTY_FILTERS);
+    writeFilters(EMPTY_FILTERS);
+    setSearch('');
+  }, []);
+
   // Load sites for the org picker in the dialog.
   const loadAssembleSites = useCallback(async (orgId: string) => {
     setAssembleSiteId('');
@@ -290,11 +297,16 @@ export function InvoicesPage() {
     const open = invoices.filter((i) => i.status !== 'void' && num(i.balance) > 0);
     const outstanding = open.reduce((sum, i) => sum + num(i.balance), 0);
     const overdue = invoices.filter((i) => i.status === 'overdue').length;
+    const draftCount = invoices.filter((i) => i.status === 'draft').length;
     // Single-currency partners are the norm; label the strip with the first
     // invoice's currency. Multi-currency outstanding totals are not split in v1.
     const ccy = (invoices[0]?.currencyCode) || 'USD';
-    return { outstanding, overdue, openCount: open.length, ccy };
+    return { outstanding, overdue, draftCount, openCount: open.length, ccy };
   }, [invoices]);
+
+  // Any server- or client-side filter narrowing the list. Drives both the Clear
+  // affordance and whether the toolbar shows on an otherwise-empty list.
+  const filtersActive = !!(filters.orgId || filters.status || filters.from || filters.to || search.trim());
 
   const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
     const active = sort?.key === sortKey;
@@ -362,6 +374,18 @@ export function InvoicesPage() {
             <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outstanding, summary.ccy)}</div>
             <div className="text-xs text-muted-foreground">{summary.openCount} open</div>
           </div>
+          {summary.draftCount > 0 && (
+            <button
+              type="button"
+              onClick={() => applyFilter({ status: 'draft' })}
+              className="rounded-lg border bg-card px-4 py-3 text-left transition hover:bg-muted/40"
+              data-testid="invoices-drafts-card"
+            >
+              <div className="text-xs text-muted-foreground">Drafts</div>
+              <div className="mt-0.5 text-lg font-semibold tabular-nums">{summary.draftCount}</div>
+              <div className="text-xs text-muted-foreground">not yet issued</div>
+            </button>
+          )}
           {summary.overdue > 0 && (
             <button
               type="button"
@@ -377,7 +401,9 @@ export function InvoicesPage() {
         </div>
       )}
 
-      {/* Toolbar: search + filters */}
+      {/* Toolbar: search + filters. Hidden on a genuinely-empty list (no invoices
+          and nothing filtered) — controls with nothing to act on are just noise. */}
+      {(invoices.length > 0 || filtersActive) && (
       <div className="flex flex-wrap items-end gap-2" data-testid="invoices-filters">
         <input
           value={search}
@@ -426,10 +452,22 @@ export function InvoicesPage() {
           aria-label="Issued to"
           className="h-10 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
         />
+        {filtersActive && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            data-testid="invoices-filters-clear"
+            className="inline-flex h-10 items-center rounded-md px-3 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+          >
+            Clear
+          </button>
+        )}
       </div>
+      )}
 
-      {/* Table */}
-      <div className="rounded-lg border bg-card shadow-xs">
+      {/* Table. The card chrome is desktop-only: on mobile the stacked DataCards
+          carry their own borders, so a wrapping card here would nest borders. */}
+      <div className="sm:rounded-lg sm:border sm:bg-card sm:shadow-xs">
         {loading ? (
           <div className="divide-y" data-testid="invoices-loading">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -477,7 +515,10 @@ export function InvoicesPage() {
           </div>
         ) : (
           <div className="relative">
-            <div className="overflow-x-auto">
+            {/* Desktop: scrollable table from `sm` up. Below `sm` a 8-column table
+                pushes Balance + Status into horizontal overflow, so the phone gets
+                a stacked card list instead (same rows, same data, same actions). */}
+            <div className="hidden overflow-x-auto sm:block" data-testid="invoices-table-desktop">
               <table className="w-full text-sm" data-testid="invoices-table">
                 <thead>
                   <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
@@ -553,6 +594,57 @@ export function InvoicesPage() {
                 </tbody>
               </table>
             </div>
+
+            {/* Mobile: stacked cards (the table hides below `sm`). */}
+            <div className="space-y-2 sm:hidden" data-testid="invoices-table-cards">
+              {rows.map((inv) => {
+                const overdue = inv.status === 'overdue';
+                const hasBalance = num(inv.balance) > 0 && inv.status !== 'void';
+                return (
+                  <DataCard
+                    key={inv.id}
+                    onClick={() => void navigateTo(`/billing/invoices/${inv.id}`)}
+                    className={overdue ? 'border-destructive/30' : undefined}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <label className="flex items-center gap-2 font-medium" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select invoice ${inv.invoiceNumber ?? inv.id}`}
+                          data-testid={`invoices-card-select-${inv.id}`}
+                          checked={bulk.has(inv.id)}
+                          onChange={() => bulk.toggle(inv.id)}
+                        />
+                        {inv.invoiceNumber ?? (
+                          <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                            Draft
+                          </span>
+                        )}
+                      </label>
+                      <span
+                        className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
+                        data-testid={`invoices-card-status-${inv.id}`}
+                        aria-label={`Status: ${statusLabel(inv)}`}
+                      >
+                        {statusLabel(inv)}
+                      </span>
+                    </div>
+                    <div className="mt-3 space-y-1.5">
+                      <CardField label="Organization">{orgName(inv.orgId)}</CardField>
+                      <CardField label="Issued">{formatDate(inv.issueDate)}</CardField>
+                      <CardField label="Due">
+                        <span className={overdue ? 'font-medium text-destructive' : undefined}>{formatDate(inv.dueDate)}</span>
+                      </CardField>
+                      <CardField label="Total"><span className="tabular-nums">{formatMoney(inv.total, inv.currencyCode)}</span></CardField>
+                      <CardField label="Balance">
+                        <span className={`tabular-nums ${hasBalance ? 'font-medium' : 'text-muted-foreground'}`}>{formatMoney(inv.balance, inv.currencyCode)}</span>
+                      </CardField>
+                    </div>
+                  </DataCard>
+                );
+              })}
+            </div>
+
             <BulkActionBar
               count={bulk.size}
               onClear={bulk.clear}
@@ -568,10 +660,10 @@ export function InvoicesPage() {
       </div>
 
       {/* Bulk void dialog */}
-      <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoices" maxWidth="md" className="p-6">
+      <Dialog open={voidOpen} onClose={() => setVoidOpen(false)} title="Void invoices" labelledBy="invoices-bulk-void-title" maxWidth="md" className="p-6">
         <div className="space-y-4" data-testid="invoices-bulk-void-dialog">
           <div>
-            <h2 className="text-lg font-semibold">Void invoices</h2>
+            <h2 id="invoices-bulk-void-title" className="text-lg font-semibold">Void invoices</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               Voiding releases billed work so it can be re-invoiced. This cannot be undone.
             </p>
@@ -622,12 +714,13 @@ export function InvoicesPage() {
         open={assembleOpen}
         onClose={() => setAssembleOpen(false)}
         title="New invoice"
+        labelledBy="invoices-assemble-title"
         maxWidth="lg"
         className="p-6"
       >
         <div className="space-y-4" data-testid="invoices-assemble-dialog">
           <div>
-            <h2 className="text-lg font-semibold">New invoice</h2>
+            <h2 id="invoices-assemble-title" className="text-lg font-semibold">New invoice</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               Assemble unbilled work into a draft, or start a blank invoice.
             </p>

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -44,27 +44,40 @@ export function RecurringBillingNote({ className, testId }: { className?: string
 }
 
 /**
- * Internal cost / profit summary for a quote. Single source so the editor rail
- * and the internal detail view show the same figures with the same labels — and
- * so the "missing cost" warning stays readable (dark amber text + icon) instead
- * of the low-contrast bright-amber it used to be. NEVER rendered on the customer
- * document. Both the editor rail and the internal detail view gate it on
- * `quotes:read` (cost is a read affordance, not a write one).
+ * Internal cost / profit summary for a quote or invoice. Single source so the
+ * editor rail and the internal detail view show the same figures with the same
+ * labels — and so the "missing cost" warning stays readable (dark amber text +
+ * icon) instead of the low-contrast bright-amber it used to be. NEVER rendered on
+ * the customer document. Each surface gates it on its own read permission
+ * (`quotes:read` / `invoices:read`) — cost is a read affordance, not a write one.
+ *
+ * `idPrefix` namespaces the data-testids so quote and invoice instances don't
+ * collide in tests; it defaults to `quote` for the original quote callers.
+ * Invoices are one-time, so their `QuoteProfit` carries zero monthly/annual net
+ * and those rows self-hide — the component needs no invoice-specific shape.
  */
-export function MarginPanel({ profit, currency }: { profit: QuoteProfit; currency: string }) {
+export function MarginPanel({
+  profit,
+  currency,
+  idPrefix = 'quote',
+}: {
+  profit: QuoteProfit;
+  currency: string;
+  idPrefix?: string;
+}) {
   return (
-    <div className="mt-3 rounded-md bg-muted/40 p-2 text-sm" data-testid="quote-margin">
+    <div className="mt-3 rounded-md bg-muted/40 p-2 text-sm" data-testid={`${idPrefix}-margin`}>
       <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-[hsl(220_12%_40%)] dark:text-muted-foreground">
         Margin (internal)
       </div>
       <dl className="space-y-1 tabular-nums">
-        <div className="flex justify-between"><dt className="text-muted-foreground">Cost</dt><dd data-testid="quote-margin-cost">{formatMoney(profit.totalCost, currency)}</dd></div>
-        <div className="flex justify-between"><dt className="text-muted-foreground">Profit (one-time)</dt><dd data-testid="quote-margin-net-onetime">{formatMoney(profit.oneTimeNet, currency)}</dd></div>
-        {Number(profit.monthlyRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">Profit (monthly)</dt><dd data-testid="quote-margin-net-monthly">{formatMoney(profit.monthlyRecurringNet, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd></div>}
-        {Number(profit.annualRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">Profit (annual)</dt><dd data-testid="quote-margin-net-annual">{formatMoney(profit.annualRecurringNet, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd></div>}
+        <div className="flex justify-between"><dt className="text-muted-foreground">Cost</dt><dd data-testid={`${idPrefix}-margin-cost`}>{formatMoney(profit.totalCost, currency)}</dd></div>
+        <div className="flex justify-between"><dt className="text-muted-foreground">Profit (one-time)</dt><dd data-testid={`${idPrefix}-margin-net-onetime`}>{formatMoney(profit.oneTimeNet, currency)}</dd></div>
+        {Number(profit.monthlyRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">Profit (monthly)</dt><dd data-testid={`${idPrefix}-margin-net-monthly`}>{formatMoney(profit.monthlyRecurringNet, currency)}<span className="text-xs text-muted-foreground">/mo</span></dd></div>}
+        {Number(profit.annualRecurringNet) !== 0 && <div className="flex justify-between"><dt className="text-muted-foreground">Profit (annual)</dt><dd data-testid={`${idPrefix}-margin-net-annual`}>{formatMoney(profit.annualRecurringNet, currency)}<span className="text-xs text-muted-foreground">/yr</span></dd></div>}
       </dl>
       {profit.linesMissingCost > 0 && (
-        <p className="mt-1 flex items-start gap-1 text-xs text-warning-foreground" data-testid="quote-margin-missing-cost">
+        <p className="mt-1 flex items-start gap-1 text-xs text-warning-foreground" data-testid={`${idPrefix}-margin-missing-cost`}>
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
           <span>
             Profit estimate is incomplete — {profit.linesMissingCost} line{profit.linesMissingCost === 1 ? '' : 's'} missing a cost.

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -212,28 +212,42 @@ export function lineTaxAmount(
 
 /**
  * Internal profit summary for an invoice, computed with the same shared cents
- * math (`computeQuoteProfit`) the quote editor/detail rails use — so an invoice
- * margin can never settle to a different figure than the quote it came from.
+ * math (`computeQuoteProfit`) the quote editor/detail rails use — so the invoice
+ * margin is rounded and labelled identically to a quote's, with no second,
+ * drifting implementation. (It does NOT assert numeric equality with any
+ * originating quote: invoices are edited independently after issue and need not
+ * originate from a quote at all.)
  *
- * Invoices are one-time, so every line maps to `recurrence: 'one_time'` (the
- * monthly/annual nets stay 0 and `MarginPanel` self-hides those rows). Revenue
- * mirrors the per-line "Accounting view" (`revenueAllocation ?? lineTotal`) and
- * cost is the full line cost (`costBasis × quantity`); both are folded into a
- * single synthetic unit (`quantity: '1'`) so the shared per-line math reproduces
- * exactly those figures. Lines with no `costBasis` are excluded from the net and
- * counted in `linesMissingCost` (drives the "estimate incomplete" warning) — the
- * same billed-only (`customerVisible`), tax-excluded contract as quotes.
+ * Bundles are the subtlety. A bundle persists as a parent rollup line whose
+ * `costBasis` is the FULL bundle cost (`Σ component.costBasis × component.qty`,
+ * see `computeBundleEconomicsFrom`) plus child component lines that each carry
+ * their OWN `costBasis` and may be `customerVisible`. Folding over every line
+ * would count a visible component's cost twice (parent rollup + child). So we
+ * fold over TOP-LEVEL lines only (`parentLineId === null`): the parent represents
+ * each bundle exactly once, and every manual/catalog line is already top-level.
+ * Children are excluded by parentage, not visibility — a *visible* component must
+ * still not be double-counted.
+ *
+ * Each top-level line maps straight through (raw `quantity`/`unitPrice`/
+ * `costBasis`, same as the quote mapping) so the shared cents math does a single
+ * round and a null `costBasis` is counted in `linesMissingCost` (driving the
+ * "estimate incomplete" warning) rather than silently booked as $0. Invoices are
+ * one-time → `recurrence: 'one_time'`, so the monthly/annual nets stay 0 and
+ * `MarginPanel` self-hides those rows. Billed-only (`customerVisible`) and
+ * tax-excluded — the same contract as quotes.
  */
 export function computeInvoiceProfit(lines: InvoiceLine[]): QuoteProfit {
   return computeQuoteProfit(
-    lines.map((l) => ({
-      quantity: '1',
-      unitPrice: l.revenueAllocation ?? l.lineTotal,
-      unitCost: l.costBasis == null ? null : (Number(l.costBasis) * Number(l.quantity)).toFixed(2),
-      taxable: l.taxable,
-      customerVisible: l.customerVisible,
-      recurrence: 'one_time' as const,
-    })),
+    lines
+      .filter((l) => l.parentLineId === null)
+      .map((l) => ({
+        quantity: l.quantity,
+        unitPrice: l.unitPrice,
+        unitCost: l.costBasis,
+        taxable: l.taxable,
+        customerVisible: l.customerVisible,
+        recurrence: 'one_time' as const,
+      })),
   );
 }
 

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -35,6 +35,7 @@ export function sellerLines(a: SellerSnapshot['address'] | null | undefined): st
 // (packages/shared/src/types/billing-enums.ts). Imported for the Record maps
 // below and re-exported so existing './invoiceTypes' consumers are unaffected.
 import type { InvoiceStatus, PaymentMethod, InvoiceLineSourceType } from '@breeze/shared';
+import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 export type { InvoiceStatus, PaymentMethod, InvoiceLineSourceType };
 
 export interface InvoiceSummary {
@@ -207,6 +208,33 @@ export function lineTaxAmount(
   const cents = Math.round(Number(lineTotal) * 100);
   if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
   return Math.round(cents * rate) / 100;
+}
+
+/**
+ * Internal profit summary for an invoice, computed with the same shared cents
+ * math (`computeQuoteProfit`) the quote editor/detail rails use — so an invoice
+ * margin can never settle to a different figure than the quote it came from.
+ *
+ * Invoices are one-time, so every line maps to `recurrence: 'one_time'` (the
+ * monthly/annual nets stay 0 and `MarginPanel` self-hides those rows). Revenue
+ * mirrors the per-line "Accounting view" (`revenueAllocation ?? lineTotal`) and
+ * cost is the full line cost (`costBasis × quantity`); both are folded into a
+ * single synthetic unit (`quantity: '1'`) so the shared per-line math reproduces
+ * exactly those figures. Lines with no `costBasis` are excluded from the net and
+ * counted in `linesMissingCost` (drives the "estimate incomplete" warning) — the
+ * same billed-only (`customerVisible`), tax-excluded contract as quotes.
+ */
+export function computeInvoiceProfit(lines: InvoiceLine[]): QuoteProfit {
+  return computeQuoteProfit(
+    lines.map((l) => ({
+      quantity: '1',
+      unitPrice: l.revenueAllocation ?? l.lineTotal,
+      unitCost: l.costBasis == null ? null : (Number(l.costBasis) * Number(l.quantity)).toFixed(2),
+      taxable: l.taxable,
+      customerVisible: l.customerVisible,
+      recurrence: 'one_time' as const,
+    })),
+  );
 }
 
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */

--- a/apps/web/src/components/shared/Dialog.tsx
+++ b/apps/web/src/components/shared/Dialog.tsx
@@ -29,8 +29,13 @@ const FOCUSABLE =
 export interface DialogProps {
   open: boolean;
   onClose: () => void;
-  /** Accessible label (used as aria-label) */
+  /** Accessible label (used as aria-label). Ignored when `labelledBy` is set. */
   title: string;
+  /** Id of a visible heading inside the dialog. When provided, the dialog is
+   *  named via `aria-labelledby` instead of `aria-label`, so a screen reader
+   *  doesn't announce the same text twice (once as the dialog name, once as the
+   *  visible heading). */
+  labelledBy?: string;
   /** Maps to Tailwind max-w-{value}. Default: 'lg' */
   maxWidth?: DialogMaxWidth;
   /** Top-align instead of center (for tall content that scrolls the backdrop) */
@@ -44,6 +49,7 @@ export function Dialog({
   open,
   onClose,
   title,
+  labelledBy,
   maxWidth = 'lg',
   alignTop = false,
   className = '',
@@ -127,7 +133,7 @@ export function Dialog({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        {...(labelledBy ? { 'aria-labelledby': labelledBy } : { 'aria-label': title })}
         tabIndex={-1}
         className={`dialog-panel w-full ${maxWidthClass[maxWidth]} rounded-lg border bg-card shadow-lg focus:outline-hidden ${className}`}
         style={{ animation: 'dialog-panel-in 200ms cubic-bezier(0.25, 1, 0.5, 1)' }}


### PR DESCRIPTION
## Summary

Two related pieces of invoice work on top of the catalog/quotes margin pipeline (#2025):

### 1. Invoice editor/detail/document UX polish
- **Payments gated on draft** — a draft has no number and isn't owed yet, so the payment form/pay-link are hidden with an "Issue this invoice to record payments." hint.
- **Document header dedupe** — the seller wordmark + letterhead rule only render when the seller is named; the redundant "Invoice" type label is dropped on an unnumbered draft.
- **Operator hints** — "Lines are marked taxable, but no tax rate is set" (tax rate lives in Billing settings) and "No billing contact set" (links to Organization settings).
- **Segmented add-line control** matching the New-invoice source toggle; dialog a11y (`labelledBy`); payment-confirm date formatting.

### 2. Invoice "Margin (internal)" summary panel
Reuses the shared `computeQuoteProfit` math + `MarginPanel` component shipped with quotes (#2025) to render an at-a-glance internal profit summary in the **InvoiceEditor** and **InvoiceDetail** right rails, gated on `invoices:read` (cost is a read affordance, mirroring the quote rails).

- `computeInvoiceProfit` adapter maps invoice lines (`costBasis` + `revenueAllocation`, one-time) into the shared `QuoteProfit` shape, so an invoice margin can never diverge from the quote it was issued from. Billed-only (`customerVisible`), tax-excluded — same contract as quotes.
- `MarginPanel` gains an optional `idPrefix` so quote/invoice instances don't collide on `data-testid`s (defaults to `quote`; quote callers unchanged).
- The per-line **Accounting view** columns in InvoiceDetail stay as the line-level breakdown; the panel is the summary.

**Out of scope** (deliberately): per-line internal strip in the editor, markup/distributor editing, recurring profit.

## Testing
- **Unit:** 134/134 billing tests green (`pnpm --filter @breeze/web test src/components/billing`); web `tsc --noEmit` clean. New coverage: margin totals from `costBasis`, missing-cost warning, recurring rows absent, read-gated visibility (read shows / write-without-read hides), and a guard that the customer `InvoiceDocument` carries no cost.
- **Live (Playwright, isolated worktree stack):**
  - InvoiceDetail + InvoiceEditor panels render; missing-cost path exercised on real seed data.
  - Customer Preview tab carries **no** Margin/Cost/Profit — leak guard holds in the real UI.
  - Positive path verified by setting a `cost_basis` in the isolated DB → Cost $120.00, Profit $130.00 (math matches), then reverted.
  - 0 console errors/warnings on invoice pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
