### PR TITLE
fix(installer): MSI bootstrap CA never delivered the enrollment token

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -309,13 +309,15 @@
          Target has already been formatted by then.) Verified on the shipped
          v0.86.0 MSI: the formatted Target carries the full path with the token.
 
-         Do NOT revert this to "[CustomActionData]". A deferred EXE custom action
-         cannot read CustomActionData from its command line — [CustomActionData]
-         formats to an EMPTY string at schedule time, so the agent received an
-         empty install-data argument and silently skipped enrollment on EVERY
-         install ("no bootstrap token present" then unenrolled). That was the real
-         cause of the field reports; it was misattributed to #1956's
-         bracket-stripping, but brackets were never the issue and the prior
+         Do NOT revert this to "[CustomActionData]". For a deferred EXE custom
+         action, [CustomActionData] in the ExeCommand formats to an EMPTY string
+         at schedule time (CustomActionData only exists at deferred-execution time,
+         and only DLL/script CAs can read it — an EXE CA gets nothing on its
+         command line). So the agent received an empty install-data argument and
+         silently skipped enrollment on EVERY install ("no bootstrap token
+         present" then unenrolled). That was the real cause of the field reports.
+         It was misattributed to #1956's bracket-stripping — a real but separate
+         bug that just wasn't the cause of non-enrollment; the prior
          SetBootstrapData then CustomActionData indirection never delivered the
          token at all.
 

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -297,28 +297,40 @@
       Return="check"
       HideTarget="yes" />
 
-    <!-- Capture the launched MSI path + bootstrap inputs while the original
-         session properties are still readable (immediate CA). OriginalDatabase
-         points at the user's downloaded file here; by deferred execution the
-         package is cached to C:\Windows\Installer and the (TOKEN@HOST) name is
-         gone. Packed pipe-delimited because deferred CAs only see CustomActionData.
+    <!-- Pass the launched MSI path (which carries the bootstrap token in its
+         filename — Breeze Agent (TOKEN@HOST).msi) to the agent on the deferred
+         CA's command line, via [OriginalDatabase] referenced DIRECTLY.
 
-         The download filename carries the token in PARENTHESES — Breeze Agent
-         (TOKEN@HOST).msi — NOT square brackets. This value flows through MSI's
-         Formatted-field engine, where "[...]" is the property-reference
-         delimiter, and a bracketed token substring gets stripped along the way,
-         silently dropping the token (observed in #1956). Parens are literal in
-         Formatted fields and survive into CustomActionData. The agent parser
-         accepts both forms. -->
-    <CustomAction
-      Id="SetBootstrapData"
-      Property="BootstrapEnroll"
-      Value="[OriginalDatabase]|[BOOTSTRAP_TOKEN]|[SERVER_URL]" />
+         MSI formats a deferred CA's Target at SCHEDULE time (the immediate
+         execute-sequence pass), where OriginalDatabase still points at the user's
+         downloaded file — the (TOKEN@HOST) name is intact and is baked into the
+         script. (By deferred EXECUTION time the package is cached to
+         C:\Windows\Installer and OriginalDatabase would be tokenless, but the
+         Target has already been formatted by then.) Verified on the shipped
+         v0.86.0 MSI: the formatted Target carries the full path with the token.
 
+         Do NOT revert this to "[CustomActionData]". A deferred EXE custom action
+         cannot read CustomActionData from its command line — [CustomActionData]
+         formats to an EMPTY string at schedule time, so the agent received an
+         empty install-data argument and silently skipped enrollment on EVERY
+         install ("no bootstrap token present" then unenrolled). That was the real
+         cause of the field reports; it was misattributed to #1956's
+         bracket-stripping, but brackets were never the issue and the prior
+         SetBootstrapData then CustomActionData indirection never delivered the
+         token at all.
+
+         The token rides in PARENTHESES — Breeze Agent (TOKEN@HOST).msi — not
+         square brackets, because "[...]" is MSI's Formatted-field delimiter and a
+         bracketed substring is stripped; parens are literal and survive. The
+         agent parser (installer_filename.go) accepts both. The pipe-delimited
+         <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL> shape mirrors the
+         agent's resolveBootstrapInputs payload (an explicitly-supplied token +
+         server take precedence; both are empty on the filename-bootstrap path).
+         HideTarget keeps the token out of the verbose log. -->
     <CustomAction
       Id="BootstrapEnroll"
       FileRef="filBreezeAgentExe"
