### PR TITLE
fix(web): disable Connect Desktop & Power for offline devices (#2013)

### DIFF
--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DeviceActions from './DeviceActions';
@@ -99,6 +99,33 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
       const wake = button(/^wake$/i);
       expect(wake).toBeInTheDocument();
       expect(wake).not.toBeDisabled();
+    });
+  });
+
+  // The compact variant duplicates the gating logic in its own menu, so it gets
+  // its own coverage. The menu is collapsed until the trigger is clicked.
+  describe('compact variant', () => {
+    it('disables Connect Desktop when offline (with the offline tooltip) but keeps Wake enabled', () => {
+      render(<DeviceActions device={offlineDevice} compact />);
+
+      // Only the MoreHorizontal trigger is rendered until the menu opens.
+      fireEvent.click(screen.getByRole('button'));
+
+      const connect = button(/^connect desktop$/i);
+      expect(connect).toBeDisabled();
+      expect(connect).toHaveAttribute('title', 'Device is offline');
+
+      const wake = button(/^wake$/i);
+      expect(wake).toBeInTheDocument();
+      expect(wake).not.toBeDisabled();
+    });
+
+    it('leaves Connect Desktop enabled when online', () => {
+      render(<DeviceActions device={onlineDevice} compact />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(button(/^connect desktop$/i)).not.toBeDisabled();
     });
   });
 });

--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceActions from './DeviceActions';
+import type { Device } from './DeviceList';
+
+// ConnectDesktopButton (rendered inside DeviceActions) imports fetchWithAuth and
+// the Toast helper. Mock both so the action bar renders without touching the
+// network or the toast store.
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', async () => {
+  const actual = await vi.importActual<typeof import('../shared/Toast')>('../shared/Toast');
+  return {
+    ...actual,
+    showToast: vi.fn(),
+  };
+});
+
+const baseDevice: Device = {
+  id: 'device-1',
+  hostname: 'edge-01',
+  os: 'windows',
+  osVersion: '11',
+  status: 'online',
+  cpuPercent: 10,
+  ramPercent: 20,
+  lastSeen: '2026-06-29T10:00:00.000Z',
+  orgId: 'org-1',
+  orgName: 'Org One',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '1.0.0',
+  tags: [],
+};
+
+const onlineDevice: Device = { ...baseDevice, status: 'online' };
+const offlineDevice: Device = { ...baseDevice, status: 'offline' };
+
+// Native disabled buttons aren't reported as disabled via getByRole's name in
+// every jsdom case, so query the DOM element directly and read its props.
+const button = (name: RegExp) => screen.getByRole('button', { name });
+
+describe('DeviceActions — offline gating (issue #2013)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('online device', () => {
+    it('leaves Connect Desktop, Power, Run Script and Remote Tools all enabled', () => {
+      render(<DeviceActions device={onlineDevice} />);
+
+      expect(button(/run script/i)).not.toBeDisabled();
+      expect(button(/^connect desktop$/i)).not.toBeDisabled();
+      expect(button(/remote tools/i)).not.toBeDisabled();
+      expect(button(/^power$/i)).not.toBeDisabled();
+    });
+
+    it('does not render the Wake button when the device is online', () => {
+      render(<DeviceActions device={onlineDevice} />);
+      expect(screen.queryByRole('button', { name: /^wake$/i })).toBeNull();
+    });
+  });
+
+  describe('offline device', () => {
+    it('disables Connect Desktop with the "Device is offline" tooltip', () => {
+      render(<DeviceActions device={offlineDevice} />);
+
+      const connect = button(/^connect desktop$/i);
+      expect(connect).toBeDisabled();
+      expect(connect).toHaveAttribute('title', 'Device is offline');
+    });
+
+    it('disables the Power button with the "Device is offline" tooltip', () => {
+      render(<DeviceActions device={offlineDevice} />);
+
+      const power = button(/^power$/i);
+      expect(power).toBeDisabled();
+      expect(power).toHaveAttribute('title', 'Device is offline');
+    });
+
+    it('keeps Run Script and Remote Tools disabled with the offline tooltip (existing behavior)', () => {
+      render(<DeviceActions device={offlineDevice} />);
+
+      const runScript = button(/run script/i);
+      expect(runScript).toBeDisabled();
+      expect(runScript).toHaveAttribute('title', 'Device is offline');
+
+      const remoteTools = button(/remote tools/i);
+      expect(remoteTools).toBeDisabled();
+      expect(remoteTools).toHaveAttribute('title', 'Device is offline');
+    });
+
+    it('keeps Wake ENABLED — Wake-on-LAN is intended for offline devices', () => {
+      render(<DeviceActions device={offlineDevice} />);
+
+      const wake = button(/^wake$/i);
+      expect(wake).toBeInTheDocument();
+      expect(wake).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -162,7 +162,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
                 <Play className="h-4 w-4" />
                 Run Script
               </button>
-              <ConnectDesktopButton deviceId={device.id} compact disabled={device.status === 'offline'} isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
+              <ConnectDesktopButton deviceId={device.id} compact disabled={device.status === 'offline'} disabledTitle="Device is offline" isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
               <button
                 type="button"
                 onClick={() => handleAction('remote-tools')}
@@ -303,7 +303,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           <Play className="h-4 w-4" />
           Run Script
         </button>
-        <ConnectDesktopButton deviceId={device.id} disabled={device.status === 'offline'} isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
+        <ConnectDesktopButton deviceId={device.id} disabled={device.status === 'offline'} disabledTitle="Device is offline" isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
         <button
           type="button"
           onClick={() => handleAction('remote-tools')}
@@ -318,7 +318,8 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           <button
             type="button"
             onClick={() => { setPowerMenuOpen(!powerMenuOpen); setMenuOpen(false); }}
-            disabled={loading}
+            disabled={device.status === 'offline' || loading}
+            title={device.status === 'offline' ? 'Device is offline' : undefined}
             aria-haspopup="true"
             aria-expanded={powerMenuOpen}
             className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -171,4 +171,31 @@ describe('ConnectDesktopButton — disabled prop gating (issue #2013)', () => {
     render(<ConnectDesktopButton deviceId="dev-on" disabledTitle="Device is offline" />);
     expect(screen.getByRole('button', { name: /connect desktop/i })).not.toBeDisabled();
   });
+
+  it('clears a stale "Connection failed" error and shows the offline tooltip when the device goes offline', async () => {
+    // GET /devices/:id (no launcher), then the sessions POST fails — drives the
+    // button into its error state while it is still enabled.
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: false,
+      remoteAccessLaunchSkipReason: 'no_provider_configured',
+    }));
+    fetchMock.mockResolvedValue(jsonRes({ error: 'Device is not online' }, false));
+
+    const { rerender } = render(
+      <ConnectDesktopButton deviceId="dev-x" disabledTitle="Device is offline" />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /connection failed/i })).toBeInTheDocument(),
+    );
+
+    // Device flips offline → disabled. The stale error must clear so the offline
+    // tooltip is visible rather than the leftover "Connection failed" title.
+    rerender(<ConnectDesktopButton deviceId="dev-x" disabled disabledTitle="Device is offline" />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'Device is offline');
+    expect(screen.queryByText(/connection failed/i)).toBeNull();
+  });
 });

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -122,3 +122,53 @@ describe('ConnectDesktopButton — launcher skip-reason toast', () => {
     expect(toastMock).not.toHaveBeenCalled();
   });
 });
