### PR TITLE
feat(patches): enforce Breeze as sole Windows Update source (#1872)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1648,6 +1648,16 @@ func (h *Heartbeat) applyConfigUpdate(update map[string]any) {
 		}
 	}
 
+	// Apply patch_source_settings if present (#1872): enforce/revert Breeze as
+	// the sole Windows Update source. No-op on non-Windows.
+	psRaw, hasPS := update["patch_source_settings"]
+	if !hasPS {
+		psRaw, hasPS = update["patchSourceSettings"]
+	}
+	if hasPS {
+		h.applyPatchSourceConfig(psRaw)
+	}
+
 	registryRaw, hasRegistry := update["policy_registry_state_probes"]
 	if !hasRegistry {
 		registryRaw, hasRegistry = update["policyRegistryStateProbes"]

--- a/agent/internal/heartbeat/patch_source.go
+++ b/agent/internal/heartbeat/patch_source.go
@@ -4,6 +4,13 @@ import (
 	"github.com/breeze-rmm/agent/internal/winupdate"
 )
 
+// applyWinUpdate is the seam to the (Windows-only) enforcement. A package var so
+// tests can capture the resolved enforce bool on any platform — the dispatch +
+// payload-parse path is where a key-name regression would silently disable the
+// whole feature, so it must be unit-tested even though the registry I/O cannot
+// run on the CI agent.
+var applyWinUpdate = winupdate.Apply
+
 // applyPatchSourceConfig handles the patch_source_settings block from the
 // heartbeat config update (#1872). When exclusiveWindowsUpdate is true the
 // Windows agent suppresses the native Windows Update automatic-install channel;
@@ -30,7 +37,7 @@ func (h *Heartbeat) applyPatchSourceConfig(raw any) {
 		return
 	}
 
-	res, err := winupdate.Apply(enforce)
+	res, err := applyWinUpdate(enforce)
 	if err != nil {
 		log.Error("failed to apply Windows Update source enforcement",
 			"enforce", enforce, "error", err.Error())

--- a/agent/internal/heartbeat/patch_source.go
+++ b/agent/internal/heartbeat/patch_source.go
@@ -1,0 +1,50 @@
+package heartbeat
+
+import (
+	"github.com/breeze-rmm/agent/internal/winupdate"
+)
+
+// applyPatchSourceConfig handles the patch_source_settings block from the
+// heartbeat config update (#1872). When exclusiveWindowsUpdate is true the
+// Windows agent suppresses the native Windows Update automatic-install channel;
+// false reverts any enforcement Breeze previously applied. No-op on non-Windows.
+func (h *Heartbeat) applyPatchSourceConfig(raw any) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		log.Warn("ignoring invalid patch_source_settings payload: not an object")
+		return
+	}
+
+	// The API may send either snake_case or camelCase.
+	v, present := m["exclusiveWindowsUpdate"]
+	if !present {
+		v, present = m["exclusive_windows_update"]
+	}
+	if !present {
+		log.Warn("patch_source_settings received without exclusiveWindowsUpdate field")
+		return
+	}
+	enforce, ok := v.(bool)
+	if !ok {
+		log.Warn("ignoring patch_source_settings: exclusiveWindowsUpdate is not a boolean")
+		return
+	}
+
+	res, err := winupdate.Apply(enforce)
+	if err != nil {
+		log.Error("failed to apply Windows Update source enforcement",
+			"enforce", enforce, "error", err.Error())
+		return
+	}
+	if !res.Supported {
+		log.Debug("Windows Update source enforcement not supported on this platform",
+			"enforce", enforce)
+		return
+	}
+	log.Info("applied Windows Update source enforcement",
+		"enforce", enforce,
+		"managed", res.Managed,
+		"enforced", res.Enforced,
+		"reverted", res.Reverted,
+		"reason", res.Reason)
+}

--- a/agent/internal/heartbeat/patch_source_test.go
+++ b/agent/internal/heartbeat/patch_source_test.go
@@ -1,0 +1,77 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/winupdate"
+)
+
+func TestApplyPatchSourceConfig_DispatchAndParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		update      map[string]any
+		wantCalled  bool
+		wantEnforce bool
+	}{
+		{
+			name:        "snake_case block + camelCase field, true",
+			update:      map[string]any{"patch_source_settings": map[string]any{"exclusiveWindowsUpdate": true}},
+			wantCalled:  true,
+			wantEnforce: true,
+		},
+		{
+			name:        "camelCase block + snake_case field, false",
+			update:      map[string]any{"patchSourceSettings": map[string]any{"exclusive_windows_update": false}},
+			wantCalled:  true,
+			wantEnforce: false,
+		},
+		{
+			name:       "missing field → no-op (never calls enforcement)",
+			update:     map[string]any{"patch_source_settings": map[string]any{}},
+			wantCalled: false,
+		},
+		{
+			name:       "non-boolean field → no-op",
+			update:     map[string]any{"patch_source_settings": map[string]any{"exclusiveWindowsUpdate": "yes"}},
+			wantCalled: false,
+		},
+		{
+			name:       "non-object payload → no-op",
+			update:     map[string]any{"patch_source_settings": "enabled"},
+			wantCalled: false,
+		},
+		{
+			name:       "block absent entirely → no-op",
+			update:     map[string]any{"event_log_settings": map[string]any{}},
+			wantCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := applyWinUpdate
+			t.Cleanup(func() { applyWinUpdate = orig })
+			var gotEnforce *bool
+			applyWinUpdate = func(enforce bool) (winupdate.Result, error) {
+				e := enforce
+				gotEnforce = &e
+				return winupdate.Result{Supported: true, Reason: "stub"}, nil
+			}
+
+			h := &Heartbeat{config: config.Default()}
+			h.applyConfigUpdate(tt.update)
+
+			if tt.wantCalled {
+				if gotEnforce == nil {
+					t.Fatalf("enforcement was not invoked; expected it with enforce=%v", tt.wantEnforce)
+				}
+				if *gotEnforce != tt.wantEnforce {
+					t.Errorf("enforce = %v, want %v", *gotEnforce, tt.wantEnforce)
+				}
+			} else if gotEnforce != nil {
+				t.Errorf("enforcement was invoked (enforce=%v) but the payload should have been a no-op", *gotEnforce)
+			}
+		})
+	}
+}

