### PR TITLE
feat(pam): pin cert thumbprint for signer matching, not just subject CN (#1776)

### DIFF
--- a/agent/internal/etwlua/etwlua.go
+++ b/agent/internal/etwlua/etwlua.go
@@ -68,6 +68,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -107,9 +108,20 @@ type Event struct {
 	// nullable hash.
 	TargetExecutableHash string `json:"target_executable_hash,omitempty"`
 
-	// TargetExecutableSigner is the Authenticode subject (best-effort).
-	// Empty when unsigned or read failed.
+	// TargetExecutableSigner is the Authenticode subject CN (best-effort).
+	// Empty when unsigned or read failed. WEAK signer tier on the server: a
+	// subject CN is attacker-choosable, so CN-only matching is spoofable.
 	TargetExecutableSigner string `json:"target_executable_signer,omitempty"`
+
+	// TargetExecutableSignerThumbprint is the SHA-256 Authenticode leaf-cert
+	// thumbprint as lowercase 64-char hex (#1776). STRONG signer tier: the
+	// server pins this for tamper-proof publisher matching (a forged cert with
+	// a trusted CN but a different key has a different thumbprint and is
+	// rejected). Empty when unsigned, on read failure, or until the Windows
+	// extraction lands — the server treats absence as "no thumbprint" and a
+	// thumbprint-pinned rule then fails closed. Normalize via
+	// NormalizeThumbprint before populating.
+	TargetExecutableSignerThumbprint string `json:"target_executable_signer_thumbprint,omitempty"`
 
 	// PID, ParentImage, CommandLine are process metadata included for
 	// forensics. CommandLine is best-effort and may be empty on locked-
@@ -349,6 +361,38 @@ func handleEvent(ctx context.Context, ev Event, limiter *ipc.RateLimiter, hb Hea
 			log.Debug("etwlua: opportunistic drain failed", "error", err.Error())
 		}
 	}
+}
+
+// NormalizeThumbprint canonicalizes a raw SHA-256 certificate thumbprint into
+// the lowercase 64-char hex form the server matches on (#1776). It drops the
+// separators Windows/CryptoAPI and PowerShell render between byte pairs (spaces,
+// colons, dashes, tabs/newlines, NUL padding) and lowercases A-F. It returns
+// ("", false) unless the result is EXACTLY 64 hex chars, and rejects any other
+// character outright — a malformed or wrong-length value is never sent, so the
+// server can't match on a half-formed pin (fail closed). The Windows
+// Authenticode extraction (still deferred — see etwlua_windows.go) will pass
+// its computed thumbprint through this before assigning Event.TargetExecutableSignerThumbprint.
+func NormalizeThumbprint(raw string) (string, bool) {
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range raw {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'F':
+			b.WriteRune(r + ('a' - 'A'))
+		case r == ' ' || r == ':' || r == '-' || r == '\t' || r == '\n' || r == '\r' || r == 0x00:
+			// separator / whitespace / NUL padding between byte pairs — skip
+		default:
+			// Any other character makes the whole value suspect → reject.
+			return "", false
+		}
+	}
+	s := b.String()
+	if len(s) != 64 {
+		return "", false
+	}
+	return s, true
 }
 
 // dedupeKey returns sha256(exe_path) + ":" + subject_username. Hashing the

