### PR TITLE
feat(billing): full-width, expandable line description boxes for quotes & invoices

### DIFF
--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -64,7 +64,9 @@ describe('InvoiceEditor', () => {
     render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
     expect(screen.getByTestId('invoice-issue')).not.toBeDisabled();
-    expect(screen.getByTestId('invoice-line-line-1')).toHaveTextContent('Consulting');
+    // Name/description are now editable inputs (full-width description row) rather
+    // than static text; the legacy name-less line shows its description in the box.
+    expect(screen.getByTestId('invoice-line-desc-line-1')).toHaveValue('Consulting');
   });
 
   it('warns when a line is taxable but no tax rate is configured', async () => {

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
@@ -11,7 +11,6 @@ import {
   type InvoiceLine,
   formatMoney,
   lineTitle,
-  lineBlurb,
   computeInvoiceProfit,
 } from './invoiceTypes';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
@@ -543,16 +542,66 @@ function LineRow({
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
   const editDisabled = disabled || !canWrite;
+  const [name, setName] = useState(line.name ?? '');
+  const [desc, setDesc] = useState(line.description ?? '');
   const [qty, setQty] = useState(line.quantity);
   const [price, setPrice] = useState(line.unitPrice);
+  // Guard an in-progress name/description edit from being clobbered by a server
+  // resync mid-type (mirrors the quote editor's EditableLineRow pattern).
+  const nameEdited = useRef(false);
+  const descEdited = useRef(false);
+  // Auto-grow the (full-width) description textarea to fit its content, while
+  // still letting the user drag the resize handle for a bigger/smaller box.
+  const descRef = useRef<HTMLTextAreaElement>(null);
+  const autoGrowDesc = () => {
+    const el = descRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
+  useEffect(() => { if (!nameEdited.current) setName(line.name ?? ''); }, [line.name]);
+  useEffect(() => { if (!descEdited.current) setDesc(line.description ?? ''); }, [line.description]);
+  useEffect(() => { autoGrowDesc(); }, [desc]);
   useEffect(() => { setQty(line.quantity); setPrice(line.unitPrice); }, [line.quantity, line.unitPrice]);
+
+  const commitName = () => {
+    if (!canWrite) return;
+    const next = name.trim();
+    nameEdited.current = false; // committing — let the server value re-adopt next
+    if (next === (line.name ?? '')) { setName(line.name ?? ''); return; }
+    // A line can't have both name and description blank (mirrors the manual-add rule).
+    if (!next && !(line.description ?? '').trim()) {
+      handleActionError(new Error('empty line'), 'A line needs a name or a description.');
+      setName(line.name ?? '');
+      return;
+    }
+    onPatch(line.id, { name: next || null });
+  };
+  const commitDesc = () => {
+    if (!canWrite) return;
+    const next = desc.trim();
+    descEdited.current = false;
+    if (next === (line.description ?? '')) { setDesc(line.description ?? ''); return; }
+    if (!next && !(line.name ?? '').trim()) {
+      handleActionError(new Error('empty line'), 'A line needs a name or a description.');
+      setDesc(line.description ?? '');
+      return;
+    }
+    onPatch(line.id, { description: next || null });
+  };
 
   return (
     <>
       <tr className="border-t" data-testid={`invoice-line-${line.id}`}>
         <td className="px-3 py-2">
-          <div className="font-medium text-foreground">{lineTitle(line)}</div>
-          {lineBlurb(line) && <div className="text-xs text-muted-foreground">{lineBlurb(line)}</div>}
+          <input
+            type="text" value={name} disabled={editDisabled}
+            aria-label="Line name" placeholder="Name"
+            onChange={(e) => { setName(e.target.value); nameEdited.current = true; }}
+            onBlur={commitName}
+            data-testid={`invoice-line-name-${line.id}`}
+            className="h-8 w-full rounded-md border bg-background px-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          />
         </td>
         <td className="px-3 py-2 text-right">
           <input
@@ -597,6 +646,24 @@ function LineRow({
               Remove
             </button>
           )}
+        </td>
+      </tr>
+      {/* Full-width description row, so writers get a roomy, expandable box
+          instead of a cramped cell — matches the quote editor. */}
+      <tr className="border-0" data-testid={`invoice-line-desc-row-${line.id}`}>
+        <td colSpan={7} className="px-3 pb-2 pt-0">
+          <textarea
+            ref={descRef}
+            value={desc}
+            disabled={editDisabled}
+            aria-label="Line description"
+            placeholder="Description (optional)"
+            onChange={(e) => { setDesc(e.target.value); descEdited.current = true; autoGrowDesc(); }}
+            onBlur={commitDesc}
+            rows={2}
+            data-testid={`invoice-line-desc-${line.id}`}
+            className="min-h-8 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          />
         </td>
       </tr>
       {children.map((ch) => (

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1698,6 +1698,15 @@ function EditableLineRow({
   //     value (e.g. 9.999 → 10.00), clearing the dirty ring and the optimism.
   const nameEdited = useRef(false);
   const descEdited = useRef(false);
+  // Auto-grow the (full-width) description textarea to fit its content, while
+  // still allowing the user to drag the resize handle for a bigger/smaller box.
+  const descRef = useRef<HTMLTextAreaElement>(null);
+  const autoGrowDesc = () => {
+    const el = descRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
   const qtyEdited = useRef(false);
   const priceEdited = useRef(false);
   const costEdited = useRef(false);
@@ -1705,6 +1714,8 @@ function EditableLineRow({
   const partEdited = useRef(false);
   useEffect(() => { if (!nameEdited.current) setName(line.name ?? ''); }, [line.name]);
   useEffect(() => { if (!descEdited.current) setDesc(line.description ?? ''); }, [line.description]);
+  // Re-fit the description box after any value change (typing or server resync).
+  useEffect(() => { autoGrowDesc(); }, [desc]);
   useEffect(() => { if (!qtyEdited.current) setQty(line.quantity); }, [line.quantity]);
   useEffect(() => { if (!priceEdited.current) setPrice(line.unitPrice); }, [line.unitPrice]);
   useEffect(() => { if (!costEdited.current) setCost(line.unitCost ?? ''); }, [line.unitCost]);
@@ -1889,17 +1900,6 @@ function EditableLineRow({
               data-testid={`quote-line-name-${line.id}`}
               className={`h-9 w-full rounded-md border bg-background px-2 py-1 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
             />
-            <textarea
-              value={desc}
-              aria-label="Line description"
-              placeholder="Description (optional)"
-              onChange={(e) => { setDesc(e.target.value); descEdited.current = true; }}
-              onBlur={commitDesc}
-              rows={2}
-              disabled={busy}
-              data-testid={`quote-line-desc-${line.id}`}
-              className={`min-h-9 w-full resize-y rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(descDirty, saved)}`}
-            />
           </div>
         </div>
       </td>
@@ -1988,6 +1988,24 @@ function EditableLineRow({
             Remove
           </button>
         </div>
+      </td>
+    </tr>
+    {/* Full-width description row, so writers get a roomy, expandable box instead
+        of a cramped textarea squeezed into the narrow Description column. */}
+    <tr className="border-0" data-testid={`quote-line-desc-row-${line.id}`}>
+      <td colSpan={8} className="px-2 pb-2">
+        <textarea
+          ref={descRef}
+          value={desc}
+          aria-label="Line description"
+          placeholder="Description (optional)"
+          onChange={(e) => { setDesc(e.target.value); descEdited.current = true; autoGrowDesc(); }}
+          onBlur={commitDesc}
+          rows={2}
+          disabled={busy}
+          data-testid={`quote-line-desc-${line.id}`}
+          className={`min-h-9 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(descDirty, saved)}`}
+        />
       </td>
     </tr>
     {/* Internal-only cost/markup/profit band — never shown to the customer.


### PR DESCRIPTION
## What & why

Line item description boxes in the quote/invoice editors were squeezed into the narrow Description column — barely readable, awkward to edit (see the cramped, clipped boxes in the original report). This makes them **usable**: full-width, auto-growing, and resizable.

## Changes

**Quotes** (`QuoteEditor.tsx`)
- Moved the description textarea out of the cramped first column into its own **full-width second row** (`<td colSpan={8}>`) below each line — same pattern the existing internal cost/margin band already uses.
- Auto-grows to fit content as you type; keeps the manual `resize-y` drag handle.
- Preserves the `quote-line-desc-${line.id}` test id, blur-commit, dirty/saved ring, and resync guard.

**Invoices** (`InvoiceEditor.tsx`)
- Invoices previously rendered line name/description as **static read-only text** — there was no inline description editing at all.
- Draft invoices now get an editable **Name** input plus a full-width, auto-growing **description** textarea, mirroring the quotes layout (`<td colSpan={7}>`).
- Wired to the existing `PATCH /invoices/:id/lines/:lineId` endpoint (already accepts `name`/`description`, draft-gated server-side) with the same resync-guard refs and "a line needs a name or a description" rule as quotes.
- The invoice editor only renders for **drafts**, so issued/paid invoices keep their clean read-only document view.

## Tests
- Updated one `InvoiceEditor.test.tsx` assertion — a legacy name-less line's text now lives in the description textarea value rather than as static row text.
- Invoice editor tests: **15 passed** · Quote editor tests: **73 passed** (incl. `QuoteEditor.editline.test.tsx`)
- `tsc --noEmit`: clean · `eslint` on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)