--- a/agent/internal/winupdate/winupdate.go
+++ b/agent/internal/winupdate/winupdate.go
@@ -1,0 +1,117 @@
+// Package winupdate enforces "Breeze as the sole patch source" on Windows
+// endpoints (issue #1872). When enabled, it disables the native Windows Update
+// automatic-install channel by setting the documented Group Policy registry
+// value NoAutoUpdate=1 under
+//
+//	HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+//
+// NoAutoUpdate=1 stops the unattended, OS-initiated Automatic Updates client
+// only. It does NOT block the Windows Update Agent COM API
+// (Microsoft.Update.Session / IUpdateInstaller) that Breeze's own patch
+// installer drives — so Breeze's scan/approve/install path keeps working.
+//
+// Enforcement is fully reversible. Breeze records its own ownership with
+// sentinel values in the same key, and revert only touches state Breeze
+// created: a pre-existing admin Group Policy is detected and left as-found.
+//
+// The platform-independent decision logic (planAction) lives here so it can be
+// unit-tested on any OS; the registry I/O is in winupdate_windows.go, with a
+// no-op stub for other platforms in winupdate_stub.go.
+package winupdate
+
+// Result reports the outcome of an Apply call, for logging.
+type Result struct {
+	// Supported is false on non-Windows platforms (Apply is a no-op there).
+	Supported bool
+	// Managed is true when Breeze owns the NoAutoUpdate policy value after this
+	// call (its sentinel is present). False when a pre-existing admin GPO was
+	// left as-found, or after a revert.
+	Managed bool
+	// Enforced reports whether NoAutoUpdate is effectively 1 after the call.
+	Enforced bool
+	// Reverted is true when this call removed Breeze's prior enforcement.
+	Reverted bool
+	// Reason is a human-readable detail for slog.
+	Reason string
+}
+
+// regState is the observed state at the WindowsUpdate\AU policy key.
+type regState struct {
+	keyExists           bool
+	noAutoUpdatePresent bool
+	noAutoUpdateValue   uint32
+	// breezeManaged is true when Breeze's NoAutoUpdate ownership sentinel is set.
+	breezeManaged bool
+	// breezeCreatedKey is true when Breeze created the AU key itself (so revert
+	// may remove it again if it ends up empty).
+	breezeCreatedKey bool
+}
+
+// plan is the set of registry mutations needed to converge to the desired state.
+type plan struct {
+	// writeEnforcement: (create the key path as needed and) set NoAutoUpdate=1
+	// plus Breeze's ownership sentinel.
+	writeEnforcement bool
+	// recordKeyCreated: the AU key did not exist, so after creating it set the
+	// "Breeze created this key" sentinel for a clean revert later.
+	recordKeyCreated bool
+	// revert: delete NoAutoUpdate and Breeze's sentinels.
+	revert bool
+	// deleteKeyIfEmpty: after reverting, delete the AU key if Breeze created it
+	// and nothing else remains.
+	deleteKeyIfEmpty bool
+	// result is the Result to surface once the plan executes successfully.
+	result Result
+}
+
+// planAction decides what to do given the desired enforcement state and the
+// currently observed registry state. It is pure and side-effect free.
+func planAction(enforce bool, st regState) plan {
+	if enforce {
+		// A NoAutoUpdate value Breeze never set means a pre-existing admin Group
+		// Policy owns this key. Leave it as-found rather than clobber it.
+		if st.noAutoUpdatePresent && !st.breezeManaged {
+			return plan{result: Result{
+				Supported: true,
+				Managed:   false,
+				Enforced:  st.noAutoUpdateValue == 1,
+				Reason:    "pre-existing Windows Update policy detected (NoAutoUpdate already set by another GPO); left as-found, not managed by Breeze",
+			}}
+		}
+		reason := "Windows Update suppression applied (NoAutoUpdate=1)"
+		if st.breezeManaged && st.noAutoUpdatePresent && st.noAutoUpdateValue == 1 {
+			reason = "Windows Update suppression already in effect (re-asserted NoAutoUpdate=1)"
+		}
+		return plan{
+			writeEnforcement: true,
+			recordKeyCreated: !st.keyExists,
+			result: Result{
+				Supported: true,
+				Managed:   true,
+				Enforced:  true,
+				Reason:    reason,
+			},
+		}
+	}
+
+	// Revert path: only undo what Breeze itself set.
+	if !st.keyExists || !st.breezeManaged {
+		return plan{result: Result{
+			Supported: true,
+			Managed:   false,
+			Enforced:  st.keyExists && st.noAutoUpdatePresent && st.noAutoUpdateValue == 1,
+			Reason:    "no Breeze-managed Windows Update suppression to revert; left as-found",
+		}}
+	}
+	return plan{
+		revert:           true,
+		deleteKeyIfEmpty: st.breezeCreatedKey,
+		result: Result{
+			Supported: true,
+			Managed:   false,
+			Enforced:  false,
+			Reverted:  true,
+			Reason:    "reverted Breeze Windows Update suppression (deleted NoAutoUpdate)",
+		},
+	}
+}

--- a/agent/internal/winupdate/winupdate.go
+++ b/agent/internal/winupdate/winupdate.go
@@ -19,6 +19,71 @@
 // no-op stub for other platforms in winupdate_stub.go.
 package winupdate
 
