### PR TITLE
M365 Exchange shared-mailbox email-to-ticket (inbound + outbound)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -460,6 +460,20 @@ C2C_M365_CLIENT_SECRET=
 # C2C_M365_CERT_THUMBPRINT=
 # C2C_M365_CERT_PRIVATE_KEY_PATH=
 
+# M365 Ticket Mailbox (Optional — email-to-ticket via a shared support mailbox)
+# --------------------------------------------
+# SEPARATE Azure app registration from the C2C app above. When set, partner admins
+# can connect an M365 shared mailbox (admin-consent flow) so customer email becomes
+# tickets and replies are sent from that mailbox via Microsoft Graph.
+# Register a multi-tenant app with Graph APPLICATION permissions: Mail.ReadWrite, Mail.Send.
+# Register the redirect URI: <PUBLIC_URL>/api/v1/tickets/mailbox/callback
+# Unset = feature disabled (routes return 400, nothing breaks at boot).
+TICKET_MAILBOX_M365_CLIENT_ID=
+TICKET_MAILBOX_M365_CLIENT_SECRET=
+# Web (PUBLIC_*, exposed to the browser): the app id shown in the New-ApplicationAccessPolicy
+# PowerShell snippet on the settings card. Safe to publish — it is the app's public id.
+PUBLIC_TICKET_MAILBOX_APP_ID=
+
 # --------------------------------------------
 # Cloudflare mTLS (API Shield Client Certificates)
 # --------------------------------------------

--- a/apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql
+++ b/apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS ticket_mailbox_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id uuid NOT NULL REFERENCES partners(id),
+  tenant_id text,
+  mailbox_address text NOT NULL,
+  display_name text,
+  status varchar(20) NOT NULL DEFAULT 'pending_consent',
+  delta_link text,
+  strict_sender_auth boolean NOT NULL DEFAULT false,
+  last_polled_at timestamptz,
+  last_message_at timestamptz,
+  last_error text,
+  created_by uuid REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ticket_mailbox_connections_partner_mailbox_idx
+  ON ticket_mailbox_connections(partner_id, mailbox_address);
+CREATE UNIQUE INDEX IF NOT EXISTS ticket_mailbox_connections_id_partner_idx
+  ON ticket_mailbox_connections(id, partner_id);
+
+ALTER TABLE ticket_mailbox_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ticket_mailbox_connections FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON ticket_mailbox_connections;
+CREATE POLICY breeze_partner_isolation_select ON ticket_mailbox_connections
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON ticket_mailbox_connections
+  FOR INSERT WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_update ON ticket_mailbox_connections
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_delete ON ticket_mailbox_connections
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));

--- a/apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
+++ b/apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
@@ -47,7 +47,8 @@ describe('M365 inbound → ticket (real DB)', () => {
       bodyPreview: 'printer down',
       hasAttachments: false,
       internetMessageHeaders: [
-        { name: 'Authentication-Results', value: 'spf=pass; dkim=pass; dmarc=pass' },
+        // authserv-id 'a.com' matches the support mailbox domain → trusted (clears R4).
+        { name: 'Authentication-Results', value: 'a.com; spf=pass; dkim=pass; dmarc=pass' },
       ],
     };
     const normalized = normalizeGraphMessage(msg, partnerId, 'support@a.com');

--- a/apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
+++ b/apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * End-to-end (real DB): a Graph message, normalized via the M365 path with a
+ * PRE-RESOLVED partner, flows through the existing processInboundEmail pipeline
+ * and creates a ticket — proving the Plan 2 ingest reuses all of the inbound
+ * threading/dedup/ticket logic.
+ *
+ * Org resolution: processInboundEmail still resolves the ORG even when the
+ * partner is pre-resolved. An unknown sender would quarantine (step 8), so we
+ * seed a portal user for the sender (findPortalUserInPartner → step 5) to
+ * exercise the 'created' path. The sender-auth gate (R4) requires DMARC pass,
+ * so the Graph message carries Authentication-Results: dmarc=pass.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { withSystemDbAccessContext } from '../../db';
+import { ticketEmailInbound, portalUsers } from '../../db/schema';
+import { createPartner, createOrganization } from './db-utils';
+import { getTestDb } from './setup';
+import { normalizeGraphMessage } from '../../services/ticketMailbox/normalizeGraphMessage';
+import { processInboundEmail } from '../../services/inboundEmail/inboundEmailService';
+import type { GraphMessage } from '../../services/ticketMailbox/graphMailClient';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('M365 inbound → ticket (real DB)', () => {
+  runDb('creates a ticket from a normalized Graph message via the pre-resolved partner', async () => {
+    const db = getTestDb() as any;
+    const suffix = `${Date.now()}-${Math.floor(performance.now())}`;
+    const custEmail = `cust-${suffix}@known.test`;
+
+    const { partnerId, orgId } = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      // Known portal user → findPortalUserInPartner resolves the org (the 'created' path).
+      await db.insert(portalUsers).values({ orgId: org.id, email: custEmail, name: 'Cust' });
+      return { partnerId: partner.id, orgId: org.id };
+    });
+
+    const msg: GraphMessage = {
+      id: `graph-${suffix}`,
+      internetMessageId: `<${suffix}@known.test>`,
+      subject: 'Cannot print',
+      from: { emailAddress: { address: custEmail, name: 'Cust' } },
+      toRecipients: [{ emailAddress: { address: 'support@a.com' } }],
+      body: { contentType: 'html', content: '<p>printer down</p>' },
+      bodyPreview: 'printer down',
+      hasAttachments: false,
+      internetMessageHeaders: [
+        { name: 'Authentication-Results', value: 'spf=pass; dkim=pass; dmarc=pass' },
+      ],
+    };
+    const normalized = normalizeGraphMessage(msg, partnerId, 'support@a.com');
+    // Pre-resolved partner + verified sender → bypasses recipient resolution, clears R4.
+    expect(normalized.resolvedPartnerId).toBe(partnerId);
+    expect(normalized.senderAuth?.verified).toBe(true);
+
+    await withSystemDbAccessContext(() => processInboundEmail(normalized));
+
+    const rows = await db
+      .select()
+      .from(ticketEmailInbound)
+      .where(and(
+        eq(ticketEmailInbound.partnerId, partnerId),
+        eq(ticketEmailInbound.providerMessageId, msg.id),
+      ));
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].provider).toBe('m365');
+    expect(rows[0].parseStatus).toBe('created');
+    expect(rows[0].ticketId).toBeTruthy();
+
+    // The created ticket lives in the portal user's org under the resolved partner.
+    const ticketRows = await withSystemDbAccessContext(async () => {
+      const { tickets } = await import('../../db/schema');
+      return db.select().from(tickets).where(eq(tickets.id, rows[0].ticketId!)).limit(1);
+    });
+    expect(ticketRows[0]?.orgId).toBe(orgId);
+    expect(ticketRows[0]?.partnerId).toBe(partnerId);
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -127,6 +127,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   ['email_verification_tokens', 'partner_id'],
   ['ticket_categories', 'partner_id'],
   ['ticket_response_templates', 'partner_id'],
+  ['ticket_mailbox_connections', 'partner_id'],
   ['partner_ticket_sequences', 'partner_id'],
   ['partner_invoice_sequences', 'partner_id'],
   ['partner_quote_sequences', 'partner_id'],

--- a/apps/api/src/__tests__/integration/ticketMailboxConnections.rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketMailboxConnections.rls.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Functional forge proof for ticket_mailbox_connections.
+ *
+ * The table is partner-axis (RLS shape 3) and must be protected by the flat
+ * public.breeze_has_partner_access(partner_id) policies. These tests run
+ * through the real driver as the unprivileged app role under the integration
+ * config; do not run them with plain unit-test Vitest config.
+ *
+ * Fixtures are deliberately re-seeded per test. The integration setup truncates
+ * tenant data between tests, so a memoized fixture would be stale and vacuous.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+import { createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function partnerCtx(partnerId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: null,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+async function seedTwoPartners() {
+  return withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    return { partnerA, partnerB, partnerAContext: partnerCtx(partnerA.id) };
+  });
+}
+
+async function captureCause(fn: () => Promise<unknown>): Promise<{ code?: string; message?: string } | undefined> {
+  try {
+    await fn();
+    return undefined;
+  } catch (err) {
+    return (err as { cause?: { code?: string; message?: string } }).cause;
+  }
+}
+
+describe('ticket_mailbox_connections RLS — partner-axis forge (breeze_app role)', () => {
+  // Non-vacuity guard: if the code-under-test pool is ever a BYPASSRLS role
+  // (e.g. a worktree missing its .env.test symlink), every forge assertion
+  // below passes even with broken policies. Fail loudly here first.
+  runDb('code-under-test runs as a non-BYPASSRLS role (guards against vacuous RLS)', async () => {
+    const { partnerAContext } = await seedTwoPartners();
+    const rows = await withDbAccessContext(partnerAContext, () =>
+      db.execute(sql`SELECT current_user AS who, rolbypassrls
+                     FROM pg_roles WHERE rolname = current_user`)
+    );
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row?.who).toBe('breeze_app');
+    expect(row?.rolbypassrls).toBe(false);
+  });
+
+  runDb('allows a legitimate partner-A ticket mailbox connection insert and read', async () => {
+    const { partnerA, partnerAContext } = await seedTwoPartners();
+
+    const [row] = await withDbAccessContext(partnerAContext, () =>
+      db
+        .insert(ticketMailboxConnections)
+        .values({
+          partnerId: partnerA.id,
+          mailboxAddress: 'support@a.com',
+        })
+        .returning({ id: ticketMailboxConnections.id })
+    );
+
+    expect(row?.id).toBeDefined();
+    if (!row) throw new Error('insert returned no row');
+
+    const rows = await withDbAccessContext(partnerAContext, () =>
+      db
+        .select({ id: ticketMailboxConnections.id })
+        .from(ticketMailboxConnections)
+        .where(eq(ticketMailboxConnections.id, row.id))
+    );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  runDb('hides a partner-B ticket mailbox connection from partner-A SELECT', async () => {
+    const { partnerB, partnerAContext } = await seedTwoPartners();
+
+    const [seeded] = await withSystemDbAccessContext(() =>
+      db
+        .insert(ticketMailboxConnections)
+        .values({
+          partnerId: partnerB.id,
+          mailboxAddress: 'support@b.com',
+        })
+        .returning({ id: ticketMailboxConnections.id })
+    );
+    expect(seeded?.id).toBeDefined();
+    if (!seeded) throw new Error('seed insert returned no row');
+
+    const systemProbe = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: ticketMailboxConnections.id })
+        .from(ticketMailboxConnections)
+        .where(eq(ticketMailboxConnections.id, seeded.id))
+    );
+    expect(systemProbe).toHaveLength(1);
+
+    const rows = await withDbAccessContext(partnerAContext, () =>
+      db
+        .select({ id: ticketMailboxConnections.id })
+        .from(ticketMailboxConnections)
+        .where(eq(ticketMailboxConnections.id, seeded.id))
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  runDb('rejects a forged cross-partner ticket mailbox connection insert', async () => {
+    const { partnerB, partnerAContext } = await seedTwoPartners();
+
+    const cause = await captureCause(() =>
+      withDbAccessContext(partnerAContext, () =>
+        db.insert(ticketMailboxConnections).values({
+          partnerId: partnerB.id,
+          mailboxAddress: 'support@b.com',
+        })
+      )
+    );
+
+    expect(cause?.code).toBe('42501');
+    expect(cause?.message).toMatch(/row-level security/i);
+    expect(cause?.message).toMatch(
+      /new row violates row-level security policy for table "ticket_mailbox_connections"/
+    );
+  });
+});

--- a/apps/api/src/__tests__/integration/ticketMailboxCursor.rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketMailboxCursor.rls.integration.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression (real DB) for the worker-write RLS hole: ticket_mailbox_connections is
+ * FORCE ROW LEVEL SECURITY, and the poll worker runs with NO request DB context.
+ * updateDeltaCursor / resetDeltaCursor / setConnectionStatus therefore self-wrap (or
+ * are wrapped at the call site) in system context — otherwise the FORCE-RLS UPDATE
+ * matches zero rows SILENTLY and the cursor never advances / status never updates.
+ *
+ * These tests call those writes with NO surrounding context (exactly as the worker
+ * does) and assert the row actually changed. Before the fix they pass-but-persist-
+ * nothing (0-row update, no error); the read-backs would still show the old values.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+import { createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedConnectedMailbox(): Promise<{ id: string; partnerId: string }> {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const [row] = await db.insert(ticketMailboxConnections).values({
+      partnerId: partner.id,
+      tenantId: '11111111-1111-1111-1111-111111111111',
+      mailboxAddress: `support-${Date.now()}@a.com`,
+      status: 'connected',
+    }).returning({ id: ticketMailboxConnections.id });
+    return { id: row!.id, partnerId: partner.id };
+  });
+}
+
+async function readBack(id: string): Promise<{ deltaLink: string | null; status: string }> {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db.select({ deltaLink: ticketMailboxConnections.deltaLink, status: ticketMailboxConnections.status })
+      .from(ticketMailboxConnections).where(eq(ticketMailboxConnections.id, id)).limit(1);
+    return rows[0]!;
+  });
+}
+
+describe('ticket_mailbox_connections worker writes persist under FORCE RLS (no request context)', () => {
+  runDb('updateDeltaCursor persists the cursor when called with no DB context', async () => {
+    const { id } = await seedConnectedMailbox();
+    const { updateDeltaCursor } = await import('../../services/ticketMailbox/connectionService');
+    // Called exactly as the worker does: no surrounding withSystemDbAccessContext.
+    await updateDeltaCursor(id, 'delta-PERSISTED', new Date(), null);
+    expect((await readBack(id)).deltaLink).toBe('delta-PERSISTED');
+  });
+
+  runDb('resetDeltaCursor clears the cursor when called with no DB context', async () => {
+    const { id } = await seedConnectedMailbox();
+    const { updateDeltaCursor, resetDeltaCursor } = await import('../../services/ticketMailbox/connectionService');
+    await updateDeltaCursor(id, 'delta-to-clear', new Date(), null);
+    await resetDeltaCursor(id);
+    expect((await readBack(id)).deltaLink).toBeNull();
+  });
+
+  runDb('setConnectionStatus persists when wrapped in system context (worker call shape)', async () => {
+    const { id, partnerId } = await seedConnectedMailbox();
+    const { setConnectionStatus } = await import('../../services/ticketMailbox/connectionService');
+    const { runOutsideDbContext, withSystemDbAccessContext: sysCtx } = await import('../../db');
+    // Mirror the worker call site: setConnectionStatus is shared (bare db), wrapped here.
+    await runOutsideDbContext(() => sysCtx(() => setConnectionStatus(id, partnerId, 'reauth_required', 'token expired')));
+    expect((await readBack(id)).status).toBe('reauth_required');
+  });
+});

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -84,6 +84,7 @@ export * from './refreshTokenFamilies';
 export * from './tickets';
 export * from './ticketConfig';
 export * from './ticketResponseTemplates';
+export * from './ticketMailbox';
 export * from './catalog';
 export * from './timeTracking';
 export * from './invoices';

--- a/apps/api/src/db/schema/ticketMailbox.ts
+++ b/apps/api/src/db/schema/ticketMailbox.ts
@@ -1,0 +1,25 @@
+import { pgTable, uuid, text, boolean, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+import { users } from './users';
+
+export const ticketMailboxConnections = pgTable('ticket_mailbox_connections', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  tenantId: text('tenant_id'),
+  mailboxAddress: text('mailbox_address').notNull(),
+  displayName: text('display_name'),
+  status: text('status').notNull().default('pending_consent'),
+  deltaLink: text('delta_link'),
+  strictSenderAuth: boolean('strict_sender_auth').notNull().default(false),
+  lastPolledAt: timestamp('last_polled_at', { withTimezone: true }),
+  lastMessageAt: timestamp('last_message_at', { withTimezone: true }),
+  lastError: text('last_error'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  partnerMailboxIdx: uniqueIndex('ticket_mailbox_connections_partner_mailbox_idx')
+    .on(table.partnerId, table.mailboxAddress),
+  idPartnerIdx: uniqueIndex('ticket_mailbox_connections_id_partner_idx')
+    .on(table.id, table.partnerId),
+}));

--- a/apps/api/src/db/schema/ticketMailbox.ts
+++ b/apps/api/src/db/schema/ticketMailbox.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, boolean, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, varchar, boolean, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
 import { partners } from './orgs';
 import { users } from './users';
 
@@ -8,7 +8,7 @@ export const ticketMailboxConnections = pgTable('ticket_mailbox_connections', {
   tenantId: text('tenant_id'),
   mailboxAddress: text('mailbox_address').notNull(),
   displayName: text('display_name'),
-  status: text('status').notNull().default('pending_consent'),
+  status: varchar('status', { length: 20 }).notNull().default('pending_consent'),
   deltaLink: text('delta_link'),
   strictSenderAuth: boolean('strict_sender_auth').notNull().default(false),
   lastPolledAt: timestamp('last_polled_at', { withTimezone: true }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,6 +30,7 @@ import { automationRoutes, automationWebhookRoutes } from './routes/automations'
 import { alertRoutes } from './routes/alerts';
 import { alertTemplateRoutes } from './routes/alertTemplates';
 import { ticketsRoutes } from './routes/tickets';
+import { mailboxRoutes } from './routes/tickets/mailboxConnect';
 import { catalogRoutes } from './routes/catalog';
 import { emailWebhookRoutes } from './routes/tickets/emailWebhook';
 import { invoiceRoutes } from './routes/invoices';
@@ -763,6 +764,13 @@ api.route('/automations/webhooks', automationWebhookRoutes);
 api.route('/automations', automationRoutes);
 api.route('/alerts', alertRoutes);
 api.route('/alert-templates', alertTemplateRoutes);
+// M365 mailbox OAuth + connection routes. Mounted as its OWN top-level router
+// (NOT under ticketsRoutes) and BEFORE /tickets so its literal /tickets/mailbox/*
+// paths win over ticketsRoutes' generic /:id matchers, and — critically — so the
+// unauthenticated /tickets/mailbox/callback escapes ticketsRoutes' .use('*',
+// authMiddleware) gate (the Microsoft admin-consent redirect carries no Bearer
+// token). The callback authenticates via signed state + binding cookie instead.
+api.route('/tickets/mailbox', mailboxRoutes);
 api.route('/tickets', ticketsRoutes);
 api.route('/catalog', catalogRoutes);
 api.route('/invoices', invoiceRoutes);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -242,6 +242,7 @@ import { initializeQuoteExpiryReaper, shutdownQuoteExpiryReaper } from './jobs/q
 import { initializeTicketNotifyWorker, shutdownTicketNotifyWorker } from './jobs/ticketNotifyWorker';
 import { initializeTicketSlaWorker, shutdownTicketSlaWorker } from './jobs/ticketSlaWorker';
 import { initializeInboundEmailWorker, shutdownInboundEmailWorker } from './jobs/inboundEmailWorker';
+import { initializeTicketMailboxPollWorker } from './jobs/ticketMailboxPollWorker';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
 import { decryptForColumn } from './services/secretCrypto';
@@ -1191,6 +1192,7 @@ async function initializeWorkers(): Promise<void> {
     ['ticketNotifyWorker', initializeTicketNotifyWorker],
     ['ticketSlaWorker', initializeTicketSlaWorker],
     ['inboundEmailWorker', initializeInboundEmailWorker],
+    ['ticketMailboxPollWorker', initializeTicketMailboxPollWorker],
     ['invoiceWorker', initializeInvoiceWorkers],
     ['contractWorker', initializeContractWorkers],
   ];

--- a/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// The worker wraps shared-path writes (setConnectionStatus) in the DB-context
+// helpers so the FORCE-RLS UPDATE runs under system scope. This is a unit test
+// with no database, so make the helpers pass-throughs that just invoke their
+// callback — the real context behavior is exercised by the cursor RLS
+// integration test (ticketMailboxCursor.rls.integration.test.ts).
+vi.mock('../db', () => ({
+  runOutsideDbContext: (fn: () => any) => fn(),
+  withSystemDbAccessContext: (fn: () => any) => fn(),
+}));
+
 vi.mock('../services/ticketMailbox/connectionService', () => ({
   listConnectedMailboxes: vi.fn(),
   updateDeltaCursor: vi.fn(async () => {}),

--- a/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/ticketMailbox/connectionService', () => ({
+  listConnectedMailboxes: vi.fn(),
+  updateDeltaCursor: vi.fn(async () => {}),
+  resetDeltaCursor: vi.fn(async () => {}),
+  setConnectionStatus: vi.fn(async () => {}),
+}));
+vi.mock('../services/ticketMailbox/mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+vi.mock('../services/ticketMailbox/graphMailClient', () => ({
+  listInboxDelta: vi.fn(),
+  markRead: vi.fn(async () => {}),
+}));
+vi.mock('../services/ticketMailbox/normalizeGraphMessage', () => ({
+  normalizeGraphMessage: vi.fn((msg: any, partnerId: string, mailbox: string) => ({
+    provider: 'm365', providerMessageId: msg.id, resolvedPartnerId: partnerId, to: mailbox,
+    from: 'x@y.com', subject: '', text: '', attachments: [], raw: {},
+  })),
+}));
+vi.mock('../services/inboundEmailQueue', () => ({ enqueueInboundEmail: vi.fn(async () => {}) }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+import { listConnectedMailboxes, updateDeltaCursor, resetDeltaCursor, setConnectionStatus } from '../services/ticketMailbox/connectionService';
+import { listInboxDelta, markRead } from '../services/ticketMailbox/graphMailClient';
+import { enqueueInboundEmail } from '../services/inboundEmailQueue';
+import { runMailboxSweep } from './ticketMailboxPollWorker';
+
+const conn = (over: Partial<any> = {}) => ({
+  id: 'c1', partnerId: 'p1', tenantId: '11111111-1111-1111-1111-111111111111',
+  mailboxAddress: 'support@a.com', status: 'connected', deltaLink: null, ...over,
+});
+
+describe('runMailboxSweep', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('enqueues each new message, marks it read, then persists the new deltaLink', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn()] as any);
+    vi.mocked(listInboxDelta).mockResolvedValue({ messages: [{ id: 'm1' }, { id: 'm2' }], deltaLink: 'delta-new' } as any);
+
+    await runMailboxSweep();
+
+    expect(enqueueInboundEmail).toHaveBeenCalledTimes(2);
+    expect(markRead).toHaveBeenCalledTimes(2);
+    expect(updateDeltaCursor).toHaveBeenCalledWith('c1', 'delta-new', expect.any(Date), expect.anything());
+    const enqueueOrder = vi.mocked(enqueueInboundEmail).mock.invocationCallOrder[0]!;
+    const cursorOrder = vi.mocked(updateDeltaCursor).mock.invocationCallOrder[0]!;
+    expect(enqueueOrder).toBeLessThan(cursorOrder);
+  });
+
+  it('does not persist a cursor if enqueue throws (replay-safe)', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn()] as any);
+    vi.mocked(listInboxDelta).mockResolvedValue({ messages: [{ id: 'm1' }], deltaLink: 'delta-new' } as any);
+    vi.mocked(enqueueInboundEmail).mockRejectedValueOnce(new Error('redis down'));
+
+    await runMailboxSweep();
+    expect(updateDeltaCursor).not.toHaveBeenCalled();
+    expect(setConnectionStatus).not.toHaveBeenCalledWith('c1', 'p1', 'reauth_required', expect.anything());
+  });
+
+  it('marks reauth_required on a 401 from Graph and isolates per mailbox', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn({ id: 'bad' }), conn({ id: 'good' })] as any);
+    vi.mocked(listInboxDelta)
+      .mockImplementationOnce(async () => { const e: any = new Error('401'); e.status = 401; throw e; })
+      .mockResolvedValueOnce({ messages: [], deltaLink: 'd' } as any);
+
+    await runMailboxSweep();
+    expect(setConnectionStatus).toHaveBeenCalledWith('bad', 'p1', 'reauth_required', expect.any(String));
+    expect(updateDeltaCursor).toHaveBeenCalledWith('good', 'd', expect.any(Date), expect.anything());
+  });
+
+  it('resets the cursor on a 410 Gone and stays connected', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn()] as any);
+    vi.mocked(listInboxDelta).mockImplementationOnce(async () => { const e: any = new Error('410'); e.status = 410; throw e; });
+
+    await runMailboxSweep();
+    expect(resetDeltaCursor).toHaveBeenCalledWith('c1');
+    expect(setConnectionStatus).not.toHaveBeenCalled();
+    expect(updateDeltaCursor).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/ticketMailboxPollWorker.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.ts
@@ -1,0 +1,110 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import {
+  listConnectedMailboxes,
+  updateDeltaCursor,
+  resetDeltaCursor,
+  setConnectionStatus,
+} from '../services/ticketMailbox/connectionService';
+import { getMailboxToken } from '../services/ticketMailbox/mailboxToken';
+import { listInboxDelta, markRead } from '../services/ticketMailbox/graphMailClient';
+import { normalizeGraphMessage } from '../services/ticketMailbox/normalizeGraphMessage';
+import { enqueueInboundEmail } from '../services/inboundEmailQueue';
+
+const QUEUE_NAME = 'ticket-mailbox-poll';
+const SWEEP_INTERVAL_MS = 90 * 1000;
+const SWEEP_JOB_ID = 'ticket-mailbox-poll-sweep';
+
+type SweepJobData = { type: 'sweep' };
+
+/** Process one mailbox end-to-end. Graph I/O runs outside any DB context. */
+async function sweepOne(c: Awaited<ReturnType<typeof listConnectedMailboxes>>[number]): Promise<void> {
+  if (!c.tenantId) return;
+
+  let page: Awaited<ReturnType<typeof listInboxDelta>>;
+  try {
+    const token = await getMailboxToken(c.tenantId);
+    page = await listInboxDelta(token, c.mailboxAddress, c.deltaLink);
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 410) {
+      await resetDeltaCursor(c.id);
+      console.warn('[mailboxPoll] delta token gone (410); cursor reset', { id: c.id });
+      return;
+    }
+
+    const next = status === 401 || status === 403 ? 'reauth_required' : 'error';
+    await setConnectionStatus(c.id, c.partnerId, next, err instanceof Error ? err.message : 'poll failed');
+    return;
+  }
+
+  let lastMessageAt: Date | null = null;
+  try {
+    const token = await getMailboxToken(c.tenantId);
+    for (const msg of page.messages) {
+      const normalized = normalizeGraphMessage(msg, c.partnerId, c.mailboxAddress);
+      await enqueueInboundEmail(normalized);
+      await markRead(token, c.mailboxAddress, msg.id).catch((e) => {
+        console.warn('[mailboxPoll] mark-read failed', { id: msg.id, err: e instanceof Error ? e.message : e });
+      });
+      if (msg.receivedDateTime) lastMessageAt = new Date(msg.receivedDateTime);
+    }
+  } catch (err) {
+    console.error('[mailboxPoll] enqueue failed; cursor not advanced', {
+      id: c.id,
+      err: err instanceof Error ? err.message : err,
+    });
+    return;
+  }
+
+  if (page.deltaLink) {
+    const polledAt = new Date();
+    await updateDeltaCursor(c.id, page.deltaLink, polledAt, lastMessageAt ?? polledAt);
+  }
+}
+
+/** Exported for tests. Reads connections in system context, processes each independently. */
+export async function runMailboxSweep(): Promise<void> {
+  const connections = await listConnectedMailboxes();
+  for (const c of connections) {
+    try {
+      await sweepOne(c);
+    } catch (err) {
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      console.error('[mailboxPoll] sweepOne crashed', { id: c.id });
+    }
+  }
+}
+
+let queue: Queue<SweepJobData> | null = null;
+let worker: Worker<SweepJobData> | null = null;
+
+export async function initializeTicketMailboxPollWorker(): Promise<void> {
+  if (worker) return;
+
+  queue = new Queue<SweepJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  await queue.add(
+    'sweep',
+    { type: 'sweep' },
+    {
+      jobId: SWEEP_JOB_ID,
+      repeat: { every: SWEEP_INTERVAL_MS },
+      removeOnComplete: { count: 50 },
+      removeOnFail: { count: 100 },
+    },
+  );
+
+  worker = new Worker<SweepJobData>(
+    QUEUE_NAME,
+    async (_job: Job<SweepJobData>) => {
+      await runMailboxSweep();
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+
+  worker.on('failed', (job, err) => {
+    console.error('[mailboxPoll] sweep job failed', { id: job?.id, err: err?.message });
+  });
+  console.log('[mailboxPoll] worker initialized');
+}

--- a/apps/api/src/jobs/ticketMailboxPollWorker.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.ts
@@ -1,5 +1,6 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { getBullMQConnection } from '../services/redis';
+import { runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { captureException } from '../services/sentry';
 import {
   listConnectedMailboxes,
@@ -35,7 +36,11 @@ async function sweepOne(c: Awaited<ReturnType<typeof listConnectedMailboxes>>[nu
     }
 
     const next = status === 401 || status === 403 ? 'reauth_required' : 'error';
-    await setConnectionStatus(c.id, c.partnerId, next, err instanceof Error ? err.message : 'poll failed');
+    // setConnectionStatus is shared with the request path (bare db); the worker has
+    // no request DB context, so wrap in system context or the FORCE-RLS UPDATE
+    // matches zero rows and the status never surfaces.
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionStatus(c.id, c.partnerId, next, err instanceof Error ? err.message : 'poll failed')));
     return;
   }
 

--- a/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mirrors ticketNotifyWorker.test.ts scaffolding, plus configurable mocks for the
+// M365 mailbox resolver and Graph senders so we can assert the customer-facing fork.
+const {
+  insertValuesMock, selectMock, updateSetMock, sendEmailMock, getEmailServiceMock,
+  withSystemDbAccessContextMock, resolveMailboxMock, sendThreadedMock, sendNewMock,
+} = vi.hoisted(() => ({
+  insertValuesMock: vi.fn().mockResolvedValue([]),
+  selectMock: vi.fn(),
+  updateSetMock: vi.fn(),
+  sendEmailMock: vi.fn().mockResolvedValue(undefined),
+  getEmailServiceMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn((fn: () => unknown) => fn()),
+  resolveMailboxMock: vi.fn(),
+  sendThreadedMock: vi.fn(async () => {}),
+  sendNewMock: vi.fn(async () => {}),
+}));
+
+vi.mock('bullmq', () => ({ Queue: vi.fn(() => ({ add: vi.fn() })), Worker: vi.fn() }));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../services/email', () => ({ getEmailService: getEmailServiceMock }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../config/validate', () => ({ getConfig: () => ({ TICKETS_INBOUND_DOMAIN: 'tickets.example.com' }) }));
+vi.mock('../db', () => ({
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => selectMock()) })) })) })),
+    insert: vi.fn(() => ({ values: vi.fn((v: unknown) => { insertValuesMock(v); return { returning: vi.fn(() => Promise.resolve([])) }; }) })),
+    update: vi.fn(() => ({ set: vi.fn((v: unknown) => { updateSetMock(v); return { where: vi.fn(() => Promise.resolve([])) }; }) })),
+  },
+}));
+vi.mock('../db/schema', () => ({
+  tickets: { id: 'id' },
+  partners: { id: 'id', slug: 'slug', name: 'name', settings: 'settings' },
+  organizations: { id: 'id', name: 'name' },
+  userNotifications: {},
+  users: { id: 'id' },
+  ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
+  ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] },
+}));
+vi.mock('../services/ticketMailbox/resolveOutboundMailbox', () => ({ resolveOutboundMailbox: resolveMailboxMock }));
+vi.mock('../services/ticketMailbox/graphReplySender', () => ({ sendThreadedReply: sendThreadedMock, sendNewMail: sendNewMock }));
+
+import { handleTicketEvent } from './ticketNotifyWorker';
+
+const MAILBOX = { tenantId: '11111111-1111-1111-1111-111111111111', mailbox: 'support@a.com' };
+
+describe('ticketNotifyWorker M365 Graph fork', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    resolveMailboxMock.mockReset();
+    withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
+    getEmailServiceMock.mockReturnValue({ sendEmail: sendEmailMock });
+  });
+
+  it('routes a threaded public reply through sendThreadedReply, not EmailService', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }]) // getTicket
+      .mockResolvedValueOnce([{ slug: 'acme', settings: {} }]); // partner (replyTo)
+    resolveMailboxMock.mockResolvedValue({ ...MAILBOX, originalMessageId: 'orig-1' });
+
+    await handleTicketEvent({
+      type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+    });
+
+    expect(sendThreadedMock).toHaveBeenCalledTimes(1);
+    expect(sendThreadedMock).toHaveBeenCalledWith(MAILBOX, 'orig-1', expect.any(String));
+    expect(sendNewMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('uses sendNewMail when the mailbox is connected but there is no original message id', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }])
+      .mockResolvedValueOnce([{ slug: 'acme', settings: {} }]);
+    resolveMailboxMock.mockResolvedValue({ ...MAILBOX, originalMessageId: null });
+
+    await handleTicketEvent({
+      type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+    });
+
+    expect(sendNewMock).toHaveBeenCalledTimes(1);
+    expect(sendNewMock).toHaveBeenCalledWith(MAILBOX, 'cust@x.com', expect.stringContaining('T-1'), expect.any(String));
+    expect(sendThreadedMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to EmailService for a public reply when the partner has no connected mailbox', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }])
+      .mockResolvedValueOnce([{ slug: 'acme', settings: {} }]);
+    resolveMailboxMock.mockResolvedValue(null);
+
+    await handleTicketEvent({
+      type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+    });
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendThreadedMock).not.toHaveBeenCalled();
+    expect(sendNewMock).not.toHaveBeenCalled();
+  });
+
+  it('NEVER routes assignee/tech notifications through Graph (ticket.assigned uses EmailService)', async () => {
+    selectMock
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }]) // getTicket
+      .mockResolvedValueOnce([{ id: 'u-2', email: 'tech@msp.example' }]); // assignee user
+    // Even if a mailbox WERE connected, the assignee path must never consult it.
+    resolveMailboxMock.mockResolvedValue({ ...MAILBOX, originalMessageId: 'orig-1' });
+
+    await handleTicketEvent({
+      type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { assigneeId: 'u-2' },
+    });
+
+    expect(sendThreadedMock).not.toHaveBeenCalled();
+    expect(sendNewMock).not.toHaveBeenCalled();
+    expect(resolveMailboxMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -44,6 +44,15 @@ vi.mock('../db/schema', () => ({
   ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] }
 }));