-      ExeCommand="bootstrap --install-data &quot;[CustomActionData]&quot; --quiet"
+      ExeCommand="bootstrap --install-data &quot;[OriginalDatabase]|[BOOTSTRAP_TOKEN]|[SERVER_URL]&quot; --quiet"
       Execute="deferred"
       Impersonate="no"
       Return="check"
@@ -374,9 +386,9 @@
       <Custom Action="EnrollAgent" Before="InstallServices" Condition="NOT Installed AND SERVER_URL AND ENROLLMENT_KEY" />
       <!-- Filename/property bootstrap enrollment: only when explicit
            SERVER_URL+ENROLLMENT_KEY were NOT supplied (those take the
-           EnrollAgent path above). SetBootstrapData (immediate) must run before
-           the deferred BootstrapEnroll so CustomActionData is populated. -->
-      <Custom Action="SetBootstrapData" Before="BootstrapEnroll" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
+           EnrollAgent path above). The deferred CA references [OriginalDatabase]
+           directly (baked at schedule time, here, while it still names the
+           downloaded file) — no immediate capture CA is needed. -->
       <Custom Action="BootstrapEnroll" Before="InstallServices" Condition="NOT Installed AND NOT (SERVER_URL AND ENROLLMENT_KEY)" />
       <Custom Action="UnregisterUserHelperTask" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot;" />
     </InstallExecuteSequence>

