### PR TITLE
feat(web): make organization type editable on the General settings tab

### DIFF
--- a/apps/web/src/components/settings/OrgSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.test.tsx
@@ -150,6 +150,30 @@ describe('OrgSettingsPage general tab — name editing', () => {
     });
   });
 
+  it('PATCHes the new organization type when the user edits and saves', async () => {
+    fetchWithAuthMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/effective-settings')) return Promise.resolve(makeJsonResponse({ locked: [] }));
+      if (init?.method === 'PATCH') return Promise.resolve(makeJsonResponse({ ...orgDetails, type: 'internal' }));
+      return Promise.resolve(makeJsonResponse({ ...orgDetails, type: 'customer' }));
+    });
+
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    const select = (await screen.findByTestId('org-type-select')) as HTMLSelectElement;
+    await userEvent.selectOptions(select, 'internal');
+    await userEvent.click(screen.getByTestId('org-type-save'));
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/orgs/organizations/org-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ type: 'internal' })
+        })
+      );
+    });
+  });
+
   it('disables save when the name is unchanged, empty, or whitespace-only', async () => {
     fetchWithAuthMock.mockImplementation((url: string) => {
       if (url.endsWith('/effective-settings')) return Promise.resolve(makeJsonResponse({ locked: [] }));

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -238,6 +238,8 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
   const [copiedOrgId, setCopiedOrgId] = useState(false);
   const [nameDraft, setNameDraft] = useState('');
   const [savingName, setSavingName] = useState(false);
+  const [typeDraft, setTypeDraft] = useState<string>('customer');
+  const [savingType, setSavingType] = useState(false);
 
   const { currentOrgId, organizations } = useOrgStore();
   const effectiveOrgId = propOrgId || currentOrgId;
@@ -262,6 +264,7 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
       const data = await response.json();
       setOrgDetails(data);
       setNameDraft(data.name ?? '');
+      setTypeDraft(data.type ?? 'customer');
 
       // Fetch effective settings to determine partner-locked fields
       const effRes = await fetchWithAuth(`/orgs/organizations/${effectiveOrgId}/effective-settings`);
@@ -333,6 +336,31 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
       setSavingName(false);
     }
   }, [effectiveOrgId, nameDraft, orgDetails, fetchOrgDetails]);
+
+  const handleSaveType = useCallback(async () => {
+    if (!effectiveOrgId) return;
+    if (typeDraft === (orgDetails?.type ?? 'customer')) return;
+
+    try {
+      setSavingType(true);
+      setError(undefined);
+      const response = await fetchWithAuth(`/orgs/organizations/${effectiveOrgId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ type: typeDraft })
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || body.message || 'Failed to save organization type');
+      }
+
+      await fetchOrgDetails();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save organization type');
+    } finally {
+      setSavingType(false);
+    }
+  }, [effectiveOrgId, typeDraft, orgDetails, fetchOrgDetails]);
 
   // Fallback display data — prefer fetched orgDetails; when accessed via URL prop the org
   // might not be in the store's organizations array, so fall back to a minimal object.
@@ -525,8 +553,26 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
                 </div>
                 <div className="rounded-md border bg-muted/40 p-4">
                   <dt className="text-xs uppercase text-muted-foreground">Type</dt>
-                  <dd className="mt-2 text-base font-semibold capitalize">
-                    {orgDetails?.type || 'Customer'}
+                  <dd className="mt-2 flex items-center gap-2">
+                    <select
+                      data-testid="org-type-select"
+                      value={typeDraft}
+                      onChange={(e) => setTypeDraft(e.target.value)}
+                      className="flex-1 rounded-md border bg-background px-3 py-1.5 text-base font-semibold focus:outline-hidden focus:ring-2 focus:ring-primary"
+                      aria-label="Organization type"
+                    >
+                      <option value="customer">Customer</option>
+                      <option value="internal">Internal</option>
+                    </select>
+                    <button
+                      type="button"
+                      data-testid="org-type-save"
+                      onClick={() => void handleSaveType()}
+                      disabled={savingType || typeDraft === (orgDetails?.type ?? 'customer')}
+                      className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {savingType ? 'Saving…' : 'Save'}
+                    </button>
                   </dd>
                   <p className="mt-1 text-xs text-muted-foreground">
                     {orgDetails?.maxDevices ? `Max ${orgDetails.maxDevices} devices` : 'Unlimited devices'}


### PR DESCRIPTION
## Make organization Type editable after create

Org `type` (Customer vs Internal) was only settable in the Add Organization dialog; afterward Settings → Organization → General showed it as read-only — even though `PATCH /orgs/organizations/:id` already accepts and persists `type` (`z.enum(['customer','internal'])`). Reported by a self-hosted MSP who needed to fix a misclassified bootstrap org without API/DB access.

**Frontend-only** — no backend change needed.

### What changed
- `apps/web/src/components/settings/OrgSettingsPage.tsx` — the General tab Type field is now an editable Customer/Internal `<select>` + Save button, mirroring the existing inline Organization-name edit in the same component (same state lifecycle, same PATCH-then-refetch pattern, Save disabled when unchanged).
- `OrgSettingsPage.test.tsx` — new test: change type to `internal`, save, assert `PATCH /orgs/organizations/:id` body is `{ type: 'internal' }`.

### Testing
- `OrgSettingsPage.test.tsx`: 11/11 passing.
- `pnpm -C apps/web build`: clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
