### PR TITLE
fix(ci): allowlist placeholder test email domains in customer-PII guard

### DIFF
--- a/scripts/security/check-customer-pii.sh
+++ b/scripts/security/check-customer-pii.sh
@@ -40,7 +40,7 @@ ALLOW_RE="$ALLOW_RE"'|(^|\.)theirmsp\.com$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)gserviceaccount\.com$'
 # Exact known-safe domains: public/example, infra, generic placeholders, and
 # owner-blessed real domains (olivetech.co — see PR #1968 discussion).
-ALLOW_RE="$ALLOW_RE"'|^(anthropic\.com|nist\.gov|google\.com|gmail\.com|mailinator\.com|contoso\.com|lanternops\.io|lantern\.it|olivetech\.co|b\.co|b\.com|x\.com|x\.io|y\.com|foo\.com|bar\.com|test\.com|corp\.com|company\.com|org\.com|msp\.com|customer\.com|partner\.com|evil\.com|notours\.com|nowhere\.com|yourcompany\.com|yourdomain\.com)$'
+ALLOW_RE="$ALLOW_RE"'|^(anthropic\.com|nist\.gov|google\.com|gmail\.com|mailinator\.com|contoso\.com|lanternops\.io|lantern\.it|olivetech\.co|a\.com|b\.co|b\.com|x\.com|mail\.x\.com|x\.io|y\.com|foo\.com|bar\.com|test\.com|corp\.com|company\.com|org\.com|msp\.com|yourmsp\.com|customer\.com|cust\.com|partner\.com|evil\.com|notours\.com|nowhere\.com|yourcompany\.com|yourdomain\.com)$'
 
 EMAIL_RE='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
 


### PR DESCRIPTION
## Summary
The `customer-pii` guard (`scripts/security/check-customer-pii.sh`) scans **all tracked files** (repo-wide `git grep`), and was **red on `main`**: ticket-mailbox / inbound-email test fixtures use placeholder sender domains that aren't in `ALLOW_RE`.

Surfaced while merging #2058 — the "Security Audit" check was failing on these pre-existing fixtures, not on that PR's diff.

## Change
Allowlist-only. Added four obvious test placeholders to the exact-domain list:

| Domain | Count | Source |
|---|---|---|
| `a.com` | 62 | `support@a.com` — ticket mailbox tests |
| `mail.x.com` | 16 | `abc/prev/root@mail.x.com` — `normalizeGraphMessage` tests |
| `yourmsp.com` | 2 | MSP placeholder (same family as allowed `yourcompany.com`) |
| `cust.com` | 1 | customer placeholder |

No production code touched.

## Verification
`bash scripts/security/check-customer-pii.sh` → `OK (no unrecognised email domains in tracked files)` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)