+// M365 mailbox routing: default to "no connected mailbox" so these existing tests
+// exercise the unchanged EmailService path (and don't consume a selectMock read).
+vi.mock('../services/ticketMailbox/resolveOutboundMailbox', () => ({
+  resolveOutboundMailbox: vi.fn(async () => null)
+}));
+vi.mock('../services/ticketMailbox/graphReplySender', () => ({
+  sendThreadedReply: vi.fn(async () => {}),
+  sendNewMail: vi.fn(async () => {})
+}));
 
 import { handleTicketEvent } from './ticketNotifyWorker';
 

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -33,6 +33,8 @@ import { getEmailService } from '../services/email';
 import { escapeHtml } from '../services/emailLayout';
 import { buildThreadingHeaders, partnerInboundAddress, ticketThreadAnchor } from '../services/inboundEmail/outboundThreading';
 import { buildAutoresponseEmail } from '../services/inboundEmail/autoresponseTemplate';
+import { resolveOutboundMailbox } from '../services/ticketMailbox/resolveOutboundMailbox';
+import { sendThreadedReply, sendNewMail } from '../services/ticketMailbox/graphReplySender';
 import type { TicketTemplateVars } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
@@ -57,6 +59,10 @@ interface EmailPayload {
   bestEffort?: boolean; // if true, swallow send errors
   replyTo?: string;
   headers?: Record<string, string>;
+  // Customer-facing only: when the partner has a connected M365 mailbox, the reply
+  // is sent FROM that mailbox via Graph (native threading) instead of EmailService.
+  // Tech/assignee payloads never set this, so they always use EmailService.
+  graphMailbox?: { tenantId: string; mailbox: string; originalMessageId: string | null };
 }
 
 async function getTicket(ticketId: string) {
@@ -143,12 +149,18 @@ async function collectRequesterEmail(
 
   const label = ticket.internalNumber ?? ticket.ticketNumber ?? ticket.id;
 
+  // Customer-facing reply routing: if this partner has a connected M365 mailbox, send
+  // FROM that mailbox via Graph (native threading). Tech/assignee notifications never
+  // call collectRequesterEmail, so they never carry graphMailbox.
+  const graphMailbox = (await resolveOutboundMailbox(ticket.id, ticket.partnerId)) ?? undefined;
+
   // Un-threaded path (e.g. ticket.status_changed 'Resolved'): unchanged from before.
   if (!commentId) {
     return [{
       to: ticket.submitterEmail,
       subject: `[${label}] ${subjectPrefix}: ${ticket.subject}`,
-      html: bodyHtml
+      html: bodyHtml,
+      graphMailbox
     }];
   }
 
@@ -183,7 +195,8 @@ async function collectRequesterEmail(
     subject: `[${label}] ${subjectPrefix}: ${ticket.subject}`,
     html: bodyHtml,
     replyTo,
-    headers
+    headers,
+    graphMailbox
   }];
 }
 
@@ -253,7 +266,12 @@ async function collectAutoresponse(
   const anchor = ticketThreadAnchor(ticket.id);
   if (anchor) headers['Message-ID'] = anchor;
 
-  return [{ to: event.payload.to, subject: tpl.subject, html: tpl.html, replyTo, headers, bestEffort: true }];
+  // Customer-facing: route the autoresponse through the partner's M365 mailbox when
+  // connected (Graph manages threading; the SMTP Auto-Submitted/Message-ID headers
+  // are only used on the EmailService fallback path).
+  const graphMailbox = (await resolveOutboundMailbox(ticket.id, ticket.partnerId)) ?? undefined;
+
+  return [{ to: event.payload.to, subject: tpl.subject, html: tpl.html, replyTo, headers, bestEffort: true, graphMailbox }];
 }
 
 async function collectSlaBreachNotification(
@@ -368,26 +386,45 @@ export async function handleTicketEvent(event: TicketEvent): Promise<void> {
   });
 
   // Send emails OUTSIDE the DB context to avoid idle-in-transaction pool poison (#1105).
+  if (emailPayloads.length === 0) return;
+  // getEmailService() may be null (no platform transport configured). Graph payloads
+  // must still send in that case, so the null-guard moved inside the loop's EmailService
+  // branch rather than short-circuiting the whole send phase.
   const email = getEmailService();
-  if (!email || emailPayloads.length === 0) return;
 
   for (const payload of emailPayloads) {
-    const sendArgs = {
-      to: payload.to,
-      subject: payload.subject,
-      html: payload.html,
-      replyTo: payload.replyTo,
-      headers: payload.headers
+    const send = async () => {
+      // Customer-facing reply via the partner's connected M365 mailbox (Graph).
+      if (payload.graphMailbox) {
+        const { tenantId, mailbox, originalMessageId } = payload.graphMailbox;
+        if (originalMessageId) {
+          await sendThreadedReply({ tenantId, mailbox }, originalMessageId, payload.html);
+        } else {
+          await sendNewMail({ tenantId, mailbox }, payload.to, payload.subject, payload.html);
+        }
+        return;
+      }
+      // Platform EmailService path (tech/assignee notifications + customers on partners
+      // with no connected mailbox). Skip silently if no transport is configured.
+      if (!email) return;
+      await email.sendEmail({
+        to: payload.to,
+        subject: payload.subject,
+        html: payload.html,
+        replyTo: payload.replyTo,
+        headers: payload.headers
+      });
     };
+
     if (payload.bestEffort) {
       try {
-        await email.sendEmail(sendArgs);
+        await send();
       } catch (err) {
         console.error('[TicketNotify] email send failed', err instanceof Error ? err.message : err);
       }
     } else {
       // Non-best-effort: let throw bubble up so BullMQ can retry.
-      await email.sendEmail(sendArgs);
+      await send();
     }
   }
 }

--- a/apps/api/src/routes/tickets/mailboxConnect.test.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { createHmac } from 'crypto';
+
+// signingSecret() falls through APP_ENCRYPTION_KEY/SECRET_ENCRYPTION_KEY/
+// SESSION_SECRET to JWT_SECRET, which the api test setup (src/__tests__/setup.ts)
+// sets. Mint state with that same ambient secret — do NOT stub env here (it would
+// perturb the shared-worker process.env that sibling tests read).
+const FIXED_SECRET = 'test-jwt-secret-must-be-at-least-32-characters-long';
+const LABEL = 'ticket-mailbox-oauth';
+const TENANT = '11111111-1111-1111-1111-111111111111';
+
+function mintState(
+  partnerId: string, connectionId: string, userId: string | null, exp = Date.now() + 60_000,
+): { state: string; cookie: string } {
+  const payload = { partnerId, userId, connectionId, nonce: 'test-nonce', exp };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const sig = createHmac('sha256', FIXED_SECRET).update(`${LABEL}:${encoded}`).digest('base64url');
+  const state = `${encoded}.${sig}`;
+  const cookie = createHmac('sha256', FIXED_SECRET).update(`${LABEL}-cookie:${state}`).digest('base64url');
+  return { state, cookie };
+}
+
+const { authState, mocks } = vi.hoisted(() => ({
+  authState: {
+    scope: 'partner' as 'partner' | 'system' | 'organization',
+    partnerId: '22222222-2222-2222-2222-222222222222' as string | null,
+    mfa: true,
+  },
+  mocks: {
+    createPendingConnection: vi.fn(),
+    getMailboxConnection: vi.fn(),
+    setConnectionTenant: vi.fn(async () => {}),
+    setConnectionStatus: vi.fn(async () => {}),
+    probeMailbox: vi.fn(),
+    listMailboxConnections: vi.fn(async (): Promise<any[]> => []),
+    disableConnection: vi.fn(async () => {}),
+    platformConfig: vi.fn((): { clientId: string; clientSecret: string } | null => ({ clientId: 'cid', clientSecret: 'csecret' })),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('auth', {
+      scope: authState.scope,
+      partnerId: authState.partnerId,
+      orgId: null,
+      accessibleOrgIds: [],
+      user: { id: '33333333-3333-3333-3333-333333333333', email: 'admin@example.com', name: 'Admin' },
+      token: { mfa: authState.mfa },
+    });
+    return next();
+  }),
+  requireScope: vi.fn((...scopes: string[]) => async (c: any, next: any) => {
+    if (!scopes.includes(authState.scope)) return c.json({ error: 'Insufficient permissions' }, 403);
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (!authState.mfa) return c.json({ error: 'MFA required' }, 403);
+    return next();
+  }),
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: <T>(fn: () => T) => fn(),
+  withSystemDbAccessContext: <T>(fn: () => T) => fn(),
+}));
+
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+
+vi.mock('../../services/ticketMailbox/mailboxToken', () => ({
+  getMailboxPlatformConfig: () => mocks.platformConfig(),
+  getMailboxCallbackUri: () => 'https://app.example.com/api/v1/tickets/mailbox/callback',
+}));
+
+vi.mock('../../services/ticketMailbox/connectionService', () => ({
+  createPendingConnection: mocks.createPendingConnection,
+  getMailboxConnection: mocks.getMailboxConnection,
+  setConnectionTenant: mocks.setConnectionTenant,
+  setConnectionStatus: mocks.setConnectionStatus,
+  probeMailbox: mocks.probeMailbox,
+  listMailboxConnections: mocks.listMailboxConnections,
+  disableConnection: mocks.disableConnection,
+}));
+
+import { mailboxRoutes } from './mailboxConnect';
+
+describe('M365 mailbox connect/callback routes', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.scope = 'partner';
+    authState.partnerId = '22222222-2222-2222-2222-222222222222';
+    authState.mfa = true;
+    mocks.platformConfig.mockReturnValue({ clientId: 'cid', clientSecret: 'csecret' });
+    mocks.createPendingConnection.mockResolvedValue({ id: 'conn-1', partnerId: authState.partnerId, mailboxAddress: 'support@a.com' });
+    mocks.getMailboxConnection.mockResolvedValue({ id: 'conn-1', partnerId: authState.partnerId, tenantId: TENANT, mailboxAddress: 'support@a.com', status: 'connected' });
+    mocks.probeMailbox.mockResolvedValue({ ok: true });
+    app = new Hono();
+    app.route('/tickets/mailbox', mailboxRoutes);
+  });
+
+  it('POST /connect returns an admin-consent authUrl and sets the state cookie', async () => {
+    const res = await app.request('/tickets/mailbox/connect', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mailboxAddress: 'support@a.com', displayName: 'Support' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authUrl).toContain('login.microsoftonline.com');
+    expect(body.authUrl).toContain('adminconsent');
+    expect(body.connectionId).toBe('conn-1');
+    expect(res.headers.get('set-cookie')).toContain('ticket_mailbox_oauth_state');
+    expect(mocks.createPendingConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ partnerId: authState.partnerId, mailboxAddress: 'support@a.com' }),
+    );
+  });
+
+  it('POST /connect returns 400 when the M365 app is not configured', async () => {
+    mocks.platformConfig.mockReturnValue(null);
+    const res = await app.request('/tickets/mailbox/connect', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mailboxAddress: 'support@a.com' }),
+    });
+    expect(res.status).toBe(400);
+    expect(mocks.createPendingConnection).not.toHaveBeenCalled();
+  });
+
+  it('POST /connect requires MFA', async () => {
+    authState.mfa = false;
+    const res = await app.request('/tickets/mailbox/connect', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mailboxAddress: 'support@a.com' }),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: 'MFA required' });
+    expect(mocks.createPendingConnection).not.toHaveBeenCalled();
+  });
+
+  it('GET /callback rejects an unsigned/invalid state with 400', async () => {
+    const res = await app.request(`/tickets/mailbox/callback?state=bogus&tenant=${TENANT}&admin_consent=True`);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringContaining('OAuth state') });
+    expect(mocks.setConnectionTenant).not.toHaveBeenCalled();
+  });
+
+  it('GET /callback is NOT behind authMiddleware: valid state+cookie + probe ok → connected redirect', async () => {
+    const { state, cookie } = mintState(authState.partnerId!, 'conn-1', '33333333-3333-3333-3333-333333333333');
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&tenant=${TENANT}&admin_consent=True`,
+      { headers: { Cookie: `ticket_mailbox_oauth_state=${cookie}` } },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('ticketMailbox=connected');
+    expect(mocks.setConnectionTenant).toHaveBeenCalledWith('conn-1', authState.partnerId, TENANT);
+    expect(mocks.setConnectionStatus).toHaveBeenCalledWith('conn-1', authState.partnerId, 'connected', null);
+  });
+
+  it('GET /callback with probe failure → needs_policy redirect (status=error)', async () => {
+    mocks.probeMailbox.mockResolvedValue({ ok: false, error: 'Graph returned 403' });
+    const { state, cookie } = mintState(authState.partnerId!, 'conn-1', null);
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&tenant=${TENANT}&admin_consent=True`,
+      { headers: { Cookie: `ticket_mailbox_oauth_state=${cookie}` } },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('ticketMailbox=needs_policy');
+    expect(mocks.setConnectionStatus).toHaveBeenCalledWith('conn-1', authState.partnerId, 'error', 'Graph returned 403');
+  });
+
+  it('GET /callback with a consent error param → error redirect, marks status error', async () => {
+    const { state, cookie } = mintState(authState.partnerId!, 'conn-1', null);
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&error=access_denied&error_description=admin%20declined`,
+      { headers: { Cookie: `ticket_mailbox_oauth_state=${cookie}` } },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('ticketMailbox=error');
+    expect(mocks.setConnectionStatus).toHaveBeenCalledWith('conn-1', authState.partnerId, 'error', 'admin declined');
+    expect(mocks.setConnectionTenant).not.toHaveBeenCalled();
+  });
+
+  it('GET /callback valid state but MISSING binding cookie is rejected (CSRF)', async () => {
+    const { state } = mintState(authState.partnerId!, 'conn-1', null);
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&tenant=${TENANT}&admin_consent=True`,
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringContaining('binding') });
+    expect(mocks.setConnectionTenant).not.toHaveBeenCalled();
+  });
+
+  it('GET /callback PRESENT but MISMATCHED binding cookie is rejected (CSRF)', async () => {
+    const { state } = mintState(authState.partnerId!, 'conn-1', null);
+    const other = mintState(authState.partnerId!, 'conn-1', null, Date.now() + 120_000);
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&tenant=${TENANT}&admin_consent=True`,
+      { headers: { Cookie: `ticket_mailbox_oauth_state=${other.cookie}` } },
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringContaining('binding') });
+    expect(mocks.setConnectionTenant).not.toHaveBeenCalled();
+  });
+
+  it('GET /callback with an EXPIRED state is rejected', async () => {
+    const { state, cookie } = mintState(authState.partnerId!, 'conn-1', null, Date.now() - 1000);
+    const res = await app.request(
+      `/tickets/mailbox/callback?state=${encodeURIComponent(state)}&tenant=${TENANT}&admin_consent=True`,
+      { headers: { Cookie: `ticket_mailbox_oauth_state=${cookie}` } },
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringContaining('OAuth state') });
+    expect(mocks.setConnectionTenant).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /connections/:id disconnects (requires MFA)', async () => {
+    const id = '44444444-4444-4444-8444-444444444444';
+    const res = await app.request(`/tickets/mailbox/connections/${id}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true });
+    expect(mocks.disableConnection).toHaveBeenCalledWith(id, authState.partnerId);
+  });
+
+  it('GET /connections lists connections for the partner', async () => {
+    mocks.listMailboxConnections.mockResolvedValue([{ id: 'conn-1', mailboxAddress: 'support@a.com' }]);
+    const res = await app.request('/tickets/mailbox/connections');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ connections: [{ id: 'conn-1' }] });
+  });
+});

--- a/apps/api/src/routes/tickets/mailboxConnect.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.ts
@@ -114,7 +114,7 @@ mailboxRoutes.get('/callback', zValidator('query', callbackQuery), async (c) => 
   if (q.error || !q.tenant || !isM365TenantId(q.tenant)) {
     await runOutsideDbContext(() => withSystemDbAccessContext(() =>
       setConnectionStatus(state.connectionId, state.partnerId, 'error', q.error_description ?? q.error ?? 'consent failed')));
-    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+    return c.redirect('/settings/partner?ticketMailbox=error#ticketing');
   }
 
   try {
@@ -123,10 +123,10 @@ mailboxRoutes.get('/callback', zValidator('query', callbackQuery), async (c) => 
     const probe = await probeMailbox(q.tenant, (await getConnAddress(state)) ?? '');
     await runOutsideDbContext(() => withSystemDbAccessContext(() =>
       setConnectionStatus(state.connectionId, state.partnerId, probe.ok ? 'connected' : 'error', probe.ok ? null : (probe.error ?? 'probe failed'))));
-    return c.redirect(probe.ok ? '/integrations?ticketMailbox=connected#ticket-mailbox' : '/integrations?ticketMailbox=needs_policy#ticket-mailbox');
+    return c.redirect(probe.ok ? '/settings/partner?ticketMailbox=connected#ticketing' : '/settings/partner?ticketMailbox=needs_policy#ticketing');
   } catch (err) {
     captureException(err instanceof Error ? err : new Error(String(err)), c);
-    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+    return c.redirect('/settings/partner?ticketMailbox=error#ticketing');
   }
 });
 

--- a/apps/api/src/routes/tickets/mailboxConnect.ts
+++ b/apps/api/src/routes/tickets/mailboxConnect.ts
@@ -1,0 +1,157 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { authMiddleware, requireScope, requireMfa, type AuthContext } from '../../middleware/auth';
+import { buildAdminConsentUrl, isM365TenantId } from '../../services/c2cM365';
+import { getMailboxCallbackUri, getMailboxPlatformConfig } from '../../services/ticketMailbox/mailboxToken';
+import {
+  createPendingConnection, getMailboxConnection, setConnectionTenant,
+  setConnectionStatus, probeMailbox, listMailboxConnections, disableConnection,
+} from '../../services/ticketMailbox/connectionService';
+import { withSystemDbAccessContext, runOutsideDbContext } from '../../db';
+import { captureException } from '../../services/sentry';
+
+// requireScope('partner','system') is the partner-scope gate (mirrors
+// routes/accounting/index.ts, which aliases the same factory call).
+const partnerScopes = requireScope('partner', 'system');
+
+// Ticket mailbox connections are partner-owned. The scope gate also admits
+// 'system', but a system token carries no partnerId to operate on, so narrow
+// to a concrete partner here (mirrors accounting's resolvePartnerId).
+function resolvePartnerId(auth: Pick<AuthContext, 'scope' | 'partnerId'>): { partnerId: string } | { error: string; status: 403 } {
+  if (auth.scope === 'partner' && auth.partnerId) return { partnerId: auth.partnerId };
+  return { error: 'Partner context required to manage ticket mailbox connections', status: 403 };
+}
+
+const STATE_COOKIE = 'ticket_mailbox_oauth_state';
+const STATE_TTL_MS = 10 * 60 * 1000;
+const LABEL = 'ticket-mailbox-oauth';
+
+interface StatePayload { partnerId: string; userId: string | null; connectionId: string; nonce: string; exp: number; }
+
+function signingSecret(): string | null {
+  return process.env.APP_ENCRYPTION_KEY?.trim() || process.env.SECRET_ENCRYPTION_KEY?.trim()
+    || process.env.SESSION_SECRET?.trim() || process.env.JWT_SECRET?.trim()
+    || (process.env.NODE_ENV === 'production' ? null : 'test-only-ticket-mailbox-oauth-state-secret');
+}
+function hmac(label: string, value: string): string | null {
+  const secret = signingSecret();
+  return secret ? createHmac('sha256', secret).update(`${label}:${value}`).digest('base64url') : null;
+}
+function constantTimeEqual(a: string, b: string): boolean {
+  const l = Buffer.from(a, 'utf8'); const r = Buffer.from(b, 'utf8');
+  return l.length === r.length && timingSafeEqual(l, r);
+}
+function createState(p: Omit<StatePayload, 'nonce' | 'exp'>): string | null {
+  const payload: StatePayload = { ...p, nonce: randomBytes(16).toString('hex'), exp: Date.now() + STATE_TTL_MS };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const sig = hmac(LABEL, encoded);
+  return sig ? `${encoded}.${sig}` : null;
+}
+function verifyState(state: string): StatePayload | null {
+  const [encoded, sig] = state.split('.');
+  if (!encoded || !sig) return null;
+  const expected = hmac(LABEL, encoded);
+  if (!expected || !constantTimeEqual(sig, expected)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as StatePayload;
+    if (!parsed.partnerId || !parsed.connectionId || !parsed.nonce || !parsed.exp || parsed.exp < Date.now()) return null;
+    return parsed;
+  } catch { return null; }
+}
+function stateCookieValue(state: string): string | null { return hmac(`${LABEL}-cookie`, state); }
+
+const connectBody = z.object({ mailboxAddress: z.string().email(), displayName: z.string().max(120).optional() });
+const callbackQuery = z.object({ state: z.string(), tenant: z.string().optional(), admin_consent: z.string().optional(), error: z.string().optional(), error_description: z.string().optional() });
+const idParam = z.object({ id: z.string().uuid() });
+
+export const mailboxRoutes = new Hono();
+
+// List
+mailboxRoutes.get('/connections', authMiddleware, partnerScopes, async (c) => {
+  const resolved = resolvePartnerId(c.get('auth'));
+  if ('error' in resolved) return c.json({ error: resolved.error }, resolved.status);
+  const list = await listMailboxConnections(resolved.partnerId);
+  return c.json({ connections: list });
+});
+
+// Initiate consent (creates the pending row, returns admin-consent URL)
+mailboxRoutes.post('/connect', authMiddleware, partnerScopes, requireMfa(), zValidator('json', connectBody), async (c) => {
+  if (!getMailboxPlatformConfig()) return c.json({ error: 'M365 ticket mailbox app is not configured' }, 400);
+  const auth = c.get('auth');
+  const resolved = resolvePartnerId(auth);
+  if ('error' in resolved) return c.json({ error: resolved.error }, resolved.status);
+  const { mailboxAddress, displayName } = c.req.valid('json');
+  const conn = await createPendingConnection({
+    partnerId: resolved.partnerId, mailboxAddress, displayName: displayName ?? null, createdBy: auth.user?.id ?? null,
+  });
+  const state = createState({ partnerId: resolved.partnerId, userId: auth.user?.id ?? null, connectionId: conn.id });
+  const cookie = state ? stateCookieValue(state) : null;
+  if (!state || !cookie) return c.json({ error: 'OAuth state signing secret is not configured' }, 500);
+  setCookie(c, STATE_COOKIE, cookie, {
+    httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'Lax', path: '/', maxAge: STATE_TTL_MS / 1000,
+  });
+  const cfg = getMailboxPlatformConfig()!;
+  const authUrl = buildAdminConsentUrl({ clientId: cfg.clientId, state, redirectUri: getMailboxCallbackUri() });
+  return c.json({ authUrl, connectionId: conn.id });
+});
+
+// OAuth redirect target — NO authMiddleware. Authenticated by signed state + cookie.
+mailboxRoutes.get('/callback', zValidator('query', callbackQuery), async (c) => {
+  const q = c.req.valid('query');
+  const state = verifyState(q.state);
+  if (!state) return c.json({ error: 'Invalid or expired OAuth state' }, 400);
+
+  const expectedCookie = stateCookieValue(q.state);
+  const presented = getCookie(c, STATE_COOKIE);
+  if (!expectedCookie || !presented || !constantTimeEqual(presented, expectedCookie)) {
+    return c.json({ error: 'OAuth state binding mismatch' }, 400);
+  }
+  deleteCookie(c, STATE_COOKIE, { path: '/' });
+
+  if (q.error || !q.tenant || !isM365TenantId(q.tenant)) {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionStatus(state.connectionId, state.partnerId, 'error', q.error_description ?? q.error ?? 'consent failed')));
+    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+  }
+
+  try {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionTenant(state.connectionId, state.partnerId, q.tenant!)));
+    const probe = await probeMailbox(q.tenant, (await getConnAddress(state)) ?? '');
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionStatus(state.connectionId, state.partnerId, probe.ok ? 'connected' : 'error', probe.ok ? null : (probe.error ?? 'probe failed'))));
+    return c.redirect(probe.ok ? '/integrations?ticketMailbox=connected#ticket-mailbox' : '/integrations?ticketMailbox=needs_policy#ticket-mailbox');
+  } catch (err) {
+    captureException(err instanceof Error ? err : new Error(String(err)), c);
+    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+  }
+});
+
+async function getConnAddress(state: StatePayload): Promise<string | null> {
+  const conn = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    getMailboxConnection(state.connectionId, state.partnerId)));
+  return conn?.mailboxAddress ?? null;
+}
+
+// Re-run the probe (after the admin scopes the Application Access Policy)
+mailboxRoutes.post('/connections/:id/retest', authMiddleware, partnerScopes, requireMfa(), zValidator('param', idParam), async (c) => {
+  const resolved = resolvePartnerId(c.get('auth'));
+  if ('error' in resolved) return c.json({ error: resolved.error }, resolved.status);
+  const { id } = c.req.valid('param');
+  const conn = await getMailboxConnection(id, resolved.partnerId);
+  if (!conn || !conn.tenantId) return c.json({ error: 'Connection not found or not consented' }, 404);
+  const probe = await probeMailbox(conn.tenantId, conn.mailboxAddress);
+  await setConnectionStatus(id, resolved.partnerId, probe.ok ? 'connected' : 'error', probe.ok ? null : (probe.error ?? 'probe failed'));
+  return c.json({ ok: probe.ok, error: probe.error });
+});
+
+// Disconnect
+mailboxRoutes.delete('/connections/:id', authMiddleware, partnerScopes, requireMfa(), zValidator('param', idParam), async (c) => {
+  const resolved = resolvePartnerId(c.get('auth'));
+  if ('error' in resolved) return c.json({ error: resolved.error }, resolved.status);
+  await disableConnection(c.req.valid('param').id, resolved.partnerId);
+  return c.json({ ok: true });
+});

