### PR TITLE
fix(security): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/apps/helper/src-tauri/Cargo.lock
+++ b/apps/helper/src-tauri/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atk"

--- a/apps/viewer/src-tauri/Cargo.lock
+++ b/apps/viewer/src-tauri/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## Problem
**Cargo Audit** (Security Scanning workflow) has been failing on `main`. CI runs `cargo audit --deny warnings`, and `anyhow` 1.0.101 is flagged by **RUSTSEC-2026-0190** — unsoundness in `Error::downcast_mut()` (can violate borrow rules → UB). The unsoundness *warning* hard-fails under `--deny warnings`.

## Fix
Bump `anyhow` 1.0.101 → **1.0.103** (the patched release, fixes >= 1.0.103) in both Tauri lockfiles:
- `apps/helper/src-tauri/Cargo.lock`
- `apps/viewer/src-tauri/Cargo.lock`

Lockfile-only; no source changes.

## Verification
`cargo audit --deny warnings` now exits 0 in both crates locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)