### PR TITLE
fix(api): allow API-key auth to write device custom-field values (#2066)

### DIFF
--- a/apps/api/src/routes/devices/customFieldValues.mountorder.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.mountorder.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+// Mount-order regression guard for #2066.
+//
+// The custom-field VALUE routes accept X-API-Key auth and MUST be mounted in
+// devices/index.ts BEFORE coreRoutes (whose `.use('*', authMiddleware)` wildcard
+// attaches to every route mounted after it). If a future edit reorders them
+// below coreRoutes, the JWT-only authMiddleware would run ahead of the API-key
+// branch and resurrect the 401. This test exercises the FULLY-ASSEMBLED
+// deviceRoutes (not the router in isolation) so that reorder is caught: a
+// real authMiddleware here throws 401 when no Bearer header is present.
+
+const ORG_A = '11111111-1111-4111-8111-111111111111';
+const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const API_KEY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+// REAL-shaped authMiddleware: 401 without a Bearer header. This is what makes
+// the reorder detectable — if coreRoutes' wildcard runs ahead of the API-key
+// branch, the X-API-Key request (no Bearer) gets 401 here.
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  return {
+    ...actual,
+    authMiddleware: vi.fn((c: any, next: any) => {
+      const header = c.req.header('Authorization');
+      if (!header?.startsWith('Bearer ')) {
+        throw new HTTPException(401, { message: 'Missing or invalid authorization header' });
+      }
+      c.set('auth', {
+        user: { id: 'user-1', email: 't@example.com' },
+        scope: 'organization',
+        orgId: ORG_A,
+        partnerId: null,
+        accessibleOrgIds: [ORG_A],
+        canAccessOrg: (orgId: string) => orgId === ORG_A,
+      });
+      return next();
+    }),
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+    requirePermission: vi.fn(() => async (c: any, next: any) => {
+      c.set('permissions', { permissions: [], orgId: ORG_A, scope: 'organization' });
+      return next();
+    }),
+    requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+vi.mock('../../middleware/apiKeyAuth', () => ({
+  apiKeyAuthMiddleware: vi.fn((c: any, next: any) => {
+    c.set('apiKey', {
+      id: API_KEY_ID,
+      orgId: ORG_A,
+      partnerId: null,
+      name: 'Automation key',
+      keyPrefix: 'brz_test',
+      scopes: ['devices:write'],
+      rateLimit: 1000,
+      createdBy: 'user-1',
+    });
+    return next();
+  }),
+  requireApiKeyScope: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/auditService', () => ({
+  createAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Other device sub-routers pulled in by the assembled router import them at
+// module load; stub the heavy ones so the import succeeds.
+vi.mock('../../services/auditEvents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/auditEvents')>();
+  return { ...actual, writeRouteAudit: vi.fn(), writeAuditEvent: vi.fn() };
+});
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn().mockResolvedValue({ policyId: null, settings: {} }),
+}));
+vi.mock('../../services/remoteAccessLauncher', () => ({
+  resolveRemoteAccessLaunch: vi.fn().mockReturnValue({ launchUrl: null, skipReason: 'no_provider_configured' }),
+}));
+vi.mock('../agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: { SELF_UNINSTALL: 'self_uninstall' },
+  queueCommandForExecution: vi.fn(),
+}));
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
+}));
+
+import { deviceRoutes } from './index';
+import { db } from '../../db';
+
+function rigDeviceLookup(device: unknown) {
+  const limit = vi.fn().mockResolvedValue(device ? [device] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+function rigUpdate(updatedRow: unknown) {
+  const returning = vi.fn().mockResolvedValue(updatedRow ? [updatedRow] : []);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+}
+
+describe('custom-field value routes mount order (#2066)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', deviceRoutes);
+  });
+
+  it('an X-API-Key PATCH reaches the handler through the assembled deviceRoutes (not 401)', async () => {
+    rigDeviceLookup({ id: DEVICE_ID, orgId: ORG_A, siteId: null, hostname: 'WS', displayName: 'WS', customFields: {} });
+    rigUpdate({ customFields: { note: 'hi' } });
+
+    const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': 'brz_test' },
+      body: JSON.stringify({ note: 'hi' }),
+    });
+
+    // The critical assertion: it is NOT 401. A reorder below coreRoutes' wildcard
+    // authMiddleware would make this 401 (no Bearer header present).
+    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(200);
+  });
+
+  it('a no-credentials PATCH is still rejected (401) through the assembled routes', async () => {
+    const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ note: 'hi' }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -58,7 +58,12 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
     // Sets the permissions context the same way the real requirePermission does.
     // An `x-test-allowed-sites` header (comma-separated) opts the session into a
     // site allowlist so the site-scope branch in loadAccessibleDevice runs.
+    // `x-test-drop-perms` simulates a (hypothetical) bug where a session reaches
+    // the handler WITHOUT a permissions context — to prove the fail-closed guard.
     requirePermission: vi.fn(() => async (c: any, next: any) => {
+      if (c.req.header('x-test-drop-perms')) {
+        return next();
+      }
       const allowedSiteIds = c.req.header('x-test-allowed-sites')
         ? (c.req.header('x-test-allowed-sites') as string).split(',')
         : undefined;
@@ -324,6 +329,28 @@ describe('device custom-field value routes (#2066)', () => {
       });
 
       expect(res.status).toBe(403);
+    });
+
+    it('fails closed if a SESSION reaches the handler with no permissions context (403, no write)', async () => {
+      // Simulates a dropped requirePermission gate on the JWT path. A user caller
+      // with no permissions context must be denied, never silently skip the site
+      // check — only org-scoped API keys legitimately carry no permissions.
+      rigDeviceLookup(makeDevice({ siteId: SITE_OUT }));
+      const updateSpy = rigUpdate(makeDevice({ siteId: SITE_OUT }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+          'x-test-drop-perms': '1',
+        },
+        body: JSON.stringify({ note: 'hi' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+      expect(vi.mocked(createAuditLog)).not.toHaveBeenCalled();
     });
 
     it('allows a PATCH when the device site is inside the allowlist', async () => {

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -55,8 +55,19 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
       return next();
     }),
     requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+    // Sets the permissions context the same way the real requirePermission does.
+    // An `x-test-allowed-sites` header (comma-separated) opts the session into a
+    // site allowlist so the site-scope branch in loadAccessibleDevice runs.
     requirePermission: vi.fn(() => async (c: any, next: any) => {
-      c.set('permissions', { permissions: [], orgId: ORG_A, scope: 'organization' });
+      const allowedSiteIds = c.req.header('x-test-allowed-sites')
+        ? (c.req.header('x-test-allowed-sites') as string).split(',')
+        : undefined;
+      c.set('permissions', {
+        permissions: [],
+        orgId: ORG_A,
+        scope: 'organization',
+        ...(allowedSiteIds ? { allowedSiteIds } : {}),
+      });
       return next();
     }),
     requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
@@ -64,8 +75,12 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
 });
 
 // API-key auth driven by test headers: x-test-org sets the key's org, and
-// x-test-scopes is a comma-separated scope list. requireApiKeyScope is the real
-// allow/deny logic so the under-scoped 403 path is genuinely exercised.
+// x-test-scopes is a comma-separated scope list. NOTE: this is app-layer only —
+// these mocks stand in for apiKeyAuthMiddleware/requireApiKeyScope and do NOT
+// establish the real DB RLS context. The reimplemented requireApiKeyScope below
+// matches the real module's allow/deny shape (it throws 403) so the scope-gate
+// branch in dualAuth is exercised, but RLS-level isolation is covered by the
+// rls-coverage integration suite, not here.
 vi.mock('../../middleware/apiKeyAuth', () => ({
   apiKeyAuthMiddleware: vi.fn((c: any, next: any) => {
     const org = c.req.header('x-test-org') ?? ORG_A;
@@ -222,6 +237,101 @@ describe('device custom-field value routes (#2066)', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it('rejects a non-scalar field value (400)', async () => {
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        // A structured object is not an allowed value — only string/number/boolean/null.
+        body: JSON.stringify({ blob: { nested: 'no' } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('fails closed if the UPDATE writes zero rows (404, not a false 200)', async () => {
+      // The device passes the org-scoped lookup, but the UPDATE returns no row —
+      // the RLS-silent-zero-row-write failure mode. The handler must 404, not
+      // report success.
+      rigDeviceLookup(makeDevice());
+      rigUpdate(null);
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        body: JSON.stringify({ bitlocker_recovery_key: 'ABC-123' }),
+      });
+
+      expect(res.status).toBe(404);
+      // The sensitive write must not be reported as audited success.
+      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('site-scope gate (JWT session with allowedSiteIds)', () => {
+    const SITE_IN = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const SITE_OUT = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+    it('rejects a PATCH when the device site is outside the allowlist (403, no write)', async () => {
+      rigDeviceLookup(makeDevice({ siteId: SITE_OUT }));
+      const updateSpy = rigUpdate(makeDevice({ siteId: SITE_OUT }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+          'x-test-allowed-sites': SITE_IN,
+        },
+        body: JSON.stringify({ note: 'hi' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+    });
+
+    it('rejects a GET when the device site is outside the allowlist (403)', async () => {
+      rigDeviceLookup(makeDevice({ siteId: SITE_OUT, customFields: { asset_tag: 'A-42' } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer session-token', 'x-test-allowed-sites': SITE_IN },
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('allows a PATCH when the device site is inside the allowlist', async () => {
+      rigDeviceLookup(makeDevice({ siteId: SITE_IN }));
+      rigUpdate(makeDevice({ siteId: SITE_IN, customFields: { existing_field: 'keep-me', note: 'hi' } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+          'x-test-allowed-sites': `${SITE_IN},${SITE_OUT}`,
+        },
+        body: JSON.stringify({ note: 'hi' }),
+      });
+
+      expect(res.status).toBe(200);
     });
   });
 

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -109,13 +109,16 @@ vi.mock('../../middleware/apiKeyAuth', () => ({
   }),
 }));
 
-vi.mock('../../services/auditEvents', () => ({
-  writeAuditEvent: vi.fn(),
+// The write path audits SYNCHRONOUSLY via createAuditLog (awaited). Mock it so
+// the assertions can verify attribution without a real DB. ANONYMOUS_ACTOR_ID
+// and the client-IP helper stay real (cheap, no DB).
+vi.mock('../../services/auditService', () => ({
+  createAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { customFieldValuesRoutes } from './customFieldValues';
 import { db } from '../../db';
-import { writeAuditEvent } from '../../services/auditEvents';
+import { createAuditLog } from '../../services/auditService';
 
 function makeDevice(overrides: Record<string, unknown> = {}) {
   return {
@@ -173,10 +176,16 @@ describe('device custom-field value routes (#2066)', () => {
       const body = await res.json();
       // Merge semantics: existing values are preserved alongside the new one.
       expect(body.customFields).toEqual({ existing_field: 'keep-me', bitlocker_recovery_key: 'ABC-123' });
-      // Audited as an api_key actor (not anonymous, not a user).
-      expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ actorType: 'api_key', actorId: API_KEY_ID, action: 'device.custom_field.update', orgId: ORG_A }),
+      // Audited synchronously as an api_key actor (not anonymous, not a user).
+      expect(vi.mocked(createAuditLog)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: 'api_key',
+          actorId: API_KEY_ID,
+          action: 'device.custom_field.update',
+          orgId: ORG_A,
+          initiatedBy: 'integration',
+          result: 'success',
+        }),
       );
     });
 
@@ -218,7 +227,7 @@ describe('device custom-field value routes (#2066)', () => {
 
       expect(res.status).toBe(404);
       expect(updateSpy.set).not.toHaveBeenCalled();
-      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+      expect(vi.mocked(createAuditLog)).not.toHaveBeenCalled();
     });
 
     it('rejects an empty field map (400)', async () => {
@@ -279,7 +288,7 @@ describe('device custom-field value routes (#2066)', () => {
 
       expect(res.status).toBe(404);
       // The sensitive write must not be reported as audited success.
-      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+      expect(vi.mocked(createAuditLog)).not.toHaveBeenCalled();
     });
   });
 
@@ -303,7 +312,7 @@ describe('device custom-field value routes (#2066)', () => {
 
       expect(res.status).toBe(403);
       expect(updateSpy.set).not.toHaveBeenCalled();
-      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+      expect(vi.mocked(createAuditLog)).not.toHaveBeenCalled();
     });
 
     it('rejects a GET when the device site is outside the allowlist (403)', async () => {
@@ -362,9 +371,8 @@ describe('device custom-field value routes (#2066)', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ actorType: 'user', actorId: USER_ID }),
+      expect(vi.mocked(createAuditLog)).toHaveBeenCalledWith(
+        expect.objectContaining({ actorType: 'user', actorId: USER_ID, initiatedBy: 'manual', result: 'success' }),
       );
     });
 

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+// Tests for the API-key-authenticated device custom-field VALUE endpoints
+// (issue #2066). The bug: writing a custom-field value was only reachable via
+// PATCH /devices/:id, which is gated on the session-JWT `authMiddleware` and so
+// rejected an `X-API-Key` request with 401 before any handler ran. These tests
+// exercise the new dual-auth (API key OR JWT) value endpoints and assert the
+// API-key write path succeeds while tenant isolation + scope gates still hold.
+
+const ORG_A = '11111111-1111-4111-8111-111111111111';
+const ORG_B = '22222222-2222-4222-8222-222222222222';
+const DEVICE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const API_KEY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const USER_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// Use the real schema so the route's real `eq(devices.id,...)`/`and(...)` and the
+// real `getDeviceWithOrgCheck` helper run against the mocked db query chain.
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+// Realistic JWT auth: 401 when there's no Bearer header (mirrors the real
+// authMiddleware), so a test that hits the API-key branch proves it never
+// touches the session-only gate.
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  return {
+    ...actual,
+    authMiddleware: vi.fn((c: any, next: any) => {
+      const header = c.req.header('Authorization');
+      if (!header?.startsWith('Bearer ')) {
+        throw new HTTPException(401, { message: 'Missing or invalid authorization header' });
+      }
+      c.set('auth', {
+        user: { id: USER_ID, email: 'tech@example.com' },
+        scope: 'organization',
+        orgId: ORG_A,
+        partnerId: null,
+        accessibleOrgIds: [ORG_A],
+        canAccessOrg: (orgId: string) => orgId === ORG_A,
+      });
+      return next();
+    }),
+    requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+    requirePermission: vi.fn(() => async (c: any, next: any) => {
+      c.set('permissions', { permissions: [], orgId: ORG_A, scope: 'organization' });
+      return next();
+    }),
+    requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  };
+});
+
+// API-key auth driven by test headers: x-test-org sets the key's org, and
+// x-test-scopes is a comma-separated scope list. requireApiKeyScope is the real
+// allow/deny logic so the under-scoped 403 path is genuinely exercised.
+vi.mock('../../middleware/apiKeyAuth', () => ({
+  apiKeyAuthMiddleware: vi.fn((c: any, next: any) => {
+    const org = c.req.header('x-test-org') ?? ORG_A;
+    const scopes = (c.req.header('x-test-scopes') ?? '').split(',').filter(Boolean);
+    c.set('apiKey', {
+      id: API_KEY_ID,
+      orgId: org,
+      partnerId: null,
+      name: 'Automation key',
+      keyPrefix: 'brz_test',
+      scopes,
+      rateLimit: 1000,
+      createdBy: USER_ID,
+    });
+    return next();
+  }),
+  // Mirrors the real requireApiKeyScope, which THROWS HTTPException(403) on an
+  // insufficient scope (it does not return a Response). The dualAuth wrapper
+  // relies on that throw to abort the chain.
+  requireApiKeyScope: vi.fn((...required: string[]) => async (c: any, next: any) => {
+    const apiKey = c.get('apiKey');
+    if (!apiKey?.scopes?.length || !required.some((s) => apiKey.scopes.includes(s))) {
+      throw new HTTPException(403, { message: 'API key does not have required permissions' });
+    }
+    return next();
+  }),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+import { customFieldValuesRoutes } from './customFieldValues';
+import { db } from '../../db';
+import { writeAuditEvent } from '../../services/auditEvents';
+
+function makeDevice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DEVICE_ID,
+    orgId: ORG_A,
+    siteId: null,
+    hostname: 'WS-001',
+    displayName: 'Workstation 1',
+    customFields: { existing_field: 'keep-me' },
+    ...overrides,
+  };
+}
+
+function rigDeviceLookup(device: unknown) {
+  const limit = vi.fn().mockResolvedValue(device ? [device] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+function rigUpdate(updatedRow: unknown) {
+  const returning = vi.fn().mockResolvedValue(updatedRow ? [updatedRow] : []);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+  return { set, where, returning };
+}
+
+describe('device custom-field value routes (#2066)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', customFieldValuesRoutes);
+  });
+
+  describe('API-key write path', () => {
+    it('writes a custom-field value with a devices:write API key', async () => {
+      rigDeviceLookup(makeDevice());
+      rigUpdate(makeDevice({ customFields: { existing_field: 'keep-me', bitlocker_recovery_key: 'ABC-123' } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        body: JSON.stringify({ bitlocker_recovery_key: 'ABC-123' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Merge semantics: existing values are preserved alongside the new one.
+      expect(body.customFields).toEqual({ existing_field: 'keep-me', bitlocker_recovery_key: 'ABC-123' });
+      // Audited as an api_key actor (not anonymous, not a user).
+      expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ actorType: 'api_key', actorId: API_KEY_ID, action: 'device.custom_field.update', orgId: ORG_A }),
+      );
+    });
+
+    it('rejects an API key that lacks the devices:write scope (403)', async () => {
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:read',
+        },
+        body: JSON.stringify({ bitlocker_recovery_key: 'ABC-123' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('does not let a key write a custom field on a device in another org (404)', async () => {
+      // Device belongs to ORG_B; key is scoped to ORG_A. The org-scoped lookup
+      // denies access, so the write never happens (cross-tenant isolation).
+      rigDeviceLookup(makeDevice({ orgId: ORG_B }));
+      const updateSpy = rigUpdate(makeDevice({ orgId: ORG_B }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        body: JSON.stringify({ bitlocker_recovery_key: 'ABC-123' }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+      expect(vi.mocked(writeAuditEvent)).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty field map (400)', async () => {
+      rigDeviceLookup(makeDevice());
+      rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('API-key read path', () => {
+    it('reads custom-field values with a devices:read API key', async () => {
+      rigDeviceLookup(makeDevice({ customFields: { asset_tag: 'A-42' } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'GET',
+        headers: { 'X-API-Key': 'brz_test', 'x-test-org': ORG_A, 'x-test-scopes': 'devices:read' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.customFields).toEqual({ asset_tag: 'A-42' });
+    });
+  });
+
+  describe('JWT session path', () => {
+    it('writes a custom-field value with a Bearer session token', async () => {
+      rigDeviceLookup(makeDevice());
+      rigUpdate(makeDevice({ customFields: { existing_field: 'keep-me', note: 'hi' } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ note: 'hi' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(writeAuditEvent)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ actorType: 'user', actorId: USER_ID }),
+      );
+    });
+
+    it('rejects a request with neither an API key nor a Bearer token (401)', async () => {
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'hi' }),
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -1,0 +1,233 @@
+import { Hono, type Context, type Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { and, eq } from 'drizzle-orm';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { db } from '../../db';
+import { devices } from '../../db/schema';
+import {
+  authMiddleware,
+  requireMfa,
+  requirePermission,
+  requireScope,
+  type AuthContext,
+} from '../../middleware/auth';
+import { apiKeyAuthMiddleware, requireApiKeyScope } from '../../middleware/apiKeyAuth';
+import { getDeviceWithOrgCheck } from './helpers';
+import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { writeAuditEvent } from '../../services/auditEvents';
+
+/**
+ * Device custom-field VALUE read/write API.
+ *
+ * Device custom-field values live in the `devices.custom_fields` JSONB column.
+ * The only built-in way to write them used to be `PATCH /devices/:id`, which is
+ * gated on `authMiddleware` (browser session JWT only) + `requireMfa()` — so an
+ * automation calling with an `X-API-Key` header was rejected at the very first
+ * gate with `401 "Missing or invalid authorization header"` (issue #2066). There
+ * was no API-key-authenticated path to stash a value (e.g. a script writing a
+ * BitLocker recovery key into a custom field).
+ *
+ * This router adds a dedicated value endpoint that accepts EITHER auth flavour,
+ * mirroring the dual-auth pattern in `routes/devPush.ts`:
+ *   - `X-API-Key` → `apiKeyAuthMiddleware` + `requireApiKeyScope('devices:write'|'devices:read')`
+ *   - `Authorization: Bearer` → `authMiddleware` + scope + `devices:write|read` permission
+ *     (+ `requireMfa()` on writes, matching the existing device PATCH posture)
+ *
+ * Tenant isolation: API-key auth runs every downstream query under a
+ * `withDbAccessContext` scoped to the key's single org, so `devices` RLS
+ * (direct `org_id`, shape 1) already denies cross-tenant rows. `getDeviceWithOrgCheck`
+ * + the explicit `org_id` predicate on the UPDATE are belt-and-suspenders on top
+ * of that — a key (or session) can only read/write values for devices in an org
+ * it can access.
+ *
+ * IMPORTANT — auth wiring: these routes use PER-ROUTE auth middleware (never
+ * `router.use('*', ...)`) and the router is mounted FIRST in `devices/index.ts`,
+ * BEFORE `coreRoutes` and the other `.use('*', authMiddleware)` sub-routers. A
+ * wildcard `.use('*')` in a sibling sub-router attaches to every route mounted
+ * AFTER it, so mounting after `coreRoutes` would re-introduce the session-only
+ * `authMiddleware` ahead of our API-key branch and resurrect the 401. See the
+ * `hono_router_use_wildcard_root_mount_auth_leak` lesson.
+ */
+export const customFieldValuesRoutes = new Hono();
+
+// Field map shared by read/write. Mirrors `updateDeviceSchema.customFields` in
+// devices/schemas.ts so the value constraints stay identical to the existing
+// PATCH /devices/:id write path.
+const customFieldValueSchema = z
+  .record(
+    z.string().min(1).max(100),
+    z.union([z.string().max(10000), z.number(), z.boolean(), z.null()]),
+  )
+  .refine((obj) => Object.keys(obj).length > 0, {
+    message: 'At least one custom field must be provided',
+  });
+
+// Accept JWT (Authorization: Bearer) or API key (X-API-Key). The write variant
+// additionally requires MFA on the JWT path to match PATCH /devices/:id.
+function dualAuth(
+  apiKeyScope: 'devices:read' | 'devices:write',
+  permission: { resource: string; action: string },
+  options: { mfa?: boolean } = {},
+) {
+  return async (c: Context, next: Next) => {
+    const apiKeyHeader = c.req.header('X-API-Key');
+    if (apiKeyHeader) {
+      return apiKeyAuthMiddleware(c, async () => {
+        await requireApiKeyScope(apiKeyScope)(c, next);
+      });
+    }
+    return authMiddleware(c, async () => {
+      await requireScope('organization', 'partner', 'system')(c, async () => {
+        await requirePermission(permission.resource, permission.action)(c, async () => {
+          if (options.mfa) {
+            await requireMfa()(c, next);
+          } else {
+            await next();
+          }
+        });
+      });
+    });
+  };
+}
+
+interface ResolvedAccess {
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>;
+  permissions: UserPermissions | undefined;
+  audit: { actorType: 'user' | 'api_key'; actorId: string | null; actorEmail: string | null };
+}
+
+// Build a uniform org-scope + audit-actor view from whichever auth flavour ran.
+function resolveAccess(c: Context): ResolvedAccess {
+  const jwtAuth = c.get('auth') as AuthContext | undefined;
+  if (jwtAuth) {
+    return {
+      auth: jwtAuth,
+      permissions: c.get('permissions') as UserPermissions | undefined,
+      audit: {
+        actorType: 'user',
+        actorId: jwtAuth.user?.id ?? null,
+        actorEmail: jwtAuth.user?.email ?? null,
+      },
+    };
+  }
+
+  const apiKey = c.get('apiKey');
+  // apiKeyAuthMiddleware only admits keys whose owning org is active (it 401s
+  // otherwise), so a null org here means the auth context is malformed. Fail
+  // closed rather than synthesizing an org-less scope.
+  const orgId = apiKey.orgId;
+  if (!orgId) {
+    throw new HTTPException(401, { message: 'API key is not scoped to an organization' });
+  }
+  return {
+    auth: {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      canAccessOrg: (candidate: string) => candidate === orgId,
+    },
+    permissions: undefined,
+    audit: { actorType: 'api_key', actorId: apiKey.id, actorEmail: null },
+  };
+}
+
+const SITE_DENIED = Symbol('SITE_DENIED');
+
+// Org-scoped device lookup that also honours a session's site allowlist. API
+// keys carry no `permissions` context (they're org-scoped, not site-scoped), so
+// the site check is skipped for them — same as devPush's API-key branch.
+async function loadAccessibleDevice(
+  deviceId: string,
+  access: ResolvedAccess,
+): Promise<typeof devices.$inferSelect | null | typeof SITE_DENIED> {
+  const device = await getDeviceWithOrgCheck(deviceId, access.auth);
+  if (!device) return null;
+
+  const perms = access.permissions;
+  if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
+    return SITE_DENIED;
+  }
+  return device;
+}
+
+function readExistingCustomFields(raw: unknown): Record<string, unknown> {
+  return raw !== null && typeof raw === 'object' && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : {};
+}
+
+// GET /devices/:id/custom-fields — read the device's custom-field values.
+customFieldValuesRoutes.get(
+  '/:id/custom-fields',
+  dualAuth('devices:read', { resource: PERMISSIONS.DEVICES_READ.resource, action: PERMISSIONS.DEVICES_READ.action }),
+  async (c) => {
+    const deviceId = c.req.param('id')!;
+    const access = resolveAccess(c);
+
+    const device = await loadAccessibleDevice(deviceId, access);
+    if (device === SITE_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    return c.json({ customFields: readExistingCustomFields(device.customFields) });
+  },
+);
+
+// PATCH /devices/:id/custom-fields — merge custom-field values into the device.
+// Body is the field map directly, e.g. `{ "bitlocker_recovery_key": "..." }`.
+customFieldValuesRoutes.patch(
+  '/:id/custom-fields',
+  dualAuth(
+    'devices:write',
+    { resource: PERMISSIONS.DEVICES_WRITE.resource, action: PERMISSIONS.DEVICES_WRITE.action },
+    { mfa: true },
+  ),
+  zValidator('json', customFieldValueSchema),
+  async (c) => {
+    const deviceId = c.req.param('id')!;
+    const access = resolveAccess(c);
+    const updates = c.req.valid('json');
+
+    const device = await loadAccessibleDevice(deviceId, access);
+    if (device === SITE_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    // Merge with existing values rather than replacing the whole object, matching
+    // the PATCH /devices/:id semantics.
+    const merged = { ...readExistingCustomFields(device.customFields), ...updates };
+
+    const [updated] = await db
+      .update(devices)
+      .set({ customFields: merged, updatedAt: new Date() })
+      // The org predicate is redundant under RLS + the org-checked lookup above,
+      // but pins the write to the exact verified device as defense-in-depth.
+      .where(and(eq(devices.id, deviceId), eq(devices.orgId, device.orgId)))
+      .returning({ customFields: devices.customFields });
+
+    if (!updated) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    writeAuditEvent(c, {
+      orgId: device.orgId,
+      actorType: access.audit.actorType,
+      actorId: access.audit.actorId,
+      actorEmail: access.audit.actorEmail,
+      action: 'device.custom_field.update',
+      resourceType: 'device',
+      resourceId: deviceId,
+      resourceName: device.hostname ?? device.displayName ?? undefined,
+      details: { changedFields: Object.keys(updates) },
+    });
+
+    return c.json({ customFields: readExistingCustomFields(updated.customFields) });
+  },
+);

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -162,6 +162,14 @@ async function loadAccessibleDevice(
   if (!device) return null;
 
   const perms = access.permissions;
+  // Fail closed for SESSION callers: the JWT branch always runs requirePermission,
+  // which sets the permissions context, so a missing context on a user path means
+  // a site gate was dropped — deny rather than silently skip the allowlist check
+  // (mirrors the fail-loud stance of getDeviceWithOrgAndSiteCheck). An absent
+  // context is legitimate ONLY for org-scoped API keys.
+  if (access.audit.actorType !== 'api_key' && !perms) {
+    return SITE_DENIED;
+  }
   if (perms?.allowedSiteIds && (typeof device.siteId !== 'string' || !canAccessSite(perms, device.siteId))) {
     return SITE_DENIED;
   }

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -15,7 +15,9 @@ import {
 import { apiKeyAuthMiddleware, requireApiKeyScope } from '../../middleware/apiKeyAuth';
 import { getDeviceWithOrgCheck } from './helpers';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { writeAuditEvent } from '../../services/auditEvents';
+import { createAuditLog } from '../../services/auditService';
+import { ANONYMOUS_ACTOR_ID } from '../../services/auditEvents';
+import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 
 /**
  * Device custom-field VALUE read/write API.
@@ -27,6 +29,15 @@ import { writeAuditEvent } from '../../services/auditEvents';
  * gate with `401 "Missing or invalid authorization header"` (issue #2066). There
  * was no API-key-authenticated path to stash a value (e.g. a script writing a
  * BitLocker recovery key into a custom field).
+ *
+ * NOT A SECRETS STORE: `custom_fields` is general automation/inventory data
+ * stored in plaintext JSONB with no field-level encryption. It is the right
+ * place for asset tags, notes, external IDs, etc. — it is NOT a vault. Real
+ * secrets (BitLocker/FileVault recovery keys and similar) belong in the
+ * dedicated, encrypted recovery-key feature tracked in #2021; exposing a value
+ * write here does not bless `custom_fields` as secret storage. Writes are
+ * audited synchronously below so a secret-class value (if a user stashes one
+ * anyway) at least leaves a durable trail.
  *
  * This router adds a dedicated value endpoint that accepts EITHER auth flavour,
  * mirroring the dual-auth pattern in `routes/devPush.ts`:
@@ -113,6 +124,12 @@ function resolveAccess(c: Context): ResolvedAccess {
   }
 
   const apiKey = c.get('apiKey');
+  // Fail closed: reaching here without an apiKey context means neither auth
+  // branch populated a principal (dualAuth always sets one or throws), so never
+  // synthesize an authorized scope from a missing key.
+  if (!apiKey) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
   // apiKeyAuthMiddleware only admits keys whose owning org is active (it 401s
   // otherwise), so a null org here means the auth context is malformed. Fail
   // closed rather than synthesizing an org-less scope.
@@ -216,16 +233,26 @@ customFieldValuesRoutes.patch(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    writeAuditEvent(c, {
+    // Audit SYNCHRONOUSLY (await, not fire-and-forget): a custom-field write can
+    // carry a secret-class value, so we want the trail to be durable before we
+    // report success. `createAuditLog` rejects on DB failure — we let that
+    // propagate to a 500 so the caller knows the audit did not land (the merge
+    // is idempotent, so a retry is safe). Only field KEYS are recorded, never
+    // values, so no secret enters the audit payload.
+    await createAuditLog({
       orgId: device.orgId,
       actorType: access.audit.actorType,
-      actorId: access.audit.actorId,
-      actorEmail: access.audit.actorEmail,
+      actorId: access.audit.actorId ?? ANONYMOUS_ACTOR_ID,
+      actorEmail: access.audit.actorEmail ?? undefined,
       action: 'device.custom_field.update',
       resourceType: 'device',
       resourceId: deviceId,
       resourceName: device.hostname ?? device.displayName ?? undefined,
       details: { changedFields: Object.keys(updates) },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header('user-agent'),
+      result: 'success',
+      initiatedBy: access.audit.actorType === 'api_key' ? 'integration' : 'manual',
     });
 
     return c.json({ customFields: readExistingCustomFields(updated.customFields) });

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -24,8 +24,17 @@ import { moveOrgRoutes } from './moveOrg';
 import { actuateElevationRoutes } from './actuateElevation';
 import { softwareActionsRoutes } from './softwareActions';
 import { networkRoutes } from './network';
+import { customFieldValuesRoutes } from './customFieldValues';
 
 export const deviceRoutes = new Hono();
+
+// Mount the custom-field VALUE routes FIRST. They use per-route auth that also
+// accepts an X-API-Key header (issue #2066). Hono attaches a sibling sub-router's
+// `.use('*', authMiddleware)` to every route mounted AFTER it, so mounting these
+// after the session-only `coreRoutes` would shadow the API-key branch with the
+// JWT-only `authMiddleware` and resurrect the 401. Mounting first keeps them
+// clear of every later wildcard auth middleware.
+deviceRoutes.route('/', customFieldValuesRoutes);
 
 // Mount provision routes FIRST — `/provision` is a static path under /devices
 // that must NOT be eaten by the `/:id` matcher in coreRoutes.


### PR DESCRIPTION
## Problem

Device custom-field **values** live in the `devices.custom_fields` JSONB column and could only be written via `PATCH /devices/:id`. That route is gated on the session-JWT `authMiddleware` (`apps/api/src/middleware/auth.ts:341`) + `requireMfa()`. An automation calling with an `X-API-Key` header sends no `Authorization: Bearer` header, so it was rejected at the very first gate with **`401 "Missing or invalid authorization header"`** — there was no API-key-authenticated path to stash a value (e.g. a script writing a BitLocker recovery key into a custom field).

**Root cause:** the two auth systems are disjoint. `authMiddleware` accepts only `Bearer <JWT>`; API keys go through a separate `apiKeyAuthMiddleware` (`X-API-Key`) that was never wired to any device route. The 401 is `authMiddleware`, not a scope/permission `403`.

## Fix

Add dedicated custom-field **value** endpoints that accept EITHER auth flavour, mirroring the dual-auth pattern already used in `routes/devPush.ts`:

- `GET /devices/:id/custom-fields` — read values (`devices:read` scope / `DEVICES_READ`)
- `PATCH /devices/:id/custom-fields` — merge values (`devices:write` scope / `DEVICES_WRITE`, MFA on the JWT path)

API keys authenticate via `X-API-Key` + `requireApiKeyScope`; browser sessions via JWT + `requirePermission`. Value constraints mirror `updateDeviceSchema.customFields`, and writes merge into the existing object (same semantics as `PATCH /devices/:id`). API-key writes are audited with `actorType: 'api_key'`.

## Tenant isolation (preserved)

- API-key auth runs **every** downstream query under a `withDbAccessContext` scoped to the key's single org, so `devices` RLS (direct `org_id`, shape 1) denies cross-tenant rows.
- `getDeviceWithOrgCheck` (org-scope check) + an explicit `org_id` predicate on the `UPDATE` are belt-and-suspenders on top of RLS.
- Site-restricted **sessions** still get their `allowedSiteIds` gate (via `requirePermission` → `loadAccessibleDevice`); API keys are org-scoped, not site-scoped (same as devPush).
- A cross-tenant or under-scoped key gets `404`/`403` and never reaches the write — covered by tests.

## Auth-wiring note

The router uses **per-route** auth (never `.use('*')`) and is mounted **first** in `devices/index.ts`, before `coreRoutes` and the other `.use('*', authMiddleware)` sub-routers. In Hono a sibling's wildcard middleware attaches to every route mounted *after* it, so mounting later would re-introduce the session-only `authMiddleware` ahead of the API-key branch and resurrect the 401.

## Tests

`apps/api/src/routes/devices/customFieldValues.test.ts` (7 cases): API-key write success + merge + `api_key` audit; under-scoped key → 403; cross-org device → 404 (no write); empty body → 400; API-key read; JWT write; no-credential → 401. Existing custom-field, device-core, routeScan, and middleware suites stay green. `tsc --noEmit` clean.

Closes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)