+import "fmt"
+
+const (
+	// noAutoUpdateValue=1 disables the unattended Automatic Updates install
+	// channel (does not affect Breeze's WUA COM-driven installs).
+	noAutoUpdateValue = "NoAutoUpdate"
+	// breezeManagedValue marks the NoAutoUpdate value as Breeze-owned so revert
+	// never clobbers a pre-existing admin GPO.
+	breezeManagedValue = "BreezeManagedNoAutoUpdate"
+	// breezeCreatedKeyValue marks that Breeze created the AU key itself, so a
+	// revert can remove the key again if nothing else remains.
+	breezeCreatedKeyValue = "BreezeCreatedAUKey"
+)
+
+// regKey is the subset of registry key operations the revert path needs. It is
+// satisfied by golang.org/x/sys/windows/registry.Key (Windows) and by a fake in
+// tests, so executeRevert's safety logic is unit-tested on the Linux CI agent
+// where the real registry I/O cannot run.
+type regKey interface {
+	DeleteValue(name string) error
+	ReadValueNames(n int) ([]string, error)
+	ReadSubKeyNames(n int) ([]string, error)
+}
+
+// executeRevert deletes Breeze's managed value + ownership sentinels from an
+// already-open AU key, then reports whether the caller should delete the key
+// itself. It is pure registry-sequence logic with two safety guarantees:
+//
+//   - A delete that fails for any reason other than "value not present"
+//     (isNotExist) is propagated, not swallowed — otherwise a real ACCESS_DENIED
+//     would leave the ownership sentinel behind while the caller reported a
+//     successful revert (state divergence).
+//   - The AU key is only reported deletable when its emptiness is positively
+//     confirmed. A read error returns removeKey=false so a transient failure can
+//     never delete the key (and any admin-added values under it); the harmless
+//     empty key is left in place instead.
+func executeRevert(k regKey, deleteKeyIfEmpty bool, isNotExist func(error) bool) (removeKey bool, err error) {
+	del := func(name string) error {
+		if e := k.DeleteValue(name); e != nil && !isNotExist(e) {
+			return e
+		}
+		return nil
+	}
+	if e := del(noAutoUpdateValue); e != nil {
+		return false, fmt.Errorf("delete NoAutoUpdate: %w", e)
+	}
+	if e := del(breezeManagedValue); e != nil {
+		return false, fmt.Errorf("delete Breeze ownership sentinel: %w", e)
+	}
+	if e := del(breezeCreatedKeyValue); e != nil {
+		return false, fmt.Errorf("delete Breeze created-key sentinel: %w", e)
+	}
+
+	if !deleteKeyIfEmpty {
+		return false, nil
+	}
+	valueNames, vErr := k.ReadValueNames(-1)
+	subKeys, sErr := k.ReadSubKeyNames(-1)
+	if vErr != nil || sErr != nil {
+		// Cannot confirm the key is empty — do not delete it.
+		return false, nil
+	}
+	return len(valueNames) == 0 && len(subKeys) == 0, nil
+}
+
 // Result reports the outcome of an Apply call, for logging.
 type Result struct {
 	// Supported is false on non-Windows platforms (Apply is a no-op there).

--- a/agent/internal/winupdate/winupdate_stub.go
+++ b/agent/internal/winupdate/winupdate_stub.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package winupdate
+
+// Apply is a no-op on non-Windows platforms. Windows Update source enforcement
+// has no meaning on macOS/Linux, so the agent simply reports it unsupported.
+func Apply(enforce bool) (Result, error) {
+	return Result{
+		Supported: false,
+		Reason:    "Windows Update source enforcement is only supported on Windows",
+	}, nil
+}

--- a/agent/internal/winupdate/winupdate_stub_test.go
+++ b/agent/internal/winupdate/winupdate_stub_test.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package winupdate
+
+import "testing"
+
+func TestApplyStubUnsupportedOnNonWindows(t *testing.T) {
+	res, err := Apply(true)
+	if err != nil {
+		t.Fatalf("Apply returned error on non-Windows stub: %v", err)
+	}
+	if res.Supported {
+		t.Errorf("stub Apply reported Supported=true on non-Windows")
+	}
+}

--- a/agent/internal/winupdate/winupdate_test.go
+++ b/agent/internal/winupdate/winupdate_test.go
@@ -1,0 +1,119 @@
+package winupdate
+
+import "testing"
+
+// planAction is platform-independent, so these run on the Linux CI agent even
+// though the registry I/O in winupdate_windows.go does not.
+func TestPlanAction(t *testing.T) {
+	tests := []struct {
+		name          string
+		enforce       bool
+		st            regState
+		wantWrite     bool
+		wantRecordKey bool
+		wantRevert    bool
+		wantDeleteKey bool
+		wantManaged   bool
+		wantEnforced  bool
+		wantReverted  bool
+	}{
+		{
+			name:          "enforce on clean machine creates and manages the key",
+			enforce:       true,
+			st:            regState{keyExists: false},
+			wantWrite:     true,
+			wantRecordKey: true,
+			wantManaged:   true,
+			wantEnforced:  true,
+		},
+		{
+			name:         "enforce re-asserts when already Breeze-managed",
+			enforce:      true,
+			st:           regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 1, breezeManaged: true},
+			wantWrite:    true,
+			wantManaged:  true,
+			wantEnforced: true,
+		},
+		{
+			name:         "enforce leaves a pre-existing admin GPO (NoAutoUpdate=1) as-found",
+			enforce:      true,
+			st:           regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 1, breezeManaged: false},
+			wantWrite:    false,
+			wantManaged:  false,
+			wantEnforced: true, // reflects the admin's value, Breeze did not set it
+		},
+		{
+			name:         "enforce leaves a pre-existing admin NoAutoUpdate=0 as-found",
+			enforce:      true,
+			st:           regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 0, breezeManaged: false},
+			wantWrite:    false,
+			wantManaged:  false,
+			wantEnforced: false,
+		},
+		{
+			name:          "revert removes Breeze enforcement and deletes a Breeze-created key",
+			enforce:       false,
+			st:            regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 1, breezeManaged: true, breezeCreatedKey: true},
+			wantRevert:    true,
+			wantDeleteKey: true,
+			wantReverted:  true,
+			wantManaged:   false,
+			wantEnforced:  false,
+		},
+		{
+			name:          "revert keeps a pre-existing key Breeze did not create",
+			enforce:       false,
+			st:            regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 1, breezeManaged: true, breezeCreatedKey: false},
+			wantRevert:    true,
+			wantDeleteKey: false,
+			wantReverted:  true,
+		},
+		{
+			name:        "revert is a no-op when not Breeze-managed",
+			enforce:     false,
+			st:          regState{keyExists: true, noAutoUpdatePresent: true, noAutoUpdateValue: 1, breezeManaged: false},
+			wantRevert:  false,
+			wantManaged: false,
+			// Enforced reflects the surviving admin value.
+			wantEnforced: true,
+		},
+		{
+			name:    "revert is a no-op when the key is absent",
+			enforce: false,
+			st:      regState{keyExists: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planAction(tt.enforce, tt.st)
+			if p.writeEnforcement != tt.wantWrite {
+				t.Errorf("writeEnforcement = %v, want %v", p.writeEnforcement, tt.wantWrite)
+			}
+			if p.recordKeyCreated != tt.wantRecordKey {
+				t.Errorf("recordKeyCreated = %v, want %v", p.recordKeyCreated, tt.wantRecordKey)
+			}
+			if p.revert != tt.wantRevert {
+				t.Errorf("revert = %v, want %v", p.revert, tt.wantRevert)
+			}
+			if p.deleteKeyIfEmpty != tt.wantDeleteKey {
+				t.Errorf("deleteKeyIfEmpty = %v, want %v", p.deleteKeyIfEmpty, tt.wantDeleteKey)
+			}
+			if p.result.Managed != tt.wantManaged {
+				t.Errorf("result.Managed = %v, want %v", p.result.Managed, tt.wantManaged)
+			}
+			if p.result.Enforced != tt.wantEnforced {
+				t.Errorf("result.Enforced = %v, want %v", p.result.Enforced, tt.wantEnforced)
+			}
+			if p.result.Reverted != tt.wantReverted {
+				t.Errorf("result.Reverted = %v, want %v", p.result.Reverted, tt.wantReverted)
+			}
+			if !p.result.Supported {
+				t.Errorf("result.Supported = false, want true for planned action")
+			}
+			if p.result.Reason == "" {
+				t.Errorf("result.Reason is empty; want a human-readable detail")
+			}
+		})
+	}
+}

