### PR TITLE
feat(contracts): prefill Pax8 sell price in subscription-link modal

### DIFF
--- a/apps/web/src/components/contracts/ContractPax8Drawer.test.tsx
+++ b/apps/web/src/components/contracts/ContractPax8Drawer.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a),
+  AuthSessionExpiredError: class AuthSessionExpiredError extends Error {},
+}));
+vi.mock('../integrations/LinkSubscriptionPicker', () => ({
+  default: () => <div data-testid="mock-picker" />,
+}));
+
+import ContractPax8Drawer from './ContractPax8Drawer';
+
+const ok = (data: unknown) => new Response(JSON.stringify({ data }), { status: 200 });
+
+const baseSub = {
+  id: 'sub-1',
+  orgId: 'org-1',
+  productName: 'Microsoft 365 E3',
+  vendorName: 'Microsoft',
+  quantity: 5,
+  unitPrice: '42.5',
+  currencyCode: 'USD',
+  contractLineId: null,
+};
+
+function renderOpen() {
+  return render(
+    <ContractPax8Drawer open orgId="org-1" integrationId="int-1" onClose={vi.fn()} onLinked={vi.fn()} />,
+  );
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('ContractPax8Drawer pick list', () => {
+  it('shows the Pax8 sell price alongside vendor and quantity', async () => {
+    fetchWithAuth.mockResolvedValue(ok([baseSub]));
+    renderOpen();
+    const meta = await screen.findByTestId('contract-pax8-meta-sub-1');
+    expect(meta.textContent).toBe('Microsoft · qty 5 · USD 42.50/ea');
+  });
+
+  it('omits the price segment when the subscription has no sell price', async () => {
+    fetchWithAuth.mockResolvedValue(ok([{ ...baseSub, unitPrice: null }]));
+    renderOpen();
+    const meta = await screen.findByTestId('contract-pax8-meta-sub-1');
+    expect(meta.textContent).toBe('Microsoft · qty 5');
+  });
+
+  it('omits a zero price and marks an already-linked subscription', async () => {
+    fetchWithAuth.mockResolvedValue(ok([{ ...baseSub, unitPrice: '0', contractLineId: 'line-9' }]));
+    renderOpen();
+    const meta = await screen.findByTestId('contract-pax8-meta-sub-1');
+    expect(meta.textContent).toBe('Microsoft · qty 5 · already linked');
+  });
+
+  it('defaults to USD when the subscription has no currency code', async () => {
+    fetchWithAuth.mockResolvedValue(ok([{ ...baseSub, currencyCode: null }]));
+    renderOpen();
+    const meta = await screen.findByTestId('contract-pax8-meta-sub-1');
+    expect(meta.textContent).toBe('Microsoft · qty 5 · USD 42.50/ea');
+  });
+});
+
+describe('ContractPax8Drawer load failures', () => {
+  it('surfaces an error when the subscriptions request is not ok', async () => {
+    fetchWithAuth.mockResolvedValue(new Response('{"error":"nope"}', { status: 500 }));
+    renderOpen();
+    expect(await screen.findByTestId('contract-pax8-error')).toBeTruthy();
+  });
+
+  it('surfaces an error instead of hanging when the request throws', async () => {
+    // A network failure rejects the fetch; the drawer must not sit on "Loading…".
+    fetchWithAuth.mockRejectedValue(new TypeError('network down'));
+    renderOpen();
+    expect(await screen.findByTestId('contract-pax8-error')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/contracts/ContractPax8Drawer.tsx
+++ b/apps/web/src/components/contracts/ContractPax8Drawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, AuthSessionExpiredError } from '../../stores/auth';
 import LinkSubscriptionPicker from '../integrations/LinkSubscriptionPicker';
 
 interface Pax8Subscription {
@@ -9,7 +9,20 @@ interface Pax8Subscription {
   productName: string | null;
   vendorName: string | null;
   quantity: number | null;
+  unitPrice: string | null;
+  currencyCode: string | null;
   contractLineId: string | null;
+}
+
+/** Format the Pax8 sell price for the pick list so the numeric value shown is the
+ *  same 2-decimal value the link form prefills (see toPriceInput in
+ *  LinkSubscriptionPicker), wrapped with the currency for display. Omitted
+ *  entirely for missing, zero, or unparseable prices. */
+function sellPriceLabel(unitPrice: string | null, currencyCode: string | null): string | null {
+  if (unitPrice == null) return null;
+  const n = Number.parseFloat(unitPrice);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return `${currencyCode ?? 'USD'} ${n.toFixed(2)}/ea`;
 }
 
 interface Props {
@@ -44,10 +57,18 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
   useEffect(() => {
     if (!open) { setSubs(null); setError(null); setPicked(null); return; }
     void (async () => {
-      const res = await fetchWithAuth(`/pax8/subscriptions?orgId=${encodeURIComponent(orgId)}&limit=100`);
-      if (!res.ok) { setError('Could not load Pax8 subscriptions for this organization.'); setSubs([]); return; }
-      const body = (await res.json().catch(() => null)) as { data?: Pax8Subscription[] } | null;
-      setSubs(body?.data ?? []);
+      try {
+        const res = await fetchWithAuth(`/pax8/subscriptions?orgId=${encodeURIComponent(orgId)}&limit=100`);
+        if (!res.ok) { setError('Could not load Pax8 subscriptions for this organization.'); setSubs([]); return; }
+        const body = (await res.json().catch(() => null)) as { data?: Pax8Subscription[] } | null;
+        setSubs(body?.data ?? []);
+      } catch (err) {
+        // A thrown fetch (network failure) must fail loud, not strand the drawer on
+        // "Loading subscriptions…" forever. Auth expiry self-redirects, so skip it.
+        if (err instanceof AuthSessionExpiredError) return;
+        setError('Could not load Pax8 subscriptions for this organization.');
+        setSubs([]);
+      }
     })();
   }, [open, orgId]);
 
@@ -83,8 +104,9 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
         <div className="p-5">
           {picked ? (
             <LinkSubscriptionPicker
+              key={picked.id}
               integrationId={integrationId}
-              subscription={{ id: picked.id, orgId: picked.orgId ?? orgId, productName: picked.productName, quantity: picked.quantity }}
+              subscription={{ id: picked.id, orgId: picked.orgId ?? orgId, productName: picked.productName, quantity: picked.quantity, unitPrice: picked.unitPrice }}
               onDone={onDone}
               onCancel={() => setPicked(null)}
             />
@@ -102,9 +124,13 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
                 <li key={s.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
                   <div className="min-w-0">
                     <div className="truncate text-sm font-medium">{s.productName ?? 'Pax8 subscription'}</div>
-                    <div className="truncate text-xs text-muted-foreground">
-                      {s.vendorName ? `${s.vendorName} · ` : ''}{s.quantity != null ? `qty ${s.quantity}` : ''}
-                      {s.contractLineId ? ' · already linked' : ''}
+                    <div className="truncate text-xs text-muted-foreground" data-testid={`contract-pax8-meta-${s.id}`}>
+                      {[
+                        s.vendorName,
+                        s.quantity != null ? `qty ${s.quantity}` : null,
+                        sellPriceLabel(s.unitPrice, s.currencyCode),
+                        s.contractLineId ? 'already linked' : null,
+                      ].filter(Boolean).join(' · ')}
                     </div>
                   </div>
                   <button

--- a/apps/web/src/components/integrations/LinkSubscriptionPicker.test.tsx
+++ b/apps/web/src/components/integrations/LinkSubscriptionPicker.test.tsx
@@ -17,7 +17,7 @@ vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchW
 import LinkSubscriptionPicker from './LinkSubscriptionPicker';
 
 const ok = (data: unknown) => new Response(JSON.stringify({ data }), { status: 200 });
-const sub = { id: 'sub-1', orgId: 'org-1', productName: 'Microsoft 365 E3', quantity: 5 };
+const sub = { id: 'sub-1', orgId: 'org-1', productName: 'Microsoft 365 E3', quantity: 5, unitPrice: null };
 
 beforeEach(() => {
   listContracts.mockReset(); getContract.mockReset(); addContractLine.mockReset(); fetchWithAuth.mockReset();
@@ -76,6 +76,42 @@ describe('LinkSubscriptionPicker', () => {
     // A valid 2-decimal value enables submit.
     fireEvent.change(screen.getByTestId('pax8-link-new-price'), { target: { value: '36.00' } });
     expect((screen.getByTestId('pax8-link-submit') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('prefills the new-line price from the Pax8 subscription sell price', async () => {
+    render(<LinkSubscriptionPicker integrationId="int-1" subscription={{ ...sub, unitPrice: '42.5' }} onDone={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('pax8-link-contract'));
+    fireEvent.change(screen.getByTestId('pax8-link-contract'), { target: { value: 'c1' } });
+    await waitFor(() => screen.getByTestId('pax8-link-line'));
+    fireEvent.change(screen.getByTestId('pax8-link-line'), { target: { value: '__new__' } });
+    // Seeded to a clean 2-decimal value and submit is immediately enabled.
+    expect((screen.getByTestId('pax8-link-new-price') as HTMLInputElement).value).toBe('42.50');
+    expect((screen.getByTestId('pax8-link-submit') as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId('pax8-link-submit'));
+    await waitFor(() => expect(addContractLine).toHaveBeenCalled());
+    expect(addContractLine.mock.calls[0][1]).toMatchObject({ unitPrice: '42.50' });
+  });
+
+  it('leaves the new-line price blank for a zero sell price and keeps submit disabled', async () => {
+    render(<LinkSubscriptionPicker integrationId="int-1" subscription={{ ...sub, unitPrice: '0.00' }} onDone={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('pax8-link-contract'));
+    fireEvent.change(screen.getByTestId('pax8-link-contract'), { target: { value: 'c1' } });
+    await waitFor(() => screen.getByTestId('pax8-link-line'));
+    fireEvent.change(screen.getByTestId('pax8-link-line'), { target: { value: '__new__' } });
+    // A zero (or negative) Pax8 price is not a real sell price — blank it so the
+    // partner must enter one, rather than seeding a $0.00 line.
+    expect((screen.getByTestId('pax8-link-new-price') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('pax8-link-submit') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('leaves the new-line price blank when the subscription has no sell price', async () => {
+    render(<LinkSubscriptionPicker integrationId="int-1" subscription={{ ...sub, unitPrice: null }} onDone={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('pax8-link-contract'));
+    fireEvent.change(screen.getByTestId('pax8-link-contract'), { target: { value: 'c1' } });
+    await waitFor(() => screen.getByTestId('pax8-link-line'));
+    fireEvent.change(screen.getByTestId('pax8-link-line'), { target: { value: '__new__' } });
+    expect((screen.getByTestId('pax8-link-new-price') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('pax8-link-submit') as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('surfaces an inline error when the contract list fails to load', async () => {

--- a/apps/web/src/components/integrations/LinkSubscriptionPicker.tsx
+++ b/apps/web/src/components/integrations/LinkSubscriptionPicker.tsx
@@ -14,9 +14,20 @@ function isMfaError(err: unknown): boolean {
   return err instanceof ActionError && err.status === 403 && /mfa required/i.test(err.message);
 }
 
+/** Seed the new-line "Unit price" from the Pax8 subscription's sell price, which
+ *  the partner sets per-subscription in Pax8 and is the accurate price to bill.
+ *  The snapshot stores it as a numeric(12,2) string; coerce to a clean 2-decimal
+ *  value that satisfies MONEY_RE, falling back to blank for missing, zero, or
+ *  unparseable prices. */
+function toPriceInput(value: string | null): string {
+  if (value == null) return '';
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) && n > 0 ? n.toFixed(2) : '';
+}
+
 interface LinkSubscriptionPickerProps {
   integrationId: string;
-  subscription: { id: string; orgId: string; productName: string | null; quantity: number | null };
+  subscription: { id: string; orgId: string; productName: string | null; quantity: number | null; unitPrice: string | null };
   onDone: () => void;
   onCancel: () => void;
 }
@@ -27,7 +38,7 @@ export default function LinkSubscriptionPicker({ integrationId, subscription, on
   const [lines, setLines] = useState<ContractLine[]>([]);
   const [lineId, setLineId] = useState('');
   const [newDesc, setNewDesc] = useState(subscription.productName ?? '');
-  const [newPrice, setNewPrice] = useState('');
+  const [newPrice, setNewPrice] = useState(() => toPriceInput(subscription.unitPrice));
   const [syncEnabled, setSyncEnabled] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/components/integrations/Pax8Integration.tsx
+++ b/apps/web/src/components/integrations/Pax8Integration.tsx
@@ -679,7 +679,7 @@ export default function Pax8Integration() {
             <LinkSubscriptionPicker
               key={linkingSub.id}
               integrationId={integration.id}
-              subscription={{ id: linkingSub.id, orgId: linkingSub.orgId, productName: linkingSub.productName, quantity: linkingSub.quantity }}
+              subscription={{ id: linkingSub.id, orgId: linkingSub.orgId, productName: linkingSub.productName, quantity: linkingSub.quantity, unitPrice: linkingSub.unitPrice }}
               onDone={() => { setLinkingSub(null); void reloadSubscriptions(); }}
               onCancel={() => setLinkingSub(null)}
             />


### PR DESCRIPTION
## What

The **"Link a Pax8 subscription"** modal left the new manual line's **Unit price** field blank, forcing the partner to re-type a price Pax8 already tracks. This seeds it from the subscription's **sell price** (`unitPrice` — the per-subscription price the partner set in Pax8, distinct from `unitCost`/buy rate). This brings the flow to parity with **"Add from Pax8 catalog"** and the Quote editor, which already prefill from Pax8 pricing.

The drawer's subscription pick-list now also shows that price (e.g. `Microsoft · qty 5 · USD 42.50/ea`) so the prefill is transparent before you click Link.

## Changes

- **`LinkSubscriptionPicker.tsx`** — seed `newPrice` via `toPriceInput()`, which coerces the `numeric(12,2)` string to a clean 2-decimal value satisfying `MONEY_RE`; blanks missing/zero/unparseable prices (leaving submit disabled). `unitPrice` is **required** on the prop so a dropped thread is a compile error.
- **`ContractPax8Drawer.tsx`** — show the sell price in the pick-list via `sellPriceLabel()` (identical coercion, so display == prefill), thread `unitPrice` to the picker, `key` the picker by subscription id (prefill can't go stale), and harden the subscriptions loader with `try/catch` so a network throw fails loud instead of hanging on "Loading…".
- **`Pax8Integration.tsx`** — thread `unitPrice` to the picker.

## Tests

- Prefill flows through to the real `addContractLine` write (`'42.5'` → `'42.50'`).
- Blank for zero / null price, submit stays disabled.
- Pick-list label: price + qty + vendor, null/zero omission, `USD` default when currency is null.
- Loader failure paths (`!res.ok` and a thrown fetch) surface an error.

17/17 web tests pass; `tsc --noEmit` clean.

## Note for review — cross-currency (no code change)

A non-USD subscription prefills its raw number into a contract line whose currency is determined elsewhere (default USD), with no conversion. The field is editable and the pick-list label shows the source currency, so it's visible rather than silently wrong. Flagging as a conscious product decision — happy to add a conversion or mismatch warning if mixed-currency partners are in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)