### PR TITLE
fix(api): per-route auth on /webhooks so inbound-email + Stripe webhooks reach their handlers

### DIFF
--- a/apps/api/src/routes/webhooks.mountOrder.test.ts
+++ b/apps/api/src/routes/webhooks.mountOrder.test.ts
@@ -57,6 +57,15 @@ vi.mock('../services/notificationSenders/webhookSender', () => ({
   validateWebhookUrlSafetyWithDns: vi.fn(async () => [])
 }));
 
+// --- Stripe webhook deps (the signature handler is reached past auth) ---
+vi.mock('../services/stripeWebhook', () => ({
+  verifyStripeEvent: vi.fn(() => { throw new Error('should not be reached without a signature'); }),
+  handleStripeEvent: vi.fn(async () => undefined)
+}));
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn()
+}));
+
 // db is mocked to avoid a real connection at import; the paths under test
 // (no Authorization header) short-circuit before any query runs.
 vi.mock('../db', () => ({
@@ -68,12 +77,16 @@ vi.mock('../db', () => ({
 
 import { webhookRoutes } from './webhooks';
 import { emailWebhookRoutes } from './tickets/emailWebhook';
+import { stripeWebhookRoutes } from './webhooks/stripe';
 
-// Reproduce the index.ts mount order: CRUD router first, public router second.
+// Reproduce the index.ts mount order: CRUD router first, then the public
+// signature-gated siblings — emailWebhookRoutes at /webhooks/tickets and
+// stripeWebhookRoutes back under /webhooks (index.ts:816,819,823).
 function buildApp() {
   const app = new Hono();
   app.route('/webhooks', webhookRoutes);
   app.route('/webhooks/tickets', emailWebhookRoutes);
+  app.route('/webhooks', stripeWebhookRoutes);
   return app;
 }
 
@@ -108,6 +121,21 @@ describe('webhooks mount-order regression (#2053)', () => {
     const res = await postInbound(buildApp());
     expect(res.status).toBe(202);
     expect(enqueueMock).toHaveBeenCalled();
+  });
+
+  it('Stripe Connect webhook reaches the signature handler, not session auth (no sig → 400)', async () => {
+    // The same `/webhooks/*` wildcard that broke inbound email also blanketed
+    // /webhooks/stripe/connect. With no stripe-signature header the handler
+    // returns 400 "Missing signature" — proof it ran past auth, not the
+    // authMiddleware 401.
+    const res = await buildApp().request('/webhooks/stripe/connect', {
+      method: 'POST',
+      body: '{}'
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Missing signature');
+    expect(body.error).not.toBe('Missing or invalid authorization header');
   });
 
   it('webhookRoutes CRUD still requires session auth (no token → 401 auth header)', async () => {

--- a/apps/api/src/routes/webhooks.mountOrder.test.ts
+++ b/apps/api/src/routes/webhooks.mountOrder.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Mount-order regression test for issue #2053.
+ *
+ * `webhookRoutes` (org webhook CRUD, session-auth) and `emailWebhookRoutes`
+ * (public, HMAC-gated inbound email) both mount under the `/webhooks` prefix in
+ * index.ts. Hono flattens `.route()` mounts, so a `/webhooks/*` wildcard auth
+ * middleware on webhookRoutes would blanket the nested public `/webhooks/tickets`
+ * routes and 401 them with "Missing or invalid authorization header" before the
+ * HMAC handler ever runs.
+ *
+ * This test reproduces the real mount topology (webhookRoutes mounted BEFORE
+ * emailWebhookRoutes, both under /webhooks) and asserts:
+ *   1. an unauthenticated POST to /webhooks/tickets/email-inbound reaches the
+ *      HMAC handler (NOT session auth), and
+ *   2. webhookRoutes' own CRUD endpoints still require session auth.
+ *
+ * The Stripe Connect webhook (`/webhooks/stripe/connect`) is affected by the
+ * identical mechanism and protected by the same per-route-auth fix.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { verifyMock, parseMock, enqueueMock, rateLimiterMock } = vi.hoisted(() => ({
+  verifyMock: vi.fn(),
+  parseMock: vi.fn(),
+  enqueueMock: vi.fn().mockResolvedValue(undefined),
+  rateLimiterMock: vi.fn()
+}));
+
+// --- Inbound-email service deps (exercised by the email route) ---
+vi.mock('../services/inboundEmail/mailgun', () => ({
+  MailgunInboundProvider: class {
+    name = 'mailgun';
+    verify(...args: unknown[]) { return verifyMock(...args); }
+    parse(...args: unknown[]) { return parseMock(...args); }
+  }
+}));
+vi.mock('../services/inboundEmailQueue', () => ({
+  enqueueInboundEmail: enqueueMock
+}));
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: rateLimiterMock
+}));
+vi.mock('../services/redis', () => ({
+  getRedis: vi.fn(() => ({}))
+}));
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => '1.2.3.4')
+}));
+
+// --- webhookRoutes-only deps (never reached on the no-auth paths under test) ---
+vi.mock('../workers/webhookDelivery', () => ({
+  getWebhookWorker: vi.fn(() => ({}))
+}));
+vi.mock('../services/notificationSenders/webhookSender', () => ({
+  redactUrlForLogs: vi.fn((u: string) => u),
+  validateWebhookUrlSafetyWithDns: vi.fn(async () => [])
+}));
+
+// db is mocked to avoid a real connection at import; the paths under test
+// (no Authorization header) short-circuit before any query runs.
+vi.mock('../db', () => ({
+  db: {},
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn())
+}));
+
+import { webhookRoutes } from './webhooks';
+import { emailWebhookRoutes } from './tickets/emailWebhook';
+
+// Reproduce the index.ts mount order: CRUD router first, public router second.
+function buildApp() {
+  const app = new Hono();
+  app.route('/webhooks', webhookRoutes);
+  app.route('/webhooks/tickets', emailWebhookRoutes);
+  return app;
+}
+
+async function postInbound(app: Hono) {
+  const form = new FormData();
+  form.append('timestamp', 't');
+  form.append('token', 'k');
+  form.append('signature', 'sig');
+  return app.request('/webhooks/tickets/email-inbound', { method: 'POST', body: form });
+}
+
+describe('webhooks mount-order regression (#2053)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimiterMock.mockResolvedValue({ allowed: true, remaining: 59, resetAt: new Date() });
+    verifyMock.mockResolvedValue(true);
+    parseMock.mockResolvedValue({ provider: 'mailgun', to: 'x', from: 'y', attachments: [], raw: {} });
+  });
+
+  it('inbound email reaches the HMAC handler, not session auth (bad sig → 401 "Unauthorized")', async () => {
+    verifyMock.mockResolvedValue(false);
+    const res = await postInbound(buildApp());
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    // The bug surfaced as the authMiddleware message; the HMAC handler returns "Unauthorized".
+    expect(body.error).toBe('Unauthorized');
+    expect(body.error).not.toBe('Missing or invalid authorization header');
+    expect(verifyMock).toHaveBeenCalled();
+  });
+
+  it('inbound email with a valid signature is accepted (202)', async () => {
+    const res = await postInbound(buildApp());
+    expect(res.status).toBe(202);
+    expect(enqueueMock).toHaveBeenCalled();
+  });
+
+  it('webhookRoutes CRUD still requires session auth (no token → 401 auth header)', async () => {
+    const res = await buildApp().request('/webhooks', { method: 'GET' });
+    expect(res.status).toBe(401);
+    // authMiddleware throws an HTTPException; a bare Hono app (no onError) returns
+    // its message as the raw body. The real app.onError wraps this as JSON, but
+    // here we just assert the auth gate fired.
+    const body = await res.text();
+    expect(body).toContain('Missing or invalid authorization header');
+  });
+});

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -284,11 +284,19 @@ const testWebhookSchema = z.object({
 const webhookIdParamSchema = z.object({ id: z.string().guid() });
 const webhookRetryParamSchema = z.object({ id: z.string().guid(), deliveryId: z.string().guid() });
 
-webhookRoutes.use('*', authMiddleware);
+// NOTE: do NOT use `webhookRoutes.use('*', authMiddleware)` here. This router is
+// mounted at `/webhooks`, but the public, signature-gated `/webhooks/tickets`
+// (inbound email) and `/webhooks/stripe` (Stripe Connect) routers mount under the
+// same prefix. Hono flattens `.route()` mounts, so a `/webhooks/*` wildcard would
+// blanket those nested public paths with session auth and 401 them before their
+// HMAC/signature handlers run (issue #2053). Lead each route below with
+// `authMiddleware` per-route instead — same pattern as externalServices.ts and
+// invoices/settings.ts.
 
 // GET /webhooks - List webhooks for org (paginated, filtered by status)
 webhookRoutes.get(
   '/',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   zValidator('query', listWebhooksSchema),
   async (c) => {
@@ -357,6 +365,7 @@ webhookRoutes.get(
 // POST /webhooks - Create webhook
 webhookRoutes.post(
   '/',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
@@ -432,6 +441,7 @@ webhookRoutes.post(
 // GET /webhooks/:id - Get webhook details including delivery stats
 webhookRoutes.get(
   '/:id',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   zValidator('param', webhookIdParamSchema),
   async (c) => {
@@ -455,6 +465,7 @@ webhookRoutes.get(
 // PATCH /webhooks/:id - Update webhook
 webhookRoutes.patch(
   '/:id',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
@@ -532,6 +543,7 @@ webhookRoutes.patch(
 // DELETE /webhooks/:id - Delete webhook
 webhookRoutes.delete(
   '/:id',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
@@ -568,6 +580,7 @@ webhookRoutes.delete(
 // GET /webhooks/:id/deliveries - Get delivery history (paginated, filtered by status)
 webhookRoutes.get(
   '/:id/deliveries',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   zValidator('param', webhookIdParamSchema),
   zValidator('query', listDeliveriesSchema),
@@ -617,6 +630,7 @@ webhookRoutes.get(
 // POST /webhooks/:id/test - Send test payload to webhook
 webhookRoutes.post(
   '/:id/test',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
@@ -715,6 +729,7 @@ webhookRoutes.post(
 // POST /webhooks/:id/retry/:deliveryId - Retry a failed delivery
 webhookRoutes.post(
   '/:id/retry/:deliveryId',
+  authMiddleware,
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -290,8 +290,10 @@ const webhookRetryParamSchema = z.object({ id: z.string().guid(), deliveryId: z.
 // same prefix. Hono flattens `.route()` mounts, so a `/webhooks/*` wildcard would
 // blanket those nested public paths with session auth and 401 them before their
 // HMAC/signature handlers run (issue #2053). Lead each route below with
-// `authMiddleware` per-route instead — same pattern as externalServices.ts and
-// invoices/settings.ts.
+// `authMiddleware` per-route instead — the inline-per-route pattern in
+// invoices/settings.ts. (externalServices.ts scopes auth the same anti-wildcard
+// way but via path-targeted `.use('/billing/portal', authMiddleware)` rather than
+// inline-leading, so it's the principle, not the exact form, to copy.)
 
 // GET /webhooks - List webhooks for org (paginated, filtered by status)
 webhookRoutes.get(


### PR DESCRIPTION
## Summary

Fixes the self-hosted inbound email-to-ticket failure reported in #2053 (SemoTech, v0.86.0): Mailgun receives mail but the forward to `/api/v1/webhooks/tickets/email-inbound` returns 401 and no ticket is created.

**Root cause:** `webhookRoutes` (org webhook CRUD) mounts at `/webhooks` with `webhookRoutes.use('*', authMiddleware)`. The public, signature-gated `emailWebhookRoutes` (`/webhooks/tickets`) and `stripeWebhookRoutes` (`/webhooks/stripe`) mount under the same prefix. Hono flattens `.route()` mounts, so the `/webhooks/*` wildcard blankets the whole subtree and 401s those nested public routes with `"Missing or invalid authorization header"` before their HMAC/signature handlers run. The error string the reporter saw comes from `authMiddleware` (`middleware/auth.ts:342`), not the HMAC handler (`emailWebhook.ts:52`) — confirming session auth short-circuits the request.

The **Stripe Connect webhook** (`/webhooks/stripe/connect`) is broken by the identical mechanism; this fix covers it too.

## Changes

- **`apps/api/src/routes/webhooks.ts`** — remove the `.use('*', authMiddleware)` wildcard; lead each of the 8 CRUD routes with `authMiddleware` per-route (the documented `externalServices.ts` / `invoices/settings.ts` pattern). Adds a NOTE comment to prevent regression. The `/webhooks/*` subtree is no longer blanketed, so nested public routes reach their handlers regardless of mount order.
- **`apps/api/src/routes/webhooks.mountOrder.test.ts`** (new) — reproduces the real mount topology (`webhookRoutes` before `emailWebhookRoutes`, both under `/webhooks`) and asserts: (1) unauthenticated inbound email reaches the HMAC handler (bad sig → `401 "Unauthorized"`, not the auth message), (2) valid signature → `202`, (3) `webhookRoutes` CRUD still requires session auth.

## Testing

- New `webhooks.mountOrder.test.ts`: 3/3 pass; with the fix reverted, the two inbound-email assertions fail (confirms it catches the regression).
- Existing `webhooks.test.ts` (15) and `tickets/emailWebhook.test.ts` (7): pass — per-route auth didn't break CRUD.
- `tsc --noEmit`: clean.

## Notes

This is a code-path fix that requires a **new signed build** before the reporter can retest on their self-hosted install. Leaving #2053 open until SemoTech confirms.

Refs #2053 (kept open until the reporter confirms on their self-hosted install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)