--- a/agent/internal/winupdate/winupdate_test.go
+++ b/agent/internal/winupdate/winupdate_test.go
@@ -1,6 +1,115 @@
 package winupdate
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
+
+var (
+	errFakeNotExist     = errors.New("value not present")
+	errFakeAccessDenied = errors.New("access denied")
+)
+
+func fakeIsNotExist(err error) bool { return errors.Is(err, errFakeNotExist) }
+
+// fakeRegKey implements regKey so executeRevert's safety logic runs on any OS.
+type fakeRegKey struct {
+	deleteErr     map[string]error // per-value-name error returned by DeleteValue
+	deleted       []string
+	valueNames    []string
+	valueNamesErr error
+	subKeys       []string
+	subKeysErr    error
+}
+
+func (f *fakeRegKey) DeleteValue(name string) error {
+	if e := f.deleteErr[name]; e != nil {
+		return e
+	}
+	f.deleted = append(f.deleted, name)
+	return nil
+}
+func (f *fakeRegKey) ReadValueNames(int) ([]string, error)  { return f.valueNames, f.valueNamesErr }
+func (f *fakeRegKey) ReadSubKeyNames(int) ([]string, error) { return f.subKeys, f.subKeysErr }
+
+func TestExecuteRevert(t *testing.T) {
+	t.Run("deletes all managed values and removes a confirmed-empty Breeze-created key", func(t *testing.T) {
+		k := &fakeRegKey{valueNames: []string{}, subKeys: []string{}}
+		removeKey, err := executeRevert(k, true, fakeIsNotExist)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !removeKey {
+			t.Errorf("removeKey = false, want true for a confirmed-empty created key")
+		}
+		if len(k.deleted) != 3 {
+			t.Errorf("deleted %v values, want 3 (NoAutoUpdate + 2 sentinels)", k.deleted)
+		}
+	})
+
+	t.Run("tolerates not-present values (idempotent revert)", func(t *testing.T) {
+		k := &fakeRegKey{
+			deleteErr:  map[string]error{noAutoUpdateValue: errFakeNotExist, breezeManagedValue: errFakeNotExist},
+			valueNames: []string{}, subKeys: []string{},
+		}
+		removeKey, err := executeRevert(k, true, fakeIsNotExist)
+		if err != nil {
+			t.Fatalf("unexpected error for not-present values: %v", err)
+		}
+		if !removeKey {
+			t.Errorf("removeKey = false, want true")
+		}
+	})
+
+	t.Run("propagates a real delete error instead of reporting a clean revert", func(t *testing.T) {
+		// ACCESS_DENIED on the ownership sentinel must surface — otherwise the
+		// sentinel persists while the caller reports Reverted:true.
+		k := &fakeRegKey{deleteErr: map[string]error{breezeManagedValue: errFakeAccessDenied}}
+		removeKey, err := executeRevert(k, true, fakeIsNotExist)
+		if err == nil {
+			t.Fatalf("expected error to propagate, got nil")
+		}
+		if !errors.Is(err, errFakeAccessDenied) {
+			t.Errorf("error = %v, want it to wrap access-denied", err)
+		}
+		if removeKey {
+			t.Errorf("removeKey = true after a failed delete; must be false")
+		}
+	})
+
+	t.Run("does NOT delete the key when emptiness cannot be confirmed (read error)", func(t *testing.T) {
+		k := &fakeRegKey{valueNamesErr: errFakeAccessDenied}
+		removeKey, err := executeRevert(k, true, fakeIsNotExist)
+		if err != nil {
+			t.Fatalf("read error should not fail the revert: %v", err)
+		}
+		if removeKey {
+			t.Errorf("removeKey = true on a read error; a transient failure must never delete the key")
+		}
+	})
+
+	t.Run("does NOT delete the key when other values remain", func(t *testing.T) {
+		k := &fakeRegKey{valueNames: []string{"SomeAdminValue"}, subKeys: []string{}}
+		removeKey, err := executeRevert(k, true, fakeIsNotExist)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if removeKey {
+			t.Errorf("removeKey = true with a surviving admin value; must be false")
+		}
+	})
+
+	t.Run("never deletes the key when deleteKeyIfEmpty is false", func(t *testing.T) {
+		k := &fakeRegKey{valueNames: []string{}, subKeys: []string{}}
+		removeKey, err := executeRevert(k, false, fakeIsNotExist)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if removeKey {
+			t.Errorf("removeKey = true with deleteKeyIfEmpty=false; must be false")
+		}
+	})
+}
 
 // planAction is platform-independent, so these run on the Linux CI agent even
 // though the registry I/O in winupdate_windows.go does not.

--- a/agent/internal/winupdate/winupdate_windows.go
+++ b/agent/internal/winupdate/winupdate_windows.go
@@ -9,20 +9,10 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-const (
-	// auKeyPath is the documented Group Policy location for the Automatic
-	// Updates client, relative to HKLM.
-	auKeyPath = `SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`
-	// noAutoUpdateValue=1 disables the unattended Automatic Updates install
-	// channel (does not affect Breeze's WUA COM-driven installs).
-	noAutoUpdateValue = "NoAutoUpdate"
-	// breezeManagedValue marks the NoAutoUpdate value as Breeze-owned so revert
-	// never clobbers a pre-existing admin GPO.
-	breezeManagedValue = "BreezeManagedNoAutoUpdate"
-	// breezeCreatedKeyValue marks that Breeze created the AU key itself, so a
-	// revert can remove the key again if nothing else remains.
-	breezeCreatedKeyValue = "BreezeCreatedAUKey"
-)
+// auKeyPath is the documented Group Policy location for the Automatic Updates
+// client, relative to HKLM. (The value-name constants are shared with the
+// platform-independent revert logic in winupdate.go.)
+const auKeyPath = `SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`
 
 // readState observes the current AU policy key without mutating it.
 func readState() (regState, error) {
@@ -94,25 +84,19 @@ func Apply(enforce bool) (Result, error) {
 		if e != nil {
 			return Result{Supported: true}, fmt.Errorf("open WindowsUpdate AU key for revert: %w", e)
 		}
-		// Delete our managed value and sentinels. Missing values are not an error
-		// (idempotent revert).
-		if e := k.DeleteValue(noAutoUpdateValue); e != nil && !errors.Is(e, registry.ErrNotExist) {
-			k.Close()
-			return Result{Supported: true}, fmt.Errorf("delete NoAutoUpdate: %w", e)
-		}
-		_ = k.DeleteValue(breezeManagedValue)
-		_ = k.DeleteValue(breezeCreatedKeyValue)
-
-		// If Breeze created the key and nothing else remains, remove it to fully
-		// restore the prior state. Leaving an empty key is harmless, so any
-		// failure here is non-fatal.
-		removeKey := false
-		if p.deleteKeyIfEmpty {
-			valueNames, _ := k.ReadValueNames(-1)
-			subKeys, _ := k.ReadSubKeyNames(-1)
-			removeKey = len(valueNames) == 0 && len(subKeys) == 0
-		}
+		// Delete our managed value + sentinels (idempotent: missing values are
+		// tolerated, real errors propagate) and decide whether the AU key itself
+		// should be removed. See executeRevert for the safety guarantees.
+		removeKey, rerr := executeRevert(k, p.deleteKeyIfEmpty, func(err error) bool {
+			return errors.Is(err, registry.ErrNotExist)
+		})
 		k.Close()
+		if rerr != nil {
+			return Result{Supported: true}, rerr
+		}
+		// If Breeze created the key and it is confirmed empty, remove it to fully
+		// restore the prior state. A leftover empty key is harmless, so a delete
+		// failure here is non-fatal.
 		if removeKey {
 			_ = registry.DeleteKey(registry.LOCAL_MACHINE, auKeyPath)
 		}

--- a/agent/internal/winupdate/winupdate_windows.go
+++ b/agent/internal/winupdate/winupdate_windows.go
@@ -1,0 +1,123 @@
+//go:build windows
+
+package winupdate
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	// auKeyPath is the documented Group Policy location for the Automatic
+	// Updates client, relative to HKLM.
+	auKeyPath = `SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`
+	// noAutoUpdateValue=1 disables the unattended Automatic Updates install
+	// channel (does not affect Breeze's WUA COM-driven installs).
+	noAutoUpdateValue = "NoAutoUpdate"
+	// breezeManagedValue marks the NoAutoUpdate value as Breeze-owned so revert
+	// never clobbers a pre-existing admin GPO.
+	breezeManagedValue = "BreezeManagedNoAutoUpdate"
+	// breezeCreatedKeyValue marks that Breeze created the AU key itself, so a
+	// revert can remove the key again if nothing else remains.
+	breezeCreatedKeyValue = "BreezeCreatedAUKey"
+)
+
+// readState observes the current AU policy key without mutating it.
+func readState() (regState, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, auKeyPath, registry.QUERY_VALUE)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return regState{keyExists: false}, nil
+		}
+		return regState{}, err
+	}
+	defer k.Close()
+
+	st := regState{keyExists: true}
+	if v, _, e := k.GetIntegerValue(noAutoUpdateValue); e == nil {
+		st.noAutoUpdatePresent = true
+		st.noAutoUpdateValue = uint32(v)
+	}
+	if v, _, e := k.GetIntegerValue(breezeManagedValue); e == nil && v == 1 {
+		st.breezeManaged = true
+	}
+	if v, _, e := k.GetIntegerValue(breezeCreatedKeyValue); e == nil && v == 1 {
+		st.breezeCreatedKey = true
+	}
+	return st, nil
+}
+
+// Apply converges the endpoint to the desired Windows Update suppression state.
+// enforce=true sets NoAutoUpdate=1 (managed by Breeze); enforce=false reverts
+// any enforcement Breeze previously applied. Caller logs the Result.
+func Apply(enforce bool) (Result, error) {
+	st, err := readState()
+	if err != nil {
+		return Result{Supported: true}, fmt.Errorf("read WindowsUpdate AU policy state: %w", err)
+	}
+
+	p := planAction(enforce, st)
+
+	if p.writeEnforcement {
+		k, existed, e := registry.CreateKey(registry.LOCAL_MACHINE, auKeyPath, registry.SET_VALUE|registry.QUERY_VALUE)
+		if e != nil {
+			return Result{Supported: true}, fmt.Errorf("open/create WindowsUpdate AU key: %w", e)
+		}
+		defer k.Close()
+		if e := k.SetDWordValue(noAutoUpdateValue, 1); e != nil {
+			return Result{Supported: true}, fmt.Errorf("set NoAutoUpdate: %w", e)
+		}
+		if e := k.SetDWordValue(breezeManagedValue, 1); e != nil {
+			// Without the ownership sentinel a future revert would refuse to act
+			// (it can't tell our value from an admin's). Surface it.
+			return Result{Supported: true, Enforced: true}, fmt.Errorf("set Breeze ownership sentinel: %w", e)
+		}
+		if p.recordKeyCreated && !existed {
+			// Best-effort: a missing created-key sentinel only means revert won't
+			// remove the (otherwise empty) key — harmless. Don't fail the apply.
+			_ = k.SetDWordValue(breezeCreatedKeyValue, 1)
+		}
+		// Verify the read-back so a silently-rejected write is reported.
+		got, _, gerr := k.GetIntegerValue(noAutoUpdateValue)
+		res := p.result
+		if gerr != nil || got != 1 {
+			res.Reason = "NoAutoUpdate write could not be verified (read-back mismatch)"
+			return res, fmt.Errorf("verify NoAutoUpdate read-back: got %d (err %v)", got, gerr)
+		}
+		return res, nil
+	}
+
+	if p.revert {
+		k, e := registry.OpenKey(registry.LOCAL_MACHINE, auKeyPath, registry.SET_VALUE|registry.QUERY_VALUE|registry.READ)
+		if e != nil {
+			return Result{Supported: true}, fmt.Errorf("open WindowsUpdate AU key for revert: %w", e)
+		}
+		// Delete our managed value and sentinels. Missing values are not an error
+		// (idempotent revert).
+		if e := k.DeleteValue(noAutoUpdateValue); e != nil && !errors.Is(e, registry.ErrNotExist) {
+			k.Close()
+			return Result{Supported: true}, fmt.Errorf("delete NoAutoUpdate: %w", e)
+		}
+		_ = k.DeleteValue(breezeManagedValue)
+		_ = k.DeleteValue(breezeCreatedKeyValue)
+
+		// If Breeze created the key and nothing else remains, remove it to fully
+		// restore the prior state. Leaving an empty key is harmless, so any
+		// failure here is non-fatal.
+		removeKey := false
+		if p.deleteKeyIfEmpty {
+			valueNames, _ := k.ReadValueNames(-1)
+			subKeys, _ := k.ReadSubKeyNames(-1)
+			removeKey = len(valueNames) == 0 && len(subKeys) == 0
+		}
+		k.Close()
+		if removeKey {
+			_ = registry.DeleteKey(registry.LOCAL_MACHINE, auKeyPath)
+		}
+		return p.result, nil
+	}
+
+	return p.result, nil
+}

