### PR TITLE
feat(reports): expose Security & Compliance Posture report in the UI

### DIFF
--- a/apps/web/src/components/reports/ReportBuilder.tsx
+++ b/apps/web/src/components/reports/ReportBuilder.tsx
@@ -641,6 +641,22 @@ const normalizeBuilderType = (value?: ReportBuilderType): BuilderReportType => {
   return legacyToBuilderType[value as LegacyReportType] ?? 'devices';
 };
 
+/**
+ * Whether a report `type` round-trips losslessly through the freeform builder:
+ * opening it (normalizeBuilderType) and re-saving it (builderToLegacyType)
+ * yields the same type. Types that do NOT survive — e.g.
+ * `security_compliance_posture` → `compliance`, `executive_summary` →
+ * `performance` — are silently downgraded by the builder and must instead be
+ * created directly with their true type. This is the single source of truth
+ * for that decision; callers should derive from it rather than hand-maintain a
+ * per-template flag.
+ */
+export const reportTypeSurvivesBuilder = (value: ReportBuilderType): boolean => {
+  // Native builder types are represented directly and always round-trip.
+  if (builderTypeValues.includes(value as BuilderReportType)) return true;
+  return builderToLegacyType[normalizeBuilderType(value)] === value;
+};
+
 const normalizeSchedule = (value?: ReportSchedule): ReportSchedule => {
   if (!value || value === 'one_time') return 'weekly';
   return value;

--- a/apps/web/src/components/reports/ReportTemplates.posture.test.tsx
+++ b/apps/web/src/components/reports/ReportTemplates.posture.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+// Mutable so individual tests can exercise the no-org (partner-wide) path.
+let currentOrgId: string | null = 'org-1';
+vi.mock('../../stores/orgStore', () => ({ useOrgStore: () => ({ currentOrgId }) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (...a: unknown[]) => showToast(...a) }));
+
+import ReportTemplates from './ReportTemplates';
+
+/** The on-mount template fetch falls back to built-in defaults (no such API yet). */
+function mockTemplatesFetch(onPost: (init?: { method?: string }) => Promise<unknown>) {
+  fetchWithAuth.mockImplementation((url: string, init?: { method?: string }) => {
+    if (url === '/reports/templates') {
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }
+    if (url === '/reports' && init?.method === 'POST') {
+      return onPost(init);
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+function postCallBody() {
+  const call = fetchWithAuth.mock.calls.find(
+    ([url, init]) => url === '/reports' && (init as { method?: string } | undefined)?.method === 'POST'
+  );
+  return call ? JSON.parse((call[1] as { body: string }).body) : undefined;
+}
+
+async function clickUseTemplate(name: string) {
+  const heading = await screen.findByText(name);
+  const card = heading.closest('div.group') as HTMLElement;
+  expect(card).toBeTruthy();
+  await userEvent.setup().click(within(card).getByRole('button', { name: /use template/i }));
+  return card;
+}
+
+describe('ReportTemplates — Security & Compliance Posture card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentOrgId = 'org-1';
+  });
+
+  it('creates a security_compliance_posture report directly instead of opening the downgrading builder', async () => {
+    mockTemplatesFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ data: { id: 'rep-9' } }) }));
+    render(<ReportTemplates />);
+
+    await clickUseTemplate('Security & Compliance Posture (Insurance)');
+
+    await waitFor(() => {
+      expect(fetchWithAuth).toHaveBeenCalledWith('/reports', expect.objectContaining({ method: 'POST' }));
+    });
+    const body = postCallBody();
+    expect(body.type).toBe('security_compliance_posture');
+    expect(body.orgId).toBe('org-1');
+    expect(body.schedule).toBe('one_time');
+    expect(body.format).toBe('pdf');
+
+    // Must NOT open the freeform builder (which would downgrade to "compliance").
+    expect(screen.queryByText(/Use Security & Compliance Posture/i)).not.toBeInTheDocument();
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith('/reports'));
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('surfaces a failure and does not navigate when the create POST fails', async () => {
+    mockTemplatesFetch(() => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: 'boom' }) }));
+    render(<ReportTemplates />);
+
+    const card = await clickUseTemplate('Security & Compliance Posture (Insurance)');
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(navigateTo).not.toHaveBeenCalledWith('/reports');
+    // Button is re-enabled (finally cleared the in-flight id).
+    await waitFor(() =>
+      expect(within(card).getByRole('button', { name: /use template/i })).not.toBeDisabled()
+    );
+  });
+
+  it('omits orgId from the POST when no org is selected (partner-wide)', async () => {
+    currentOrgId = null;
+    mockTemplatesFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ data: { id: 'rep-9' } }) }));
+    render(<ReportTemplates />);
+
+    await clickUseTemplate('Security & Compliance Posture (Insurance)');
+
+    await waitFor(() => expect(postCallBody()).toBeDefined());
+    expect(postCallBody()).not.toHaveProperty('orgId');
+  });
+});
+
+describe('ReportTemplates — builder-representable templates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentOrgId = 'org-1';
+  });
+
+  it('opens the freeform builder (no direct POST) for a template the builder round-trips', async () => {
+    // "Device Health Report" is type "performance", which survives the builder.
+    mockTemplatesFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    render(<ReportTemplates />);
+
+    await clickUseTemplate('Device Health Report');
+
+    // Modal opens with the "Use <name>" heading; no report is created directly.
+    expect(await screen.findByText(/Use Device Health Report/i)).toBeInTheDocument();
+    expect(postCallBody()).toBeUndefined();
+    expect(navigateTo).not.toHaveBeenCalledWith('/reports');
+  });
+});

