### PR TITLE
fix(tickets): surface partner-level SLAs in Priorities settings + correct precedence note

### DIFF
--- a/apps/web/src/components/settings/TicketPrioritiesTab.test.tsx
+++ b/apps/web/src/components/settings/TicketPrioritiesTab.test.tsx
@@ -121,7 +121,7 @@ describe('TicketPrioritiesTab', () => {
       render(<TicketPrioritiesTab />);
 
       await screen.findByTestId('priorities-save');
-      expect(screen.getByText(/Order of precedence: category SLA → org override → these defaults/)).toBeInTheDocument();
+      expect(screen.getByText(/These are your partner-wide SLA defaults/)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/components/settings/TicketPrioritiesTab.tsx
+++ b/apps/web/src/components/settings/TicketPrioritiesTab.tsx
@@ -108,14 +108,14 @@ export default function TicketPrioritiesTab() {
             method: 'PUT',
             body: JSON.stringify({ priorities: buildPayload(draft) }),
           }),
-        errorFallback: 'Failed to save priority settings. Retry.',
-        successMessage: 'Priority settings saved',
+        errorFallback: "Couldn't save priorities and SLAs. Retry.",
+        successMessage: 'Priorities and SLAs saved',
         onUnauthorized: UNAUTHORIZED,
       });
       invalidateTicketConfig();
       void load();
     } catch (err) {
-      handleActionError(err, 'Failed to save priority settings. Retry.');
+      handleActionError(err, "Couldn't save priorities and SLAs. Retry.");
     }
     setSaving(false);
   }, [draft, load]);
@@ -123,9 +123,9 @@ export default function TicketPrioritiesTab() {
   return (
     <div className="max-w-3xl" data-testid="ticket-priorities-tab">
       <div>
-        <h2 className="text-lg font-semibold">Ticket Priorities</h2>
+        <h2 className="text-lg font-semibold">Priorities &amp; SLAs</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Customize priority labels and set default SLA response and resolution times.
+          Rename ticket priorities and set the default response and resolution SLAs. These apply to new tickets across every organization you manage.
         </p>
       </div>
 
@@ -200,7 +200,7 @@ export default function TicketPrioritiesTab() {
             </table>
 
             <p className="mt-3 text-xs text-muted-foreground">
-              Order of precedence: category SLA → org override → these defaults.
+              These are your partner-wide SLA defaults. Each ticket uses the most specific SLA that applies — a per-ticket override, then its category, then an organization override — and falls back to these defaults otherwise. Leave a field blank to use the built-in default (Urgent and High only).
             </p>
 
             <div className="mt-4">

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -19,7 +19,7 @@ type Tab = (typeof VALID_TABS)[number];
 // backstop that hides the queue for non-admins reached directly via hash.
 const BASE_TABS: Array<{ id: Tab; label: string }> = [
   { id: 'statuses', label: 'Statuses' },
-  { id: 'priorities', label: 'Priorities' },
+  { id: 'priorities', label: 'Priorities & SLAs' },
   { id: 'categories', label: 'Categories' },
   { id: 'export', label: 'Export' }
 ];


### PR DESCRIPTION
## What

Makes partner-level SLAs discoverable in the Ticketing settings, and corrects an inaccurate precedence note.

The partner-wide SLA defaults lived inside a tab/heading named just **"Priorities"** — the word "SLA" only showed up in fine print, so the feature was easy to miss. Meanwhile the *org-level* editor already names its section **"SLA overrides"**, so the two surfaces were inconsistent.

## Changes (copy only — `apps/web/src/components/settings/`)

| Location | Before | After |
|---|---|---|
| Tab label | `Priorities` | `Priorities & SLAs` |
| Panel heading | `Ticket Priorities` | `Priorities & SLAs` |
| Subtitle | "Customize priority labels and set default SLA response and resolution times." | "Rename ticket priorities and set the default response and resolution SLAs. These apply to new tickets across every organization you manage." |
| Precedence note | "Order of precedence: category SLA → org override → these defaults." *(wrong/incomplete)* | "These are your partner-wide SLA defaults. Each ticket uses the most specific SLA that applies — a per-ticket override, then its category, then an organization override — and falls back to these defaults otherwise. Leave a field blank to use the built-in default (Urgent and High only)." |
| Save toast | "Priority settings saved" / "Failed to save priority settings." | "Priorities and SLAs saved" / "Couldn't save priorities and SLAs. Retry." |

The precedence note now matches the actual resolution chain in `apps/api/src/services/ticketSla.ts` (`ticket override → category → org override → partner → built-in default`) and explains that a blank field falls back to the built-in default (Urgent/High only).

## Notes

- No behavior, schema, or API changes — pure UX copy plus one matching test-regex update (`TicketPrioritiesTab.test.tsx`).
- Tab `id` and all `data-testid`s are unchanged, so e2e/test selectors are unaffected.
- Column headers (`Response (min)` / `Resolution (min)`) left as-is — already consistent across the partner and org editors, and the new heading carries the SLA context.

## Testing

Not run locally — this worktree has no `node_modules` installed. CI will exercise the web test suite. Changes are pure copy plus the aligned test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)