### PR TITLE
test(web): de-flake PamRuleModal preview zod-error test

### DIFF
--- a/apps/web/src/components/pam/PamRuleModal.test.tsx
+++ b/apps/web/src/components/pam/PamRuleModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PamRuleModal from './PamRuleModal';
@@ -313,7 +313,21 @@ describe('PamRuleModal', () => {
         expect(screen.getByTestId('pam-rule-hash')).toBeInTheDocument();
       });
 
-      await user.type(screen.getByTestId('pam-rule-signer'), 'Acme Corp');
+      // Set the signer atomically rather than typing it char-by-char. The modal
+      // fires cascading mount fetches (orgs → sites → signer-groups) whose
+      // resolutions re-render mid-interaction; with incremental user.type() a
+      // re-render lands between keystrokes and drops characters, so the criterion
+      // ends up empty and buildCriteria() short-circuits to "At least one match
+      // criterion is required." instead of issuing the preview. A single
+      // fireEvent.change commits the whole value in one synchronous update,
+      // immune to that race. This flaked on unrelated branches (e.g. an aws-sdk
+      // dependency bump) where the only failing test was this one.
+      fireEvent.change(screen.getByTestId('pam-rule-signer'), {
+        target: { value: 'Acme Corp' },
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId('pam-rule-signer')).toHaveValue('Acme Corp'),
+      );
       await user.click(screen.getByTestId('pam-rule-preview-btn'));
 
       await waitFor(() => {


### PR DESCRIPTION
## Problem

`PamRuleModal.test.tsx > rule preview > "surfaces the server zod error message on a 400 preview response"` is a **transient CI flake**. The same single-test failure appeared on two completely unrelated branches:

- `dependabot/npm_and_yarn/aws-sdk/client-s3` — this test was the **only** CI failure across the whole run (1 failed file, 314 passed), reddening an otherwise-clean dependency bump.
- `ToddHebebrand/Catalog-an-Quotes` — failed once, passed on the next push.

## Root cause

The CI assertion gives it away: `expected 'At least one match criterion is required.' to contain 'matchHash must be a 64-char sha256 hex string'`.

The test set the signer criterion with char-by-char `userEvent.type`. The modal fires cascading mount fetches (`orgs → sites → signer-groups`); their resolutions re-render the form **mid-typing** and drop keystrokes (locally reproducible: the input froze at `"Acme C"` / `"Acme"`). With the criterion left empty, `buildCriteria()` short-circuits to the "criterion required" error and never issues the preview request — so the zod-message assertion fails. Whether the race lands depends on timing, hence the flake.

## Fix

Set the signer value atomically with `fireEvent.change` (a single synchronous state update, immune to mid-type re-renders) and assert the value committed before clicking preview. Test-only change.

## Verification

Full-file run **12/12 green** locally (was deterministically failing after adding a value-commit barrier exposed the dropped keystrokes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)