### PR TITLE
feat(vuln): wire BE-16 correlation into a daily job, gated per-org by config policy

### DIFF
--- a/apps/api/migrations/2026-06-29-vuln-config-feature-type.sql
+++ b/apps/api/migrations/2026-06-29-vuln-config-feature-type.sql
@@ -1,0 +1,20 @@
+-- Add the `vulnerability` config-policy feature type (BE-16 correlation gating).
+-- Pattern B (inline settings only): a single `{ enabled: boolean }` toggle that
+-- gates per-device vulnerability correlation. No normalized settings table — the
+-- toggle lives in config_policy_feature_links.inline_settings (pure JSONB), like
+-- warranty/helper/pam. Default behavior with no policy assigned = disabled.
+--
+-- ALTER TYPE ... ADD VALUE is transaction-safe here because the new value is NOT
+-- used elsewhere in this migration (no table references it). Idempotent guard via
+-- pg_enum existence check, mirroring 0029-event-log-policy-settings.sql.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'vulnerability'
+      AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'config_feature_type')
+  ) THEN
+    ALTER TYPE config_feature_type ADD VALUE 'vulnerability';
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-29-vuln-config-feature-type.sql
+++ b/apps/api/migrations/2026-06-29-vuln-config-feature-type.sql
@@ -5,8 +5,12 @@
 -- warranty/helper/pam. Default behavior with no policy assigned = disabled.
 --
 -- ALTER TYPE ... ADD VALUE is transaction-safe here because the new value is NOT
--- used elsewhere in this migration (no table references it). Idempotent guard via
--- pg_enum existence check, mirroring 0029-event-log-policy-settings.sql.
+-- used elsewhere in this migration (no table references it) — Postgres 12+ allows
+-- ADD VALUE inside the transaction autoMigrate wraps each file in, as long as the
+-- value isn't consumed in that same transaction. (0029-event-log-policy-settings.sql
+-- carries an older "cannot run inside a transaction" note that predates PG12 and is
+-- now inaccurate under autoMigrate — don't follow it.) The idempotent pg_enum
+-- existence guard below uses the same pattern as 0029.
 
 DO $$
 BEGIN

--- a/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
@@ -11,6 +11,7 @@ import {
   devices,
   deviceVulnerabilities,
   organizations,
+  osVulnerabilities,
   partners,
   sites,
   softwareInventory,
@@ -22,7 +23,7 @@ import {
   resolveAllVulnerabilityEnabledDevices,
   resolveVulnerabilityEnabledForDevice,
 } from '../../services/featureConfigResolver';
-import { correlateOrg } from '../../services/vulnerabilityCorrelation';
+import { correlateOrg, correlateOsVulns } from '../../services/vulnerabilityCorrelation';
 import { correlateEnabledOrgs } from '../../jobs/vulnerabilityJobs';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -37,7 +38,7 @@ function uniq(): string {
   return `${Date.now()}-${counter}`;
 }
 
-async function seedOrgWithDevice(): Promise<{ orgId: string; siteId: string; deviceId: string }> {
+async function seedOrgWithDevice(opts?: { osType?: 'windows' | 'macos' | 'linux'; osVersion?: string }): Promise<{ partnerId: string; orgId: string; siteId: string; deviceId: string }> {
   return withSystemDbAccessContext(async () => {
     const u = uniq();
     const [partner] = await db
@@ -56,30 +57,35 @@ async function seedOrgWithDevice(): Promise<{ orgId: string; siteId: string; dev
         siteId: site!.id,
         agentId: `gate-agent-${u}`,
         hostname: `gate-host-${u}`,
-        osType: 'windows',
-        osVersion: '11',
+        osType: opts?.osType ?? 'windows',
+        osVersion: opts?.osVersion ?? '11',
         architecture: 'x86_64',
         agentVersion: '0.0.0-test',
         status: 'offline',
       })
       .returning({ id: devices.id });
-    return { orgId: org!.id, siteId: site!.id, deviceId: device!.id };
+    return { partnerId: partner!.id, orgId: org!.id, siteId: site!.id, deviceId: device!.id };
   });
 }
 
 /** Seed a config policy whose `vulnerability` feature link carries `{ enabled }`,
- *  assigned at `level`/`targetId`. Returns the policy id. */
+ *  assigned at `level`/`targetId`. `owner` is org-owned by default; pass a
+ *  partnerId to make it a partner-wide policy (org_id NULL) — required to exercise
+ *  the resolver's partner-level candidate branch across a partner's orgs. */
 async function seedVulnPolicy(opts: {
-  orgId: string;
-  level: 'organization' | 'site' | 'device';
+  owner: { orgId: string } | { partnerWide: string };
+  level: 'partner' | 'organization' | 'site' | 'device_group' | 'device';
   targetId: string;
   enabled: boolean;
   priority?: number;
 }): Promise<string> {
   return withSystemDbAccessContext(async () => {
+    const ownerCols = 'orgId' in opts.owner
+      ? { orgId: opts.owner.orgId, partnerId: null }
+      : { orgId: null, partnerId: opts.owner.partnerWide };
     const [policy] = await db
       .insert(configurationPolicies)
-      .values({ orgId: opts.orgId, name: `Vuln Policy ${uniq()}`, status: 'active' })
+      .values({ ...ownerCols, name: `Vuln Policy ${uniq()}`, status: 'active' })
       .returning({ id: configurationPolicies.id });
     await db.insert(configPolicyFeatureLinks).values({
       configPolicyId: policy!.id,
@@ -93,6 +99,33 @@ async function seedVulnPolicy(opts: {
       priority: opts.priority ?? 0,
     });
     return policy!.id;
+  });
+}
+
+/** Seed a SOFA macOS OS vulnerability fact (global) for the device's OS line,
+ *  with the device's osVersion below the fixed version so it correlates. */
+async function seedMacosOsFact(): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    const [vuln] = await db
+      .insert(vulnerabilities)
+      .values({
+        cveId: `CVE-GATE-OS-${uniq()}`,
+        source: 'sofa',
+        description: 'gate macOS test vuln',
+        severity: 'high',
+        cvssVersion: '3.1',
+        cvssScore: '7.5',
+        knownExploited: false,
+        patchAvailable: true,
+        rawPayload: { test: true },
+      })
+      .returning({ id: vulnerabilities.id });
+    await db.insert(osVulnerabilities).values({
+      platform: 'macos',
+      osLine: 'Sequoia 15',
+      fixedVersion: '15.6.1',
+      vulnerabilityId: vuln!.id,
+    });
   });
 }
 
@@ -155,6 +188,7 @@ beforeEach(async () => {
   await withSystemDbAccessContext(async () => {
     await db.delete(deviceVulnerabilities);
     await db.delete(softwareVulnerabilities);
+    await db.delete(osVulnerabilities);
     await db.delete(softwareProducts);
     await db.delete(vulnerabilities);
   });
@@ -168,14 +202,14 @@ describe('resolveVulnerabilityEnabledForDevice (gate, default off)', () => {
 
   runDb('returns true when an org-level policy enables it', async () => {
     const { orgId, deviceId } = await seedOrgWithDevice();
-    await seedVulnPolicy({ orgId, level: 'organization', targetId: orgId, enabled: true });
+    await seedVulnPolicy({ owner: { orgId }, level: 'organization', targetId: orgId, enabled: true });
     expect(await withSystemDbAccessContext(() => resolveVulnerabilityEnabledForDevice(deviceId))).toBe(true);
   });
 
   runDb('closest-wins: a device-level disable overrides an org-level enable', async () => {
     const { orgId, deviceId } = await seedOrgWithDevice();
-    await seedVulnPolicy({ orgId, level: 'organization', targetId: orgId, enabled: true });
-    await seedVulnPolicy({ orgId, level: 'device', targetId: deviceId, enabled: false });
+    await seedVulnPolicy({ owner: { orgId }, level: 'organization', targetId: orgId, enabled: true });
+    await seedVulnPolicy({ owner: { orgId }, level: 'device', targetId: deviceId, enabled: false });
     expect(await withSystemDbAccessContext(() => resolveVulnerabilityEnabledForDevice(deviceId))).toBe(false);
   });
 });
@@ -190,11 +224,25 @@ describe('resolveAllVulnerabilityEnabledDevices (batch)', () => {
   runDb('groups enabled devices by org and omits disabled ones', async () => {
     const a = await seedOrgWithDevice();
     const b = await seedOrgWithDevice();
-    await seedVulnPolicy({ orgId: a.orgId, level: 'organization', targetId: a.orgId, enabled: true });
-    await seedVulnPolicy({ orgId: b.orgId, level: 'organization', targetId: b.orgId, enabled: false });
+    await seedVulnPolicy({ owner: { orgId: a.orgId }, level: 'organization', targetId: a.orgId, enabled: true });
+    await seedVulnPolicy({ owner: { orgId: b.orgId }, level: 'organization', targetId: b.orgId, enabled: false });
     const map = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
     expect(map.get(a.orgId)).toEqual([a.deviceId]);
     expect(map.has(b.orgId)).toBe(false);
+  });
+
+  runDb('resolves a site-level assignment (site candidate branch)', async () => {
+    const { orgId, siteId, deviceId } = await seedOrgWithDevice();
+    await seedVulnPolicy({ owner: { orgId }, level: 'site', targetId: siteId, enabled: true });
+    const map = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+    expect(map.get(orgId)).toEqual([deviceId]);
+  });
+
+  runDb('resolves a partner-wide policy at the partner level (partner candidate branch)', async () => {
+    const { partnerId, orgId, deviceId } = await seedOrgWithDevice();
+    await seedVulnPolicy({ owner: { partnerWide: partnerId }, level: 'partner', targetId: partnerId, enabled: true });
+    const map = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+    expect(map.get(orgId)).toEqual([deviceId]);
   });
 });
 
@@ -232,13 +280,40 @@ describe('correlateOrg deviceIds gating', () => {
   });
 });
 