--- a/apps/api/src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { resolveSpy } = vi.hoisted(() => ({
+  resolveSpy: vi.fn(async () => 'should-not-be-called')
+}));
+
+vi.mock('./resolvePartner', () => ({ resolvePartnerByRecipient: resolveSpy }));
+
+// Make the partner look active so processing proceeds past the status gate,
+// then stop at the first unmocked dependency -- we only assert resolve is skipped.
+vi.mock('../../db', () => ({
+  db: { select: () => ({ from: () => ({ where: () => ({ limit: async () => [{ status: 'active' }] }) }) }) },
+  runOutsideDbContext: (fn: any) => fn(),
+  withSystemDbAccessContext: (fn: any) => fn(),
+}));
+
+import { processInboundEmail } from './inboundEmailService';
+import type { NormalizedInboundEmail } from './types';
+
+const base: NormalizedInboundEmail = {
+  provider: 'm365', providerMessageId: 'g1', to: 'support@a.com', from: 'cust@x.com',
+  subject: 'hi', text: 'body', attachments: [], raw: {}, resolvedPartnerId: 'partner-123',
+};
+
+describe('processInboundEmail resolvedPartnerId seam', () => {
+  it('does not call resolvePartnerByRecipient when resolvedPartnerId is present', async () => {
+    try { await processInboundEmail(base); } catch { /* later deps unmocked -- fine */ }
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -106,7 +106,7 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
     // (1) Tenant identity is established ONLY from the recipient. Sender data is untrusted.
     // Resolution runs INSIDE the try so a failure here still routes to the durable
     // failed-log instead of escaping (and being silently retried / lost).
-    partnerId = await resolvePartnerByRecipient(n.to);
+    partnerId = n.resolvedPartnerId ?? await resolvePartnerByRecipient(n.to);
     if (!partnerId) {
       // Distinguish a malformed/empty recipient (no `@`, can never resolve) from a
       // well-formed address for a domain we simply don't host. Both log `ignored`,

--- a/apps/api/src/services/inboundEmail/types.ts
+++ b/apps/api/src/services/inboundEmail/types.ts
@@ -8,7 +8,7 @@ export type InboundParseStatus = 'matched' | 'created' | 'quarantined' | 'failed
 
 // Inbound provider identity. The mailgun impl reports 'mailgun'; 'resend' is
 // reserved for the planned second provider.
-export type InboundProviderName = 'mailgun' | 'resend';
+export type InboundProviderName = 'mailgun' | 'resend' | 'm365';
 
 // A single sender-authentication verdict, normalized to lowercase. 'pass'/'fail'
 // are the meaningful states; 'none'/'neutral'/'unknown' are all treated as NOT a
@@ -33,6 +33,10 @@ export interface NormalizedInboundEmail {
   provider: InboundProviderName;
   providerMessageId: string;
   to: string;            // recipient → partner resolution
+  /** When the feeder already knows the partner (e.g. it polled THAT partner's
+   *  mailbox), skip recipient-based resolution. This is feeder-trusted, not
+   *  derived from untrusted message content. */
+  resolvedPartnerId?: string;
   from: string;          // sender (untrusted)
   fromName?: string;
   subject: string;

--- a/apps/api/src/services/ticketMailbox/connectionService.test.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { probeMailbox } from './connectionService';
+
+describe('probeMailbox', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('returns ok on a 200 from the mailbox messages endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ value: [] }) });
+    const r = await probeMailbox('11111111-1111-1111-1111-111111111111', 'support@a.com');
+    expect(r.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/users/support%40a.com/messages?%24top=1"),
+      expect.objectContaining({ redirect: 'error' })
+    );
+  });
+
+  it('returns an error string on 403 (access policy not scoped)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => 'denied' });
+    const r = await probeMailbox('11111111-1111-1111-1111-111111111111', 'support@a.com');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/403/);
+  });
+});

--- a/apps/api/src/services/ticketMailbox/connectionService.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.ts
@@ -83,12 +83,18 @@ export async function setConnectionStatus(
     .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
 }
 
+/** Worker-only. Self-wraps in system context: ticket_mailbox_connections is
+ *  FORCE RLS (partner-axis), and the poll worker runs with no request DB context,
+ *  so a bare write would match zero rows silently and the cursor would never
+ *  advance. */
 export async function updateDeltaCursor(
   id: string, deltaLink: string, polledAt: Date, lastMessageAt: Date | null,
 ): Promise<void> {
-  await db.update(ticketMailboxConnections)
-    .set({ deltaLink, lastPolledAt: polledAt, ...(lastMessageAt ? { lastMessageAt } : {}), updatedAt: new Date() })
-    .where(eq(ticketMailboxConnections.id, id));
+  await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    await db.update(ticketMailboxConnections)
+      .set({ deltaLink, lastPolledAt: polledAt, ...(lastMessageAt ? { lastMessageAt } : {}), updatedAt: new Date() })
+      .where(eq(ticketMailboxConnections.id, id));
+  }));
 }
 
 export async function disableConnection(id: string, partnerId: string): Promise<void> {
@@ -98,12 +104,14 @@ export async function disableConnection(id: string, partnerId: string): Promise<
 }
 
 /** 410 Gone: Graph invalidated the delta token. Clear it so the next sweep restarts
- *  the delta from "now" (no history backfill). Stays 'connected'. Called from the
- *  poll worker under system context. */
+ *  the delta from "now" (no history backfill). Stays 'connected'. Worker-only;
+ *  self-wraps in system context (FORCE RLS — see updateDeltaCursor). */
 export async function resetDeltaCursor(id: string): Promise<void> {
-  await db.update(ticketMailboxConnections)
-    .set({ deltaLink: null, updatedAt: new Date() })
-    .where(eq(ticketMailboxConnections.id, id));
+  await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    await db.update(ticketMailboxConnections)
+      .set({ deltaLink: null, updatedAt: new Date() })
+      .where(eq(ticketMailboxConnections.id, id));
+  }));
 }
 
 /** Lightweight Graph probe: can the app read this mailbox under the tenant's consent? */

--- a/apps/api/src/services/ticketMailbox/connectionService.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.ts
@@ -1,0 +1,121 @@
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+import { getMailboxToken } from './mailboxToken';
+
+export type MailboxConnectionStatus =
+  | 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+
+export interface MailboxConnection {
+  id: string;
+  partnerId: string;
+  tenantId: string | null;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: MailboxConnectionStatus;
+  deltaLink: string | null;
+  strictSenderAuth: boolean;
+  lastPolledAt: Date | null;
+  lastMessageAt: Date | null;
+  lastError: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type Row = typeof ticketMailboxConnections.$inferSelect;
+
+function toConnection(r: Row): MailboxConnection {
+  return { ...r, status: r.status as MailboxConnectionStatus };
+}
+
+export async function listMailboxConnections(partnerId: string): Promise<MailboxConnection[]> {
+  const rows = await db.select().from(ticketMailboxConnections)
+    .where(eq(ticketMailboxConnections.partnerId, partnerId));
+  return rows.map(toConnection);
+}
+
+/** System-context read across all partners — used by the poll worker (Plan 2). */
+export async function listConnectedMailboxes(): Promise<MailboxConnection[]> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(ticketMailboxConnections)
+      .where(eq(ticketMailboxConnections.status, 'connected'));
+    return rows.map(toConnection);
+  }));
+}
+
+export async function getMailboxConnection(id: string, partnerId: string): Promise<MailboxConnection | null> {
+  const rows = await db.select().from(ticketMailboxConnections)
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)))
+    .limit(1);
+  return rows[0] ? toConnection(rows[0]) : null;
+}
+
+export async function createPendingConnection(input: {
+  partnerId: string; mailboxAddress: string; displayName: string | null; createdBy: string | null;
+}): Promise<MailboxConnection> {
+  const rows = await db.insert(ticketMailboxConnections).values({
+    partnerId: input.partnerId,
+    mailboxAddress: input.mailboxAddress.trim().toLowerCase(),
+    displayName: input.displayName,
+    status: 'pending_consent',
+    createdBy: input.createdBy,
+  }).onConflictDoUpdate({
+    target: [ticketMailboxConnections.partnerId, ticketMailboxConnections.mailboxAddress],
+    set: { status: 'pending_consent', displayName: input.displayName, updatedAt: new Date() },
+  }).returning();
+  const row = rows[0];
+  if (!row) throw new Error('Failed to create pending mailbox connection');
+  return toConnection(row);
+}
+
+export async function setConnectionTenant(id: string, partnerId: string, tenantId: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ tenantId, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+export async function setConnectionStatus(
+  id: string, partnerId: string, status: MailboxConnectionStatus, lastError: string | null,
+): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ status, lastError, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+export async function updateDeltaCursor(
+  id: string, deltaLink: string, polledAt: Date, lastMessageAt: Date | null,
+): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ deltaLink, lastPolledAt: polledAt, ...(lastMessageAt ? { lastMessageAt } : {}), updatedAt: new Date() })
+    .where(eq(ticketMailboxConnections.id, id));
+}
+
+export async function disableConnection(id: string, partnerId: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ status: 'disabled', deltaLink: null, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+/** 410 Gone: Graph invalidated the delta token. Clear it so the next sweep restarts
+ *  the delta from "now" (no history backfill). Stays 'connected'. Called from the
+ *  poll worker under system context. */
+export async function resetDeltaCursor(id: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ deltaLink: null, updatedAt: new Date() })
+    .where(eq(ticketMailboxConnections.id, id));
+}
+
+/** Lightweight Graph probe: can the app read this mailbox under the tenant's consent? */
+export async function probeMailbox(tenantId: string, mailboxAddress: string): Promise<{ ok: boolean; error?: string }> {
+  let token: string;
+  try {
+    token = await getMailboxToken(tenantId);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'token acquisition failed' };
+  }
+  const url = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(mailboxAddress)}/messages?${encodeURIComponent('$top')}=1`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` }, redirect: 'error' });
+  if (res.ok) return { ok: true };
+  return { ok: false, error: `Graph returned ${res.status}` };
+}

--- a/apps/api/src/services/ticketMailbox/graphMailClient.test.ts
+++ b/apps/api/src/services/ticketMailbox/graphMailClient.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { listInboxDelta, markRead } from './graphMailClient';
+
+const SELECT = '%24select'; // encodeURIComponent('$select')
+
+describe('listInboxDelta', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('follows @odata.nextLink, aggregates messages, returns the final deltaLink', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map(),
+        json: async () => ({
+          value: [{ id: 'm1' }],
+          '@odata.nextLink': 'https://graph.microsoft.com/next-2',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map(),
+        json: async () => ({
+          value: [{ id: 'm2' }],
+          '@odata.deltaLink': 'https://graph.microsoft.com/delta-final',
+        }),
+      });
+
+    const page = await listInboxDelta('tok', 'support@a.com', null);
+    expect(page.messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(page.deltaLink).toBe('https://graph.microsoft.com/delta-final');
+    expect(fetchMock.mock.calls[0]![0]).toContain('/mailFolders/inbox/messages/delta');
+    expect(fetchMock.mock.calls[0]![0]).toContain(SELECT);
+  });
+
+  it('uses the stored deltaLink verbatim when provided', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: async () => ({
+        value: [],
+        '@odata.deltaLink': 'https://graph.microsoft.com/delta-2',
+      }),
+    });
+    await listInboxDelta('tok', 'support@a.com', 'https://graph.microsoft.com/stored-delta');
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://graph.microsoft.com/stored-delta');
+  });
+
+  it('retries once on 429 honoring Retry-After', async () => {
+    const headers429 = new Map([['retry-after', '0']]);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: headers429,
+        text: async () => 'throttled',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Map(),
+        json: async () => ({ value: [], '@odata.deltaLink': 'd' }),
+      });
+    const page = await listInboxDelta('tok', 'support@a.com', null);
+    expect(page.deltaLink).toBe('d');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('markRead', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('PATCHes isRead true', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: async () => ({}),
+    });
+    await markRead('tok', 'support@a.com', 'm1');
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit & { body: string }];
+    expect(url).toContain('/messages/m1');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ isRead: true });
+  });
+});