--- a/agent/internal/etwlua/etwlua_thumbprint_test.go
+++ b/agent/internal/etwlua/etwlua_thumbprint_test.go
@@ -1,0 +1,66 @@
+package etwlua
+
+import "testing"
+
+func TestNormalizeThumbprint(t *testing.T) {
+	const hex64 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantOK  bool
+	}{
+		{name: "plain lowercase 64-hex", raw: hex64, want: hex64, wantOK: true},
+		{
+			name:   "uppercase is lowercased",
+			raw:    "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+			want:   hex64,
+			wantOK: true,
+		},
+		{
+			name:   "colon-separated byte pairs (PowerShell/CertUtil style)",
+			raw:    "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+			want:   hex64,
+			wantOK: true,
+		},
+		{
+			name:   "spaces and trailing NUL padding stripped",
+			raw:    "ab cd ef 01 23 45 67 89 ab cd ef 01 23 45 67 89 ab cd ef 01 23 45 67 89 ab cd ef 01 23 45 67 89\x00",
+			want:   hex64,
+			wantOK: true,
+		},
+		{name: "empty", raw: "", want: "", wantOK: false},
+		{name: "too short (SHA-1 40-hex) rejected", raw: "abcdef0123456789abcdef0123456789abcdef01", want: "", wantOK: false},
+		{
+			name:   "too long rejected",
+			raw:    hex64 + "ab",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "non-hex char rejected (no half-formed pin)",
+			raw:    "zbcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "0x prefix rejected",
+			raw:    "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+			want:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NormalizeThumbprint(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("NormalizeThumbprint(%q) ok = %v, want %v", tt.raw, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeThumbprint(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/internal/etwlua/etwlua_windows.go
+++ b/agent/internal/etwlua/etwlua_windows.go
@@ -181,8 +181,15 @@ func decodeConsentRequest(raw []byte) (Event, bool) {
 	if hash, err := hashFile(targetPath); err == nil {
 		ev.TargetExecutableHash = hash
 	}
-	// Authenticode signer extraction is deferred (WinTrust/CryptoAPI) — see
-	// #1776. The server schema accepts a NULL signer.
+	// Authenticode signer extraction is still deferred (WinTrust/CryptoAPI) —
+	// see #1776. When wired in, this must populate BOTH the subject CN
+	// (ev.TargetExecutableSigner, weak tier) and the SHA-256 leaf-cert
+	// thumbprint (ev.TargetExecutableSignerThumbprint, strong tier) via
+	// NormalizeThumbprint; the server/payload fields and matching already
+	// accept the thumbprint. The actual extraction needs a Windows CI runner to
+	// validate (same blocker as #1771), so it remains a follow-up. The server
+	// schema accepts a NULL signer and a NULL thumbprint, and a thumbprint-pinned
+	// rule fails closed until the agent emits one.
 	return ev, true
 }
 

--- a/apps/api/migrations/2026-06-29-pam-signer-thumbprint.sql
+++ b/apps/api/migrations/2026-06-29-pam-signer-thumbprint.sql
@@ -1,0 +1,28 @@
+-- PAM signer-group / rule certificate thumbprint pinning (#1776).
+--
+-- Subject-CN-only signer matching is spoofable (anyone can mint a cert bearing
+-- a trusted CN), and with the trusted-publisher catalog (#1771) a matched
+-- signer can auto-approve privilege elevation. This adds a STRONG tier: pin the
+-- SHA-256 Authenticode leaf-cert thumbprint, which is bound to a specific key
+-- and not forgeable. CN matching stays as the clearly-labeled WEAK/legacy tier.
+--
+-- Additive + backward-compatible:
+--   * pam_rules gains a nullable match_signer_thumbprint (parallel to
+--     match_signer); existing rows are untouched.
+--   * pam_signer_groups.signers keeps its jsonb column — its element shape
+--     evolves in app code from `string[]` (bare CNs) to entry objects that may
+--     carry a thumbprint. A read normalizer (normalizeSignerGroupEntries) maps
+--     legacy bare strings to {subjectCn}, so existing rows need NO data
+--     migration and keep matching on CN exactly as before. No SQL change is
+--     required for that column.
+--
+-- Tenancy: both tables are RLS Shape 1 (direct org_id), already enabled +
+-- forced. Adding a column does not change the tenancy shape and needs no new
+-- policy — the existing breeze_has_org_access(org_id) policies cover the new
+-- column. No rls-coverage allowlist change.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. Re-applying is a no-op. autoMigrate
+-- wraps each file in a transaction; no inner BEGIN/COMMIT.
+
+ALTER TABLE pam_rules
+  ADD COLUMN IF NOT EXISTS match_signer_thumbprint varchar(64);

--- a/apps/api/src/db/schema/pam.test.ts
+++ b/apps/api/src/db/schema/pam.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for normalizeSignerGroupEntries (#1776) — the read-normalizer that
+ * maps the persisted pam_signer_groups.signers jsonb (legacy bare CNs and/or
+ * new entry objects) to the canonical entries the PAM engine matches against.
+ * Its job is to defend against untrusted jsonb (DB tamper / manual edits /
+ * future writers), so the security-relevant behavior is: a PRESENT-but-invalid
+ * thumbprint must NOT degrade to a weak CN match.
+ */
+import { describe, expect, it } from 'vitest';
+import { normalizeSignerGroupEntries } from './pam';
+
+const TP = 'a'.repeat(64);
+
+describe('normalizeSignerGroupEntries', () => {
+  it('maps legacy bare-CN strings to weak CN entries (backward-compat)', () => {
+    expect(normalizeSignerGroupEntries(['Acme Corp', '  Beta Inc  '])).toEqual([
+      { subjectCn: 'Acme Corp' },
+      { subjectCn: 'Beta Inc' },
+    ]);
+  });
+
+  it('keeps a CN-only object entry as a weak entry', () => {
+    expect(normalizeSignerGroupEntries([{ subjectCn: 'Acme Corp' }])).toEqual([
+      { subjectCn: 'Acme Corp' },
+    ]);
+  });
+
+  it('lowercases and preserves a valid thumbprint pin (strong)', () => {
+    expect(
+      normalizeSignerGroupEntries([{ subjectCn: 'Acme Corp', thumbprint: TP.toUpperCase() }]),
+    ).toEqual([{ subjectCn: 'Acme Corp', thumbprint: TP }]);
+    expect(normalizeSignerGroupEntries([{ thumbprint: TP }])).toEqual([{ thumbprint: TP }]);
+  });
+
+  it('DROPS an entry whose thumbprint is PRESENT but malformed — never degrades to CN-only (#1776)', () => {
+    // A corrupted strong pin must fail closed, not silently become a weak CN
+    // entry that a forged "Acme Corp" cert could match.
+    expect(
+      normalizeSignerGroupEntries([{ subjectCn: 'Acme Corp', thumbprint: 'not-a-real-hash' }]),
+    ).toEqual([]);
+    // wrong length (SHA-1) is also dropped
+    expect(
+      normalizeSignerGroupEntries([{ subjectCn: 'Acme Corp', thumbprint: 'a'.repeat(40) }]),
+    ).toEqual([]);
+    // thumbprint-only but malformed → dropped (no CN to fall back to anyway)
+    expect(normalizeSignerGroupEntries([{ thumbprint: 'zzz' }])).toEqual([]);
+  });
+
+  it('treats an absent/empty thumbprint field as a legitimate CN-only entry', () => {
+    expect(normalizeSignerGroupEntries([{ subjectCn: 'Acme Corp', thumbprint: '   ' }])).toEqual([
+      { subjectCn: 'Acme Corp' },
+    ]);
+  });
+
+  it('tolerates arbitrary jsonb (fail closed)', () => {
+    expect(normalizeSignerGroupEntries(null)).toEqual([]);
+    expect(normalizeSignerGroupEntries('nope')).toEqual([]);
+    expect(normalizeSignerGroupEntries([{}, 42, null, '', { subjectCn: '   ' }])).toEqual([]);
+  });
+});

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -54,6 +54,7 @@ export interface PamRuleTimeWindow {
  */
 export const PAM_RULE_NEGATE_KEYS = [
   'signer',
+  'signerThumbprint',
   'signerGroup',
   'hash',
   'pathGlob',
@@ -65,6 +66,62 @@ export const PAM_RULE_NEGATE_KEYS = [
   'riskTier',
 ] as const;
 export type PamRuleNegateKey = (typeof PAM_RULE_NEGATE_KEYS)[number];
+
+/**
+ * Signer-group catalog entry (#1776). A group pins a publisher by:
+ *   - subject CN only (WEAK tier — attacker-choosable, kept for back-compat);
+ *   - SHA-256 Authenticode leaf-cert thumbprint only (STRONG tier — bound to a
+ *     specific key, not forgeable without the private key); or
+ *   - both (STRONG — the engine requires BOTH to match; see pamRuleEngine).
+ * `thumbprint` is lowercase 64-char hex. A thumbprint-pinned entry NEVER falls
+ * through to a CN match, so a forged cert bearing a trusted CN but a different
+ * thumbprint is rejected — the elevation-of-privilege threat #1776 closes.
+ */
+export type SignerGroupEntry =
+  | { subjectCn: string; thumbprint?: string }
+  | { thumbprint: string };
+
+/**
+ * As persisted in pam_signer_groups.signers (jsonb). Backward-compatible with
+ * the legacy `string[]` form: a bare string is a subject-CN-only entry. New
+ * writes use the object form. normalizeSignerGroupEntries() maps either to the
+ * canonical SignerGroupEntry the engine consumes — existing rows need no data
+ * migration. The stored object form is intentionally looser than
+ * SignerGroupEntry (both fields optional) so a malformed/partial row can't be a
+ * type error on read; the normalizer drops entries with neither field.
+ */
+export type StoredSignerEntry = string | { subjectCn?: string; thumbprint?: string };
+
+const SIGNER_THUMBPRINT_RE = /^[0-9a-f]{64}$/;
+
+/**
+ * Normalize the persisted `signers` array (legacy bare CNs and/or new entry
+ * objects) into the canonical SignerGroupEntry[] the engine matches against.
+ * Defensive: tolerates arbitrary jsonb (returns [] for non-arrays), trims, and
+ * drops entries that carry neither a usable CN nor a valid 64-hex thumbprint
+ * (fail closed — a junk entry must never widen a match).
+ */
+export function normalizeSignerGroupEntries(raw: unknown): SignerGroupEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SignerGroupEntry[] = [];
+  for (const el of raw) {
+    if (typeof el === 'string') {
+      const cn = el.trim();
+      if (cn) out.push({ subjectCn: cn });
+      continue;
+    }
+    if (el && typeof el === 'object') {
+      const rec = el as { subjectCn?: unknown; thumbprint?: unknown };
+      const cn = typeof rec.subjectCn === 'string' ? rec.subjectCn.trim() : '';
+      const tpRaw = typeof rec.thumbprint === 'string' ? rec.thumbprint.trim().toLowerCase() : '';
+      const tp = SIGNER_THUMBPRINT_RE.test(tpRaw) ? tpRaw : '';
+      if (cn && tp) out.push({ subjectCn: cn, thumbprint: tp });
+      else if (tp) out.push({ thumbprint: tp });
+      else if (cn) out.push({ subjectCn: cn });
+    }
+  }
+  return out;
+}
 
 /** Default verdict applied when no software policy or PAM rule matches. */
 export const pamUnmatchedVerdictEnum = pgEnum('pam_unmatched_verdict', [
@@ -91,9 +148,12 @@ export const pamSignerGroups = pgTable(
       .references(() => organizations.id, { onDelete: 'cascade' }),
     name: varchar('name', { length: 255 }).notNull(),
     description: text('description'),
-    // Signer subject-CN patterns; matched case-insensitively, exact (same
-    // semantics as pam_rules.match_signer). Empty = matches nothing.
-    signers: jsonb('signers').$type<string[]>().notNull().default([]),
+    // Signer catalog entries (#1776). Legacy rows hold a `string[]` of subject
+    // CNs (weak tier); new rows may hold entry objects pinning a SHA-256
+    // thumbprint (strong tier). Read via normalizeSignerGroupEntries(); the
+    // engine resolves these to SignerGroupEntry[] and matches per the
+    // strong/weak precedence. Empty = matches nothing.
+    signers: jsonb('signers').$type<StoredSignerEntry[]>().notNull().default([]),
     createdByUserId: uuid('created_by_user_id').references(() => users.id, {
       onDelete: 'set null',
     }),
@@ -130,9 +190,17 @@ export const pamRules = pgTable(
     // Match criteria — all provided criteria must match (AND). A rule with
     // no criteria matches nothing (guarded at the API layer).
     matchSigner: varchar('match_signer', { length: 255 }),
+    // STRONG-tier signer pin (#1776): SHA-256 Authenticode leaf-cert thumbprint,
+    // lowercase 64-char hex. Present-gated + constant-time compared in the
+    // engine — a rule pinning a thumbprint matches ONLY when the candidate
+    // carries that exact thumbprint (fail closed when absent), closing the
+    // CN-spoofing elevation-of-privilege gap. ANDs with matchSigner when both
+    // are set (max strength); mutually exclusive with matchSignerGroupId.
+    matchSignerThumbprint: varchar('match_signer_thumbprint', { length: 64 }),
     // Alternative to matchSigner: match the candidate signer against ANY member
     // of a reusable signer group (pam_signer_groups). Mutually exclusive with
-    // matchSigner (the API rejects setting both). Resolved server-side.
+    // matchSigner / matchSignerThumbprint (the API rejects combining them).
+    // Resolved server-side.
     matchSignerGroupId: uuid('match_signer_group_id').references(
       () => pamSignerGroups.id,
       { onDelete: 'restrict' },

--- a/apps/api/src/db/schema/pam.ts
+++ b/apps/api/src/db/schema/pam.ts
@@ -114,10 +114,19 @@ export function normalizeSignerGroupEntries(raw: unknown): SignerGroupEntry[] {
       const rec = el as { subjectCn?: unknown; thumbprint?: unknown };
       const cn = typeof rec.subjectCn === 'string' ? rec.subjectCn.trim() : '';
       const tpRaw = typeof rec.thumbprint === 'string' ? rec.thumbprint.trim().toLowerCase() : '';
-      const tp = SIGNER_THUMBPRINT_RE.test(tpRaw) ? tpRaw : '';
-      if (cn && tp) out.push({ subjectCn: cn, thumbprint: tp });
-      else if (tp) out.push({ thumbprint: tp });
-      else if (cn) out.push({ subjectCn: cn });
+      // A thumbprint field that is PRESENT but not valid 64-hex is a CORRUPTED
+      // strong pin (DB tamper / manual edit / a future writer), NOT a CN-only
+      // entry. Drop the whole entry — never silently degrade an intended-strong
+      // pin to a weak CN match, or a forged cert bearing the trusted CN would
+      // auto-approve (the exact EoP #1776 closes). Mirrors the rule-level
+      // matchSignerThumbprint, which fails closed for the same case. A thumbprint
+      // field that is ABSENT/empty is a legitimate CN-only (weak) entry.
+      if (tpRaw !== '') {
+        if (!SIGNER_THUMBPRINT_RE.test(tpRaw)) continue;
+        out.push(cn ? { subjectCn: cn, thumbprint: tpRaw } : { thumbprint: tpRaw });
+      } else if (cn) {
+        out.push({ subjectCn: cn });
+      }
     }
   }
   return out;

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -11,7 +11,13 @@ vi.mock('../../db', () => ({
   },
 }));
 
-vi.mock('../../db/schema', () => ({
+vi.mock('../../db/schema', async () => ({
+  // Real, pure normalizer (#1776) — the route maps signer-group jsonb through
+  // it before matching. Pulled from the actual module so the test can't drift
+  // from production behavior; the drizzle tables stay mocked below.
+  normalizeSignerGroupEntries: (
+    await vi.importActual<typeof import('../../db/schema')>('../../db/schema')
+  ).normalizeSignerGroupEntries,
   devices: {
     id: 'id',
     orgId: 'orgId',
@@ -193,7 +199,7 @@ function mockSelectsWithConfig(
 function mockSelectsWithSignerGroups(
   deviceRows: Array<{ id: string; orgId: string; siteId: string | null }>,
   ruleRows: unknown[],
-  groupRows: Array<{ id: string; signers: string[] }>,
+  groupRows: Array<{ id: string; signers: unknown[] }>,
 ) {
   let call = 0;
   vi.mocked(db.select).mockImplementation(() => {
@@ -565,6 +571,81 @@ describe('ingest decisioning (#1163)', () => {
       expect.objectContaining({ elevationRequestId: 'req-sg' }),
       'pam-ingest',
     );
+  });
+
+  it('thumbprint-pinned signer group: auto_approves only with the matching thumbprint (#1776)', async () => {
+    const REAL_TP = 'a'.repeat(64);
+    const rule = {
+      id: 'rule-tp',
+      orgId: 'org-1',
+      siteId: null,
+      name: 'Pinned vendor',
+      description: null,
+      enabled: true,
+      priority: 10,
+      matchSigner: null,
+      matchSignerThumbprint: null,
+      matchSignerGroupId: 'grp-tp',
+      matchHash: null,
+      matchPathGlob: null,
+      matchParentImage: null,
+      matchCommandLine: null,
+      matchUser: null,
+      matchAdGroup: null,
+      matchToolName: null,
+      matchRiskTier: null,
+      matchNegate: null,
+      timeWindow: null,
+      verdict: 'auto_approve',
+      approvalDurationMinutes: null,
+      createdByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // Group entry pins both the trusted CN and its real leaf-cert thumbprint.
+    mockSelectsWithSignerGroups(
+      [{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }],
+      [rule],
+      [{ id: 'grp-tp', signers: [{ subjectCn: 'Acme Corp', thumbprint: REAL_TP }] }],
+    );
+    const { values } = happyPathInsert([{ id: 'req-tp', status: 'auto_approved' }]);
+
+    // A forged "Acme Corp" cert (matching CN, NO thumbprint reported) must NOT
+    // auto-approve — it falls through to pending.
+    const forged = await buildApp().request('/agents/agent-123/elevation-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...goodPayload, target_executable_signer: 'Acme Corp' }),
+    });
+    expect(forged.status).toBe(201);
+    expect(
+      vi
+        .mocked(values)
+        .mock.calls.find((args) => (args[0] as { status?: string }).status === 'auto_approved'),
+    ).toBeUndefined();
+
+    // The legitimate publisher (matching CN + matching thumbprint) auto-approves.
+    vi.mocked(values).mockClear();
+    mockSelectsWithSignerGroups(
+      [{ id: 'device-1', orgId: 'org-1', siteId: 'site-1' }],
+      [rule],
+      [{ id: 'grp-tp', signers: [{ subjectCn: 'Acme Corp', thumbprint: REAL_TP }] }],
+    );
+    const ok = await buildApp().request('/agents/agent-123/elevation-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...goodPayload,
+        target_executable_signer: 'Acme Corp',
+        target_executable_signer_thumbprint: REAL_TP,
+      }),
+    });
+    expect(ok.status).toBe(201);
+    expect(
+      vi
+        .mocked(values)
+        .mock.calls.find((args) => (args[0] as { status?: string }).status === 'auto_approved'),
+    ).toBeTruthy();
   });
 
   it('pam rule ignore -> no insert, 200 ignored', async () => {

--- a/apps/api/src/routes/agents/elevationRequests.ts
+++ b/apps/api/src/routes/agents/elevationRequests.ts
@@ -9,9 +9,11 @@ import {
   devices,
   elevationAudit,
   elevationRequests,
+  normalizeSignerGroupEntries,
   pamOrgConfig,
   pamRules,
   pamSignerGroups,
+  type SignerGroupEntry,
 } from '../../db/schema';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { getRedis } from '../../services/redis';
@@ -95,6 +97,15 @@ export const elevationRequestSchema = z.object({
   target_executable_path: z.string().min(1).max(4096),
   target_executable_hash: z.string().max(128).optional(),
   target_executable_signer: z.string().max(255).optional(),
+  // STRONG signer signal (#1776): SHA-256 Authenticode leaf-cert thumbprint,
+  // 64-hex. Optional — older agents and the current Windows extraction (which
+  // still defers WinTrust, see agent/internal/etwlua) don't send it yet, so the
+  // engine treats absence as "no thumbprint" (thumbprint-pinned rules fail
+  // closed). Validated as exactly 64 hex chars when present.
+  target_executable_signer_thumbprint: z
+    .string()
+    .regex(/^[0-9a-fA-F]{64}$/)
+    .optional(),
   pid: z.number().int().min(0).max(2 ** 32 - 1).optional(),
   parent_image: z.string().max(4096).optional(),
   command_line: z.string().max(8192).optional(),
@@ -376,7 +387,7 @@ elevationRequestsRoutes.post(
               .filter((x): x is string => x != null),
           ),
         ];
-        let signerGroups: Map<string, string[]> | undefined;
+        let signerGroups: Map<string, SignerGroupEntry[]> | undefined;
         if (signerGroupIds.length > 0) {
           const groups = await db
             .select({ id: pamSignerGroups.id, signers: pamSignerGroups.signers })
@@ -387,7 +398,9 @@ elevationRequestsRoutes.post(
                 inArray(pamSignerGroups.id, signerGroupIds),
               ),
             );
-          signerGroups = new Map(groups.map((g) => [g.id, g.signers]));
+          // Normalize the stored jsonb (legacy bare CNs and/or new entry
+          // objects) to canonical entries the engine matches against (#1776).
+          signerGroups = new Map(groups.map((g) => [g.id, normalizeSignerGroupEntries(g.signers)]));
         }
         const ruleMatch = evaluatePamRules(
           orgRules,
@@ -395,6 +408,7 @@ elevationRequestsRoutes.post(
             targetExecutablePath: payload.target_executable_path,
             targetExecutableHash: payload.target_executable_hash,
             targetExecutableSigner: payload.target_executable_signer,
+            targetExecutableSignerThumbprint: payload.target_executable_signer_thumbprint,
             subjectUsername: payload.subject_username,
             parentImage: payload.parent_image,
             commandLine: payload.command_line,

--- a/apps/api/src/routes/pam.test.ts
+++ b/apps/api/src/routes/pam.test.ts
@@ -43,7 +43,12 @@ vi.mock('../db', () => ({
   },
 }));
 
-vi.mock('../db/schema', () => ({
+vi.mock('../db/schema', async () => ({
+  // Real, pure normalizer (#1776) — the preview handler maps signer-group jsonb
+  // through it. Pulled from the actual module so it can't drift; tables mocked.
+  normalizeSignerGroupEntries: (
+    await vi.importActual<typeof import('../db/schema')>('../db/schema')
+  ).normalizeSignerGroupEntries,
   devices: { id: 'id', hostname: 'hostname' },
   sites: { id: 'id', name: 'name' },
   users: { id: 'id', name: 'name' },
@@ -2210,6 +2215,80 @@ describe('Signer groups', () => {
         name: 'conflicting signer rule',
         verdict: 'auto_approve',
         matchSigner: 'Acme Corp',
+        matchSignerGroupId: GROUP_ID,
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('POST /signer-groups stores a thumbprint-pinned entry with a lowercased thumbprint (#1776)', async () => {
+    const TP = 'A'.repeat(64);
+    const returning = vi
+      .fn()
+      .mockResolvedValue([{ id: GROUP_ID, name: 'Pinned', signers: [{ subjectCn: 'Acme Corp' }] }]);
+    vi.mocked(db.insert).mockReturnValue({ values: vi.fn(() => ({ returning })) } as any);
+
+    const res = await app().request('/pam/signer-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Pinned',
+        // Mixed: a legacy bare CN (weak) + a pinned entry (strong, uppercase hex).
+        signers: ['Legacy Vendor', { subjectCn: 'Acme Corp', thumbprint: TP }],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { signers: unknown[] };
+    expect(valuesArg.signers).toEqual([
+      'Legacy Vendor',
+      { subjectCn: 'Acme Corp', thumbprint: TP.toLowerCase() },
+    ]);
+  });
+
+  it('POST /signer-groups rejects an entry object with neither subjectCn nor thumbprint (400)', async () => {
+    const res = await app().request('/pam/signer-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Bad', signers: [{}] }),
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('POST /rules accepts matchSignerThumbprint and stores it lowercased (#1776)', async () => {
+    const TP = 'A'.repeat(64);
+    const returning = vi
+      .fn()
+      .mockResolvedValue([{ id: 'rule-tp', name: 'pinned', verdict: 'auto_approve', priority: 100 }]);
+    vi.mocked(db.insert).mockReturnValue({ values: vi.fn(() => ({ returning })) } as any);
+
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'pinned',
+        verdict: 'auto_approve',
+        matchSignerThumbprint: TP,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const valuesArg = (vi.mocked(db.insert).mock.results[0]!.value.values as any).mock
+      .calls[0][0] as { matchSignerThumbprint: string };
+    expect(valuesArg.matchSignerThumbprint).toBe(TP.toLowerCase());
+  });
+
+  it('POST /rules rejects combining matchSignerThumbprint with matchSignerGroupId (400)', async () => {
+    const res = await app().request('/pam/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'conflicting',
+        verdict: 'auto_approve',
+        matchSignerThumbprint: 'a'.repeat(64),
         matchSignerGroupId: GROUP_ID,
       }),
     });

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -31,10 +31,13 @@ import {
   devices,
   elevationAudit,
   elevationRequests,
+  normalizeSignerGroupEntries,
   PAM_RULE_NEGATE_KEYS,
   pamOrgConfig,
   pamRules,
   pamSignerGroups,
+  type SignerGroupEntry,
+  type StoredSignerEntry,
   sites,
   softwarePolicies,
   users,
@@ -804,6 +807,7 @@ pamRoutes.post(
 
 const ruleCriteriaFields = [
   'matchSigner',
+  'matchSignerThumbprint',
   'matchSignerGroupId',
   'matchHash',
   'matchPathGlob',
@@ -825,6 +829,12 @@ const timeWindowSchema = z.object({
 const ruleCriteriaValidators = {
   siteId: z.string().guid().nullable().optional(),
   matchSigner: z.string().min(1).max(255).nullable().optional(),
+  matchSignerThumbprint: z
+    .string()
+    .trim()
+    .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex thumbprint')
+    .nullable()
+    .optional(),
   matchSignerGroupId: z.string().guid().nullable().optional(),
   matchHash: z
     .string()
@@ -861,6 +871,7 @@ const ruleBaseSchema = z.object({
 
 type RuleCriteriaShape = {
   matchSigner?: string | null;
+  matchSignerThumbprint?: string | null;
   matchSignerGroupId?: string | null;
   matchHash?: string | null;
   matchPathGlob?: string | null;
@@ -884,6 +895,7 @@ function hasAnyCriterion(rule: RuleCriteriaShape): boolean {
 // group/time only narrow; they don't identify a binary).
 const executableCriteriaFields = [
   'matchSigner',
+  'matchSignerThumbprint',
   'matchSignerGroupId',
   'matchHash',
   'matchPathGlob',
@@ -912,8 +924,8 @@ function validateRuleShape(rule: RuleCriteriaShape): string | null {
   if (hasExecutableShapeCriteria(rule) && hasToolActionCriteria(rule)) {
     return 'A rule cannot mix executable criteria with tool-action criteria';
   }
-  if (rule.matchSigner && rule.matchSignerGroupId) {
-    return 'A rule cannot set both matchSigner and matchSignerGroupId — use one or the other';
+  if ((rule.matchSigner || rule.matchSignerThumbprint) && rule.matchSignerGroupId) {
+    return 'A rule cannot combine matchSignerGroupId with matchSigner/matchSignerThumbprint — use a group or a direct signer match, not both';
   }
   if (hasToolActionCriteria(rule) && rule.verdict === 'ignore') {
     return "verdict 'ignore' is not valid for tool-action rules — a tool action must be decided";
@@ -999,6 +1011,9 @@ pamRoutes.post('/rules', requirePamWrite, requireMfa(), zValidator('json', creat
       enabled: payload.enabled ?? true,
       priority: payload.priority ?? 100,
       matchSigner: payload.matchSigner ?? null,
+      matchSignerThumbprint: payload.matchSignerThumbprint
+        ? payload.matchSignerThumbprint.toLowerCase()
+        : null,
       matchSignerGroupId: payload.matchSignerGroupId ?? null,
       matchHash: payload.matchHash ? payload.matchHash.toLowerCase() : null,
       matchPathGlob: payload.matchPathGlob ?? null,
@@ -1101,6 +1116,9 @@ pamRoutes.post(
       createdAt: new Date(),
       updatedAt: new Date(),
       matchSigner: body.matchSigner ?? null,
+      matchSignerThumbprint: body.matchSignerThumbprint
+        ? body.matchSignerThumbprint.toLowerCase()
+        : null,
       matchSignerGroupId: body.matchSignerGroupId ?? null,
       matchHash: body.matchHash ? body.matchHash.toLowerCase() : null,
       matchPathGlob: body.matchPathGlob ?? null,
@@ -1117,14 +1135,18 @@ pamRoutes.post(
     // Resolve the draft's signer group (if any) so the preview can match it.
     // Org-scoped by RLS — a group the caller can't see yields no resolution
     // and the draft's group criterion fails closed.
-    let previewSignerGroups: Map<string, string[]> | undefined;
+    // NOTE: historical elevation_requests rows do not store a signer
+    // thumbprint, so a draft pinning a thumbprint (direct or via a group entry)
+    // reports 0 matches in preview — the candidate below carries no thumbprint.
+    // Same known limitation as matchAdGroup (criteria are ANDed / present-gated).
+    let previewSignerGroups: Map<string, SignerGroupEntry[]> | undefined;
     if (draftRule.matchSignerGroupId) {
       const [grp] = await db
         .select({ id: pamSignerGroups.id, signers: pamSignerGroups.signers })
         .from(pamSignerGroups)
         .where(eq(pamSignerGroups.id, draftRule.matchSignerGroupId))
         .limit(1);
-      if (grp) previewSignerGroups = new Map([[grp.id, grp.signers]]);
+      if (grp) previewSignerGroups = new Map([[grp.id, normalizeSignerGroupEntries(grp.signers)]]);
     }
 
     let totalMatched = 0;
@@ -1227,6 +1249,13 @@ pamRoutes.patch('/rules/:id', requirePamWrite, requireMfa(), zValidator('json', 
       ...(payload.enabled !== undefined ? { enabled: payload.enabled } : {}),
       ...(payload.priority !== undefined ? { priority: payload.priority } : {}),
       ...(payload.matchSigner !== undefined ? { matchSigner: payload.matchSigner } : {}),
+      ...(payload.matchSignerThumbprint !== undefined
+        ? {
+            matchSignerThumbprint: payload.matchSignerThumbprint
+              ? payload.matchSignerThumbprint.toLowerCase()
+              : null,
+          }
+        : {}),
       ...(payload.matchSignerGroupId !== undefined
         ? { matchSignerGroupId: payload.matchSignerGroupId }
         : {}),
@@ -1385,18 +1414,52 @@ pamRoutes.put(
 // ============================================================
 // A named, org-scoped set of signer (subject CN) patterns referenced from
 // rules via matchSignerGroupId. Manage vendors once, reference everywhere.
+// A signer-group entry is EITHER a bare subject-CN string (legacy / weak tier,
+// stored as-is for backward-compatibility) OR an object pinning a SHA-256
+// thumbprint (strong tier) and/or a CN (#1776). At least one field is required
+// on the object form. Stored shape stays read-compatible with the legacy
+// string[] — see normalizeSignerGroupEntries / StoredSignerEntry.
+const signerEntryObjectSchema = z
+  .object({
+    subjectCn: z.string().trim().min(1).max(255).optional(),
+    thumbprint: z
+      .string()
+      .trim()
+      .regex(/^[0-9a-fA-F]{64}$/, 'must be a sha256 hex thumbprint')
+      .optional(),
+  })
+  .refine((e) => Boolean(e.subjectCn) || Boolean(e.thumbprint), {
+    message: 'each signer entry needs a subjectCn or a thumbprint',
+  });
+
 const signerListSchema = z
-  .array(z.string().trim().min(1).max(255))
+  .array(z.union([z.string().trim().min(1).max(255), signerEntryObjectSchema]))
   .max(500)
-  // Drop blanks and de-duplicate case-insensitively, preserving first spelling.
+  // Normalize to the stored form (bare CN strings stay strings; pins become
+  // objects with a lowercased thumbprint) and de-duplicate, preserving the
+  // first spelling.
   .transform((arr) => {
     const seen = new Set<string>();
-    const out: string[] = [];
-    for (const s of arr) {
-      const key = s.toLowerCase();
-      if (!seen.has(key)) {
+    const out: StoredSignerEntry[] = [];
+    for (const el of arr) {
+      if (typeof el === 'string') {
+        const cn = el.trim();
+        const key = `cn:${cn.toLowerCase()}`;
+        if (cn && !seen.has(key)) {
+          seen.add(key);
+          out.push(cn);
+        }
+        continue;
+      }
+      const cn = el.subjectCn?.trim();
+      const thumbprint = el.thumbprint?.trim().toLowerCase();
+      const key = `obj:${cn?.toLowerCase() ?? ''}|${thumbprint ?? ''}`;
+      if ((cn || thumbprint) && !seen.has(key)) {
         seen.add(key);
-        out.push(s);
+        const entry: { subjectCn?: string; thumbprint?: string } = {};
+        if (cn) entry.subjectCn = cn;
+        if (thumbprint) entry.thumbprint = thumbprint;
+        out.push(entry);
       }
     }
     return out;

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { PamRule } from '../db/schema/pam';
+import { normalizeSignerGroupEntries } from '../db/schema/pam';
 import {
   evaluatePamRules,
   evaluatePamToolActionRules,
@@ -632,6 +633,22 @@ describe('signer thumbprint pinning (#1776)', () => {
       // forged "Acme Corp" cert with NO thumbprint reported → REJECTED (fail closed)
       expect(
         evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Acme Corp' }, groups),
+      ).toBeNull();
+    });
+
+    it('a corrupted thumbprint pin (via the normalizer) does NOT degrade to a CN match (#1776)', () => {
+      // End-to-end: stored jsonb has a CN + a PRESENT-but-malformed thumbprint.
+      // normalizeSignerGroupEntries drops it (fail closed), so the resolved group
+      // is empty and a forged cert with the trusted CN (no thumbprint) does NOT
+      // auto-approve.
+      const resolved = normalizeSignerGroupEntries([
+        { subjectCn: 'Acme Corp', thumbprint: 'not-a-real-hash' },
+      ]);
+      expect(resolved).toEqual([]);
+      const corrupted: SignerGroupResolver = new Map([[GROUP_ID, resolved]]);
+      const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+      expect(
+        evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Acme Corp' }, corrupted),
       ).toBeNull();
     });
 

--- a/apps/api/src/services/pamRuleEngine.test.ts
+++ b/apps/api/src/services/pamRuleEngine.test.ts
@@ -8,6 +8,7 @@ import {
   evaluatePamToolActionRules,
   isWithinTimeWindow,
   type PamRuleCandidate,
+  type SignerGroupResolver,
 } from './pamRuleEngine';
 
 let seq = 0;
@@ -22,6 +23,7 @@ function rule(overrides: Partial<PamRule>): PamRule {
     enabled: true,
     priority: 100,
     matchSigner: null,
+    matchSignerThumbprint: null,
     matchSignerGroupId: null,
     matchHash: null,
     matchPathGlob: null,
@@ -421,8 +423,16 @@ describe('rule negation (match_negate)', () => {
 
 describe('signer group matching (matchSignerGroupId)', () => {
   const GROUP_ID = '11111111-1111-1111-1111-111111111111';
-  const groups = new Map<string, readonly string[]>([
-    [GROUP_ID, ['Intuit Inc.', 'Microsoft Corporation', 'TeamViewer GmbH']],
+  // CN-only (weak/legacy) entries — the back-compat shape after normalization.
+  const groups: SignerGroupResolver = new Map([
+    [
+      GROUP_ID,
+      [
+        { subjectCn: 'Intuit Inc.' },
+        { subjectCn: 'Microsoft Corporation' },
+        { subjectCn: 'TeamViewer GmbH' },
+      ],
+    ],
   ]);
 
   it('matches when the candidate signer is any member of the group', () => {
@@ -451,7 +461,7 @@ describe('signer group matching (matchSignerGroupId)', () => {
       evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Intuit Inc.' }),
     ).toBeNull();
     // empty group → no match
-    const empty = new Map<string, readonly string[]>([[GROUP_ID, []]]);
+    const empty: SignerGroupResolver = new Map([[GROUP_ID, []]]);
     expect(
       evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Intuit Inc.' }, empty),
     ).toBeNull();
@@ -507,5 +517,151 @@ describe('signer group matching (matchSignerGroupId)', () => {
       evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Random LLC', targetExecutablePath: 'C:\\a.exe' }, groups)
         ?.verdict,
     ).toBe('auto_deny');
+  });
+});
+
+describe('signer thumbprint pinning (#1776)', () => {
+  const GROUP_ID = '22222222-2222-2222-2222-222222222222';
+  const REAL_TP = 'a'.repeat(64); // the trusted publisher's real leaf-cert SHA-256
+  const FORGED_TP = 'b'.repeat(64); // a forged cert that copied the CN but not the key
+
+  describe('direct matchSignerThumbprint criterion', () => {
+    it('matches only the exact thumbprint, case-insensitively', () => {
+      const r = rule({ matchSignerThumbprint: REAL_TP, verdict: 'auto_approve' });
+      expect(
+        evaluatePamRules([r], { ...candidate, targetExecutableSignerThumbprint: REAL_TP })?.verdict,
+      ).toBe('auto_approve');
+      // pin stored lowercase; candidate may report uppercase hex → still matches
+      expect(
+        evaluatePamRules([r], {
+          ...candidate,
+          targetExecutableSignerThumbprint: REAL_TP.toUpperCase(),
+        }),
+      ).not.toBeNull();
+    });
+
+    it('REJECTS a forged cert: right CN, wrong thumbprint (the core property)', () => {
+      // A thumbprint-pinned rule must NOT match a binary whose signer CN equals
+      // the trusted CN but whose cert thumbprint differs — that is exactly the
+      // CN-spoofing elevation-of-privilege #1776 closes.
+      const r = rule({ matchSignerThumbprint: REAL_TP, verdict: 'auto_approve' });
+      expect(
+        evaluatePamRules([r], {
+          ...candidate,
+          targetExecutableSigner: candidate.targetExecutableSigner, // trusted CN present
+          targetExecutableSignerThumbprint: FORGED_TP, // but a different key
+        }),
+      ).toBeNull();
+    });
+
+    it('fails closed when the candidate carries no thumbprint (older agent)', () => {
+      const r = rule({ matchSignerThumbprint: REAL_TP, verdict: 'auto_approve' });
+      expect(evaluatePamRules([r], { ...candidate })).toBeNull();
+    });
+
+    it('ANDs with matchSigner: both CN and thumbprint must match (max strength)', () => {
+      const r = rule({
+        matchSigner: 'Vendor Inc.',
+        matchSignerThumbprint: REAL_TP,
+        verdict: 'auto_approve',
+      });
+      // both match
+      expect(
+        evaluatePamRules([r], {
+          ...candidate,
+          targetExecutableSigner: 'Vendor Inc.',
+          targetExecutableSignerThumbprint: REAL_TP,
+        }),
+      ).not.toBeNull();
+      // correct CN but wrong thumbprint → no match
+      expect(
+        evaluatePamRules([r], {
+          ...candidate,
+          targetExecutableSigner: 'Vendor Inc.',
+          targetExecutableSignerThumbprint: FORGED_TP,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('signer-group entry pinning', () => {
+    it('thumbprint-only entry matches only the pinned thumbprint', () => {
+      const groups: SignerGroupResolver = new Map([[GROUP_ID, [{ thumbprint: REAL_TP }]]]);
+      const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSignerThumbprint: REAL_TP },
+          groups,
+        )?.verdict,
+      ).toBe('auto_approve');
+      // forged thumbprint → no match (even though the candidate CN is set)
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSignerThumbprint: FORGED_TP },
+          groups,
+        ),
+      ).toBeNull();
+    });
+
+    it('a thumbprint-pinned entry NEVER falls through to a CN match', () => {
+      // Entry pins BOTH the CN and the real thumbprint. A forged cert with the
+      // matching CN but the wrong thumbprint must be rejected — it must not
+      // match on CN alone.
+      const groups: SignerGroupResolver = new Map([
+        [GROUP_ID, [{ subjectCn: 'Acme Corp', thumbprint: REAL_TP }]],
+      ]);
+      const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+      // legitimate publisher: right CN + right thumbprint → match
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSigner: 'Acme Corp', targetExecutableSignerThumbprint: REAL_TP },
+          groups,
+        ),
+      ).not.toBeNull();
+      // forged "Acme Corp" cert: right CN, wrong thumbprint → REJECTED
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSigner: 'Acme Corp', targetExecutableSignerThumbprint: FORGED_TP },
+          groups,
+        ),
+      ).toBeNull();
+      // forged "Acme Corp" cert with NO thumbprint reported → REJECTED (fail closed)
+      expect(
+        evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Acme Corp' }, groups),
+      ).toBeNull();
+    });
+
+    it('mixes weak (CN) and strong (thumbprint) entries in one group', () => {
+      // A group can carry a legacy CN-only entry alongside a pinned entry; each
+      // entry keeps its own tier. The CN-only entry still matches on CN (weak).
+      const groups: SignerGroupResolver = new Map([
+        [GROUP_ID, [{ subjectCn: 'Legacy Vendor' }, { thumbprint: REAL_TP }]],
+      ]);
+      const r = rule({ matchSignerGroupId: GROUP_ID, verdict: 'auto_approve' });
+      // matches the weak CN entry
+      expect(
+        evaluatePamRules([r], { ...candidate, targetExecutableSigner: 'Legacy Vendor' }, groups),
+      ).not.toBeNull();
+      // matches the strong thumbprint entry
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSigner: 'Whoever', targetExecutableSignerThumbprint: REAL_TP },
+          groups,
+        ),
+      ).not.toBeNull();
+      // matches neither → no match
+      expect(
+        evaluatePamRules(
+          [r],
+          { ...candidate, targetExecutableSigner: 'Whoever', targetExecutableSignerThumbprint: FORGED_TP },
+          groups,
+        ),
+      ).toBeNull();
+    });
   });
 });

--- a/apps/api/src/services/pamRuleEngine.ts
+++ b/apps/api/src/services/pamRuleEngine.ts
@@ -30,7 +30,13 @@
  *   evaluated via evaluatePamToolActionRules, which only considers rules
  *   carrying a tool-action criterion.
  */
-import type { PamRule, PamRuleNegateKey, PamRuleTimeWindow } from '../db/schema/pam';
+import { timingSafeEqual } from 'node:crypto';
+import type {
+  PamRule,
+  PamRuleNegateKey,
+  PamRuleTimeWindow,
+  SignerGroupEntry,
+} from '../db/schema/pam';
 import { matchPathGlob } from './pamBridge';
 
 export interface PamRuleCandidate {
@@ -38,6 +44,13 @@ export interface PamRuleCandidate {
   targetExecutablePath?: string;
   targetExecutableHash?: string;
   targetExecutableSigner?: string;
+  /**
+   * SHA-256 Authenticode leaf-cert thumbprint (64-hex, case-insensitive) the
+   * agent measured from the on-disk binary. The STRONG signer signal (#1776):
+   * a thumbprint-pinned rule/group entry matches ONLY when this is present and
+   * exact. Absent (older agents / unsigned) → thumbprint criteria fail closed.
+   */
+  targetExecutableSignerThumbprint?: string;
   subjectUsername: string;
   parentImage?: string;
   /** Launched process command line, when the agent captured it. */
@@ -61,13 +74,60 @@ export interface PamRuleMatch {
 
 const eqCi = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 
+const THUMBPRINT_RE = /^[0-9a-f]{64}$/;
+
 /**
- * Resolved signer groups: groupId → member signer patterns. The caller
- * (ingest / preview) fetches the org's referenced pam_signer_groups and passes
- * this map so the pure engine can evaluate matchSignerGroupId without DB access.
+ * Constant-time, case-insensitive equality for SHA-256 cert thumbprints (#1776).
+ * Both operands must be present and valid 64-hex; anything else is a non-match
+ * (fail closed — a malformed pin or an absent candidate thumbprint never
+ * matches). Uses timingSafeEqual on the normalized lowercase bytes so the
+ * compare doesn't leak how many leading chars of a pinned thumbprint a probe
+ * guessed. (CN matching stays eqCi — a CN is not a secret.)
+ */
+function thumbprintEq(pinned: string | undefined, candidate: string | undefined): boolean {
+  if (!pinned || !candidate) return false;
+  const a = pinned.toLowerCase();
+  const b = candidate.toLowerCase();
+  if (!THUMBPRINT_RE.test(a) || !THUMBPRINT_RE.test(b)) return false;
+  // Both are exactly 64 ASCII chars here, so the buffers are equal-length and
+  // timingSafeEqual won't throw.
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+/**
+ * Does a single signer-group entry match the candidate (#1776)? ALL fields the
+ * entry carries must match (AND), and a present thumbprint is checked first and
+ * present-gated:
+ *   - thumbprint-only entry → matches iff the candidate's thumbprint is present
+ *     and equal (STRONG). Never falls through to CN.
+ *   - CN-only entry         → matches iff the candidate's signer CN is present
+ *     and eqCi (WEAK / legacy).
+ *   - both                  → BOTH must match (STRONGest — the candidate must
+ *     carry the pinned key AND the expected CN).
+ * An entry with neither field is treated as no-match (fail closed).
+ */
+function signerEntryMatches(entry: SignerGroupEntry, candidate: PamRuleCandidate): boolean {
+  const cn = 'subjectCn' in entry ? entry.subjectCn : undefined;
+  const thumbprint = entry.thumbprint;
+  if (!cn && !thumbprint) return false;
+  if (thumbprint && !thumbprintEq(thumbprint, candidate.targetExecutableSignerThumbprint)) {
+    return false;
+  }
+  if (cn) {
+    if (candidate.targetExecutableSigner == null) return false;
+    if (!eqCi(cn, candidate.targetExecutableSigner)) return false;
+  }
+  return true;
+}
+
+/**
+ * Resolved signer groups: groupId → normalized member entries. The caller
+ * (ingest / preview) fetches the org's referenced pam_signer_groups, runs the
+ * stored `signers` jsonb through normalizeSignerGroupEntries, and passes this
+ * map so the pure engine can evaluate matchSignerGroupId without DB access.
  * A rule whose group is absent from the map (or has no members) fails closed.
  */
-export type SignerGroupResolver = ReadonlyMap<string, readonly string[]>;
+export type SignerGroupResolver = ReadonlyMap<string, readonly SignerGroupEntry[]>;
 
 // A time window NARROWS a rule; it is not an identifying criterion on its
 // own. A rule whose only "criterion" is a time window would match every
@@ -76,6 +136,7 @@ export type SignerGroupResolver = ReadonlyMap<string, readonly string[]>;
 function hasAnyCriteria(rule: PamRule): boolean {
   return Boolean(
     rule.matchSigner ||
+      rule.matchSignerThumbprint ||
       rule.matchSignerGroupId ||
       rule.matchHash ||
       rule.matchPathGlob ||
@@ -171,15 +232,28 @@ function ruleMatches(
     const positive = present && eqCi(rule.matchSigner, candidate.targetExecutableSigner!);
     if (!satisfied('signer', present, positive)) return false;
   }
-  if (rule.matchSignerGroupId) {
-    // Match the candidate signer against ANY member of the resolved group.
-    // Unresolvable (group missing from the map or empty) or no candidate signer
-    // → not present → fails closed, even when negated.
-    const members = signerGroups?.get(rule.matchSignerGroupId);
-    const present =
-      candidate.targetExecutableSigner != null && members != null && members.length > 0;
+  if (rule.matchSignerThumbprint) {
+    // STRONG signer pin (#1776): present-gated + constant-time. A candidate
+    // without a thumbprint (older agent / unsigned) never satisfies this, so a
+    // thumbprint-pinned auto_approve rule fails closed rather than matching on
+    // CN alone. Negation can't turn absent data into a grant (satisfied()).
+    const present = candidate.targetExecutableSignerThumbprint != null;
     const positive =
-      present && members!.some((s) => eqCi(s, candidate.targetExecutableSigner!));
+      present && thumbprintEq(rule.matchSignerThumbprint, candidate.targetExecutableSignerThumbprint);
+    if (!satisfied('signerThumbprint', present, positive)) return false;
+  }
+  if (rule.matchSignerGroupId) {
+    // Match the candidate against ANY entry of the resolved group (#1776).
+    // Entries may pin a CN (weak), a thumbprint (strong), or both — see
+    // signerEntryMatches. Unresolvable (group missing/empty) or a candidate
+    // carrying neither a signer CN nor a thumbprint → not present → fails
+    // closed, even when negated (absent data can't become a grant).
+    const members = signerGroups?.get(rule.matchSignerGroupId);
+    const candidateHasSignal =
+      candidate.targetExecutableSigner != null ||
+      candidate.targetExecutableSignerThumbprint != null;
+    const present = candidateHasSignal && members != null && members.length > 0;
+    const positive = present && members!.some((e) => signerEntryMatches(e, candidate));
     if (!satisfied('signerGroup', present, positive)) return false;
   }
   if (rule.matchPathGlob) {


### PR DESCRIPTION
## Summary

PAM signer matching compared the code-signing cert's **subject CN** case-insensitively. Subject CNs are attacker-choosable (anyone can mint a self-signed cert bearing `"Acme Corp"`), and with the trusted-publisher catalog (#1771) a matched signer can **auto-approve privilege elevation** — so CN-only matching is an elevation-of-privilege risk. This adds a **STRONG tier**: pin the SHA-256 Authenticode leaf-cert **thumbprint** (bound to a specific key, not forgeable). CN matching stays as the clearly-labeled **WEAK/legacy** tier.

This follows the owner's plan (`docs/superpowers/plans/2026-06-22-pam-signer-thumbprint-pinning.md`) and its safe layering. It ships the **agent wire field + API/schema (accept, present-gated, fail-closed, CN unchanged)** — explicitly **not** the gated web editor (the "ship before fleet rollout" foot-gun the plan warns about).

## Verified current flow (before changing anything)
- The agent extracts **no** signer info today — `decodeConsentRequest` defers all Authenticode extraction (`agent/internal/etwlua/etwlua_windows.go`), so `target_executable_signer` is always absent and signer rules already fail closed from the uac_intercept flow.
- `matchSigner` / `matchSignerGroupId` are present-gated `eqCi` (`services/pamRuleEngine.ts`); the catalog stores `signers jsonb` as a CN `string[]`. No thumbprint anywhere.

## What changed (file:line)

**Schema** — `apps/api/src/db/schema/pam.ts`
- `pam_rules.match_signer_thumbprint varchar(64)` (nullable, parallel to `match_signer`).
- `pam_signer_groups.signers` element `$type` → `SignerGroupEntry` (CN-only / thumbprint-only / both), read-compatible with legacy bare-CN strings via `normalizeSignerGroupEntries`. Existing rows need **no** data migration.
- Migration `apps/api/migrations/2026-06-29-pam-signer-thumbprint.sql` — additive `ADD COLUMN IF NOT EXISTS`, idempotent. **No RLS change**: both tables are already forced shape-1 (direct `org_id`); a column add doesn't alter tenancy and the existing `breeze_has_org_access(org_id)` policy covers it (rls-coverage auto-discovers the table).

**Engine** — `apps/api/src/services/pamRuleEngine.ts`
- `PamRuleCandidate.targetExecutableSignerThumbprint`; `SignerGroupResolver` carries normalized entries.
- Thumbprint match is **present-gated** and **constant-time** (`timingSafeEqual` on normalized 64-hex) and **fails closed** when the candidate has no thumbprint.
- A thumbprint-pinned signer-group entry **never falls through to a CN match** → a forged cert with a trusted CN but a different key is rejected. An entry pinning both requires **both** (max strength). CN-only entries stay `eqCi`. Negation can't turn absent data into a grant.

**Ingest** — `apps/api/src/routes/agents/elevationRequests.ts`: optional 64-hex `target_executable_signer_thumbprint`, threaded into the candidate; signer groups normalized.

**Admin routes** — `apps/api/src/routes/pam.ts`: `signerListSchema` accepts entry objects (bare CN string stays weak/legacy); `matchSignerThumbprint` validator (mutually exclusive with a signer group). Preview documents that historical rows carry no thumbprint.

**Agent** — `agent/internal/etwlua/etwlua.go`: `Event.TargetExecutableSignerThumbprint` + JSON tag, and a pure unit-tested `NormalizeThumbprint` helper.

## What is NOT in this PR (the blocker)
The **Windows Authenticode/WinTrust extraction** that actually *produces* the thumbprint remains deferred (`etwlua_windows.go`) — it needs a Windows CI runner to validate (same blocker #1771 flagged), and writing untested Windows-only crypto in a security path is exactly the half-implementation to avoid. Until an agent emits a thumbprint, thumbprint-pinned rules simply **fail closed** (no auto-approve), which is safe. The wire field, schema, and matching are ready for that follow-up. The gated web editor (plan T7) is also intentionally deferred.

## Tests
- **Engine** (`pamRuleEngine.test.ts`): a thumbprint-pinned entry matches only the correct thumbprint and **REJECTS a forged cert with a matching CN but wrong/absent thumbprint** (the core security property), plus CN-tier fallback, direct `matchSignerThumbprint`, and mixed weak/strong groups.
- **Ingest** (`elevationRequests.test.ts`): thumbprint-pinned group auto-approves only with the matching thumbprint; forged CN-only → pending.
- **Routes** (`pam.test.ts`): entry-object create (thumbprint lowercased), entry rejection, `matchSignerThumbprint` create + exclusivity.
- **Agent** (`etwlua_thumbprint_test.go`): table-driven `NormalizeThumbprint`.

Local: API affected suites green single-fork (`pamRuleEngine` 51, `pam` 84, `elevationRequests` 27, `autoMigrate` 43); `tsc --noEmit` clean; `go test -race ./internal/etwlua/...` + heartbeat green; `GOOS=windows go build` OK. No local DB → drift check / RLS-forge integration not run here (additive column matching the schema; integration job is skipped on PRs).

Refs #1776 (kept open — not end-to-end until the deferred Windows extraction emits a thumbprint; see below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)