+describe('correlateOsVulns deviceIds gating (macOS)', () => {
+  runDb('flags only when the macOS device is in the deviceIds set, and empty never resolves', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice({ osType: 'macos', osVersion: '15.6.0' });
+    await seedMacosOsFact();
+
+    // Empty set → no-op.
+    const none = await correlateOsVulns(orgId, { deviceIds: [] });
+    expect(none).toEqual({ created: 0, resolved: 0 });
+    expect(await openFindingCount(orgId, deviceId)).toBe(0);
+
+    // Set excluding the device → nothing.
+    const other = await correlateOsVulns(orgId, { deviceIds: ['00000000-0000-0000-0000-000000000000'] });
+    expect(other.created).toBe(0);
+    expect(await openFindingCount(orgId, deviceId)).toBe(0);
+
+    // Set including the device → one OS finding.
+    const hit = await correlateOsVulns(orgId, { deviceIds: [deviceId] });
+    expect(hit.created).toBe(1);
+    expect(await openFindingCount(orgId, deviceId)).toBe(1);
+
+    // Subsequent empty-set pass must NOT resolve the existing macOS finding.
+    const noop = await correlateOsVulns(orgId, { deviceIds: [] });
+    expect(noop).toEqual({ created: 0, resolved: 0 });
+    expect(await openFindingCount(orgId, deviceId)).toBe(1);
+  });
+});
+
 describe('correlateEnabledOrgs (wired job)', () => {
   runDb('correlates only devices whose effective config enables scanning', async () => {
     const enabled = await seedOrgWithDevice();
     const disabled = await seedOrgWithDevice();
     await seedVulnerableInventory(enabled.orgId, enabled.deviceId);
     await seedVulnerableInventory(disabled.orgId, disabled.deviceId);
-    await seedVulnPolicy({ orgId: enabled.orgId, level: 'organization', targetId: enabled.orgId, enabled: true });
+    await seedVulnPolicy({ owner: { orgId: enabled.orgId }, level: 'organization', targetId: enabled.orgId, enabled: true });
     // `disabled` org gets no policy → stays off.
 
     const summary = await correlateEnabledOrgs();

--- a/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilityCorrelationGating.integration.test.ts
@@ -1,0 +1,251 @@
+import './setup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configPolicyAssignments,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  devices,
+  deviceVulnerabilities,
+  organizations,
+  partners,
+  sites,
+  softwareInventory,
+  softwareProducts,
+  softwareVulnerabilities,
+  vulnerabilities,
+} from '../../db/schema';
+import {
+  resolveAllVulnerabilityEnabledDevices,
+  resolveVulnerabilityEnabledForDevice,
+} from '../../services/featureConfigResolver';
+import { correlateOrg } from '../../services/vulnerabilityCorrelation';
+import { correlateEnabledOrgs } from '../../jobs/vulnerabilityJobs';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function orgCtx(orgId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+}
+
+let counter = 0;
+function uniq(): string {
+  counter += 1;
+  return `${Date.now()}-${counter}`;
+}
+
+async function seedOrgWithDevice(): Promise<{ orgId: string; siteId: string; deviceId: string }> {
+  return withSystemDbAccessContext(async () => {
+    const u = uniq();
+    const [partner] = await db
+      .insert(partners)
+      .values({ name: `Gate Partner ${u}`, slug: `gate-partner-${u}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [org] = await db
+      .insert(organizations)
+      .values({ partnerId: partner!.id, name: `Gate Org ${u}`, slug: `gate-org-${u}`, type: 'customer', status: 'active' })
+      .returning({ id: organizations.id });
+    const [site] = await db.insert(sites).values({ orgId: org!.id, name: `Gate Site ${u}` }).returning({ id: sites.id });
+    const [device] = await db
+      .insert(devices)
+      .values({
+        orgId: org!.id,
+        siteId: site!.id,
+        agentId: `gate-agent-${u}`,
+        hostname: `gate-host-${u}`,
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+        status: 'offline',
+      })
+      .returning({ id: devices.id });
+    return { orgId: org!.id, siteId: site!.id, deviceId: device!.id };
+  });
+}
+
+/** Seed a config policy whose `vulnerability` feature link carries `{ enabled }`,
+ *  assigned at `level`/`targetId`. Returns the policy id. */
+async function seedVulnPolicy(opts: {
+  orgId: string;
+  level: 'organization' | 'site' | 'device';
+  targetId: string;
+  enabled: boolean;
+  priority?: number;
+}): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: opts.orgId, name: `Vuln Policy ${uniq()}`, status: 'active' })
+      .returning({ id: configurationPolicies.id });
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'vulnerability',
+      inlineSettings: { enabled: opts.enabled },
+    });
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policy!.id,
+      level: opts.level,
+      targetId: opts.targetId,
+      priority: opts.priority ?? 0,
+    });
+    return policy!.id;
+  });
+}
+
+/** Seed an MSRC product+CVE+fact and a below-FixedBuild inventory row on a device.
+ *  `software_products` is GLOBAL with a unique (normalized_name, normalized_vendor)
+ *  index, so each call uses a distinct product name; the inventory `name` matches
+ *  it via the resolver's `lower(trim(name))` join. */
+async function seedVulnerableInventory(orgId: string, deviceId: string): Promise<void> {
+  const productName = `gate product ${uniq()}`;
+  await withSystemDbAccessContext(async () => {
+    const [product] = await db
+      .insert(softwareProducts)
+      .values({
+        normalizedName: productName,
+        normalizedVendor: 'microsoft',
+        cpe: `cpe:2.3:a:microsoft:gate_${counter}:*:*:*:*:*:*:*:*`,
+        cpeConfidence: 'authoritative',
+      })
+      .returning({ id: softwareProducts.id });
+    const [vuln] = await db
+      .insert(vulnerabilities)
+      .values({
+        cveId: `CVE-GATE-${uniq()}`,
+        source: 'msrc',
+        description: 'gate test vuln',
+        severity: 'critical',
+        cvssVersion: '3.1',
+        cvssScore: '9.8',
+        knownExploited: false,
+        patchAvailable: true,
+        rawPayload: { test: true },
+      })
+      .returning({ id: vulnerabilities.id });
+    await db.insert(softwareVulnerabilities).values({
+      productId: product!.id,
+      vulnerabilityId: vuln!.id,
+      versionEndExcluding: '16.0.14332.20500',
+    });
+    await db.insert(softwareInventory).values({
+      orgId,
+      deviceId,
+      name: productName, // matches softwareProducts.normalizedName via lower(trim())
+      version: '16.0.14332.20481',
+      vendor: 'Microsoft',
+    });
+  });
+}
+
+async function openFindingCount(orgId: string, deviceId: string): Promise<number> {
+  const rows = await withDbAccessContext(orgCtx(orgId), () =>
+    db
+      .select({ id: deviceVulnerabilities.id })
+      .from(deviceVulnerabilities)
+      .where(and(eq(deviceVulnerabilities.orgId, orgId), eq(deviceVulnerabilities.deviceId, deviceId), eq(deviceVulnerabilities.status, 'open'))),
+  );
+  return rows.length;
+}
+
+beforeEach(async () => {
+  await withSystemDbAccessContext(async () => {
+    await db.delete(deviceVulnerabilities);
+    await db.delete(softwareVulnerabilities);
+    await db.delete(softwareProducts);
+    await db.delete(vulnerabilities);
+  });
+});
+
+describe('resolveVulnerabilityEnabledForDevice (gate, default off)', () => {
+  runDb('returns false when no vulnerability policy is assigned', async () => {
+    const { deviceId } = await seedOrgWithDevice();
+    expect(await withSystemDbAccessContext(() => resolveVulnerabilityEnabledForDevice(deviceId))).toBe(false);
+  });
+
+  runDb('returns true when an org-level policy enables it', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await seedVulnPolicy({ orgId, level: 'organization', targetId: orgId, enabled: true });
+    expect(await withSystemDbAccessContext(() => resolveVulnerabilityEnabledForDevice(deviceId))).toBe(true);
+  });
+
+  runDb('closest-wins: a device-level disable overrides an org-level enable', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await seedVulnPolicy({ orgId, level: 'organization', targetId: orgId, enabled: true });
+    await seedVulnPolicy({ orgId, level: 'device', targetId: deviceId, enabled: false });
+    expect(await withSystemDbAccessContext(() => resolveVulnerabilityEnabledForDevice(deviceId))).toBe(false);
+  });
+});
+
+describe('resolveAllVulnerabilityEnabledDevices (batch)', () => {
+  runDb('returns empty map when nothing is enabled', async () => {
+    await seedOrgWithDevice();
+    const map = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+    expect(map.size).toBe(0);
+  });
+
+  runDb('groups enabled devices by org and omits disabled ones', async () => {
+    const a = await seedOrgWithDevice();
+    const b = await seedOrgWithDevice();
+    await seedVulnPolicy({ orgId: a.orgId, level: 'organization', targetId: a.orgId, enabled: true });
+    await seedVulnPolicy({ orgId: b.orgId, level: 'organization', targetId: b.orgId, enabled: false });
+    const map = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+    expect(map.get(a.orgId)).toEqual([a.deviceId]);
+    expect(map.has(b.orgId)).toBe(false);
+  });
+});
+
+describe('correlateOrg deviceIds gating', () => {
+  runDb('flags only when the target device is in the deviceIds set', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await seedVulnerableInventory(orgId, deviceId);
+
+    // Empty set → no-op, no findings created.
+    const none = await correlateOrg(orgId, { deviceIds: [] });
+    expect(none).toEqual({ created: 0, resolved: 0 });
+    expect(await openFindingCount(orgId, deviceId)).toBe(0);
+
+    // Set excluding the device → still nothing.
+    const other = await correlateOrg(orgId, { deviceIds: ['00000000-0000-0000-0000-000000000000'] });
+    expect(other.created).toBe(0);
+    expect(await openFindingCount(orgId, deviceId)).toBe(0);
+
+    // Set including the device → one finding.
+    const hit = await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(hit.created).toBe(1);
+    expect(await openFindingCount(orgId, deviceId)).toBe(1);
+  });
+
+  runDb('empty deviceIds set does NOT resolve existing open findings', async () => {
+    const { orgId, deviceId } = await seedOrgWithDevice();
+    await seedVulnerableInventory(orgId, deviceId);
+    await correlateOrg(orgId, { deviceIds: [deviceId] });
+    expect(await openFindingCount(orgId, deviceId)).toBe(1);
+
+    // A subsequent empty-set pass must be a true no-op, not a resolve-everything.
+    const noop = await correlateOrg(orgId, { deviceIds: [] });
+    expect(noop).toEqual({ created: 0, resolved: 0 });
+    expect(await openFindingCount(orgId, deviceId)).toBe(1);
+  });
+});
+
+describe('correlateEnabledOrgs (wired job)', () => {
+  runDb('correlates only devices whose effective config enables scanning', async () => {
+    const enabled = await seedOrgWithDevice();
+    const disabled = await seedOrgWithDevice();
+    await seedVulnerableInventory(enabled.orgId, enabled.deviceId);
+    await seedVulnerableInventory(disabled.orgId, disabled.deviceId);
+    await seedVulnPolicy({ orgId: enabled.orgId, level: 'organization', targetId: enabled.orgId, enabled: true });
+    // `disabled` org gets no policy → stays off.
+
+    const summary = await correlateEnabledOrgs();
+
+    expect(summary.orgs).toBe(1);
+    expect(summary.created).toBe(1);
+    expect(await openFindingCount(enabled.orgId, enabled.deviceId)).toBe(1);
+    expect(await openFindingCount(disabled.orgId, disabled.deviceId)).toBe(0);
+  });
+});

--- a/apps/api/src/db/schema/configurationPolicies.ts
+++ b/apps/api/src/db/schema/configurationPolicies.ts
@@ -43,6 +43,7 @@ export const configFeatureTypeEnum = pgEnum('config_feature_type', [
   'remote_access',
   'pam',
   'onedrive_helper',
+  'vulnerability',
 ]);
 
 export const configAssignmentLevelEnum = pgEnum('config_assignment_level', [

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -10,6 +10,8 @@ import {
   vulnerabilitySources,
 } from '../db/schema';
 import { computeRiskScore } from '../services/vulnerabilityRiskScore';
+import { correlateOrg, correlateOsVulns } from '../services/vulnerabilityCorrelation';
+import { resolveAllVulnerabilityEnabledDevices } from '../services/featureConfigResolver';
 import {
   fetchCvrf,
   listUpdateMonths,
@@ -41,6 +43,7 @@ const KEV_EPSS_DAILY_CRON = '0 11 * * *';
 const SOFA_DAILY_CRON = '0 12 * * *';
 const RISK_SCORE_REFRESH_CRON = '0 * * * *'; // hourly
 const ACCEPT_EXPIRY_CRON = '0 1 * * *'; // daily 01:00 UTC
+const VULN_CORRELATE_CRON = '0 13 * * *'; // daily 13:00 UTC, after the 09:00–12:00 source syncs
 const NVD_MAX_WINDOW_DAYS = 120;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MSRC_MONTH_INDEX = new Map([
@@ -92,6 +95,16 @@ function getVulnMaintenanceQueue(): Queue {
     });
   }
   return vulnMaintenanceQueue;
+}
+
+/**
+ * Enqueue a one-off correlation pass (admin manual trigger). Uses the same
+ * `vuln-maintenance` queue + `vuln-correlate` job name the worker dispatches, so
+ * a manual run is identical to the daily scheduled one. Returns the BullMQ job id.
+ */
+export async function enqueueVulnCorrelation(): Promise<string | undefined> {
+  const job = await getVulnMaintenanceQueue().add('vuln-correlate', {});
+  return job.id;
 }
 
 function cvssVersionFromVector(vector: string | null): string | null {
@@ -797,6 +810,27 @@ export async function expireAcceptedRisks(now: Date): Promise<number> {
   return reopened.length;
 }
 
+/**
+ * Wire BE-16 correlation into the runtime: for every device whose effective
+ * config-policy enables vulnerability scanning (default OFF — see
+ * resolveAllVulnerabilityEnabledDevices), correlate that org's inventory scoped
+ * to just the enabled devices. The resolver read runs in system context;
+ * correlateOrg/correlateOsVulns each open their OWN system context, so we exit
+ * the resolver context before the loop (no nested contexts). Returns a summary.
+ */
+export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: number; resolved: number }> {
+  const byOrg = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
+  let created = 0;
+  let resolved = 0;
+  for (const [orgId, deviceIds] of byOrg) {
+    const sw = await correlateOrg(orgId, { deviceIds });
+    const os = await correlateOsVulns(orgId, { deviceIds });
+    created += sw.created + os.created;
+    resolved += sw.resolved + os.resolved;
+  }
+  return { orgs: byOrg.size, created, resolved };
+}
+
 function createVulnMaintenanceWorker(): Worker {
   return new Worker(
     VULN_MAINTENANCE_QUEUE,
@@ -808,6 +842,10 @@ function createVulnMaintenanceWorker(): Worker {
       if (job.name === 'vuln-accept-expiry') {
         const reopened = await expireAcceptedRisks(new Date());
         return { task: 'vuln-accept-expiry', reopened };
+      }
+      if (job.name === 'vuln-correlate') {
+        const summary = await correlateEnabledOrgs();
+        return { task: 'vuln-correlate', ...summary };
       }
       throw new Error(`Unsupported vuln-maintenance job: ${job.name}`);
     },
@@ -912,7 +950,17 @@ async function scheduleVulnMaintenanceJobs(): Promise<void> {
     }
   );
 
-  console.log('[VulnerabilityJobs] Scheduled risk-score refresh + accepted-risk expiry');
+  await queue.add(
+    'vuln-correlate',
+    {},
+    {
+      repeat: { pattern: VULN_CORRELATE_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 },
+    }
+  );
+
+  console.log('[VulnerabilityJobs] Scheduled risk-score refresh + accepted-risk expiry + correlation');
 }
 
 export async function initializeVulnerabilityJobs(): Promise<void> {

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -12,6 +12,7 @@ import {
 import { computeRiskScore } from '../services/vulnerabilityRiskScore';
 import { correlateOrg, correlateOsVulns } from '../services/vulnerabilityCorrelation';
 import { resolveAllVulnerabilityEnabledDevices } from '../services/featureConfigResolver';
+import { captureException } from '../services/sentry';
 import {
   fetchCvrf,
   listUpdateMonths,
@@ -816,19 +817,33 @@ export async function expireAcceptedRisks(now: Date): Promise<number> {
  * resolveAllVulnerabilityEnabledDevices), correlate that org's inventory scoped
  * to just the enabled devices. The resolver read runs in system context;
  * correlateOrg/correlateOsVulns each open their OWN system context, so we exit
- * the resolver context before the loop (no nested contexts). Returns a summary.
+ * the resolver context before the loop (no nested contexts).
+ *
+ * Each org is correlated under its own try/catch so a single failing tenant
+ * (e.g. a malformed osVersion or a transient DB error) cannot abort the whole
+ * daily pass and skip every org after it — mirroring the per-source isolation
+ * in the source-sync path. A failure is reported with the offending orgId
+ * (which the worker-level handler would otherwise lack) and surfaced in the
+ * returned `failedOrgs` count so a partial run is observable.
  */
-export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: number; resolved: number }> {
+export async function correlateEnabledOrgs(): Promise<{ orgs: number; created: number; resolved: number; failedOrgs: number }> {
   const byOrg = await withSystemDbAccessContext(() => resolveAllVulnerabilityEnabledDevices());
   let created = 0;
   let resolved = 0;
+  let failedOrgs = 0;
   for (const [orgId, deviceIds] of byOrg) {
-    const sw = await correlateOrg(orgId, { deviceIds });
-    const os = await correlateOsVulns(orgId, { deviceIds });
-    created += sw.created + os.created;
-    resolved += sw.resolved + os.resolved;
+    try {
+      const sw = await correlateOrg(orgId, { deviceIds });
+      const os = await correlateOsVulns(orgId, { deviceIds });
+      created += sw.created + os.created;
+      resolved += sw.resolved + os.resolved;
+    } catch (error) {
+      failedOrgs += 1;
+      console.error(`[VulnerabilityJobs] correlation failed for org ${orgId}:`, error);
+      captureException(error);
+    }
   }
-  return { orgs: byOrg.size, created, resolved };
+  return { orgs: byOrg.size, created, resolved, failedOrgs };
 }
 
 function createVulnMaintenanceWorker(): Worker {

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -59,9 +59,12 @@ vi.mock('../services/vulnerabilityRemediation', () => ({
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../middleware/platformAdmin', () => ({ platformAdminMiddleware: (_c: any, next: any) => next() }));
 vi.mock('../middleware/userRateLimit', () => ({ userRateLimit: () => (_c: any, next: any) => next() }));
-vi.mock('../jobs/vulnerabilityJobs', () => ({ enqueueVulnSourceSync: vi.fn(async () => 'job-1') }));
+vi.mock('../jobs/vulnerabilityJobs', () => ({
+  enqueueVulnSourceSync: vi.fn(async () => 'job-1'),
+  enqueueVulnCorrelation: vi.fn(async () => 'job-2'),
+}));
 
-import { vulnerabilityRoutes } from './vulnerabilities';
+import { vulnerabilityRoutes, vulnerabilitySyncRoutes } from './vulnerabilities';
 
 const ID = '11111111-1111-1111-8111-111111111111';
 
@@ -187,5 +190,39 @@ describe('vulnerability fleet GET / — site-axis narrowing', () => {
     expect(res.status).toBe(200);
     // Only one db.select call: the deviceVulnerabilities query, no site-device lookup.
     expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+import { enqueueVulnCorrelation } from '../jobs/vulnerabilityJobs';
+import { writeRouteAudit } from '../services/auditEvents';
+
+describe('POST /vulnerabilities/sync/correlate (admin manual trigger)', () => {
+  function syncApp() {
+    const a = new Hono();
+    // Mounted deeper than the main router, exactly as in index.ts.
+    a.route('/vulnerabilities/sync', vulnerabilitySyncRoutes);
+    return a;
+  }
+
+  beforeEach(() => {
+    vi.mocked(enqueueVulnCorrelation).mockClear();
+    vi.mocked(writeRouteAudit).mockClear();
+  });
+
+  it('enqueues a correlation job and writes the manual_correlate audit', async () => {
+    const res = await syncApp().request('/vulnerabilities/sync/correlate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enqueued: true, jobId: 'job-2' });
+    expect(vi.mocked(enqueueVulnCorrelation)).toHaveBeenCalledTimes(1);
+    // The audit action string is load-bearing (forensic trail) — assert it exactly.
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.manual_correlate', resourceType: 'vulnerability_source' }),
+    );
   });
 });

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -11,7 +11,7 @@ import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
 import { writeRouteAudit } from '../services/auditEvents';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
 import { userRateLimit } from '../middleware/userRateLimit';
-import { enqueueVulnSourceSync } from '../jobs/vulnerabilityJobs';
+import { enqueueVulnSourceSync, enqueueVulnCorrelation } from '../jobs/vulnerabilityJobs';
 
 export const vulnerabilityRoutes = new Hono();
 
@@ -547,6 +547,25 @@ vulnerabilitySyncRoutes.post(
       action: 'vulnerability.manual_sync',
       resourceType: 'vulnerability_source',
       details: { source, jobId },
+    });
+    return c.json({ enqueued: true, jobId });
+  },
+);
+
+// Manually trigger a correlation pass (platform-admin + MFA via the `*` mw above).
+// Useful to populate device_vulnerabilities immediately after enabling the
+// `vulnerability` config-policy feature for an org, instead of waiting for the
+// daily 13:00 UTC schedule.
+vulnerabilitySyncRoutes.post(
+  '/correlate',
+  userRateLimit('vuln-manual-correlate', 10, 3600), // 10/hour/user
+  async (c) => {
+    const jobId = await enqueueVulnCorrelation();
+    writeRouteAudit(c, {
+      orgId: null,
+      action: 'vulnerability.manual_correlate',
+      resourceType: 'vulnerability_source',
+      details: { jobId },
     });
     return c.json({ enqueued: true, jobId });
   },

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -550,6 +550,7 @@ Inline settings shapes by feature type:
 - warranty: { enabled: true, warnDays: 90, criticalDays: 30 }
 - helper: { enabled: true, showOpenPortal: true, showDeviceInfo: true, showRequestSupport: true, portalUrl?: "" }
 - pam: inlineSettings {uacInterceptionEnabled: boolean} — Windows UAC elevation prompt capture (default false / opt-in: capture is OFF when no policy assigns this feature). PAM rules/approvals are managed separately in the /pam console, not via config policies.
+- vulnerability: inlineSettings {enabled: boolean} — per-device CVE correlation / vulnerability scanning (default false / opt-in: devices with no policy are NOT scanned). Findings appear in the /vulnerabilities console; correlation runs daily.
 
 For link-only types, set featurePolicyId instead of inlineSettings:
 - software_policy: featurePolicyId → existing software policy UUID
@@ -568,7 +569,7 @@ For link-only types, set featurePolicyId instead of inlineSettings:
               'patch', 'alert_rule', 'backup', 'security', 'monitoring',
               'maintenance', 'compliance', 'automation', 'event_log',
               'software_policy', 'sensitive_data', 'peripheral_control',
-              'warranty', 'helper', 'remote_access', 'pam',
+              'warranty', 'helper', 'remote_access', 'pam', 'vulnerability',
             ],
             description: 'Feature type (required for add)',
           },

--- a/apps/api/src/services/configFeatureTypes.ts
+++ b/apps/api/src/services/configFeatureTypes.ts
@@ -19,6 +19,7 @@ export const CONFIG_FEATURE_TYPES = [
   'patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance',
   'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data',
   'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'onedrive_helper',
+  'vulnerability',
 ] as const;
 
 export type ConfigFeatureType = typeof CONFIG_FEATURE_TYPES[number];

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -13,7 +13,7 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
-import { addFeatureLink, updateFeatureLink, listFeatureLinks, pamInlineSettingsSchema } from './configurationPolicy';
+import { addFeatureLink, updateFeatureLink, listFeatureLinks, pamInlineSettingsSchema, validateFeaturePolicyExists } from './configurationPolicy';
 import { db } from '../db';
 
 // Chain for `db.select().from(...).where(...)` awaited directly (links query)
@@ -500,5 +500,114 @@ describe('updateFeatureLink — pam inlineSettings service-layer validation', ()
     // null inlineSettings means "clear" — pam validation is skipped
     const result = await updateFeatureLink('link-pam', { inlineSettings: null }, 'policy-1');
     expect(result).not.toBeNull();
+  });
+});
+
+// ============================================================
+// vulnerability inlineSettings service-layer validation (BE-16 gating)
+// ============================================================
+
+describe('addFeatureLink — vulnerability inlineSettings service-layer validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockTxReturning(inlineSettings: unknown) {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([
+              { id: 'link-vuln', configPolicyId: 'policy-1', featureType: 'vulnerability', featurePolicyId: null, inlineSettings },
+            ])
+          ),
+        })),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+  }
+
+  it('throws ZodError before the transaction when enabled is the string "true"', async () => {
+    await expect(
+      addFeatureLink('policy-1', 'vulnerability', null, { enabled: 'true' })
+    ).rejects.toThrow();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('throws ZodError for an unknown extra key', async () => {
+    await expect(
+      addFeatureLink('policy-1', 'vulnerability', null, { enabled: true, rogue: 'x' })
+    ).rejects.toThrow();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('enters the transaction for valid { enabled: false } and {}', async () => {
+    mockTxReturning({ enabled: false });
+    await expect(addFeatureLink('policy-1', 'vulnerability', null, { enabled: false })).resolves.toBeDefined();
+    mockTxReturning({});
+    await expect(addFeatureLink('policy-1', 'vulnerability', null, {})).resolves.toBeDefined();
+  });
+
+  it('skips validation when inlineSettings is null/undefined', async () => {
+    mockTxReturning(null);
+    await expect(addFeatureLink('policy-1', 'vulnerability', null, null)).resolves.toBeDefined();
+    await expect(addFeatureLink('policy-1', 'vulnerability', null, undefined)).resolves.toBeDefined();
+  });
+});
+
+describe('updateFeatureLink — vulnerability inlineSettings service-layer validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeTxWithExistingVulnLink() {
+    const tx: any = {
+      select: vi.fn(() => selectLimitRows([
+        { id: 'link-vuln', configPolicyId: 'policy-1', featureType: 'vulnerability', featurePolicyId: null, inlineSettings: {} },
+      ])),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([{ id: 'link-vuln', featureType: 'vulnerability' }])),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+      insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve([])) })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+    return tx;
+  }
+
+  it('throws ZodError when updating with a non-boolean enabled', async () => {
+    makeTxWithExistingVulnLink();
+    await expect(
+      updateFeatureLink('link-vuln', { inlineSettings: { enabled: 'true' } }, 'policy-1')
+    ).rejects.toThrow();
+  });
+
+  it('throws ZodError when updating with an unknown extra key', async () => {
+    makeTxWithExistingVulnLink();
+    await expect(
+      updateFeatureLink('link-vuln', { inlineSettings: { enabled: true, rogue: true } }, 'policy-1')
+    ).rejects.toThrow();
+  });
+
+  it('succeeds when updating with valid { enabled: true }', async () => {
+    makeTxWithExistingVulnLink();
+    const result = await updateFeatureLink('link-vuln', { inlineSettings: { enabled: true } }, 'policy-1');
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('validateFeaturePolicyExists — vulnerability is inline-only', () => {
+  it('rejects a featurePolicyId (vulnerability has no standalone policy table)', async () => {
+    const result = await validateFeaturePolicyExists('vulnerability', 'some-uuid', 'org-1');
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts inline-only (no featurePolicyId)', async () => {
+    const result = await validateFeaturePolicyExists('vulnerability', null, 'org-1');
+    expect(result.valid).toBe(true);
   });
 });

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -64,6 +64,17 @@ export const pamInlineSettingsSchema = z
   })
   .strict();
 
+// Vulnerability scanning is a single opt-in toggle (BE-16 correlation gating).
+// `enabled` defaults to false so an absent/empty settings object means "off" —
+// the per-device gate (resolveVulnerabilityEnabledForDevice) and the daily
+// correlation job both treat no-policy / enabled:false as disabled. .strict()
+// rejects unknown keys, matching pam/patch posture.
+export const vulnerabilityInlineSettingsSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .strict();
+
 // ============================================
 // Types
 // ============================================
@@ -541,6 +552,7 @@ async function decomposeInlineSettings(
     case 'warranty':
     case 'helper':
     case 'pam':
+    case 'vulnerability':
       // Pure JSONB — no normalized table needed
       break;
 
@@ -597,6 +609,7 @@ async function deleteNormalizedRows(
     case 'warranty':
     case 'helper':
     case 'pam':
+    case 'vulnerability':
       // Pure JSONB — no normalized table to delete
       break;
     default:
@@ -874,6 +887,7 @@ async function assembleInlineSettings(
     case 'warranty':
     case 'helper':
     case 'pam':
+    case 'vulnerability':
       // Pure JSONB — settings stored directly on feature link
       return null;
 
@@ -894,6 +908,10 @@ export async function addFeatureLink(
 ) {
   if (featureType === 'pam' && inlineSettings !== undefined && inlineSettings !== null) {
     pamInlineSettingsSchema.parse(inlineSettings);
+  }
+
+  if (featureType === 'vulnerability' && inlineSettings !== undefined && inlineSettings !== null) {
+    vulnerabilityInlineSettingsSchema.parse(inlineSettings);
   }
 
   return db.transaction(async (tx) => {
@@ -944,6 +962,10 @@ export async function updateFeatureLink(
 
     if (existing.featureType === 'pam' && updates.inlineSettings !== undefined && updates.inlineSettings !== null) {
       pamInlineSettingsSchema.parse(updates.inlineSettings);
+    }
+
+    if (existing.featureType === 'vulnerability' && updates.inlineSettings !== undefined && updates.inlineSettings !== null) {
+      vulnerabilityInlineSettingsSchema.parse(updates.inlineSettings);
     }
 
     const setValues: Record<string, unknown> = { updatedAt: new Date() };
@@ -1502,8 +1524,13 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  if (featureType === 'monitoring' || featureType === 'event_log' || featureType === 'onedrive_helper') {
-    // Monitoring, event_log, and onedrive_helper have no policy table — requires inlineSettings
+  if (
+    featureType === 'monitoring' ||
+    featureType === 'event_log' ||
+    featureType === 'onedrive_helper' ||
+    featureType === 'vulnerability'
+  ) {
+    // Monitoring, event_log, onedrive_helper, vulnerability have no policy table — requires inlineSettings
     if (featurePolicyId) {
       return { valid: false, error: `${featureType} feature type does not support featurePolicyId; use inlineSettings instead` };
     }

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -881,6 +881,187 @@ export async function resolveDeviceIdsForSoftwarePolicy(
 }
 
 // ============================================
+// Vulnerability scanning gate (BE-16 correlation)
+// ============================================
+
+/**
+ * Resolve whether per-device vulnerability correlation is enabled for a device,
+ * via the config-policy hierarchy ("closest wins"). Reads the winning
+ * `vulnerability` feature link's `inlineSettings.enabled`.
+ *
+ * DEFAULT DISABLED: no `vulnerability` policy anywhere in the hierarchy → false,
+ * and a closer assignment with `enabled:false` correctly overrides a broader
+ * `enabled:true` (e.g. a device- or group-level opt-out under an org-wide opt-in).
+ * Pattern B inline toggle — there is no normalized table; the flag lives in the
+ * feature link's JSONB `inlineSettings`.
+ */
+export async function resolveVulnerabilityEnabledForDevice(deviceId: string): Promise<boolean> {
+  const hierarchy = await loadDeviceHierarchy(deviceId);
+  if (!hierarchy) return false;
+
+  const targetConditions = buildTargetConditions(hierarchy);
+  const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
+
+  const rows = await db
+    .select({
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
+      )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'vulnerability')
+      )
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
+
+  if (rows.length === 0) return false;
+
+  const winner = sortByHierarchy(rows)[0]!;
+  const settings = winner.inlineSettings as { enabled?: unknown } | null;
+  return settings?.enabled === true;
+}
+
+/**
+ * Batch resolver: every device for which vulnerability correlation is enabled,
+ * grouped by orgId. Drives the daily `vuln-correlate` job so correlation only
+ * touches opted-in devices.
+ *
+ * Mirrors {@link resolveDeviceIdsForSoftwarePolicy}: gather candidate devices
+ * from every active config policy that carries a `vulnerability` feature link,
+ * then verify each candidate's WINNING vulnerability link is enabled (closest-
+ * wins, so a device/group-level `enabled:false` suppresses a broader opt-in).
+ * Returns an empty map when nothing is enabled.
+ *
+ * Run inside `withSystemDbAccessContext` (config-policy tables are RLS-scoped).
+ */
+export async function resolveAllVulnerabilityEnabledDevices(): Promise<Map<string, string[]>> {
+  // 1. Active config policies that carry a vulnerability feature link.
+  const links = await db
+    .select({ configPolicyId: configPolicyFeatureLinks.configPolicyId })
+    .from(configPolicyFeatureLinks)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active')
+      )
+    )
+    .where(eq(configPolicyFeatureLinks.featureType, 'vulnerability'));
+
+  if (links.length === 0) return new Map();
+
+  const configPolicyIds = [...new Set(links.map((l) => l.configPolicyId))];
+
+  // 2. Assignments for those policies → candidate device IDs.
+  const assignments = await db
+    .select({ level: configPolicyAssignments.level, targetId: configPolicyAssignments.targetId })
+    .from(configPolicyAssignments)
+    .where(inArray(configPolicyAssignments.configPolicyId, configPolicyIds));
+
+  if (assignments.length === 0) return new Map();
+
+  const candidateDeviceIds = new Set<string>();
+  for (const assignment of assignments) {
+    let ids: string[];
+    switch (assignment.level) {
+      case 'device':
+        ids = [assignment.targetId];
+        break;
+      case 'device_group': {
+        const rows = await db
+          .select({ deviceId: deviceGroupMemberships.deviceId })
+          .from(deviceGroupMemberships)
+          .where(eq(deviceGroupMemberships.groupId, assignment.targetId));
+        ids = rows.map((r) => r.deviceId);
+        break;
+      }
+      case 'site': {
+        const rows = await db.select({ id: devices.id }).from(devices).where(eq(devices.siteId, assignment.targetId));
+        ids = rows.map((r) => r.id);
+        break;
+      }
+      case 'organization': {
+        const rows = await db.select({ id: devices.id }).from(devices).where(eq(devices.orgId, assignment.targetId));
+        ids = rows.map((r) => r.id);
+        break;
+      }
+      case 'partner': {
+        const orgs = await db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, assignment.targetId));
+        if (orgs.length === 0) {
+          ids = [];
+          break;
+        }
+        const rows = await db
+          .select({ id: devices.id })
+          .from(devices)
+          .where(inArray(devices.orgId, orgs.map((o) => o.id)));
+        ids = rows.map((r) => r.id);
+        break;
+      }
+      default:
+        ids = [];
+    }
+    for (const id of ids) candidateDeviceIds.add(id);
+  }
+
+  if (candidateDeviceIds.size === 0) return new Map();
+
+  // 3. Verify each candidate (closest-wins) — batched to bound parallel queries.
+  const candidates = [...candidateDeviceIds];
+  const enabledIds: string[] = [];
+  const BATCH_SIZE = 50;
+  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+    const batch = candidates.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (deviceId) => ({
+        deviceId,
+        enabled: await resolveVulnerabilityEnabledForDevice(deviceId),
+      }))
+    );
+    for (const { deviceId, enabled } of results) {
+      if (enabled) enabledIds.push(deviceId);
+    }
+  }
+
+  if (enabledIds.length === 0) return new Map();
+
+  // 4. Group enabled devices by org.
+  const orgRows = await db
+    .select({ id: devices.id, orgId: devices.orgId })
+    .from(devices)
+    .where(inArray(devices.id, enabledIds));
+
+  const byOrg = new Map<string, string[]>();
+  for (const row of orgRows) {
+    const list = byOrg.get(row.orgId) ?? [];
+    list.push(row.id);
+    byOrg.set(row.orgId, list);
+  }
+  return byOrg;
+}
+
+// ============================================
 // Batch Scan Helpers (for workers)
 // ============================================
 

--- a/apps/api/src/services/policyBaselineDefaults.ts
+++ b/apps/api/src/services/policyBaselineDefaults.ts
@@ -75,6 +75,7 @@ const NOT_ENFORCED: Record<Exclude<ConfigFeatureType, 'remote_access' | 'pam'>, 
   warranty:          { label: 'Warranty',           behavior: 'Not enforced — no warranty alerts apply.' },
   helper:            { label: 'Breeze Assist',      behavior: 'Not enforced — Breeze Assist uses its built-in defaults.' },
   onedrive_helper:   { label: 'OneDrive Helper',    behavior: 'Not enforced — no OneDrive helper config applies.' },
+  vulnerability:     { label: 'Vulnerability Scanning', behavior: 'Not enforced — vulnerability correlation does not run for these devices.' },
 };
 
 export function getPolicyBaselineDefaults(): BaselineEntry[] {

--- a/apps/api/src/services/vulnerabilityCorrelation.ts
+++ b/apps/api/src/services/vulnerabilityCorrelation.ts
@@ -167,7 +167,24 @@ async function upsertDeviceVulnerability(args: {
   return { id: inserted.id, created: true };
 }
 
-export async function correlateOrg(orgId: string): Promise<{ created: number; resolved: number }> {
+/**
+ * Correlate an org's software inventory against the CVE catalog into
+ * `device_vulnerabilities`. When `opts.deviceIds` is supplied, correlation is
+ * scoped to exactly those devices (the gated path — the daily job passes the set
+ * of devices whose effective config enables vulnerability scanning). An EMPTY
+ * `deviceIds` array is an explicit "no enabled devices" → no-op (it must NOT be
+ * treated as "all devices", which would resolve every open finding). Omitting
+ * `opts` preserves the legacy whole-org behavior.
+ */
+export async function correlateOrg(
+  orgId: string,
+  opts?: { deviceIds?: string[] }
+): Promise<{ created: number; resolved: number }> {
+  const deviceIds = opts?.deviceIds;
+  if (deviceIds && deviceIds.length === 0) return { created: 0, resolved: 0 };
+  const inventoryDeviceFilter = deviceIds ? inArray(softwareInventory.deviceId, deviceIds) : undefined;
+  const findingDeviceFilter = deviceIds ? inArray(deviceVulnerabilities.deviceId, deviceIds) : undefined;
+
   const { created, resolved, criticals, remediated } = await withSystemDbAccessContext(async () => {
     const fixedBuildCandidates = await db
       .select({
@@ -196,7 +213,8 @@ export async function correlateOrg(orgId: string): Promise<{ created: number; re
         eq(softwareInventory.orgId, orgId),
         isNotNull(softwareInventory.version),
         eq(vulnerabilities.source, 'msrc'),
-        isNotNull(softwareVulnerabilities.versionEndExcluding)
+        isNotNull(softwareVulnerabilities.versionEndExcluding),
+        inventoryDeviceFilter
       ));
 
     const matchedIds = new Set<string>();
@@ -252,7 +270,8 @@ export async function correlateOrg(orgId: string): Promise<{ created: number; re
       .where(and(
         eq(softwareInventory.orgId, orgId),
         isNotNull(softwareInventory.version),
-        isNotNull(softwareProducts.cpe)
+        isNotNull(softwareProducts.cpe),
+        inventoryDeviceFilter
       ));
 
     for (const candidate of cpeRangeCandidates) {
@@ -285,7 +304,8 @@ export async function correlateOrg(orgId: string): Promise<{ created: number; re
     const baseResolveWhere = and(
       eq(deviceVulnerabilities.orgId, orgId),
       eq(deviceVulnerabilities.status, 'open'),
-      isNotNull(deviceVulnerabilities.softwareInventoryId)
+      isNotNull(deviceVulnerabilities.softwareInventoryId),
+      findingDeviceFilter
     );
     const resolveWhere = matchedIds.size > 0
       ? and(baseResolveWhere, notInArray(deviceVulnerabilities.id, Array.from(matchedIds)))
@@ -319,7 +339,14 @@ export async function correlateOrg(orgId: string): Promise<{ created: number; re
   return { created, resolved };
 }
 
-export async function correlateOsVulns(orgId: string): Promise<{ created: number; resolved: number }> {
+export async function correlateOsVulns(
+  orgId: string,
+  opts?: { deviceIds?: string[] }
+): Promise<{ created: number; resolved: number }> {
+  const deviceIds = opts?.deviceIds;
+  if (deviceIds && deviceIds.length === 0) return { created: 0, resolved: 0 };
+  const macDeviceFilter = deviceIds ? inArray(devices.id, deviceIds) : undefined;
+
   const { created, resolved, criticals, remediated } = await withSystemDbAccessContext(async () => {
     const macDevices = await db
       .select({
@@ -330,7 +357,8 @@ export async function correlateOsVulns(orgId: string): Promise<{ created: number
       .where(and(
         eq(devices.orgId, orgId),
         eq(devices.osType, 'macos'),
-        isNotNull(devices.osVersion)
+        isNotNull(devices.osVersion),
+        macDeviceFilter
       ));
 
     const facts = await db

--- a/apps/api/src/services/vulnerabilityInlineSettings.test.ts
+++ b/apps/api/src/services/vulnerabilityInlineSettings.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { vulnerabilityInlineSettingsSchema } from './configurationPolicy';
+
+describe('vulnerabilityInlineSettingsSchema', () => {
+  it('defaults enabled to false for an empty object (absent = disabled)', () => {
+    expect(vulnerabilityInlineSettingsSchema.parse({})).toEqual({ enabled: false });
+  });
+
+  it('accepts an explicit boolean', () => {
+    expect(vulnerabilityInlineSettingsSchema.parse({ enabled: true })).toEqual({ enabled: true });
+    expect(vulnerabilityInlineSettingsSchema.parse({ enabled: false })).toEqual({ enabled: false });
+  });
+
+  it('rejects a non-boolean enabled (no silent string→default inversion)', () => {
+    expect(() => vulnerabilityInlineSettingsSchema.parse({ enabled: 'true' })).toThrow();
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(() => vulnerabilityInlineSettingsSchema.parse({ enabled: true, extra: 1 })).toThrow();
+  });
+});

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   HardDrive,
   Shield,
   ShieldCheck,
+  ShieldAlert,
   KeyRound,
   ScrollText,
   ScanSearch,
@@ -45,6 +46,7 @@ import WarrantyTab from './featureTabs/WarrantyTab';
 import HelperTab from './featureTabs/HelperTab';
 import RemoteAccessTab from './featureTabs/RemoteAccessTab';
 import PamTab from './featureTabs/PamTab';
+import VulnerabilityTab from './featureTabs/VulnerabilityTab';
 import ComplianceStatusTab from './ComplianceStatusTab';
 
 type Tab = 'overview' | FeatureType | 'assignments' | 'compliance_status';
@@ -83,9 +85,10 @@ const featureTabIcons: Partial<Record<FeatureType, React.ReactNode>> = {
   helper: <LifeBuoy className="h-4 w-4" />,
   remote_access: <Monitor className="h-4 w-4" />,
   pam: <KeyRound className="h-4 w-4" />,
+  vulnerability: <ShieldAlert className="h-4 w-4" />,
 };
 
-const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam'];
+const FEATURE_TYPES: FeatureType[] = ['patch', 'alert_rule', 'backup', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'vulnerability'];
 
 type ConfigPolicyDetailPageProps = {
   policyId?: string;
@@ -301,6 +304,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
       case 'helper': return <HelperTab {...props} />;
       case 'remote_access': return <RemoteAccessTab {...props} />;
       case 'pam': return <PamTab {...props} />;
+      case 'vulnerability': return <VulnerabilityTab {...props} />;
     }
   };
 

--- a/apps/web/src/components/configurationPolicies/featureTabs/VulnerabilityTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/VulnerabilityTab.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VulnerabilityTab from './VulnerabilityTab';
+
+// useFeatureLink wraps the save/remove API calls; stub it so we can assert the
+// payload the tab submits without hitting the network.
+const saveMock = vi.fn(async () => ({ id: 'link-1' }));
+const removeMock = vi.fn(async () => true);
+
+vi.mock('./useFeatureLink', () => ({
+  useFeatureLink: () => ({
+    save: saveMock,
+    remove: removeMock,
+    saving: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+import type { FeatureTabProps } from './types';
+
+const baseProps: FeatureTabProps = {
+  policyId: 'policy-1',
+  existingLink: undefined,
+  linkedPolicyId: null,
+  onLinkChanged: vi.fn(),
+};
+
+function inlineSettingsFromCall(call: unknown[]): Record<string, unknown> | undefined {
+  for (const arg of call) {
+    if (arg && typeof arg === 'object' && 'inlineSettings' in (arg as object)) {
+      return (arg as { inlineSettings: Record<string, unknown> }).inlineSettings;
+    }
+  }
+  return undefined;
+}
+
+describe('VulnerabilityTab', () => {
+  beforeEach(() => {
+    saveMock.mockClear();
+    removeMock.mockClear();
+  });
+
+  it('renders the enable-scanning toggle, defaulted OFF (opt-in)', () => {
+    render(<VulnerabilityTab {...baseProps} />);
+    expect(screen.getByText('Enable vulnerability scanning')).toBeTruthy();
+  });
+
+  it('saves enabled=false by default (opt-in) without toggling', () => {
+    render(<VulnerabilityTab {...baseProps} />);
+    const saveButton = screen
+      .getAllByRole('button')
+      .find((b) => /save/i.test(b.textContent ?? '')) as HTMLButtonElement;
+    fireEvent.click(saveButton);
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(inlineSettingsFromCall(saveMock.mock.calls[0])).toEqual({ enabled: false });
+  });
+
+  it('saves enabled=true after toggling on', () => {
+    render(<VulnerabilityTab {...baseProps} />);
+    fireEvent.click(screen.getByTestId('vulnerability-tab-enabled-toggle'));
+
+    const saveButton = screen
+      .getAllByRole('button')
+      .find((b) => /save/i.test(b.textContent ?? '')) as HTMLButtonElement;
+    fireEvent.click(saveButton);
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(inlineSettingsFromCall(saveMock.mock.calls[0])).toEqual({ enabled: true });
+  });
+
+  it('links findings out to the /vulnerabilities console', () => {
+    render(<VulnerabilityTab {...baseProps} />);
+    const link = screen.getByRole('link', { name: /vulnerabilities console/i }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/vulnerabilities');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/VulnerabilityTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/VulnerabilityTab.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import { ShieldAlert } from 'lucide-react';
+import type { FeatureTabProps } from './types';
+import { FEATURE_META } from './types';
+import { useFeatureLink } from './useFeatureLink';
+import FeatureTabShell from './FeatureTabShell';
+
+type VulnerabilitySettings = {
+  enabled: boolean;
+};
+
+// Default OFF (opt-in). A device with no 'vulnerability' policy is NOT correlated
+// against the CVE catalog, so its dashboard stays empty until scanning is enabled
+// here (matches resolveVulnerabilityEnabledForDevice's default-false on the API).
+const defaults: VulnerabilitySettings = {
+  enabled: false,
+};
+
+export default function VulnerabilityTab({ policyId, existingLink, onLinkChanged, linkedPolicyId, parentLink }: FeatureTabProps) {
+  const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
+  const isInherited = !!parentLink && !existingLink;
+  const effectiveLink = existingLink ?? parentLink;
+  const [settings, setSettings] = useState<VulnerabilitySettings>(() => ({
+    ...defaults,
+    ...(effectiveLink?.inlineSettings as Partial<VulnerabilitySettings> | undefined),
+  }));
+
+  useEffect(() => {
+    const link = existingLink ?? parentLink;
+    if (link?.inlineSettings) {
+      setSettings((prev) => ({ ...prev, ...(link.inlineSettings as Partial<VulnerabilitySettings>) }));
+    }
+  }, [existingLink, parentLink]);
+
+  const handleSave = async () => {
+    clearError();
+    const result = await save(existingLink?.id ?? null, {
+      featureType: 'vulnerability',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'vulnerability');
+  };
+
+  const handleRemove = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'vulnerability');
+  };
+
+  const handleOverride = async () => {
+    clearError();
+    const result = await save(null, {
+      featureType: 'vulnerability',
+      featurePolicyId: linkedPolicyId,
+      inlineSettings: { ...settings },
+    });
+    if (result) onLinkChanged(result, 'vulnerability');
+  };
+
+  const handleRevert = async () => {
+    if (!existingLink) return;
+    const ok = await remove(existingLink.id);
+    if (ok) onLinkChanged(null, 'vulnerability');
+  };
+
+  const meta = FEATURE_META.vulnerability;
+
+  return (
+    <FeatureTabShell
+      title={meta.label}
+      description={meta.description}
+      icon={<ShieldAlert className="h-5 w-5" />}
+      isConfigured={!!existingLink || isInherited}
+      saving={saving}
+      error={error}
+      onSave={handleSave}
+      onRemove={existingLink && !linkedPolicyId ? handleRemove : undefined}
+      isInherited={isInherited}
+      onOverride={isInherited ? handleOverride : undefined}
+      onRevert={!isInherited && !!linkedPolicyId && !!existingLink ? handleRevert : undefined}
+    >
+      <div className="space-y-6">
+        {/* Enable scanning toggle */}
+        <div className="flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div>
+            <p className="text-sm font-medium">Enable vulnerability scanning</p>
+            <p className="text-xs text-muted-foreground">
+              Correlate this scope's installed software and OS versions against the CVE catalog (MSRC, NVD, Apple) to surface vulnerabilities on the device and fleet dashboards. Scanning is off by default — enable it here to opt a customer's devices in. Correlation runs daily.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="vulnerability-tab-enabled-toggle"
+            onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${settings.enabled ? 'bg-emerald-500/80' : 'bg-muted'}`}
+          >
+            <span className={`inline-block h-5 w-5 rounded-full bg-white transition ${settings.enabled ? 'translate-x-5' : 'translate-x-1'}`} />
+          </button>
+        </div>
+
+        {/* Pointer to the vulnerabilities dashboard */}
+        <div className="rounded-md border bg-muted/40 px-4 py-3">
+          <p className="text-sm font-medium">Findings appear in the Vulnerabilities dashboard</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            This policy only controls whether devices are scanned. Detected CVEs, risk scores, and remediation actions are managed in the{' '}
+            <a href="/vulnerabilities" className="underline underline-offset-2 hover:text-foreground">Vulnerabilities console</a>.
+          </p>
+        </div>
+      </div>
+    </FeatureTabShell>
+  );
+}

--- a/apps/web/src/components/configurationPolicies/featureTabs/types.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/types.ts
@@ -1,4 +1,4 @@
-export type FeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam';
+export type FeatureType = 'patch' | 'alert_rule' | 'backup' | 'security' | 'monitoring' | 'maintenance' | 'compliance' | 'automation' | 'event_log' | 'software_policy' | 'sensitive_data' | 'peripheral_control' | 'warranty' | 'helper' | 'remote_access' | 'pam' | 'vulnerability';
 
 export type FeatureLink = {
   id: string;
@@ -40,4 +40,5 @@ export const FEATURE_META: Record<FeatureType, {
   helper:      { label: 'Breeze Assist',     fetchUrl: null,                   description: 'End-user Breeze Assist tray application' },
   remote_access: { label: 'Remote Access',  fetchUrl: null,                   description: 'Remote desktop, proxy tunnels, and session limits' },
   pam:         { label: 'Privileged Access', fetchUrl: null,              description: 'Windows UAC elevation prompt capture (PAM)' },
+  vulnerability: { label: 'Vulnerability Scanning', fetchUrl: null,       description: 'Enable per-device CVE correlation (vulnerability detection)' },
 };

--- a/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
+++ b/apps/web/src/components/devices/DeviceEffectiveConfigTab.tsx
@@ -13,6 +13,7 @@ import {
   ScrollText,
   Shield,
   ShieldCheck,
+  ShieldAlert,
   Activity,
   Usb,
   Wrench,
@@ -40,7 +41,8 @@ type FeatureType =
   | 'software_policy'
   | 'sensitive_data'
   | 'peripheral_control'
-  | 'onedrive_helper';
+  | 'onedrive_helper'
+  | 'vulnerability';
 
 type AssignmentLevel = 'partner' | 'organization' | 'site' | 'device_group' | 'device' | 'default';
 
@@ -106,6 +108,7 @@ const FEATURE_META: Record<FeatureType, { label: string; Icon: LucideIcon }> = {
   event_log:          { label: 'Event Logs',          Icon: ScrollText },
   helper:             { label: 'Breeze Assist',       Icon: LifeBuoy },
   onedrive_helper:    { label: 'OneDrive Helper',     Icon: Cloud },
+  vulnerability:      { label: 'Vulnerability Scanning', Icon: ShieldAlert },
 };
 
 // Display order = FEATURE_META insertion order. Derived (not hand-listed) so the

--- a/docs/superpowers/plans/2026-06-29-vuln-correlation-wireup-and-gating.md
+++ b/docs/superpowers/plans/2026-06-29-vuln-correlation-wireup-and-gating.md
@@ -1,0 +1,71 @@
+# Vulnerability correlation wire-up + per-org config-policy gating
+
+**Date:** 2026-06-29
+**Branch:** ToddHebebrand/Vulnerabilities-check
+
+## Problem
+
+BE-16 (PR #1861, live in 0.86.0) ships source sync + a global CVE catalog, but the
+correlation step that produces `device_vulnerabilities` (`correlateOrg` /
+`correlateOsVulns`) has **no production caller** — only tests invoke it. Verified on US
+prod: catalog full (13.3K vulns / 3.4K products / 83K mappings / 4.3K OS facts), but
+`device_vulnerabilities = 0`, so the dashboard is empty. Correlation must be wired into a
+recurring job.
+
+## Decision (Todd, 2026-06-29)
+
+Gate correlation behind a **config-policy inline feature** (`vulnerability` → `{ enabled }`),
+**default disabled** (absent policy = off). Correlation only runs for devices whose
+**effective** config enables it. Rationale: correlation fires `vulnerability.critical_detected`
+events per CVSS≥9 finding — gating lets us roll out org-by-org instead of flooding all orgs
+at once, and matches MSP "vuln mgmt as a paid tier" monetization. Pattern B (inline), per the
+configuration-policy skill decision guide: it's a toggle, no standalone table, no shared rules,
+no compliance worker.
+
+## Layers
+
+### L1 — Register the `vulnerability` feature type
+- [ ] `db/schema/configurationPolicies.ts`: add `'vulnerability'` to `configFeatureTypeEnum`.
+- [ ] `services/configFeatureTypes.ts`: add `'vulnerability'` to `CONFIG_FEATURE_TYPES`.
+- [ ] `packages/shared/src/validators/index.ts:491`: add `'vulnerability'` to `addFeatureLinkSchema.featureType`.
+- [ ] Migration `2026-06-29-vuln-config-feature-type.sql`: idempotent `DO $$ … ALTER TYPE config_feature_type ADD VALUE 'vulnerability'` (pure JSONB → no normalized table, value unused in same migration → tx-safe). Mirrors 0029.
+- [ ] Parity tests (`resolution.test.ts`, `policyBaselineDefaults.test.ts`) stay green.
+
+### L2 — Inline settings handling (pure JSONB, like pam/helper/warranty)
+- [ ] `configurationPolicy.ts`: export `vulnerabilityInlineSettingsSchema = z.object({ enabled: z.boolean().default(false) }).strict()`.
+- [ ] Validate it in `addFeatureLink` + `updateFeatureLink` (mirror pam).
+- [ ] `decomposeInlineSettings` / `deleteNormalizedRows`: add `case 'vulnerability':` to the pure-JSONB no-op group.
+- [ ] `assembleInlineSettings`: `case 'vulnerability': return null` (settings live on the link).
+- [ ] `validateFeaturePolicyExists`: add `vulnerability` to the "no policy table → reject featurePolicyId" branch.
+
+### L3 — Effective-config resolver (featureConfigResolver.ts)
+- [ ] `resolveVulnerabilityEnabledForDevice(deviceId): Promise<boolean>` — mirror `resolveSoftwarePolicyForDevice`; winning `vulnerability` link's `inlineSettings.enabled`; **default false**.
+- [ ] `resolveAllVulnerabilityEnabledDevices(): Promise<Map<orgId, string[]>>` — global scan mirroring `resolveDeviceIdsForSoftwarePolicy`: feature links (`vulnerability`) on active policies → assignments → candidate device IDs → look up each candidate's orgId → verify each via `resolveVulnerabilityEnabledForDevice` (closest-wins; a closer `enabled:false` overrides org-level `enabled:true`) → group enabled devices by org.
+
+### L4 — Gate correlation (vulnerabilityCorrelation.ts)
+- [ ] `correlateOrg(orgId, opts?: { deviceIds?: string[] })`: when `deviceIds` provided, `inArray(softwareInventory.deviceId, …)` on both candidate queries + scope the resolve WHERE to those devices. **Empty array → early-return {0,0}** (must NOT mean "all" — would resolve everything).
+- [ ] `correlateOsVulns(orgId, opts?)`: filter `macDevices` by `inArray(devices.id, deviceIds)`; empty → early-return.
+- [ ] Omitting `opts` keeps current behavior (all devices) → existing tests green.
+
+### L5 — Recurring + manual correlation job (vulnerabilityJobs.ts)
+- [ ] `correlateEnabledOrgs()`: `resolveAllVulnerabilityEnabledDevices()` → per org `correlateOrg(orgId,{deviceIds})` + `correlateOsVulns(orgId,{deviceIds})`; aggregate {orgs, created, resolved}.
+- [ ] `VULN_CORRELATE_CRON = '0 13 * * *'` (after SOFA 12:00). Add `'vuln-correlate'` repeatable to `scheduleVulnMaintenanceJobs` + handler in `createVulnMaintenanceWorker`.
+- [ ] `enqueueVulnCorrelation()` for manual trigger.
+
+### L6 — Admin manual trigger (routes/vulnerabilities.ts)
+- [ ] Add `POST /vulnerabilities/sync/correlate` (platformAdmin + MFA + rate-limit), enqueues `vuln-correlate`. Lets us trigger a run on the droplet for testing.
+
+### L7 — Frontend feature tab (Opus, in-session)
+- [ ] `featureTabs/VulnerabilityTab.tsx` (copy PamTab — single `enabled` toggle).
+- [ ] `featureTabs/types.ts`: `FeatureType` union + `FEATURE_META`.
+- [ ] `ConfigPolicyDetailPage.tsx`: `FEATURE_TYPES`, `featureTabIcons`, `renderFeatureTab`.
+- [ ] `VulnerabilityTab.test.tsx`; no-silent-mutations count/glob if needed.
+
+### L8 — AI tool doc + tests
+- [ ] `aiToolsConfigPolicy.ts` `manage_policy_feature_link` description: add `vulnerability: { enabled }` shape (generic tool already supports it via the enum).
+- [ ] Integration tests: resolver (closest-wins, default-off), gated correlation (deviceIds filter, empty no-op), `correlateEnabledOrgs`.
+
+## Verification gate
+- tsc clean; web astro check; vuln integration suite; rls-coverage; site-scope-coverage;
+  config-policy parity tests; web tab test. Then live-trigger on US droplet for one enabled org.
+</content>

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -488,7 +488,7 @@ export const updateConfigPolicySchema = z.object({
 });
 
 export const addFeatureLinkSchema = z.object({
-  featureType: z.enum(['patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam']),
+  featureType: z.enum(['patch', 'alert_rule', 'backup', 'security', 'monitoring', 'maintenance', 'compliance', 'automation', 'event_log', 'software_policy', 'sensitive_data', 'peripheral_control', 'warranty', 'helper', 'remote_access', 'pam', 'vulnerability']),
   featurePolicyId: z.string().guid().optional(),
   inlineSettings: z.record(z.string(), z.unknown()).optional(),
 }).refine(


### PR DESCRIPTION
## Why

BE-16 (#1861) shipped vuln **source sync + the global CVE catalog**, but the **correlation** step that materializes `device_vulnerabilities` had **no production caller** — only tests invoked it. Verified on US prod: catalog is full (13.3K vulns / 3.4K products / 83K mappings / 4.3K OS facts) while `device_vulnerabilities = 0`, so the Vulnerabilities dashboard is empty for everyone.

## What

Wire correlation into a recurring job, **gated behind a new `vulnerability` config-policy feature** (inline `{ enabled }`, **default OFF**). Correlation only runs for devices whose **effective** config enables scanning — so it rolls out org-by-org instead of firing `vulnerability.critical_detected` events fleet-wide on first run, and matches the MSP "vuln mgmt as a paid tier" model.

### Backend
- **New `vulnerability` feature type** (Pattern B inline toggle): DB enum + `CONFIG_FEATURE_TYPES` + validator + baseline defaults + idempotent migration. Pure JSONB (no normalized table, like pam/helper), validated by a `.strict()` schema (`{}` → `enabled:false`).
- **Gate** (`featureConfigResolver.ts`): `resolveVulnerabilityEnabledForDevice` (closest-wins; default false; a device-level opt-out overrides an org-level opt-in) and `resolveAllVulnerabilityEnabledDevices` (batched, grouped by org — mirrors `resolveDeviceIdsForSoftwarePolicy`).
- **Gated correlation**: `correlateOrg`/`correlateOsVulns` take an optional `{ deviceIds }` scope. An **empty set is an explicit no-op** (does *not* resolve existing findings); omitting `opts` keeps the legacy whole-org behavior, so existing correlation tests are unchanged.
- **Job**: `correlateEnabledOrgs` runs **daily 13:00 UTC** (after the 09:00–12:00 source syncs) on the existing `vuln-maintenance` queue. `POST /vulnerabilities/sync/correlate` (platform-admin + MFA) triggers a run on demand.

### Frontend / AI
- `VulnerabilityTab.tsx` — single enable toggle in the config-policy detail page (modeled on PamTab), wired into the tab registry/icons.
- `vulnerability: { enabled }` shape documented in the `manage_policy_feature_link` AI tool.

## How to use (post-release)
Add a config policy with the **Vulnerability Scanning** toggle on → assign to an org → `POST /vulnerabilities/sync/correlate` (or wait for the daily run) → findings populate for just that org.

## Tests
- New gating integration suite **8/8** (default-off, org-enable, closest-wins override, `deviceIds` filter, empty no-op, job end-to-end)
- Inline-schema unit 4/4, frontend tab unit 4/4
- Backward-compat correlation **11/11**, config-policy routes/services/AI green (146), vuln route+risk green
- Migration-ordering 43/43, site-scope-coverage 7/7
- API / shared / web `tsc` clean

> rls-coverage forge tests fail in this worktree due to a missing `.env.test` (privileged-role connection — known worktree gotcha); this change adds **no** tenant-scoped tables. `db:check-drift` failure is shared-local-DB contamination from other worktrees; the migration is the only new file and is consistent with the schema enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)