--- a/apps/api/src/services/ticketMailbox/graphMailClient.ts
+++ b/apps/api/src/services/ticketMailbox/graphMailClient.ts
@@ -1,0 +1,117 @@
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+const DELTA_SELECT = [
+  'id',
+  'internetMessageId',
+  'subject',
+  'from',
+  'toRecipients',
+  'ccRecipients',
+  'receivedDateTime',
+  'conversationId',
+  'body',
+  'bodyPreview',
+  'hasAttachments',
+  'internetMessageHeaders',
+].join(',');
+
+export interface GraphRecipient {
+  emailAddress?: { address?: string; name?: string };
+}
+
+export interface GraphHeader {
+  name: string;
+  value: string;
+}
+
+export interface GraphMessage {
+  id: string;
+  internetMessageId?: string;
+  subject?: string;
+  from?: GraphRecipient;
+  toRecipients?: GraphRecipient[];
+  ccRecipients?: GraphRecipient[];
+  receivedDateTime?: string;
+  conversationId?: string;
+  body?: { contentType?: string; content?: string };
+  bodyPreview?: string;
+  hasAttachments?: boolean;
+  internetMessageHeaders?: GraphHeader[];
+}
+
+export interface DeltaPage {
+  messages: GraphMessage[];
+  deltaLink: string | null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Graph fetch with one 429 retry honoring Retry-After. Never follows redirects with the bearer token. */
+async function graphFetch(url: string, token: string, init?: RequestInit): Promise<Response> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const res = await fetch(url, {
+      ...init,
+      headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) },
+      redirect: 'error',
+    });
+    if (res.status !== 429) return res;
+
+    const retryAfter = Number(res.headers.get?.('retry-after') ?? '1');
+    await sleep(Math.min(Number.isFinite(retryAfter) ? retryAfter : 1, 30) * 1000);
+  }
+
+  return fetch(url, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) },
+    redirect: 'error',
+  });
+}
+
+export async function listInboxDelta(
+  token: string,
+  mailbox: string,
+  deltaLink: string | null,
+): Promise<DeltaPage> {
+  let url =
+    deltaLink ??
+    `${GRAPH}/users/${encodeURIComponent(mailbox)}/mailFolders/inbox/messages/delta` +
+      `?${encodeURIComponent('$select')}=${encodeURIComponent(DELTA_SELECT)}`;
+  const messages: GraphMessage[] = [];
+  let finalDelta: string | null = null;
+
+  for (let guard = 0; guard < 1000; guard++) {
+    const res = await graphFetch(url, token);
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const err = new Error(`Graph delta ${res.status}: ${body.slice(0, 200)}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+
+    const data = (await res.json()) as {
+      value?: GraphMessage[];
+      '@odata.nextLink'?: string;
+      '@odata.deltaLink'?: string;
+    };
+    if (Array.isArray(data.value)) messages.push(...data.value);
+    if (data['@odata.nextLink']) {
+      url = data['@odata.nextLink'];
+      continue;
+    }
+
+    finalDelta = data['@odata.deltaLink'] ?? null;
+    break;
+  }
+
+  return { messages, deltaLink: finalDelta };
+}
+
+export async function markRead(token: string, mailbox: string, messageId: string): Promise<void> {
+  const url = `${GRAPH}/users/${encodeURIComponent(mailbox)}/messages/${encodeURIComponent(messageId)}`;
+  await graphFetch(url, token, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isRead: true }),
+  });
+}

--- a/apps/api/src/services/ticketMailbox/graphReplySender.test.ts
+++ b/apps/api/src/services/ticketMailbox/graphReplySender.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('./mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+import { sendThreadedReply, sendNewMail } from './graphReplySender';
+
+const target = { tenantId: '11111111-1111-1111-1111-111111111111', mailbox: 'support@a.com' };
+
+describe('sendThreadedReply', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('createReply -> PATCH body -> send (3 calls, in order)', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ id: 'draft-9' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, status: 202, text: async () => '' });
+
+    await sendThreadedReply(target, 'orig-1', '<p>reply</p>');
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const createReplyCall = fetchMock.mock.calls[0]!;
+    const patchDraftCall = fetchMock.mock.calls[1]!;
+    const sendDraftCall = fetchMock.mock.calls[2]!;
+
+    expect(createReplyCall[0]).toContain('/messages/orig-1/createReply');
+    expect(createReplyCall[1].method).toBe('POST');
+    expect(patchDraftCall[0]).toContain('/messages/draft-9');
+    expect(patchDraftCall[1].method).toBe('PATCH');
+    expect(JSON.parse(patchDraftCall[1].body).body).toEqual({ contentType: 'HTML', content: '<p>reply</p>' });
+    expect(sendDraftCall[0]).toContain('/messages/draft-9/send');
+    expect(sendDraftCall[1].method).toBe('POST');
+  });
+
+  it('throws if createReply fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403, text: async () => 'denied' });
+    await expect(sendThreadedReply(target, 'orig-1', '<p>x</p>')).rejects.toThrow(/403/);
+  });
+});
+
+describe('sendNewMail', () => {
+  beforeEach(() => fetchMock.mockReset());
+  it('POSTs sendMail with the message envelope', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 202, text: async () => '' });
+    await sendNewMail(target, 'cust@x.com', 'Re: hi [T-2026-0007]', '<p>hello</p>');
+    const [url, opts] = fetchMock.mock.calls[0]!;
+    expect(url).toContain('/users/support%40a.com/sendMail');
+    const payload = JSON.parse(opts.body);
+    expect(payload.message.toRecipients[0].emailAddress.address).toBe('cust@x.com');
+    expect(payload.message.subject).toBe('Re: hi [T-2026-0007]');
+    expect(payload.saveToSentItems).toBe(true);
+  });
+});

--- a/apps/api/src/services/ticketMailbox/graphReplySender.ts
+++ b/apps/api/src/services/ticketMailbox/graphReplySender.ts
@@ -1,0 +1,55 @@
+import { getMailboxToken } from './mailboxToken';
+
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+
+export interface GraphSendTarget { tenantId: string; mailbox: string; }
+
+async function gfetch(url: string, token: string, init: RequestInit): Promise<Response> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, ...(init.headers ?? {}) },
+    redirect: 'error',
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Graph ${init.method ?? 'GET'} ${url} -> ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res;
+}
+
+/** Threaded reply from the support mailbox: createReply -> set body -> send. */
+export async function sendThreadedReply(t: GraphSendTarget, originalMessageId: string, html: string): Promise<void> {
+  const token = await getMailboxToken(t.tenantId);
+  const base = `${GRAPH}/users/${encodeURIComponent(t.mailbox)}/messages`;
+
+  const draftRes = await gfetch(`${base}/${encodeURIComponent(originalMessageId)}/createReply`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+  });
+  const draft = (await draftRes.json()) as { id?: string };
+  if (!draft.id) throw new Error('Graph createReply returned no draft id');
+
+  await gfetch(`${base}/${encodeURIComponent(draft.id)}`, token, {
+    method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: { contentType: 'HTML', content: html } }),
+  });
+
+  await gfetch(`${base}/${encodeURIComponent(draft.id)}/send`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+  });
+}
+
+/** First-contact / autoresponse with no original message to reply to. */
+export async function sendNewMail(t: GraphSendTarget, to: string, subject: string, html: string): Promise<void> {
+  const token = await getMailboxToken(t.tenantId);
+  await gfetch(`${GRAPH}/users/${encodeURIComponent(t.mailbox)}/sendMail`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: {
+        subject,
+        body: { contentType: 'HTML', content: html },
+        toRecipients: [{ emailAddress: { address: to } }],
+      },
+      saveToSentItems: true,
+    }),
+  });
+}

--- a/apps/api/src/services/ticketMailbox/mailboxToken.test.ts
+++ b/apps/api/src/services/ticketMailbox/mailboxToken.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../c2cM365', () => ({
+  isM365TenantId: (x: string) => /^[0-9a-f-]{36}$/i.test(x),
+  acquireClientCredentialsToken: vi.fn(async () => ({ accessToken: 'tok-1', expiresIn: 3600 })),
+}));
+
+import { acquireClientCredentialsToken } from '../c2cM365';
+import { getMailboxToken, _clearMailboxTokenCache } from './mailboxToken';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+
+describe('getMailboxToken', () => {
+  beforeEach(() => {
+    _clearMailboxTokenCache();
+    vi.mocked(acquireClientCredentialsToken).mockClear();
+    process.env.TICKET_MAILBOX_M365_CLIENT_ID = 'cid';
+    process.env.TICKET_MAILBOX_M365_CLIENT_SECRET = 'csecret';
+  });
+
+  it('acquires once and caches within the freshness window', async () => {
+    const a = await getMailboxToken(TENANT);
+    const b = await getMailboxToken(TENANT);
+    expect(a).toBe('tok-1');
+    expect(b).toBe('tok-1');
+    expect(acquireClientCredentialsToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a non-GUID tenant id', async () => {
+    await expect(getMailboxToken('common')).rejects.toThrow(/tenant id/i);
+  });
+
+  it('throws when app creds are not configured', async () => {
+    delete process.env.TICKET_MAILBOX_M365_CLIENT_ID;
+    await expect(getMailboxToken(TENANT)).rejects.toThrow(/not configured/i);
+  });
+});

--- a/apps/api/src/services/ticketMailbox/mailboxToken.ts
+++ b/apps/api/src/services/ticketMailbox/mailboxToken.ts
@@ -1,0 +1,48 @@
+import { acquireClientCredentialsToken, isM365TenantId } from '../c2cM365';
+
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CachedToken>();
+const FRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export function _clearMailboxTokenCache(): void {
+  cache.clear();
+}
+
+export function getMailboxPlatformConfig(): { clientId: string; clientSecret: string } | null {
+  const clientId = process.env.TICKET_MAILBOX_M365_CLIENT_ID?.trim();
+  const clientSecret = process.env.TICKET_MAILBOX_M365_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret };
+}
+
+export function getMailboxCallbackUri(): string {
+  const base = (
+    process.env.PUBLIC_URL ||
+    process.env.PUBLIC_APP_URL ||
+    process.env.DASHBOARD_URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+  return `${base}/api/v1/tickets/mailbox/callback`;
+}
+
+/** App-only Graph token for a partner's tenant. Cached in-memory keyed by tenant. */
+export async function getMailboxToken(tenantId: string): Promise<string> {
+  if (!isM365TenantId(tenantId)) throw new Error('Invalid M365 tenant id');
+  const cached = cache.get(tenantId);
+  if (cached && cached.expiresAt - Date.now() > FRESH_BUFFER_MS) return cached.token;
+
+  const cfg = getMailboxPlatformConfig();
+  if (!cfg) throw new Error('TICKET_MAILBOX_M365_CLIENT_ID/SECRET not configured');
+
+  const res = await acquireClientCredentialsToken({
+    tenantId: tenantId as Parameters<typeof acquireClientCredentialsToken>[0]['tenantId'],
+    clientId: cfg.clientId,
+    clientSecret: cfg.clientSecret,
+  });
+  cache.set(tenantId, { token: res.accessToken, expiresAt: Date.now() + res.expiresIn * 1000 });
+  return res.accessToken;
+}

--- a/apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
+++ b/apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeGraphMessage } from './normalizeGraphMessage';
+import type { GraphMessage } from './graphMailClient';
+
+const msg: GraphMessage = {
+  id: 'AAA-graph-id',
+  internetMessageId: '<abc@mail.x.com>',
+  subject: 'Printer down [T-2026-0007]',
+  from: { emailAddress: { address: 'Cust@X.com', name: 'Cust' } },
+  toRecipients: [{ emailAddress: { address: 'support@a.com' } }],
+  conversationId: 'conv-1',
+  body: { contentType: 'html', content: '<p>help</p>' },
+  bodyPreview: 'help',
+  hasAttachments: false,
+  internetMessageHeaders: [
+    { name: 'In-Reply-To', value: '<prev@mail.x.com>' },
+    { name: 'References', value: '<root@mail.x.com> <prev@mail.x.com>' },
+    { name: 'Authentication-Results', value: 'spf=pass; dkim=pass; dmarc=pass action=none' },
+  ],
+};
+
+describe('normalizeGraphMessage', () => {
+  it('maps core fields, provider, and pre-resolved partner', () => {
+    const n = normalizeGraphMessage(msg, 'partner-9', 'support@a.com');
+    expect(n.provider).toBe('m365');
+    expect(n.providerMessageId).toBe('AAA-graph-id');
+    expect(n.resolvedPartnerId).toBe('partner-9');
+    expect(n.to).toBe('support@a.com');
+    expect(n.from).toBe('cust@x.com');
+    expect(n.subject).toBe('Printer down [T-2026-0007]');
+    expect(n.messageId).toBe('<abc@mail.x.com>');
+    expect(n.inReplyTo).toBe('<prev@mail.x.com>');
+    expect(n.references).toEqual(['<root@mail.x.com>', '<prev@mail.x.com>']);
+    expect(n.html).toBe('<p>help</p>');
+  });
+
+  it('extracts a full sender-auth verdict (dmarc=pass -> verified)', () => {
+    const n = normalizeGraphMessage(msg, 'partner-9', 'support@a.com');
+    expect(n.senderAuth).toEqual({ spf: 'pass', dkim: 'pass', dmarc: 'pass', verified: true });
+  });
+
+  it('fails closed when Authentication-Results is missing (full object, verified=false)', () => {
+    const n = normalizeGraphMessage({ ...msg, internetMessageHeaders: [] }, 'partner-9', 'support@a.com');
+    expect(n.senderAuth).toBeDefined();
+    expect(n.senderAuth?.verified).toBe(false);
+    expect(n.senderAuth?.dmarc).toBe('unknown');
+  });
+});

--- a/apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
+++ b/apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
@@ -15,7 +15,8 @@ const msg: GraphMessage = {
   internetMessageHeaders: [
     { name: 'In-Reply-To', value: '<prev@mail.x.com>' },
     { name: 'References', value: '<root@mail.x.com> <prev@mail.x.com>' },
-    { name: 'Authentication-Results', value: 'spf=pass; dkim=pass; dmarc=pass action=none' },
+    // authserv-id 'a.com' matches the support mailbox domain → trusted (EOP stamp).
+    { name: 'Authentication-Results', value: 'a.com; spf=pass; dkim=pass; dmarc=pass action=none' },
   ],
 };
 
@@ -44,5 +45,31 @@ describe('normalizeGraphMessage', () => {
     expect(n.senderAuth).toBeDefined();
     expect(n.senderAuth?.verified).toBe(false);
     expect(n.senderAuth?.dmarc).toBe('unknown');
+  });
+
+  it('does NOT trust a sender-forged Authentication-Results (authserv-id mismatch → verified=false)', () => {
+    const forged: GraphMessage = {
+      ...msg,
+      internetMessageHeaders: [
+        // A header the sender injected into their own message; authserv-id is NOT
+        // the mailbox domain, so it must be ignored (spoof defense).
+        { name: 'Authentication-Results', value: 'attacker.test; spf=pass; dkim=pass; dmarc=pass' },
+      ],
+    };
+    const n = normalizeGraphMessage(forged, 'partner-9', 'support@a.com');
+    expect(n.senderAuth?.verified).toBe(false);
+    expect(n.senderAuth?.dmarc).toBe('unknown');
+  });
+
+  it('trusts the genuine EOP header even when a forged one is also present', () => {
+    const both: GraphMessage = {
+      ...msg,
+      internetMessageHeaders: [
+        { name: 'Authentication-Results', value: 'attacker.test; dmarc=pass' },          // forged
+        { name: 'Authentication-Results', value: 'a.com; spf=pass; dkim=pass; dmarc=pass' }, // EOP
+      ],
+    };
+    const n = normalizeGraphMessage(both, 'partner-9', 'support@a.com');
+    expect(n.senderAuth?.verified).toBe(true);
   });
 });

--- a/apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts
+++ b/apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts
@@ -1,0 +1,66 @@
+import type { GraphMessage } from './graphMailClient';
+import type { NormalizedInboundEmail, SenderAuth, SenderAuthVerdict } from '../inboundEmail/types';
+
+function header(headers: GraphMessage['internetMessageHeaders'], name: string): string | undefined {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+// Mirror mailgun.ts normalizeVerdict: map a raw mechanism token -> SenderAuthVerdict.
+function normalizeVerdict(raw: string | undefined): SenderAuthVerdict {
+  const v = raw?.trim().toLowerCase();
+  if (v === 'pass') return 'pass';
+  if (v === 'fail' || v === 'softfail' || v === 'permerror' || v === 'temperror') return 'fail';
+  if (v === 'neutral') return 'neutral';
+  if (v === 'none') return 'none';
+  return 'unknown';
+}
+
+function mechanism(authResults: string | undefined, name: string): string | undefined {
+  if (!authResults) return undefined;
+  return new RegExp(`\\b${name}=(\\w+)`, 'i').exec(authResults)?.[1];
+}
+
+/** Always returns a full SenderAuth (fail-closed). verified iff DMARC passed. */
+function buildSenderAuth(authResults: string | undefined): SenderAuth {
+  const spf = normalizeVerdict(mechanism(authResults, 'spf'));
+  const dkim = normalizeVerdict(mechanism(authResults, 'dkim'));
+  const dmarc = normalizeVerdict(mechanism(authResults, 'dmarc'));
+  return { spf, dkim, dmarc, verified: dmarc === 'pass' };
+}
+
+/** Pure mapping: Graph message -> the pipeline's NormalizedInboundEmail. */
+export function normalizeGraphMessage(
+  msg: GraphMessage,
+  partnerId: string,
+  mailboxAddress: string,
+): NormalizedInboundEmail {
+  const fromAddr = msg.from?.emailAddress?.address?.trim().toLowerCase() ?? '';
+  const references = header(msg.internetMessageHeaders, 'References')?.trim().split(/\s+/).filter(Boolean);
+  const contentType = msg.body?.contentType?.toLowerCase();
+  const html = contentType === 'html' ? msg.body?.content : undefined;
+  const text = contentType === 'text' ? (msg.body?.content ?? '') : (msg.bodyPreview ?? '');
+
+  return {
+    provider: 'm365',
+    providerMessageId: msg.id,
+    resolvedPartnerId: partnerId,
+    to: mailboxAddress.trim().toLowerCase(),
+    from: fromAddr,
+    fromName: msg.from?.emailAddress?.name,
+    subject: msg.subject ?? '',
+    text,
+    html,
+    messageId: msg.internetMessageId,
+    inReplyTo: header(msg.internetMessageHeaders, 'In-Reply-To'),
+    references,
+    autoSubmitted: header(msg.internetMessageHeaders, 'Auto-Submitted'),
+    precedence: header(msg.internetMessageHeaders, 'Precedence'),
+    senderAuth: buildSenderAuth(header(msg.internetMessageHeaders, 'Authentication-Results')),
+    // Phase-1 parity: attachment bodies deferred; metadata not fetched yet.
+    attachments: [],
+    raw: {
+      graphConversationId: msg.conversationId,
+      receivedDateTime: msg.receivedDateTime,
+    },
+  };
+}

--- a/apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts
+++ b/apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts
@@ -20,6 +20,32 @@ function mechanism(authResults: string | undefined, name: string): string | unde
   return new RegExp(`\\b${name}=(\\w+)`, 'i').exec(authResults)?.[1];
 }
 
+/**
+ * Return the value of the Authentication-Results header we can TRUST, or '' if none.
+ *
+ * Graph's `internetMessageHeaders` returns the full header set, which can include an
+ * `Authentication-Results` line a malicious sender put into their OWN message
+ * (e.g. `Authentication-Results: anything; dmarc=pass`). Exchange Online stamps a
+ * GENUINE header whose authserv-id is the receiving (accepted) domain. So — mirroring
+ * the mailgun normalizer's authserv-id check — trust ONLY a header whose authserv-id
+ * matches the support mailbox's own domain; ignore foreign/absent authserv-id headers.
+ * Unmatched → '' → all verdicts 'unknown' → verified=false → the R4 gate quarantines
+ * (never drops) for manual review. NOTE: if a tenant's EOP stamps a different
+ * authserv-id than the mailbox domain, genuine mail will quarantine until this is
+ * tuned — safe because nothing is lost.
+ */
+function trustedAuthResults(
+  headers: GraphMessage['internetMessageHeaders'], mailboxDomain: string,
+): string {
+  if (!mailboxDomain) return '';
+  for (const h of headers ?? []) {
+    if (h.name.toLowerCase() !== 'authentication-results') continue;
+    const authservId = (h.value.split(';')[0] ?? '').trim().split(/\s+/)[0]?.toLowerCase();
+    if (authservId === mailboxDomain) return h.value;
+  }
+  return '';
+}
+
 /** Always returns a full SenderAuth (fail-closed). verified iff DMARC passed. */
 function buildSenderAuth(authResults: string | undefined): SenderAuth {
   const spf = normalizeVerdict(mechanism(authResults, 'spf'));
@@ -35,6 +61,7 @@ export function normalizeGraphMessage(
   mailboxAddress: string,
 ): NormalizedInboundEmail {
   const fromAddr = msg.from?.emailAddress?.address?.trim().toLowerCase() ?? '';
+  const mailboxDomain = mailboxAddress.split('@')[1]?.trim().toLowerCase() ?? '';
   const references = header(msg.internetMessageHeaders, 'References')?.trim().split(/\s+/).filter(Boolean);
   const contentType = msg.body?.contentType?.toLowerCase();
   const html = contentType === 'html' ? msg.body?.content : undefined;
@@ -55,7 +82,7 @@ export function normalizeGraphMessage(
     references,
     autoSubmitted: header(msg.internetMessageHeaders, 'Auto-Submitted'),
     precedence: header(msg.internetMessageHeaders, 'Precedence'),
-    senderAuth: buildSenderAuth(header(msg.internetMessageHeaders, 'Authentication-Results')),
+    senderAuth: buildSenderAuth(trustedAuthResults(msg.internetMessageHeaders, mailboxDomain)),
     // Phase-1 parity: attachment bodies deferred; metadata not fetched yet.
     attachments: [],
     raw: {

--- a/apps/api/src/services/ticketMailbox/resolveOutboundMailbox.test.ts
+++ b/apps/api/src/services/ticketMailbox/resolveOutboundMailbox.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const connRows = vi.fn();
+const inboundRows = vi.fn();
+vi.mock('../../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => connRows(),
+          orderBy: () => ({ limit: async () => inboundRows() }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import { resolveOutboundMailbox } from './resolveOutboundMailbox';
+
+describe('resolveOutboundMailbox', () => {
+  beforeEach(() => { connRows.mockReset(); inboundRows.mockReset(); });
+
+  it('returns null when the partner has no connected mailbox', async () => {
+    connRows.mockResolvedValue([]);
+    expect(await resolveOutboundMailbox('t1', 'p1')).toBeNull();
+  });
+
+  it('returns mailbox + originalMessageId from the latest m365 inbound row', async () => {
+    connRows.mockResolvedValue([{ tenantId: 'ten', mailboxAddress: 'support@a.com' }]);
+    inboundRows.mockResolvedValue([{ providerMessageId: 'graph-77' }]);
+    const r = await resolveOutboundMailbox('t1', 'p1');
+    expect(r).toEqual({ tenantId: 'ten', mailbox: 'support@a.com', originalMessageId: 'graph-77' });
+  });
+
+  it('returns originalMessageId null when no m365 inbound row exists', async () => {
+    connRows.mockResolvedValue([{ tenantId: 'ten', mailboxAddress: 'support@a.com' }]);
+    inboundRows.mockResolvedValue([]);
+    const r = await resolveOutboundMailbox('t1', 'p1');
+    expect(r?.originalMessageId).toBeNull();
+  });
+
+  it('returns null when partnerId is null', async () => {
+    expect(await resolveOutboundMailbox('t1', null)).toBeNull();
+  });
+});

--- a/apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts
+++ b/apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts
@@ -1,0 +1,44 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { ticketEmailInbound } from '../../db/schema/emailInbound';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+
+export interface OutboundMailbox {
+  tenantId: string;
+  mailbox: string;
+  originalMessageId: string | null;
+}
+
+export async function resolveOutboundMailbox(
+  ticketId: string,
+  partnerId: string | null
+): Promise<OutboundMailbox | null> {
+  if (!partnerId) return null;
+
+  const conn = await db.select({
+    tenantId: ticketMailboxConnections.tenantId,
+    mailboxAddress: ticketMailboxConnections.mailboxAddress,
+  }).from(ticketMailboxConnections)
+    .where(and(
+      eq(ticketMailboxConnections.partnerId, partnerId),
+      eq(ticketMailboxConnections.status, 'connected'),
+    )).limit(1);
+
+  const connectedMailbox = conn[0];
+  if (!connectedMailbox?.tenantId) return null;
+
+  const inbound = await db.select({ providerMessageId: ticketEmailInbound.providerMessageId })
+    .from(ticketEmailInbound)
+    .where(and(
+      eq(ticketEmailInbound.ticketId, ticketId),
+      eq(ticketEmailInbound.provider, 'm365'),
+    ))
+    .orderBy(desc(ticketEmailInbound.createdAt))
+    .limit(1);
+
+  return {
+    tenantId: connectedMailbox.tenantId,
+    mailbox: connectedMailbox.mailboxAddress,
+    originalMessageId: inbound[0]?.providerMessageId ?? null,
+  };
+}

--- a/apps/web/src/components/settings/M365MailboxCard.test.tsx
+++ b/apps/web/src/components/settings/M365MailboxCard.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../lib/authScope', () => ({ loginPathWithNext: () => '/login' }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+// Faithful options-based runAction mock: returns the parsed JSON body (as the real
+// one does), invokes onUnauthorized + throws ActionError on 401.
+vi.mock('../../lib/runAction', () => {
+  class ActionError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    ActionError,
+    handleActionError: vi.fn(),
+    runAction: async (opts: any) => {
+      const res = await opts.request();
+      const data = await res.json().catch(() => null);
+      if (res.status === 401) {
+        opts.onUnauthorized?.();
+        throw new ActionError('Unauthorized', 401);
+      }
+      return opts.parseSuccess ? opts.parseSuccess(data) : data;
+    },
+  };
+});
+
+import M365MailboxCard from './M365MailboxCard';
+
+function jsonRes(body: any, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+describe('M365MailboxCard', () => {
+  beforeEach(() => fetchWithAuth.mockReset());
+
+  it('lists existing connections on mount', async () => {
+    fetchWithAuth.mockResolvedValueOnce(
+      jsonRes({
+        connections: [
+          { id: 'c1', mailboxAddress: 'support@a.com', displayName: 'Support', status: 'connected', tenantId: 't', lastPolledAt: null, lastError: null },
+        ],
+      }),
+    );
+    render(<M365MailboxCard />);
+    expect(await screen.findByText('support@a.com')).toBeTruthy();
+    expect(screen.getByText(/connected/i)).toBeTruthy();
+  });
+
+  it('Connect posts the address and redirects the browser to authUrl', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonRes({ connections: [] }))
+      .mockResolvedValueOnce(jsonRes({ authUrl: 'https://login.microsoftonline.com/x', connectionId: 'c2' }));
+    const assign = vi.fn();
+    Object.defineProperty(window, 'location', { value: { assign, href: '', hash: '', pathname: '/settings/partner' }, writable: true });
+
+    render(<M365MailboxCard />);
+    fireEvent.change(await screen.findByLabelText(/mailbox address/i), { target: { value: 'support@a.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining('/tickets/mailbox/connect'),
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('https://login.microsoftonline.com/x'));
+  });
+
+  it('Re-test calls the retest endpoint', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(
+        jsonRes({
+          connections: [
+            { id: 'c1', mailboxAddress: 'support@a.com', displayName: null, status: 'error', tenantId: 't', lastPolledAt: null, lastError: 'Graph returned 403' },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonRes({ ok: true }))
+      .mockResolvedValueOnce(jsonRes({ connections: [] }));
+    render(<M365MailboxCard />);
+    fireEvent.click(await screen.findByRole('button', { name: /re-test/i }));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining('/tickets/mailbox/connections/c1/retest'),
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+  });
+
+  it('Disconnect calls the delete endpoint', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(
+        jsonRes({
+          connections: [
+            { id: 'c1', mailboxAddress: 'support@a.com', displayName: null, status: 'connected', tenantId: 't', lastPolledAt: null, lastError: null },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonRes({ ok: true }))
+      .mockResolvedValueOnce(jsonRes({ connections: [] }));
+    render(<M365MailboxCard />);
+    fireEvent.click(await screen.findByRole('button', { name: /disconnect/i }));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining('/tickets/mailbox/connections/c1'),
+        expect.objectContaining({ method: 'DELETE' }),
+      ),
+    );
+  });
+});

--- a/apps/web/src/components/settings/M365MailboxCard.tsx
+++ b/apps/web/src/components/settings/M365MailboxCard.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import { showToast } from '../shared/Toast';
+
+interface MailboxConnectionDTO {
+  id: string;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+  tenantId: string | null;
+  lastPolledAt: string | null;
+  lastError: string | null;
+}
+
+const STATUS_LABEL: Record<MailboxConnectionDTO['status'], string> = {
+  pending_consent: 'Pending consent',
+  connected: 'Connected',
+  error: 'Needs attention',
+  reauth_required: 'Re-auth required',
+  disabled: 'Disabled',
+};
+
+const APP_ID =
+  (import.meta.env.PUBLIC_TICKET_MAILBOX_APP_ID as string | undefined)?.trim() ||
+  '<Breeze Ticketing app id>';
+
+function powershellSnippet(mailbox: string): string {
+  return [
+    '# Run in Exchange Online PowerShell (Connect-ExchangeOnline) as a tenant admin:',
+    `New-DistributionGroup -Name "Breeze Ticketing Mailboxes" -Type Security -Members "${mailbox}"`,
+    `New-ApplicationAccessPolicy -AppId ${APP_ID} \\`,
+    '  -PolicyScopeGroupId "Breeze Ticketing Mailboxes" -AccessRight RestrictAccess \\',
+    '  -Description "Restrict Breeze Ticketing to the support mailbox"',
+  ].join('\n');
+}
+
+export default function M365MailboxCard() {
+  const [connections, setConnections] = useState<MailboxConnectionDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [address, setAddress] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const onUnauthorized = useCallback(() => {
+    navigateTo(loginPathWithNext());
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth('/tickets/mailbox/connections');
+      if (res.ok) {
+        const body = await res.json().catch(() => null);
+        setConnections((body?.connections ?? []) as MailboxConnectionDTO[]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Surface the consent redirect-back status (Plan 1 callback redirects with
+  // ?ticketMailbox=connected|needs_policy|error), then strip it so a refresh
+  // doesn't re-toast. Non-mutating UI — no runAction.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search || '');
+    const status = params.get('ticketMailbox');
+    if (!status) return;
+    if (status === 'connected') showToast({ type: 'success', message: 'Mailbox connected' });
+    else if (status === 'needs_policy')
+      showToast({ type: 'warning', message: 'Consent granted — scope the mailbox with the Application Access Policy below, then Re-test' });
+    else if (status === 'error') showToast({ type: 'error', message: 'M365 connection failed' });
+    params.delete('ticketMailbox');
+    const qs = params.toString();
+    window.history.replaceState({}, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
+  }, []);
+
+  const handleConnect = useCallback(async () => {
+    if (!address.trim()) return;
+    setBusy(true);
+    try {
+      const data = await runAction<{ authUrl?: string; connectionId?: string }>({
+        request: () =>
+          fetchWithAuth('/tickets/mailbox/connect', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              mailboxAddress: address.trim(),
+              displayName: displayName.trim() || undefined,
+            }),
+          }),
+        errorFallback: 'Could not start M365 consent.',
+        onUnauthorized,
+      });
+      if (data?.authUrl) window.location.assign(data.authUrl);
+    } catch (err) {
+      if (!(err instanceof ActionError)) handleActionError(err, 'Could not start M365 consent.');
+    } finally {
+      setBusy(false);
+    }
+  }, [address, displayName, onUnauthorized]);
+
+  const handleRetest = useCallback(
+    async (id: string) => {
+      try {
+        await runAction({
+          request: () => fetchWithAuth(`/tickets/mailbox/connections/${id}/retest`, { method: 'POST' }),
+          errorFallback: 'Re-test failed.',
+          onUnauthorized,
+        });
+        await refresh();
+      } catch (err) {
+        if (!(err instanceof ActionError)) handleActionError(err, 'Re-test failed.');
+      }
+    },
+    [onUnauthorized, refresh],
+  );
+
+  const handleDisconnect = useCallback(
+    async (id: string) => {
+      try {
+        await runAction({
+          request: () => fetchWithAuth(`/tickets/mailbox/connections/${id}`, { method: 'DELETE' }),
+          errorFallback: 'Disconnect failed.',
+          successMessage: 'Mailbox disconnected',
+          onUnauthorized,
+        });
+        await refresh();
+      } catch (err) {
+        if (!(err instanceof ActionError)) handleActionError(err, 'Disconnect failed.');
+      }
+    },
+    [onUnauthorized, refresh],
+  );
+
+  const visible = connections.filter((c) => c.status !== 'disabled');
+
+  return (
+    <section data-testid="m365-mailbox-card" className="rounded-lg border p-4">
+      <h3 className="text-base font-semibold">Microsoft 365 support mailbox</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Connect your shared support mailbox so customer email becomes tickets and replies are sent from
+        it. No MX or forwarding changes required.
+      </p>
+
+      {loading ? (
+        <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
+      ) : visible.length > 0 ? (
+        <ul className="mt-4 space-y-3">
+          {visible.map((c) => (
+            <li
+              key={c.id}
+              data-testid="m365-connection"
+              className="flex flex-col gap-2 rounded border p-3"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="font-medium">{c.mailboxAddress}</span>
+                  {c.displayName ? (
+                    <span className="ml-2 text-sm text-muted-foreground">{c.displayName}</span>
+                  ) : null}
+                </div>
+                <span className="text-sm" data-testid="m365-status">
+                  {STATUS_LABEL[c.status]}
+                </span>
+              </div>
+              {c.lastError ? <p className="text-xs text-destructive">{c.lastError}</p> : null}
+              {c.status === 'error' || c.status === 'reauth_required' || c.status === 'pending_consent' ? (
+                <details className="text-xs">
+                  <summary className="cursor-pointer">Scope this mailbox (Application Access Policy)</summary>
+                  <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2">
+                    {powershellSnippet(c.mailboxAddress)}
+                  </pre>
+                </details>
+              ) : null}
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  className="text-sm text-primary hover:underline"
+                  onClick={() => handleRetest(c.id)}
+                >
+                  Re-test
+                </button>
+                <button
+                  type="button"
+                  className="text-sm text-destructive hover:underline"
+                  onClick={() => handleDisconnect(c.id)}
+                >
+                  Disconnect
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-sm text-muted-foreground">No mailbox connected yet.</p>
+      )}
+
+      <div className="mt-4 flex flex-col gap-2 border-t pt-4">
+        <label className="text-sm" htmlFor="m365-address">
+          Mailbox address
+        </label>
+        <input
+          id="m365-address"
+          className="rounded border p-2 text-sm"
+          placeholder="support@yourmsp.com"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+        <label className="text-sm" htmlFor="m365-name">
+          Display name (optional)
+        </label>
+        <input
+          id="m365-name"
+          className="rounded border p-2 text-sm"
+          placeholder="Support"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+        <button
+          type="button"
+          disabled={busy || !address.trim()}
+          onClick={handleConnect}
+          className="mt-1 self-start rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+        >
+          Connect
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -134,6 +134,14 @@ export default function PartnerSettingsPage() {
   const [error, setError] = useState<string>();
   const [activeTab, setActiveTab] = useState<TabKey>('company');
 
+  // The M365 consent callback returns to `/settings/partner?ticketMailbox=…#ticketing`.
+  // Capture that signal ONCE at mount (this page mounts a single time), before the
+  // mailbox card strips the param, so we can deep-link the embedded Ticketing group's
+  // Inbound sub-tab deterministically — see TicketingSettingsTabs `initialTab`.
+  const [deepLinkTicketMailbox] = useState(
+    () => typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('ticketMailbox')
+  );
+
   // Regional form state
   const [timezone, setTimezone] = useState('UTC');
   const [dateFormat, setDateFormat] = useState<DateFormat>('MM/DD/YYYY');
@@ -627,7 +635,7 @@ export default function PartnerSettingsPage() {
             Configure ticket statuses, priority SLA defaults, categories, and billing exports.
             These apply across all of your organizations.
           </p>
-          <TicketingSettingsTabs syncHash={false} />
+          <TicketingSettingsTabs syncHash={false} initialTab={deepLinkTicketMailbox ? 'inbound' : undefined} />
         </section>
       )}
     </div>

--- a/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
@@ -58,6 +58,15 @@ describe('TicketingSettingsTabs', () => {
     expect(window.location.hash).toBe('#ticketing');
   });
 
+  it('seeds the initial sub-tab from the initialTab prop (deterministic deep-link)', () => {
+    // The M365 consent deep-link relies on the parent passing initialTab so the group
+    // opens on the right sub-tab regardless of remounts — independent of any URL param
+    // the mailbox card may have already stripped.
+    render(<TicketingSettingsTabs syncHash={false} initialTab="export" />);
+    expect(screen.getByTestId('stub-billables-export-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticketing-tab-panel-statuses')).toBeNull();
+  });
+
   it('ignores #tab= deep links when syncHash is false', () => {
     window.location.hash = '#tab=export';
     render(<TicketingSettingsTabs syncHash={false} />);

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -89,6 +89,17 @@ export default function TicketingSettingsTabs({ syncHash = true }: { syncHash?: 
     return () => window.removeEventListener('hashchange', onHashChange);
   }, [syncHash]);
 
+  // The M365 consent callback redirects back to `/settings/partner?ticketMailbox=...#ticketing`,
+  // which opens the Ticketing section but not this sub-tab group's Inbound sub-tab (where the
+  // mailbox card — and its redirect-status toast — lives). Force Inbound open when that param is
+  // present so the user lands on the card that owns the feedback. Runs regardless of `syncHash`.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !canManageInbound) return;
+    if (new URLSearchParams(window.location.search || '').has('ticketMailbox')) {
+      setActiveTab('inbound');
+    }
+  }, [canManageInbound]);
+
   return (
     <div className="space-y-6">
       <div role="tablist" className="flex gap-1 border-b" data-testid="ticketing-settings-tabs">

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -55,8 +55,20 @@ function hashFor(tab: Tab): string {
  * Partner hub (which owns the top-level tab hash, e.g. `#ticketing`) we leave it
  * off so the two don't fight over `window.location.hash`.
  */
-export default function TicketingSettingsTabs({ syncHash = true }: { syncHash?: boolean }) {
-  const [activeTab, setActiveTab] = useState<Tab>('statuses');
+export default function TicketingSettingsTabs({
+  syncHash = true,
+  initialTab,
+}: {
+  syncHash?: boolean;
+  initialTab?: Tab;
+}) {
+  // `initialTab` seeds the sub-tab deterministically for the embedded (syncHash=false)
+  // case — used by the M365 consent deep-link (`?ticketMailbox=…`) so this group opens
+  // on Inbound regardless of when it mounts. The parent captures that signal once (it
+  // mounts a single time); we must NOT re-read the URL param here because the mailbox
+  // card strips it on mount, and this group can remount when the parent's loading state
+  // toggles — re-reading would lose the signal (the tab would snap back to Statuses).
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab ?? 'statuses');
 
   // Render the Inbound Email tab only for partner-scoped users (matches how the
   // Sidebar gates other partner-only settings surfaces). Decoded client-side as
@@ -88,17 +100,6 @@ export default function TicketingSettingsTabs({ syncHash = true }: { syncHash?: 
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
   }, [syncHash]);
-
-  // The M365 consent callback redirects back to `/settings/partner?ticketMailbox=...#ticketing`,
-  // which opens the Ticketing section but not this sub-tab group's Inbound sub-tab (where the
-  // mailbox card — and its redirect-status toast — lives). Force Inbound open when that param is
-  // present so the user lands on the card that owns the feedback. Runs regardless of `syncHash`.
-  useEffect(() => {
-    if (typeof window === 'undefined' || !canManageInbound) return;
-    if (new URLSearchParams(window.location.search || '').has('ticketMailbox')) {
-      setActiveTab('inbound');
-    }
-  }, [canManageInbound]);
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -5,6 +5,7 @@ import BillablesExportCard from './BillablesExportCard';
 import TicketStatusesTab from './TicketStatusesTab';
 import TicketPrioritiesTab from './TicketPrioritiesTab';
 import InboundEmailCard from './InboundEmailCard';
+import M365MailboxCard from './M365MailboxCard';
 import CannedResponsesCard from './CannedResponsesCard';
 import { getJwtClaims } from '../../lib/authScope';
 
@@ -128,8 +129,9 @@ export default function TicketingSettingsTabs({ syncHash = true }: { syncHash?: 
       {activeTab === 'export' && <BillablesExportCard />}
 
       {activeTab === 'inbound' && canManageInbound && (
-        <div data-testid="ticketing-tab-panel-inbound">
+        <div data-testid="ticketing-tab-panel-inbound" className="space-y-6">
           <InboundEmailCard />
+          <M365MailboxCard />
         </div>
       )}
 

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -50,6 +50,7 @@ const TARGET_GLOBS = [
   'src/components/settings/TicketStatusesTab.tsx',
   'src/components/settings/TicketPrioritiesTab.tsx',
   'src/components/settings/InboundEmailCard.tsx',
+  'src/components/settings/M365MailboxCard.tsx',
   'src/components/settings/OrgPortalSettingsEditor.tsx',
   'src/components/settings/OrgTicketSettingsEditor.tsx',
   'src/components/alerts/CreateTicketFromAlertDialog.tsx',
@@ -273,7 +274,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(54);
+    expect(absoluteFiles.length).toBe(55);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/docs/superpowers/plans/2026-06-29-m365-mailbox-1-connection-foundation.md
+++ b/docs/superpowers/plans/2026-06-29-m365-mailbox-1-connection-foundation.md
@@ -1,0 +1,831 @@
+# M365 Mailbox — Plan 1: Connection Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP partner register an M365 shared mailbox, complete admin consent for Breeze's Graph app, and have Breeze store the per-partner tenant + mailbox so inbound (Plan 2) and outbound (Plan 3) can authenticate.
+
+**Architecture:** A new partner-axis table `ticket_mailbox_connections` (Shape 3 RLS, no secret column — Breeze's app secret lives in env). An app-only token helper reuses the existing `c2cM365.ts` client-credentials primitives against a *new* Azure app. Connect/callback routes mirror the accounting OAuth pattern: signed-state JWT + CSRF cookie, callback unauthenticated at the middleware layer, writes under system DB context.
+
+**Tech Stack:** Hono, Drizzle ORM, PostgreSQL RLS, BullMQ (later plans), Vitest, Microsoft Graph (OAuth2 client-credentials).
+
+## Global Constraints
+
+- Node pinned to v22.20.0; fresh worktrees need `pnpm install` and a symlinked `.env`/`.env.test` (else RLS forge passes vacuously).
+- Migrations: filename `^\d{4}-.*\.sql$`, applied in `localeCompare` order; idempotent (`IF NOT EXISTS`, `pg_policies` checks); **no inner `BEGIN;`/`COMMIT;`** (autoMigrate wraps each file in a txn); never edit a shipped migration.
+- Every tenant-scoped table MUST have RLS enabled + forced + policies in the **same migration** that creates it, and an allowlist entry in `rls-coverage.integration.test.ts` in the **same PR**.
+- Background/non-request DB work runs under `runOutsideDbContext(() => withSystemDbAccessContext(...))`; bare pool is forbidden in request code.
+- OAuth callback that receives a browser redirect must NOT use `authMiddleware` (Bearer-only) — authenticate via signed `state` + binding cookie, write under system context.
+- App registration is **separate** from the C2C backup app: env `TICKET_MAILBOX_M365_CLIENT_ID` / `TICKET_MAILBOX_M365_CLIENT_SECRET`. Graph permissions: `Mail.ReadWrite`, `Mail.Send` (app-only).
+- `M365TenantId` is a GUID; the well-known `common`/`organizations`/`consumers` aliases are invalid for client-credentials.
+
+## File Structure
+
+- Create `apps/api/src/db/schema/ticketMailbox.ts` — Drizzle schema for `ticket_mailbox_connections`.
+- Modify `apps/api/src/db/schema/index.ts` — export the new schema.
+- Create `apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql` — table + RLS.
+- Create `apps/api/src/services/ticketMailbox/mailboxToken.ts` — app-only token helper + in-memory cache.
+- Create `apps/api/src/services/ticketMailbox/connectionService.ts` — typed CRUD + status transitions + `probeMailbox`.
+- Create `apps/api/src/routes/tickets/mailboxConnect.ts` — connect/callback/list/retest/disconnect routes.
+- Modify `apps/api/src/routes/tickets/index.ts` — mount the mailbox routes.
+- Modify `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — add to `PARTNER_TENANT_TABLES` + `ORG_AXIS_EXCLUDED`.
+- Tests co-located: `mailboxToken.test.ts`, `connectionService.test.ts`, `mailboxConnect.test.ts`, and an RLS forge integration test.
+
+## Shared Interface Contract (used by Plans 2 & 3)
+
+```typescript
+// services/ticketMailbox/connectionService.ts
+export type MailboxConnectionStatus =
+  | 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+
+export interface MailboxConnection {
+  id: string;
+  partnerId: string;
+  tenantId: string | null;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: MailboxConnectionStatus;
+  deltaLink: string | null;
+  strictSenderAuth: boolean;
+  lastPolledAt: Date | null;
+  lastMessageAt: Date | null;
+  lastError: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function listMailboxConnections(partnerId: string): Promise<MailboxConnection[]>;
+export function listConnectedMailboxes(): Promise<MailboxConnection[]>; // system-context, all partners
+export function getMailboxConnection(id: string, partnerId: string): Promise<MailboxConnection | null>;
+export function createPendingConnection(input: { partnerId: string; mailboxAddress: string; displayName: string | null; createdBy: string | null; }): Promise<MailboxConnection>;
+export function setConnectionTenant(id: string, partnerId: string, tenantId: string): Promise<void>;
+export function setConnectionStatus(id: string, partnerId: string, status: MailboxConnectionStatus, lastError: string | null): Promise<void>;
+export function updateDeltaCursor(id: string, deltaLink: string, polledAt: Date, lastMessageAt: Date | null): Promise<void>;
+export function resetDeltaCursor(id: string): Promise<void>; // 410-Gone resync → start delta from "now"
+export function disableConnection(id: string, partnerId: string): Promise<void>;
+export function probeMailbox(tenantId: string, mailboxAddress: string): Promise<{ ok: boolean; error?: string }>;
+
+// services/ticketMailbox/mailboxToken.ts
+export function getMailboxPlatformConfig(): { clientId: string; clientSecret: string } | null;
+export function getMailboxToken(tenantId: string): Promise<string>;
+export function getMailboxCallbackUri(): string;
+```
+
+---
+
+### Task 1: Drizzle schema + migration for `ticket_mailbox_connections`
+
+**Files:**
+- Create: `apps/api/src/db/schema/ticketMailbox.ts`
+- Modify: `apps/api/src/db/schema/index.ts`
+- Create: `apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql`
+
+**Interfaces:**
+- Produces: `ticketMailboxConnections` Drizzle table; SQL table `ticket_mailbox_connections`.
+
+- [ ] **Step 1: Write the Drizzle schema**
+
+```typescript
+// apps/api/src/db/schema/ticketMailbox.ts
+import { pgTable, uuid, text, boolean, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+import { users } from './users';
+
+export const ticketMailboxConnections = pgTable('ticket_mailbox_connections', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  tenantId: text('tenant_id'),                       // Entra GUID; null until consent callback
+  mailboxAddress: text('mailbox_address').notNull(), // shared support UPN
+  displayName: text('display_name'),
+  status: text('status').notNull().default('pending_consent'), // see MailboxConnectionStatus
+  deltaLink: text('delta_link'),
+  strictSenderAuth: boolean('strict_sender_auth').notNull().default(false),
+  lastPolledAt: timestamp('last_polled_at', { withTimezone: true }),
+  lastMessageAt: timestamp('last_message_at', { withTimezone: true }),
+  lastError: text('last_error'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  partnerMailboxIdx: uniqueIndex('ticket_mailbox_connections_partner_mailbox_idx')
+    .on(table.partnerId, table.mailboxAddress),
+  idPartnerIdx: uniqueIndex('ticket_mailbox_connections_id_partner_idx')
+    .on(table.id, table.partnerId),
+}));
+```
+
+- [ ] **Step 2: Export from the schema index**
+
+Add to `apps/api/src/db/schema/index.ts` (alongside the other `export *` lines):
+
+```typescript
+export * from './ticketMailbox';
+```
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql
+CREATE TABLE IF NOT EXISTS ticket_mailbox_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id uuid NOT NULL REFERENCES partners(id),
+  tenant_id text,
+  mailbox_address text NOT NULL,
+  display_name text,
+  status varchar(20) NOT NULL DEFAULT 'pending_consent',
+  delta_link text,
+  strict_sender_auth boolean NOT NULL DEFAULT false,
+  last_polled_at timestamptz,
+  last_message_at timestamptz,
+  last_error text,
+  created_by uuid REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ticket_mailbox_connections_partner_mailbox_idx
+  ON ticket_mailbox_connections(partner_id, mailbox_address);
+CREATE UNIQUE INDEX IF NOT EXISTS ticket_mailbox_connections_id_partner_idx
+  ON ticket_mailbox_connections(id, partner_id);
+
+ALTER TABLE ticket_mailbox_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ticket_mailbox_connections FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_partner_isolation_select ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_insert ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_update ON ticket_mailbox_connections;
+DROP POLICY IF EXISTS breeze_partner_isolation_delete ON ticket_mailbox_connections;
+CREATE POLICY breeze_partner_isolation_select ON ticket_mailbox_connections
+  FOR SELECT USING (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_insert ON ticket_mailbox_connections
+  FOR INSERT WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_update ON ticket_mailbox_connections
+  FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+  WITH CHECK (public.breeze_has_partner_access(partner_id));
+CREATE POLICY breeze_partner_isolation_delete ON ticket_mailbox_connections
+  FOR DELETE USING (public.breeze_has_partner_access(partner_id));
+```
+
+- [ ] **Step 4: Apply the migration and verify no drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+npx tsx -e "import('./apps/api/src/db/autoMigrate').then(m => m.autoMigrate()).then(() => process.exit(0))"
+pnpm db:check-drift
+```
+Expected: migration applies; `db:check-drift` reports **no drift**.
+
+- [ ] **Step 5: Verify isolation as `breeze_app`**
+
+Run:
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze \
+  -c "INSERT INTO ticket_mailbox_connections (partner_id, mailbox_address) VALUES (gen_random_uuid(), 'x@y.com');"
+```
+Expected: FAIL with `new row violates row-level security policy`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/db/schema/ticketMailbox.ts apps/api/src/db/schema/index.ts apps/api/migrations/2026-06-29-ticket-mailbox-connections.sql
+git commit -m "feat(tickets): ticket_mailbox_connections table + partner-axis RLS"
+```
+
+---
+
+### Task 2: Add the table to the RLS coverage allowlist
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/ticketMailboxConnections.rls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `ticket_mailbox_connections` from Task 1.
+
+- [ ] **Step 1: Add to the partner-axis allowlists**
+
+In `rls-coverage.integration.test.ts`, add `'ticket_mailbox_connections'` to the `PARTNER_TENANT_TABLES` array and to the `ORG_AXIS_EXCLUDED` array (the table has no `org_id`). Keep arrays alphabetically ordered if they already are.
+
+- [ ] **Step 2: Write the forge test (must fail cross-partner)**
+
+```typescript
+// apps/api/src/__tests__/integration/ticketMailboxConnections.rls.integration.test.ts
+import { describe, it, expect } from 'vitest';
+import { withDbAccessContext } from '../../db';
+import { getTestPartners } from './helpers/rlsFixtures'; // existing helper used by other forge tests
+
+describe('ticket_mailbox_connections RLS (real driver)', () => {
+  it('rejects a cross-partner insert as breeze_app', async () => {
+    const { partnerA, partnerB } = await getTestPartners();
+    await expect(
+      withDbAccessContext({ scope: 'partner', partnerIds: [partnerA] }, async (db) => {
+        await db.execute(
+          `INSERT INTO ticket_mailbox_connections (partner_id, mailbox_address)
+           VALUES ('${partnerB}', 'support@b.com')`
+        );
+      })
+    ).rejects.toThrow(/row-level security/i);
+  });
+
+  it('allows insert + read within the same partner', async () => {
+    const { partnerA } = await getTestPartners();
+    await withDbAccessContext({ scope: 'partner', partnerIds: [partnerA] }, async (db) => {
+      await db.execute(
+        `INSERT INTO ticket_mailbox_connections (partner_id, mailbox_address)
+         VALUES ('${partnerA}', 'support@a.com')
+         ON CONFLICT (partner_id, mailbox_address) DO NOTHING`
+      );
+      const rows = await db.execute(
+        `SELECT mailbox_address FROM ticket_mailbox_connections WHERE partner_id = '${partnerA}'`
+      );
+      expect(rows.length).toBeGreaterThan(0);
+    });
+  });
+});
+```
+
+> Adapt `getTestPartners`/`withDbAccessContext` call shapes to match the nearest existing forge test in that directory — copy its imports and fixture helper exactly. Confirm `breeze_app` is `rolbypassrls=f` (else the forge passes vacuously).
+
+- [ ] **Step 3: Run the RLS suites**
+
+Run:
+```bash
+cd apps/api
+npx vitest run --config vitest.integration.config.ts ticketMailboxConnections.rls
+npx vitest run --config vitest.config.rls.ts rls-coverage
+```
+Expected: both PASS (coverage no longer reports `ticket_mailbox_connections` as unscoped).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts apps/api/src/__tests__/integration/ticketMailboxConnections.rls.integration.test.ts
+git commit -m "test(tickets): RLS coverage + forge for ticket_mailbox_connections"
+```
+
+---
+
+### Task 3: App-only token helper (`mailboxToken.ts`)
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/mailboxToken.ts`
+- Test: `apps/api/src/services/ticketMailbox/mailboxToken.test.ts`
+
+**Interfaces:**
+- Consumes: `acquireClientCredentialsToken`, `isM365TenantId`, `buildAdminConsentUrl` from `../c2cM365`.
+- Produces: `getMailboxPlatformConfig()`, `getMailboxToken(tenantId)`, `getMailboxCallbackUri()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/ticketMailbox/mailboxToken.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../c2cM365', () => ({
+  isM365TenantId: (x: string) => /^[0-9a-f-]{36}$/i.test(x),
+  acquireClientCredentialsToken: vi.fn(async () => ({ accessToken: 'tok-1', expiresIn: 3600 })),
+}));
+
+import { acquireClientCredentialsToken } from '../c2cM365';
+import { getMailboxToken, _clearMailboxTokenCache } from './mailboxToken';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+
+describe('getMailboxToken', () => {
+  beforeEach(() => {
+    _clearMailboxTokenCache();
+    vi.mocked(acquireClientCredentialsToken).mockClear();
+    process.env.TICKET_MAILBOX_M365_CLIENT_ID = 'cid';
+    process.env.TICKET_MAILBOX_M365_CLIENT_SECRET = 'csecret';
+  });
+
+  it('acquires once and caches within the freshness window', async () => {
+    const a = await getMailboxToken(TENANT);
+    const b = await getMailboxToken(TENANT);
+    expect(a).toBe('tok-1');
+    expect(b).toBe('tok-1');
+    expect(acquireClientCredentialsToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a non-GUID tenant id', async () => {
+    await expect(getMailboxToken('common')).rejects.toThrow(/tenant id/i);
+  });
+
+  it('throws when app creds are not configured', async () => {
+    delete process.env.TICKET_MAILBOX_M365_CLIENT_ID;
+    await expect(getMailboxToken(TENANT)).rejects.toThrow(/not configured/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/mailboxToken.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/ticketMailbox/mailboxToken.ts
+import { acquireClientCredentialsToken, isM365TenantId } from '../c2cM365';
+
+interface CachedToken { token: string; expiresAt: number; }
+const cache = new Map<string, CachedToken>();
+const FRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export function _clearMailboxTokenCache(): void {
+  cache.clear();
+}
+
+export function getMailboxPlatformConfig(): { clientId: string; clientSecret: string } | null {
+  const clientId = process.env.TICKET_MAILBOX_M365_CLIENT_ID?.trim();
+  const clientSecret = process.env.TICKET_MAILBOX_M365_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret };
+}
+
+export function getMailboxCallbackUri(): string {
+  const base = (
+    process.env.PUBLIC_URL ||
+    process.env.PUBLIC_APP_URL ||
+    process.env.DASHBOARD_URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+  return `${base}/api/v1/tickets/mailbox/callback`;
+}
+
+/** App-only Graph token for a partner's tenant. Cached in-memory keyed by tenant. */
+export async function getMailboxToken(tenantId: string): Promise<string> {
+  if (!isM365TenantId(tenantId)) throw new Error('Invalid M365 tenant id');
+  const cached = cache.get(tenantId);
+  if (cached && cached.expiresAt - Date.now() > FRESH_BUFFER_MS) return cached.token;
+
+  const cfg = getMailboxPlatformConfig();
+  if (!cfg) throw new Error('TICKET_MAILBOX_M365_CLIENT_ID/SECRET not configured');
+
+  const res = await acquireClientCredentialsToken({
+    tenantId: tenantId as Parameters<typeof acquireClientCredentialsToken>[0]['tenantId'],
+    clientId: cfg.clientId,
+    clientSecret: cfg.clientSecret,
+  });
+  cache.set(tenantId, { token: res.accessToken, expiresAt: Date.now() + res.expiresIn * 1000 });
+  return res.accessToken;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/mailboxToken.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/mailboxToken.ts apps/api/src/services/ticketMailbox/mailboxToken.test.ts
+git commit -m "feat(tickets): app-only Graph token helper for ticket mailbox"
+```
+
+---
+
+### Task 4: Connection service (`connectionService.ts`)
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/connectionService.ts`
+- Test: `apps/api/src/services/ticketMailbox/connectionService.test.ts`
+
+**Interfaces:**
+- Consumes: `getMailboxToken` (Task 3), `db`/`withSystemDbAccessContext`/`runOutsideDbContext` from `../../db`, `ticketMailboxConnections` schema.
+- Produces: the full Shared Interface Contract block (`MailboxConnection`, `MailboxConnectionStatus`, and all functions).
+
+- [ ] **Step 1: Write the failing test (probe + status mapping)**
+
+```typescript
+// apps/api/src/services/ticketMailbox/connectionService.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { probeMailbox } from './connectionService';
+
+describe('probeMailbox', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('returns ok on a 200 from the mailbox messages endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ value: [] }) });
+    const r = await probeMailbox('11111111-1111-1111-1111-111111111111', 'support@a.com');
+    expect(r.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/users/support%40a.com/messages?%24top=1"),
+      expect.objectContaining({ redirect: 'error' })
+    );
+  });
+
+  it('returns an error string on 403 (access policy not scoped)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, text: async () => 'denied' });
+    const r = await probeMailbox('11111111-1111-1111-1111-111111111111', 'support@a.com');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/403/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/connectionService.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the service**
+
+```typescript
+// apps/api/src/services/ticketMailbox/connectionService.ts
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+import { getMailboxToken } from './mailboxToken';
+
+export type MailboxConnectionStatus =
+  | 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+
+export interface MailboxConnection {
+  id: string;
+  partnerId: string;
+  tenantId: string | null;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: MailboxConnectionStatus;
+  deltaLink: string | null;
+  strictSenderAuth: boolean;
+  lastPolledAt: Date | null;
+  lastMessageAt: Date | null;
+  lastError: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type Row = typeof ticketMailboxConnections.$inferSelect;
+function toConnection(r: Row): MailboxConnection {
+  return { ...r, status: r.status as MailboxConnectionStatus };
+}
+
+export async function listMailboxConnections(partnerId: string): Promise<MailboxConnection[]> {
+  const rows = await db.select().from(ticketMailboxConnections)
+    .where(eq(ticketMailboxConnections.partnerId, partnerId));
+  return rows.map(toConnection);
+}
+
+/** System-context read across all partners — used by the poll worker (Plan 2). */
+export async function listConnectedMailboxes(): Promise<MailboxConnection[]> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(ticketMailboxConnections)
+      .where(eq(ticketMailboxConnections.status, 'connected'));
+    return rows.map(toConnection);
+  }));
+}
+
+export async function getMailboxConnection(id: string, partnerId: string): Promise<MailboxConnection | null> {
+  const rows = await db.select().from(ticketMailboxConnections)
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)))
+    .limit(1);
+  return rows[0] ? toConnection(rows[0]) : null;
+}
+
+export async function createPendingConnection(input: {
+  partnerId: string; mailboxAddress: string; displayName: string | null; createdBy: string | null;
+}): Promise<MailboxConnection> {
+  const rows = await db.insert(ticketMailboxConnections).values({
+    partnerId: input.partnerId,
+    mailboxAddress: input.mailboxAddress.trim().toLowerCase(),
+    displayName: input.displayName,
+    status: 'pending_consent',
+    createdBy: input.createdBy,
+  }).onConflictDoUpdate({
+    target: [ticketMailboxConnections.partnerId, ticketMailboxConnections.mailboxAddress],
+    set: { status: 'pending_consent', displayName: input.displayName, updatedAt: new Date() },
+  }).returning();
+  return toConnection(rows[0]);
+}
+
+export async function setConnectionTenant(id: string, partnerId: string, tenantId: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ tenantId, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+export async function setConnectionStatus(
+  id: string, partnerId: string, status: MailboxConnectionStatus, lastError: string | null,
+): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ status, lastError, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+export async function updateDeltaCursor(
+  id: string, deltaLink: string, polledAt: Date, lastMessageAt: Date | null,
+): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ deltaLink, lastPolledAt: polledAt, ...(lastMessageAt ? { lastMessageAt } : {}), updatedAt: new Date() })
+    .where(eq(ticketMailboxConnections.id, id));
+}
+
+export async function disableConnection(id: string, partnerId: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ status: 'disabled', deltaLink: null, updatedAt: new Date() })
+    .where(and(eq(ticketMailboxConnections.id, id), eq(ticketMailboxConnections.partnerId, partnerId)));
+}
+
+/** 410 Gone: Graph invalidated the delta token. Clear it so the next sweep restarts
+ *  the delta from "now" (no history backfill). Stays 'connected'. Called from the
+ *  poll worker under system context. */
+export async function resetDeltaCursor(id: string): Promise<void> {
+  await db.update(ticketMailboxConnections)
+    .set({ deltaLink: null, updatedAt: new Date() })
+    .where(eq(ticketMailboxConnections.id, id));
+}
+
+/** Lightweight Graph probe: can the app read this mailbox under the tenant's consent? */
+export async function probeMailbox(tenantId: string, mailboxAddress: string): Promise<{ ok: boolean; error?: string }> {
+  let token: string;
+  try {
+    token = await getMailboxToken(tenantId);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'token acquisition failed' };
+  }
+  const url = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(mailboxAddress)}/messages?${encodeURIComponent('$top')}=1`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` }, redirect: 'error' });
+  if (res.ok) return { ok: true };
+  return { ok: false, error: `Graph returned ${res.status}` };
+}
+```
+
+> Mark the table's `connected_by` / write paths system-safe: callers in routes use the request DB context; the poll worker uses `listConnectedMailboxes`/`updateDeltaCursor` under system context (Plan 2 wraps those calls).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/connectionService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/connectionService.ts apps/api/src/services/ticketMailbox/connectionService.test.ts
+git commit -m "feat(tickets): mailbox connection service (CRUD + probe)"
+```
+
+---
+
+### Task 5: Connect/callback/list/retest/disconnect routes
+
+**Files:**
+- Create: `apps/api/src/routes/tickets/mailboxConnect.ts`
+- Modify: `apps/api/src/routes/tickets/index.ts`
+- Test: `apps/api/src/routes/tickets/mailboxConnect.test.ts`
+
+**Interfaces:**
+- Consumes: connection service (Task 4), `getMailboxToken`/`getMailboxCallbackUri` (Task 3), `buildAdminConsentUrl` + `isM365TenantId` from `services/c2cM365`, `authMiddleware`/`partnerScopes`/`requireMfa` middlewares, `zValidator`.
+- Produces: routes under `/api/v1/tickets/mailbox/*`.
+
+The state-signing helpers (`createState`/`verifyState`/`stateCookieValue`/`constantTimeEqual`/`signingSecret`/`hmac`) are copied from `routes/accounting/index.ts` but with label `'ticket-mailbox-oauth'` and a payload that adds `connectionId`. Reproduce them verbatim in this file (do not import from accounting — the label differs and they are file-private there).
+
+- [ ] **Step 1: Write the failing route tests**
+
+```typescript
+// apps/api/src/routes/tickets/mailboxConnect.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../../services/ticketMailbox/connectionService', () => ({
+  createPendingConnection: vi.fn(async () => ({ id: 'conn-1', partnerId: 'p1', mailboxAddress: 'support@a.com' })),
+  getMailboxConnection: vi.fn(async () => ({ id: 'conn-1', partnerId: 'p1', tenantId: '11111111-1111-1111-1111-111111111111', mailboxAddress: 'support@a.com', status: 'connected' })),
+  setConnectionTenant: vi.fn(async () => {}),
+  setConnectionStatus: vi.fn(async () => {}),
+  probeMailbox: vi.fn(async () => ({ ok: true })),
+  listMailboxConnections: vi.fn(async () => []),
+  disableConnection: vi.fn(async () => {}),
+}));
+vi.mock('../../services/ticketMailbox/mailboxToken', () => ({
+  getMailboxCallbackUri: () => 'https://app.example.com/api/v1/tickets/mailbox/callback',
+}));
+
+import { mailboxRoutes } from './mailboxConnect';
+
+function appWithAuth() {
+  const app = new Hono();
+  app.use('*', async (c, next) => { c.set('auth', { user: { id: 'u1' }, partnerId: 'p1', scope: 'partner' }); await next(); });
+  app.route('/tickets/mailbox', mailboxRoutes);
+  return app;
+}
+
+describe('mailbox connect/callback routes', () => {
+  beforeEach(() => { process.env.SESSION_SECRET = 'test-secret'; process.env.TICKET_MAILBOX_M365_CLIENT_ID = 'cid'; });
+
+  it('POST /connect returns an admin-consent authUrl and sets the state cookie', async () => {
+    const res = await appWithAuth().request('/tickets/mailbox/connect', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mailboxAddress: 'support@a.com', displayName: 'Support' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authUrl).toContain('login.microsoftonline.com');
+    expect(body.authUrl).toContain('adminconsent');
+    expect(res.headers.get('set-cookie')).toContain('ticket_mailbox_oauth_state');
+  });
+
+  it('GET /callback rejects an unsigned/invalid state with 400', async () => {
+    const res = await appWithAuth().request('/tickets/mailbox/callback?state=bogus&tenant=11111111-1111-1111-1111-111111111111&admin_consent=True');
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/routes/tickets/mailboxConnect.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the routes**
+
+```typescript
+// apps/api/src/routes/tickets/mailboxConnect.ts
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { authMiddleware } from '../../middleware/auth';
+import { partnerScopes } from '../../middleware/partnerScopes';
+import { requireMfa } from '../../middleware/mfa';
+import { buildAdminConsentUrl, isM365TenantId } from '../../services/c2cM365';
+import { getMailboxCallbackUri, getMailboxPlatformConfig } from '../../services/ticketMailbox/mailboxToken';
+import {
+  createPendingConnection, getMailboxConnection, setConnectionTenant,
+  setConnectionStatus, probeMailbox, listMailboxConnections, disableConnection,
+} from '../../services/ticketMailbox/connectionService';
+import { withSystemDbAccessContext, runOutsideDbContext } from '../../db';
+import { captureException } from '../../services/sentry';
+
+const STATE_COOKIE = 'ticket_mailbox_oauth_state';
+const STATE_TTL_MS = 10 * 60 * 1000;
+const LABEL = 'ticket-mailbox-oauth';
+
+interface StatePayload { partnerId: string; userId: string | null; connectionId: string; nonce: string; exp: number; }
+
+function signingSecret(): string | null {
+  return process.env.APP_ENCRYPTION_KEY?.trim() || process.env.SECRET_ENCRYPTION_KEY?.trim()
+    || process.env.SESSION_SECRET?.trim() || process.env.JWT_SECRET?.trim()
+    || (process.env.NODE_ENV === 'production' ? null : 'test-only-ticket-mailbox-oauth-state-secret');
+}
+function hmac(label: string, value: string): string | null {
+  const secret = signingSecret();
+  return secret ? createHmac('sha256', secret).update(`${label}:${value}`).digest('base64url') : null;
+}
+function constantTimeEqual(a: string, b: string): boolean {
+  const l = Buffer.from(a, 'utf8'); const r = Buffer.from(b, 'utf8');
+  return l.length === r.length && timingSafeEqual(l, r);
+}
+function createState(p: Omit<StatePayload, 'nonce' | 'exp'>): string | null {
+  const payload: StatePayload = { ...p, nonce: randomBytes(16).toString('hex'), exp: Date.now() + STATE_TTL_MS };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const sig = hmac(LABEL, encoded);
+  return sig ? `${encoded}.${sig}` : null;
+}
+function verifyState(state: string): StatePayload | null {
+  const [encoded, sig] = state.split('.');
+  if (!encoded || !sig) return null;
+  const expected = hmac(LABEL, encoded);
+  if (!expected || !constantTimeEqual(sig, expected)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as StatePayload;
+    if (!parsed.partnerId || !parsed.connectionId || !parsed.nonce || !parsed.exp || parsed.exp < Date.now()) return null;
+    return parsed;
+  } catch { return null; }
+}
+function stateCookieValue(state: string): string | null { return hmac(`${LABEL}-cookie`, state); }
+
+const connectBody = z.object({ mailboxAddress: z.string().email(), displayName: z.string().max(120).optional() });
+const callbackQuery = z.object({ state: z.string(), tenant: z.string().optional(), admin_consent: z.string().optional(), error: z.string().optional(), error_description: z.string().optional() });
+const idParam = z.object({ id: z.string().uuid() });
+
+export const mailboxRoutes = new Hono();
+
+// List
+mailboxRoutes.get('/connections', authMiddleware, partnerScopes, async (c) => {
+  const auth = c.get('auth');
+  const list = await listMailboxConnections(auth.partnerId);
+  return c.json({ connections: list });
+});
+
+// Initiate consent (creates the pending row, returns admin-consent URL)
+mailboxRoutes.post('/connect', authMiddleware, partnerScopes, requireMfa(), zValidator('json', connectBody), async (c) => {
+  if (!getMailboxPlatformConfig()) return c.json({ error: 'M365 ticket mailbox app is not configured' }, 400);
+  const auth = c.get('auth');
+  const { mailboxAddress, displayName } = c.req.valid('json');
+  const conn = await createPendingConnection({
+    partnerId: auth.partnerId, mailboxAddress, displayName: displayName ?? null, createdBy: auth.user?.id ?? null,
+  });
+  const state = createState({ partnerId: auth.partnerId, userId: auth.user?.id ?? null, connectionId: conn.id });
+  const cookie = state ? stateCookieValue(state) : null;
+  if (!state || !cookie) return c.json({ error: 'OAuth state signing secret is not configured' }, 500);
+  setCookie(c, STATE_COOKIE, cookie, {
+    httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'Lax', path: '/', maxAge: STATE_TTL_MS / 1000,
+  });
+  const cfg = getMailboxPlatformConfig()!;
+  const authUrl = buildAdminConsentUrl({ clientId: cfg.clientId, state, redirectUri: getMailboxCallbackUri() });
+  return c.json({ authUrl, connectionId: conn.id });
+});
+
+// OAuth redirect target — NO authMiddleware. Authenticated by signed state + cookie.
+mailboxRoutes.get('/callback', zValidator('query', callbackQuery), async (c) => {
+  const q = c.req.valid('query');
+  const state = verifyState(q.state);
+  if (!state) return c.json({ error: 'Invalid or expired OAuth state' }, 400);
+
+  const expectedCookie = stateCookieValue(q.state);
+  const presented = getCookie(c, STATE_COOKIE);
+  if (!expectedCookie || !presented || !constantTimeEqual(presented, expectedCookie)) {
+    return c.json({ error: 'OAuth state binding mismatch' }, 400);
+  }
+  deleteCookie(c, STATE_COOKIE, { path: '/' });
+
+  if (q.error || !q.tenant || !isM365TenantId(q.tenant)) {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionStatus(state.connectionId, state.partnerId, 'error', q.error_description ?? q.error ?? 'consent failed')));
+    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+  }
+
+  try {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionTenant(state.connectionId, state.partnerId, q.tenant!)));
+    const probe = await probeMailbox(q.tenant, (await getConnAddress(state)) ?? '');
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      setConnectionStatus(state.connectionId, state.partnerId, probe.ok ? 'connected' : 'error', probe.ok ? null : (probe.error ?? 'probe failed'))));
+    return c.redirect(probe.ok ? '/integrations?ticketMailbox=connected#ticket-mailbox' : '/integrations?ticketMailbox=needs_policy#ticket-mailbox');
+  } catch (err) {
+    captureException(err instanceof Error ? err : new Error(String(err)), c);
+    return c.redirect('/integrations?ticketMailbox=error#ticket-mailbox');
+  }
+});
+
+async function getConnAddress(state: StatePayload): Promise<string | null> {
+  const conn = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    getMailboxConnection(state.connectionId, state.partnerId)));
+  return conn?.mailboxAddress ?? null;
+}
+
+// Re-run the probe (after the admin scopes the Application Access Policy)
+mailboxRoutes.post('/connections/:id/retest', authMiddleware, partnerScopes, requireMfa(), zValidator('param', idParam), async (c) => {
+  const auth = c.get('auth');
+  const { id } = c.req.valid('param');
+  const conn = await getMailboxConnection(id, auth.partnerId);
+  if (!conn || !conn.tenantId) return c.json({ error: 'Connection not found or not consented' }, 404);
+  const probe = await probeMailbox(conn.tenantId, conn.mailboxAddress);
+  await setConnectionStatus(id, auth.partnerId, probe.ok ? 'connected' : 'error', probe.ok ? null : (probe.error ?? 'probe failed'));
+  return c.json({ ok: probe.ok, error: probe.error });
+});
+
+// Disconnect
+mailboxRoutes.delete('/connections/:id', authMiddleware, partnerScopes, requireMfa(), zValidator('param', idParam), async (c) => {
+  const auth = c.get('auth');
+  await disableConnection(c.req.valid('param').id, auth.partnerId);
+  return c.json({ ok: true });
+});
+```
+
+> Confirm the exact middleware import paths and the `auth` context shape (`auth.partnerId`, `auth.user?.id`) against `routes/accounting/index.ts` — copy whatever it uses (`partnerScopes` may be named `partnerScopeMiddleware`; `requireMfa` may be `requireMfa()` factory). Adjust the redirect base to match the accounting card's redirect convention.
+
+- [ ] **Step 4: Mount the routes**
+
+In `apps/api/src/routes/tickets/index.ts`, import and mount:
+
+```typescript
+import { mailboxRoutes } from './mailboxConnect';
+// ... within the tickets router hub setup:
+ticketsRoutes.route('/mailbox', mailboxRoutes);
+```
+
+> Verify the callback path resolves to `/api/v1/tickets/mailbox/callback` given how the tickets hub is mounted in the top-level router. If the tickets hub already applies `authMiddleware` via `.use('*')`, the callback would be wrongly gated — mount `mailboxRoutes` so the callback escapes any wildcard auth (per the Hono wildcard-auth-leak lesson). Prefer per-route middleware on the tickets hub, not a `.use('*')`.
+
+- [ ] **Step 5: Run the route tests**
+
+Run: `cd apps/api && npx vitest run src/routes/tickets/mailboxConnect.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+cd apps/api && npx tsc --noEmit
+git add apps/api/src/routes/tickets/mailboxConnect.ts apps/api/src/routes/tickets/mailboxConnect.test.ts apps/api/src/routes/tickets/index.ts
+git commit -m "feat(tickets): M365 mailbox connect/callback/retest/disconnect routes"
+```
+
+---
+
+## Self-Review (Plan 1)
+
+- **Spec coverage:** table + RLS (Task 1–2), env-based separate app + token helper (Task 3), connection lifecycle + probe (Task 4), admin-consent connect/callback + retest/disconnect with the QuickBooks-callback hardening (Task 5). ✅
+- **Callback security:** no `authMiddleware`; signed state + CSRF cookie; writes under `runOutsideDbContext(withSystemDbAccessContext(...))`; tenant validated via `isM365TenantId`. ✅
+- **Type consistency:** `MailboxConnection`/`MailboxConnectionStatus` and all function names match the Shared Interface Contract used by Plans 2 & 3. ✅
+- **Open verification for the implementer:** exact middleware names/paths, the `auth` context property names, the tickets-hub mount point (avoid `.use('*')` auth leak), and the redirect base — all flagged inline to confirm against `routes/accounting/index.ts`.

--- a/docs/superpowers/plans/2026-06-29-m365-mailbox-2-inbound-ingest.md
+++ b/docs/superpowers/plans/2026-06-29-m365-mailbox-2-inbound-ingest.md
@@ -1,0 +1,731 @@
+# M365 Mailbox — Plan 2: Inbound Delta-Poll Ingest — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Poll each connected M365 mailbox via Microsoft Graph `/messages/delta`, normalize new messages into the existing `NormalizedInboundEmail` shape, enqueue them onto the existing `inbound-email` queue, mark them read, and persist the delta cursor — reusing all of `processInboundEmail`'s threading/dedup/ticket logic.
+
+**Architecture:** A `graphMailClient` wraps the Graph calls (delta paging + mark-read + 429 backoff). A pure `normalizeGraphMessage` maps a Graph message to `NormalizedInboundEmail` (provider `'m365'`, pre-resolved partner, sender-auth verdict from the `Authentication-Results` header). A BullMQ repeatable sweep worker iterates connected mailboxes outside any DB transaction (no connection-hold during network I/O) and uses the existing dedup index for at-least-once safety. One tiny seam: `processInboundEmail` honors a `resolvedPartnerId` to skip recipient resolution.
+
+**Tech Stack:** Hono/Node, Microsoft Graph v1.0, BullMQ, Drizzle, Vitest.
+
+## Global Constraints
+
+- Depends on **Plan 1** (merged): `getMailboxToken`, `listConnectedMailboxes`, `updateDeltaCursor`, `setConnectionStatus`, `MailboxConnection`.
+- Never hold a DB transaction across a network call (idle-in-txn pool poison, #1105). Read connections in a short system-context txn, do Graph I/O outside any DB context, then persist the cursor in another short system-context txn.
+- Worker DB writes: `runOutsideDbContext(() => withSystemDbAccessContext(...))`. Defensive `getConfig()` on the worker path.
+- At-least-once delivery: persist the new `delta_link` only after the whole page is enqueued; the existing `ticket_email_inbound (partner_id, provider_message_id)` unique index absorbs replays.
+- BullMQ jobId must contain 0 or exactly 2 colons — use hyphens. Repeatable sweep is a singleton per queue.
+- No history backfill: a fresh connection and a 410-Gone resync both start the delta from "now".
+- Graph 429: honor `Retry-After`, exponential backoff; per-mailbox failures are isolated (one bad tenant must not stall others).
+
+## File Structure
+
+- Modify `apps/api/src/services/inboundEmail/types.ts` — add `'m365'` to `InboundProviderName`; add `resolvedPartnerId?` to `NormalizedInboundEmail`.
+- Modify `apps/api/src/services/inboundEmail/inboundEmailService.ts` — honor `resolvedPartnerId`.
+- Create `apps/api/src/services/ticketMailbox/graphMailClient.ts` — `listInboxDelta`, `markRead`, `graphFetch`.
+- Create `apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts` — Graph message → `NormalizedInboundEmail`.
+- Create `apps/api/src/jobs/ticketMailboxPollWorker.ts` — repeatable sweep worker.
+- Modify the worker-bootstrap file (where `initializeInboundEmailWorker()` / `ticketSlaWorker` are started) — start the poll worker.
+- Tests co-located.
+
+## Shared Interface Contract (produced here)
+
+```typescript
+// services/ticketMailbox/graphMailClient.ts
+export interface GraphRecipient { emailAddress?: { address?: string; name?: string }; }
+export interface GraphHeader { name: string; value: string; }
+export interface GraphMessage {
+  id: string;
+  internetMessageId?: string;
+  subject?: string;
+  from?: GraphRecipient;
+  toRecipients?: GraphRecipient[];
+  ccRecipients?: GraphRecipient[];
+  receivedDateTime?: string;
+  conversationId?: string;
+  body?: { contentType?: string; content?: string };
+  bodyPreview?: string;
+  hasAttachments?: boolean;
+  internetMessageHeaders?: GraphHeader[];
+}
+export interface DeltaPage { messages: GraphMessage[]; deltaLink: string | null; }
+export function listInboxDelta(token: string, mailbox: string, deltaLink: string | null): Promise<DeltaPage>;
+export function markRead(token: string, mailbox: string, messageId: string): Promise<void>;
+
+// services/ticketMailbox/normalizeGraphMessage.ts
+export function normalizeGraphMessage(msg: GraphMessage, partnerId: string, mailboxAddress: string): NormalizedInboundEmail;
+```
+
+---
+
+### Task 1: Seam — `resolvedPartnerId` on the inbound pipeline
+
+**Files:**
+- Modify: `apps/api/src/services/inboundEmail/types.ts`
+- Modify: `apps/api/src/services/inboundEmail/inboundEmailService.ts:101-118`
+- Test: `apps/api/src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts`
+
+**Interfaces:**
+- Produces: `NormalizedInboundEmail.resolvedPartnerId?: string`; `InboundProviderName` includes `'m365'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+const resolveSpy = vi.fn(async () => 'should-not-be-called');
+vi.mock('./resolvePartner', () => ({ resolvePartnerByRecipient: resolveSpy }));
+// Make the partner look active so processing proceeds past the status gate,
+// then stop at the first unmocked dependency — we only assert resolve is skipped.
+vi.mock('../../db', () => ({
+  db: { select: () => ({ from: () => ({ where: () => ({ limit: async () => [{ status: 'active' }] }) }) }) },
+  runOutsideDbContext: (fn: any) => fn(),
+  withSystemDbAccessContext: (fn: any) => fn(),
+}));
+
+import { processInboundEmail } from './inboundEmailService';
+import type { NormalizedInboundEmail } from './types';
+
+const base: NormalizedInboundEmail = {
+  provider: 'm365', providerMessageId: 'g1', to: 'support@a.com', from: 'cust@x.com',
+  subject: 'hi', text: 'body', attachments: [], raw: {}, resolvedPartnerId: 'partner-123',
+};
+
+describe('processInboundEmail resolvedPartnerId seam', () => {
+  it('does not call resolvePartnerByRecipient when resolvedPartnerId is present', async () => {
+    try { await processInboundEmail(base); } catch { /* later deps unmocked — fine */ }
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts`
+Expected: FAIL (`resolvePartnerByRecipient` is still called).
+
+- [ ] **Step 3: Edit the type**
+
+In `apps/api/src/services/inboundEmail/types.ts`: add `'m365'` to the `InboundProviderName` union, and add to `NormalizedInboundEmail`:
+
+```typescript
+  /** When the feeder already knows the partner (e.g. polled that partner's mailbox),
+   *  skip recipient-based resolution. */
+  resolvedPartnerId?: string;
+```
+
+- [ ] **Step 4: Honor it in `processInboundEmail`**
+
+In `inboundEmailService.ts`, replace the resolution line (currently `partnerId = await resolvePartnerByRecipient(n.to);`) with:
+
+```typescript
+    partnerId = n.resolvedPartnerId ?? await resolvePartnerByRecipient(n.to);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/inboundEmail/types.ts apps/api/src/services/inboundEmail/inboundEmailService.ts apps/api/src/services/inboundEmail/inboundEmailService.resolvedPartner.test.ts
+git commit -m "feat(tickets): inbound pipeline honors a pre-resolved partner id"
+```
+
+---
+
+### Task 2: Graph mail client (delta paging + mark-read + 429 backoff)
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/graphMailClient.ts`
+- Test: `apps/api/src/services/ticketMailbox/graphMailClient.test.ts`
+
+**Interfaces:**
+- Produces: `GraphMessage`, `GraphHeader`, `GraphRecipient`, `DeltaPage`, `listInboxDelta`, `markRead`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/ticketMailbox/graphMailClient.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+import { listInboxDelta, markRead } from './graphMailClient';
+
+const SELECT = '%24select'; // encodeURIComponent('$select')
+
+describe('listInboxDelta', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('follows @odata.nextLink, aggregates messages, returns the final deltaLink', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Map(), json: async () => ({
+        value: [{ id: 'm1' }], '@odata.nextLink': 'https://graph.microsoft.com/next-2' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Map(), json: async () => ({
+        value: [{ id: 'm2' }], '@odata.deltaLink': 'https://graph.microsoft.com/delta-final' }) });
+
+    const page = await listInboxDelta('tok', 'support@a.com', null);
+    expect(page.messages.map(m => m.id)).toEqual(['m1', 'm2']);
+    expect(page.deltaLink).toBe('https://graph.microsoft.com/delta-final');
+    // First call hits the inbox delta endpoint with a $select.
+    expect(fetchMock.mock.calls[0][0]).toContain('/mailFolders/inbox/messages/delta');
+    expect(fetchMock.mock.calls[0][0]).toContain(SELECT);
+  });
+
+  it('uses the stored deltaLink verbatim when provided', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, headers: new Map(), json: async () => ({
+      value: [], '@odata.deltaLink': 'https://graph.microsoft.com/delta-2' }) });
+    await listInboxDelta('tok', 'support@a.com', 'https://graph.microsoft.com/stored-delta');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://graph.microsoft.com/stored-delta');
+  });
+
+  it('retries once on 429 honoring Retry-After', async () => {
+    const headers429 = new Map([['retry-after', '0']]);
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: headers429, text: async () => 'throttled' })
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Map(), json: async () => ({ value: [], '@odata.deltaLink': 'd' }) });
+    const page = await listInboxDelta('tok', 'support@a.com', null);
+    expect(page.deltaLink).toBe('d');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('markRead', () => {
+  beforeEach(() => fetchMock.mockReset());
+  it('PATCHes isRead true', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, headers: new Map(), json: async () => ({}) });
+    await markRead('tok', 'support@a.com', 'm1');
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/messages/m1');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ isRead: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/graphMailClient.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/ticketMailbox/graphMailClient.ts
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+const DELTA_SELECT = [
+  'id', 'internetMessageId', 'subject', 'from', 'toRecipients', 'ccRecipients',
+  'receivedDateTime', 'conversationId', 'body', 'bodyPreview', 'hasAttachments', 'internetMessageHeaders',
+].join(',');
+
+export interface GraphRecipient { emailAddress?: { address?: string; name?: string }; }
+export interface GraphHeader { name: string; value: string; }
+export interface GraphMessage {
+  id: string; internetMessageId?: string; subject?: string; from?: GraphRecipient;
+  toRecipients?: GraphRecipient[]; ccRecipients?: GraphRecipient[]; receivedDateTime?: string;
+  conversationId?: string; body?: { contentType?: string; content?: string }; bodyPreview?: string;
+  hasAttachments?: boolean; internetMessageHeaders?: GraphHeader[];
+}
+export interface DeltaPage { messages: GraphMessage[]; deltaLink: string | null; }
+
+function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
+
+/** Graph fetch with one 429 retry honoring Retry-After. Never follows redirects with the bearer token. */
+async function graphFetch(url: string, token: string, init?: RequestInit): Promise<Response> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const res = await fetch(url, {
+      ...init,
+      headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) },
+      redirect: 'error',
+    });
+    if (res.status !== 429) return res;
+    const retryAfter = Number(res.headers.get?.('retry-after') ?? '1');
+    await sleep(Math.min(Number.isFinite(retryAfter) ? retryAfter : 1, 30) * 1000);
+  }
+  // Final attempt without retry budget.
+  return fetch(url, { ...init, headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) }, redirect: 'error' });
+}
+
+export async function listInboxDelta(token: string, mailbox: string, deltaLink: string | null): Promise<DeltaPage> {
+  let url = deltaLink
+    ?? `${GRAPH}/users/${encodeURIComponent(mailbox)}/mailFolders/inbox/messages/delta`
+       + `?${encodeURIComponent('$select')}=${encodeURIComponent(DELTA_SELECT)}`;
+  const messages: GraphMessage[] = [];
+  let finalDelta: string | null = null;
+
+  // Page through nextLink; the last page carries deltaLink.
+  for (let guard = 0; guard < 1000; guard++) {
+    const res = await graphFetch(url, token);
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const err = new Error(`Graph delta ${res.status}: ${body.slice(0, 200)}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+    const data = (await res.json()) as {
+      value?: GraphMessage[]; '@odata.nextLink'?: string; '@odata.deltaLink'?: string;
+    };
+    if (Array.isArray(data.value)) messages.push(...data.value);
+    if (data['@odata.nextLink']) { url = data['@odata.nextLink']; continue; }
+    finalDelta = data['@odata.deltaLink'] ?? null;
+    break;
+  }
+  return { messages, deltaLink: finalDelta };
+}
+
+export async function markRead(token: string, mailbox: string, messageId: string): Promise<void> {
+  const url = `${GRAPH}/users/${encodeURIComponent(mailbox)}/messages/${encodeURIComponent(messageId)}`;
+  await graphFetch(url, token, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isRead: true }),
+  });
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/graphMailClient.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/graphMailClient.ts apps/api/src/services/ticketMailbox/graphMailClient.test.ts
+git commit -m "feat(tickets): Graph mail client (delta paging, mark-read, 429 backoff)"
+```
+
+---
+
+### Task 3: Normalizer (`normalizeGraphMessage`)
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts`
+- Test: `apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts`
+
+**Interfaces:**
+- Consumes: `GraphMessage` (Task 2), `NormalizedInboundEmail`/`SenderAuth` (`../inboundEmail/types`).
+- Produces: `normalizeGraphMessage(msg, partnerId, mailboxAddress)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeGraphMessage } from './normalizeGraphMessage';
+import type { GraphMessage } from './graphMailClient';
+
+const msg: GraphMessage = {
+  id: 'AAA-graph-id',
+  internetMessageId: '<abc@mail.x.com>',
+  subject: 'Printer down [T-2026-0007]',
+  from: { emailAddress: { address: 'Cust@X.com', name: 'Cust' } },
+  toRecipients: [{ emailAddress: { address: 'support@a.com' } }],
+  conversationId: 'conv-1',
+  body: { contentType: 'html', content: '<p>help</p>' },
+  bodyPreview: 'help',
+  hasAttachments: false,
+  internetMessageHeaders: [
+    { name: 'In-Reply-To', value: '<prev@mail.x.com>' },
+    { name: 'References', value: '<root@mail.x.com> <prev@mail.x.com>' },
+    { name: 'Authentication-Results', value: 'spf=pass; dkim=pass; dmarc=pass action=none' },
+  ],
+};
+
+describe('normalizeGraphMessage', () => {
+  it('maps core fields, provider, and pre-resolved partner', () => {
+    const n = normalizeGraphMessage(msg, 'partner-9', 'support@a.com');
+    expect(n.provider).toBe('m365');
+    expect(n.providerMessageId).toBe('AAA-graph-id');
+    expect(n.resolvedPartnerId).toBe('partner-9');
+    expect(n.to).toBe('support@a.com');
+    expect(n.from).toBe('cust@x.com');           // lowercased
+    expect(n.subject).toBe('Printer down [T-2026-0007]');
+    expect(n.messageId).toBe('<abc@mail.x.com>');
+    expect(n.inReplyTo).toBe('<prev@mail.x.com>');
+    expect(n.references).toEqual(['<root@mail.x.com>', '<prev@mail.x.com>']);
+    expect(n.html).toBe('<p>help</p>');
+  });
+
+  it('extracts dmarc=pass into senderAuth', () => {
+    const n = normalizeGraphMessage(msg, 'partner-9', 'support@a.com');
+    expect(n.senderAuth?.dmarc).toBe('pass');
+  });
+
+  it('leaves senderAuth dmarc unset when the header is missing', () => {
+    const n = normalizeGraphMessage({ ...msg, internetMessageHeaders: [] }, 'partner-9', 'support@a.com');
+    expect(n.senderAuth?.dmarc).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/normalizeGraphMessage.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts
+import type { GraphMessage } from './graphMailClient';
+import type { NormalizedInboundEmail, SenderAuth } from '../inboundEmail/types';
+
+function header(headers: GraphMessage['internetMessageHeaders'], name: string): string | undefined {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function parseDmarc(authResults: string | undefined): SenderAuth | undefined {
+  if (!authResults) return undefined;
+  const m = /\bdmarc=(\w+)/i.exec(authResults);
+  const spf = /\bspf=(\w+)/i.exec(authResults)?.[1]?.toLowerCase();
+  const dkim = /\bdkim=(\w+)/i.exec(authResults)?.[1]?.toLowerCase();
+  return {
+    ...(spf ? { spf } : {}),
+    ...(dkim ? { dkim } : {}),
+    ...(m ? { dmarc: m[1].toLowerCase() } : {}),
+  } as SenderAuth;
+}
+
+/** Pure mapping: Graph message → the pipeline's NormalizedInboundEmail. */
+export function normalizeGraphMessage(
+  msg: GraphMessage, partnerId: string, mailboxAddress: string,
+): NormalizedInboundEmail {
+  const fromAddr = msg.from?.emailAddress?.address?.trim().toLowerCase() ?? '';
+  const references = header(msg.internetMessageHeaders, 'References')?.trim().split(/\s+/).filter(Boolean);
+  const html = msg.body?.contentType?.toLowerCase() === 'html' ? msg.body?.content : undefined;
+  const text = msg.body?.contentType?.toLowerCase() === 'text' ? (msg.body?.content ?? '') : (msg.bodyPreview ?? '');
+  const autoSubmitted = header(msg.internetMessageHeaders, 'Auto-Submitted');
+  const precedence = header(msg.internetMessageHeaders, 'Precedence');
+
+  return {
+    provider: 'm365',
+    providerMessageId: msg.id,
+    resolvedPartnerId: partnerId,
+    to: mailboxAddress.trim().toLowerCase(),
+    from: fromAddr,
+    fromName: msg.from?.emailAddress?.name,
+    subject: msg.subject ?? '',
+    text,
+    html,
+    messageId: msg.internetMessageId,
+    inReplyTo: header(msg.internetMessageHeaders, 'In-Reply-To'),
+    references,
+    autoSubmitted,
+    precedence,
+    senderAuth: parseDmarc(header(msg.internetMessageHeaders, 'Authentication-Results')),
+    attachments: msg.hasAttachments
+      ? [] // Phase 1 parity: attachment metadata only; bodies not fetched (deferred).
+      : [],
+    raw: {
+      graphConversationId: msg.conversationId,
+      receivedDateTime: msg.receivedDateTime,
+    },
+  };
+}
+```
+
+> Confirm the `SenderAuth` shape in `types.ts` (field names `spf`/`dkim`/`dmarc` and their value type). If the existing type uses an enum/literal union, coerce accordingly. Mirror exactly how `mailgun.ts` populates `senderAuth` so the R4 gate in `processInboundEmail` interprets it identically.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/normalizeGraphMessage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/normalizeGraphMessage.ts apps/api/src/services/ticketMailbox/normalizeGraphMessage.test.ts
+git commit -m "feat(tickets): normalize Graph message to NormalizedInboundEmail"
+```
+
+---
+
+### Task 4: Poll worker (repeatable sweep)
+
+**Files:**
+- Create: `apps/api/src/jobs/ticketMailboxPollWorker.ts`
+- Modify: the worker bootstrap file that starts `initializeInboundEmailWorker()` (grep for that call; same file starts the SLA worker).
+- Test: `apps/api/src/jobs/ticketMailboxPollWorker.test.ts`
+
+**Interfaces:**
+- Consumes: `listConnectedMailboxes`, `updateDeltaCursor`, `setConnectionStatus` (Plan 1); `getMailboxToken` (Plan 1); `listInboxDelta`, `markRead` (Task 2); `normalizeGraphMessage` (Task 3); `enqueueInboundEmail` (`services/inboundEmailQueue`).
+- Produces: `runMailboxSweep()` (exported for tests), `initializeTicketMailboxPollWorker()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/jobs/ticketMailboxPollWorker.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/ticketMailbox/connectionService', () => ({
+  listConnectedMailboxes: vi.fn(),
+  updateDeltaCursor: vi.fn(async () => {}),
+  setConnectionStatus: vi.fn(async () => {}),
+}));
+vi.mock('../services/ticketMailbox/mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+vi.mock('../services/ticketMailbox/graphMailClient', () => ({
+  listInboxDelta: vi.fn(),
+  markRead: vi.fn(async () => {}),
+}));
+vi.mock('../services/inboundEmailQueue', () => ({ enqueueInboundEmail: vi.fn(async () => {}) }));
+
+import { listConnectedMailboxes, updateDeltaCursor, setConnectionStatus } from '../services/ticketMailbox/connectionService';
+import { listInboxDelta, markRead } from '../services/ticketMailbox/graphMailClient';
+import { enqueueInboundEmail } from '../services/inboundEmailQueue';
+import { runMailboxSweep } from './ticketMailboxPollWorker';
+
+const conn = (over: Partial<any> = {}) => ({
+  id: 'c1', partnerId: 'p1', tenantId: '11111111-1111-1111-1111-111111111111',
+  mailboxAddress: 'support@a.com', status: 'connected', deltaLink: null, ...over,
+});
+
+describe('runMailboxSweep', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('enqueues each new message, marks it read, then persists the new deltaLink', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn()] as any);
+    vi.mocked(listInboxDelta).mockResolvedValue({ messages: [{ id: 'm1' }, { id: 'm2' }], deltaLink: 'delta-new' } as any);
+
+    await runMailboxSweep();
+
+    expect(enqueueInboundEmail).toHaveBeenCalledTimes(2);
+    expect(markRead).toHaveBeenCalledTimes(2);
+    // Cursor persisted AFTER enqueue (ordering: enqueue calls happen before updateDeltaCursor).
+    expect(updateDeltaCursor).toHaveBeenCalledWith('c1', 'delta-new', expect.any(Date), expect.anything());
+    const enqueueOrder = vi.mocked(enqueueInboundEmail).mock.invocationCallOrder[0];
+    const cursorOrder = vi.mocked(updateDeltaCursor).mock.invocationCallOrder[0];
+    expect(enqueueOrder).toBeLessThan(cursorOrder);
+  });
+
+  it('does not persist a cursor if enqueue throws (replay-safe)', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn()] as any);
+    vi.mocked(listInboxDelta).mockResolvedValue({ messages: [{ id: 'm1' }], deltaLink: 'delta-new' } as any);
+    vi.mocked(enqueueInboundEmail).mockRejectedValueOnce(new Error('redis down'));
+
+    await runMailboxSweep();
+    expect(updateDeltaCursor).not.toHaveBeenCalled();
+    expect(setConnectionStatus).not.toHaveBeenCalledWith('c1', 'p1', 'reauth_required', expect.anything());
+  });
+
+  it('marks reauth_required on a 401 from Graph and isolates per mailbox', async () => {
+    vi.mocked(listConnectedMailboxes).mockResolvedValue([conn({ id: 'bad' }), conn({ id: 'good' })] as any);
+    vi.mocked(listInboxDelta)
+      .mockImplementationOnce(async () => { const e: any = new Error('401'); e.status = 401; throw e; })
+      .mockResolvedValueOnce({ messages: [], deltaLink: 'd' } as any);
+
+    await runMailboxSweep();
+    expect(setConnectionStatus).toHaveBeenCalledWith('bad', 'p1', 'reauth_required', expect.any(String));
+    // The good mailbox still processed.
+    expect(updateDeltaCursor).toHaveBeenCalledWith('good', 'd', expect.any(Date), expect.anything());
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/jobs/ticketMailboxPollWorker.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/jobs/ticketMailboxPollWorker.ts
+import { Job, Queue, Worker } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import {
+  listConnectedMailboxes, updateDeltaCursor, resetDeltaCursor, setConnectionStatus,
+} from '../services/ticketMailbox/connectionService';
+import { getMailboxToken } from '../services/ticketMailbox/mailboxToken';
+import { listInboxDelta, markRead } from '../services/ticketMailbox/graphMailClient';
+import { normalizeGraphMessage } from '../services/ticketMailbox/normalizeGraphMessage';
+import { enqueueInboundEmail } from '../services/inboundEmailQueue';
+
+const QUEUE_NAME = 'ticket-mailbox-poll';
+const SWEEP_INTERVAL_MS = 90 * 1000;
+const SWEEP_JOB_ID = 'ticket-mailbox-poll-sweep'; // colon-free singleton
+
+type SweepJobData = { type: 'sweep' };
+
+/** Process one mailbox end-to-end. Graph I/O runs OUTSIDE any DB context. */
+async function sweepOne(c: Awaited<ReturnType<typeof listConnectedMailboxes>>[number]): Promise<void> {
+  if (!c.tenantId) return;
+  let page;
+  try {
+    const token = await getMailboxToken(c.tenantId);
+    page = await listInboxDelta(token, c.mailboxAddress, c.deltaLink);
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 410) {
+      // Delta token invalidated by Graph — clear it and resync from "now" next sweep.
+      await resetDeltaCursor(c.id);
+      console.warn('[mailboxPoll] delta token gone (410); cursor reset', { id: c.id });
+      return;
+    }
+    const next = status === 401 || status === 403 ? 'reauth_required' : 'error';
+    await setConnectionStatus(c.id, c.partnerId, next, err instanceof Error ? err.message : 'poll failed');
+    return;
+  }
+
+  let lastMessageAt: Date | null = null;
+  try {
+    const token = await getMailboxToken(c.tenantId);
+    for (const msg of page.messages) {
+      const normalized = normalizeGraphMessage(msg, c.partnerId, c.mailboxAddress);
+      await enqueueInboundEmail(normalized);                 // Redis, not DB
+      await markRead(token, c.mailboxAddress, msg.id).catch((e) => {
+        console.warn('[mailboxPoll] mark-read failed', { id: msg.id, err: e instanceof Error ? e.message : e });
+      });
+      const rcv = (msg.raw as never) || (msg.receivedDateTime ? new Date(msg.receivedDateTime) : null);
+      if (msg.receivedDateTime) lastMessageAt = new Date(msg.receivedDateTime);
+    }
+  } catch (err) {
+    // Enqueue failed mid-page: DO NOT advance the cursor — replay is safe (dedup index).
+    console.error('[mailboxPoll] enqueue failed; cursor not advanced', { id: c.id, err: err instanceof Error ? err.message : err });
+    return;
+  }
+
+  // All messages enqueued — now it's safe to advance the cursor.
+  if (page.deltaLink) {
+    await updateDeltaCursor(c.id, page.deltaLink, new Date(), lastMessageAt);
+  }
+}
+
+/** Exported for tests. Reads connections in system context, processes each independently. */
+export async function runMailboxSweep(): Promise<void> {
+  const connections = await listConnectedMailboxes();
+  for (const c of connections) {
+    try {
+      await sweepOne(c);
+    } catch (err) {
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      console.error('[mailboxPoll] sweepOne crashed', { id: c.id });
+    }
+  }
+}
+
+let queue: Queue<SweepJobData> | null = null;
+let worker: Worker<SweepJobData> | null = null;
+
+export async function initializeTicketMailboxPollWorker(): Promise<void> {
+  if (worker) return;
+  queue = new Queue<SweepJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  // Singleton repeatable sweep.
+  await queue.add('sweep', { type: 'sweep' }, {
+    jobId: SWEEP_JOB_ID,
+    repeat: { every: SWEEP_INTERVAL_MS },
+    removeOnComplete: { count: 50 },
+    removeOnFail: { count: 100 },
+  });
+  worker = new Worker<SweepJobData>(QUEUE_NAME, async (_job: Job<SweepJobData>) => {
+    await runMailboxSweep();
+  }, { connection: getBullMQConnection(), concurrency: 1 });
+  worker.on('failed', (job, err) => {
+    console.error('[mailboxPoll] sweep job failed', { id: job?.id, err: err?.message });
+  });
+  console.log('[mailboxPoll] worker initialized');
+}
+```
+
+> Remove the dead `rcv` line if your linter flags it — it's a leftover; `lastMessageAt` is the only thing that matters. Keep the cursor-advance-after-enqueue ordering exactly: it's the at-least-once guarantee.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/jobs/ticketMailboxPollWorker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Start the worker at bootstrap**
+
+Grep for where the inbound worker starts: `grep -rn "initializeInboundEmailWorker" apps/api/src`. In that bootstrap file, add:
+
+```typescript
+import { initializeTicketMailboxPollWorker } from './jobs/ticketMailboxPollWorker';
+// ... alongside the other initialize* calls:
+await initializeTicketMailboxPollWorker();
+```
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+cd apps/api && npx tsc --noEmit
+git add apps/api/src/jobs/ticketMailboxPollWorker.ts apps/api/src/jobs/ticketMailboxPollWorker.test.ts <bootstrap-file>
+git commit -m "feat(tickets): M365 mailbox delta-poll sweep worker"
+```
+
+---
+
+### Task 5: Integration test — normalized Graph message → ticket
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeGraphMessage`, `processInboundEmail`, a connected partner fixture.
+
+- [ ] **Step 1: Write the integration test**
+
+```typescript
+// apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeGraphMessage } from '../../services/ticketMailbox/normalizeGraphMessage';
+import { processInboundEmail } from '../../services/inboundEmail/inboundEmailService';
+import { withSystemDbAccessContext, runOutsideDbContext, db } from '../../db';
+import { getActiveTestPartner } from './helpers/rlsFixtures'; // returns an 'active' partner id
+import type { GraphMessage } from '../../services/ticketMailbox/graphMailClient';
+
+describe('M365 inbound → ticket (real DB)', () => {
+  it('creates a ticket from a normalized Graph message via the pre-resolved partner', async () => {
+    const partnerId = await getActiveTestPartner();
+    const msg: GraphMessage = {
+      id: `graph-${Date.now()}`,
+      internetMessageId: `<${Date.now()}@cust.com>`,
+      subject: 'Cannot print',
+      from: { emailAddress: { address: 'cust@cust.com', name: 'Cust' } },
+      toRecipients: [{ emailAddress: { address: 'support@a.com' } }],
+      body: { contentType: 'html', content: '<p>printer down</p>' },
+      bodyPreview: 'printer down',
+      internetMessageHeaders: [{ name: 'Authentication-Results', value: 'dmarc=pass' }],
+    };
+    const normalized = normalizeGraphMessage(msg, partnerId, 'support@a.com');
+
+    await runOutsideDbContext(() => withSystemDbAccessContext(() => processInboundEmail(normalized)));
+
+    const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db.execute(`SELECT ticket_id, parse_status, provider FROM ticket_email_inbound
+                  WHERE provider_message_id = '${msg.id}'`)));
+    expect(rows[0]?.provider).toBe('m365');
+    expect(['created', 'matched']).toContain(rows[0]?.parse_status);
+    expect(rows[0]?.ticket_id).toBeTruthy();
+  });
+});
+```
+
+> Adapt `getActiveTestPartner`/fixtures to the nearest existing inbound-email integration test. Run on the 5433 test DB.
+
+- [ ] **Step 2: Run**
+
+Run:
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts m365InboundToTicket
+```
+Expected: PASS (ticket created, `ticket_email_inbound` row with `provider='m365'`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/m365InboundToTicket.integration.test.ts
+git commit -m "test(tickets): M365 normalized message creates a ticket end-to-end"
+```
+
+---
+
+## Self-Review (Plan 2)
+
+- **Spec coverage:** delta poll + `$select` headers (Task 2), normalize with DMARC verdict + threading keys (Task 3), per-mailbox sweep with mark-read + cursor-after-enqueue + 401→reauth isolation (Task 4), `resolvedPartnerId` seam (Task 1), end-to-end ticket creation (Task 5). ✅
+- **No-history-backfill + 410 resync:** first run passes `deltaLink=null`; a 410 from `listInboxDelta` is caught in `sweepOne` and routed to `resetDeltaCursor(id)` (added to Plan 1's contract), which nulls the cursor and leaves status `connected` so the next sweep restarts the delta from "now". ✅
+- **Type consistency:** `GraphMessage`/`DeltaPage`/`normalizeGraphMessage` names match across Tasks 2–4 and Plan 3's consumption. `resolvedPartnerId` matches Plan 1/3. ✅
+- **Connection-hold safety:** Graph I/O never inside a DB txn; reads/writes wrapped in `runOutsideDbContext(withSystemDbAccessContext(...))` inside the service functions. ✅

--- a/docs/superpowers/plans/2026-06-29-m365-mailbox-3-outbound-reply.md
+++ b/docs/superpowers/plans/2026-06-29-m365-mailbox-3-outbound-reply.md
@@ -1,0 +1,458 @@
+# M365 Mailbox — Plan 3: Outbound Graph Reply — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a ticket's partner has a connected M365 mailbox and the ticket arrived through it, send customer-facing replies via Microsoft Graph **from the real support mailbox** (native conversation threading), instead of the platform `{slug}@tickets.<domain>` sender. Internal/tech notifications stay on the existing `EmailService`.
+
+**Architecture:** A `graphReplySender` performs Graph `createReply` → PATCH body → send for threaded replies, and `sendMail` for first-contact/autoresponse with no original message. `collectRequesterEmail` (in `ticketNotifyWorker`) is extended to attach a `graphMailbox` descriptor to the customer payload when the partner has a connected mailbox; the send loop forks on that field. The original Graph message id to reply to is looked up from `ticket_email_inbound` (most recent `provider='m365'` row for the ticket) — no schema change.
+
+**Tech Stack:** Microsoft Graph v1.0, BullMQ worker, Drizzle, Vitest.
+
+## Global Constraints
+
+- Depends on **Plan 1** (`getMailboxToken`, `MailboxConnection`, connection lookups) and reuses **Plan 2**'s `graphFetch` 429 handling pattern.
+- Only **customer-facing** email may route through the mailbox: `ticket.commented` (public), resolved `ticket.status_changed`, autoresponse. `ticket.assigned` and any tech/internal payload ALWAYS use `EmailService`.
+- Threading via Graph: you CANNOT set `In-Reply-To`/`References` through `internetMessageHeaders` (Graph only allows `x-`-prefixed custom headers). Use `createReply` on the original message — Graph maintains `conversationId` + `References` natively.
+- Loop safety: replies land in Sent Items; the poll worker reads Inbox only → no self-ingest. The existing one-time autoresponder + two-layer loop-prevention still apply unchanged.
+- Send happens OUTSIDE the DB context (the worker already sends outside the txn to avoid pool poison, #1105). Mailbox/message-id lookups are short reads.
+- A Graph send failure for a non-best-effort payload must still bubble so BullMQ retries (parity with the existing `EmailService` path).
+
+## File Structure
+
+- Create `apps/api/src/services/ticketMailbox/graphReplySender.ts` — `sendThreadedReply`, `sendNewMail`.
+- Create `apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts` — given a ticket, return `{ tenantId, mailbox, originalMessageId? } | null`.
+- Modify `apps/api/src/jobs/ticketNotifyWorker.ts` — attach `graphMailbox` to customer payloads in `collectRequesterEmail`; fork the send loop.
+- Tests co-located.
+
+## Shared Interface Contract (produced here)
+
+```typescript
+// services/ticketMailbox/graphReplySender.ts
+export interface GraphSendTarget { tenantId: string; mailbox: string; }
+export function sendThreadedReply(t: GraphSendTarget, originalMessageId: string, html: string): Promise<void>;
+export function sendNewMail(t: GraphSendTarget, to: string, subject: string, html: string): Promise<void>;
+
+// services/ticketMailbox/resolveOutboundMailbox.ts
+export interface OutboundMailbox { tenantId: string; mailbox: string; originalMessageId: string | null; }
+export function resolveOutboundMailbox(ticketId: string, partnerId: string | null): Promise<OutboundMailbox | null>;
+
+// jobs/ticketNotifyWorker.ts — EmailPayload gains:
+//   graphMailbox?: { tenantId: string; mailbox: string; originalMessageId: string | null };
+```
+
+---
+
+### Task 1: Graph reply sender (`graphReplySender.ts`)
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/graphReplySender.ts`
+- Test: `apps/api/src/services/ticketMailbox/graphReplySender.test.ts`
+
+**Interfaces:**
+- Consumes: `getMailboxToken` (Plan 1).
+- Produces: `GraphSendTarget`, `sendThreadedReply`, `sendNewMail`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/ticketMailbox/graphReplySender.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('./mailboxToken', () => ({ getMailboxToken: vi.fn(async () => 'tok') }));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+import { sendThreadedReply, sendNewMail } from './graphReplySender';
+
+const target = { tenantId: '11111111-1111-1111-1111-111111111111', mailbox: 'support@a.com' };
+
+describe('sendThreadedReply', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('createReply → PATCH body → send (3 calls, in order)', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ id: 'draft-9' }) }) // createReply
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })                // PATCH
+      .mockResolvedValueOnce({ ok: true, status: 202, text: async () => '' });                 // send
+
+    await sendThreadedReply(target, 'orig-1', '<p>reply</p>');
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toContain('/messages/orig-1/createReply');
+    expect(fetchMock.mock.calls[0][1].method).toBe('POST');
+    expect(fetchMock.mock.calls[1][0]).toContain('/messages/draft-9');
+    expect(fetchMock.mock.calls[1][1].method).toBe('PATCH');
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).body).toEqual({ contentType: 'HTML', content: '<p>reply</p>' });
+    expect(fetchMock.mock.calls[2][0]).toContain('/messages/draft-9/send');
+    expect(fetchMock.mock.calls[2][1].method).toBe('POST');
+  });
+
+  it('throws if createReply fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403, text: async () => 'denied' });
+    await expect(sendThreadedReply(target, 'orig-1', '<p>x</p>')).rejects.toThrow(/403/);
+  });
+});
+
+describe('sendNewMail', () => {
+  beforeEach(() => fetchMock.mockReset());
+  it('POSTs sendMail with the message envelope', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 202, text: async () => '' });
+    await sendNewMail(target, 'cust@x.com', 'Re: hi [T-2026-0007]', '<p>hello</p>');
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/users/support%40a.com/sendMail');
+    const payload = JSON.parse(opts.body);
+    expect(payload.message.toRecipients[0].emailAddress.address).toBe('cust@x.com');
+    expect(payload.message.subject).toBe('Re: hi [T-2026-0007]');
+    expect(payload.saveToSentItems).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/graphReplySender.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/ticketMailbox/graphReplySender.ts
+import { getMailboxToken } from './mailboxToken';
+
+const GRAPH = 'https://graph.microsoft.com/v1.0';
+
+export interface GraphSendTarget { tenantId: string; mailbox: string; }
+
+async function gfetch(url: string, token: string, init: RequestInit): Promise<Response> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, ...(init.headers ?? {}) },
+    redirect: 'error',
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Graph ${init.method ?? 'GET'} ${url} → ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res;
+}
+
+/** Threaded reply from the support mailbox: createReply → set body → send.
+ *  Graph keeps it in the customer's existing conversation (References/conversationId). */
+export async function sendThreadedReply(t: GraphSendTarget, originalMessageId: string, html: string): Promise<void> {
+  const token = await getMailboxToken(t.tenantId);
+  const base = `${GRAPH}/users/${encodeURIComponent(t.mailbox)}/messages`;
+
+  const draftRes = await gfetch(`${base}/${encodeURIComponent(originalMessageId)}/createReply`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+  });
+  const draft = (await draftRes.json()) as { id?: string };
+  if (!draft.id) throw new Error('Graph createReply returned no draft id');
+
+  await gfetch(`${base}/${encodeURIComponent(draft.id)}`, token, {
+    method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: { contentType: 'HTML', content: html } }),
+  });
+
+  await gfetch(`${base}/${encodeURIComponent(draft.id)}/send`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+  });
+}
+
+/** First-contact / autoresponse with no original message to reply to. */
+export async function sendNewMail(t: GraphSendTarget, to: string, subject: string, html: string): Promise<void> {
+  const token = await getMailboxToken(t.tenantId);
+  await gfetch(`${GRAPH}/users/${encodeURIComponent(t.mailbox)}/sendMail`, token, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: {
+        subject,
+        body: { contentType: 'HTML', content: html },
+        toRecipients: [{ emailAddress: { address: to } }],
+      },
+      saveToSentItems: true,
+    }),
+  });
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/graphReplySender.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/graphReplySender.ts apps/api/src/services/ticketMailbox/graphReplySender.test.ts
+git commit -m "feat(tickets): Graph reply sender (createReply + sendMail from mailbox)"
+```
+
+---
+
+### Task 2: Resolve the outbound mailbox for a ticket
+
+**Files:**
+- Create: `apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts`
+- Test: `apps/api/src/services/ticketMailbox/resolveOutboundMailbox.test.ts`
+
+**Interfaces:**
+- Consumes: `db` + `ticketMailboxConnections` schema (Plan 1), `ticket_email_inbound` (existing).
+- Produces: `OutboundMailbox`, `resolveOutboundMailbox(ticketId, partnerId)`.
+
+Returns `null` unless the partner has exactly one `status='connected'` mailbox; `originalMessageId` is the most recent `ticket_email_inbound.provider_message_id` for this ticket with `provider='m365'` (null if the ticket never had an M365 inbound message — e.g. created in-app — so the caller uses `sendNewMail`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/api/src/services/ticketMailbox/resolveOutboundMailbox.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const connRows = vi.fn();
+const inboundRows = vi.fn();
+vi.mock('../../db', () => ({
+  db: {
+    select: (..._a: any[]) => ({
+      from: (tbl: any) => ({
+        where: () => ({
+          limit: async () => (String(tbl).includes('mailbox') ? connRows() : inboundRows()),
+          orderBy: () => ({ limit: async () => inboundRows() }),
+        }),
+      }),
+    }),
+  },
+}));
+// Schema identity stubs so `String(tbl)` discriminates the two selects.
+vi.mock('../../db/schema/ticketMailbox', () => ({ ticketMailboxConnections: { _: 'ticket_mailbox_connections' } }));
+
+import { resolveOutboundMailbox } from './resolveOutboundMailbox';
+
+describe('resolveOutboundMailbox', () => {
+  beforeEach(() => { connRows.mockReset(); inboundRows.mockReset(); });
+
+  it('returns null when the partner has no connected mailbox', async () => {
+    connRows.mockResolvedValue([]);
+    expect(await resolveOutboundMailbox('t1', 'p1')).toBeNull();
+  });
+
+  it('returns mailbox + originalMessageId from the latest m365 inbound row', async () => {
+    connRows.mockResolvedValue([{ tenantId: 'ten', mailboxAddress: 'support@a.com' }]);
+    inboundRows.mockResolvedValue([{ providerMessageId: 'graph-77' }]);
+    const r = await resolveOutboundMailbox('t1', 'p1');
+    expect(r).toEqual({ tenantId: 'ten', mailbox: 'support@a.com', originalMessageId: 'graph-77' });
+  });
+
+  it('returns originalMessageId null when no m365 inbound row exists', async () => {
+    connRows.mockResolvedValue([{ tenantId: 'ten', mailboxAddress: 'support@a.com' }]);
+    inboundRows.mockResolvedValue([]);
+    const r = await resolveOutboundMailbox('t1', 'p1');
+    expect(r?.originalMessageId).toBeNull();
+  });
+
+  it('returns null when partnerId is null', async () => {
+    expect(await resolveOutboundMailbox('t1', null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/resolveOutboundMailbox.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts
+import { and, desc, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { ticketMailboxConnections } from '../../db/schema/ticketMailbox';
+import { ticketEmailInbound } from '../../db/schema/emailInbound';
+
+export interface OutboundMailbox { tenantId: string; mailbox: string; originalMessageId: string | null; }
+
+export async function resolveOutboundMailbox(ticketId: string, partnerId: string | null): Promise<OutboundMailbox | null> {
+  if (!partnerId) return null;
+
+  const conn = await db.select({
+    tenantId: ticketMailboxConnections.tenantId,
+    mailboxAddress: ticketMailboxConnections.mailboxAddress,
+  }).from(ticketMailboxConnections)
+    .where(and(
+      eq(ticketMailboxConnections.partnerId, partnerId),
+      eq(ticketMailboxConnections.status, 'connected'),
+    )).limit(1);
+  if (!conn[0]?.tenantId) return null;
+
+  const inbound = await db.select({ providerMessageId: ticketEmailInbound.providerMessageId })
+    .from(ticketEmailInbound)
+    .where(and(eq(ticketEmailInbound.ticketId, ticketId), eq(ticketEmailInbound.provider, 'm365')))
+    .orderBy(desc(ticketEmailInbound.createdAt))
+    .limit(1);
+
+  return {
+    tenantId: conn[0].tenantId,
+    mailbox: conn[0].mailboxAddress,
+    originalMessageId: inbound[0]?.providerMessageId ?? null,
+  };
+}
+```
+
+> Confirm the `ticket_email_inbound` Drizzle export name (`ticketEmailInbound`), its `ticketId`/`provider`/`providerMessageId`/`createdAt` column accessors, and its import path (`../../db/schema/emailInbound`). Adjust if the schema file names differ.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/services/ticketMailbox/resolveOutboundMailbox.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketMailbox/resolveOutboundMailbox.ts apps/api/src/services/ticketMailbox/resolveOutboundMailbox.test.ts
+git commit -m "feat(tickets): resolve outbound mailbox + original message id for a ticket"
+```
+
+---
+
+### Task 3: Fork the notify worker's customer-facing send
+
+**Files:**
+- Modify: `apps/api/src/jobs/ticketNotifyWorker.ts` (the `EmailPayload` type, `collectRequesterEmail` ~lines 130-188, and the send loop ~lines 374-392).
+- Test: `apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveOutboundMailbox` (Task 2), `sendThreadedReply`/`sendNewMail` (Task 1).
+- Produces: `EmailPayload.graphMailbox?` + forked dispatch.
+
+- [ ] **Step 1: Add `graphMailbox` to the `EmailPayload` type**
+
+In `ticketNotifyWorker.ts`, extend the `EmailPayload` interface:
+
+```typescript
+  graphMailbox?: { tenantId: string; mailbox: string; originalMessageId: string | null };
+```
+
+- [ ] **Step 2: Attach `graphMailbox` in `collectRequesterEmail`**
+
+In `collectRequesterEmail`, after the ticket is loaded and `ticket.submitterEmail` is confirmed, resolve the mailbox once and attach it to the returned payload(s). Add near the top of the function (after the `if (!ticket.submitterEmail) return [];` guard):
+
+```typescript
+  // Customer-facing only: if this partner has a connected M365 mailbox, the reply
+  // goes out FROM that mailbox via Graph (native threading). Tech/assignee emails
+  // never call collectRequesterEmail, so they never get graphMailbox.
+  const graphMailbox = (await resolveOutboundMailbox(ticket.id, ticket.partnerId)) ?? undefined;
+```
+
+Then add `graphMailbox` to BOTH returned payload objects (the un-threaded resolved-status branch and the threaded branch). For example, the threaded `return` becomes:
+
+```typescript
+  return [{
+    to: ticket.submitterEmail,
+    subject: `[${label}] ${subjectPrefix}: ${ticket.subject}`,
+    html: bodyHtml,
+    replyTo,
+    headers,
+    graphMailbox,
+  }];
+```
+
+and the un-threaded `return` adds `graphMailbox` likewise.
+
+> Import at the top of the file:
+> ```typescript
+> import { resolveOutboundMailbox } from '../services/ticketMailbox/resolveOutboundMailbox';
+> import { sendThreadedReply, sendNewMail } from '../services/ticketMailbox/graphReplySender';
+> ```
+
+- [ ] **Step 3: Fork the send loop**
+
+Replace the per-payload send body (the `if (payload.bestEffort) { ... } else { ... }` block in the send loop ~lines 380-392) so it routes through Graph when `graphMailbox` is present:
+
+```typescript
+  for (const payload of emailPayloads) {
+    const send = async () => {
+      if (payload.graphMailbox) {
+        const { tenantId, mailbox, originalMessageId } = payload.graphMailbox;
+        if (originalMessageId) {
+          await sendThreadedReply({ tenantId, mailbox }, originalMessageId, payload.html);
+        } else {
+          await sendNewMail({ tenantId, mailbox }, Array.isArray(payload.to) ? payload.to[0] : payload.to, payload.subject, payload.html);
+        }
+        return;
+      }
+      await email.sendEmail({
+        to: payload.to, subject: payload.subject, html: payload.html,
+        replyTo: payload.replyTo, headers: payload.headers,
+      });
+    };
+
+    if (payload.bestEffort) {
+      try { await send(); }
+      catch (err) { console.error('[TicketNotify] email send failed', err instanceof Error ? err.message : err); }
+    } else {
+      await send(); // let throw bubble so BullMQ retries
+    }
+  }
+```
+
+> Note: the existing guard `if (!email || emailPayloads.length === 0) return;` early-returns when no `EmailService` is configured. Keep that guard, but Graph payloads should still send even if `EmailService` is unconfigured. Change the guard to `if (emailPayloads.length === 0) return;` and inside the non-graph branch keep a local `if (!email) { ...skip/log... }` so a missing platform transport doesn't suppress Graph sends. Confirm against the actual code and adjust minimally.
+
+- [ ] **Step 4: Write the fork test**
+
+```typescript
+// apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sendThreaded = vi.fn(async () => {});
+const sendNew = vi.fn(async () => {});
+const emailSend = vi.fn(async () => {});
+vi.mock('../services/ticketMailbox/graphReplySender', () => ({ sendThreadedReply: sendThreaded, sendNewMail: sendNew }));
+// ... mock getEmailService() to return { sendEmail: emailSend }, getTicket(), resolveOutboundMailbox(), buildThreadingHeaders(), db, partners, etc.
+// Follow the existing ticketNotifyWorker test file's mock scaffolding exactly.
+
+describe('ticketNotifyWorker Graph fork', () => {
+  beforeEach(() => { sendThreaded.mockClear(); sendNew.mockClear(); emailSend.mockClear(); });
+
+  it('routes a threaded customer reply through sendThreadedReply, not EmailService', async () => {
+    // Arrange: ticket.commented (public) on a partner WITH a connected mailbox and an originalMessageId.
+    // Act: dispatch the event through the worker handler.
+    // Assert:
+    expect(sendThreaded).toHaveBeenCalledTimes(1);
+    expect(emailSend).not.toHaveBeenCalled();
+  });
+
+  it('uses sendNewMail when there is no original message id', async () => {
+    expect(sendNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes assignee/tech notifications through EmailService (never Graph)', async () => {
+    // Arrange: ticket.assigned event.
+    expect(emailSend).toHaveBeenCalled();
+    expect(sendThreaded).not.toHaveBeenCalled();
+    expect(sendNew).not.toHaveBeenCalled();
+  });
+});
+```
+
+> Fill the Arrange/Act using the existing `ticketNotifyWorker.test.ts` harness in the same directory — copy its event-dispatch entrypoint and mock setup. The assertions above are the contract; the scaffolding mirrors the existing tests.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd apps/api && npx vitest run src/jobs/ticketNotifyWorker.graphFork.test.ts src/jobs/ticketNotifyWorker.test.ts`
+Expected: PASS (both the new fork test and the existing worker tests).
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+cd apps/api && npx tsc --noEmit
+git add apps/api/src/jobs/ticketNotifyWorker.ts apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+git commit -m "feat(tickets): route customer-facing replies through the M365 mailbox"
+```
+
+---
+
+## Self-Review (Plan 3)
+
+- **Spec coverage:** createReply threaded send + sendMail fallback (Task 1), mailbox+original-message resolution with no schema change (Task 2), customer-only fork with tech notifications staying on `EmailService` (Task 3). ✅
+- **Graph threading correctness:** uses `createReply` (not `internetMessageHeaders`) so `In-Reply-To`/`References` are set natively — matches the Global Constraint. ✅
+- **Loop safety:** `saveToSentItems: true` + Inbox-only polling = no self-ingest; existing autoresponder/loop-prevention untouched. ✅
+- **Type consistency:** `GraphSendTarget`, `OutboundMailbox`, and `EmailPayload.graphMailbox` names match across Tasks 1–3; `getMailboxToken` matches Plan 1. ✅
+- **Failure semantics:** non-best-effort Graph sends bubble for BullMQ retry; best-effort swallow+log — parity with the existing `EmailService` path. ✅
+- **Implementer verifications flagged inline:** `ticket_email_inbound` schema export/columns; the exact `EmailService`-unconfigured guard rewrite; the existing notify-worker test harness shape.

--- a/docs/superpowers/plans/2026-06-29-m365-mailbox-4-settings-ui.md
+++ b/docs/superpowers/plans/2026-06-29-m365-mailbox-4-settings-ui.md
@@ -1,0 +1,410 @@
+# M365 Mailbox — Plan 4: Settings Web UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give partner admins a settings card to connect/disconnect an M365 support mailbox: enter the address, launch admin consent, see status, copy the `New-ApplicationAccessPolicy` PowerShell snippet, re-test after scoping, and disconnect.
+
+**Architecture:** A single React island `M365MailboxCard.tsx` rendered next to `InboundEmailCard` on the ticketing settings surface. All mutations go through `runAction` (per the Web Mutation Handlers rule). The Connect button POSTs to `/tickets/mailbox/connect` and redirects the browser to the returned `authUrl`; the callback redirects back with a `?ticketMailbox=...` status the card reads on mount.
+
+**Tech Stack:** Astro + React islands, `runAction`, `fetchWithAuth`, Vitest + jsdom.
+
+## Global Constraints
+
+- Depends on **Plan 1** routes: `GET /tickets/mailbox/connections`, `POST /tickets/mailbox/connect`, `POST /tickets/mailbox/connections/:id/retest`, `DELETE /tickets/mailbox/connections/:id`.
+- Every POST/DELETE wraps in `runAction` (`apps/web/src/lib/runAction.ts`); catch pattern: 401 → let auth redirect; non-401 `ActionError` already toasted by `runAction`; other errors → `showToast`.
+- The component path must be added to `no-silent-mutations.test.ts` `TARGET_GLOBS` AND the hardcoded count bumped in the same change.
+- Web has NO client-side permission store — render for everyone; the API enforces admin+MFA. (Don't gate buttons on a missing permission store.)
+- No internal infra details; the PowerShell snippet uses the Breeze Ticketing app id from a public config value (`PUBLIC_TICKET_MAILBOX_APP_ID`) or is fetched from the connections endpoint — never hardcode a tenant/secret.
+
+## File Structure
+
+- Create `apps/web/src/components/settings/M365MailboxCard.tsx` — the card island.
+- Modify the ticketing-settings page/host that renders `InboundEmailCard` (grep `InboundEmailCard`) — mount `M365MailboxCard` beside it.
+- Modify `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` — add the glob + bump the count.
+- Test: `apps/web/src/components/settings/M365MailboxCard.test.tsx`.
+
+## Interface Contract (server shapes consumed)
+
+```typescript
+// GET /tickets/mailbox/connections → { connections: MailboxConnectionDTO[] }
+interface MailboxConnectionDTO {
+  id: string;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+  tenantId: string | null;
+  lastPolledAt: string | null;
+  lastError: string | null;
+}
+// POST /tickets/mailbox/connect { mailboxAddress, displayName? } → { authUrl, connectionId }
+// POST /tickets/mailbox/connections/:id/retest → { ok, error? }
+// DELETE /tickets/mailbox/connections/:id → { ok: true }
+```
+
+---
+
+### Task 1: The `M365MailboxCard` component
+
+**Files:**
+- Create: `apps/web/src/components/settings/M365MailboxCard.tsx`
+- Test: `apps/web/src/components/settings/M365MailboxCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `runAction`, `fetchWithAuth`, `showToast` (match the imports used by `apps/web/src/components/integrations/QuickbooksIntegration.tsx`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/web/src/components/settings/M365MailboxCard.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../lib/fetchWithAuth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+// runAction passthrough that still surfaces thrown errors like the real one.
+vi.mock('../../lib/runAction', () => ({
+  runAction: async (fn: any) => fn(),
+  ActionError: class ActionError extends Error { status = 500; },
+}));
+vi.mock('../../lib/toast', () => ({ showToast: vi.fn() }));
+
+import { M365MailboxCard } from './M365MailboxCard';
+
+function jsonRes(body: any, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+describe('M365MailboxCard', () => {
+  beforeEach(() => fetchWithAuth.mockReset());
+
+  it('lists existing connections on mount', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ connections: [
+      { id: 'c1', mailboxAddress: 'support@a.com', displayName: 'Support', status: 'connected', tenantId: 't', lastPolledAt: null, lastError: null },
+    ]}));
+    render(<M365MailboxCard />);
+    expect(await screen.findByText('support@a.com')).toBeTruthy();
+    expect(screen.getByText(/connected/i)).toBeTruthy();
+  });
+
+  it('Connect posts the address and redirects the browser to authUrl', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonRes({ connections: [] }))                                   // initial list
+      .mockResolvedValueOnce(jsonRes({ authUrl: 'https://login.microsoftonline.com/x', connectionId: 'c2' })); // connect
+    const assign = vi.fn();
+    Object.defineProperty(window, 'location', { value: { assign, href: '', hash: '' }, writable: true });
+
+    render(<M365MailboxCard />);
+    fireEvent.change(await screen.findByLabelText(/mailbox address/i), { target: { value: 'support@a.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
+      expect.stringContaining('/tickets/mailbox/connect'),
+      expect.objectContaining({ method: 'POST' }),
+    ));
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('https://login.microsoftonline.com/x'));
+  });
+
+  it('Re-test calls the retest endpoint', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(jsonRes({ connections: [
+        { id: 'c1', mailboxAddress: 'support@a.com', displayName: null, status: 'error', tenantId: 't', lastPolledAt: null, lastError: 'Graph returned 403' },
+      ]}))
+      .mockResolvedValueOnce(jsonRes({ ok: true }))      // retest
+      .mockResolvedValueOnce(jsonRes({ connections: [] })); // refresh
+    render(<M365MailboxCard />);
+    fireEvent.click(await screen.findByRole('button', { name: /re-test/i }));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
+      expect.stringContaining('/tickets/mailbox/connections/c1/retest'),
+      expect.objectContaining({ method: 'POST' }),
+    ));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/components/settings/M365MailboxCard.test.tsx`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// apps/web/src/components/settings/M365MailboxCard.tsx
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../lib/fetchWithAuth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../../lib/toast';
+
+interface MailboxConnectionDTO {
+  id: string;
+  mailboxAddress: string;
+  displayName: string | null;
+  status: 'pending_consent' | 'connected' | 'error' | 'reauth_required' | 'disabled';
+  tenantId: string | null;
+  lastPolledAt: string | null;
+  lastError: string | null;
+}
+
+const STATUS_LABEL: Record<MailboxConnectionDTO['status'], string> = {
+  pending_consent: 'Pending consent',
+  connected: 'Connected',
+  error: 'Needs attention',
+  reauth_required: 'Re-auth required',
+  disabled: 'Disabled',
+};
+
+const APP_ID = (import.meta as unknown as { env?: Record<string, string> }).env?.PUBLIC_TICKET_MAILBOX_APP_ID ?? '<Breeze Ticketing app id>';
+
+function powershellSnippet(mailbox: string): string {
+  return [
+    '# Run in Exchange Online PowerShell (Connect-ExchangeOnline) as a tenant admin:',
+    `New-DistributionGroup -Name "Breeze Ticketing Mailboxes" -Type Security -Members "${mailbox}"`,
+    `New-ApplicationAccessPolicy -AppId ${APP_ID} \\`,
+    '  -PolicyScopeGroupId "Breeze Ticketing Mailboxes" -AccessRight RestrictAccess \\',
+    '  -Description "Restrict Breeze Ticketing to the support mailbox"',
+  ].join('\n');
+}
+
+export function M365MailboxCard() {
+  const [connections, setConnections] = useState<MailboxConnectionDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [address, setAddress] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth('/tickets/mailbox/connections');
+      if (res.ok) {
+        const body = await res.json();
+        setConnections(body.connections ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void refresh(); }, []);
+
+  async function handleConnect() {
+    if (!address.trim()) return;
+    setBusy(true);
+    try {
+      const body = await runAction(async () => {
+        const res = await fetchWithAuth('/tickets/mailbox/connect', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mailboxAddress: address.trim(), displayName: displayName.trim() || undefined }),
+        });
+        return res;
+      });
+      const json = await body.json();
+      if (json.authUrl) window.location.assign(json.authUrl);
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Could not start M365 consent' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRetest(id: string) {
+    try {
+      await runAction(() => fetchWithAuth(`/tickets/mailbox/connections/${id}/retest`, { method: 'POST' }));
+      await refresh();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Re-test failed' });
+    }
+  }
+
+  async function handleDisconnect(id: string) {
+    try {
+      await runAction(() => fetchWithAuth(`/tickets/mailbox/connections/${id}`, { method: 'DELETE' }));
+      await refresh();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Disconnect failed' });
+    }
+  }
+
+  return (
+    <section data-testid="m365-mailbox-card" className="rounded-lg border border-gray-200 p-4">
+      <h3 className="text-base font-semibold">Microsoft 365 support mailbox</h3>
+      <p className="mt-1 text-sm text-gray-500">
+        Connect your shared support mailbox so customer email becomes tickets and replies are sent from it. No MX or forwarding changes required.
+      </p>
+
+      {loading ? (
+        <p className="mt-4 text-sm text-gray-400">Loading…</p>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {connections.filter((c) => c.status !== 'disabled').map((c) => (
+            <li key={c.id} data-testid="m365-connection" className="flex flex-col gap-2 rounded border border-gray-100 p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="font-medium">{c.mailboxAddress}</span>
+                  {c.displayName ? <span className="ml-2 text-sm text-gray-400">{c.displayName}</span> : null}
+                </div>
+                <span className="text-sm">{STATUS_LABEL[c.status]}</span>
+              </div>
+              {c.lastError ? <p className="text-xs text-red-600">{c.lastError}</p> : null}
+              {(c.status === 'error' || c.status === 'reauth_required' || c.status === 'pending_consent') ? (
+                <details className="text-xs">
+                  <summary className="cursor-pointer">Scope this mailbox (Application Access Policy)</summary>
+                  <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded bg-gray-50 p-2">{powershellSnippet(c.mailboxAddress)}</pre>
+                </details>
+              ) : null}
+              <div className="flex gap-2">
+                <button type="button" className="text-sm text-blue-600" onClick={() => handleRetest(c.id)}>Re-test</button>
+                <button type="button" className="text-sm text-red-600" onClick={() => handleDisconnect(c.id)}>Disconnect</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-4 flex flex-col gap-2 border-t border-gray-100 pt-4">
+        <label className="text-sm" htmlFor="m365-address">Mailbox address</label>
+        <input id="m365-address" className="rounded border border-gray-300 p-2 text-sm" placeholder="support@yourmsp.com"
+          value={address} onChange={(e) => setAddress(e.target.value)} />
+        <label className="text-sm" htmlFor="m365-name">Display name (optional)</label>
+        <input id="m365-name" className="rounded border border-gray-300 p-2 text-sm" placeholder="Support"
+          value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+        <button type="button" disabled={busy || !address.trim()} onClick={handleConnect}
+          className="mt-1 self-start rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-50">
+          Connect
+        </button>
+      </div>
+    </section>
+  );
+}
+```
+
+> Match the real import paths and `showToast` signature to `QuickbooksIntegration.tsx` exactly (it may be `showToast(message, type)` positional vs object). Use the repo's existing Card/Button primitives if the integrations page uses them, rather than raw Tailwind, to stay visually consistent. `fetchWithAuth` base path: confirm whether it prefixes `/api/v1` automatically (QuickBooks card shows the convention).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/components/settings/M365MailboxCard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/settings/M365MailboxCard.tsx apps/web/src/components/settings/M365MailboxCard.test.tsx
+git commit -m "feat(web): M365 mailbox connection settings card"
+```
+
+---
+
+### Task 2: Mount the card + enroll in no-silent-mutations
+
+**Files:**
+- Modify: the ticketing-settings host that renders `InboundEmailCard` (grep `InboundEmailCard`).
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`
+
+**Interfaces:**
+- Consumes: `M365MailboxCard` (Task 1).
+
+- [ ] **Step 1: Mount the card**
+
+Run `grep -rn "InboundEmailCard" apps/web/src` to find where it's rendered (a settings page/tab). Import and render `M365MailboxCard` directly beside it:
+
+```tsx
+import { M365MailboxCard } from './M365MailboxCard'; // adjust relative path
+// ...
+<InboundEmailCard />
+<M365MailboxCard />
+```
+
+If `InboundEmailCard` is rendered inside an Astro page via a client island, add `M365MailboxCard` the same way (`client:load`/`client:visible`) as a sibling, mirroring how `InboundEmailCard` is hydrated.
+
+- [ ] **Step 2: Enroll in `no-silent-mutations`**
+
+In `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`, add to `TARGET_GLOBS`:
+
+```typescript
+  'src/components/settings/M365MailboxCard.tsx',
+```
+
+Then bump the hardcoded expected count assertion (search the file for the numeric `TARGET_GLOBS.length` / count expectation and increase it by 1).
+
+- [ ] **Step 3: Run the guard test**
+
+Run: `cd apps/web && npx vitest run src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS (all mutations in `M365MailboxCard` are `runAction`-wrapped; count matches).
+
+- [ ] **Step 4: Typecheck/build + commit**
+
+Run:
+```bash
+cd apps/web && npx astro check
+```
+Expected: no new errors in the touched files.
+
+```bash
+git add apps/web/src/lib/__tests__/no-silent-mutations.test.ts <settings-host-file>
+git commit -m "feat(web): mount M365 mailbox card + enroll in no-silent-mutations"
+```
+
+---
+
+### Task 3: Status banner on redirect-back (optional polish)
+
+**Files:**
+- Modify: `apps/web/src/components/settings/M365MailboxCard.tsx`
+
+**Interfaces:**
+- Consumes: the `?ticketMailbox=connected|needs_policy|error` query the callback redirects with (Plan 1).
+
+- [ ] **Step 1: Read the redirect status on mount and toast once**
+
+Add to `M365MailboxCard`, inside the mount effect (after `refresh()`):
+
+```typescript
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get('ticketMailbox');
+    if (!status) return;
+    if (status === 'connected') showToast({ type: 'success', message: 'Mailbox connected' });
+    else if (status === 'needs_policy') showToast({ type: 'warning', message: 'Consent granted — scope the mailbox with the Application Access Policy, then Re-test' });
+    else if (status === 'error') showToast({ type: 'error', message: 'M365 connection failed' });
+    // Clean the query so a refresh doesn't re-toast.
+    params.delete('ticketMailbox');
+    const qs = params.toString();
+    window.history.replaceState({}, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
+  }, []);
+```
+
+> Adjust the `showToast` call signature to the repo's (object vs positional). This is non-mutating UI, so no `runAction` needed.
+
+- [ ] **Step 2: Run the component tests again**
+
+Run: `cd apps/web && npx vitest run src/components/settings/M365MailboxCard.test.tsx`
+Expected: PASS (existing tests still green; jsdom `window.location.search` defaults to empty so the banner effect no-ops).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/settings/M365MailboxCard.tsx
+git commit -m "feat(web): surface M365 consent redirect status as a toast"
+```
+
+---
+
+## Self-Review (Plan 4)
+
+- **Spec coverage:** connect (address → admin consent redirect), status display, PowerShell `New-ApplicationAccessPolicy` guidance, re-test, disconnect, redirect-back status (Tasks 1–3). ✅
+- **runAction discipline:** every POST/DELETE wrapped; catch pattern follows the CLAUDE.md template; enrolled in `no-silent-mutations` with count bump. ✅
+- **No permission-store gating:** buttons render for all; API enforces admin+MFA. ✅
+- **No infra leakage:** app id from `PUBLIC_TICKET_MAILBOX_APP_ID`, no tenant/secret in the snippet. ✅
+- **Implementer verifications flagged inline:** exact `showToast`/`fetchWithAuth` signatures + base path, the `InboundEmailCard` host file, the existing repo Card/Button primitives, and the `no-silent-mutations` count location.
+
+---
+
+## Cross-Plan Wrap-Up
+
+Suggested PR sequence (stacked, mirroring Phase 4): **Plan 1 → Plan 2 → Plan 3 → Plan 4**, each off the prior. Plan 1 ships the table + consent (verifiable in isolation: connect a mailbox, see `connected`). Plan 2 ships inbound (mail becomes tickets). Plan 3 ships outbound (replies from the mailbox). Plan 4 ships the UI. Each plan's RLS/test gates must be green before stacking the next.
+
+**Env to add across deploys** (`/opt/breeze/.env` + the `api` service `environment:` block): `TICKET_MAILBOX_M365_CLIENT_ID`, `TICKET_MAILBOX_M365_CLIENT_SECRET`, and `PUBLIC_TICKET_MAILBOX_APP_ID` (web). The Azure "Breeze Ticketing" app needs `Mail.ReadWrite` + `Mail.Send` (application) and the callback `…/api/v1/tickets/mailbox/callback` registered as a redirect URI.

--- a/docs/superpowers/specs/2026-06-29-m365-exchange-mailbox-email-to-ticket-design.md
+++ b/docs/superpowers/specs/2026-06-29-m365-exchange-mailbox-email-to-ticket-design.md
@@ -1,0 +1,167 @@
+# M365 Exchange Mailbox — Email-to-Ticket (Inbound + Outbound)
+
+**Date:** 2026-06-29
+**Status:** Design approved, pending implementation plan
+**Author:** Todd Hebebrand (brainstormed with Claude)
+
+## Summary
+
+Let an MSP connect their own Microsoft 365 shared support mailbox (e.g. `support@msp.com`) directly to Breeze ticketing via Microsoft Graph, so inbound customer email becomes tickets and outbound replies are sent from that real mailbox — with **no MX changes and no forwarding rules**. Breeze reads and sends through the mailbox using an app-only (client-credentials) Graph connection that the MSP's Global Admin consents to once.
+
+This is the API-based realization of the "Model B custom-domain" inbound path that Phase 4 deferred. It bolts a new feeder (delta-poll worker) and a new sender (Graph reply) onto the **existing** email-to-ticket pipeline; the core `processInboundEmail` / ticketing / SLA logic is unchanged.
+
+Microsoft Teams is explicitly **out of scope** here and will be specced separately as a follow-on.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Auth model | App-only client-credentials, single multi-tenant Breeze Azure app, per-MSP admin consent | Survives staff turnover; true service-account; no per-user token. Microsoft retired Basic Auth + EWS, so OAuth/Graph is the only path. |
+| App registration | **Separate** "Breeze Ticketing" app (own `TICKET_MAILBOX_M365_CLIENT_ID/SECRET`), distinct from the existing C2C backup app | Least privilege (only `Mail.ReadWrite` + `Mail.Send`); clean per-feature Application Access Policy scoping; admin consents to mail permissions separately from backup. |
+| Tenancy axis | Per-partner (MSP's own support mailbox) | Matches existing partner-axis email-to-ticket model (`partner_inbound_domains`, partner-scoped ingest). |
+| Inbound delivery | Scheduled **delta-query polling** (no webhooks) | No public webhook validation, no subscription renewal, naturally resilient to downtime. ~60–90s latency acceptable. |
+| Mailbox hygiene | **Mark ingested messages read** (`Mail.ReadWrite`) | Human-visible mailbox reflects handled state; non-destructive. Delta cursor + dedup index are the real idempotency guarantee. |
+| Outbound routing | Customer-facing replies via Graph `createReply` from the support mailbox; internal/tech notifications stay on the existing platform `EmailService` | Replies come from the MSP's real address and thread natively in the customer's mailbox; techs aren't routed through the customer mailbox. |
+| Mailboxes per partner | N (multiple rows allowed) from day one | support@, helpdesk@, billing@ are common; low cost to allow. |
+
+## Reuse map (what already exists)
+
+| Existing asset | File | How reused |
+|---|---|---|
+| App-only token + admin-consent primitives | `apps/api/src/services/c2cM365.ts` | `acquireClientCredentialsToken`, `buildAdminConsentUrl`, `testGraphAccess`, `isM365TenantId` / `M365TenantId` brand, 5-min-buffer freshness — pointed at the new app's env creds. |
+| Signed-state + CSRF-cookie OAuth callback pattern | `apps/api/src/routes/accounting/index.ts` | Connect/callback hardening; callback is **unauthenticated at middleware**, authenticated via signed state + browser-binding cookie, written under system context (the QuickBooks callback gotcha). |
+| Inbound pipeline core | `apps/api/src/services/inboundEmail/inboundEmailService.ts` (`processInboundEmail`, `findTicketInPartner`, `createFromEmail`, `appendInboundComment`) | Consumed unchanged via the `NormalizedInboundEmail` shape. |
+| Dedup + audit/dead-letter | `ticket_email_inbound` `(partner_id, provider_message_id)` unique index, `provider` column | New `provider='m365'`, `provider_message_id` = Graph immutable message id. |
+| Inbound queue + worker shape | `inbound-email` BullMQ queue, `jobs/inboundEmailWorker.ts` | New poll worker enqueues into the same queue. |
+| Outbound threading + subject token | `apps/api/src/services/inboundEmail/outboundThreading.ts` | Subject token `[T-YYYY-NNNN]` kept for human visibility + fallback matching. |
+| Notification fan-out | `apps/api/src/jobs/ticketNotifyWorker.ts` | Customer-facing branches gain a "partner has M365 conn?" routing fork. |
+| Secret-at-rest registry | `apps/api/src/services/encryptedColumnRegistry.ts` | Available if a BYO-creds column is ever added (not in Phase 1). |
+
+> **Not reused:** `m365_connections` (`db/schema/m365.ts`) is **org-axis** and stores a per-org BYO client secret for a different feature. Wrong axis, wrong model — left untouched.
+
+## Architecture
+
+```
+                 ┌─ scheduled poll worker (per connected mailbox) ─┐
+Graph mailbox ──▶│  /messages/delta  →  normalize  →  mark read    │──▶ inbound-email queue
+ (Inbox)         └──────────────────────────────────────────────────┘        │
+                                                                              ▼
+                                                          processInboundEmail()  (UNCHANGED)
+                                                          threading · dedup · org-route · create/append
+                                                                              │
+ticket.commented (public) ─▶ ticketNotifyWorker ─┬─ partner has M365 conn? ─▶ Graph createReply (FROM support@)
+                                                  └─ else ──────────────────▶ existing EmailService (platform)
+ticket.assigned / tech notes ────────────────────────────────────────────▶ existing EmailService (always)
+```
+
+### New units (each independently testable)
+
+| Unit | File (proposed) | Responsibility |
+|---|---|---|
+| Mailbox connection service | `services/ticketMailbox/connectionService.ts` | CRUD + consent state for `ticket_mailbox_connections`; verify via `testGraphAccess` + mailbox read probe |
+| Connect/callback routes | `routes/tickets/mailboxConnect.ts` | admin-consent initiation + callback (signed state + CSRF cookie) |
+| Graph mail client | `services/ticketMailbox/graphMailClient.ts` | thin Graph wrapper: delta list, get message + headers, mark-read, createReply, sendMail; token via reused `c2cM365` primitives; 429 `Retry-After` backoff |
+| Delta poll worker | `jobs/ticketMailboxPollWorker.ts` | per-mailbox delta sweep on schedule; normalize → enqueue; persist `delta_link`; mark read |
+| Graph normalizer | `services/ticketMailbox/normalizeGraphMessage.ts` | Graph message → existing `NormalizedInboundEmail` |
+| Graph outbound sender | `services/ticketMailbox/graphReplySender.ts` | invoked by ticketNotifyWorker for customer-facing email on M365-connected partners |
+
+## Data model & tenancy
+
+### New table `ticket_mailbox_connections` — partner-axis (Shape 3)
+
+| Column | Notes |
+|---|---|
+| `id` uuid pk | |
+| `partner_id` uuid not null | FK→partners; `breeze_has_partner_access(partner_id)` policy |
+| `tenant_id` text not null | Entra GUID (validated by `M365_TENANT_ID_REGEX`); **not a secret** |
+| `mailbox_address` text not null | shared support UPN, e.g. `support@msp.com` |
+| `display_name` text | |
+| `status` text/enum | `pending_consent` · `connected` · `error` · `reauth_required` · `disabled` |
+| `delta_link` text | opaque Graph delta cursor; nullable until first sweep |
+| `last_polled_at` timestamptz | observability |
+| `last_message_at` timestamptz | observability |
+| `last_error` text | last probe/poll failure |
+| `strict_sender_auth` boolean default false | quarantine non-DMARC-pass senders when true |
+| `created_by` uuid / `created_at` / `updated_at` | |
+
+- Unique `(partner_id, mailbox_address)`. Multiple mailboxes per partner allowed.
+- **No secret column.** Breeze's app secret lives in env; per-partner we store only the non-sensitive tenant GUID.
+- App-only tokens are short-lived and **cached in-memory** keyed by `tenant_id` (re-acquired on 5-min buffer via `acquireClientCredentialsToken`). No token persisted; no refresh rotation (client-credentials has no refresh token). `delta_link` is the only durable cursor.
+
+### RLS / tenancy contract (per CLAUDE.md)
+
+- Migration creates table **and** policies together; idempotent (`IF NOT EXISTS` / `pg_policies` checks); `FOR ALL TO breeze_app` + system-scope-bypass form copied from the canonical partner-axis policy (`2026-06-09-a` style).
+- Add to `PARTNER_TENANT_TABLES` **and** `ORG_AXIS_EXCLUDED` (no `org_id`) in `rls-coverage.integration.test.ts`, **same PR**.
+- Background-path writes/reads run under `runOutsideDbContext(() => withSystemDbAccessContext(...))` — partner-axis reads need system context; bare-pool write = silent 0-row.
+- `ticket_email_inbound.provider` gains `'m365'`; dedup rides the existing `(partner_id, provider_message_id)` unique index.
+
+## Inbound flow (delta poll → ticket)
+
+**Scheduling.** BullMQ repeatable job (`jobId: ticket-mailbox-poll-sweep`, colon-free) every ~60–90s; fans out one job per `status='connected'` mailbox. Per-mailbox advisory lock prevents overlapping double-processing.
+
+**Per-mailbox sweep:**
+1. Acquire app-only token (cached). `GET /users/{mailbox}/mailFolders/inbox/messages/delta` — no cursor on first run, else stored `delta_link`. `$select=id,internetMessageId,subject,from,toRecipients,ccRecipients,receivedDateTime,conversationId,body,bodyPreview,hasAttachments,internetMessageHeaders`. Page through `@odata.nextLink`.
+2. Each new message → `normalizeGraphMessage()` → `NormalizedInboundEmail`:
+   - `provider='m365'`, `providerMessageId = message.id`, `resolvedPartnerId` set (we polled this partner's mailbox).
+   - Threading keys from `internetMessageHeaders`: `Message-Id` → `internetMessageId`; `In-Reply-To` / `References` parsed from headers, feeding existing `findTicketInPartner`. `conversationId` retained as secondary match hint and for outbound `createReply`.
+   - Sender auth (R4 anti-spoof gate): parse `Authentication-Results` for `dmarc=pass`. If absent/≠pass, fall back to "delivered to Inbox (not Junk) by Exchange" as the trust signal; `strict_sender_auth=true` quarantines non-DMARC-pass senders. Verdict recorded in `ticket_email_inbound`.
+3. Enqueue to `inbound-email` → `processInboundEmail()` unchanged (match/create/append, autoresponse, loop-prevention, customer→org routing).
+4. After successful enqueue, **mark read** (`PATCH …/messages/{id} {isRead:true}`). Mark-read failure logged, non-fatal.
+5. Persist new `delta_link` **only after** the page is fully enqueued (at-least-once; crash mid-page replays; dedup index absorbs duplicates).
+
+**Seam addition:** `NormalizedInboundEmail` gains an optional `resolvedPartnerId`; when present, `processInboundEmail` skips `resolvePartnerByRecipient`. Single optional field; Mailgun path untouched.
+
+**Outbound targeting:** store the Graph message id on the ticket thread (via the `ticket_email_inbound` row / `emailMessageId`) so outbound `createReply` can target the original message.
+
+## Outbound flow (Graph reply from support@)
+
+In `ticketNotifyWorker`, customer-facing branches (`ticket.commented` public, resolved `status_changed`, autoresponse) check: does this ticket's partner have a `connected` M365 mailbox the ticket arrived through?
+- **Yes** → `graphReplySender`:
+  - Existing email thread → `POST /users/{mailbox}/messages/{originalGraphMessageId}/createReply`, PATCH body with comment content, then `POST …/send`. Graph maintains `conversationId` + `References` natively; lands in the customer's existing thread, `From: support@msp.com`. (Graph rejects setting `In-Reply-To`/`References` via `internetMessageHeaders` — only `x-`-prefixed custom headers — so `createReply` is the correct threading primitive, not `sendMail`.)
+  - No original message id (in-app ticket, first outbound) → `POST /users/{mailbox}/sendMail` with subject token `[T-YYYY-NNNN]` for fallback matching.
+- **No** → existing `EmailService` (platform `{slug}@tickets.<domain>`), exactly as today.
+
+**Tech/assignee notifications always stay on `EmailService`.**
+
+**Loop safety:** sent replies go to Sent Items; we poll Inbox only → no self-ingest. Existing two-layer loop-prevention + one-time autoresponder still apply.
+
+## Setup / consent UX
+
+"Connect Microsoft 365 mailbox" card in partner ticketing settings (admin + MFA-gated, mirroring the accounting card):
+1. Admin enters support mailbox address → **Connect** → `GET …/mailbox/connect` builds admin-consent URL (`buildAdminConsentUrl`, signed-state JWT + CSRF cookie), redirects browser. Row created `status='pending_consent'`.
+2. Callback (`GET …/mailbox/callback`, **unauthenticated at middleware** — Microsoft redirects the browser with no Bearer; authenticated via signed state + cookie; written under system context) captures `?tenant=` GUID, persists it.
+3. Breeze probes: acquire token + `GET /users/{mailbox}/messages?$top=1`. Success → `connected`; failure (commonly Application Access Policy not yet scoped) → `error` with remediation hint.
+4. **Documented admin step:** MSP admin runs `New-ApplicationAccessPolicy` (Exchange Online PowerShell) to scope Breeze's app to *only* the support mailbox (least privilege — `Mail.ReadWrite`/`Mail.Send` are tenant-wide otherwise). Card shows the exact snippet with their mailbox + Breeze's app id. **Re-test** button re-runs the probe.
+
+Disconnect → `status='disabled'`, stops polling, drops cached token (admin separately revokes consent in Entra — show the link).
+
+## Error handling & edge cases
+
+- **Token failure / consent revoked** → 401 → `status='reauth_required'`, polling paused, partner notified in-app (mirrors accounting reauth).
+- **`delta_link` expired (410 Gone)** → resync: restart delta from now (`$deltatoken=latest`), warn. No history backfill (avoids ancient mail flooding into tickets).
+- **Failure-row durability** → audit/quarantine writes use a **fresh** `runOutsideDbContext(() => withSystemDbAccessContext(insert))`, never the poisoned worker txn; `getConfig()` reads on the worker path are defensive.
+- **Attachments** → Phase 1 parity with the Mailgun path only; Graph attachment fetch flagged as a follow-up if needed.
+- **Graph throttling (429)** → honor `Retry-After`, exponential backoff in `graphMailClient`; per-mailbox sweeps independent so one throttled tenant doesn't stall others.
+- **Mailbox deleted / address changed** → probe 404 → `status='error'`, polling paused, surfaced on the card.
+
+## Testing
+
+- **Unit:** `normalizeGraphMessage` (header parsing, threading keys, DMARC verdict, missing-header fallbacks); `graphReplySender` createReply-vs-sendMail decision; token-cache freshness. Graph HTTP mocked.
+- **Worker:** delta paging + cursor persistence + at-least-once replay hitting the dedup index; mark-read failure non-fatal; advisory-lock no-double-process. System-actor reopen via direct partner-scoped UPDATE (Phase 4 gotcha #3), real driver.
+- **RLS (real-DB integration):** `ticket_mailbox_connections` forge — cross-partner insert/select fail as `breeze_app` (non-vacuous; `.env.test` symlinked so `breeze_app` is `rolbypassrls=f`). Allowlist entry; `rls-coverage` green.
+- **Route:** connect builds signed state + CSRF cookie; callback rejects bad state/cookie; callback has **no** `authMiddleware`; MFA gate on connect/disconnect.
+- **Integration (5433 test DB):** normalized-message → `processInboundEmail` → ticket created/threaded, reusing existing harness.
+- **`no-silent-mutations`** count bumped for any new web mutation handler.
+
+## Scope / phasing
+
+**In scope (Phase 1):** per-partner connect/consent, delta-poll inbound with mark-read, Graph outbound customer replies, settings card + PowerShell guidance, full RLS/tests.
+
+**Explicitly deferred:** Microsoft Teams (own spec); BYO-app-registration variant; webhook (push) inbound as a latency optimization; attachment handling beyond Mailgun parity; per-org mailbox connections.
+
+## Open follow-ups (post-Phase-1)
+
+- Teams integration spec (notifications first, then chat→ticket).
+- Optional webhook inbound for sub-minute latency, with delta-query backstop.
+- Attachment ingestion via Graph `$value`.
+- Per-org mailbox connections (org-axis variant) if customers want to connect their own mailboxes.


### PR DESCRIPTION
## M365 Exchange shared-mailbox → email-to-ticket (inbound + outbound)

Lets an MSP partner connect a Microsoft 365 shared mailbox so customer email becomes tickets, and ticket replies are sent back from that mailbox. No MX or forwarding changes required. Built as four stacked plans via subagent-driven development (backend tasks delegated to codex `gpt-5.5 high`; auth/RLS/UI and all DB-dependent verification kept in-session).

### What's included
- **Connection foundation** — `ticket_mailbox_connections` table with **partner-axis RLS** (FORCE + 4 policies, registered in `PARTNER_TENANT_TABLES`); admin-consent OAuth (signed-state JWT + CSRF cookie, `redirect:'error'` to avoid bearer leak); connect / callback / list / retest / disconnect routes. Uses a **separate** `TICKET_MAILBOX_M365_*` Azure app (not the C2C app).
- **Inbound ingest** — Graph `/messages/delta` poll worker (delta cursor, 429 backoff) → normalize → existing inbound-email → ticket pipeline, via a pre-resolved `resolvedPartnerId` seam.
- **Outbound reply** — customer-facing replies sent from the connected mailbox (`createReply` → PATCH → send, threaded). Forked **only** on requester + autoresponse paths; internal/assignee/SLA notifications cannot egress through the mailbox.
- **Settings UI** — `M365MailboxCard` under **Partner settings → Ticketing → Inbound Email** (connect, status, re-test, disconnect, Application Access Policy PowerShell snippet). All mutations `runAction`-wrapped; enrolled in `no-silent-mutations`.

### Two CRITICAL issues caught & fixed in review during the build
- **RLS context (silent 0-row writes):** worker writes (`updateDeltaCursor` / `resetDeltaCursor` / `setConnectionStatus`) ran with no DB context → FORCE-RLS silently wrote 0 rows. Now wrapped in `runOutsideDbContext(() => withSystemDbAccessContext(...))`; regression test added.
- **Sender-auth spoofing:** `normalizeGraphMessage` trusted any `Authentication-Results` header. Now gated on `authserv-id` matching the mailbox domain, fail-closed.

### Verification
API 95/95 unit · 8/8 integration (forge / cursor-RLS / m365-inbound) · 45/45 RLS coverage · web 73/73 · `tsc` clean · `astro check` 0 errors.

### Setup required before this works in an environment
- Azure app with application permissions **`Mail.ReadWrite` + `Mail.Send`** (admin-consented); redirect URI `<PUBLIC_URL>/api/v1/tickets/mailbox/callback`.
- Env (all optional — absence does **not** block boot): `TICKET_MAILBOX_M365_CLIENT_ID`, `TICKET_MAILBOX_M365_CLIENT_SECRET` (API), `PUBLIC_TICKET_MAILBOX_APP_ID` (web).

### Note for reviewers
On first connect the delta cursor starts from current inbox state — pre-existing mail is **not** retroactively ticketed (chosen to avoid a ticket flood on connect). Flag if an initial-backfill option is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
