### PR TITLE
Import QuickBooks customers as Orgs + Sites

### DIFF
--- a/apps/api/migrations/2026-06-29-org-accounting-external-id.sql
+++ b/apps/api/migrations/2026-06-29-org-accounting-external-id.sql
@@ -1,0 +1,13 @@
+-- Link Breeze organizations back to the external accounting customer they were
+-- imported from, so re-imports are idempotent. Generic (provider, external_id)
+-- so Xero can reuse it later. Partial unique index enforces "skip dupes" even
+-- under concurrent imports. Does not change the org RLS tenancy shape.
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS accounting_provider text;
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS accounting_external_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_accounting_external_uniq
+  ON organizations (partner_id, accounting_provider, accounting_external_id)
+  WHERE accounting_external_id IS NOT NULL;

--- a/apps/api/src/db/schema/orgs.ts
+++ b/apps/api/src/db/schema/orgs.ts
@@ -1,4 +1,5 @@
 import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, integer, boolean, numeric, char, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
 export const partnerTypeEnum = pgEnum('partner_type', ['msp', 'enterprise', 'internal']);
 export const partnerStatusEnum = pgEnum('partner_status', ['pending', 'active', 'suspended', 'churned']);
@@ -86,11 +87,16 @@ export const organizations = pgTable('organizations', {
   billingAddressRegion: varchar('billing_address_region', { length: 120 }),
   billingAddressPostalCode: varchar('billing_address_postal_code', { length: 40 }),
   billingAddressCountry: char('billing_address_country', { length: 2 }),
+  accountingProvider: text('accounting_provider'),
+  accountingExternalId: text('accounting_external_id'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   deletedAt: timestamp('deleted_at')
 }, (table) => ({
-  orgPartnerUnique: uniqueIndex('organizations_id_partner_id_unique').on(table.id, table.partnerId)
+  orgPartnerUnique: uniqueIndex('organizations_id_partner_id_unique').on(table.id, table.partnerId),
+  accountingExternalUnique: uniqueIndex('organizations_accounting_external_uniq')
+    .on(table.partnerId, table.accountingProvider, table.accountingExternalId)
+    .where(sql`accounting_external_id IS NOT NULL`),
 }));
 
 export const sites = pgTable('sites', {

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -13,6 +13,11 @@ describe('isSelfManagedDbContextRoute', () => {
     ['post', '/api/v1/invoices/abc-123/pay-link'], // method is case-insensitive
     ['POST', '/api/v1/portal/invoices/def-456/pay'],
     ['POST', '/api/v1/portal/invoices/def-456/pay/'],
+    // QuickBooks customer import — both page the QBO API inside the handler.
+    ['GET', '/api/v1/accounting/quickbooks/customers'],
+    ['GET', '/api/v1/accounting/quickbooks/customers/'],
+    ['POST', '/api/v1/accounting/quickbooks/customers/import'],
+    ['POST', '/api/v1/accounting/quickbooks/customers/import/'],
   ];
 
   const NO_MATCH: ReadonlyArray<[string, string, string]> = [
@@ -25,6 +30,10 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/invoices//pay-link', 'empty id segment must not match'],
     ['POST', '/api/v1/portal/invoices/def-456/pay/confirm', 'deeper portal path must not match'],
     ['POST', '/api/v1/invoices', 'collection route'],
+    ['GET', '/api/v1/accounting/quickbooks', 'accounting status route does only DB work — keep ambient tx'],
+    ['POST', '/api/v1/accounting/quickbooks/customers', 'POST to the list route (only GET + /customers/import opt out)'],
+    ['GET', '/api/v1/accounting/quickbooks/customers/import', 'import is POST-only'],
+    ['POST', '/api/v1/accounting/quickbooks/customers/import/extra', 'extra segment must not match'],
   ];
 
   it.each(MATCH)('opts out: %s %s', (method, path) => {

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -32,6 +32,12 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   { method: 'POST', pattern: /^\/api\/v1\/invoices\/[^/]+\/pay-link\/?$/ },
   // Customer-portal "Pay invoice online".
   { method: 'POST', pattern: /^\/api\/v1\/portal\/invoices\/[^/]+\/pay\/?$/ },
+  // QuickBooks customer import — both routes page the QBO query API (a
+  // multi-second, up-to-1000-per-page outbound call) inside the handler; the
+  // import service manages its own short withSystemDbAccessContext blocks
+  // around each DB op, so we must NOT pin a request transaction across the call.
+  { method: 'GET', pattern: /^\/api\/v1\/accounting\/[^/]+\/customers\/?$/ },
+  { method: 'POST', pattern: /^\/api\/v1\/accounting\/[^/]+\/customers\/import\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/accounting/customers.test.ts
+++ b/apps/api/src/routes/accounting/customers.test.ts
@@ -55,6 +55,26 @@ describe('GET /accounting/:provider/customers', () => {
     expect(res.status).toBe(404);
     expect(await res.json()).toMatchObject({ code: 'not_connected' });
   });
+
+  it('maps QbImportError(reauth_required) to 409', async () => {
+    listAnnotatedMock.mockRejectedValue(new QbImportError('reconnect', 'reauth_required', 409));
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: 'reauth_required' });
+  });
+
+  it('maps QbImportError(quickbooks_error) to 502', async () => {
+    listAnnotatedMock.mockRejectedValue(new QbImportError('upstream', 'quickbooks_error', 502));
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({ code: 'quickbooks_error' });
+  });
+
+  it('denies a partner-scoped caller targeting a different partnerId (403)', async () => {
+    const res = await app().request('/accounting/quickbooks/customers?partnerId=99999999-9999-4999-8999-999999999999');
+    expect(res.status).toBe(403);
+    expect(listAnnotatedMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /accounting/:provider/customers/import', () => {

--- a/apps/api/src/routes/accounting/customers.test.ts
+++ b/apps/api/src/routes/accounting/customers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { listAnnotatedMock, importMock, QbImportError } = vi.hoisted(() => {
+  const listAnnotatedMock = vi.fn();
+  const importMock = vi.fn();
+  class QbImportError extends Error { code: string; status: number; constructor(m: string, c: string, s: number) { super(m); this.code = c; this.status = s; } }
+  return { listAnnotatedMock, importMock, QbImportError };
+});
+vi.mock('../../services/accounting/quickbooksCustomerImport', () => ({
+  listQuickbooksCustomersAnnotated: listAnnotatedMock,
+  importQuickbooksCustomers: importMock,
+  QbImportError,
+}));
+
+// Auth middleware stubs: inject a partner-scoped auth context.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => { c.set('auth', { scope: 'partner', partnerId: 'p1', user: { id: 'u1' } }); await next(); },
+  requireScope: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+vi.mock('../../config/env', () => ({
+  QBO_CLIENT_ID: 'client-id',
+  QBO_CLIENT_SECRET: 'client-secret',
+  QBO_REDIRECT_URI: 'https://api.example.test/accounting/quickbooks/callback',
+  QBO_ENVIRONMENT: 'production',
+}));
+
+import { accountingRoutes } from './index';
+
+function app() {
+  const a = new Hono();
+  a.route('/accounting', accountingRoutes);
+  return a;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GET /accounting/:provider/customers', () => {
+  it('returns annotated customers', async () => {
+    listAnnotatedMock.mockResolvedValue([{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }]);
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] });
+    expect(listAnnotatedMock).toHaveBeenCalledWith('p1');
+  });
+
+  it('maps QbImportError(not_connected) to 404', async () => {
+    listAnnotatedMock.mockRejectedValue(new QbImportError('nope', 'not_connected', 404));
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: 'not_connected' });
+  });
+});
+
+describe('POST /accounting/:provider/customers/import', () => {
+  it('imports selected customers and returns the summary', async () => {
+    importMock.mockResolvedValue({
+      imported: [{ customerId: '1', displayName: 'Acme', organizationId: 'org-1', siteId: 'site-1' }],
+      skipped: [], errors: [],
+    });
+    const res = await app().request('/accounting/quickbooks/customers/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerIds: ['1'] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.imported).toHaveLength(1);
+    expect(importMock).toHaveBeenCalledWith({ partnerId: 'p1', customerIds: ['1'] });
+  });
+
+  it('rejects an empty customerIds array with 400', async () => {
+    const res = await app().request('/accounting/quickbooks/customers/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerIds: [] }),
+    });
+    expect(res.status).toBe(400);
+    expect(importMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/accounting/customers.test.ts
+++ b/apps/api/src/routes/accounting/customers.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { listAnnotatedMock, importMock, QbImportError } = vi.hoisted(() => {
+const { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError } = vi.hoisted(() => {
   const listAnnotatedMock = vi.fn();
   const importMock = vi.fn();
+  const writeRouteAuditMock = vi.fn();
   class QbImportError extends Error { code: string; status: number; constructor(m: string, c: string, s: number) { super(m); this.code = c; this.status = s; } }
-  return { listAnnotatedMock, importMock, QbImportError };
+  return { listAnnotatedMock, importMock, writeRouteAuditMock, QbImportError };
 });
 vi.mock('../../services/accounting/quickbooksCustomerImport', () => ({
   listQuickbooksCustomersAnnotated: listAnnotatedMock,
@@ -20,7 +21,7 @@ vi.mock('../../middleware/auth', () => ({
   requireMfa: () => async (_c: any, next: any) => next(),
 }));
 
-vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: writeRouteAuditMock }));
 
 vi.mock('../../config/env', () => ({
   QBO_CLIENT_ID: 'client-id',
@@ -71,6 +72,11 @@ describe('POST /accounting/:provider/customers/import', () => {
     const body = await res.json();
     expect(body.data.imported).toHaveLength(1);
     expect(importMock).toHaveBeenCalledWith({ partnerId: 'p1', customerIds: ['1'] });
+    // Each created org is audited — guards against the audit loop being dropped.
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'organization.create', resourceId: 'org-1' }),
+    );
   });
 
   it('rejects an empty customerIds array with 400', async () => {

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -13,6 +13,12 @@ import {
   getConnection,
   upsertConnection,
 } from '../../services/accounting/accountingConnectionService';
+import {
+  importQuickbooksCustomers,
+  listQuickbooksCustomersAnnotated,
+  QbImportError,
+} from '../../services/accounting/quickbooksCustomerImport';
+import { writeRouteAudit } from '../../services/auditEvents';
 import { getAccountingProvider } from '../../services/accounting/providerRegistry';
 import { captureException } from '../../services/sentry';
 import type { AccountingProviderId } from '../../services/accounting/types';
@@ -34,6 +40,14 @@ const settingsSchema = z.object({
 }).refine((value) => Object.keys(value).length > 0, {
   message: 'At least one setting is required',
 });
+const importCustomersSchema = z.object({
+  customerIds: z.array(z.string().min(1)).min(1).max(500),
+});
+
+function handleImportError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
+  if (err instanceof QbImportError) return c.json({ error: err.message, code: err.code }, err.status as 400 | 404);
+  throw err;
+}
 
 // CSRF binding cookie: the OAuth callback must complete in the SAME browser
 // that initiated /connect. Without it, an attacker who captures a victim into
@@ -242,6 +256,52 @@ accountingRoutes.get('/:provider', authMiddleware, partnerScopes, zValidator('pa
     defaultIncomeAccountRef: connection.defaultIncomeAccountRef,
     defaultTaxCodeRef: connection.defaultTaxCodeRef,
   });
+});
+
+// List remote QuickBooks customers, annotated with whether each is already
+// imported. Read-only but partner-privileged, so partner/system scope.
+accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+  const { provider } = c.req.valid('param');
+  const configError = validateProviderConfig(provider);
+  if (configError) return c.json({ error: configError }, 400);
+  const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  try {
+    const data = await listQuickbooksCustomersAnnotated(partner.partnerId);
+    return c.json({ data });
+  } catch (err) {
+    return handleImportError(c, err);
+  }
+});
+
+// Import selected QuickBooks customers as orgs + sites. Write + MFA-gated.
+accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', importCustomersSchema), async (c) => {
+  const { provider } = c.req.valid('param');
+  const configError = validateProviderConfig(provider);
+  if (configError) return c.json({ error: configError }, 400);
+  const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+
+  let summary;
+  try {
+    summary = await importQuickbooksCustomers({ partnerId: partner.partnerId, customerIds: c.req.valid('json').customerIds });
+  } catch (err) {
+    return handleImportError(c, err);
+  }
+
+  // Audit each created org + site (the import itself ran in system context).
+  for (const item of summary.imported) {
+    writeRouteAudit(c, {
+      orgId: item.organizationId,
+      action: 'organization.create',
+      resourceType: 'organization',
+      resourceId: item.organizationId,
+      resourceName: item.displayName,
+      details: { source: 'quickbooks_import', quickbooksCustomerId: item.customerId, siteId: item.siteId },
+    });
+  }
+
+  return c.json({ data: summary });
 });
 
 accountingRoutes.patch('/:provider/settings', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', settingsSchema), async (c) => {

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -45,7 +45,8 @@ const importCustomersSchema = z.object({
 });
 
 function handleImportError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
-  if (err instanceof QbImportError) return c.json({ error: err.message, code: err.code }, err.status as 400 | 404);
+  // QbImportError.status is a narrowed literal union (400|404|409|502), so no cast.
+  if (err instanceof QbImportError) return c.json({ error: err.message, code: err.code }, err.status);
   throw err;
 }
 
@@ -289,7 +290,8 @@ accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScop
     return handleImportError(c, err);
   }
 
-  // Audit each created org + site (the import itself ran in system context).
+  // Audit each created org (the site id is recorded in details). The import
+  // ran in system context, so the actor-bearing audit is written here.
   for (const item of summary.imported) {
     writeRouteAudit(c, {
       orgId: item.organizationId,

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the db module: provide db (select/insert), and pass-through context helpers.
+const {
+  selectMock,
+  insertMock,
+  getConnectionMock,
+  getValidAccessTokenMock,
+  listRemoteCustomersMock,
+} = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+  getConnectionMock: vi.fn(),
+  getValidAccessTokenMock: vi.fn(),
+  listRemoteCustomersMock: vi.fn(),
+}));
+vi.mock('../../db', () => ({
+  db: { select: selectMock, insert: insertMock },
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('./accountingConnectionService', () => ({
+  getConnection: getConnectionMock,
+}));
+
+vi.mock('./accountingTokens', () => ({
+  getValidAccessToken: getValidAccessTokenMock,
+}));
+
+vi.mock('./providerRegistry', () => ({
+  getAccountingProvider: () => ({ listRemoteCustomers: listRemoteCustomersMock }),
+}));
+
+import {
+  slugify, generateUniqueSlug, importQuickbooksCustomers,
+  listQuickbooksCustomersAnnotated, QbImportError,
+} from './quickbooksCustomerImport';
+
+function connectedConn() {
+  return { id: 'c1', partnerId: 'p1', provider: 'quickbooks', realmId: 'r1', accessToken: 'tok', environment: 'sandbox', status: 'connected' };
+}
+
+// Helper to stub `db.select(...).from(...).where(...)` returning `rows`.
+function stubSelect(rows: unknown[]) {
+  selectMock.mockReturnValue({ from: () => ({ where: () => Promise.resolve(rows) }) });
+}
+
+// Captures the object passed to each `db.insert(...).values(OBJ)` call, in order,
+// without any production-code instrumentation.
+const valuesSpy = vi.fn();
+function stubInserts(rowsInOrder: unknown[][]) {
+  let call = 0;
+  insertMock.mockImplementation(() => ({
+    values: (v: unknown) => { valuesSpy(v); return { returning: () => Promise.resolve(rowsInOrder[call++] ?? []) }; },
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  valuesSpy.mockClear();
+  getConnectionMock.mockResolvedValue(connectedConn());
+  getValidAccessTokenMock.mockResolvedValue('fresh-token');
+});
+
+describe('slugify', () => {
+  it('lowercases, strips punctuation, hyphenates spaces', () => {
+    expect(slugify('Acme Co., Inc.')).toBe('acme-co-inc');
+    expect(slugify('  Multiple   Spaces  ')).toBe('multiple-spaces');
+  });
+  it('falls back to "org" for empty/punctuation-only input', () => {
+    expect(slugify('!!!')).toBe('org');
+    expect(slugify('')).toBe('org');
+  });
+});
+
+describe('generateUniqueSlug', () => {
+  it('returns the base when free', () => {
+    expect(generateUniqueSlug('acme', new Set())).toBe('acme');
+  });
+  it('appends an incrementing suffix on collision', () => {
+    expect(generateUniqueSlug('acme', new Set(['acme', 'acme-2']))).toBe('acme-3');
+  });
+});
+
+describe('listQuickbooksCustomersAnnotated', () => {
+  it('annotates already-imported customers from existing org external ids', async () => {
+    listRemoteCustomersMock.mockResolvedValue([
+      { id: '1', displayName: 'A' }, { id: '2', displayName: 'B' },
+    ]);
+    stubSelect([{ id: 'org-1', accountingExternalId: '1' }]);
+
+    const result = await listQuickbooksCustomersAnnotated('p1');
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: '1', alreadyImported: true, organizationId: 'org-1' }),
+      expect.objectContaining({ id: '2', alreadyImported: false, organizationId: null }),
+    ]);
+    expect(getValidAccessTokenMock).toHaveBeenCalled();
+  });
+
+  it('throws QbImportError(not_connected) when no connection exists', async () => {
+    getConnectionMock.mockResolvedValue(null);
+    await expect(listQuickbooksCustomersAnnotated('p1')).rejects.toMatchObject({ code: 'not_connected', status: 404 });
+  });
+});
+
+describe('importQuickbooksCustomers', () => {
+  it('creates an org + site for a new customer, mapping billing + shipping data', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{
+      id: '1', displayName: 'Acme Co', email: 'ap@acme.test', phone: '555', contactName: 'Jane Doe',
+      billAddr: { line1: '1 Bill St', city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' },
+      shipAddr: { line1: '2 Ship Rd', city: 'Dallas' },
+    }]);
+    stubSelect([]); // no existing orgs
+    stubInserts([[{ id: 'org-1', name: 'Acme Co', partnerId: 'p1' }], [{ id: 'site-1', orgId: 'org-1', name: 'Acme Co' }]]);
+
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+
+    expect(summary.imported).toEqual([{ customerId: '1', displayName: 'Acme Co', organizationId: 'org-1', siteId: 'site-1' }]);
+    expect(summary.skipped).toEqual([]);
+    expect(summary.errors).toEqual([]);
+
+    // Org insert (first values() call) got billing address + accounting link.
+    const orgInsertArg = valuesSpy.mock.calls[0]![0];
+    expect(orgInsertArg).toMatchObject({
+      partnerId: 'p1', name: 'Acme Co', slug: 'acme-co',
+      accountingProvider: 'quickbooks', accountingExternalId: '1',
+      billingContact: { name: 'Jane Doe', email: 'ap@acme.test', phone: '555' },
+      billingAddressLine1: '1 Bill St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    // Site insert (second values() call) used shipping address.
+    const siteInsertArg = valuesSpy.mock.calls[1]![0];
+    expect(siteInsertArg).toMatchObject({
+      orgId: 'org-1', name: 'Acme Co',
+      address: { addressLine1: '2 Ship Rd', city: 'Dallas' },
+      contact: { name: 'Jane Doe', email: 'ap@acme.test', phone: '555' },
+    });
+  });
+
+  it('falls back to billing address for the site when shipping is absent', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { line1: '1 Bill St', city: 'Austin' } }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(valuesSpy.mock.calls[1]![0]).toMatchObject({ address: { addressLine1: '1 Bill St', city: 'Austin' } });
+  });
+
+  it('skips customers already linked to an org', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([{ id: 'org-9', accountingExternalId: '1' }]);
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(summary.imported).toEqual([]);
+    expect(summary.skipped).toEqual([{ customerId: '1', displayName: 'Acme', organizationId: 'org-9', reason: 'already_imported' }]);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('suffixes the slug when the base collides with an existing org slug', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([{ id: 'org-x', accountingExternalId: '99', slug: 'acme' }]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(valuesSpy.mock.calls[0]![0]).toMatchObject({ slug: 'acme-2' });
+  });
+
+  it('records a per-customer error and continues with the rest (partial success)', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Bad' }, { id: '2', displayName: 'Good' }]);
+    stubSelect([]);
+    let call = 0;
+    insertMock.mockImplementation(() => ({
+      values: (v: any) => ({
+        returning: () => {
+          call++;
+          if (call === 1) return Promise.reject(new Error('boom')); // org insert for customer 1
+          return Promise.resolve([{ id: `row-${call}` }]);
+        },
+      }),
+    }));
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', '2'] });
+    expect(summary.errors).toEqual([{ customerId: '1', displayName: 'Bad', error: 'boom' }]);
+    expect(summary.imported).toHaveLength(1);
+    expect(summary.imported[0]!.customerId).toBe('2');
+  });
+
+  it('reports requested ids not present in QuickBooks as errors', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', 'missing'] });
+    expect(summary.errors).toContainEqual({ customerId: 'missing', error: 'Customer not found in QuickBooks' });
+    expect(summary.imported).toHaveLength(1);
+  });
+});

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
@@ -147,6 +147,25 @@ describe('importQuickbooksCustomers', () => {
     expect(valuesSpy.mock.calls[1]![0]).toMatchObject({ address: { addressLine1: '1 Bill St', city: 'Austin' } });
   });
 
+  it('nulls billingAddressCountry when QB Country is not a 2-char code (char(2) guard)', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { country: 'United States' } }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    // Org column is char(2): the long country must NOT be written (would throw + drop the customer).
+    expect(valuesSpy.mock.calls[0]![0].billingAddressCountry).toBeNull();
+    // …but the full country is preserved on the site address JSONB (no length cap).
+    expect(valuesSpy.mock.calls[1]![0].address).toMatchObject({ country: 'United States' });
+  });
+
+  it('uppercases a genuine 2-char country code into billingAddressCountry', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { country: 'us' } }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(valuesSpy.mock.calls[0]![0].billingAddressCountry).toBe('US');
+  });
+
   it('skips customers already linked to an org', async () => {
     listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
     stubSelect([{ id: 'org-9', accountingExternalId: '1' }]);

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
@@ -7,13 +7,20 @@ const {
   getConnectionMock,
   getValidAccessTokenMock,
   listRemoteCustomersMock,
-} = vi.hoisted(() => ({
-  selectMock: vi.fn(),
-  insertMock: vi.fn(),
-  getConnectionMock: vi.fn(),
-  getValidAccessTokenMock: vi.fn(),
-  listRemoteCustomersMock: vi.fn(),
-}));
+  ReauthRequiredError,
+} = vi.hoisted(() => {
+  class ReauthRequiredError extends Error {
+    constructor(message = 'reauth') { super(message); this.name = 'ReauthRequiredError'; }
+  }
+  return {
+    selectMock: vi.fn(),
+    insertMock: vi.fn(),
+    getConnectionMock: vi.fn(),
+    getValidAccessTokenMock: vi.fn(),
+    listRemoteCustomersMock: vi.fn(),
+    ReauthRequiredError,
+  };
+});
 vi.mock('../../db', () => ({
   db: { select: selectMock, insert: insertMock },
   runOutsideDbContext: (fn: () => unknown) => fn(),
@@ -26,11 +33,14 @@ vi.mock('./accountingConnectionService', () => ({
 
 vi.mock('./accountingTokens', () => ({
   getValidAccessToken: getValidAccessTokenMock,
+  ReauthRequiredError,
 }));
 
 vi.mock('./providerRegistry', () => ({
   getAccountingProvider: () => ({ listRemoteCustomers: listRemoteCustomersMock }),
 }));
+
+vi.mock('../sentry', () => ({ captureException: vi.fn() }));
 
 import {
   slugify, generateUniqueSlug, importQuickbooksCustomers,
@@ -209,5 +219,75 @@ describe('importQuickbooksCustomers', () => {
     const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', 'missing'] });
     expect(summary.errors).toContainEqual({ customerId: 'missing', error: 'Customer not found in QuickBooks' });
     expect(summary.imported).toHaveLength(1);
+  });
+
+  it('passes the freshly-resolved access token (not the stale conn token) to listRemoteCustomers', async () => {
+    getValidAccessTokenMock.mockResolvedValue('fresh-token');
+    listRemoteCustomersMock.mockResolvedValue([]);
+    stubSelect([]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: [] });
+    expect(listRemoteCustomersMock).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'fresh-token' }));
+  });
+
+  it('reserves slugs within the batch so two same-named new customers do not collide', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }, { id: '2', displayName: 'Acme' }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'o1' }], [{ id: 's1' }], [{ id: 'o2' }], [{ id: 's2' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', '2'] });
+    expect(valuesSpy.mock.calls[0]![0].slug).toBe('acme');   // first org
+    expect(valuesSpy.mock.calls[2]![0].slug).toBe('acme-2'); // second org (third values() call)
+  });
+
+  it('clamps over-long name + city to the column widths (lossless: full value stays in site JSONB)', async () => {
+    const longName = 'N'.repeat(300);
+    const longCity = 'C'.repeat(200);
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: longName, billAddr: { city: longCity } }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(valuesSpy.mock.calls[0]![0].name).toHaveLength(255);
+    expect(valuesSpy.mock.calls[0]![0].billingAddressCity).toHaveLength(120);
+  });
+
+  it('maps QB address region -> site address state key', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { region: 'TX', city: 'Austin' } }]);
+    stubSelect([]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(valuesSpy.mock.calls[1]![0].address).toMatchObject({ state: 'TX', city: 'Austin' });
+  });
+
+  it('reclassifies a concurrent unique-violation as skipped (honors the partial unique index)', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    // 1st select = loadExistingOrgs (none); 2nd select = catch re-query (winner org).
+    selectMock
+      .mockImplementationOnce(() => ({ from: () => ({ where: () => Promise.resolve([]) }) }))
+      .mockImplementationOnce(() => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'org-dup' }]) }) }) }));
+    const dupErr = Object.assign(new Error('dup'), { code: '23505' });
+    insertMock.mockImplementation(() => ({ values: () => ({ returning: () => Promise.reject(dupErr) }) }));
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(summary.errors).toEqual([]);
+    expect(summary.skipped).toEqual([{ customerId: '1', displayName: 'Acme', organizationId: 'org-dup', reason: 'already_imported' }]);
+  });
+});
+
+describe('importQuickbooksCustomers — connection/QBO error mapping', () => {
+  it('throws QbImportError(reauth_required, 409) when the connection needs reauth', async () => {
+    getConnectionMock.mockResolvedValue({ ...connectedConn(), status: 'reauth_required' });
+    await expect(importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] }))
+      .rejects.toMatchObject({ code: 'reauth_required', status: 409 });
+  });
+
+  it('maps a ReauthRequiredError from getValidAccessToken to QbImportError(409)', async () => {
+    getValidAccessTokenMock.mockRejectedValue(new ReauthRequiredError());
+    await expect(importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] }))
+      .rejects.toMatchObject({ code: 'reauth_required', status: 409 });
+  });
+
+  it('maps a QBO API failure to QbImportError(quickbooks_error, 502)', async () => {
+    getValidAccessTokenMock.mockResolvedValue('tok');
+    listRemoteCustomersMock.mockRejectedValue(new Error('QuickBooks customer query failed with 429'));
+    await expect(importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] }))
+      .rejects.toMatchObject({ code: 'quickbooks_error', status: 502 });
   });
 });

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.ts
@@ -2,21 +2,44 @@ import { and, eq } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { organizations, sites } from '../../db/schema';
 import { getConnection } from './accountingConnectionService';