--- a/apps/web/src/components/reports/ReportTemplates.tsx
+++ b/apps/web/src/components/reports/ReportTemplates.tsx
@@ -13,9 +13,11 @@ import {
   X
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import ReportBuilder, { type ReportBuilderFormValues } from './ReportBuilder';
+import ReportBuilder, { reportTypeSurvivesBuilder, type ReportBuilderFormValues } from './ReportBuilder';
 import type { ReportFormat, ReportSchedule } from './ReportsList';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { runAction } from '@/lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 
 type TemplateTone = {
@@ -358,11 +360,13 @@ const TemplateSpec = ({ items }: { items: { label: string; value: string }[] }) 
 );
 
 export default function ReportTemplates() {
+  const { currentOrgId } = useOrgStore();
   const [templates, setTemplates] = useState<ReportTemplate[]>(defaultTemplates);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [activeTemplate, setActiveTemplate] = useState<ReportTemplate | null>(null);
   const [builderOpen, setBuilderOpen] = useState(false);
+  const [creatingId, setCreatingId] = useState<string | null>(null);
 
   const fetchTemplates = useCallback(async () => {
     setLoading(true);
@@ -392,6 +396,58 @@ export default function ReportTemplates() {
     setActiveTemplate(template ?? null);
     setBuilderOpen(true);
   }, []);
+
+  // Reports whose type the freeform builder would downgrade are saved directly
+  // with their true type instead of being routed through it.
+  const handleCreateDirect = useCallback(
+    async (template: ReportTemplate) => {
+      setCreatingId(template.id);
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth('/reports', {
+              method: 'POST',
+              body: JSON.stringify({
+                name: template.defaults.name ?? template.name,
+                type: template.defaults.type,
+                schedule: template.defaults.schedule ?? 'one_time',
+                format: template.defaults.format ?? 'pdf',
+                ...(currentOrgId ? { orgId: currentOrgId } : {}),
+                config: {
+                  dateRange: template.defaults.dateRange ?? { preset: 'last_30_days' }
+                }
+              })
+            }),
+          errorFallback: 'Failed to create report',
+          successMessage: `Created "${template.defaults.name ?? template.name}". Generate it from the Reports list.`,
+          onUnauthorized: () => {
+            void navigateTo('/login', { replace: true });
+          }
+        });
+        void navigateTo('/reports');
+      } catch {
+        // runAction already surfaced the failure (toast, or redirect on 401).
+      } finally {
+        setCreatingId(null);
+      }
+    },
+    [currentOrgId]
+  );
+
+  const handleUseTemplate = useCallback(
+    (template: ReportTemplate) => {
+      // Curated templates whose report type the builder can't represent (it
+      // would silently downgrade them) are created directly; everything the
+      // builder round-trips losslessly goes through the builder for tailoring.
+      const type = template.defaults.type;
+      if (type && !reportTypeSurvivesBuilder(type)) {
+        void handleCreateDirect(template);
+        return;
+      }
+      handleOpenBuilder(template);
+    },
+    [handleCreateDirect, handleOpenBuilder]
+  );
 
   const handleCloseBuilder = useCallback(() => {
     setBuilderOpen(false);
@@ -496,9 +552,11 @@ export default function ReportTemplates() {
               <div className="mt-auto pt-4">
                 <button
                   type="button"
-                  onClick={() => handleOpenBuilder(template)}
-                  className="inline-flex h-9 w-full items-center justify-center rounded-md bg-primary px-4 text-xs font-semibold text-primary-foreground transition hover:opacity-90"
+                  onClick={() => handleUseTemplate(template)}
+                  disabled={creatingId === template.id}
+                  className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-xs font-semibold text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
                 >
+                  {creatingId === template.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                   Use template
                 </button>
               </div>

--- a/apps/web/src/components/reports/ReportsList.templates.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.templates.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+vi.mock('./reportExport', () => ({
+  exportReport: vi.fn(),
+  downloadBlob: vi.fn(),
+  getBrowserTimezone: () => 'UTC',
+}));
+
+import ReportsList from './ReportsList';
+
+describe('ReportsList templates entry point', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url === '/reports') return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+      if (url.startsWith('/reports/runs?')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    });
+  });
+
+  it('links to the report templates gallery', async () => {
+    render(
+      <ReportsList onEdit={() => {}} onGenerate={() => {}} onDelete={() => {}} />
+    );
+
+    const link = await waitFor(() =>
+      screen.getByRole('link', { name: /templates/i })
+    );
+    expect(link).toHaveAttribute('href', '/reports/templates');
+  });
+});

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -10,7 +10,8 @@ import {
   Clock,
   CheckCircle,
   XCircle,
-  Loader2
+  Loader2,
+  LayoutTemplate
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
@@ -284,6 +285,13 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
           <p className="text-muted-foreground">Generate and schedule reports for your infrastructure.</p>
         </div>
         <div className="flex items-center gap-2">
+          <a
+            href="/reports/templates"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
+          >
+            <LayoutTemplate className="h-4 w-4" />
+            Templates
+          </a>
           <a
             href="/reports/builder"
             className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"

--- a/apps/web/src/components/reports/reportTypeSurvivesBuilder.test.ts
+++ b/apps/web/src/components/reports/reportTypeSurvivesBuilder.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { reportTypeSurvivesBuilder } from './ReportBuilder';
+
+// Guards the drift the type-design review flagged: the predicate is the single
+// source of truth for "can the freeform builder represent this type without
+// downgrading it". If the builder's type maps change, these expectations
+// should change with them — deliberately, not silently.
+describe('reportTypeSurvivesBuilder', () => {
+  it('returns true for types the builder round-trips losslessly', () => {
+    for (const type of [
+      'device_inventory',
+      'software_inventory',
+      'alert_summary',
+      'compliance',
+      'performance'
+    ] as const) {
+      expect(reportTypeSurvivesBuilder(type)).toBe(true);
+    }
+  });
+
+  it('returns true for native builder types', () => {
+    for (const type of ['devices', 'alerts', 'patches', 'compliance', 'activity'] as const) {
+      expect(reportTypeSurvivesBuilder(type)).toBe(true);
+    }
+  });
+
+  it('returns false for types the builder would downgrade', () => {
+    // posture → compliance, executive_summary → performance
+    expect(reportTypeSurvivesBuilder('security_compliance_posture')).toBe(false);
+    expect(reportTypeSurvivesBuilder('executive_summary')).toBe(false);
+  });
+});

--- a/apps/web/src/pages/reports/templates.astro
+++ b/apps/web/src/pages/reports/templates.astro
@@ -1,0 +1,15 @@
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import ReportTemplates from '../../components/reports/ReportTemplates';
+import Breadcrumbs from '../../components/layout/Breadcrumbs';
+---
+
+<DashboardLayout title="Report Templates">
+  <Breadcrumbs client:load items={[
+    { label: 'Reports', href: '/reports' },
+    { label: 'Templates' }
+  ]} />
+  <div class="mt-6">
+    <ReportTemplates client:only="react" />
+  </div>
+</DashboardLayout>


### PR DESCRIPTION
## Problem

The `security_compliance_posture` report is fully built end-to-end (service, migration, schema, list/render/download) but has **no UI entry point**:

- Its host component `ReportTemplates` was never mounted on any route.
- The freeform `ReportBuilder` silently downgrades the posture type to `compliance` (`legacyToBuilderType` → `builderToLegacyType`), so even routing it through the builder would persist the **wrong** report type — one that never runs the posture generator.

## What this does

- Mounts the `ReportTemplates` gallery at a new **`/reports/templates`** page and adds a **"Templates"** link in the Reports list header. Discoverable path: Reports → Templates → "Security & Compliance Posture (Insurance)" → Use template → saved to the Reports list → Generate.
- Curated templates whose type the builder can't represent are created **directly** via `POST /reports` with their true type (through `runAction`, per the no-silent-mutations convention), instead of the downgrading builder.
- That decision is **derived** from a single source of truth — `reportTypeSurvivesBuilder()` exported from `ReportBuilder` — rather than a hand-maintained per-template flag. This also fixes **Executive Summary**, which silently downgraded to `performance`.
- 401s are surfaced via `onUnauthorized` (redirect to `/login`) instead of failing silently.

## Why derive instead of a flag

A PR review flagged that a hand-set `directCreate` flag (my first cut) was already drifting: Executive Summary also downgrades but would have lacked the flag, and `normalizeTemplate` dropped the flag (so the feature would regress the moment a backend `/reports/templates` endpoint serves the posture template). Deriving from the builder's own type maps removes that whole class of bug.

## Tests

- Direct-create happy path: true type preserved, builder bypassed, success toast.
- Failure path: error toast, no navigation, button re-enabled.
- Partner-wide (no org selected): `orgId` omitted from the body.
- Regression guard: builder-round-trippable templates still open the builder (no direct POST).
- Templates header link present.
- Unit test pinning the `reportTypeSurvivesBuilder` round-trip table (guards future drift).

Verification: `tsc` clean, `eslint` clean, 100 reports + mutation-guard tests pass (8 new). Reviewed via `/pr-review-toolkit:review-pr` (code, tests, errors, types, comments) and all confirmed findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)