### PR TITLE
feat(dns-security): add Pi-hole v6 REST API client (#2017)

### DIFF
--- a/apps/api/src/db/schema/dnsSecurity.ts
+++ b/apps/api/src/db/schema/dnsSecurity.ts
@@ -65,6 +65,10 @@ export interface DnsIntegrationConfig {
   categories?: string[];
   blocklistId?: string;
   allowlistId?: string;
+  // Pi-hole admin API version. v5 uses the legacy `/admin/api.php?...&auth=`
+  // token endpoint; v6 reworked it into a session-based REST API at `/api/...`.
+  // Unset defaults to 'v5' so existing Pi-hole integrations keep working.
+  piholeVersion?: 'v5' | 'v6';
 }
 
 export interface DnsPolicyDomain {

--- a/apps/api/src/jobs/dnsSyncJob.ts
+++ b/apps/api/src/jobs/dnsSyncJob.ts
@@ -661,7 +661,15 @@ export async function processSyncIntegration(data: SyncIntegrationJobData): Prom
 
     // Phase 2 — fetch from the DNS provider with NO DB context held
     // (#1105/#1697). The ~20s-timeout HTTP must not pin a pooled connection.
-    const events = await dbModule.runOutsideDbContext(() => provider.syncEvents(since, until));
+    // Release any provider-held session afterwards (best-effort; see
+    // DnsProvider.dispose — relevant for the seat-limited Pi-hole v6 client).
+    const events = await dbModule.runOutsideDbContext(async () => {
+      try {
+        return await provider.syncEvents(since, until);
+      } finally {
+        await provider.dispose?.();
+      }
+    });
 
     // Phase 3 — process + persist all events in ONE context (security events,
     // aggregations, retention prune and success status commit together).
@@ -761,12 +769,17 @@ export async function processPolicySync(data: SyncPolicyJobData): Promise<{
     // sequentially — see runSequentialDomainMutations for why concurrency here
     // causes silent rule clobbering (issue #827).
     await dbModule.runOutsideDbContext(async () => {
-      if (row.policy.type === 'blocklist') {
-        await runSequentialDomainMutations(addDomains, (domain) => provider.addBlocklistDomain(domain));
-        await runSequentialDomainMutations(removeDomains, (domain) => provider.removeBlocklistDomain(domain));
-      } else {
-        await runSequentialDomainMutations(addDomains, (domain) => provider.addAllowlistDomain(domain));
-        await runSequentialDomainMutations(removeDomains, (domain) => provider.removeAllowlistDomain(domain));
+      try {
+        if (row.policy.type === 'blocklist') {
+          await runSequentialDomainMutations(addDomains, (domain) => provider.addBlocklistDomain(domain));
+          await runSequentialDomainMutations(removeDomains, (domain) => provider.removeBlocklistDomain(domain));
+        } else {
+          await runSequentialDomainMutations(addDomains, (domain) => provider.addAllowlistDomain(domain));
+          await runSequentialDomainMutations(removeDomains, (domain) => provider.removeAllowlistDomain(domain));
+        }
+      } finally {
+        // Release any provider-held session (best-effort; Pi-hole v6 only).
+        await provider.dispose?.();
       }
     });
 

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -165,7 +165,10 @@ const integrationConfigSchema = z.object({
   retentionDays: z.number().int().min(1).max(365).optional(),
   categories: z.array(z.string().min(1).max(100)).max(100).optional(),
   blocklistId: z.string().min(1).optional(),
-  allowlistId: z.string().min(1).optional()
+  allowlistId: z.string().min(1).optional(),
+  // Pi-hole admin API version (v6 uses the session-based REST API). Defaults to
+  // v5 when unset. Ignored by non-Pi-hole providers.
+  piholeVersion: z.enum(['v5', 'v6']).optional()
 });
 
 const createIntegrationSchema = z.object({

--- a/apps/api/src/services/dnsProviders/index.test.ts
+++ b/apps/api/src/services/dnsProviders/index.test.ts
@@ -102,6 +102,26 @@ describe('createDnsProvider — on-prem allowPrivateNetwork gating', () => {
       expect(lastInit().allowPrivateNetwork).toBe(true);
     });
 
+    it('pihole v6 routes to the session API and threads private networking', async () => {
+      // v6 auths first (POST /api/auth → session.sid) then POSTs the domain;
+      // both requests must carry the on-prem allowPrivateNetwork opt-in.
+      requestJsonMock.mockImplementation(async () => ({
+        session: { valid: true, sid: 'SID', validity: 300 }
+      }) as never);
+      const provider = createDnsProvider({
+        provider: 'pihole',
+        apiKey: 'app-password',
+        apiSecret: null,
+        config: { apiEndpoint: 'https://pi.hole.local', piholeVersion: 'v6' } as never
+      });
+      await provider.addBlocklistDomain('bad.example');
+      const authCall = requestJsonMock.mock.calls[0]!;
+      expect(String(authCall[0])).toBe('https://pi.hole.local/api/auth');
+      expect((authCall[1] as { allowPrivateNetwork?: boolean }).allowPrivateNetwork).toBe(true);
+      expect(String(requestJsonMock.mock.calls.at(-1)![0])).toBe('https://pi.hole.local/api/domains/deny/exact');
+      expect(lastInit().allowPrivateNetwork).toBe(true);
+    });
+
     it('adguard_home opts INTO private networking', async () => {
       const provider = createDnsProvider({
         provider: 'adguard_home',

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -4,6 +4,7 @@ import { UmbrellaProvider } from './umbrella';
 import { CloudflareGatewayProvider } from './cloudflare';
 import { DnsFilterProvider } from './dnsfilter';
 import { PiHoleProvider } from './pihole';
+import { PiHoleV6Provider } from './piholeV6';
 import { AdGuardHomeProvider } from './adguardHome';
 
 export interface DnsEvent {
@@ -66,7 +67,11 @@ export function createDnsProvider(input: DnsProviderFactoryInput): DnsProvider {
     case 'dnsfilter':
       return new DnsFilterProvider(input.apiKey, input.config);
     case 'pihole':
-      return new PiHoleProvider(input.apiKey, input.config, allowPrivateNetwork);
+      // v6 reworked the admin API into a session-based REST surface; v5 (default
+      // when unset) keeps the legacy /admin/api.php?...&auth= token endpoint.
+      return input.config.piholeVersion === 'v6'
+        ? new PiHoleV6Provider(input.apiKey, input.config, allowPrivateNetwork)
+        : new PiHoleProvider(input.apiKey, input.config, allowPrivateNetwork);
     case 'adguard_home':
       return new AdGuardHomeProvider(input.apiKey, input.apiSecret, input.config, allowPrivateNetwork);
     case 'opendns':
@@ -82,6 +87,7 @@ export {
   CloudflareGatewayProvider,
   DnsFilterProvider,
   PiHoleProvider,
+  PiHoleV6Provider,
   AdGuardHomeProvider
 };
 

--- a/apps/api/src/services/dnsProviders/index.ts
+++ b/apps/api/src/services/dnsProviders/index.ts
@@ -26,6 +26,14 @@ export interface DnsProvider {
   removeBlocklistDomain(domain: string): Promise<void>;
   addAllowlistDomain(domain: string): Promise<void>;
   removeAllowlistDomain(domain: string): Promise<void>;
+  /**
+   * Optional teardown — release any session/connection the provider holds.
+   * Stateless providers (v5 Pi-hole token, AdGuard HTTP Basic, cloud APIs) omit
+   * it; the session-based Pi-hole v6 client implements it to free its seat.
+   * Callers must treat it as best-effort and not let it mask the operation
+   * result. Invoked once after a sync run / mutation batch completes.
+   */
+  dispose?(): Promise<void>;
 }
 
 export interface DnsProviderFactoryInput {

--- a/apps/api/src/services/dnsProviders/piholeV6.test.ts
+++ b/apps/api/src/services/dnsProviders/piholeV6.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PiHoleV6Provider } from './piholeV6';
+import { DnsProviderHttpError, requestJson } from './http';
+
+// Transport is mocked — these tests exercise the v6 provider's request shaping
+// (auth handshake, X-FTL-SID header, query/domain endpoints) and response
+// handling, not real HTTP. requestJson returns the parsed JSON body directly.
+vi.mock('./http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./http')>();
+  return {
+    ...actual,
+    requestJson: vi.fn()
+  };
+});
+
+const requestJsonMock = vi.mocked(requestJson);
+
+const AUTH_OK = { session: { valid: true, sid: 'SID-123', validity: 300 } };
+
+function queueResponses(responses: unknown[]): void {
+  const queue = [...responses];
+  requestJsonMock.mockImplementation(async () => {
+    if (queue.length === 0) throw new Error('requestJson mock exhausted');
+    return queue.shift() as never;
+  });
+}
+
+function newProvider(): PiHoleV6Provider {
+  return new PiHoleV6Provider('app-password', { apiEndpoint: 'https://pi.hole.local/' });
+}
+
+describe('PiHoleV6Provider', () => {
+  beforeEach(() => {
+    requestJsonMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when apiEndpoint is missing', async () => {
+    const provider = new PiHoleV6Provider('app-password', {});
+    await expect(provider.syncEvents(new Date(0), new Date())).rejects.toThrow(/apiEndpoint/);
+  });
+
+  it('authenticates then sends the X-FTL-SID header on subsequent requests', async () => {
+    queueResponses([AUTH_OK, { queries: [] }]);
+
+    await newProvider().syncEvents(new Date(0), new Date());
+
+    expect(requestJsonMock).toHaveBeenCalledTimes(2);
+    const [authUrl, authInit] = requestJsonMock.mock.calls[0]! as [string, RequestInit];
+    expect(authUrl).toBe('https://pi.hole.local/api/auth');
+    expect(authInit.method).toBe('POST');
+    expect(JSON.parse(authInit.body as string)).toEqual({ password: 'app-password' });
+
+    const [queryUrl, queryInit] = requestJsonMock.mock.calls[1]! as [string, RequestInit];
+    expect(queryUrl).toContain('https://pi.hole.local/api/queries');
+    expect((queryInit.headers as Record<string, string>)['X-FTL-SID']).toBe('SID-123');
+  });
+
+  it('throws when authentication returns no valid session', async () => {
+    queueResponses([{ session: { valid: false } }]);
+    await expect(newProvider().addBlocklistDomain('bad.example')).rejects.toThrow(/authentication failed/i);
+  });
+
+  it('maps blocked statuses to action=blocked and parses domain/time/client', async () => {
+    queueResponses([
+      AUTH_OK,
+      {
+        queries: [
+          {
+            id: 42,
+            time: 1_700_000_100,
+            type: 'A',
+            domain: 'tracker.bad.example',
+            status: 'GRAVITY',
+            client: { ip: '10.0.0.5', name: 'workstation-3' }
+          },
+          {
+            id: 43,
+            time: 1_700_000_200,
+            type: 'AAAA',
+            domain: 'ok.example',
+            status: 'FORWARDED',
+            client: { ip: '10.0.0.6', name: null }
+          }
+        ]
+      }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events).toHaveLength(2);
+    const blocked = events[0]!;
+    expect(blocked.domain).toBe('tracker.bad.example');
+    expect(blocked.action).toBe('blocked');
+    expect(blocked.sourceIp).toBe('10.0.0.5');
+    expect(blocked.sourceHostname).toBe('workstation-3');
+    expect(blocked.queryType).toBe('A');
+    expect(blocked.providerEventId).toBe('v6-42');
+    expect(blocked.metadata?.status).toBe('GRAVITY');
+    expect(events[1]!.action).toBe('allowed');
+  });
+
+  it('treats *_CNAME and EXTERNAL_BLOCKED_* statuses as blocked', async () => {
+    queueResponses([
+      AUTH_OK,
+      {
+        queries: [
+          { id: 1, time: 1_700_000_100, type: 'A', domain: 'a.example', status: 'DENYLIST_CNAME', client: { ip: '10.0.0.1' } },
+          { id: 2, time: 1_700_000_110, type: 'A', domain: 'b.example', status: 'EXTERNAL_BLOCKED_NULL', client: { ip: '10.0.0.1' } },
+          { id: 3, time: 1_700_000_120, type: 'A', domain: 'c.example', status: 'CACHE', client: { ip: '10.0.0.1' } }
+        ]
+      }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events.map((e) => e.action)).toEqual(['blocked', 'blocked', 'allowed']);
+  });
+
+  it('drops queries outside the [since, until] window', async () => {
+    queueResponses([
+      AUTH_OK,
+      {
+        queries: [
+          { id: 1, time: 1_700_000_500, type: 'A', domain: 'in.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } },
+          { id: 2, time: 1_699_999_000, type: 'A', domain: 'before.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } },
+          { id: 3, time: 1_700_002_000, type: 'A', domain: 'after.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } }
+        ]
+      }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events.map((e) => e.domain)).toEqual(['in.example']);
+  });
+
+  it('pages back through the cursor until a short page is returned', async () => {
+    // All 1000 entries sit inside the [since, until] window so none are filtered;
+    // the test is exercising cursor paging, not the window guard.
+    const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+      id: 2000 - i,
+      time: 1_700_000_500,
+      type: 'A',
+      domain: `d${i}.example`,
+      status: 'FORWARDED',
+      client: { ip: '10.0.0.1' }
+    }));
+    queueResponses([
+      AUTH_OK,
+      { queries: fullPage, cursor: 999 },
+      { queries: [{ id: 999, time: 1_700_000_050, type: 'A', domain: 'last.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } }] }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    // 1000 from the first page + 1 from the short second page.
+    expect(events).toHaveLength(1001);
+    // Second query request carried the cursor from the first page.
+    const secondQuery = requestJsonMock.mock.calls[2]![0] as string;
+    expect(secondQuery).toContain('cursor=999');
+  });
+
+  it('re-authenticates once and retries on a 401', async () => {
+    requestJsonMock
+      .mockResolvedValueOnce(AUTH_OK as never) // initial auth
+      .mockRejectedValueOnce(new DnsProviderHttpError(401, 'Unauthorized', '')) // expired session
+      .mockResolvedValueOnce(AUTH_OK as never) // re-auth
+      .mockResolvedValueOnce({} as never); // retried POST
+
+    await newProvider().addBlocklistDomain('bad.example');
+
+    expect(requestJsonMock).toHaveBeenCalledTimes(4);
+    // Calls 1 and 3 are auth; calls 2 and 4 are the domain POST.
+    expect(requestJsonMock.mock.calls[2]![0]).toBe('https://pi.hole.local/api/auth');
+    expect(requestJsonMock.mock.calls[3]![0]).toBe('https://pi.hole.local/api/domains/deny/exact');
+  });
+
+  it('addBlocklistDomain POSTs to /api/domains/deny/exact', async () => {
+    queueResponses([AUTH_OK, {}]);
+
+    await newProvider().addBlocklistDomain('bad.example');
+
+    const [url, init] = requestJsonMock.mock.calls[1]! as [string, RequestInit];
+    expect(url).toBe('https://pi.hole.local/api/domains/deny/exact');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ domain: 'bad.example' });
+  });
+
+  it('addAllowlistDomain POSTs to /api/domains/allow/exact', async () => {
+    queueResponses([AUTH_OK, {}]);
+
+    await newProvider().addAllowlistDomain('safe.example');
+
+    const [url] = requestJsonMock.mock.calls[1]! as [string, RequestInit];
+    expect(url).toBe('https://pi.hole.local/api/domains/allow/exact');
+  });
+
+  it('removeBlocklistDomain DELETEs the url-encoded domain', async () => {
+    queueResponses([AUTH_OK, {}]);
+
+    await newProvider().removeBlocklistDomain('bad sub.example');
+
+    const [url, init] = requestJsonMock.mock.calls[1]! as [string, RequestInit];
+    expect(init.method).toBe('DELETE');
+    expect(url).toBe('https://pi.hole.local/api/domains/deny/exact/bad%20sub.example');
+  });
+
+  it('removeBlocklistDomain treats a 404 as a no-op (already absent)', async () => {
+    requestJsonMock
+      .mockResolvedValueOnce(AUTH_OK as never)
+      .mockRejectedValueOnce(new DnsProviderHttpError(404, 'Not Found', ''));
+
+    await expect(newProvider().removeBlocklistDomain('gone.example')).resolves.toBeUndefined();
+  });
+
+  it('propagates non-404 errors from a removal', async () => {
+    requestJsonMock
+      .mockResolvedValueOnce(AUTH_OK as never)
+      .mockRejectedValueOnce(new DnsProviderHttpError(500, 'Server Error', ''));
+
+    await expect(newProvider().removeBlocklistDomain('boom.example')).rejects.toThrow(DnsProviderHttpError);
+  });
+});

--- a/apps/api/src/services/dnsProviders/piholeV6.test.ts
+++ b/apps/api/src/services/dnsProviders/piholeV6.test.ts
@@ -64,6 +64,18 @@ describe('PiHoleV6Provider', () => {
     await expect(newProvider().addBlocklistDomain('bad.example')).rejects.toThrow(/authentication failed/i);
   });
 
+  it('maps a 429 no_seats auth failure to a distinct, actionable error', async () => {
+    requestJsonMock.mockRejectedValueOnce(
+      new DnsProviderHttpError(429, 'Too Many Requests', '{"error":{"key":"no_seats"}}')
+    );
+    await expect(newProvider().syncEvents(new Date(0), new Date())).rejects.toThrow(/session seats are in use/i);
+  });
+
+  it('propagates a generic (non-no_seats) 429 auth failure unchanged', async () => {
+    requestJsonMock.mockRejectedValueOnce(new DnsProviderHttpError(429, 'Too Many Requests', 'rate limited'));
+    await expect(newProvider().syncEvents(new Date(0), new Date())).rejects.toThrow(DnsProviderHttpError);
+  });
+
   it('maps blocked statuses to action=blocked and parses domain/time/client', async () => {
     queueResponses([
       AUTH_OK,
@@ -234,5 +246,125 @@ describe('PiHoleV6Provider', () => {
       .mockRejectedValueOnce(new DnsProviderHttpError(500, 'Server Error', ''));
 
     await expect(newProvider().removeBlocklistDomain('boom.example')).rejects.toThrow(DnsProviderHttpError);
+  });
+
+  it('removeAllowlistDomain DELETEs the allow list url-encoded', async () => {
+    queueResponses([AUTH_OK, {}]);
+
+    await newProvider().removeAllowlistDomain('safe sub.example');
+
+    const [url, init] = requestJsonMock.mock.calls[1]! as [string, RequestInit];
+    expect(init.method).toBe('DELETE');
+    expect(url).toBe('https://pi.hole.local/api/domains/allow/exact/safe%20sub.example');
+  });
+
+  it('returns [] and bounds the window with from/until/length on the query call', async () => {
+    queueResponses([AUTH_OK, { queries: [] }]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events).toEqual([]);
+    const queryUrl = new URL(requestJsonMock.mock.calls[1]![0] as string);
+    expect(queryUrl.searchParams.get('from')).toBe('1700000000');
+    expect(queryUrl.searchParams.get('until')).toBe('1700001000');
+    expect(queryUrl.searchParams.get('length')).toBe('1000');
+  });
+
+  it('synthesizes a composite providerEventId when the row has no id', async () => {
+    queueResponses([
+      AUTH_OK,
+      {
+        queries: [
+          { time: 1_700_000_100, type: 'A', domain: 'noid.example', status: 'FORWARDED', client: { ip: '10.0.0.9' } },
+          // No id AND no client.ip → falls back to the 'unknown' source tail.
+          { time: 1_700_000_200, type: 'A', domain: 'noip.example', status: 'FORWARDED', client: {} }
+        ]
+      }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events[0]!.providerEventId).toBe('1700000100-noid.example-10.0.0.9');
+    expect(events[1]!.providerEventId).toBe('1700000200-noip.example-unknown');
+  });
+
+  it('drops malformed rows (missing domain/time) while keeping valid ones', async () => {
+    queueResponses([
+      AUTH_OK,
+      {
+        queries: [
+          { id: 1, time: 1_700_000_100, type: 'A', domain: 'good.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } },
+          { id: 2, time: 1_700_000_110, type: 'A', status: 'FORWARDED', client: { ip: '10.0.0.1' } }, // no domain
+          { id: 3, type: 'A', domain: 'notime.example', status: 'FORWARDED', client: { ip: '10.0.0.1' } } // no time
+        ]
+      }
+    ]);
+
+    const events = await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    expect(events.map((e) => e.domain)).toEqual(['good.example']);
+  });
+
+  it('stops paging when the server repeats the same cursor (no infinite loop)', async () => {
+    const page = Array.from({ length: 1000 }, (_, i) => ({
+      id: 2000 - i,
+      time: 1_700_000_500,
+      type: 'A',
+      domain: `d${i}.example`,
+      status: 'FORWARDED',
+      client: { ip: '10.0.0.1' }
+    }));
+    // Both full pages report the SAME cursor — the guard must stop after page 2.
+    queueResponses([
+      AUTH_OK,
+      { queries: page, cursor: 555 },
+      { queries: page, cursor: 555 }
+    ]);
+
+    await newProvider().syncEvents(
+      new Date(1_700_000_000 * 1000),
+      new Date(1_700_001_000 * 1000)
+    );
+
+    // auth + 2 query pages, then it stops rather than re-requesting cursor=555.
+    expect(requestJsonMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('dispose() releases the session via DELETE /api/auth with the SID', async () => {
+    queueResponses([AUTH_OK, {}, {}]);
+    const provider = newProvider();
+
+    await provider.addBlocklistDomain('bad.example'); // establishes the session
+    await provider.dispose();
+
+    const [url, init] = requestJsonMock.mock.calls[2]! as [string, RequestInit];
+    expect(url).toBe('https://pi.hole.local/api/auth');
+    expect(init.method).toBe('DELETE');
+    expect((init.headers as Record<string, string>)['X-FTL-SID']).toBe('SID-123');
+  });
+
+  it('dispose() is a no-op when no session was established', async () => {
+    await newProvider().dispose();
+    expect(requestJsonMock).not.toHaveBeenCalled();
+  });
+
+  it('dispose() swallows a logout failure (best-effort)', async () => {
+    requestJsonMock
+      .mockResolvedValueOnce(AUTH_OK as never)
+      .mockResolvedValueOnce({} as never)
+      .mockRejectedValueOnce(new DnsProviderHttpError(401, 'Unauthorized', ''));
+    const provider = newProvider();
+
+    await provider.addBlocklistDomain('bad.example');
+    await expect(provider.dispose()).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/services/dnsProviders/piholeV6.ts
+++ b/apps/api/src/services/dnsProviders/piholeV6.ts
@@ -44,12 +44,31 @@ export class PiHoleV6Provider implements DnsProvider {
 
   // POST /api/auth { password } → { session: { valid, sid, validity, … } }.
   private async authenticate(): Promise<string> {
-    const payload = await requestJson<Record<string, unknown>>(`${this.baseUrl()}/api/auth`, {
-      method: 'POST',
-      allowPrivateNetwork: this.allowPrivateNetwork,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: this.appPassword })
-    });
+    let payload: Record<string, unknown>;
+    try {
+      payload = await requestJson<Record<string, unknown>>(`${this.baseUrl()}/api/auth`, {
+        method: 'POST',
+        allowPrivateNetwork: this.allowPrivateNetwork,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: this.appPassword })
+      });
+    } catch (error) {
+      // Pi-hole has a finite pool of session seats and returns 429 with a
+      // `no_seats` error body when they're exhausted. That is NOT a transient
+      // rate-limit — retrying won't free a seat on this timescale — so surface
+      // a distinct, actionable message instead of a generic HTTP 429. (We only
+      // INSPECT responseBody server-side to pick the message; it is never
+      // reflected to the tenant — see DnsProviderHttpError.) dispose() releasing
+      // sessions after each run is what keeps this from happening in the first
+      // place.
+      if (error instanceof DnsProviderHttpError && error.status === 429 && error.responseBody.includes('no_seats')) {
+        throw new Error(
+          'Pi-hole v6 authentication failed: all session seats are in use (HTTP 429 no_seats). ' +
+          'Existing sessions must expire or be released before a new sync can authenticate.'
+        );
+      }
+      throw error;
+    }
 
     const session = asRecord(payload.session);
     const sid = asString(session?.sid);
@@ -97,6 +116,10 @@ export class PiHoleV6Provider implements DnsProvider {
     const perPage = 1000;
     const maxPages = 50;
     const events: DnsEvent[] = [];
+    // Count rows we drop as unparseable (NOT in-window trims) so a silent
+    // upstream shape drift — which would otherwise return [] and be recorded as
+    // a healthy "success" sync — is observable in the server logs.
+    let skipped = 0;
     let cursor: number | undefined;
 
     for (let page = 0; page < maxPages; page++) {
@@ -112,14 +135,16 @@ export class PiHoleV6Provider implements DnsProvider {
 
       for (const entry of rows) {
         const record = asRecord(entry);
-        if (!record) continue;
+        if (!record) { skipped++; continue; }
 
         const epoch = asNumber(record.time);
         const domain = asString(record.domain);
-        if (!epoch || !domain) continue;
+        if (!epoch || !domain) { skipped++; continue; }
 
         const timestamp = new Date(epoch * 1000);
-        if (Number.isNaN(timestamp.getTime())) continue;
+        if (Number.isNaN(timestamp.getTime())) { skipped++; continue; }
+        // In-window trim is expected (defensive double-check of the server-side
+        // from/until bound), not malformed data — don't count it as skipped.
         if (timestamp < since || timestamp > until) continue;
 
         const status = asString(record.status) ?? '';
@@ -143,10 +168,24 @@ export class PiHoleV6Provider implements DnsProvider {
       }
 
       // Advance to the next (older) page. Stop when the server reports no
-      // further cursor, returns a short page, or we hit the page cap.
+      // further cursor, returns a short page, or repeats the cursor (a
+      // pagination quirk that would otherwise spin).
       const nextCursor = asNumber(payload.cursor);
       if (rows.length < perPage || nextCursor === undefined || nextCursor === cursor) break;
       cursor = nextCursor;
+      if (page === maxPages - 1) {
+        // Hit the page budget with a further cursor still available: older
+        // in-window events were NOT fetched. The next run's `since` advances to
+        // this run's `until`, so they would be lost silently — surface it.
+        console.warn(
+          `[PiHoleV6] query sync reached the ${maxPages}-page cap with more results available; ` +
+          'some older in-window events were not fetched this run.'
+        );
+      }
+    }
+
+    if (skipped > 0) {
+      console.warn(`[PiHoleV6] query sync skipped ${skipped} unparseable row(s) (possible API shape drift).`);
     }
 
     return events;
@@ -190,5 +229,22 @@ export class PiHoleV6Provider implements DnsProvider {
 
   async removeAllowlistDomain(domain: string): Promise<void> {
     await this.removeDomain('allow', domain);
+  }
+
+  // Release the session (DELETE /api/auth) so it doesn't occupy one of Pi-hole's
+  // finite session seats until it ages out. v6 auth is stateful and seat-limited
+  // (POST /api/auth can return 429 `no_seats`), so a sync that runs every few
+  // minutes against a 30-minute session lifetime would otherwise accumulate
+  // orphaned sessions. Best-effort: a failed logout just lets the session age
+  // out on its own, so this never throws and never masks the sync result.
+  async dispose(): Promise<void> {
+    const sid = this.sid;
+    if (!sid) return;
+    this.sid = null;
+    try {
+      await this.callWithSid('/api/auth', sid, { method: 'DELETE' });
+    } catch (error) {
+      console.warn('[PiHoleV6] failed to release session:', error instanceof Error ? error.message : error);
+    }
   }
 }

--- a/apps/api/src/services/dnsProviders/piholeV6.ts
+++ b/apps/api/src/services/dnsProviders/piholeV6.ts
@@ -1,0 +1,194 @@
+import type { DnsEvent, DnsProvider } from './index';
+import { DnsProviderHttpError, requestJson } from './http';
+import { asArray, asNumber, asRecord, asString } from './helpers';
+
+export interface PiHoleV6ProviderConfig {
+  apiEndpoint?: string;
+}
+
+// Pi-hole v6 query status strings (FTL `enum query_status`). A query is "blocked"
+// when it was stopped by gravity, an exact denylist, a regex denylist, a special
+// (e.g. Mozilla canary) domain, or an external/upstream block. We match on
+// substrings so the *_CNAME variants (GRAVITY_CNAME, DENYLIST_CNAME, …) and any
+// future EXTERNAL_BLOCKED_* additions are covered without an exhaustive list.
+// Everything else (FORWARDED, CACHE, CACHE_STALE, RETRIED, …) is "allowed".
+const BLOCKED_STATUS_PATTERN = /GRAVITY|DENYLIST|REGEX|BLOCKED|SPECIAL_DOMAIN/;
+
+/**
+ * Pi-hole v6 client.
+ *
+ * v6 replaced the v5 `/admin/api.php?...&auth=<token>` surface with a
+ * session-based REST API: POST `/api/auth` with the app password returns a
+ * session id (SID), which is then sent on every subsequent request via the
+ * `X-FTL-SID` header. We authenticate lazily on the first call and reuse the
+ * SID for the lifetime of this provider instance (one sync run), re-authing
+ * once if the session expires mid-run (HTTP 401).
+ */
+export class PiHoleV6Provider implements DnsProvider {
+  private sid: string | null = null;
+
+  constructor(
+    // The Pi-hole v6 app password (used as the `password` in POST /api/auth).
+    private readonly appPassword: string,
+    private readonly config: PiHoleV6ProviderConfig,
+    private readonly allowPrivateNetwork = false
+  ) {}
+
+  private baseUrl(): string {
+    const endpoint = this.config.apiEndpoint;
+    if (!endpoint) {
+      throw new Error('Pi-hole integration requires config.apiEndpoint');
+    }
+    return endpoint.replace(/\/+$/, '');
+  }
+
+  // POST /api/auth { password } → { session: { valid, sid, validity, … } }.
+  private async authenticate(): Promise<string> {
+    const payload = await requestJson<Record<string, unknown>>(`${this.baseUrl()}/api/auth`, {
+      method: 'POST',
+      allowPrivateNetwork: this.allowPrivateNetwork,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: this.appPassword })
+    });
+
+    const session = asRecord(payload.session);
+    const sid = asString(session?.sid);
+    if (!sid || session?.valid === false) {
+      throw new Error('Pi-hole v6 authentication failed (no valid session returned)');
+    }
+    this.sid = sid;
+    return sid;
+  }
+
+  // Authenticated request with the X-FTL-SID header. If the session has expired
+  // (401), re-authenticate once and retry — long sync runs can outlive the
+  // session validity window.
+  private async call<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const sid = this.sid ?? (await this.authenticate());
+    try {
+      return await this.callWithSid<T>(path, sid, init);
+    } catch (error) {
+      if (error instanceof DnsProviderHttpError && error.status === 401) {
+        const fresh = await this.authenticate();
+        return this.callWithSid<T>(path, fresh, init);
+      }
+      throw error;
+    }
+  }
+
+  private async callWithSid<T>(path: string, sid: string, init: RequestInit): Promise<T> {
+    return requestJson<T>(`${this.baseUrl()}${path}`, {
+      ...init,
+      allowPrivateNetwork: this.allowPrivateNetwork,
+      headers: {
+        'X-FTL-SID': sid,
+        ...(init.headers ?? {})
+      }
+    });
+  }
+
+  async syncEvents(since: Date, until: Date): Promise<DnsEvent[]> {
+    // Pi-hole's /api/queries is paginated newest-first. We bound the window
+    // server-side with from/until (unix seconds) and page back with the
+    // returned `cursor` until we run out, capping pages to keep one sync
+    // bounded on a busy resolver.
+    const fromSec = Math.floor(since.getTime() / 1000);
+    const untilSec = Math.ceil(until.getTime() / 1000);
+    const perPage = 1000;
+    const maxPages = 50;
+    const events: DnsEvent[] = [];
+    let cursor: number | undefined;
+
+    for (let page = 0; page < maxPages; page++) {
+      const params = new URLSearchParams({
+        from: String(fromSec),
+        until: String(untilSec),
+        length: String(perPage)
+      });
+      if (cursor !== undefined) params.set('cursor', String(cursor));
+
+      const payload = await this.call<Record<string, unknown>>(`/api/queries?${params.toString()}`);
+      const rows = asArray(payload.queries);
+
+      for (const entry of rows) {
+        const record = asRecord(entry);
+        if (!record) continue;
+
+        const epoch = asNumber(record.time);
+        const domain = asString(record.domain);
+        if (!epoch || !domain) continue;
+
+        const timestamp = new Date(epoch * 1000);
+        if (Number.isNaN(timestamp.getTime())) continue;
+        if (timestamp < since || timestamp > until) continue;
+
+        const status = asString(record.status) ?? '';
+        const client = asRecord(record.client);
+        const sourceIp = asString(client?.ip);
+        const sourceHostname = asString(client?.name);
+        const id = asNumber(record.id);
+
+        events.push({
+          timestamp,
+          domain,
+          queryType: asString(record.type) ?? 'A',
+          action: BLOCKED_STATUS_PATTERN.test(status) ? 'blocked' : 'allowed',
+          sourceIp,
+          sourceHostname,
+          providerEventId: id !== undefined
+            ? `v6-${id}`
+            : `${epoch}-${domain}-${sourceIp ?? 'unknown'}`,
+          metadata: { status }
+        });
+      }
+
+      // Advance to the next (older) page. Stop when the server reports no
+      // further cursor, returns a short page, or we hit the page cap.
+      const nextCursor = asNumber(payload.cursor);
+      if (rows.length < perPage || nextCursor === undefined || nextCursor === cursor) break;
+      cursor = nextCursor;
+    }
+
+    return events;
+  }
+
+  // Pi-hole v6 exact-match domain lists: POST /api/domains/{deny|allow}/exact to
+  // add, DELETE /api/domains/{deny|allow}/exact/{domain} to remove.
+  private async addDomain(type: 'deny' | 'allow', domain: string): Promise<void> {
+    await this.call<unknown>(`/api/domains/${type}/exact`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain })
+    });
+  }
+
+  private async removeDomain(type: 'deny' | 'allow', domain: string): Promise<void> {
+    try {
+      await this.call<unknown>(`/api/domains/${type}/exact/${encodeURIComponent(domain)}`, {
+        method: 'DELETE'
+      });
+    } catch (error) {
+      // A 404 means the domain is already absent — that is the desired end
+      // state for a removal, so treat it as a no-op rather than a sync error.
+      // Any other error still propagates.
+      if (error instanceof DnsProviderHttpError && error.status === 404) return;
+      throw error;
+    }
+  }
+
+  async addBlocklistDomain(domain: string): Promise<void> {
+    await this.addDomain('deny', domain);
+  }
+
+  async removeBlocklistDomain(domain: string): Promise<void> {
+    await this.removeDomain('deny', domain);
+  }
+
+  async addAllowlistDomain(domain: string): Promise<void> {
+    await this.addDomain('allow', domain);
+  }
+
+  async removeAllowlistDomain(domain: string): Promise<void> {
+    await this.removeDomain('allow', domain);
+  }
+}


### PR DESCRIPTION
## Summary

Pi-hole v6 reworked the admin API: the v5 `/admin/api.php?...&auth=<token>` pattern was replaced by a session-based REST API at `/api/...`. The existing `PiHoleProvider` (v5) cannot authenticate against or read a v6 instance, so DNS Security sync silently fails for v6 users.

This adds a **`PiHoleV6Provider`** alongside the v5 client and selects between them via config.

## What changed

- **`apps/api/src/services/dnsProviders/piholeV6.ts`** (new) — v6 client:
  - **Auth:** `POST /api/auth` with `{ password }` → `session.sid`; SID sent on every request via the `X-FTL-SID` header. Authenticates lazily on first call and reuses the SID for the provider's lifetime (one sync run); re-authenticates **once** on a `401` if the session expires mid-run.
  - **Query log:** `GET /api/queries?from=&until=&length=&cursor=` (unix-second window), paging back through the returned `cursor` (capped at 50 pages). Blocked vs allowed is derived from the FTL status enum via `GRAVITY|DENYLIST|REGEX|BLOCKED|SPECIAL_DOMAIN` (covers `*_CNAME` and `EXTERNAL_BLOCKED_*` variants without an exhaustive list).
  - **List mutations:** `POST /api/domains/{deny,allow}/exact` to add, `DELETE /api/domains/{deny,allow}/exact/{domain}` to remove. A `404` on delete is treated as a no-op (domain already absent); other errors propagate.
- **`dnsProviders/index.ts`** — factory routes `pihole` to `PiHoleV6Provider` when `config.piholeVersion === 'v6'`, else the v5 `PiHoleProvider`. Reuses the existing on-prem `allowPrivateNetwork` gating and SSRF-guarded `http` transport unchanged.
- **`db/schema/dnsSecurity.ts`** — added `piholeVersion?: 'v5' | 'v6'` to `DnsIntegrationConfig` (unset ⇒ v5, backward compatible).
- **`routes/dnsSecurity.ts`** — `integrationConfigSchema` accepts `piholeVersion: z.enum(['v5','v6']).optional()`.

No migration needed — `config` is a free-form `jsonb` column.

## Design notes

- **Version select, not auto-detect.** The reporter scoped this "Small" and auto-detection adds a probe round-trip plus failure modes; an explicit `piholeVersion` flag (defaulting to v5) is predictable, testable, and backward compatible. Auto-detection could be a follow-up.
- Backend only — DNS Security has no web UI today (per project notes), so this is an API/integration change with no UI work.

## Tests

- `piholeV6.test.ts` (new, 13 cases): auth handshake + `X-FTL-SID`, auth failure, blocked/allowed status mapping incl. `*_CNAME`/`EXTERNAL_BLOCKED_*`, window filtering, cursor paging, 401 re-auth+retry, add/remove deny+allow endpoints, 404-on-delete no-op, non-404 propagation.
- `index.test.ts`: added a v6 case asserting the factory routes to the session API and threads `allowPrivateNetwork`.
- `apps/api` affected suites green; `tsc --noEmit` clean.

Refs #2017

🤖 Generated with [Claude Code](https://claude.com/claude-code)