+
+describe('ConnectDesktopButton — disabled prop gating (issue #2013)', () => {
+  beforeEach(() => {
+    _resetToastQueueForTests();
+    fetchMock.mockReset();
+    toastMock.mockReset();
+  });
+
+  // The full and compact render variants previously dropped the `disabled` prop
+  // on the floor (only iconOnly honored it), so an offline device's button
+  // stayed clickable and fired a doomed POST /remote/sessions. These assert all
+  // three variants now honor `disabled` and surface `disabledTitle`.
+  for (const variant of ['full', 'compact', 'iconOnly'] as const) {
+    it(`honors disabled + disabledTitle in the ${variant} variant`, () => {
+      render(
+        <ConnectDesktopButton
+          deviceId="dev-off"
+          disabled
+          disabledTitle="Device is offline"
+          {...(variant === 'compact' ? { compact: true } : {})}
+          {...(variant === 'iconOnly' ? { iconOnly: true } : {})}
+        />,
+      );
+
+      const btn = screen.getByRole('button');
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Device is offline');
+    });
+
+    it(`does NOT fire a session request when clicked while disabled (${variant} variant)`, () => {
+      render(
+        <ConnectDesktopButton
+          deviceId="dev-off"
+          disabled
+          disabledTitle="Device is offline"
+          {...(variant === 'compact' ? { compact: true } : {})}
+          {...(variant === 'iconOnly' ? { iconOnly: true } : {})}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  }
+
+  it('stays enabled when not disabled', () => {
+    render(<ConnectDesktopButton deviceId="dev-on" disabledTitle="Device is offline" />);
+    expect(screen.getByRole('button', { name: /connect desktop/i })).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -102,6 +102,13 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
     };
   }, []);
 
+  // Clear any stale "Connection failed" error once the button becomes disabled
+  // (e.g. the device just went offline). Otherwise the leftover error label and
+  // title would mask the `disabledTitle` ("Device is offline") tooltip.
+  useEffect(() => {
+    if (disabled) setError(null);
+  }, [disabled]);
+
   const endSession = useCallback((sessionId: string) => {
     fetchWithAuth(`/remote/sessions/${sessionId}/end`, { method: 'POST' }).catch(() => {});
   }, []);

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -15,6 +15,8 @@ interface Props {
   compact?: boolean;
   iconOnly?: boolean;
   disabled?: boolean;
+  /** Tooltip shown while the button is disabled via the `disabled` prop (e.g. "Device is offline"). */
+  disabledTitle?: string;
   isHeadless?: boolean;
   desktopAccess?: DesktopAccessState | null;
   remoteAccessPolicy?: RemoteAccessPolicy | null;
@@ -82,7 +84,7 @@ function desktopAccessUnavailableReason(
   }
 }
 
-export default function ConnectDesktopButton({ deviceId, className = '', compact = false, iconOnly = false, disabled = false, isHeadless = false, desktopAccess = null, remoteAccessPolicy = null }: Props) {
+export default function ConnectDesktopButton({ deviceId, className = '', compact = false, iconOnly = false, disabled = false, disabledTitle, isHeadless = false, desktopAccess = null, remoteAccessPolicy = null }: Props) {
   const [status, setStatus] = useState<'idle' | 'creating' | 'launching' | 'fallback' | 'denied'>('idle');
   const [error, setError] = useState<string | null>(null);
   // Populated when the VNC auto-fallback path times out — carries the info needed
@@ -682,7 +684,7 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
           type="button"
           onClick={handleConnect}
           disabled={disabled || status === 'creating' || status === 'launching'}
-          title={error || 'Connect Desktop'}
+          title={error || (disabled ? disabledTitle : undefined) || 'Connect Desktop'}
           className={`flex h-8 w-8 items-center justify-center rounded-md transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 ${error ? 'text-red-500' : ''}`}
         >
           {status === 'creating' || status === 'launching' ? (
@@ -703,8 +705,8 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
         <button
           type="button"
           onClick={handleConnect}
-          disabled={status === 'creating' || status === 'launching'}
-          title={error || undefined}
+          disabled={disabled || status === 'creating' || status === 'launching'}
+          title={error || (disabled ? disabledTitle : undefined)}
           className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 ${error ? 'text-red-500' : ''}`}
         >
           <Monitor className="h-4 w-4" />
@@ -724,8 +726,8 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
       <button
         type="button"
         onClick={handleConnect}
-        disabled={status === 'creating' || status === 'launching'}
-        title={error || undefined}
+        disabled={disabled || status === 'creating' || status === 'launching'}
+        title={error || (disabled ? disabledTitle : undefined)}
         className={`flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60 ${error ? 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-950 dark:text-red-400 dark:hover:bg-red-900' : 'bg-background hover:bg-muted'}`}
       >
         <Monitor className="h-4 w-4" />


### PR DESCRIPTION
## Summary

On an **offline** device's detail page, `Run Script` and `Remote Tools` were correctly disabled with a "Device is offline" tooltip, but **Connect Desktop** and **Power** stayed enabled. Clicking Connect Desktop fired `POST /api/v1/remote/sessions`, which the API rejects with `400 { error: "Device is not online" }` — surfaced only as the button turning red, with the reason buried in the hover `title`.

## Root cause

Two separate gaps, both in the device action bar:

- **Connect Desktop** — `apps/web/src/components/devices/DeviceActions.tsx` already passed `disabled={device.status === 'offline'}` to `ConnectDesktopButton`, but the component's **compact** and **full** render variants ignored the `disabled` prop entirely (only the `iconOnly` variant honored it). The offline gate was dropped on the floor, so the button stayed clickable.
- **Power** — the Power dropdown trigger was only `disabled={loading}`, never gated on offline. Its inner items (Reboot / Reboot to Safe Mode / Shutdown) were individually gated, but the trigger itself opened with no tooltip.

## Fix

- `ConnectDesktopButton` now honors `disabled` in all three variants (`full`, `compact`, `iconOnly`) and accepts a `disabledTitle` prop for the disabled-state tooltip.
- `DeviceActions` passes `disabledTitle="Device is offline"` to both `ConnectDesktopButton` usages and gates the **Power** button on `device.status === 'offline'` with the same `"Device is offline"` tooltip pattern already used by Run Script / Remote Tools.
- **Wake stays enabled** — it's Wake-on-LAN, intended for offline devices. It's a separate primary button, untouched.

## Files changed

- `apps/web/src/components/remote/ConnectDesktopButton.tsx` — new `disabledTitle` prop; `disabled` now applied in all variants.
- `apps/web/src/components/devices/DeviceActions.tsx` — pass `disabledTitle`; gate Power button on offline.
- `apps/web/src/components/devices/DeviceActions.test.tsx` — **new**; asserts offline gating + tooltips, Wake-stays-enabled, and the online all-enabled case.
- `apps/web/src/components/remote/ConnectDesktopButton.test.tsx` — extended; asserts all variants honor `disabled`/`disabledTitle` and that no request fires while disabled.

## Testing

- `vitest run` on both touched test files: **19 passed**. Verified non-vacuous — 7 of the new assertions fail against the pre-fix source.
- `tsc --noEmit` on `apps/web`: clean.

Closes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)