--- a/apps/api/migrations/2026-07-06-patch-exclusive-windows-update.sql
+++ b/apps/api/migrations/2026-07-06-patch-exclusive-windows-update.sql
@@ -1,0 +1,9 @@
+-- Issue #1872: Config Policy option to enforce Breeze as the sole patch source.
+-- Adds a per-patch-feature-link toggle that, when enabled, tells the Windows
+-- agent to suppress the native Windows Update automatic-install channel
+-- (NoAutoUpdate=1) so updates only flow through Breeze's approval rings.
+-- Breeze's own WUA-driven install path (Microsoft.Update.Session COM API) is
+-- unaffected by NoAutoUpdate, which only governs the unattended OS-initiated
+-- Automatic Updates client.
+ALTER TABLE config_policy_patch_settings
+  ADD COLUMN IF NOT EXISTS exclusive_windows_update boolean NOT NULL DEFAULT false;

--- a/apps/api/src/db/schema/configurationPolicies.ts
+++ b/apps/api/src/db/schema/configurationPolicies.ts
@@ -182,6 +182,10 @@ export const configPolicyPatchSettings = pgTable('config_policy_patch_settings',
   scheduleDayOfWeek: varchar('schedule_day_of_week', { length: 10 }).default('sun'),
   scheduleDayOfMonth: integer('schedule_day_of_month').default(1),
   rebootPolicy: varchar('reboot_policy', { length: 20 }).notNull().default('if_required'),
+  // #1872: when true, the Windows agent suppresses the native Windows Update
+  // automatic-install channel (NoAutoUpdate=1) so patches flow only through
+  // Breeze. Breeze's own WUA-driven installs are unaffected.
+  exclusiveWindowsUpdate: boolean('exclusive_windows_update').notNull().default(false),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -869,7 +869,8 @@ describe('agent routes', () => {
         ],
         policy_config_state_probes: [
           { file_path: '/etc/ssh/sshd_config', config_key: 'PermitRootLogin' }
-        ]
+        ],
+        patch_source_settings: { exclusiveWindowsUpdate: false }
       });
     });
 
