### PR TITLE
fix(web): relabel agent update policy modes to match actual behavior (#1962)

### DIFF
--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -67,9 +67,14 @@ const defaultValues: DefaultsData = {
     requireApproval: false,
     sendWelcome: true
   },
-  agentUpdatePolicy: 'staged',
+  // The UI exposes only "Automatic" and "Manual" — the legacy 'staged' value is
+  // behaviourally identical to 'auto' (both are gated by the maintenance window;
+  // there is no rings/canaries machinery behind it — see issue #1962), so we
+  // default unconfigured orgs to 'auto' and fold any stored 'staged' into it on
+  // load (the backend still accepts 'staged' for back-compat).
+  agentUpdatePolicy: 'auto',
   // Default to the explicit "always" state so an unconfigured org matches the
-  // backend's permissive default (staged + no window = update anytime) instead
+  // backend's permissive default (auto + no window = update anytime) instead
   // of silently committing to a Sunday window the first time defaults are saved.
   maintenanceWindow: MAINTENANCE_WINDOW_ALWAYS
 };
@@ -94,7 +99,13 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
   const [deviceGroup, setDeviceGroup] = useState(initialData.deviceGroup || defaultValues.deviceGroup!);
   const [alertThreshold, setAlertThreshold] = useState(initialData.alertThreshold || defaultValues.alertThreshold!);
   const [autoEnrollment, setAutoEnrollment] = useState(initialData.autoEnrollment || defaultValues.autoEnrollment!);
-  const [agentUpdatePolicy, setAgentUpdatePolicy] = useState(initialData.agentUpdatePolicy || defaultValues.agentUpdatePolicy!);
+  // Fold the legacy 'staged' value into 'auto' (identical behaviour; see #1962)
+  // so the select shows a valid selection rather than falling back to no match.
+  const [agentUpdatePolicy, setAgentUpdatePolicy] = useState(
+    (initialData.agentUpdatePolicy ?? defaultValues.agentUpdatePolicy!) === 'staged'
+      ? 'auto'
+      : initialData.agentUpdatePolicy || defaultValues.agentUpdatePolicy!
+  );
   const initialWindow = deriveWindowState(initialData.maintenanceWindow);
   // A stored value that is neither the always-state nor a parseable window was
   // silently reset to seeded defaults by deriveWindowState. Surface that so the
@@ -307,10 +318,14 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
             }}
             className="h-10 w-full rounded-md border bg-background px-3 text-sm"
           >
-            <option value="auto">Automatic updates</option>
-            <option value="staged">Staged rollout</option>
-            <option value="manual">Manual approval</option>
+            <option value="auto">Automatic</option>
+            <option value="manual">Manual (block automatic updates)</option>
           </select>
+          <p className="text-xs text-muted-foreground">
+            <strong>Automatic</strong> installs agent updates during the maintenance window below
+            (or at any time when set to 24/7). <strong>Manual</strong> blocks automatic updates
+            entirely — agents stay on their current version until you update them yourself.
+          </p>
           <div className="space-y-3">
             <span className="text-xs font-medium uppercase text-muted-foreground">
               Maintenance window

--- a/apps/web/src/components/settings/PartnerDefaultsTab.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.tsx
@@ -23,14 +23,17 @@ export default function PartnerDefaultsTab({ data, onChange }: Props) {
         <div className="space-y-2">
           <label className="text-sm font-medium">Agent Update Policy</label>
           <select
-            value={data.agentUpdatePolicy ?? ''}
+            // Fold the legacy 'staged' value into 'auto' for display — they are
+            // behaviourally identical (both maintenance-window gated; no real
+            // staged rollout exists, see #1962). The backend still accepts
+            // 'staged' for back-compat.
+            value={data.agentUpdatePolicy === 'staged' ? 'auto' : (data.agentUpdatePolicy ?? '')}
             onChange={e => set({ agentUpdatePolicy: e.target.value || undefined })}
             className="h-10 w-full rounded-md border bg-background px-3 text-sm"
           >
             <option value="">{PLACEHOLDER}</option>
-            <option value="auto">Auto-update</option>
-            <option value="manual">Manual</option>
-            <option value="staged">Staged rollout</option>
+            <option value="auto">Automatic</option>
+            <option value="manual">Manual (block automatic updates)</option>
           </select>
         </div>
 


### PR DESCRIPTION
## Summary

Honest-labels fix for the Agent Update Policy select. On current `main` the three exposed modes do not map to three distinct behaviors (confirmed in `apps/api/src/routes/agents/agentUpdatePolicy.ts`):

- **Staged rollout** is behaviourally identical to **Automatic** — both are gated only by the maintenance window; there is no rings/canaries/cohorts/percentage machinery behind it.
- **Manual approval** correctly blocks heartbeat auto-upgrades (`{ allow: false, reason: 'manual-approval' }`) but exposes no approval / "update now" operator UI.

This PR relabels the UI so it stops implying workflows that aren't built. **This is the near-term "honest labels" half only** — true staged rollout (waves/percentages/deferrals) and a manual-approval/"update now" operator workflow remain the larger build (tracked alongside #1964).

## Changes (web copy + light display logic)

`apps/web/src/components/settings/OrgDefaultsEditor.tsx` and `apps/web/src/components/settings/PartnerDefaultsTab.tsx`:

| Old label | New label |
|---|---|
| Automatic updates / Auto-update | **Automatic** |
| Staged rollout | *(removed — collapsed into Automatic)* |
| Manual approval / Manual | **Manual (block automatic updates)** |

- Removed the **Staged rollout** option from both selects.
- Fold any stored `'staged'` value into `'auto'` for display, so an org/partner that previously saved `staged` still shows a valid selection rather than an empty/no-match control.
- Changed the org editor's local default from `'staged'` to `'auto'` (identical behavior).
- Added help text under the org-level select describing what each mode actually does.

## Back-compat / data

- **No backend change.** The `'auto' | 'staged' | 'manual'` enum and the `staged → auto` gate behavior are untouched; the backend still accepts `'staged'`.
- **No data migration.** Existing rows keep their stored value; `staged` simply renders as **Automatic**. (An org that opens settings and re-saves will persist `'auto'`, which is behaviourally identical.)

## User-facing — please review wording

These are operator-visible labels. Flagging for wording review before merge.

## Verification

- `apps/web` affected tests green: `vitest run OrgDefaultsEditor.test.tsx OrgSettingsPage.test.tsx` → 18 passed.
- `astro check` → 0 errors.

Refs #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)