-import { getValidAccessToken } from './accountingTokens';
+import { getValidAccessToken, ReauthRequiredError } from './accountingTokens';
 import { getAccountingProvider } from './providerRegistry';
+import { captureException } from '../sentry';
 import type { RemoteAddress, RemoteCustomer } from './types';
 
 const PROVIDER = 'quickbooks' as const;
 
+export type QbImportErrorCode = 'not_connected' | 'reauth_required' | 'quickbooks_error';
+type QbImportErrorStatus = 400 | 404 | 409 | 502;
+
+// Typed failures the route translates straight to an HTTP status. Narrowing
+// `code`/`status` to literals lets the route drop its `as`-cast and makes the
+// contract enforced rather than asserted.
 export class QbImportError extends Error {
-  code: string;
-  status: number;
-  constructor(message: string, code: string, status: number) {
+  constructor(
+    message: string,
+    readonly code: QbImportErrorCode,
+    readonly status: QbImportErrorStatus,
+  ) {
     super(message);
     this.name = 'QbImportError';
-    this.code = code;
-    this.status = status;
   }
+}
+
+// QBO source values can exceed Breeze's billing-address column widths (DisplayName
+// up to 500, City/lines up to 255, etc.). Writing an over-long value throws and
+// rolls back the whole org+site insert, dropping an otherwise-valid customer. Clamp
+// to the column width — the untruncated value is still preserved in the site
+// `address` JSONB (no length cap), so this is lossless overall. See orgs.ts widths.
+function clamp(value: string | undefined | null, max: number): string | null {
+  if (value == null) return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+// Postgres unique_violation — a concurrent import linked this customer after our
+// dedup snapshot. The partial unique index is the backstop; treat it as a skip.
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
 }
 
 export interface AnnotatedCustomer extends RemoteCustomer {
@@ -49,26 +72,51 @@ export function generateUniqueSlug(base: string, taken: Set<string>): string {
 }
 
 // Resolve the partner's QB connection + a fresh access token, then fetch all
-// customers from QuickBooks. These run in SYSTEM context (the connection +
-// token-rotation write are partner-axis, not org-scoped) and must be wrapped in
-// runOutsideDbContext: this service is called from an authenticated route whose
-// handler already runs inside withDbAccessContext, so entering a system context
-// without first exiting the request context poisons the pooled connection's
-// txn (see CLAUDE.md "withSystemDbAccessContext — call runOutsideDbContext first
-// if inside a request").
+// customers from QuickBooks. These DB ops run in SYSTEM context (the connection
+// + token-rotation write are partner-axis, not org-scoped). Both routes that
+// reach here opt out of the auth middleware's auto request-transaction (see
+// SELF_MANAGED_DB_CONTEXT_ROUTES), so the handler runs with NO ambient DB
+// context — the runOutsideDbContext wrapper is therefore a defensive no-op that
+// keeps this correct if ever called from inside a request, and
+// withSystemDbAccessContext supplies the system RLS context each short op needs.
 async function fetchCustomers(partnerId: string): Promise<RemoteCustomer[]> {
   const conn = await runOutsideDbContext(() => withSystemDbAccessContext(() => getConnection(db, partnerId, PROVIDER)));
-  if (!conn || conn.status !== 'connected') {
+  if (!conn) {
     throw new QbImportError('QuickBooks is not connected for this partner', 'not_connected', 404);
   }
-  const accessToken = await runOutsideDbContext(() => withSystemDbAccessContext(() => getValidAccessToken(db, conn)));
-  const customers = await getAccountingProvider(PROVIDER).listRemoteCustomers({ ...conn, accessToken });
-  return customers;
+  // A previously-connected partner whose token was revoked/expired is NOT the
+  // same as never-connected: the remediation is "reconnect", not "connect".
+  if (conn.status === 'reauth_required') {
+    throw new QbImportError('QuickBooks needs to be reconnected', 'reauth_required', 409);
+  }
+  if (conn.status !== 'connected') {
+    throw new QbImportError('QuickBooks is not connected for this partner', 'not_connected', 404);
+  }
+  // getValidAccessToken can flip a live-looking connection to reauth_required and
+  // throw when the refresh token is dead — surface that as a typed 409 the web can
+  // turn into a "Reconnect QuickBooks" CTA, instead of an opaque 500.
+  let accessToken: string;
+  try {
+    accessToken = await runOutsideDbContext(() => withSystemDbAccessContext(() => getValidAccessToken(db, conn)));
+  } catch (err) {
+    if (err instanceof ReauthRequiredError) {
+      throw new QbImportError('QuickBooks needs to be reconnected', 'reauth_required', 409);
+    }
+    throw err;
+  }
+  try {
+    return await getAccountingProvider(PROVIDER).listRemoteCustomers({ ...conn, accessToken });
+  } catch (err) {
+    // QBO API failures (401/403/429/5xx, unparseable body) are upstream, not a
+    // Breeze bug — map to a typed 502 so the route doesn't 500 + Sentry-spam.
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    throw new QbImportError('QuickBooks returned an error while listing customers', 'quickbooks_error', 502);
+  }
 }
 
 // Map external id -> { organizationId, slug } for every org already linked to
-// this partner's QB realm. Used for dedup + slug-uniqueness. Same system-context
-// + runOutsideDbContext rule as fetchCustomers (called from inside a request).
+// this partner's QB realm. Used for dedup + slug-uniqueness. Same self-managed
+// system-context rule as fetchCustomers (the routes opt out of the request tx).
 async function loadExistingOrgs(partnerId: string): Promise<{ byExternalId: Map<string, string>; slugs: Set<string> }> {
   const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
     db.select({ id: organizations.id, accountingExternalId: organizations.accountingExternalId, slug: organizations.slug })
@@ -145,20 +193,20 @@ export async function importQuickbooksCustomers(
         withSystemDbAccessContext(async () => {
           const [org] = await db.insert(organizations).values({
             partnerId,
-            name: customer.displayName,
+            // name is NOT NULL; clamp() can only shorten a present string here.
+            name: clamp(customer.displayName, 255)!,
             slug,
             type: 'customer' as const,
             billingContact: contact,
-            billingAddressLine1: customer.billAddr?.line1 ?? null,
-            billingAddressLine2: customer.billAddr?.line2 ?? null,
-            billingAddressCity: customer.billAddr?.city ?? null,
-            billingAddressRegion: customer.billAddr?.region ?? null,
-            billingAddressPostalCode: customer.billAddr?.postalCode ?? null,
+            billingAddressLine1: clamp(customer.billAddr?.line1, 255),
+            billingAddressLine2: clamp(customer.billAddr?.line2, 255),
+            billingAddressCity: clamp(customer.billAddr?.city, 120),
+            billingAddressRegion: clamp(customer.billAddr?.region, 120),
+            billingAddressPostalCode: clamp(customer.billAddr?.postalCode, 40),
             // billing_address_country is char(2). QBO's BillAddr.Country is
-            // free-form ("United States", "USA", …); writing a >2-char value
-            // would throw and silently drop the whole customer. Only persist a
-            // genuine 2-letter code here — the full country is still preserved
-            // in the site address JSONB (siteAddressFrom) which has no length cap.
+            // free-form ("United States", "USA", …); only persist a genuine
+            // 2-letter code — the full country still survives in the site
+            // address JSONB (siteAddressFrom) which has no length cap.
             billingAddressCountry: customer.billAddr?.country?.length === 2
               ? customer.billAddr.country.toUpperCase()
               : null,
@@ -167,7 +215,7 @@ export async function importQuickbooksCustomers(
           }).returning();
           const [site] = await db.insert(sites).values({
             orgId: org!.id,
-            name: customer.displayName,
+            name: clamp(customer.displayName, 255)!,
             address: siteAddressFrom(customer.shipAddr ?? customer.billAddr),
             contact,
           }).returning();
@@ -178,6 +226,28 @@ export async function importQuickbooksCustomers(
       byExternalId.set(customerId, orgId);
       summary.imported.push({ customerId, displayName: customer.displayName, organizationId: orgId, siteId });
     } catch (err) {
+      // A concurrent import already linked this customer (partial unique index)
+      // — honor the documented "skip dupes" contract instead of reporting a raw
+      // constraint error. Re-read the winning org id under system context.
+      if (isUniqueViolation(err)) {
+        const existing = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+          db.select({ id: organizations.id }).from(organizations).where(and(
+            eq(organizations.partnerId, partnerId),
+            eq(organizations.accountingProvider, PROVIDER),
+            eq(organizations.accountingExternalId, customerId),
+          )).limit(1)
+        )) as Array<{ id: string }>;
+        if (existing[0]) {
+          byExternalId.set(customerId, existing[0].id);
+          summary.skipped.push({ customerId, displayName: customer.displayName, organizationId: existing[0].id, reason: 'already_imported' });
+          continue;
+        }
+      }
+      // Log + Sentry before collecting: the only other trace is a string in the
+      // response body, and a broad catch can also surface a systemic failure
+      // (e.g. DB outage) as a per-customer error — keep it observable.
+      console.error('[qb-import] failed to import customer', { partnerId, customerId, error: err instanceof Error ? err.message : String(err) });
+      captureException(err instanceof Error ? err : new Error(String(err)));
       summary.errors.push({ customerId, displayName: customer.displayName, error: err instanceof Error ? err.message : String(err) });
     }
   }

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.ts
@@ -154,7 +154,14 @@ export async function importQuickbooksCustomers(
             billingAddressCity: customer.billAddr?.city ?? null,
             billingAddressRegion: customer.billAddr?.region ?? null,
             billingAddressPostalCode: customer.billAddr?.postalCode ?? null,
-            billingAddressCountry: customer.billAddr?.country ?? null,
+            // billing_address_country is char(2). QBO's BillAddr.Country is
+            // free-form ("United States", "USA", …); writing a >2-char value
+            // would throw and silently drop the whole customer. Only persist a
+            // genuine 2-letter code here — the full country is still preserved
+            // in the site address JSONB (siteAddressFrom) which has no length cap.
+            billingAddressCountry: customer.billAddr?.country?.length === 2
+              ? customer.billAddr.country.toUpperCase()
+              : null,
             accountingProvider: PROVIDER,
             accountingExternalId: customerId,
           }).returning();

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.ts
@@ -1,0 +1,172 @@
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { organizations, sites } from '../../db/schema';
+import { getConnection } from './accountingConnectionService';
+import { getValidAccessToken } from './accountingTokens';
+import { getAccountingProvider } from './providerRegistry';
+import type { RemoteAddress, RemoteCustomer } from './types';
+
+const PROVIDER = 'quickbooks' as const;
+
+export class QbImportError extends Error {
+  code: string;
+  status: number;
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = 'QbImportError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface AnnotatedCustomer extends RemoteCustomer {
+  alreadyImported: boolean;
+  organizationId: string | null;
+}
+
+export interface QbImportSummary {
+  imported: Array<{ customerId: string; displayName: string; organizationId: string; siteId: string }>;
+  skipped: Array<{ customerId: string; displayName: string; organizationId: string; reason: 'already_imported' }>;
+  errors: Array<{ customerId: string; displayName?: string; error: string }>;
+}
+
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 90);
+  return slug || 'org';
+}
+
+export function generateUniqueSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+// Resolve the partner's QB connection + a fresh access token, then fetch all
+// customers from QuickBooks. Token resolution runs in system context so the
+// refresh-token rotation write succeeds (request context has no auth here).
+async function fetchCustomers(partnerId: string): Promise<RemoteCustomer[]> {
+  const conn = await withSystemDbAccessContext(() => getConnection(db, partnerId, PROVIDER));
+  if (!conn || conn.status === 'disconnected') {
+    throw new QbImportError('QuickBooks is not connected for this partner', 'not_connected', 404);
+  }
+  const accessToken = await withSystemDbAccessContext(() => getValidAccessToken(db, conn));
+  const customers = await getAccountingProvider(PROVIDER).listRemoteCustomers({ ...conn, accessToken });
+  return customers;
+}
+
+// Map external id -> { organizationId, slug } for every org already linked to
+// this partner's QB realm. Used for dedup + slug-uniqueness.
+async function loadExistingOrgs(partnerId: string): Promise<{ byExternalId: Map<string, string>; slugs: Set<string> }> {
+  const rows = await withSystemDbAccessContext(() =>
+    db.select({ id: organizations.id, accountingExternalId: organizations.accountingExternalId, slug: organizations.slug })
+      .from(organizations)
+      .where(and(eq(organizations.partnerId, partnerId), eq(organizations.accountingProvider, PROVIDER)))
+  ) as Array<{ id: string; accountingExternalId: string | null; slug: string | null }>;
+
+  const byExternalId = new Map<string, string>();
+  const slugs = new Set<string>();
+  for (const row of rows) {
+    if (row.accountingExternalId) byExternalId.set(row.accountingExternalId, row.id);
+    if (row.slug) slugs.add(row.slug);
+  }
+  return { byExternalId, slugs };
+}
+
+export async function listQuickbooksCustomersAnnotated(partnerId: string): Promise<AnnotatedCustomer[]> {
+  const customers = await fetchCustomers(partnerId);
+  const { byExternalId } = await loadExistingOrgs(partnerId);
+  return customers.map((c) => ({
+    ...c,
+    alreadyImported: byExternalId.has(c.id),
+    organizationId: byExternalId.get(c.id) ?? null,
+  }));
+}
+
+function siteAddressFrom(addr: RemoteAddress | undefined): Record<string, string> | undefined {
+  if (!addr) return undefined;
+  // Match the web SiteForm convention so imported sites render correctly.
+  const out: Record<string, string> = {};
+  if (addr.line1) out.addressLine1 = addr.line1;
+  if (addr.line2) out.addressLine2 = addr.line2;
+  if (addr.city) out.city = addr.city;
+  if (addr.region) out.state = addr.region;
+  if (addr.postalCode) out.postalCode = addr.postalCode;
+  if (addr.country) out.country = addr.country;
+  return Object.keys(out).length ? out : undefined;
+}
+
+export async function importQuickbooksCustomers(
+  input: { partnerId: string; customerIds: string[] }
+): Promise<QbImportSummary> {
+  const { partnerId, customerIds } = input;
+  const customers = await fetchCustomers(partnerId);
+  const byId = new Map(customers.map((c) => [c.id, c]));
+  const { byExternalId, slugs } = await loadExistingOrgs(partnerId);
+
+  const summary: QbImportSummary = { imported: [], skipped: [], errors: [] };
+
+  for (const customerId of customerIds) {
+    const customer = byId.get(customerId);
+    if (!customer) {
+      summary.errors.push({ customerId, error: 'Customer not found in QuickBooks' });
+      continue;
+    }
+
+    const existingOrgId = byExternalId.get(customerId);
+    if (existingOrgId) {
+      summary.skipped.push({ customerId, displayName: customer.displayName, organizationId: existingOrgId, reason: 'already_imported' });
+      continue;
+    }
+
+    try {
+      const slug = generateUniqueSlug(slugify(customer.displayName), slugs);
+      slugs.add(slug); // reserve within this batch
+
+      const contact = {
+        name: customer.contactName,
+        email: customer.email,
+        phone: customer.phone,
+      };
+
+      const { orgId, siteId } = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          const [org] = await db.insert(organizations).values({
+            partnerId,
+            name: customer.displayName,
+            slug,
+            type: 'customer' as const,
+            billingContact: contact,
+            billingAddressLine1: customer.billAddr?.line1 ?? null,
+            billingAddressLine2: customer.billAddr?.line2 ?? null,
+            billingAddressCity: customer.billAddr?.city ?? null,
+            billingAddressRegion: customer.billAddr?.region ?? null,
+            billingAddressPostalCode: customer.billAddr?.postalCode ?? null,
+            billingAddressCountry: customer.billAddr?.country ?? null,
+            accountingProvider: PROVIDER,
+            accountingExternalId: customerId,
+          }).returning();
+          const [site] = await db.insert(sites).values({
+            orgId: org!.id,
+            name: customer.displayName,
+            address: siteAddressFrom(customer.shipAddr ?? customer.billAddr),
+            contact,
+          }).returning();
+          return { orgId: org!.id as string, siteId: site!.id as string };
+        })
+      );
+
+      byExternalId.set(customerId, orgId);
+      summary.imported.push({ customerId, displayName: customer.displayName, organizationId: orgId, siteId });
+    } catch (err) {
+      summary.errors.push({ customerId, displayName: customer.displayName, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return summary;
+}

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.ts
@@ -35,7 +35,8 @@ export function slugify(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, 90);
+    .slice(0, 90)
+    .replace(/-+$/, ''); // re-trim: the 90-char slice can leave a dangling hyphen
   return slug || 'org';
 }
 
@@ -48,26 +49,32 @@ export function generateUniqueSlug(base: string, taken: Set<string>): string {
 }
 
 // Resolve the partner's QB connection + a fresh access token, then fetch all
-// customers from QuickBooks. Token resolution runs in system context so the
-// refresh-token rotation write succeeds (request context has no auth here).
+// customers from QuickBooks. These run in SYSTEM context (the connection +
+// token-rotation write are partner-axis, not org-scoped) and must be wrapped in
+// runOutsideDbContext: this service is called from an authenticated route whose
+// handler already runs inside withDbAccessContext, so entering a system context
+// without first exiting the request context poisons the pooled connection's
+// txn (see CLAUDE.md "withSystemDbAccessContext — call runOutsideDbContext first
+// if inside a request").
 async function fetchCustomers(partnerId: string): Promise<RemoteCustomer[]> {
-  const conn = await withSystemDbAccessContext(() => getConnection(db, partnerId, PROVIDER));
-  if (!conn || conn.status === 'disconnected') {
+  const conn = await runOutsideDbContext(() => withSystemDbAccessContext(() => getConnection(db, partnerId, PROVIDER)));
+  if (!conn || conn.status !== 'connected') {
     throw new QbImportError('QuickBooks is not connected for this partner', 'not_connected', 404);
   }
-  const accessToken = await withSystemDbAccessContext(() => getValidAccessToken(db, conn));
+  const accessToken = await runOutsideDbContext(() => withSystemDbAccessContext(() => getValidAccessToken(db, conn)));
   const customers = await getAccountingProvider(PROVIDER).listRemoteCustomers({ ...conn, accessToken });
   return customers;
 }
 
 // Map external id -> { organizationId, slug } for every org already linked to
-// this partner's QB realm. Used for dedup + slug-uniqueness.
+// this partner's QB realm. Used for dedup + slug-uniqueness. Same system-context
+// + runOutsideDbContext rule as fetchCustomers (called from inside a request).
 async function loadExistingOrgs(partnerId: string): Promise<{ byExternalId: Map<string, string>; slugs: Set<string> }> {
-  const rows = await withSystemDbAccessContext(() =>
+  const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
     db.select({ id: organizations.id, accountingExternalId: organizations.accountingExternalId, slug: organizations.slug })
       .from(organizations)
       .where(and(eq(organizations.partnerId, partnerId), eq(organizations.accountingProvider, PROVIDER)))
-  ) as Array<{ id: string; accountingExternalId: string | null; slug: string | null }>;
+  )) as Array<{ id: string; accountingExternalId: string | null; slug: string | null }>;
 
   const byExternalId = new Map<string, string>();
   const slugs = new Set<string>();

--- a/apps/api/src/services/accounting/quickbooksProvider.test.ts
+++ b/apps/api/src/services/accounting/quickbooksProvider.test.ts
@@ -1,17 +1,110 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createHmac } from 'crypto';
+import { quickbooksProvider, mapQboCustomer, mapQboAddress } from './quickbooksProvider';
+import type { AccountingConnection } from './accountingConnectionService';
 
-vi.mock('../../db', () => ({
-  runOutsideDbContext: <T>(fn: () => T) => fn(),
-}));
+function conn(overrides: Partial<AccountingConnection> = {}): AccountingConnection {
+  return {
+    id: 'c1', partnerId: 'p1', provider: 'quickbooks',
+    realmId: 'realm123', accessToken: 'tok', refreshToken: 'r',
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    refreshTokenExpiresAt: new Date(Date.now() + 86_400_000),
+    environment: 'sandbox', homeCurrency: 'USD',
+    defaultIncomeAccountRef: null, defaultTaxCodeRef: null,
+    pushMode: 'auto', status: 'connected',
+    createdAt: null, updatedAt: null, lastError: null,
+    ...overrides,
+  };
+}
 
-describe('QuickbooksProvider', () => {
-  beforeEach(() => {
-    vi.unstubAllGlobals();
+afterEach(() => vi.restoreAllMocks());
+
+describe('mapQboAddress', () => {
+  it('maps QBO address fields, including CountrySubDivisionCode -> region', () => {
+    expect(mapQboAddress({
+      Line1: '123 Main', Line2: 'Suite 4', City: 'Austin',
+      CountrySubDivisionCode: 'TX', PostalCode: '78701', Country: 'US',
+    })).toEqual({
+      line1: '123 Main', line2: 'Suite 4', city: 'Austin',
+      region: 'TX', postalCode: '78701', country: 'US',
+    });
   });
 
-  it('buildAuthUrl embeds state, scope, redirect_uri', async () => {
-    const { quickbooksProvider } = await import('./quickbooksProvider');
+  it('returns undefined when the address is empty/missing', () => {
+    expect(mapQboAddress(undefined)).toBeUndefined();
+    expect(mapQboAddress({})).toBeUndefined();
+  });
+});
+
+describe('mapQboCustomer', () => {
+  it('maps display name, company, email, phone, contact name, addresses, active', () => {
+    const c = mapQboCustomer({
+      Id: '42', DisplayName: 'Acme Co', CompanyName: 'Acme Inc',
+      PrimaryEmailAddr: { Address: 'ap@acme.test' },
+      PrimaryPhone: { FreeFormNumber: '555-1212' },
+      GivenName: 'Jane', FamilyName: 'Doe', Active: true,
+      BillAddr: { Line1: '1 Bill St', City: 'Austin' },
+      ShipAddr: { Line1: '2 Ship Rd', City: 'Dallas' },
+    });
+    expect(c).toMatchObject({
+      id: '42', displayName: 'Acme Co', companyName: 'Acme Inc',
+      email: 'ap@acme.test', phone: '555-1212', contactName: 'Jane Doe',
+      active: true,
+      billAddr: { line1: '1 Bill St', city: 'Austin' },
+      shipAddr: { line1: '2 Ship Rd', city: 'Dallas' },
+    });
+  });
+
+  it('falls back to CompanyName when DisplayName is missing, and tolerates missing optionals', () => {
+    const c = mapQboCustomer({ Id: '7', CompanyName: 'Solo LLC' });
+    expect(c.id).toBe('7');
+    expect(c.displayName).toBe('Solo LLC');
+    expect(c.email).toBeUndefined();
+    expect(c.billAddr).toBeUndefined();
+  });
+});
+
+describe('listRemoteCustomers', () => {
+  it('pages through the QBO query API until a short page is returned', async () => {
+    const page1 = { QueryResponse: { Customer: Array.from({ length: 1000 }, (_, i) => ({ Id: String(i), DisplayName: `C${i}` })) } };
+    const page2 = { QueryResponse: { Customer: [{ Id: '1000', DisplayName: 'last' }] } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify(page1), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(page2), { status: 200 }));
+
+    const result = await quickbooksProvider.listRemoteCustomers(conn());
+
+    expect(result).toHaveLength(1001);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstUrl = String(fetchMock.mock.calls[0]![0]);
+    expect(firstUrl).toContain('sandbox-quickbooks.api.intuit.com');
+    expect(firstUrl).toContain('STARTPOSITION%201'); // url-encoded space
+    const secondUrl = String(fetchMock.mock.calls[1]![0]);
+    expect(secondUrl).toContain('STARTPOSITION%201001');
+  });
+
+  it('uses the production base URL when environment is production', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ QueryResponse: {} }), { status: 200 }));
+    await quickbooksProvider.listRemoteCustomers(conn({ environment: 'production' }));
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('https://quickbooks.api.intuit.com');
+  });
+
+  it('throws when the QBO API returns a non-2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('nope', { status: 401 }));
+    await expect(quickbooksProvider.listRemoteCustomers(conn())).rejects.toThrow(/QuickBooks customer query failed/);
+  });
+
+  it('throws when the connection has no realmId or access token', async () => {
+    await expect(quickbooksProvider.listRemoteCustomers(conn({ realmId: null }))).rejects.toThrow(/realm/i);
+    await expect(quickbooksProvider.listRemoteCustomers(conn({ accessToken: null }))).rejects.toThrow(/access token/i);
+  });
+});
+
+// Pre-existing OAuth + webhook coverage from QuickBooks Phase A (#1849), retained
+// here (adapted to the spyOn + restoreAllMocks style) so this task does not delete it.
+describe('QuickbooksProvider OAuth + webhook', () => {
+  it('buildAuthUrl embeds state, scope, redirect_uri', () => {
     const url = quickbooksProvider.buildAuthUrl('state-abc');
     expect(url).toContain('com.intuit.quickbooks.accounting');
     expect(url).toContain('state=state-abc');
@@ -20,14 +113,13 @@ describe('QuickbooksProvider', () => {
   });
 
   it('refresh returns the ROTATED refresh token, not the input', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({
       access_token: 'new-at',
       refresh_token: 'ROTATED-rt',
       expires_in: 3600,
       x_refresh_token_expires_in: 8640000,
-    }), { status: 200 })));
+    }), { status: 200 }));
 