@@ -979,7 +980,8 @@ describe('agent routes', () => {
           collection_interval_minutes: 5,
         },
         policy_registry_state_probes: [],
-        policy_config_state_probes: []
+        policy_config_state_probes: [],
+        patch_source_settings: { exclusiveWindowsUpdate: false }
       });
       expect(insertValues).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -95,6 +95,7 @@ vi.mock('./helpers', () => ({
   buildMonitoringConfigUpdate: vi.fn(() => undefined),
   buildHelperConfigUpdate: vi.fn(() => undefined),
   buildPamConfigUpdate: vi.fn(async () => ({ uacInterceptionEnabled: false })),
+  buildPatchSourceConfigUpdate: vi.fn(async () => ({ exclusiveWindowsUpdate: false })),
   // Permissive default (staged + no window = upgrade anytime) so the upgrade
   // gating is transparent to tests that don't care about the org policy.
   getOrgAgentUpdatePolicy: vi.fn(async () => ({ policy: 'staged', maintenanceWindow: null })),
@@ -1034,6 +1035,38 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.uacInterceptionEnabled).toBe(false);
+  });
+
+  it('includes patch_source_settings in configUpdate when enforcement is enabled (#1872)', async () => {
+    const { buildPatchSourceConfigUpdate } = await import('./helpers');
+    vi.mocked(buildPatchSourceConfigUpdate).mockResolvedValueOnce({ exclusiveWindowsUpdate: true });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.patch_source_settings).toEqual({ exclusiveWindowsUpdate: true });
+  });
+
+  it('omits patch_source_settings when the patch resolver throws (no unintended revert)', async () => {
+    const { buildPatchSourceConfigUpdate } = await import('./helpers');
+    vi.mocked(buildPatchSourceConfigUpdate).mockRejectedValueOnce(new Error('boom'));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.patch_source_settings).toBeUndefined();
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -23,6 +23,7 @@ import {
   buildHelperConfigUpdate,
   buildPamConfigUpdate,
   buildOnedriveHelperConfigUpdate,
+  buildPatchSourceConfigUpdate,
   getOrgAgentUpdatePolicy,
   type OnedriveConfigUpdate,
 } from './helpers';
@@ -714,8 +715,19 @@ if (latestHelper) {
     captureException(err);
   }
 
+  // #1872: sole-patch-source enforcement. Omit the block on a resolver error so
+  // a transient failure never reverts an endpoint already under enforcement;
+  // a successful resolve with no patch policy returns false → agent reverts.
+  let patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null = null;
+  try {
+    patchSourceSettings = await buildPatchSourceConfigUpdate(device.id);
+  } catch (err) {
+    console.error(`[agents] failed to build patch_source config update for ${agentId}:`, err);
+    captureException(err);
+  }
+
   let mergedConfigUpdate: Record<string, unknown> | null = null;
-  if (configUpdate || eventLogSettings || monitoringSettings || onedriveSettings) {
+  if (configUpdate || eventLogSettings || monitoringSettings || onedriveSettings || patchSourceSettings) {
     mergedConfigUpdate = { ...(configUpdate ?? {}) };
     if (eventLogSettings) {
       mergedConfigUpdate.event_log_settings = eventLogSettings;
@@ -725,6 +737,9 @@ if (latestHelper) {
     }
     if (onedriveSettings) {
       mergedConfigUpdate.onedrive_helper_settings = onedriveSettings;
+    }
+    if (patchSourceSettings) {
+      mergedConfigUpdate.patch_source_settings = patchSourceSettings;
     }
   }
 

--- a/apps/api/src/routes/agents/helpers.patchSource.test.ts
+++ b/apps/api/src/routes/agents/helpers.patchSource.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for buildPatchSourceConfigUpdate (#1872) — the heartbeat helper that
+ * surfaces the sole-Windows-Update-source enforcement flag to the agent.
+ *
+ * resolvePatchConfigForDevice is mocked directly (its DB resolution is covered
+ * by configPolicyPatching/featureConfigResolver tests), so this file pins only
+ * the mapping the heartbeat relies on:
+ *   - no patch policy resolved (null) → { exclusiveWindowsUpdate: false }
+ *     (the revert-on-unassign contract — a device that loses its patch policy
+ *     must be told to revert, not left enforced)
+ *   - resolved row → pass the column through verbatim
+ *
+ * The load-time module mocks mirror helpers.pam.test.ts so helpers.ts imports
+ * cleanly without a real DB/Redis.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolvePatchConfigForDeviceMock } = vi.hoisted(() => ({
+  resolvePatchConfigForDeviceMock: vi.fn(),
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: {},
+  organizations: {},
+  deviceGroupMemberships: {},
+  configPolicyAssignments: {},
+  configurationPolicies: {},
+  configPolicyFeatureLinks: {},
+  pamOrgConfig: {},
+  softwarePolicies: {},
+  softwareComplianceStatus: {},
+  deviceCommands: { $inferSelect: {} },
+  deviceDisks: {},
+  deviceFilesystemSnapshots: {},
+  automationPolicies: {},
+  cisBaselines: {},
+  cisBaselineResults: {},
+  cisRemediationActions: {},
+  securityStatus: {},
+  securityThreats: {},
+  securityScans: {},
+  sensitiveDataFindings: {},
+  sensitiveDataScans: {},
+  sites: {},
+  users: {},
+  deviceGroups: {},
+  configPolicyMonitoringSettings: {},
+  configPolicyMonitoringWatches: {},
+  configPolicyEventLogSettings: {},
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: vi.fn(() => null) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/cisHardening', () => ({ parseCisCollectorOutput: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/featureConfigResolver', () => ({
+  resolvePatchConfigForDevice: resolvePatchConfigForDeviceMock,
+}));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../metrics', () => ({
+  recordSoftwareRemediationDecision: vi.fn(),
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({
+  scheduleSoftwareComplianceCheck: vi.fn(),
+}));
+vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
+
+import { buildPatchSourceConfigUpdate } from './helpers';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+
+describe('buildPatchSourceConfigUpdate (#1872)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns exclusiveWindowsUpdate:false when the device has no patch policy (revert-on-unassign)', async () => {
+    resolvePatchConfigForDeviceMock.mockResolvedValue(null);
+
+    const result = await buildPatchSourceConfigUpdate(DEVICE_ID);
+
+    expect(result).toEqual({ exclusiveWindowsUpdate: false });
+  });
+
+  it('passes through exclusiveWindowsUpdate:true from a resolved patch settings row', async () => {
+    resolvePatchConfigForDeviceMock.mockResolvedValue({ exclusiveWindowsUpdate: true });
+
+    const result = await buildPatchSourceConfigUpdate(DEVICE_ID);
+
+    expect(result).toEqual({ exclusiveWindowsUpdate: true });
+  });
+
+  it('passes through exclusiveWindowsUpdate:false from a resolved patch settings row', async () => {
+    resolvePatchConfigForDeviceMock.mockResolvedValue({ exclusiveWindowsUpdate: false });
+
+    const result = await buildPatchSourceConfigUpdate(DEVICE_ID);
+
+    expect(result).toEqual({ exclusiveWindowsUpdate: false });
+  });
+
+  it('coerces a missing column on a resolved row to false (back-compat)', async () => {
+    // A pre-migration row read back without the column must not push undefined.
+    resolvePatchConfigForDeviceMock.mockResolvedValue({ rebootPolicy: 'if_required' });
+
+    const result = await buildPatchSourceConfigUpdate(DEVICE_ID);
+
+    expect(result).toEqual({ exclusiveWindowsUpdate: false });
+  });
+});

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -51,6 +51,7 @@ import {
   upsertFilesystemScanState,
 } from '../../services/filesystemAnalysis';
 import { recordSoftwarePolicyAudit } from '../../services/softwarePolicyService';
+import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
 import { captureException } from '../../services/sentry';
 import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { isAllowedPolicyConfigProbe } from './policyProbeSafety';
@@ -2392,6 +2393,34 @@ export async function buildPamConfigUpdate(deviceId: string): Promise<PamSetting
   }
 
   return settings;
+}
+
+// ============================================
+// Patch Source Enforcement Config (#1872)
+// ============================================
+
+export interface PatchSourceSettings {
+  /**
+   * When true the Windows agent suppresses the native Windows Update
+   * automatic-install channel (NoAutoUpdate=1) so updates flow only through
+   * Breeze's approval rings. False explicitly tells the agent to revert any
+   * enforcement Breeze previously applied (a pre-existing admin GPO is left
+   * untouched, agent-side). Breeze's own WUA-driven install path is unaffected.
+   */
+  exclusiveWindowsUpdate: boolean;
+}
+
+/**
+ * Resolves the patch feature link for the device and surfaces the
+ * sole-source-enforcement flag for the heartbeat config push. A device with no
+ * patch policy assigned resolves to `false`, which the agent treats as "revert
+ * any prior Breeze enforcement" — so removing the policy cleanly reverts the
+ * endpoint. The caller (heartbeat) omits the block entirely on a resolver error
+ * so a transient failure never triggers an unintended revert.
+ */
+export async function buildPatchSourceConfigUpdate(deviceId: string): Promise<PatchSourceSettings> {
+  const patch = await resolvePatchConfigForDevice(deviceId);
+  return { exclusiveWindowsUpdate: patch?.exclusiveWindowsUpdate ?? false };
 }
 
 // ============================================