--- a/agent/internal/agentapp/bootstrap_test.go
+++ b/agent/internal/agentapp/bootstrap_test.go
@@ -41,6 +41,17 @@ func TestResolveBootstrapInputs(t *testing.T) {
 			wantErr: errNoBootstrapInput,
 		},
 		{
+			// Post-fix the BootstrapEnroll CA formats [OriginalDatabase] directly
+			// into the command line, so install-data is ALWAYS a non-empty MSI path
+			// (never the old "" empty arg). A plain install whose filename carries no
+			// (TOKEN@HOST) must still resolve to errNoBootstrapInput so runBootstrap
+			// soft-exits 0 — otherwise the deferred CA's Return="check" would roll
+			// back every tokenless/manual install.
+			name:    "real product filename without token (manual install, must not error-rollback)",
+			data:    `C:\Program Files\Breeze\Breeze Agent.msi||`,
+			wantErr: errNoBootstrapInput,
+		},
+		{
 			name:       "property token without server falls back to filename",
 			data:       `C:\dl\Breeze Agent [ABCDE12345@eu.2breeze.app].msi|ZZZZZ99999|`,
 			wantToken:  "ABCDE12345",

--- a/agent/internal/agentapp/installer_filename.go
+++ b/agent/internal/agentapp/installer_filename.go
@@ -12,11 +12,11 @@ var errNoFilenameToken = errors.New("no bootstrap token in installer filename")
 // installerTokenParenRe is the canonical Windows form: a 10-char base36 token
 // and a host wrapped in PARENTHESES. The Windows MSI download filename uses
 // parens (not brackets) because the path travels through MSI's Formatted-field
-// engine — OriginalDatabase -> SetBootstrapData -> CustomActionData -> agent
-// --install-data — and a "[...]" substring (brackets are that engine's
-// property-reference delimiter) gets stripped along the way, silently dropping
-// the token (observed in #1956). Parens are not special in MSI Formatted
-// fields, so they survive intact.
+// engine — [OriginalDatabase] is formatted directly into the BootstrapEnroll
+// deferred CA's command line (agent bootstrap --install-data) — and a "[...]"
+// substring (brackets are that engine's property-reference delimiter) gets
+// stripped along the way, silently dropping the token (observed in #1956).
+// Parens are not special in MSI Formatted fields, so they survive intact.
 var installerTokenParenRe = regexp.MustCompile(`\(([A-Z0-9]{10})@([a-zA-Z0-9.\-]+)\)`)
 
 // installerTokenBracketRe is the legacy form: [TOKEN@HOST] in square brackets

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -227,7 +227,7 @@ func init() {
 	enrollCmd.Flags().StringVar(&enrollDeviceRole, "device-role", "", "Device role override (e.g. workstation, server)")
 	enrollCmd.Flags().BoolVar(&forceEnroll, "force", false, "Re-enroll even if already enrolled; replaces AgentID/AuthToken on success (no-op on failure)")
 	enrollCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr). Intended for unattended installs.")
-	bootstrapCmd.Flags().StringVar(&bootstrapInstallData, "install-data", "", "Packed WiX CustomActionData: <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>")
+	bootstrapCmd.Flags().StringVar(&bootstrapInstallData, "install-data", "", "Pipe-packed bootstrap inputs from the MSI BootstrapEnroll CA: <OriginalDatabase>|<BOOTSTRAP_TOKEN>|<SERVER_URL>")
 	bootstrapCmd.Flags().BoolVar(&quietEnroll, "quiet", false, "Suppress stdout progress output (errors still go to stderr)")
 	userHelperCmd.Flags().StringVar(&helperRole, "role", "user", "Helper role: 'system' (desktop capture) or 'user' (script execution)")
 	desktopHelperCmd.Flags().StringVar(&desktopContext, "context", ipc.DesktopContextUserSession, "Desktop context: 'user_session' or 'login_window'")


### PR DESCRIPTION
## Problem

MSI installs **succeed** (status 0) but the agent never enrolls — it logs `no bootstrap token present` and idles. Surfaced via NinjaRMM deploys, but it affects **every** filename-bootstrap install, not just Ninja.

## Root cause

`BootstrapEnroll` is a **deferred EXE** custom action that passed the token via `ExeCommand="bootstrap --install-data \"[CustomActionData]\" --quiet"`. A deferred EXE CA cannot read `[CustomActionData]` from its command line — it formats to an **empty string** at schedule time (only DLL/script CAs receive CustomActionData at execution). So the agent always got `--install-data ""`, found no token, and soft-exited 0. `#1956` (brackets→parens) fixed a real-but-separate bug; the token never reached the agent at all.

**Reproduced and verified on the shipped v0.86.0 MSI** (PackageCode `{404DA5EC-…}`, matching field installs). Unmasking the CA in the verbose log showed:
```
Target=bootstrap --install-data "" --quiet                    ← agent got EMPTY
CustomActionData=C:\…\Breeze Agent (TESTTOKEN0@…).msi||        ← token was right here
```

## Fix

Reference `[OriginalDatabase]` **directly** in the deferred CA's `ExeCommand`. MSI formats a deferred CA's `Target` at **schedule time**, where `OriginalDatabase` still names the downloaded `Breeze Agent (TOKEN@HOST).msi` (token intact). The now-redundant `SetBootstrapData`/`CustomActionData` indirection is removed. This makes `BootstrapEnroll` consistent with the sibling `EnrollAgent`/`HardenProgramDataAcl` CAs, which already format properties directly into deferred Targets and ship today.

**Verified end-to-end** on the real MSI: after the change the formatted Target carries the full token-bearing path and the agent redeems the token (rolls back on a fake token, exactly as expected for valid delivery).

## Deploy / workaround

- Takes effect only in the **next signed release MSI** (build + sign + promote).
- **Immediate workaround** for managed deploys (NinjaRMM, etc.) — property-based silent install bypasses the filename path entirely:
  ```
  msiexec /i breeze-agent.msi /qn SERVER_URL=https://<host> ENROLLMENT_KEY=<64-hex-key>
  ```

## Review follow-ups (2nd commit)

PR review (code-reviewer + comment-analyzer) returned no critical/important issues. Addressed suggestions:
- Fixed comment rot in `installer_filename.go` / `main.go` that still described the deleted `SetBootstrapData→CustomActionData` flow.
- Tightened two comment claims in `breeze.wxs`.
- Added a `bootstrap_test.go` case: now that `--install-data` is always a non-empty MSI path, a tokenless/manual install must still resolve to `errNoBootstrapInput` so the CA's `Return="check"` doesn't roll back every such install.

## Test plan

- [x] `xmllint` — WiX XML well-formed
- [x] `go test ./internal/agentapp/` — passes (incl. new rollback-contract case)
- [x] End-to-end on a Windows VM against the real v0.86.0 MSI: token delivered, agent redeems
- [ ] Build/sign a release MSI and confirm enrollment in the field (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)