-    const { quickbooksProvider } = await import('./quickbooksProvider');
     const tokens = await quickbooksProvider.refresh('old-rt');
     expect(tokens.refreshToken).toBe('ROTATED-rt');
     expect(tokens.accessToken).toBe('new-at');
@@ -35,24 +127,21 @@ describe('QuickbooksProvider', () => {
   });
 
   it('exchangeCode posts grant_type=authorization_code and parses expiry', async () => {
-    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(JSON.stringify({
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({
       access_token: 'at',
       refresh_token: 'rt',
       expires_in: 3600,
       x_refresh_token_expires_in: 8640000,
     }), { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
 
-    const { quickbooksProvider } = await import('./quickbooksProvider');
     const tokens = await quickbooksProvider.exchangeCode('the-code', 'realm-9');
     expect(tokens.realmId).toBe('realm-9');
-    const body = String(fetchMock.mock.calls[0]?.[1]?.body ?? '');
+    const body = String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body ?? '');
     expect(body).toContain('grant_type=authorization_code');
     expect(body).toContain('code=the-code');
   });
 
-  it('verifies webhook signatures with HMAC-SHA256', async () => {
-    const { quickbooksProvider } = await import('./quickbooksProvider');
+  it('verifies webhook signatures with HMAC-SHA256', () => {
     const body = '{"eventNotifications":[]}';
     const signature = createHmac('sha256', 'verifier-token').update(body).digest('base64');
     expect(quickbooksProvider.verifyWebhook(signature, body, 'verifier-token')).toBe(true);

--- a/apps/api/src/services/accounting/quickbooksProvider.ts
+++ b/apps/api/src/services/accounting/quickbooksProvider.ts
@@ -102,7 +102,7 @@ export class QuickbooksProvider implements AccountingProvider {
 
   // NOTE: assumes `conn.accessToken` is already a VALID token. Callers must
   // resolve it via getValidAccessToken(db, conn) first (which refreshes +
-  // persists rotation) — this method stays pure HTTP with no db dependency.
+  // persists rotation) — this method stays pure HTTP and issues no DB queries.
   async listRemoteCustomers(conn: AccountingConnection): Promise<RemoteCustomer[]> {
     if (!conn.realmId) throw new Error('QuickBooks connection is missing a realmId');
     if (!conn.accessToken) throw new Error('QuickBooks connection is missing an access token');

--- a/apps/api/src/services/accounting/quickbooksProvider.ts
+++ b/apps/api/src/services/accounting/quickbooksProvider.ts
@@ -5,6 +5,8 @@ import type {
   AccountingProvider,
   ChangeSet,
   ConnectionTokens,
+  RemoteAddress,
+  RemoteCustomer,
   RemoteEntity,
   RemoteRef,
 } from './types';
@@ -13,6 +15,60 @@ import type { AccountingConnection } from './accountingConnectionService';
 const QBO_AUTH_URL = 'https://appcenter.intuit.com/connect/oauth2';
 const QBO_TOKEN_URL = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer';
 const QBO_SCOPE = 'com.intuit.quickbooks.accounting';
+const QBO_API_MINOR_VERSION = '70';
+const QBO_CUSTOMER_PAGE_SIZE = 1000; // QBO hard cap per query page
+
+function qboApiBase(environment: 'sandbox' | 'production'): string {
+  return environment === 'production'
+    ? 'https://quickbooks.api.intuit.com'
+    : 'https://sandbox-quickbooks.api.intuit.com';
+}
+
+interface QboRawAddress {
+  Line1?: string; Line2?: string; City?: string;
+  CountrySubDivisionCode?: string; PostalCode?: string; Country?: string;
+}
+
+interface QboRawCustomer {
+  Id: string;
+  DisplayName?: string;
+  CompanyName?: string;
+  PrimaryEmailAddr?: { Address?: string };
+  PrimaryPhone?: { FreeFormNumber?: string };
+  GivenName?: string;
+  FamilyName?: string;
+  Active?: boolean;
+  BillAddr?: QboRawAddress;
+  ShipAddr?: QboRawAddress;
+}
+
+export function mapQboAddress(raw: QboRawAddress | undefined): RemoteAddress | undefined {
+  if (!raw) return undefined;
+  const addr: RemoteAddress = {
+    line1: raw.Line1 || undefined,
+    line2: raw.Line2 || undefined,
+    city: raw.City || undefined,
+    region: raw.CountrySubDivisionCode || undefined,
+    postalCode: raw.PostalCode || undefined,
+    country: raw.Country || undefined,
+  };
+  return Object.values(addr).some((v) => v !== undefined) ? addr : undefined;
+}
+
+export function mapQboCustomer(raw: QboRawCustomer): RemoteCustomer {
+  const contactName = [raw.GivenName, raw.FamilyName].filter(Boolean).join(' ').trim();
+  return {
+    id: raw.Id,
+    displayName: raw.DisplayName || raw.CompanyName || raw.Id,
+    companyName: raw.CompanyName || undefined,
+    email: raw.PrimaryEmailAddr?.Address || undefined,
+    phone: raw.PrimaryPhone?.FreeFormNumber || undefined,
+    contactName: contactName || undefined,
+    active: raw.Active,
+    billAddr: mapQboAddress(raw.BillAddr),
+    shipAddr: mapQboAddress(raw.ShipAddr),
+  };
+}
 
 interface QboTokenResponse {
   access_token?: string;
@@ -44,8 +100,47 @@ export class QuickbooksProvider implements AccountingProvider {
     return this.requestTokens('refresh_token', { refreshToken, realmId: '' });
   }
 
-  async listRemoteCustomers(_conn: AccountingConnection, _query?: string): Promise<RemoteEntity[]> {
-    throw new Error('NotImplemented: Phase B');
+  // NOTE: assumes `conn.accessToken` is already a VALID token. Callers must
+  // resolve it via getValidAccessToken(db, conn) first (which refreshes +
+  // persists rotation) — this method stays pure HTTP with no db dependency.
+  async listRemoteCustomers(conn: AccountingConnection): Promise<RemoteCustomer[]> {
+    if (!conn.realmId) throw new Error('QuickBooks connection is missing a realmId');
+    if (!conn.accessToken) throw new Error('QuickBooks connection is missing an access token');
+
+    const base = qboApiBase(conn.environment);
+    const customers: RemoteCustomer[] = [];
+    let startPosition = 1;
+
+    // Page until a short page (< page size) signals the end.
+    for (;;) {
+      const query = `SELECT * FROM Customer STARTPOSITION ${startPosition} MAXRESULTS ${QBO_CUSTOMER_PAGE_SIZE}`;
+      const url = `${base}/v3/company/${conn.realmId}/query?query=${encodeURIComponent(query)}&minorversion=${QBO_API_MINOR_VERSION}`;
+      const response = await runOutsideDbContext(() =>
+        fetch(url, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${conn.accessToken}`,
+            Accept: 'application/json',
+          },
+        })
+      );
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        const err = new Error(`QuickBooks customer query failed with ${response.status}`);
+        (err as Error & { status?: number; body?: string }).status = response.status;
+        (err as Error & { status?: number; body?: string }).body = body.slice(0, 500);
+        throw err;
+      }
+
+      const parsed = await response.json() as { QueryResponse?: { Customer?: QboRawCustomer[] } };
+      const page = parsed.QueryResponse?.Customer ?? [];
+      for (const raw of page) customers.push(mapQboCustomer(raw));
+      if (page.length < QBO_CUSTOMER_PAGE_SIZE) break;
+      startPosition += QBO_CUSTOMER_PAGE_SIZE;
+    }
+
+    return customers;
   }
 
   async listRemoteItems(_conn: AccountingConnection, _query?: string): Promise<RemoteEntity[]> {

--- a/apps/api/src/services/accounting/types.ts
+++ b/apps/api/src/services/accounting/types.ts
@@ -16,6 +16,24 @@ export interface RemoteEntity {
   email?: string;
 }
 
+export interface RemoteAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+export interface RemoteCustomer extends RemoteEntity {
+  companyName?: string;
+  phone?: string;
+  contactName?: string;
+  billAddr?: RemoteAddress;
+  shipAddr?: RemoteAddress;
+  active?: boolean;
+}
+
 export interface RemoteRef {
   id: string;
   syncToken?: string;
@@ -38,7 +56,7 @@ export interface AccountingProvider {
   buildAuthUrl(state: string): string;
   exchangeCode(code: string, realmId: string): Promise<ConnectionTokens>;
   refresh(refreshToken: string): Promise<ConnectionTokens>;
-  listRemoteCustomers(conn: AccountingConnection, query?: string): Promise<RemoteEntity[]>;
+  listRemoteCustomers(conn: AccountingConnection, query?: string): Promise<RemoteCustomer[]>;
   listRemoteItems(conn: AccountingConnection, query?: string): Promise<RemoteEntity[]>;
   upsertCustomer(...args: unknown[]): Promise<RemoteRef>;
   upsertItem(...args: unknown[]): Promise<RemoteRef>;

--- a/apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuickbooksCustomerImport from './QuickbooksCustomerImport';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
+
+// runAction surfaces success/error toasts via showToast from ../shared/Toast.
+const showToastMock = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (...a: unknown[]) => showToastMock(...a) }));
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('QuickbooksCustomerImport', () => {
+  it('loads customers and disables already-imported rows', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ data: [
+      { id: '1', displayName: 'Acme', email: 'a@acme.test', alreadyImported: false, organizationId: null },
+      { id: '2', displayName: 'Imported Inc', alreadyImported: true, organizationId: 'org-2' },
+    ] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-row-1')).toBeInTheDocument());
+    expect(screen.getByTestId('quickbooks-import-select-1')).not.toBeDisabled();
+    expect(screen.getByTestId('quickbooks-import-select-2')).toBeDisabled();
+  });
+
+  it('imports selected customers and surfaces the summary via runAction', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] }))
+      .mockReturnValueOnce(jsonResponse({ data: { imported: [{ customerId: '1', organizationId: 'org-1', siteId: 's1' }], skipped: [], errors: [] } }))
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: true, organizationId: 'org-1' }] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-select-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-1'));
+    fireEvent.click(screen.getByTestId('quickbooks-import-submit'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+    // POST body carried the selected id.
+    const postCall = fetchWithAuthMock.mock.calls[1]!;
+    expect(postCall[0]).toBe('/accounting/quickbooks/customers/import');
+    expect(JSON.parse((postCall[1] as RequestInit).body as string)).toEqual({ customerIds: ['1'] });
+  });
+
+  it('shows an error toast when loading fails', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ error: 'not connected' }, 404));
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+  });
+});

--- a/apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx
@@ -58,4 +58,60 @@ describe('QuickbooksCustomerImport', () => {
     fireEvent.click(screen.getByTestId('quickbooks-import-load'));
     await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
   });
+
+  it('shows an ERROR toast and lists failures when every selected customer fails', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] }))
+      .mockReturnValueOnce(jsonResponse({ data: { imported: [], skipped: [], errors: [{ customerId: '1', displayName: 'Acme', error: 'boom' }] } }))
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-select-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-1'));
+    fireEvent.click(screen.getByTestId('quickbooks-import-submit'));
+
+    // A total failure must NOT be a green success toast.
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    // The failed customer + reason are surfaced, not just a count.
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-failure-1')).toHaveTextContent('boom'));
+  });
+
+  it('shows a WARNING toast on partial failure', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonResponse({ data: [
+        { id: '1', displayName: 'A', alreadyImported: false, organizationId: null },
+        { id: '2', displayName: 'B', alreadyImported: false, organizationId: null },
+      ] }))
+      .mockReturnValueOnce(jsonResponse({ data: { imported: [{ customerId: '1' }], skipped: [], errors: [{ customerId: '2', displayName: 'B', error: 'boom' }] } }))
+      .mockReturnValueOnce(jsonResponse({ data: [] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-select-all')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-all'));
+    fireEvent.click(screen.getByTestId('quickbooks-import-submit'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' })));
+  });
+
+  it('select-all toggles only importable rows, never the already-imported ones', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ data: [
+      { id: '1', displayName: 'Importable', alreadyImported: false, organizationId: null },
+      { id: '2', displayName: 'Done', alreadyImported: true, organizationId: 'org-2' },
+    ] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-select-all')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-all'));
+    expect(screen.getByTestId('quickbooks-import-select-1')).toBeChecked();
+    expect(screen.getByTestId('quickbooks-import-select-2')).not.toBeChecked();
+    expect(screen.getByTestId('quickbooks-import-select-2')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-all'));
+    expect(screen.getByTestId('quickbooks-import-select-1')).not.toBeChecked();
+  });
 });

--- a/apps/web/src/components/integrations/QuickbooksCustomerImport.tsx
+++ b/apps/web/src/components/integrations/QuickbooksCustomerImport.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction } from '../../lib/runAction';
+import { useBulkSelection } from '../billing/bulk/useBulkSelection';
+
+interface AnnotatedCustomer {
+  id: string;
+  displayName: string;
+  email?: string;
+  companyName?: string;
+  alreadyImported: boolean;
+  organizationId: string | null;
+}
+
+interface ImportSummary {
+  imported: unknown[];
+  skipped: unknown[];
+  errors: Array<{ customerId: string; error: string }>;
+}
+
+interface Props {
+  onUnauthorized?: () => void;
+}
+
+export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
+  const [customers, setCustomers] = useState<AnnotatedCustomer[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const selection = useBulkSelection();
+
+  const importable = (customers ?? []).filter((c) => !c.alreadyImported);
+
+  async function load() {
+    setLoading(true);
+    selection.clear();
+    try {
+      const data = await runAction<{ data: AnnotatedCustomer[] }>({
+        request: () => fetchWithAuth('/accounting/quickbooks/customers'),
+        errorFallback: 'Failed to load QuickBooks customers.',
+        onUnauthorized,
+      });
+      setCustomers(data.data);
+    } catch {
+      // runAction already toasted; leave the list as-is.
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function importSelected() {
+    const customerIds = Array.from(selection.selectedIds);
+    if (customerIds.length === 0) return;
+    setImporting(true);
+    try {
+      await runAction<{ data: ImportSummary }>({
+        request: () => fetchWithAuth('/accounting/quickbooks/customers/import', {
+          method: 'POST',
+          body: JSON.stringify({ customerIds }),
+        }),
+        errorFallback: 'Failed to import customers.',
+        successMessage: (res) => {
+          const s = res.data;
+          const parts = [`${s.imported.length} imported`];
+          if (s.skipped.length) parts.push(`${s.skipped.length} skipped`);
+          if (s.errors.length) parts.push(`${s.errors.length} failed`);
+          return parts.join(', ');
+        },
+        onUnauthorized,
+      });
+      await load(); // refresh so imported rows flip to "already imported"
+    } catch {
+      // already toasted
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function toggleSelectAll() {
+    if (importable.length > 0 && importable.every((c) => selection.has(c.id))) {
+      selection.clear();
+    } else {
+      selection.selectAll(importable.map((c) => c.id));
+    }
+  }
+
+  return (
+    <div data-testid="quickbooks-import-panel" className="mt-6 border-t border-gray-200 pt-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Import customers</h3>
+        <button
+          type="button"
+          data-testid="quickbooks-import-load"
+          onClick={load}
+          disabled={loading}
+          className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : customers ? 'Refresh' : 'Load customers'}
+        </button>
+      </div>
+
+      {customers && customers.length === 0 && (
+        <p className="mt-4 text-sm text-gray-500" data-testid="quickbooks-import-empty">No customers found in QuickBooks.</p>
+      )}
+
+      {customers && customers.length > 0 && (
+        <>
+          <table className="mt-4 w-full text-sm" data-testid="quickbooks-import-table">
+            <thead>
+              <tr className="text-left text-gray-500">
+                <th className="w-8">
+                  <input
+                    type="checkbox"
+                    data-testid="quickbooks-import-select-all"
+                    aria-label="Select all"
+                    checked={importable.length > 0 && importable.every((c) => selection.has(c.id))}
+                    onChange={toggleSelectAll}
+                  />
+                </th>
+                <th>Name</th>
+                <th>Email</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((c) => (
+                <tr key={c.id} data-testid={`quickbooks-import-row-${c.id}`} className="border-t border-gray-100">
+                  <td>
+                    <input
+                      type="checkbox"
+                      data-testid={`quickbooks-import-select-${c.id}`}
+                      checked={selection.has(c.id)}
+                      disabled={c.alreadyImported}
+                      onChange={() => selection.toggle(c.id)}
+                    />
+                  </td>
+                  <td className="py-1.5 text-gray-900">{c.displayName}</td>
+                  <td className="py-1.5 text-gray-500">{c.email ?? '—'}</td>
+                  <td className="py-1.5">
+                    {c.alreadyImported && (
+                      <span data-testid={`quickbooks-import-badge-${c.id}`} className="rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                        Already imported
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-4">
+            <button
+              type="button"
+              data-testid="quickbooks-import-submit"
+              onClick={importSelected}
+              disabled={importing || selection.size === 0}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {importing ? 'Importing…' : `Import ${selection.size} selected`}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/QuickbooksCustomerImport.tsx
+++ b/apps/web/src/components/integrations/QuickbooksCustomerImport.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
 import { useBulkSelection } from '../billing/bulk/useBulkSelection';
 
 interface AnnotatedCustomer {
@@ -15,7 +16,7 @@ interface AnnotatedCustomer {
 interface ImportSummary {
   imported: unknown[];
   skipped: unknown[];
-  errors: Array<{ customerId: string; error: string }>;
+  errors: Array<{ customerId: string; displayName?: string; error: string }>;
 }
 
 interface Props {
@@ -26,6 +27,7 @@ export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
   const [customers, setCustomers] = useState<AnnotatedCustomer[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [failures, setFailures] = useState<ImportSummary['errors']>([]);
   const selection = useBulkSelection();
 
   const importable = (customers ?? []).filter((c) => !c.alreadyImported);
@@ -33,6 +35,7 @@ export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
   async function load() {
     setLoading(true);
     selection.clear();
+    setFailures([]);
     try {
       const data = await runAction<{ data: AnnotatedCustomer[] }>({
         request: () => fetchWithAuth('/accounting/quickbooks/customers'),
@@ -52,24 +55,34 @@ export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
     if (customerIds.length === 0) return;
     setImporting(true);
     try {
-      await runAction<{ data: ImportSummary }>({
+      // The endpoint always returns HTTP 200 with a summary (partial success is
+      // a feature), so runAction can't tell a total failure from a win — we own
+      // the outcome toast here. No `successMessage`: it only emits green.
+      const res = await runAction<{ data: ImportSummary }>({
         request: () => fetchWithAuth('/accounting/quickbooks/customers/import', {
           method: 'POST',
           body: JSON.stringify({ customerIds }),
         }),
         errorFallback: 'Failed to import customers.',
-        successMessage: (res) => {
-          const s = res.data;
-          const parts = [`${s.imported.length} imported`];
-          if (s.skipped.length) parts.push(`${s.skipped.length} skipped`);
-          if (s.errors.length) parts.push(`${s.errors.length} failed`);
-          return parts.join(', ');
-        },
         onUnauthorized,
       });
-      await load(); // refresh so imported rows flip to "already imported"
+      const s = res.data;
+      const parts = [`${s.imported.length} imported`];
+      if (s.skipped.length) parts.push(`${s.skipped.length} skipped`);
+      if (s.errors.length) parts.push(`${s.errors.length} failed`);
+      const message = parts.join(', ');
+      if (s.imported.length === 0 && s.errors.length > 0) {
+        showToast({ type: 'error', message: `Import failed — ${message}.` });
+      } else if (s.errors.length > 0) {
+        showToast({ type: 'warning', message: `${message}.` });
+      } else {
+        showToast({ type: 'success', message: `${message}.` });
+      }
+      await load(); // refresh so imported rows flip to "already imported" (clears failures)
+      setFailures(s.errors); // re-set after the refresh so they stay visible
+
     } catch {
-      // already toasted
+      // runAction already toasted the request-level failure (non-200 / thrown).
     } finally {
       setImporting(false);
     }
@@ -158,6 +171,19 @@ export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
               {importing ? 'Importing…' : `Import ${selection.size} selected`}
             </button>
           </div>
+
+          {failures.length > 0 && (
+            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3" data-testid="quickbooks-import-failures">
+              <p className="text-sm font-medium text-red-800">{failures.length} customer{failures.length === 1 ? '' : 's'} failed to import</p>
+              <ul className="mt-2 space-y-1 text-xs text-red-700">
+                {failures.map((f) => (
+                  <li key={f.customerId} data-testid={`quickbooks-import-failure-${f.customerId}`}>
+                    <span className="font-medium">{f.displayName ?? f.customerId}</span>: {f.error}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/apps/web/src/components/integrations/QuickbooksIntegration.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.tsx
@@ -13,6 +13,7 @@ import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext, getJwtClaims } from '../../lib/authScope';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { showToast } from '../shared/Toast';
+import QuickbooksCustomerImport from './QuickbooksCustomerImport';
 
 type ConnectionStatus = 'connected' | 'disconnected' | 'reauth_required' | 'error';
 type PushMode = 'auto' | 'manual';
@@ -296,6 +297,8 @@ export default function QuickbooksIntegration() {
           </div>
         </div>
       )}
+
+      {isConnected && <QuickbooksCustomerImport onUnauthorized={onUnauthorized} />}
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-06-29-quickbooks-customer-import.md
+++ b/docs/superpowers/plans/2026-06-29-quickbooks-customer-import.md
@@ -1,0 +1,1371 @@
+# QuickBooks Customer Import → Orgs + Sites Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a partner browse their QuickBooks customers and import selected ones into Breeze as Organizations, each with one default Site, carrying contact + address data, idempotently.
+
+**Architecture:** Implement the stubbed `QuickbooksProvider.listRemoteCustomers` against the QBO query API. A new service (`quickbooksCustomerImport.ts`) fetches customers (handling token refresh) and creates org+site rows under the tenant-create RLS escape (`runOutsideDbContext(() => withSystemDbAccessContext(...))`). Two new routes under `/accounting/:provider` (list + import) mirror the catalog distributor import pattern. A new web component renders a selectable table inside the existing QuickBooks integration panel.
+
+**Tech Stack:** Hono + Zod (API), Drizzle ORM, Postgres (hand-written SQL migration), Vitest (API + web), React island (Astro web).
+
+## Global Constraints
+
+- **Migrations:** hand-written SQL in `apps/api/migrations/`, filename `2026-06-29-org-accounting-external-id.sql`. Idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE UNIQUE INDEX IF NOT EXISTS`). No inner `BEGIN;`/`COMMIT;`. Never edit a shipped migration.
+- **RLS:** `organizations`/`sites` already have RLS; the new columns do not change org tenancy shape, so **no** `rls-coverage` allowlist changes. Org+site inserts for tenant-create must run inside `runOutsideDbContext(() => withSystemDbAccessContext(...))` — a request-scoped insert of a brand-new org matches 0 rows under `breeze_app` RLS.
+- **Connection scope:** accounting connections are keyed by `partnerId` (one QB realm per partner). Imports create orgs under that partner.
+- **Token access:** never call the QBO data API with a raw stored token — always resolve via `getValidAccessToken(db, conn)` (rotates + persists the refresh token). Run it under system context so the rotation write succeeds.
+- **Web mutations:** the import POST MUST be wrapped in `runAction` (`apps/web/src/lib/runAction.ts`).
+- **data-testid:** kebab-case `quickbooks-import-*` (no text/role/CSS selectors in e2e).
+- **Node:** v22.20.0 (worktrees need `pnpm install`).
+- **Provider param enum:** routes are locked to `z.enum(['quickbooks'])` today; keep that.
+
+---
+
+## File Structure
+
+- `apps/api/migrations/2026-06-29-org-accounting-external-id.sql` — new columns + partial unique index (CREATE).
+- `apps/api/src/db/schema/orgs.ts` — add `accountingProvider`, `accountingExternalId` to the `organizations` table + partial unique index (MODIFY).
+- `apps/api/src/services/accounting/types.ts` — add `RemoteAddress`, `RemoteCustomer`; widen `listRemoteCustomers` return type (MODIFY).
+- `apps/api/src/services/accounting/quickbooksProvider.ts` — implement `listRemoteCustomers` + exported mapping helpers (MODIFY).
+- `apps/api/src/services/accounting/quickbooksProvider.test.ts` — mapping + pagination tests (CREATE).
+- `apps/api/src/services/accounting/quickbooksCustomerImport.ts` — slug helpers + `listQuickbooksCustomersAnnotated` + `importQuickbooksCustomers` (CREATE).
+- `apps/api/src/services/accounting/quickbooksCustomerImport.test.ts` — service tests (CREATE).
+- `apps/api/src/routes/accounting/index.ts` — add GET `/customers` + POST `/customers/import` (MODIFY).
+- `apps/api/src/routes/accounting/customers.test.ts` — route tests (CREATE).
+- `apps/web/src/components/integrations/QuickbooksCustomerImport.tsx` — import panel (CREATE).
+- `apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx` — component test (CREATE).
+- `apps/web/src/components/integrations/QuickbooksIntegration.tsx` — render the import panel when connected (MODIFY).
+
+---
+
+## Task 1: Migration + schema columns
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-29-org-accounting-external-id.sql`
+- Modify: `apps/api/src/db/schema/orgs.ts:67-94`
+
+**Interfaces:**
+- Produces: `organizations.accounting_provider` (text, nullable), `organizations.accounting_external_id` (text, nullable), partial unique index `organizations_accounting_external_uniq` on `(partner_id, accounting_provider, accounting_external_id) WHERE accounting_external_id IS NOT NULL`. Drizzle columns `accountingProvider`, `accountingExternalId`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-29-org-accounting-external-id.sql`:
+
+```sql
+-- Link Breeze organizations back to the external accounting customer they were
+-- imported from, so re-imports are idempotent. Generic (provider, external_id)
+-- so Xero can reuse it later. Partial unique index enforces "skip dupes" even
+-- under concurrent imports. Does not change the org RLS tenancy shape.
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS accounting_provider text;
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS accounting_external_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_accounting_external_uniq
+  ON organizations (partner_id, accounting_provider, accounting_external_id)
+  WHERE accounting_external_id IS NOT NULL;
+```
+
+- [ ] **Step 2: Add the columns to the Drizzle schema**
+
+In `apps/api/src/db/schema/orgs.ts`, add inside the `organizations` `pgTable` column list (after `billingAddressCountry` at line 88, before `createdAt`):
+
+```ts
+  accountingProvider: text('accounting_provider'),
+  accountingExternalId: text('accounting_external_id'),
+```
+
+Then add the partial unique index to the table's index callback (line 92-94), so it reads:
+
+```ts
+}, (table) => ({
+  orgPartnerUnique: uniqueIndex('organizations_id_partner_id_unique').on(table.id, table.partnerId),
+  accountingExternalUnique: uniqueIndex('organizations_accounting_external_uniq')
+    .on(table.partnerId, table.accountingProvider, table.accountingExternalId)
+    .where(sql`accounting_external_id IS NOT NULL`),
+}));
+```
+
+Add `sql` to the `drizzle-orm` import at the top of the file if not present:
+
+```ts
+import { sql } from 'drizzle-orm';
+```
+
+(`text` is already imported on line 1.)
+
+- [ ] **Step 3: Apply the migration and verify no drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts
+pnpm db:check-drift
+```
+Expected: autoMigrate test passes (migration applies + is ordered correctly); `db:check-drift` reports no drift between schema and migrations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-29-org-accounting-external-id.sql apps/api/src/db/schema/orgs.ts
+git commit -m "feat(api): add accounting external-id link columns to organizations"
+```
+
+---
+
+## Task 2: RemoteCustomer types + QBO listRemoteCustomers
+
+**Files:**
+- Modify: `apps/api/src/services/accounting/types.ts:13-17,41-42`
+- Modify: `apps/api/src/services/accounting/quickbooksProvider.ts`
+- Test: `apps/api/src/services/accounting/quickbooksProvider.test.ts`
+
+**Interfaces:**
+- Consumes: `AccountingConnection` (`accountingConnectionService.ts:10`) — uses `realmId`, `accessToken`, `environment`.
+- Produces:
+  - `RemoteAddress { line1?, line2?, city?, region?, postalCode?, country? }`
+  - `RemoteCustomer extends RemoteEntity { companyName?, phone?, contactName?, billAddr?: RemoteAddress, shipAddr?: RemoteAddress, active?: boolean }`
+  - `QuickbooksProvider.listRemoteCustomers(conn): Promise<RemoteCustomer[]>` — uses `conn.accessToken` directly (caller pre-resolves a valid token), pages the QBO query API.
+  - Exported pure helpers `mapQboAddress(raw): RemoteAddress | undefined` and `mapQboCustomer(raw): RemoteCustomer`.
+
+- [ ] **Step 1: Add the types**
+
+In `apps/api/src/services/accounting/types.ts`, after `RemoteEntity` (line 17) add:
+
+```ts
+export interface RemoteAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+export interface RemoteCustomer extends RemoteEntity {
+  companyName?: string;
+  phone?: string;
+  contactName?: string;
+  billAddr?: RemoteAddress;
+  shipAddr?: RemoteAddress;
+  active?: boolean;
+}
+```
+
+Then widen the interface method (line 41) to:
+
+```ts
+  listRemoteCustomers(conn: AccountingConnection, query?: string): Promise<RemoteCustomer[]>;
+```
+
+(`RemoteCustomer extends RemoteEntity`, so this stays compatible with the unimplemented Xero path.)
+
+- [ ] **Step 2: Write the failing mapping + pagination tests**
+
+Create `apps/api/src/services/accounting/quickbooksProvider.test.ts`:
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { quickbooksProvider, mapQboCustomer, mapQboAddress } from './quickbooksProvider';
+import type { AccountingConnection } from './accountingConnectionService';
+
+function conn(overrides: Partial<AccountingConnection> = {}): AccountingConnection {
+  return {
+    id: 'c1', partnerId: 'p1', provider: 'quickbooks',
+    realmId: 'realm123', accessToken: 'tok', refreshToken: 'r',
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    refreshTokenExpiresAt: new Date(Date.now() + 86_400_000),
+    environment: 'sandbox', homeCurrency: 'USD',
+    defaultIncomeAccountRef: null, defaultTaxCodeRef: null,
+    pushMode: 'auto', status: 'connected',
+    createdAt: null, updatedAt: null, lastError: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('mapQboAddress', () => {
+  it('maps QBO address fields, including CountrySubDivisionCode -> region', () => {
+    expect(mapQboAddress({
+      Line1: '123 Main', Line2: 'Suite 4', City: 'Austin',
+      CountrySubDivisionCode: 'TX', PostalCode: '78701', Country: 'US',
+    })).toEqual({
+      line1: '123 Main', line2: 'Suite 4', city: 'Austin',
+      region: 'TX', postalCode: '78701', country: 'US',
+    });
+  });
+
+  it('returns undefined when the address is empty/missing', () => {
+    expect(mapQboAddress(undefined)).toBeUndefined();
+    expect(mapQboAddress({})).toBeUndefined();
+  });
+});
+
+describe('mapQboCustomer', () => {
+  it('maps display name, company, email, phone, contact name, addresses, active', () => {
+    const c = mapQboCustomer({
+      Id: '42', DisplayName: 'Acme Co', CompanyName: 'Acme Inc',
+      PrimaryEmailAddr: { Address: 'ap@acme.test' },
+      PrimaryPhone: { FreeFormNumber: '555-1212' },
+      GivenName: 'Jane', FamilyName: 'Doe', Active: true,
+      BillAddr: { Line1: '1 Bill St', City: 'Austin' },
+      ShipAddr: { Line1: '2 Ship Rd', City: 'Dallas' },
+    });
+    expect(c).toMatchObject({
+      id: '42', displayName: 'Acme Co', companyName: 'Acme Inc',
+      email: 'ap@acme.test', phone: '555-1212', contactName: 'Jane Doe',
+      active: true,
+      billAddr: { line1: '1 Bill St', city: 'Austin' },
+      shipAddr: { line1: '2 Ship Rd', city: 'Dallas' },
+    });
+  });
+
+  it('falls back to CompanyName when DisplayName is missing, and tolerates missing optionals', () => {
+    const c = mapQboCustomer({ Id: '7', CompanyName: 'Solo LLC' });
+    expect(c.id).toBe('7');
+    expect(c.displayName).toBe('Solo LLC');
+    expect(c.email).toBeUndefined();
+    expect(c.billAddr).toBeUndefined();
+  });
+});
+
+describe('listRemoteCustomers', () => {
+  it('pages through the QBO query API until a short page is returned', async () => {
+    const page1 = { QueryResponse: { Customer: Array.from({ length: 1000 }, (_, i) => ({ Id: String(i), DisplayName: `C${i}` })) } };
+    const page2 = { QueryResponse: { Customer: [{ Id: '1000', DisplayName: 'last' }] } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify(page1), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(page2), { status: 200 }));
+
+    const result = await quickbooksProvider.listRemoteCustomers(conn());
+
+    expect(result).toHaveLength(1001);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstUrl = String(fetchMock.mock.calls[0]![0]);
+    expect(firstUrl).toContain('sandbox-quickbooks.api.intuit.com');
+    expect(firstUrl).toContain('STARTPOSITION%201'); // url-encoded space
+    const secondUrl = String(fetchMock.mock.calls[1]![0]);
+    expect(secondUrl).toContain('STARTPOSITION%201001');
+  });
+
+  it('uses the production base URL when environment is production', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ QueryResponse: {} }), { status: 200 }));
+    await quickbooksProvider.listRemoteCustomers(conn({ environment: 'production' }));
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('https://quickbooks.api.intuit.com');
+  });
+
+  it('throws when the QBO API returns a non-2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('nope', { status: 401 }));
+    await expect(quickbooksProvider.listRemoteCustomers(conn())).rejects.toThrow(/QuickBooks customer query failed/);
+  });
+
+  it('throws when the connection has no realmId or access token', async () => {
+    await expect(quickbooksProvider.listRemoteCustomers(conn({ realmId: null }))).rejects.toThrow(/realm/i);
+    await expect(quickbooksProvider.listRemoteCustomers(conn({ accessToken: null }))).rejects.toThrow(/access token/i);
+  });
+});
+```
+
+- [ ] **Step 2b: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/accounting/quickbooksProvider.test.ts`
+Expected: FAIL — `mapQboCustomer`/`mapQboAddress` are not exported and `listRemoteCustomers` throws `NotImplemented: Phase B`.
+
+- [ ] **Step 3: Implement the mapping helpers + listRemoteCustomers**
+
+In `apps/api/src/services/accounting/quickbooksProvider.ts`:
+
+Update the type import (line 4-10) to add `RemoteAddress`, `RemoteCustomer`:
+
+```ts
+import type {
+  AccountingProvider,
+  ChangeSet,
+  ConnectionTokens,
+  RemoteAddress,
+  RemoteCustomer,
+  RemoteEntity,
+  RemoteRef,
+} from './types';
+```
+
+Add base-URL + minor-version constants near the other constants (line 15):
+
+```ts
+const QBO_API_MINOR_VERSION = '70';
+const QBO_CUSTOMER_PAGE_SIZE = 1000; // QBO hard cap per query page
+
+function qboApiBase(environment: 'sandbox' | 'production'): string {
+  return environment === 'production'
+    ? 'https://quickbooks.api.intuit.com'
+    : 'https://sandbox-quickbooks.api.intuit.com';
+}
+```
+
+Add the exported mapping helpers (module scope, e.g. just below the constants):
+
+```ts
+interface QboRawAddress {
+  Line1?: string; Line2?: string; City?: string;
+  CountrySubDivisionCode?: string; PostalCode?: string; Country?: string;
+}
+
+interface QboRawCustomer {
+  Id: string;
+  DisplayName?: string;
+  CompanyName?: string;
+  PrimaryEmailAddr?: { Address?: string };
+  PrimaryPhone?: { FreeFormNumber?: string };
+  GivenName?: string;
+  FamilyName?: string;
+  Active?: boolean;
+  BillAddr?: QboRawAddress;
+  ShipAddr?: QboRawAddress;
+}
+
+export function mapQboAddress(raw: QboRawAddress | undefined): RemoteAddress | undefined {
+  if (!raw) return undefined;
+  const addr: RemoteAddress = {
+    line1: raw.Line1 || undefined,
+    line2: raw.Line2 || undefined,
+    city: raw.City || undefined,
+    region: raw.CountrySubDivisionCode || undefined,
+    postalCode: raw.PostalCode || undefined,
+    country: raw.Country || undefined,
+  };
+  return Object.values(addr).some((v) => v !== undefined) ? addr : undefined;
+}
+
+export function mapQboCustomer(raw: QboRawCustomer): RemoteCustomer {
+  const contactName = [raw.GivenName, raw.FamilyName].filter(Boolean).join(' ').trim();
+  return {
+    id: raw.Id,
+    displayName: raw.DisplayName || raw.CompanyName || raw.Id,
+    companyName: raw.CompanyName || undefined,
+    email: raw.PrimaryEmailAddr?.Address || undefined,
+    phone: raw.PrimaryPhone?.FreeFormNumber || undefined,
+    contactName: contactName || undefined,
+    active: raw.Active,
+    billAddr: mapQboAddress(raw.BillAddr),
+    shipAddr: mapQboAddress(raw.ShipAddr),
+  };
+}
+```
+
+Replace the `listRemoteCustomers` stub (line 47-49) with:
+
+```ts
+  // NOTE: assumes `conn.accessToken` is already a VALID token. Callers must
+  // resolve it via getValidAccessToken(db, conn) first (which refreshes +
+  // persists rotation) — this method stays pure HTTP with no db dependency.
+  async listRemoteCustomers(conn: AccountingConnection): Promise<RemoteCustomer[]> {
+    if (!conn.realmId) throw new Error('QuickBooks connection is missing a realmId');
+    if (!conn.accessToken) throw new Error('QuickBooks connection is missing an access token');
+
+    const base = qboApiBase(conn.environment);
+    const customers: RemoteCustomer[] = [];
+    let startPosition = 1;
+
+    // Page until a short page (< page size) signals the end.
+    for (;;) {
+      const query = `SELECT * FROM Customer STARTPOSITION ${startPosition} MAXRESULTS ${QBO_CUSTOMER_PAGE_SIZE}`;
+      const url = `${base}/v3/company/${conn.realmId}/query?query=${encodeURIComponent(query)}&minorversion=${QBO_API_MINOR_VERSION}`;
+      const response = await runOutsideDbContext(() =>
+        fetch(url, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${conn.accessToken}`,
+            Accept: 'application/json',
+          },
+        })
+      );
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        const err = new Error(`QuickBooks customer query failed with ${response.status}`);
+        (err as Error & { status?: number; body?: string }).status = response.status;
+        (err as Error & { status?: number; body?: string }).body = body.slice(0, 500);
+        throw err;
+      }
+
+      const parsed = await response.json() as { QueryResponse?: { Customer?: QboRawCustomer[] } };
+      const page = parsed.QueryResponse?.Customer ?? [];
+      for (const raw of page) customers.push(mapQboCustomer(raw));
+      if (page.length < QBO_CUSTOMER_PAGE_SIZE) break;
+      startPosition += QBO_CUSTOMER_PAGE_SIZE;
+    }
+
+    return customers;
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/accounting/quickbooksProvider.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/accounting/types.ts apps/api/src/services/accounting/quickbooksProvider.ts apps/api/src/services/accounting/quickbooksProvider.test.ts
+git commit -m "feat(api): implement QuickBooks listRemoteCustomers + customer mapping"
+```
+
+---
+
+## Task 3: Import service (slug helpers + list/annotate + import)
+
+**Files:**
+- Create: `apps/api/src/services/accounting/quickbooksCustomerImport.ts`
+- Test: `apps/api/src/services/accounting/quickbooksCustomerImport.test.ts`
+
+**Interfaces:**
+- Consumes: `getConnection` (`accountingConnectionService.ts:103`), `getValidAccessToken` (`accountingTokens.ts:29`), `getAccountingProvider` (`providerRegistry.ts`), `db`/`runOutsideDbContext`/`withSystemDbAccessContext` (`../../db`), `organizations`/`sites` schema.
+- Produces:
+  - `slugify(name: string): string`
+  - `generateUniqueSlug(base: string, taken: Set<string>): string`
+  - `class QbImportError extends Error { code: string; status: number }`
+  - `interface AnnotatedCustomer extends RemoteCustomer { alreadyImported: boolean; organizationId: string | null }`
+  - `listQuickbooksCustomersAnnotated(partnerId: string): Promise<AnnotatedCustomer[]>`
+  - `interface QbImportSummary { imported: Array<{ customerId; displayName; organizationId; siteId }>; skipped: Array<{ customerId; displayName; organizationId; reason: 'already_imported' }>; errors: Array<{ customerId; displayName?; error }> }`
+  - `importQuickbooksCustomers(input: { partnerId: string; customerIds: string[] }): Promise<QbImportSummary>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/services/accounting/quickbooksCustomerImport.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the db module: provide db (select/insert), and pass-through context helpers.
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+vi.mock('../../db', () => ({
+  db: { select: selectMock, insert: insertMock },
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+
+const getConnectionMock = vi.fn();
+vi.mock('./accountingConnectionService', () => ({
+  getConnection: getConnectionMock,
+}));
+
+const getValidAccessTokenMock = vi.fn();
+vi.mock('./accountingTokens', () => ({
+  getValidAccessToken: getValidAccessTokenMock,
+}));
+
+const listRemoteCustomersMock = vi.fn();
+vi.mock('./providerRegistry', () => ({
+  getAccountingProvider: () => ({ listRemoteCustomers: listRemoteCustomersMock }),
+}));
+
+import {
+  slugify, generateUniqueSlug, importQuickbooksCustomers,
+  listQuickbooksCustomersAnnotated, QbImportError,
+} from './quickbooksCustomerImport';
+
+function connectedConn() {
+  return { id: 'c1', partnerId: 'p1', provider: 'quickbooks', realmId: 'r1', accessToken: 'tok', environment: 'sandbox', status: 'connected' };
+}
+
+// Helper to stub `db.select(...).from(...).where(...)` returning `rows`.
+function stubSelect(rows: unknown[]) {
+  selectMock.mockReturnValue({ from: () => ({ where: () => Promise.resolve(rows) }) });
+}
+
+// Helper to stub `db.insert(...).values(...).returning()` returning `row`.
+function stubInsertReturning(rowsInOrder: unknown[][]) {
+  let call = 0;
+  insertMock.mockImplementation(() => ({
+    values: () => ({ returning: () => Promise.resolve(rowsInOrder[call++] ?? []) }),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getConnectionMock.mockResolvedValue(connectedConn());
+  getValidAccessTokenMock.mockResolvedValue('fresh-token');
+});
+
+describe('slugify', () => {
+  it('lowercases, strips punctuation, hyphenates spaces', () => {
+    expect(slugify('Acme Co., Inc.')).toBe('acme-co-inc');
+    expect(slugify('  Multiple   Spaces  ')).toBe('multiple-spaces');
+  });
+  it('falls back to "org" for empty/punctuation-only input', () => {
+    expect(slugify('!!!')).toBe('org');
+    expect(slugify('')).toBe('org');
+  });
+});
+
+describe('generateUniqueSlug', () => {
+  it('returns the base when free', () => {
+    expect(generateUniqueSlug('acme', new Set())).toBe('acme');
+  });
+  it('appends an incrementing suffix on collision', () => {
+    expect(generateUniqueSlug('acme', new Set(['acme', 'acme-2']))).toBe('acme-3');
+  });
+});
+
+describe('listQuickbooksCustomersAnnotated', () => {
+  it('annotates already-imported customers from existing org external ids', async () => {
+    listRemoteCustomersMock.mockResolvedValue([
+      { id: '1', displayName: 'A' }, { id: '2', displayName: 'B' },
+    ]);
+    stubSelect([{ id: 'org-1', accountingExternalId: '1' }]);
+
+    const result = await listQuickbooksCustomersAnnotated('p1');
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: '1', alreadyImported: true, organizationId: 'org-1' }),
+      expect.objectContaining({ id: '2', alreadyImported: false, organizationId: null }),
+    ]);
+    expect(getValidAccessTokenMock).toHaveBeenCalled();
+  });
+
+  it('throws QbImportError(not_connected) when no connection exists', async () => {
+    getConnectionMock.mockResolvedValue(null);
+    await expect(listQuickbooksCustomersAnnotated('p1')).rejects.toMatchObject({ code: 'not_connected', status: 404 });
+  });
+});
+
+describe('importQuickbooksCustomers', () => {
+  it('creates an org + site for a new customer, mapping billing + shipping data', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{
+      id: '1', displayName: 'Acme Co', email: 'ap@acme.test', phone: '555', contactName: 'Jane Doe',
+      billAddr: { line1: '1 Bill St', city: 'Austin', region: 'TX', postalCode: '78701', country: 'US' },
+      shipAddr: { line1: '2 Ship Rd', city: 'Dallas' },
+    }]);
+    stubSelect([]); // no existing orgs
+    stubInsertReturning([[{ id: 'org-1', name: 'Acme Co', partnerId: 'p1' }], [{ id: 'site-1', orgId: 'org-1', name: 'Acme Co' }]]);
+
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+
+    expect(summary.imported).toEqual([{ customerId: '1', displayName: 'Acme Co', organizationId: 'org-1', siteId: 'site-1' }]);
+    expect(summary.skipped).toEqual([]);
+    expect(summary.errors).toEqual([]);
+
+    // Org insert got billing address + accounting link.
+    const orgValues = (insertMock.mock.results[0]!.value.values as any);
+    // (Assert via the recorded call below.)
+    const orgInsertArg = insertCalls()[0];
+    expect(orgInsertArg).toMatchObject({
+      partnerId: 'p1', name: 'Acme Co', slug: 'acme-co',
+      accountingProvider: 'quickbooks', accountingExternalId: '1',
+      billingContact: { name: 'Jane Doe', email: 'ap@acme.test', phone: '555' },
+      billingAddressLine1: '1 Bill St', billingAddressCity: 'Austin',
+      billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+    // Site insert used shipping address.
+    const siteInsertArg = insertCalls()[1];
+    expect(siteInsertArg).toMatchObject({
+      orgId: 'org-1', name: 'Acme Co',
+      address: { addressLine1: '2 Ship Rd', city: 'Dallas' },
+      contact: { name: 'Jane Doe', email: 'ap@acme.test', phone: '555' },
+    });
+  });
+
+  it('falls back to billing address for the site when shipping is absent', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { line1: '1 Bill St', city: 'Austin' } }]);
+    stubSelect([]);
+    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(insertCalls()[1]).toMatchObject({ address: { addressLine1: '1 Bill St', city: 'Austin' } });
+  });
+
+  it('skips customers already linked to an org', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([{ id: 'org-9', accountingExternalId: '1' }]);
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(summary.imported).toEqual([]);
+    expect(summary.skipped).toEqual([{ customerId: '1', displayName: 'Acme', organizationId: 'org-9', reason: 'already_imported' }]);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('suffixes the slug when the base collides with an existing org slug', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([{ id: 'org-x', accountingExternalId: '99', slug: 'acme' }]);
+    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
+    expect(insertCalls()[0]).toMatchObject({ slug: 'acme-2' });
+  });
+
+  it('records a per-customer error and continues with the rest (partial success)', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Bad' }, { id: '2', displayName: 'Good' }]);
+    stubSelect([]);
+    let call = 0;
+    insertMock.mockImplementation(() => ({
+      values: (v: any) => ({
+        returning: () => {
+          call++;
+          if (call === 1) return Promise.reject(new Error('boom')); // org insert for customer 1
+          return Promise.resolve([{ id: `row-${call}` }]);
+        },
+      }),
+    }));
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', '2'] });
+    expect(summary.errors).toEqual([{ customerId: '1', displayName: 'Bad', error: 'boom' }]);
+    expect(summary.imported).toHaveLength(1);
+    expect(summary.imported[0]!.customerId).toBe('2');
+  });
+
+  it('reports requested ids not present in QuickBooks as errors', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
+    stubSelect([]);
+    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', 'missing'] });
+    expect(summary.errors).toContainEqual({ customerId: 'missing', error: 'Customer not found in QuickBooks' });
+    expect(summary.imported).toHaveLength(1);
+  });
+});
+
+// Records the object passed to each `db.insert(...).values(OBJ)` call, in order.
+function insertCalls(): any[] {
+  return insertMock.mock.calls.length
+    ? (insertMock.mock.results.map((r: any) => r.value.__values).filter(Boolean))
+    : [];
+}
+```
+
+> Note on `insertCalls()`: the implementation below stores the values object on the chain (`__values`) so tests can assert it. Keep that shim in the impl.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/accounting/quickbooksCustomerImport.test.ts`
+Expected: FAIL — module `./quickbooksCustomerImport` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+Create `apps/api/src/services/accounting/quickbooksCustomerImport.ts`:
+
+```ts
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { organizations, sites } from '../../db/schema';
+import { getConnection } from './accountingConnectionService';
+import { getValidAccessToken } from './accountingTokens';
+import { getAccountingProvider } from './providerRegistry';
+import type { RemoteAddress, RemoteCustomer } from './types';
+
+const PROVIDER = 'quickbooks' as const;
+
+export class QbImportError extends Error {
+  code: string;
+  status: number;
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = 'QbImportError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface AnnotatedCustomer extends RemoteCustomer {
+  alreadyImported: boolean;
+  organizationId: string | null;
+}
+
+export interface QbImportSummary {
+  imported: Array<{ customerId: string; displayName: string; organizationId: string; siteId: string }>;
+  skipped: Array<{ customerId: string; displayName: string; organizationId: string; reason: 'already_imported' }>;
+  errors: Array<{ customerId: string; displayName?: string; error: string }>;
+}
+
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 90);
+  return slug || 'org';
+}
+
+export function generateUniqueSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+// Resolve the partner's QB connection + a fresh access token, then fetch all
+// customers from QuickBooks. Token resolution runs in system context so the
+// refresh-token rotation write succeeds (request context has no auth here).
+async function fetchCustomers(partnerId: string): Promise<RemoteCustomer[]> {
+  const conn = await withSystemDbAccessContext(() => getConnection(db, partnerId, PROVIDER));
+  if (!conn || conn.status === 'disconnected') {
+    throw new QbImportError('QuickBooks is not connected for this partner', 'not_connected', 404);
+  }
+  const accessToken = await withSystemDbAccessContext(() => getValidAccessToken(db, conn));
+  const customers = await getAccountingProvider(PROVIDER).listRemoteCustomers({ ...conn, accessToken });
+  return customers;
+}
+
+// Map external id -> { organizationId, slug } for every org already linked to
+// this partner's QB realm. Used for dedup + slug-uniqueness.
+async function loadExistingOrgs(partnerId: string): Promise<{ byExternalId: Map<string, string>; slugs: Set<string> }> {
+  const rows = await withSystemDbAccessContext(() =>
+    db.select({ id: organizations.id, accountingExternalId: organizations.accountingExternalId, slug: organizations.slug })
+      .from(organizations)
+      .where(and(eq(organizations.partnerId, partnerId), eq(organizations.accountingProvider, PROVIDER)))
+  ) as Array<{ id: string; accountingExternalId: string | null; slug: string | null }>;
+
+  const byExternalId = new Map<string, string>();
+  const slugs = new Set<string>();
+  for (const row of rows) {
+    if (row.accountingExternalId) byExternalId.set(row.accountingExternalId, row.id);
+    if (row.slug) slugs.add(row.slug);
+  }
+  return { byExternalId, slugs };
+}
+
+export async function listQuickbooksCustomersAnnotated(partnerId: string): Promise<AnnotatedCustomer[]> {
+  const customers = await fetchCustomers(partnerId);
+  const { byExternalId } = await loadExistingOrgs(partnerId);
+  return customers.map((c) => ({
+    ...c,
+    alreadyImported: byExternalId.has(c.id),
+    organizationId: byExternalId.get(c.id) ?? null,
+  }));
+}
+
+function siteAddressFrom(addr: RemoteAddress | undefined): Record<string, string> | undefined {
+  if (!addr) return undefined;
+  // Match the web SiteForm convention so imported sites render correctly.
+  const out: Record<string, string> = {};
+  if (addr.line1) out.addressLine1 = addr.line1;
+  if (addr.line2) out.addressLine2 = addr.line2;
+  if (addr.city) out.city = addr.city;
+  if (addr.region) out.state = addr.region;
+  if (addr.postalCode) out.postalCode = addr.postalCode;
+  if (addr.country) out.country = addr.country;
+  return Object.keys(out).length ? out : undefined;
+}
+
+export async function importQuickbooksCustomers(
+  input: { partnerId: string; customerIds: string[] }
+): Promise<QbImportSummary> {
+  const { partnerId, customerIds } = input;
+  const customers = await fetchCustomers(partnerId);
+  const byId = new Map(customers.map((c) => [c.id, c]));
+  const { byExternalId, slugs } = await loadExistingOrgs(partnerId);
+
+  const summary: QbImportSummary = { imported: [], skipped: [], errors: [] };
+
+  for (const customerId of customerIds) {
+    const customer = byId.get(customerId);
+    if (!customer) {
+      summary.errors.push({ customerId, error: 'Customer not found in QuickBooks' });
+      continue;
+    }
+
+    const existingOrgId = byExternalId.get(customerId);
+    if (existingOrgId) {
+      summary.skipped.push({ customerId, displayName: customer.displayName, organizationId: existingOrgId, reason: 'already_imported' });
+      continue;
+    }
+
+    try {
+      const slug = generateUniqueSlug(slugify(customer.displayName), slugs);
+      slugs.add(slug); // reserve within this batch
+
+      const contact = {
+        name: customer.contactName,
+        email: customer.email,
+        phone: customer.phone,
+      };
+
+      const { orgId, siteId } = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          const [org] = await insertReturning(db.insert(organizations), {
+            partnerId,
+            name: customer.displayName,
+            slug,
+            type: 'customer' as const,
+            billingContact: contact,
+            billingAddressLine1: customer.billAddr?.line1 ?? null,
+            billingAddressLine2: customer.billAddr?.line2 ?? null,
+            billingAddressCity: customer.billAddr?.city ?? null,
+            billingAddressRegion: customer.billAddr?.region ?? null,
+            billingAddressPostalCode: customer.billAddr?.postalCode ?? null,
+            billingAddressCountry: customer.billAddr?.country ?? null,
+            accountingProvider: PROVIDER,
+            accountingExternalId: customerId,
+          });
+          const [site] = await insertReturning(db.insert(sites), {
+            orgId: org!.id,
+            name: customer.displayName,
+            address: siteAddressFrom(customer.shipAddr ?? customer.billAddr),
+            contact,
+          });
+          return { orgId: org!.id as string, siteId: site!.id as string };
+        })
+      );
+
+      byExternalId.set(customerId, orgId);
+      summary.imported.push({ customerId, displayName: customer.displayName, organizationId: orgId, siteId });
+    } catch (err) {
+      summary.errors.push({ customerId, displayName: customer.displayName, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return summary;
+}
+
+// Thin wrapper around Drizzle's `.values(v).returning()` that also stamps the
+// values object onto the chain so unit tests can assert what was inserted.
+function insertReturning(chain: { values: (v: unknown) => { returning: () => Promise<any[]> } }, values: Record<string, unknown>) {
+  const next = chain.values(values);
+  (next as unknown as { __values?: unknown }).__values = values;
+  return next.returning();
+}
+```
+
+> Note: the test's `insertCalls()` reads `__values` off the chain returned by `db.insert(...).values(...)`. The impl's `insertReturning` stamps it there. In production Drizzle, the extra property is harmless.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/accounting/quickbooksCustomerImport.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/accounting/quickbooksCustomerImport.ts apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
+git commit -m "feat(api): QuickBooks customer import service (orgs + sites, idempotent)"
+```
+
+---
+
+## Task 4: Routes — list + import
+
+**Files:**
+- Modify: `apps/api/src/routes/accounting/index.ts`
+- Test: `apps/api/src/routes/accounting/customers.test.ts`
+
+**Interfaces:**
+- Consumes: `listQuickbooksCustomersAnnotated`, `importQuickbooksCustomers`, `QbImportError` (Task 3); existing `resolvePartnerId`, `partnerScopes`, `providerParamSchema`, `partnerQuerySchema`, `validateProviderConfig`, `writeRouteAudit`.
+- Produces:
+  - `GET /accounting/:provider/customers?partnerId=` → `{ data: AnnotatedCustomer[] }`
+  - `POST /accounting/:provider/customers/import` (body `{ customerIds: string[] }`, optional `?partnerId=`) → `{ data: QbImportSummary }`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Create `apps/api/src/routes/accounting/customers.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const listAnnotatedMock = vi.fn();
+const importMock = vi.fn();
+class QbImportError extends Error { code: string; status: number; constructor(m: string, c: string, s: number) { super(m); this.code = c; this.status = s; } }
+vi.mock('../../services/accounting/quickbooksCustomerImport', () => ({
+  listQuickbooksCustomersAnnotated: listAnnotatedMock,
+  importQuickbooksCustomers: importMock,
+  QbImportError,
+}));
+
+// Auth middleware stubs: inject a partner-scoped auth context.
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => { c.set('auth', { scope: 'partner', partnerId: 'p1', user: { id: 'u1' } }); await next(); },
+  requireScope: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+import { accountingRoutes } from './index';
+
+function app() {
+  const a = new Hono();
+  a.route('/accounting', accountingRoutes);
+  return a;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GET /accounting/:provider/customers', () => {
+  it('returns annotated customers', async () => {
+    listAnnotatedMock.mockResolvedValue([{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }]);
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] });
+    expect(listAnnotatedMock).toHaveBeenCalledWith('p1');
+  });
+
+  it('maps QbImportError(not_connected) to 404', async () => {
+    listAnnotatedMock.mockRejectedValue(new QbImportError('nope', 'not_connected', 404));
+    const res = await app().request('/accounting/quickbooks/customers');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: 'not_connected' });
+  });
+});
+
+describe('POST /accounting/:provider/customers/import', () => {
+  it('imports selected customers and returns the summary', async () => {
+    importMock.mockResolvedValue({
+      imported: [{ customerId: '1', displayName: 'Acme', organizationId: 'org-1', siteId: 'site-1' }],
+      skipped: [], errors: [],
+    });
+    const res = await app().request('/accounting/quickbooks/customers/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerIds: ['1'] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.imported).toHaveLength(1);
+    expect(importMock).toHaveBeenCalledWith({ partnerId: 'p1', customerIds: ['1'] });
+  });
+
+  it('rejects an empty customerIds array with 400', async () => {
+    const res = await app().request('/accounting/quickbooks/customers/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerIds: [] }),
+    });
+    expect(res.status).toBe(400);
+    expect(importMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/accounting/customers.test.ts`
+Expected: FAIL — routes not defined (404 for both).
+
+- [ ] **Step 3: Implement the routes**
+
+In `apps/api/src/routes/accounting/index.ts`:
+
+Add imports near the existing service imports (after line 16):
+
+```ts
+import {
+  importQuickbooksCustomers,
+  listQuickbooksCustomersAnnotated,
+  QbImportError,
+} from '../../services/accounting/quickbooksCustomerImport';
+import { writeRouteAudit } from '../../services/auditEvents';
+```
+
+Add an import-body schema near the other schemas (after `settingsSchema`, line 36):
+
+```ts
+const importCustomersSchema = z.object({
+  customerIds: z.array(z.string().min(1)).min(1).max(500),
+});
+
+function handleImportError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
+  if (err instanceof QbImportError) return c.json({ error: err.message, code: err.code }, err.status as 400 | 404);
+  throw err;
+}
+```
+
+Add the two routes (place them after the `GET /:provider` status route, before `PATCH /:provider/settings`):
+
+```ts
+// List remote QuickBooks customers, annotated with whether each is already
+// imported. Read-only but partner-privileged, so partner/system scope.
+accountingRoutes.get('/:provider/customers', authMiddleware, partnerScopes, zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), async (c) => {
+  const { provider } = c.req.valid('param');
+  const configError = validateProviderConfig(provider);
+  if (configError) return c.json({ error: configError }, 400);
+  const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  try {
+    const data = await listQuickbooksCustomersAnnotated(partner.partnerId);
+    return c.json({ data });
+  } catch (err) {
+    return handleImportError(c, err);
+  }
+});
+
+// Import selected QuickBooks customers as orgs + sites. Write + MFA-gated.
+accountingRoutes.post('/:provider/customers/import', authMiddleware, partnerScopes, requireMfa(), zValidator('param', providerParamSchema), zValidator('query', partnerQuerySchema), zValidator('json', importCustomersSchema), async (c) => {
+  const { provider } = c.req.valid('param');
+  const configError = validateProviderConfig(provider);
+  if (configError) return c.json({ error: configError }, 400);
+  const partner = resolvePartnerId(c.get('auth'), c.req.valid('query').partnerId);
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+
+  let summary;
+  try {
+    summary = await importQuickbooksCustomers({ partnerId: partner.partnerId, customerIds: c.req.valid('json').customerIds });
+  } catch (err) {
+    return handleImportError(c, err);
+  }
+
+  // Audit each created org + site (the import itself ran in system context).
+  for (const item of summary.imported) {
+    writeRouteAudit(c, {
+      orgId: item.organizationId,
+      action: 'organization.create',
+      resourceType: 'organization',
+      resourceId: item.organizationId,
+      resourceName: item.displayName,
+      details: { source: 'quickbooks_import', quickbooksCustomerId: item.customerId, siteId: item.siteId },
+    });
+  }
+
+  return c.json({ data: summary });
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/accounting/customers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/accounting/index.ts apps/api/src/routes/accounting/customers.test.ts
+git commit -m "feat(api): add QuickBooks customers list + import routes"
+```
+
+---
+
+## Task 5: Web import panel
+
+**Files:**
+- Create: `apps/web/src/components/integrations/QuickbooksCustomerImport.tsx`
+- Test: `apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx`
+- Modify: `apps/web/src/components/integrations/QuickbooksIntegration.tsx`
+
+**Interfaces:**
+- Consumes: `fetchWithAuth` (`../../stores/auth`), `runAction` (`../../lib/runAction`), `useBulkSelection` (`../billing/bulk/useBulkSelection`), the API routes from Task 4.
+- Produces: default-exported `<QuickbooksCustomerImport onUnauthorized?={() => void} />`, rendered by `QuickbooksIntegration` when connected.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuickbooksCustomerImport from './QuickbooksCustomerImport';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a) }));
+
+const showToastMock = vi.fn();
+vi.mock('../../lib/toast', () => ({ showToast: (...a: unknown[]) => showToastMock(...a) }));
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('QuickbooksCustomerImport', () => {
+  it('loads customers and disables already-imported rows', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ data: [
+      { id: '1', displayName: 'Acme', email: 'a@acme.test', alreadyImported: false, organizationId: null },
+      { id: '2', displayName: 'Imported Inc', alreadyImported: true, organizationId: 'org-2' },
+    ] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-row-1')).toBeInTheDocument());
+    expect(screen.getByTestId('quickbooks-import-select-1')).not.toBeDisabled();
+    expect(screen.getByTestId('quickbooks-import-select-2')).toBeDisabled();
+  });
+
+  it('imports selected customers and surfaces the summary via runAction', async () => {
+    fetchWithAuthMock
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: false, organizationId: null }] }))
+      .mockReturnValueOnce(jsonResponse({ data: { imported: [{ customerId: '1', organizationId: 'org-1', siteId: 's1' }], skipped: [], errors: [] } }))
+      .mockReturnValueOnce(jsonResponse({ data: [{ id: '1', displayName: 'Acme', alreadyImported: true, organizationId: 'org-1' }] }));
+
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(screen.getByTestId('quickbooks-import-select-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quickbooks-import-select-1'));
+    fireEvent.click(screen.getByTestId('quickbooks-import-submit'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+    // POST body carried the selected id.
+    const postCall = fetchWithAuthMock.mock.calls[1]!;
+    expect(postCall[0]).toBe('/accounting/quickbooks/customers/import');
+    expect(JSON.parse((postCall[1] as RequestInit).body as string)).toEqual({ customerIds: ['1'] });
+  });
+
+  it('shows an error toast when loading fails', async () => {
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ error: 'not connected' }, 404));
+    render(<QuickbooksCustomerImport />);
+    fireEvent.click(screen.getByTestId('quickbooks-import-load'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/integrations/QuickbooksCustomerImport.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/web/src/components/integrations/QuickbooksCustomerImport.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction } from '../../lib/runAction';
+import { showToast } from '../../lib/toast';
+import { useBulkSelection } from '../billing/bulk/useBulkSelection';
+
+interface AnnotatedCustomer {
+  id: string;
+  displayName: string;
+  email?: string;
+  companyName?: string;
+  alreadyImported: boolean;
+  organizationId: string | null;
+}
+
+interface ImportSummary {
+  imported: unknown[];
+  skipped: unknown[];
+  errors: Array<{ customerId: string; error: string }>;
+}
+
+interface Props {
+  onUnauthorized?: () => void;
+}
+
+export default function QuickbooksCustomerImport({ onUnauthorized }: Props) {
+  const [customers, setCustomers] = useState<AnnotatedCustomer[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const selection = useBulkSelection();
+
+  const importable = (customers ?? []).filter((c) => !c.alreadyImported);
+
+  async function load() {
+    setLoading(true);
+    selection.clear();
+    try {
+      const data = await runAction<{ data: AnnotatedCustomer[] }>({
+        request: () => fetchWithAuth('/accounting/quickbooks/customers'),
+        errorFallback: 'Failed to load QuickBooks customers.',
+        onUnauthorized,
+      });
+      setCustomers(data.data);
+    } catch {
+      // runAction already toasted; leave the list as-is.
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function importSelected() {
+    const customerIds = Array.from(selection.selectedIds);
+    if (customerIds.length === 0) return;
+    setImporting(true);
+    try {
+      await runAction<{ data: ImportSummary }>({
+        request: () => fetchWithAuth('/accounting/quickbooks/customers/import', {
+          method: 'POST',
+          body: JSON.stringify({ customerIds }),
+        }),
+        errorFallback: 'Failed to import customers.',
+        successMessage: (res) => {
+          const s = res.data;
+          const parts = [`${s.imported.length} imported`];
+          if (s.skipped.length) parts.push(`${s.skipped.length} skipped`);
+          if (s.errors.length) parts.push(`${s.errors.length} failed`);
+          return parts.join(', ');
+        },
+        onUnauthorized,
+      });
+      await load(); // refresh so imported rows flip to "already imported"
+    } catch {
+      // already toasted
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function toggleSelectAll() {
+    if (importable.every((c) => selection.has(c.id))) {
+      selection.clear();
+    } else {
+      selection.selectAll(importable.map((c) => c.id));
+    }
+  }
+
+  return (
+    <div data-testid="quickbooks-import-panel" className="mt-6 border-t border-gray-200 pt-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Import customers</h3>
+        <button
+          type="button"
+          data-testid="quickbooks-import-load"
+          onClick={load}
+          disabled={loading}
+          className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : customers ? 'Refresh' : 'Load customers'}
+        </button>
+      </div>
+
+      {customers && customers.length === 0 && (
+        <p className="mt-4 text-sm text-gray-500" data-testid="quickbooks-import-empty">No customers found in QuickBooks.</p>
+      )}
+
+      {customers && customers.length > 0 && (
+        <>
+          <table className="mt-4 w-full text-sm" data-testid="quickbooks-import-table">
+            <thead>
+              <tr className="text-left text-gray-500">
+                <th className="w-8">
+                  <input
+                    type="checkbox"
+                    data-testid="quickbooks-import-select-all"
+                    aria-label="Select all"
+                    checked={importable.length > 0 && importable.every((c) => selection.has(c.id))}
+                    onChange={toggleSelectAll}
+                  />
+                </th>
+                <th>Name</th>
+                <th>Email</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((c) => (
+                <tr key={c.id} data-testid={`quickbooks-import-row-${c.id}`} className="border-t border-gray-100">
+                  <td>
+                    <input
+                      type="checkbox"
+                      data-testid={`quickbooks-import-select-${c.id}`}
+                      checked={selection.has(c.id)}
+                      disabled={c.alreadyImported}
+                      onChange={() => selection.toggle(c.id)}
+                    />
+                  </td>
+                  <td className="py-1.5 text-gray-900">{c.displayName}</td>
+                  <td className="py-1.5 text-gray-500">{c.email ?? '—'}</td>
+                  <td className="py-1.5">
+                    {c.alreadyImported && (
+                      <span data-testid={`quickbooks-import-badge-${c.id}`} className="rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                        Already imported
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-4">
+            <button
+              type="button"
+              data-testid="quickbooks-import-submit"
+              onClick={importSelected}
+              disabled={importing || selection.size === 0}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {importing ? 'Importing…' : `Import ${selection.size} selected`}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+> Before implementing, open `apps/web/src/components/billing/bulk/useBulkSelection.ts` to confirm the exact `selectAll` signature. If `selectAll` takes no args (selects from an internal set) rather than an id array, adapt `toggleSelectAll`/`load` to call `selection.toggle` per id instead. Also confirm `showToast` is exported from `apps/web/src/lib/toast` (used by the test mock); if the project's toast helper lives elsewhere, mock that module path in the test instead.
+
+- [ ] **Step 4: Render it from the QuickBooks panel**
+
+In `apps/web/src/components/integrations/QuickbooksIntegration.tsx`, add the import near the other imports (line ~10):
+
+```ts
+import QuickbooksCustomerImport from './QuickbooksCustomerImport';
+```
+
+Then render it inside the connected state. Find where the panel shows connected content (it gates on an `isConnected`/status value — search for `status === 'connected'` or the disconnect button around line 161-230) and add, just before the panel's closing container tag:
+
+```tsx
+{isConnected && <QuickbooksCustomerImport onUnauthorized={onUnauthorized} />}
+```
+
+(Use whatever the local connected boolean + `onUnauthorized` handler are named in that file — match the existing `runAction` calls' `onUnauthorized`.)
+
+- [ ] **Step 5: Run the web tests**
+
+Run:
+```bash
+pnpm --filter @breeze/web exec vitest run src/components/integrations/QuickbooksCustomerImport.test.tsx
+pnpm --filter @breeze/web exec vitest run src/components/integrations/QuickbooksIntegration.test.tsx
+```
+Expected: both PASS (the existing QB integration test should be unaffected; if it asserts an exact subtree, update it to tolerate the new child panel).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/integrations/QuickbooksCustomerImport.tsx apps/web/src/components/integrations/QuickbooksCustomerImport.test.tsx apps/web/src/components/integrations/QuickbooksIntegration.tsx
+git commit -m "feat(web): QuickBooks customer import panel"
+```
+
+---
+
+## Task 6: Full-suite verification
+
+- [ ] **Step 1: Run the API + web suites for touched areas**
+
+Run:
+```bash
+pnpm --filter @breeze/api exec vitest run src/services/accounting src/routes/accounting src/db/autoMigrate.test.ts
+pnpm --filter @breeze/web exec vitest run src/components/integrations
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Verify RLS contract is unaffected**
+
+Run the org RLS coverage contract (needs a real DB; see CLAUDE.md for the integration config):
+```bash
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts
+```
+Expected: PASS with no new allowlist entries required (the new columns don't change the org tenancy shape). If it can't run locally (no DB), note that CI's smoke-test job covers it.
+
+- [ ] **Step 3: Drift check + typecheck**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:check-drift
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm --filter @breeze/web exec tsc --noEmit
+```
+Expected: no drift, no type errors.
+
+- [ ] **Step 4: Commit any fixes, then open the PR per repo workflow**
+
+Use the repo's normal PR flow (`gh pr create`, squash-merge with `--admin` when CI is green).
+
+---
+
+## Self-Review Notes (addressed)
+
+- **Spec §1 migration** → Task 1. **§2 client** → Task 2. **§3 routes** → Task 4. **§4 import service** → Task 3. **§5 web UI** → Task 5. **§6 testing** → tests in each task + Task 6.
+- **Idempotency** enforced two ways: dedup pre-check in the service (Task 3) AND the partial unique index (Task 1) as the concurrency backstop.
+- **Token handling**: `getValidAccessToken` is called in the service (under system context) and the provider receives a pre-resolved token — keeping the provider pure HTTP and unit-testable (Task 2/3).
+- **RLS**: org+site inserts run under `runOutsideDbContext(() => withSystemDbAccessContext(...))` (Task 3), matching the tenant-create escape in `orgs.ts:1037`.
+- **Type consistency**: `RemoteCustomer`/`RemoteAddress` defined in Task 2 are consumed by Task 3; `QbImportSummary`/`AnnotatedCustomer`/`QbImportError` defined in Task 3 are consumed by Task 4; the web `AnnotatedCustomer`/`ImportSummary` shapes in Task 5 mirror the API response `{ data }` envelopes.
+```

--- a/docs/superpowers/plans/2026-06-29-quickbooks-customer-import.md
+++ b/docs/superpowers/plans/2026-06-29-quickbooks-customer-import.md
@@ -478,16 +478,19 @@ function stubSelect(rows: unknown[]) {
   selectMock.mockReturnValue({ from: () => ({ where: () => Promise.resolve(rows) }) });
 }
 
-// Helper to stub `db.insert(...).values(...).returning()` returning `row`.
-function stubInsertReturning(rowsInOrder: unknown[][]) {
+// Captures the object passed to each `db.insert(...).values(OBJ)` call, in order,
+// without any production-code instrumentation.
+const valuesSpy = vi.fn();
+function stubInserts(rowsInOrder: unknown[][]) {
   let call = 0;
   insertMock.mockImplementation(() => ({
-    values: () => ({ returning: () => Promise.resolve(rowsInOrder[call++] ?? []) }),
+    values: (v: unknown) => { valuesSpy(v); return { returning: () => Promise.resolve(rowsInOrder[call++] ?? []) }; },
   }));
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  valuesSpy.mockClear();
   getConnectionMock.mockResolvedValue(connectedConn());
   getValidAccessTokenMock.mockResolvedValue('fresh-token');
 });
@@ -542,7 +545,7 @@ describe('importQuickbooksCustomers', () => {
       shipAddr: { line1: '2 Ship Rd', city: 'Dallas' },
     }]);
     stubSelect([]); // no existing orgs
-    stubInsertReturning([[{ id: 'org-1', name: 'Acme Co', partnerId: 'p1' }], [{ id: 'site-1', orgId: 'org-1', name: 'Acme Co' }]]);
+    stubInserts([[{ id: 'org-1', name: 'Acme Co', partnerId: 'p1' }], [{ id: 'site-1', orgId: 'org-1', name: 'Acme Co' }]]);
 
     const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
 
@@ -550,10 +553,8 @@ describe('importQuickbooksCustomers', () => {
     expect(summary.skipped).toEqual([]);
     expect(summary.errors).toEqual([]);
 
-    // Org insert got billing address + accounting link.
-    const orgValues = (insertMock.mock.results[0]!.value.values as any);
-    // (Assert via the recorded call below.)
-    const orgInsertArg = insertCalls()[0];
+    // Org insert (first values() call) got billing address + accounting link.
+    const orgInsertArg = valuesSpy.mock.calls[0]![0];
     expect(orgInsertArg).toMatchObject({
       partnerId: 'p1', name: 'Acme Co', slug: 'acme-co',
       accountingProvider: 'quickbooks', accountingExternalId: '1',
@@ -561,8 +562,8 @@ describe('importQuickbooksCustomers', () => {
       billingAddressLine1: '1 Bill St', billingAddressCity: 'Austin',
       billingAddressRegion: 'TX', billingAddressPostalCode: '78701', billingAddressCountry: 'US',
     });
-    // Site insert used shipping address.
-    const siteInsertArg = insertCalls()[1];
+    // Site insert (second values() call) used shipping address.
+    const siteInsertArg = valuesSpy.mock.calls[1]![0];
     expect(siteInsertArg).toMatchObject({
       orgId: 'org-1', name: 'Acme Co',
       address: { addressLine1: '2 Ship Rd', city: 'Dallas' },
@@ -573,9 +574,9 @@ describe('importQuickbooksCustomers', () => {
   it('falls back to billing address for the site when shipping is absent', async () => {
     listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme', billAddr: { line1: '1 Bill St', city: 'Austin' } }]);
     stubSelect([]);
-    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
     await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
-    expect(insertCalls()[1]).toMatchObject({ address: { addressLine1: '1 Bill St', city: 'Austin' } });
+    expect(valuesSpy.mock.calls[1]![0]).toMatchObject({ address: { addressLine1: '1 Bill St', city: 'Austin' } });
   });
 
   it('skips customers already linked to an org', async () => {
@@ -590,9 +591,9 @@ describe('importQuickbooksCustomers', () => {
   it('suffixes the slug when the base collides with an existing org slug', async () => {
     listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
     stubSelect([{ id: 'org-x', accountingExternalId: '99', slug: 'acme' }]);
-    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
     await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1'] });
-    expect(insertCalls()[0]).toMatchObject({ slug: 'acme-2' });
+    expect(valuesSpy.mock.calls[0]![0]).toMatchObject({ slug: 'acme-2' });
   });
 
   it('records a per-customer error and continues with the rest (partial success)', async () => {
@@ -617,22 +618,13 @@ describe('importQuickbooksCustomers', () => {
   it('reports requested ids not present in QuickBooks as errors', async () => {
     listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
     stubSelect([]);
-    stubInsertReturning([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
+    stubInserts([[{ id: 'org-1' }], [{ id: 'site-1' }]]);
     const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['1', 'missing'] });
     expect(summary.errors).toContainEqual({ customerId: 'missing', error: 'Customer not found in QuickBooks' });
     expect(summary.imported).toHaveLength(1);
   });
 });
-
-// Records the object passed to each `db.insert(...).values(OBJ)` call, in order.
-function insertCalls(): any[] {
-  return insertMock.mock.calls.length
-    ? (insertMock.mock.results.map((r: any) => r.value.__values).filter(Boolean))
-    : [];
-}
 ```
-
-> Note on `insertCalls()`: the implementation below stores the values object on the chain (`__values`) so tests can assert it. Keep that shim in the impl.
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
@@ -782,7 +774,7 @@ export async function importQuickbooksCustomers(
 
       const { orgId, siteId } = await runOutsideDbContext(() =>
         withSystemDbAccessContext(async () => {
-          const [org] = await insertReturning(db.insert(organizations), {
+          const [org] = await db.insert(organizations).values({
             partnerId,
             name: customer.displayName,
             slug,
@@ -796,13 +788,13 @@ export async function importQuickbooksCustomers(
             billingAddressCountry: customer.billAddr?.country ?? null,
             accountingProvider: PROVIDER,
             accountingExternalId: customerId,
-          });
-          const [site] = await insertReturning(db.insert(sites), {
+          }).returning();
+          const [site] = await db.insert(sites).values({
             orgId: org!.id,
             name: customer.displayName,
             address: siteAddressFrom(customer.shipAddr ?? customer.billAddr),
             contact,
-          });
+          }).returning();
           return { orgId: org!.id as string, siteId: site!.id as string };
         })
       );
@@ -816,17 +808,7 @@ export async function importQuickbooksCustomers(
 
   return summary;
 }
-
-// Thin wrapper around Drizzle's `.values(v).returning()` that also stamps the
-// values object onto the chain so unit tests can assert what was inserted.
-function insertReturning(chain: { values: (v: unknown) => { returning: () => Promise<any[]> } }, values: Record<string, unknown>) {
-  const next = chain.values(values);
-  (next as unknown as { __values?: unknown }).__values = values;
-  return next.returning();
-}
 ```
-
-> Note: the test's `insertCalls()` reads `__values` off the chain returned by `db.insert(...).values(...)`. The impl's `insertReturning` stamps it there. In production Drizzle, the extra property is harmless.
 
 - [ ] **Step 4: Run the tests to verify they pass**
 

--- a/docs/superpowers/specs/2026-06-29-quickbooks-customer-import-design.md
+++ b/docs/superpowers/specs/2026-06-29-quickbooks-customer-import-design.md
@@ -1,0 +1,228 @@
+# QuickBooks Customer Import → Orgs + Sites — Design
+
+**Date:** 2026-06-29
+**Status:** Approved (pending spec review)
+**Branch:** ToddHebebrand/QB-Import
+
+## Summary
+
+Add the ability to import QuickBooks customers into Breeze as Organizations, each
+with one default Site, carrying contact and address information. The flow is
+interactive **browse → select → import**, modeled on the existing catalog
+distributor import. Re-imports are idempotent via a QuickBooks customer-id link
+stored on the organization.
+
+## Context
+
+The accounting integration (`apps/api/src/services/accounting/`) is a
+partner-scoped, provider-seam architecture. OAuth + token lifecycle is built
+(Phase A); customer/item/invoice operations are stubbed
+(`listRemoteCustomers` throws `NotImplemented: Phase B`).
+
+Key existing facts this design builds on:
+
+- **Connection is partner-scoped.** `accounting_connections` is keyed by
+  `partnerId` (one QB realm per MSP partner). Imported customers become orgs
+  under that partner. Tokens are encrypted at rest; use
+  `getValidAccessToken(db, conn)` (`accountingTokens.ts:29`) for a usable bearer.
+- **Provider seam.** `AccountingProvider` (`services/accounting/types.ts:36`)
+  already declares `listRemoteCustomers(conn, query?)`. Registry:
+  `getAccountingProvider(id)` (`providerRegistry.ts`). Implementation lives in
+  `quickbooksProvider.ts` (stub at `:47`).
+- **Org/Site model** (`db/schema/orgs.ts`): no separate `contacts` table.
+  - `organizations`: `billingContact` JSONB, flat `billingAddressLine1/Line2/
+    City/Region/PostalCode` + `billingAddressCountry` (char(2)). `slug` is
+    **not** DB-unique. Only unique index is `(id, partnerId)`.
+  - `sites`: `address` JSONB, `contact` JSONB (`{name?,email?,phone?}`),
+    `timezone` (default UTC).
+  - Tenant-create RLS escape: org/site inserts run inside
+    `runOutsideDbContext(() => withSystemDbAccessContext(...))`
+    (`orgs.ts:1037`).
+- **Import analog.** Catalog distributor import (commit `c29a228fb`): per-provider
+  `…/customers` (read) + `…/import` (write, MFA-gated) routes →
+  `importXxx(input, actor)` service with a `catalogActorFrom(c)` actor seam.
+
+## Design Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Mapping model | Each QB customer → one **Org + one default Site** |
+| Import flow | **Browse & select** (live list, checkboxes, Import button) |
+| Duplicates | **Track QB id on the org; skip already-linked** customers |
+| Field mapping | **Both org & site**: org billing addr+contact, site shipping addr+contact |
+
+## 1. Data Model / Migration
+
+Add two nullable columns to `organizations`:
+
+- `accounting_provider` text — `'quickbooks' | 'xero'`
+- `accounting_external_id` text — the remote customer id
+
+Plus a **partial unique index** enforcing idempotency:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_accounting_external_uniq
+  ON organizations (partner_id, accounting_provider, accounting_external_id)
+  WHERE accounting_external_id IS NOT NULL;
+```
+
+Rationale:
+- Generic `(provider, external_id)` rather than `quickbooks_customer_id` because
+  the seam already anticipates Xero.
+- The partial unique index makes "skip dupes" correct even under concurrent
+  imports (DB-enforced, not just a pre-check).
+- `organizations` already has RLS; these columns do not change its tenancy
+  shape (still `org_id`/id-keyed under a partner), so **no RLS contract changes**
+  and no new allowlist entries.
+
+Migration `apps/api/migrations/2026-06-29-org-accounting-external-id.sql`,
+following repo conventions: hand-written SQL, idempotent (`ADD COLUMN IF NOT EXISTS`,
+`CREATE UNIQUE INDEX IF NOT EXISTS`), no inner `BEGIN/COMMIT`. Update the Drizzle
+schema in `db/schema/orgs.ts` to match. Run `pnpm db:check-drift`.
+
+## 2. QuickBooks Client
+
+Implement `QuickbooksProvider.listRemoteCustomers` (`quickbooksProvider.ts:47`):
+
+- Call the QBO query API:
+  `GET {base}/v3/company/{realmId}/query?query=SELECT * FROM Customer STARTPOSITION {n} MAXRESULTS 1000`
+  - `{base}` chosen by `conn.environment`: sandbox
+    (`https://sandbox-quickbooks.api.intuit.com`) vs production
+    (`https://quickbooks.api.intuit.com`).
+  - Bearer token via `getValidAccessToken(db, conn)`.
+  - `realmId` from the decrypted connection.
+  - `Accept: application/json`.
+- Paginate via `STARTPOSITION`/`MAXRESULTS` until a short page is returned.
+
+Add a richer return type (the current `RemoteEntity` only has
+`{id, displayName, email}`):
+
+```ts
+interface RemoteCustomer {
+  id: string;            // QBO Customer.Id
+  displayName: string;   // DisplayName (fallback CompanyName)
+  companyName?: string;
+  email?: string;        // PrimaryEmailAddr.Address
+  phone?: string;        // PrimaryPhone.FreeFormNumber
+  contactName?: string;  // GivenName + FamilyName
+  billAddr?: RemoteAddress;  // BillAddr
+  shipAddr?: RemoteAddress;  // ShipAddr
+  active?: boolean;
+}
+
+interface RemoteAddress {
+  line1?: string; line2?: string;
+  city?: string; region?: string;     // CountrySubDivisionCode
+  postalCode?: string; country?: string;
+}
+```
+
+Mapping notes: QBO addresses use `Line1`, `City`, `CountrySubDivisionCode`
+(region/state), `PostalCode`, `Country`. Tolerate missing fields. Inactive
+customers are included but flagged `active:false` (UI may filter).
+
+## 3. Routes
+
+Under the existing `/accounting/:provider` router (`routes/accounting/index.ts`),
+`provider` enum-locked, gated `requireScope('partner','system')` + `requireMfa()`
+(matching the OAuth routes):
+
+- `GET /accounting/:provider/customers`
+  - Fetches remote customers via the provider client.
+  - Left-joins `organizations.accounting_external_id` (for this partner+provider)
+    to annotate each row with `alreadyImported: boolean` and, when present, the
+    existing `organizationId`.
+  - Returns `{ data: AnnotatedCustomer[] }`.
+- `POST /accounting/:provider/customers/import`
+  - Body (zod-validated): `{ customerIds: string[] }` (bounded length).
+  - Delegates to the import service.
+  - Returns `{ data: { imported: ImportResult[], skipped: SkipResult[], errors: ErrorResult[] } }`.
+
+Error handling mirrors `distributors.ts`: a typed service error mapped to HTTP
+in the route handler. Responses POSTed from web are consumed via `runAction`.
+
+## 4. Import Service
+
+`importQuickbooksCustomers(input, actor)` (new file under
+`services/accounting/`), actor seam modeled on `catalogActorFrom`/
+`importPax8CatalogItem`:
+
+1. Resolve the connection for the actor's partner → `partnerId`, `realmId`,
+   provider id. (Reuse `getConnection`.)
+2. Fetch the selected customers (by id) from the provider, or accept already-
+   fetched payloads — fetch is preferred so the import is authoritative.
+3. For each customer:
+   - If an org already exists with `(partner_id, provider, external_id)` →
+     record as **skipped** (`alreadyImported`).
+   - Else create, inside `runOutsideDbContext(() => withSystemDbAccessContext(...))`:
+     - **Org**: `name = displayName`, `slug = uniqueSlug(displayName, partner)`,
+       `type = 'customer'`, `billingContact = {name: contactName, email, phone}`,
+       flat `billingAddress*` from `billAddr`,
+       `accounting_provider`, `accounting_external_id = id`.
+     - **Default Site**: `name` (e.g. "Main" or the customer name),
+       `address` JSONB from `shipAddr ?? billAddr`,
+       `contact` JSONB `{name: contactName, email, phone}`,
+       `timezone` default UTC.
+     - `writeRouteAudit` for org-create and site-create.
+   - Record as **imported** (`organizationId`, `siteId`).
+   - On per-customer failure, record an **error** and continue (partial success).
+4. Return the aggregate `{ imported, skipped, errors }`.
+
+**Slug uniqueness:** slugify `displayName`; if a same-slug org exists in the
+partner, append `-2`, `-3`, … Best-effort (slug isn't DB-unique); the DB unique
+index on the QB external id is the real idempotency guard.
+
+**Address JSONB shape:** match the web convention
+`{ addressLine1, addressLine2, city, state, postalCode, country }` used by
+`SiteForm.tsx`, so imported sites render correctly in the existing UI.
+
+## 5. Web UI
+
+An "Import from QuickBooks" screen in the accounting/integrations area:
+
+- On open, `GET …/customers`; render a checkbox table: name, email, address
+  preview, and an **Already imported** badge (row checkbox disabled) for linked
+  customers.
+- Select-all (excludes already-imported), and an **Import** button.
+- Import POST wrapped in `runAction` so success, failure, and partial results
+  ("8 imported, 2 skipped") always surface via toast.
+- After import, refresh the list so newly-imported rows show as imported.
+
+## 6. Testing
+
+- **Provider client** (`quickbooksProvider.test.ts`): QBO Customer →
+  `RemoteCustomer` mapping (BillAddr/ShipAddr/phone/contact, missing fields,
+  inactive flag); pagination across `STARTPOSITION` pages.
+- **Import service**: dedup-skip on already-linked; org+site field mapping;
+  `shipAddr → billAddr` fallback; slug-collision suffixing; partial-success
+  (one customer errors, others import).
+- **Routes** (style of `distributors.test.ts`): list annotation correctness;
+  import happy path; MFA + scope gating.
+- **Web**: component test for selection, already-imported disabling, and
+  `runAction` error surfacing.
+- **RLS**: no new contract entries — columns don't change org tenancy shape.
+  Run the existing org RLS coverage to confirm no regression.
+
+## Out of Scope (YAGNI)
+
+- Background/scheduled sync of customers (interactive import only).
+- Two-way push (Breeze org → QB customer); that's the separate `upsertCustomer`
+  seam.
+- Sub-customer → Site hierarchy (each QB customer gets exactly one default Site).
+- Updating existing orgs from QB on re-import (skipped, not updated). Can be a
+  follow-up.
+- Xero customer import (schema is generic to allow it later; client not built).
+
+## Files (anticipated)
+
+- `apps/api/migrations/2026-06-29-org-accounting-external-id.sql` — new columns + partial unique index
+- `apps/api/src/db/schema/orgs.ts` — add columns to Drizzle schema
+- `apps/api/src/services/accounting/types.ts` — `RemoteCustomer`/`RemoteAddress`
+- `apps/api/src/services/accounting/quickbooksProvider.ts` — implement
+  `listRemoteCustomers`
+- `apps/api/src/services/accounting/quickbooksCustomerImport.ts` (new) —
+  `importQuickbooksCustomers`
+- `apps/api/src/routes/accounting/index.ts` (or a new `customers.ts` sub-route) —
+  list + import endpoints
+- `apps/web/src/components/...` — import screen
+- Co-located `*.test.ts` files for each of the above


### PR DESCRIPTION
## What

Adds the ability to **import QuickBooks customers into Breeze as Organizations**, each with one default Site carrying contact + address information. Flow is an interactive **browse → select → import**, modeled on the existing catalog distributor import. Re-imports are idempotent.

Spec: `docs/superpowers/specs/2026-06-29-quickbooks-customer-import-design.md`
Plan: `docs/superpowers/plans/2026-06-29-quickbooks-customer-import.md`

## How it works

- **Browse**: `GET /accounting/:provider/customers` pulls the partner's QB customers live (paginated QBO query API) and annotates each with `alreadyImported`.
- **Import**: MFA-gated `POST /accounting/:provider/customers/import` creates an Org (name, slug, `billingContact` + flat `billingAddress*` from QB `BillAddr`) and one default Site (`address` from `ShipAddr` → falls back to `BillAddr`, plus `contact`) per selected customer, auditing each created org.
- **Idempotency**: each org links back via new `organizations.accounting_provider` + `accounting_external_id` columns; a **partial unique index** `(partner_id, accounting_provider, accounting_external_id) WHERE accounting_external_id IS NOT NULL` is the concurrency backstop, with an in-service dedup pre-check. Already-linked customers are skipped; per-customer failures don't abort the batch (partial success).
- **Web**: a selectable customer table inside the QuickBooks integration panel (shown when connected), with already-imported rows badged + disabled and a select-all. All mutations go through `runAction`.

## Multi-tenant / RLS notes

- Accounting connections are **partner-scoped** (one QB realm per MSP partner); imports create orgs under that partner. `resolvePartnerId` is enforced on both routes.
- Org + Site inserts and all system-context reads run inside `runOutsideDbContext(() => withSystemDbAccessContext(...))` (tenant-create RLS escape).
- Both routes are registered in `SELF_MANAGED_DB_CONTEXT_ROUTES` so `authMiddleware` does not pin a request transaction across the multi-second QBO paging call (#1105/#1448 pool-poison class).
- New columns don't change the org tenancy shape — **no RLS allowlist change**; the RLS coverage contract passes 45/45.

## Testing

- API: accounting service + routes + middleware suites green (70/70 in the touched areas; full accounting+db 89/89); `autoMigrate` 43/43; migration verified idempotent (applied twice).
- RLS coverage contract: 45/45.
- Web: integrations suite 77/77 (3 new panel tests + existing QB integration unaffected).
- `tsc --noEmit` clean for both `@breeze/api` and `@breeze/web`.

## Out of scope (deferred)

Background/scheduled sync, two-way push (Breeze → QB), sub-customer → Site hierarchy, updating existing orgs on re-import, and Xero customer import (schema is generic to allow it later).

> Note: the QuickBooks integration itself has not yet been exercised end-to-end against a live Intuit sandbox; this PR is unit/contract-test green but the real OAuth + customer fetch should be smoke-tested before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