--- a/apps/api/src/services/configPolicyPatching.test.ts
+++ b/apps/api/src/services/configPolicyPatching.test.ts
@@ -84,6 +84,7 @@ describe('normalizePatchInlineSettings', () => {
       scheduleDayOfWeek: 'mon',
       scheduleDayOfMonth: 15,
       rebootPolicy: 'always',
+      exclusiveWindowsUpdate: true,
     };
 
     const result = normalizePatchInlineSettings(input);
@@ -96,6 +97,7 @@ describe('normalizePatchInlineSettings', () => {
     expect(result.scheduleDayOfWeek).toBe('mon');
     expect(result.scheduleDayOfMonth).toBe(15);
     expect(result.rebootPolicy).toBe('always');
+    expect(result.exclusiveWindowsUpdate).toBe(true);
   });
 
   it('returns defaults when given empty object', () => {
@@ -109,6 +111,8 @@ describe('normalizePatchInlineSettings', () => {
     expect(result.scheduleDayOfWeek).toBe('sun');
     expect(result.scheduleDayOfMonth).toBe(1);
     expect(result.rebootPolicy).toBe('if_required');
+    // #1872: sole-patch-source enforcement is opt-in (off by default).
+    expect(result.exclusiveWindowsUpdate).toBe(false);
   });
 
   it('returns defaults when given null', () => {
@@ -235,6 +239,32 @@ describe('loadPolicyLocalPatchConfig', () => {
     expect(result?.settings.apps).toEqual([
       { source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' },
     ]);
+  });
+
+  it('surfaces exclusiveWindowsUpdate from the normalized column (#1872)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(selectJoinLimitRows([{
+      configPolicyId: 'policy-1',
+      configPolicyName: 'Policy 1',
+      orgId: 'org-1',
+      featureLinkId: 'link-1',
+      featurePolicyId: null,
+      storedInlineSettings: { sources: ['os'] },
+      patchSettings: {
+        sources: ['os'],
+        autoApprove: false,
+        autoApproveSeverities: [],
+        scheduleFrequency: 'weekly',
+        scheduleTime: '02:00',
+        scheduleDayOfWeek: 'sun',
+        scheduleDayOfMonth: 1,
+        rebootPolicy: 'if_required',
+        exclusiveWindowsUpdate: true,
+      },
+    }]) as any);
+
+    const result = await loadPolicyLocalPatchConfig('policy-1');
+
+    expect(result?.settings.exclusiveWindowsUpdate).toBe(true);
   });
 
   it('salvages valid app rules and deferral when stored inline JSON is malformed, with warn + Sentry', async () => {

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -297,6 +297,7 @@ export async function loadPolicyLocalPatchConfig(
         scheduleDayOfWeek: row.patchSettings.scheduleDayOfWeek ?? undefined,
         scheduleDayOfMonth: row.patchSettings.scheduleDayOfMonth ?? undefined,
         rebootPolicy: row.patchSettings.rebootPolicy,
+        exclusiveWindowsUpdate: row.patchSettings.exclusiveWindowsUpdate,
       })
     : storedInline;
 
@@ -372,6 +373,7 @@ export async function backfillMissingPatchSettings(): Promise<{
       scheduleDayOfWeek: normalized.settings.scheduleDayOfWeek,
       scheduleDayOfMonth: normalized.settings.scheduleDayOfMonth,
       rebootPolicy: normalized.settings.rebootPolicy,
+      exclusiveWindowsUpdate: normalized.settings.exclusiveWindowsUpdate,
     });
     repaired += 1;
     if (normalized.valid) repairedFromInline += 1;

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -384,6 +384,7 @@ async function decomposeInlineSettings(
         scheduleDayOfWeek: parsed.scheduleDayOfWeek,
         scheduleDayOfMonth: parsed.scheduleDayOfMonth,
         rebootPolicy: parsed.rebootPolicy,
+        exclusiveWindowsUpdate: parsed.exclusiveWindowsUpdate,
       });
       break;
     }
@@ -711,6 +712,7 @@ async function assembleInlineSettings(
         scheduleDayOfWeek: row.scheduleDayOfWeek,
         scheduleDayOfMonth: row.scheduleDayOfMonth,
         rebootPolicy: row.rebootPolicy,
+        exclusiveWindowsUpdate: row.exclusiveWindowsUpdate,
       };
     }
 

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.test.tsx
@@ -139,6 +139,41 @@ describe('PatchTab', () => {
     await waitFor(() => expect(saveMock).toHaveBeenCalled());
   });
 
+  // #1872: sole-patch-source enforcement toggle.
+  it('renders the exclusive Windows Update toggle, off by default', async () => {
+    render(<PatchTab {...baseProps} />);
+    const toggle = await screen.findByTestId('patch-exclusive-windows-update-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByText('Manage Windows Update exclusively through Breeze')).toBeInTheDocument();
+  });
+
+  it('persists exclusiveWindowsUpdate=true in the save payload when toggled on', async () => {
+    render(<PatchTab {...baseProps} />);
+    fireEvent.click(await screen.findByTestId('patch-exclusive-windows-update-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const [, payload] = saveMock.mock.calls[0];
+    expect(payload.inlineSettings.exclusiveWindowsUpdate).toBe(true);
+  });
+
+  it('hydrates the toggle from a stored exclusiveWindowsUpdate value', async () => {
+    render(
+      <PatchTab
+        {...baseProps}
+        existingLink={{
+          id: 'link-1',
+          featureType: 'patch',
+          featurePolicyId: null,
+          inlineSettings: { sources: ['os'], exclusiveWindowsUpdate: true },
+        }}
+      />
+    );
+    const toggle = await screen.findByTestId('patch-exclusive-windows-update-toggle');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
   describe('inline ring editor', () => {
     it('creates a ring inline, refetches, and auto-selects it', async () => {
       fetchMock.mockImplementation((_url: any, opts: any) => {

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -29,6 +29,7 @@ type PatchDeploymentSettings = {
   scheduleDayOfWeek: string;
   scheduleDayOfMonth: number;
   rebootPolicy: RebootPolicy;
+  exclusiveWindowsUpdate: boolean;
 };
 
 const defaults: PatchDeploymentSettings = {
@@ -42,6 +43,7 @@ const defaults: PatchDeploymentSettings = {
   scheduleDayOfWeek: 'sun',
   scheduleDayOfMonth: 1,
   rebootPolicy: 'if_required',
+  exclusiveWindowsUpdate: false,
 };
 
 const OS_VALUE_ALIASES = new Set(['os', 'microsoft', 'apple', 'linux']);
@@ -417,6 +419,40 @@ export default function PatchTab({ policyId, existingLink, onLinkChanged, linked
               <span className="text-xs text-muted-foreground">{option.description}</span>
             </label>
           ))}
+        </div>
+      </div>
+
+      {/* Windows Update source enforcement (#1872) */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold">Windows Update Source</h3>
+        <div className="mt-2 flex items-center justify-between rounded-md border bg-background px-4 py-3">
+          <div className="pr-4">
+            <p className="text-sm font-medium">Manage Windows Update exclusively through Breeze</p>
+            <p className="text-xs text-muted-foreground">
+              Suppresses the endpoint&apos;s native Windows Update automatic-install channel so updates only
+              flow through Breeze&apos;s approval rings — preventing unexpected reboots and patches outside
+              your schedule. Windows-only; Breeze&apos;s own scan/approve/install path is unaffected. Reverts
+              cleanly when disabled (a pre-existing admin Group Policy is left untouched).
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.exclusiveWindowsUpdate}
+            data-testid="patch-exclusive-windows-update-toggle"
+            onClick={() => update('exclusiveWindowsUpdate', !settings.exclusiveWindowsUpdate)}
+            className={cn(
+              'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition',
+              settings.exclusiveWindowsUpdate ? 'bg-emerald-500/80' : 'bg-muted'
+            )}
+          >
+            <span
+              className={cn(
+                'inline-block h-5 w-5 rounded-full bg-white transition',
+                settings.exclusiveWindowsUpdate ? 'translate-x-5' : 'translate-x-1'
+              )}
+            />
+          </button>
         </div>
       </div>
 

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -571,6 +571,10 @@ export const patchInlineSettingsSchema = z.object({
   scheduleDayOfWeek: z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']).default('sun'),
   scheduleDayOfMonth: z.number().int().min(1).max(28).default(1),
   rebootPolicy: z.enum(['never', 'if_required', 'always', 'maintenance_window']).default('if_required'),
+  // #1872: enforce Breeze as the sole patch source on Windows endpoints. When
+  // true the agent suppresses the native Windows Update automatic-install
+  // channel (NoAutoUpdate=1); Breeze's own WUA-driven installs are unaffected.
+  exclusiveWindowsUpdate: z.boolean().default(false),
 }).superRefine((data, ctx) => {
   if (data.autoApprove && data.autoApproveSeverities.length === 0) {
     ctx.addIssue({


### PR DESCRIPTION
## What

Adds a Configuration Policy (Patches tab) toggle — **"Manage Windows Update exclusively through Breeze"** — that suppresses an endpoint's native Windows Update automatic-install channel so updates only flow through Breeze's approval rings (no unexpected reboots, no patches outside the policy's schedule/rings).

Closes #1872. Design direction was approved by the owner in the issue thread.

## Enforcement mechanism + reversibility

- **Mechanism:** the Windows agent sets the documented Group Policy value `NoAutoUpdate=1` under `HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`. This disables the unattended, OS-initiated **Automatic Updates** client.
- **Breeze's own install path is unaffected.** `NoAutoUpdate` governs only the automatic-update agent, not the WUA COM API. Breeze installs via `Microsoft.Update.Session` / `IUpdateInstaller` (`agent/internal/patching/windows.go:65,245`), which keeps working — suppression targets only the *unattended OS-initiated* channel, exactly as the issue requires.
- **Fully reversible + logged.** Breeze records ownership with sentinel registry values (`BreezeManagedNoAutoUpdate`, `BreezeCreatedAUKey`) in the same key — mirroring the existing peripheral-enforcement pattern (`enforce_windows.go`). On revert it deletes only what Breeze set (and removes the AU key if Breeze created it and it is now empty). A **pre-existing admin GPO is detected and left as-found** (logged, not clobbered). Every set/revert is logged via slog using `err.Error()`.
- **Windows-only.** No-op stub on macOS/Linux.

## Layers / key files

**Web** — `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx:34,93` (new `exclusiveWindowsUpdate` setting + toggle UI in a "Windows Update Source" section).

**API**
- `apps/api/migrations/2026-07-06-patch-exclusive-windows-update.sql` — idempotent `ADD COLUMN exclusive_windows_update`.
- `apps/api/src/db/schema/configurationPolicies.ts:184` — column on `config_policy_patch_settings`.
- `packages/shared/src/validators/index.ts:574` — `exclusiveWindowsUpdate` on `patchInlineSettingsSchema` (default false).
- `apps/api/src/services/configurationPolicy.ts:386,713` and `apps/api/src/services/configPolicyPatching.ts:299,373` — decompose/assemble/resolve threading.
- `apps/api/src/routes/agents/helpers.ts:2401` (`buildPatchSourceConfigUpdate`) + `apps/api/src/routes/agents/heartbeat.ts:717` — pushed to the agent in the heartbeat `configUpdate` as `patch_source_settings`. Omitted on resolver error (a transient failure must not trigger an unintended revert); a successful resolve with no patch policy returns `false` → agent reverts cleanly.

**Agent (Go)**
- `agent/internal/winupdate/` — new package: pure, platform-independent decision logic (`planAction`), Windows registry I/O (`winupdate_windows.go`), and non-Windows stub.
- `agent/internal/heartbeat/patch_source.go` + `agent/internal/heartbeat/heartbeat.go:1646` — applies the `patch_source_settings` block from the heartbeat config update.

## Tests

- **Go:** `winupdate_test.go` (CI-runnable on Linux) covers all `planAction` cases — clean-machine enforce, re-assert, pre-existing-GPO left as-found (NoAutoUpdate=1 and =0), revert with/without Breeze-created key, no-op when not Breeze-managed, no-op when key absent. Stub no-op test gated to non-Windows. `go test -race ./internal/winupdate/... ./internal/heartbeat/...` green; cross-compiles for `GOOS=windows`.
- **API:** `configPolicyPatching.test.ts` (default false + pass-through + column→resolution surfacing), `heartbeat.test.ts` (block included when enabled; omitted when resolver throws).
- **Web:** `PatchTab.test.tsx` (toggle renders off by default, persists `true` in save payload, hydrates from stored value).

### Verification
- `vitest run` (no-file-parallelism): configPolicyPatching (40), heartbeat (45), configurationPolicy (31), shared validators (930), autoMigrate ordering (43), PatchTab web (11) — all green.
- `tsc --noEmit` clean for `@breeze/shared`, `@breeze/api`, `@breeze/web`.
- `db:check-drift` could not run locally (no Postgres/Docker available); the migration mirrors the schema column exactly (same type + default), matching every other column's pattern.

## Notes / scope
- Per the issue, this only adds the **source-enforcement** toggle to the current Patches tab where the other patch settings live. It does **not** touch #1317's planned move of approval rules to Update Rings — if that later relocates settings, this toggle moves with them as a separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)