### PR TITLE
feat(software): detection rules for .exe/.msi deploys + reboot-code fix (#2022)

### DIFF
--- a/agent/internal/remote/tools/software_detection.go
+++ b/agent/internal/remote/tools/software_detection.go
@@ -1,7 +1,10 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"strings"
 )
@@ -81,10 +84,23 @@ func detectionStringField(m map[string]any, key string) string {
 	return ""
 }
 
-// fileExists returns true if path exists as a file or directory.
-func fileExists(path string) bool {
+// evaluateFileExists reports whether path exists as a file or directory.
+//
+// A stat error is NOT blindly read as "absent": only a genuine not-exist error
+// counts as a clean negative (matched=false, supported=true). Any other error
+// (permission denied, transient I/O) means we cannot determine presence, so we
+// report supported=false and let the caller fall back to exit-code behavior
+// rather than mis-reporting an installed package as missing (#2022).
+func evaluateFileExists(path string) (matched bool, supported bool) {
 	_, err := os.Stat(path)
-	return err == nil
+	if err == nil {
+		return true, true
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, true
+	}
+	slog.Warn("detection: cannot stat path, treating as undeterminable", "path", path, "error", err.Error())
+	return false, false
 }
 
 // EvaluateDetectionRules evaluates a slice of DetectionRule clauses (AND
@@ -134,7 +150,7 @@ func EvaluateDetectionRules(rules []DetectionRule) DetectionOutcome {
 func evaluateClause(rule DetectionRule) (matched bool, supported bool) {
 	switch rule.Type {
 	case "file_exists":
-		return fileExists(rule.Path), true
+		return evaluateFileExists(rule.Path)
 	case "registry":
 		return evaluateRegistryRule(rule)
 	case "msi_product_code":

--- a/agent/internal/remote/tools/software_detection.go
+++ b/agent/internal/remote/tools/software_detection.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DetectionRule describes one clause in a software detection rule set.
+// A package is considered detected only when ALL clauses evaluate to true.
+type DetectionRule struct {
+	Type string `json:"type"` // "registry" | "file_exists" | "msi_product_code"
+
+	// registry fields
+	Hive      string `json:"hive,omitempty"`      // HKLM (default) | HKCU | HKCR | HKU | HKCC
+	Path      string `json:"path,omitempty"`      // registry key path, or file/dir path for file_exists
+	ValueName string `json:"valueName,omitempty"` // optional value name under the key
+	ValueData string `json:"valueData,omitempty"` // optional exact-match expected data
+
+	// msi_product_code fields
+	ProductCode string `json:"productCode,omitempty"` // GUID, braces optional
+}
+
+// DetectionOutcome is the result of evaluating a rule set on this device.
+type DetectionOutcome struct {
+	// Detected is true only when Supported is true and ALL clauses matched.
+	Detected bool
+	// Supported is false when at least one clause type is not evaluable on this
+	// platform (e.g. a registry/msi clause on non-Windows). Callers must then
+	// fall back to exit-code behaviour — never silently treat unsupported as
+	// pass or fail.
+	Supported bool
+	// Detail is a short human-readable explanation for logs/output.
+	Detail string
+}
+
+// parseDetectionRules extracts detection rules from the command payload.
+// payload["detectionRules"] must be []any of map[string]any (the natural
+// shape after JSON→map[string]any decode). Clauses with an empty Type are
+// silently skipped. Returns nil for absent, empty, or entirely-garbage input.
+func parseDetectionRules(payload map[string]any) []DetectionRule {
+	raw, ok := payload["detectionRules"]
+	if !ok {
+		return nil
+	}
+	slice, ok := raw.([]any)
+	if !ok || len(slice) == 0 {
+		return nil
+	}
+
+	var rules []DetectionRule
+	for _, item := range slice {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		rule := DetectionRule{
+			Type:        detectionStringField(m, "type"),
+			Hive:        detectionStringField(m, "hive"),
+			Path:        detectionStringField(m, "path"),
+			ValueName:   detectionStringField(m, "valueName"),
+			ValueData:   detectionStringField(m, "valueData"),
+			ProductCode: detectionStringField(m, "productCode"),
+		}
+		if rule.Type == "" {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+// detectionStringField is a nil-safe type-asserting field reader for map[string]any
+// used by parseDetectionRules.
+func detectionStringField(m map[string]any, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// fileExists returns true if path exists as a file or directory.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// EvaluateDetectionRules evaluates a slice of DetectionRule clauses (AND
+// logic) against the current device state and returns a DetectionOutcome.
+//
+// Platform dispatch:
+//   - "file_exists"      → cross-platform os.Stat check (this file)
+//   - "registry"         → evaluateRegistryRule    (platform files)
+//   - "msi_product_code" → evaluateMsiProductCodeRule (platform files)
+//   - anything else      → unsupported
+func EvaluateDetectionRules(rules []DetectionRule) DetectionOutcome {
+	if len(rules) == 0 {
+		return DetectionOutcome{
+			Detected:  false,
+			Supported: false,
+			Detail:    "no detection rules",
+		}
+	}
+
+	for _, rule := range rules {
+		matched, supported := evaluateClause(rule)
+		if !supported {
+			return DetectionOutcome{
+				Detected:  false,
+				Supported: false,
+				Detail:    fmt.Sprintf("unsupported on this platform: %s", rule.Type),
+			}
+		}
+		if !matched {
+			return DetectionOutcome{
+				Detected:  false,
+				Supported: true,
+				Detail:    ruleNotSatisfiedDetail(rule),
+			}
+		}
+	}
+
+	return DetectionOutcome{
+		Detected:  true,
+		Supported: true,
+		Detail:    fmt.Sprintf("all %d rule(s) satisfied", len(rules)),
+	}
+}
+
+// evaluateClause dispatches a single DetectionRule clause.
+// Returns (matched, supported).
+func evaluateClause(rule DetectionRule) (matched bool, supported bool) {
+	switch rule.Type {
+	case "file_exists":
+		return fileExists(rule.Path), true
+	case "registry":
+		return evaluateRegistryRule(rule)
+	case "msi_product_code":
+		return evaluateMsiProductCodeRule(rule)
+	default:
+		return false, false
+	}
+}
+
+// ruleNotSatisfiedDetail builds a human-readable detail string for a failed clause.
+func ruleNotSatisfiedDetail(rule DetectionRule) string {
+	switch rule.Type {
+	case "registry":
+		hive := rule.Hive
+		if hive == "" {
+			hive = "HKLM"
+		}
+		path := strings.Join([]string{hive, rule.Path}, `\`)
+		if rule.ValueName != "" {
+			path += " -> " + rule.ValueName
+		}
+		return "rule not satisfied: registry " + path
+	case "file_exists":
+		return "rule not satisfied: file_exists " + rule.Path
+	case "msi_product_code":
+		return "rule not satisfied: msi_product_code " + rule.ProductCode
+	default:
+		return "rule not satisfied: " + rule.Type
+	}
+}

--- a/agent/internal/remote/tools/software_detection_other.go
+++ b/agent/internal/remote/tools/software_detection_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package tools
+
+// evaluateRegistryRule is not supported on non-Windows platforms.
+// Returns (false, false) to signal "unsupported" to EvaluateDetectionRules.
+func evaluateRegistryRule(_ DetectionRule) (matched bool, supported bool) {
+	return false, false
+}
+
+// evaluateMsiProductCodeRule is not supported on non-Windows platforms.
+// Returns (false, false) to signal "unsupported" to EvaluateDetectionRules.
+func evaluateMsiProductCodeRule(_ DetectionRule) (matched bool, supported bool) {
+	return false, false
+}

--- a/agent/internal/remote/tools/software_detection_test.go
+++ b/agent/internal/remote/tools/software_detection_test.go
@@ -1,0 +1,295 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// parseDetectionRules
+// ---------------------------------------------------------------------------
+
+func TestParseDetectionRules(t *testing.T) {
+	t.Run("absent key returns nil", func(t *testing.T) {
+		got := parseDetectionRules(map[string]any{})
+		if got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("nil slice value returns nil", func(t *testing.T) {
+		got := parseDetectionRules(map[string]any{"detectionRules": nil})
+		if got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("wrong type returns nil", func(t *testing.T) {
+		got := parseDetectionRules(map[string]any{"detectionRules": "bad"})
+		if got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("empty slice returns nil", func(t *testing.T) {
+		got := parseDetectionRules(map[string]any{"detectionRules": []any{}})
+		if got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("clause with empty type is skipped", func(t *testing.T) {
+		payload := map[string]any{
+			"detectionRules": []any{
+				map[string]any{"type": "", "path": "/some/path"},
+				map[string]any{"type": "file_exists", "path": "/foo"},
+			},
+		}
+		got := parseDetectionRules(payload)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+		if got[0].Type != "file_exists" {
+			t.Errorf("expected file_exists, got %q", got[0].Type)
+		}
+	})
+
+	t.Run("garbage entry (not a map) is skipped", func(t *testing.T) {
+		payload := map[string]any{
+			"detectionRules": []any{
+				"not a map",
+				map[string]any{"type": "file_exists", "path": "/foo"},
+			},
+		}
+		got := parseDetectionRules(payload)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+	})
+
+	t.Run("valid file_exists rule", func(t *testing.T) {
+		payload := map[string]any{
+			"detectionRules": []any{
+				map[string]any{"type": "file_exists", "path": "/usr/bin/foo"},
+			},
+		}
+		got := parseDetectionRules(payload)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+		r := got[0]
+		if r.Type != "file_exists" {
+			t.Errorf("Type: want file_exists, got %q", r.Type)
+		}
+		if r.Path != "/usr/bin/foo" {
+			t.Errorf("Path: want /usr/bin/foo, got %q", r.Path)
+		}
+	})
+
+	t.Run("valid registry rule", func(t *testing.T) {
+		payload := map[string]any{
+			"detectionRules": []any{
+				map[string]any{
+					"type":      "registry",
+					"hive":      "HKLM",
+					"path":      `SOFTWARE\MyApp`,
+					"valueName": "Version",
+					"valueData": "1.0",
+				},
+			},
+		}
+		got := parseDetectionRules(payload)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+		r := got[0]
+		if r.Type != "registry" || r.Hive != "HKLM" || r.Path != `SOFTWARE\MyApp` ||
+			r.ValueName != "Version" || r.ValueData != "1.0" {
+			t.Errorf("unexpected parsed rule: %+v", r)
+		}
+	})
+
+	t.Run("valid msi_product_code rule", func(t *testing.T) {
+		payload := map[string]any{
+			"detectionRules": []any{
+				map[string]any{
+					"type":        "msi_product_code",
+					"productCode": "{AABBCCDD-1234-5678-ABCD-000000000001}",
+				},
+			},
+		}
+		got := parseDetectionRules(payload)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+		if got[0].ProductCode != "{AABBCCDD-1234-5678-ABCD-000000000001}" {
+			t.Errorf("unexpected ProductCode: %q", got[0].ProductCode)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateDetectionRules — file_exists (cross-platform)
+// ---------------------------------------------------------------------------
+
+func TestEvaluateDetectionRules_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := filepath.Join(dir, "present.txt")
+	if err := os.WriteFile(existingFile, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	missingPath := filepath.Join(dir, "absent.txt")
+
+	tests := []struct {
+		name          string
+		rules         []DetectionRule
+		wantDetected  bool
+		wantSupported bool
+	}{
+		{
+			name:          "existing file => detected",
+			rules:         []DetectionRule{{Type: "file_exists", Path: existingFile}},
+			wantDetected:  true,
+			wantSupported: true,
+		},
+		{
+			name:          "missing path => not detected",
+			rules:         []DetectionRule{{Type: "file_exists", Path: missingPath}},
+			wantDetected:  false,
+			wantSupported: true,
+		},
+		{
+			name:          "directory path => detected",
+			rules:         []DetectionRule{{Type: "file_exists", Path: dir}},
+			wantDetected:  true,
+			wantSupported: true,
+		},
+		{
+			name: "AND two existing => detected",
+			rules: []DetectionRule{
+				{Type: "file_exists", Path: existingFile},
+				{Type: "file_exists", Path: dir},
+			},
+			wantDetected:  true,
+			wantSupported: true,
+		},
+		{
+			name: "AND existing + missing => not detected",
+			rules: []DetectionRule{
+				{Type: "file_exists", Path: existingFile},
+				{Type: "file_exists", Path: missingPath},
+			},
+			wantDetected:  false,
+			wantSupported: true,
+		},
+		{
+			name: "AND missing + existing => not detected (short-circuits on first fail)",
+			rules: []DetectionRule{
+				{Type: "file_exists", Path: missingPath},
+				{Type: "file_exists", Path: existingFile},
+			},
+			wantDetected:  false,
+			wantSupported: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := EvaluateDetectionRules(tc.rules)
+			if out.Detected != tc.wantDetected {
+				t.Errorf("Detected: want %v, got %v (detail: %q)", tc.wantDetected, out.Detected, out.Detail)
+			}
+			if out.Supported != tc.wantSupported {
+				t.Errorf("Supported: want %v, got %v (detail: %q)", tc.wantSupported, out.Supported, out.Detail)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateDetectionRules — empty rules
+// ---------------------------------------------------------------------------
+
+func TestEvaluateDetectionRules_EmptyRules(t *testing.T) {
+	out := EvaluateDetectionRules(nil)
+	if out.Supported {
+		t.Error("expected Supported=false for nil rules")
+	}
+	if out.Detected {
+		t.Error("expected Detected=false for nil rules")
+	}
+
+	out = EvaluateDetectionRules([]DetectionRule{})
+	if out.Supported {
+		t.Error("expected Supported=false for empty rules slice")
+	}
+	if out.Detected {
+		t.Error("expected Detected=false for empty rules slice")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateDetectionRules — platform-unsupported clauses (non-Windows)
+// On Windows CI these tests would behave differently; we guard with
+// runtime.GOOS so the assertions always match the platform being tested.
+// ---------------------------------------------------------------------------
+
+func TestEvaluateDetectionRules_UnsupportedOnNonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unsupported-clause path only tested on non-Windows")
+	}
+
+	t.Run("registry clause alone => Supported=false", func(t *testing.T) {
+		rules := []DetectionRule{
+			{Type: "registry", Hive: "HKLM", Path: `SOFTWARE\MyApp`},
+		}
+		out := EvaluateDetectionRules(rules)
+		if out.Supported {
+			t.Errorf("expected Supported=false, got true (detail: %q)", out.Detail)
+		}
+		if out.Detected {
+			t.Errorf("expected Detected=false, got true (detail: %q)", out.Detail)
+		}
+	})
+
+	t.Run("msi_product_code clause alone => Supported=false", func(t *testing.T) {
+		rules := []DetectionRule{
+			{Type: "msi_product_code", ProductCode: "{AABBCCDD-1234-5678-ABCD-000000000001}"},
+		}
+		out := EvaluateDetectionRules(rules)
+		if out.Supported {
+			t.Errorf("expected Supported=false, got true (detail: %q)", out.Detail)
+		}
+	})
+
+	t.Run("file_exists (present) + registry => Supported=false", func(t *testing.T) {
+		dir := t.TempDir()
+		existingFile := filepath.Join(dir, "present.txt")
+		if err := os.WriteFile(existingFile, []byte("hello"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		rules := []DetectionRule{
+			{Type: "file_exists", Path: existingFile},
+			{Type: "registry", Hive: "HKLM", Path: `SOFTWARE\MyApp`},
+		}
+		out := EvaluateDetectionRules(rules)
+		if out.Supported {
+			t.Errorf("expected Supported=false due to registry clause, got true (detail: %q)", out.Detail)
+		}
+		if out.Detected {
+			t.Errorf("expected Detected=false, got true (detail: %q)", out.Detail)
+		}
+	})
+
+	t.Run("unknown clause type => Supported=false", func(t *testing.T) {
+		rules := []DetectionRule{
+			{Type: "wmi_query", Path: "SELECT * FROM Win32_Product"},
+		}
+		out := EvaluateDetectionRules(rules)
+		if out.Supported {
+			t.Errorf("expected Supported=false for unknown type, got true (detail: %q)", out.Detail)
+		}
+	})
+}

--- a/agent/internal/remote/tools/software_detection_windows.go
+++ b/agent/internal/remote/tools/software_detection_windows.go
@@ -3,11 +3,22 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/windows/registry"
 )
+
+// registryKeyMissing reports whether an OpenKey error means the key simply does
+// not exist (a clean negative) rather than an error we couldn't interpret (e.g.
+// ACCESS_DENIED), which must NOT be read as "absent". OpenKey returns the raw
+// syscall errno, so this checks the Windows not-found codes directly.
+func registryKeyMissing(err error) bool {
+	return errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) || errors.Is(err, syscall.ERROR_PATH_NOT_FOUND)
+}
 
 // evaluateRegistryRule checks whether a registry key (and optionally a value
 // and its data) exists on Windows.
@@ -21,14 +32,20 @@ func evaluateRegistryRule(rule DetectionRule) (matched bool, supported bool) {
 
 	root, err := resolveDetectionRegistryRoot(hive)
 	if err != nil {
-		// Unknown hive — treat as not matched but still supported.
-		return false, true
+		// Unknown hive — we can't evaluate, so report unsupported (fall back to
+		// exit-code) rather than a false negative.
+		slog.Warn("detection: unknown registry hive", "hive", hive)
+		return false, false
 	}
 
 	key, err := registry.OpenKey(root, rule.Path, registry.QUERY_VALUE|registry.READ)
 	if err != nil {
-		// Key absent.
-		return false, true
+		if registryKeyMissing(err) {
+			return false, true // key genuinely absent → clean negative
+		}
+		// ACCESS_DENIED / unexpected — can't determine presence.
+		slog.Warn("detection: cannot open registry key", "hive", hive, "path", rule.Path, "error", err.Error())
+		return false, false
 	}
 	defer key.Close()
 
@@ -37,14 +54,23 @@ func evaluateRegistryRule(rule DetectionRule) (matched bool, supported bool) {
 		return true, true
 	}
 
-	// Read the value as a string; fall back to integer.
+	// Read the value as a string; a wrong-type value falls back to integer.
 	strVal, _, err := key.GetStringValue(rule.ValueName)
 	if err != nil {
-		// Try integer.
+		if errors.Is(err, registry.ErrNotExist) {
+			return false, true // value genuinely absent → clean negative
+		}
+		// Wrong type (e.g. DWORD) or other — try reading it as an integer.
 		intVal, _, intErr := key.GetIntegerValue(rule.ValueName)
 		if intErr != nil {
-			// Value absent.
-			return false, true
+			if errors.Is(intErr, registry.ErrNotExist) {
+				return false, true
+			}
+			// A value type we don't handle (binary/multi-string) or an access
+			// error — can't compare it, so report unsupported.
+			slog.Warn("detection: cannot read registry value",
+				"hive", hive, "path", rule.Path, "value", rule.ValueName, "error", intErr.Error())
+			return false, false
 		}
 		strVal = fmt.Sprintf("%d", intVal)
 	}
@@ -74,14 +100,25 @@ func evaluateMsiProductCodeRule(rule DetectionRule) (matched bool, supported boo
 		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\` + code,
 	}
 
+	sawUndeterminable := false
 	for _, path := range paths {
 		key, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.QUERY_VALUE)
 		if err == nil {
 			key.Close()
 			return true, true
 		}
+		if !registryKeyMissing(err) {
+			// Not a clean "not found" — couldn't determine for this path.
+			slog.Warn("detection: cannot open MSI uninstall key", "path", path, "error", err.Error())
+			sawUndeterminable = true
+		}
 	}
 
+	if sawUndeterminable {
+		// Neither path matched, but at least one couldn't be evaluated — don't
+		// claim the product is absent; fall back to exit-code behavior.
+		return false, false
+	}
 	return false, true
 }
 

--- a/agent/internal/remote/tools/software_detection_windows.go
+++ b/agent/internal/remote/tools/software_detection_windows.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// evaluateRegistryRule checks whether a registry key (and optionally a value
+// and its data) exists on Windows.
+//
+// Returns (matched, supported=true) always on Windows.
+func evaluateRegistryRule(rule DetectionRule) (matched bool, supported bool) {
+	hive := rule.Hive
+	if hive == "" {
+		hive = "HKLM"
+	}
+
+	root, err := resolveDetectionRegistryRoot(hive)
+	if err != nil {
+		// Unknown hive — treat as not matched but still supported.
+		return false, true
+	}
+
+	key, err := registry.OpenKey(root, rule.Path, registry.QUERY_VALUE|registry.READ)
+	if err != nil {
+		// Key absent.
+		return false, true
+	}
+	defer key.Close()
+
+	// Key exists; if no value name required we're done.
+	if rule.ValueName == "" {
+		return true, true
+	}
+
+	// Read the value as a string; fall back to integer.
+	strVal, _, err := key.GetStringValue(rule.ValueName)
+	if err != nil {
+		// Try integer.
+		intVal, _, intErr := key.GetIntegerValue(rule.ValueName)
+		if intErr != nil {
+			// Value absent.
+			return false, true
+		}
+		strVal = fmt.Sprintf("%d", intVal)
+	}
+
+	// Value exists; if no data match required we're done.
+	if rule.ValueData == "" {
+		return true, true
+	}
+
+	// Case-insensitive exact match.
+	return strings.EqualFold(strVal, rule.ValueData), true
+}
+
+// evaluateMsiProductCodeRule checks whether a product code (MSI GUID) is
+// present in the Windows uninstall registry.
+//
+// Returns (matched, supported=true) always on Windows.
+func evaluateMsiProductCodeRule(rule DetectionRule) (matched bool, supported bool) {
+	code := normalizeMsiProductCode(rule.ProductCode)
+	if code == "" {
+		return false, true
+	}
+
+	// Check both the native and WOW6432Node uninstall paths.
+	paths := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\` + code,
+		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\` + code,
+	}
+
+	for _, path := range paths {
+		key, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.QUERY_VALUE)
+		if err == nil {
+			key.Close()
+			return true, true
+		}
+	}
+
+	return false, true
+}
+
+// normalizeMsiProductCode converts a product-code GUID to the uppercase
+// braced form required by the uninstall registry key name.
+// Returns "" for empty or obviously invalid input.
+func normalizeMsiProductCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return ""
+	}
+	// Strip braces if present, then re-add in uppercase.
+	code = strings.TrimPrefix(code, "{")
+	code = strings.TrimSuffix(code, "}")
+	code = strings.ToUpper(code)
+	if code == "" {
+		return ""
+	}
+	return "{" + code + "}"
+}
+
+// resolveDetectionRegistryRoot maps a hive abbreviation to a registry.Key root.
+// Mirrors the logic in registry_windows.go's resolveRegistryRoot but is kept
+// separate to avoid coupling the detection logic to the registry tool.
+func resolveDetectionRegistryRoot(hive string) (registry.Key, error) {
+	switch hive {
+	case "HKLM", "HKEY_LOCAL_MACHINE":
+		return registry.LOCAL_MACHINE, nil
+	case "HKCU", "HKEY_CURRENT_USER":
+		return registry.CURRENT_USER, nil
+	case "HKCR", "HKEY_CLASSES_ROOT":
+		return registry.CLASSES_ROOT, nil
+	case "HKU", "HKEY_USERS":
+		return registry.USERS, nil
+	case "HKCC", "HKEY_CURRENT_CONFIG":
+		return registry.CURRENT_CONFIG, nil
+	default:
+		return 0, fmt.Errorf("unknown registry hive: %s", hive)
+	}
+}

--- a/agent/internal/remote/tools/software_detection_windows_test.go
+++ b/agent/internal/remote/tools/software_detection_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package tools
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestNormalizeMsiProductCode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"{3f2504e0-4f89-41d3-9a0c-0305e82c3301}", "{3F2504E0-4F89-41D3-9A0C-0305E82C3301}"},
+		{"3f2504e0-4f89-41d3-9a0c-0305e82c3301", "{3F2504E0-4F89-41D3-9A0C-0305E82C3301}"},
+		{"  {3F2504E0-4F89-41D3-9A0C-0305E82C3301}  ", "{3F2504E0-4F89-41D3-9A0C-0305E82C3301}"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeMsiProductCode(tc.in); got != tc.want {
+			t.Fatalf("normalizeMsiProductCode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveDetectionRegistryRoot(t *testing.T) {
+	cases := []struct {
+		hive    string
+		want    registry.Key
+		wantErr bool
+	}{
+		{"HKLM", registry.LOCAL_MACHINE, false},
+		{"HKEY_LOCAL_MACHINE", registry.LOCAL_MACHINE, false},
+		{"HKCU", registry.CURRENT_USER, false},
+		{"HKCR", registry.CLASSES_ROOT, false},
+		{"HKU", registry.USERS, false},
+		{"HKCC", registry.CURRENT_CONFIG, false},
+		{"BOGUS", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := resolveDetectionRegistryRoot(tc.hive)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("resolveDetectionRegistryRoot(%q) expected error", tc.hive)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("resolveDetectionRegistryRoot(%q) unexpected error: %v", tc.hive, err)
+		}
+		if got != tc.want {
+			t.Fatalf("resolveDetectionRegistryRoot(%q) = %v, want %v", tc.hive, got, tc.want)
+		}
+	}
+}

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -52,6 +52,32 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
 
+	// Detection rules (#2022): evaluated against the device's real state so the
+	// reported status reflects whether the app is actually present rather than
+	// just the installer exit code.
+	detectionRules := parseDetectionRules(payload)
+	forceReinstall := GetPayloadBool(payload, "forceReinstall", false)
+
+	// Pre-install gate: when a detection rule is configured and the package is
+	// already present, skip the download+install entirely (unless the deployment
+	// forces a reinstall). Unsupported rule types on this platform can't be
+	// evaluated, so we fall through and install rather than guessing.
+	if len(detectionRules) > 0 && !forceReinstall {
+		if pre := EvaluateDetectionRules(detectionRules); pre.Supported && pre.Detected {
+			return NewSuccessResult(map[string]any{
+				"softwareName":       softwareName,
+				"version":            version,
+				"fileType":           fileType,
+				"action":             "install",
+				"success":            true,
+				"skipped":            true,
+				"detectionPerformed": true,
+				"detectionSatisfied": true,
+				"detail":             "already installed; " + pre.Detail,
+			}, time.Since(startTime).Milliseconds())
+		}
+	}
+
 	if err := validateDownloadURL(downloadUrl); err != nil {
 		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
@@ -101,6 +127,11 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 		return result
 	}
 
+	// Post-install verification (#2022): when a detection rule is configured, the
+	// device's real state — not the installer exit code — decides success. An
+	// installer can exit 0 yet leave nothing installed; that must report failed.
+	// Unsupported rule types on this platform can't be evaluated, so we keep the
+	// exit-code result and note that detection was skipped.
 	successPayload := map[string]any{
 		"softwareName": softwareName,
 		"version":      version,
@@ -113,6 +144,29 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 	if outputTruncated {
 		successPayload["outputTruncated"] = true
 	}
+
+	if len(detectionRules) > 0 {
+		post := EvaluateDetectionRules(detectionRules)
+		if post.Supported {
+			successPayload["detectionPerformed"] = true
+			successPayload["detectionSatisfied"] = post.Detected
+			if !post.Detected {
+				// Installer reported success but the app isn't actually present.
+				return CommandResult{
+					Status:     "failed",
+					ExitCode:   exitCode,
+					Stdout:     output,
+					Error:      "installer reported success but detection rule was not satisfied: " + post.Detail,
+					DurationMs: time.Since(startTime).Milliseconds(),
+				}
+			}
+			successPayload["detail"] = post.Detail
+		} else {
+			successPayload["detectionPerformed"] = false
+			successPayload["detail"] = post.Detail
+		}
+	}
+
 	return NewSuccessResult(successPayload, time.Since(startTime).Milliseconds())
 }
 
@@ -335,16 +389,29 @@ func executeInstaller(localPath, fileType, silentInstallArgs string) (int, strin
 		}
 	}
 
-	// MSI exit codes: 0 = success, 3010 = success pending reboot
-	if fileType == "msi" && (exitCode == 0 || exitCode == 3010) {
+	if installerExitIndicatesSuccess(fileType, exitCode) {
 		return exitCode, procoutput.BytesToUTF8(output), nil
 	}
 
-	if exitCode != 0 {
-		return exitCode, procoutput.BytesToUTF8(output), fmt.Errorf("installer exited with code %d", exitCode)
-	}
+	return exitCode, procoutput.BytesToUTF8(output), fmt.Errorf("installer exited with code %d", exitCode)
+}
 
-	return 0, procoutput.BytesToUTF8(output), nil
+// installerExitIndicatesSuccess reports whether an installer exit code means the
+// install succeeded. 0 is universal success. 3010 (ERROR_SUCCESS_REBOOT_REQUIRED)
+// and 1641 (ERROR_SUCCESS_REBOOT_INITIATED) are Windows installer "success, a
+// reboot is pending/underway" codes returned by both MSI and many EXE installers.
+// Previously only MSI 3010 was honored, so a reboot-pending EXE install — and any
+// MSI returning 1641 — was wrongly reported as failed (#2022).
+func installerExitIndicatesSuccess(fileType string, exitCode int) bool {
+	if exitCode == 0 {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(fileType)) {
+	case "exe", "msi":
+		return exitCode == 3010 || exitCode == 1641
+	default:
+		return false
+	}
 }
 
 func buildMSIExecArgs(localPath, silentInstallArgs string) []string {

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -127,11 +127,6 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 		return result
 	}
 
-	// Post-install verification (#2022): when a detection rule is configured, the
-	// device's real state — not the installer exit code — decides success. An
-	// installer can exit 0 yet leave nothing installed; that must report failed.
-	// Unsupported rule types on this platform can't be evaluated, so we keep the
-	// exit-code result and note that detection was skipped.
 	successPayload := map[string]any{
 		"softwareName": softwareName,
 		"version":      version,
@@ -145,29 +140,47 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 		successPayload["outputTruncated"] = true
 	}
 
-	if len(detectionRules) > 0 {
-		post := EvaluateDetectionRules(detectionRules)
-		if post.Supported {
-			successPayload["detectionPerformed"] = true
-			successPayload["detectionSatisfied"] = post.Detected
-			if !post.Detected {
-				// Installer reported success but the app isn't actually present.
-				return CommandResult{
-					Status:     "failed",
-					ExitCode:   exitCode,
-					Stdout:     output,
-					Error:      "installer reported success but detection rule was not satisfied: " + post.Detail,
-					DurationMs: time.Since(startTime).Milliseconds(),
-				}
-			}
-			successPayload["detail"] = post.Detail
-		} else {
-			successPayload["detectionPerformed"] = false
-			successPayload["detail"] = post.Detail
-		}
+	return applyPostInstallDetection(successPayload, exitCode, output, detectionRules, time.Since(startTime).Milliseconds())
+}
+
+// applyPostInstallDetection decides the final install result from the device's
+// REAL state when detection rules are configured (#2022). The installer's exit
+// code alone is not trusted: an installer can exit 0 yet leave nothing behind.
+//
+// Three outcomes:
+//   - supported + detected   → success (the install verified).
+//   - supported + !detected  → failed ("reported success but detection rule
+//     was not satisfied") — the marquee guarantee of this feature.
+//   - unsupported on platform → keep the exit-code success result and note that
+//     detection was not performed (never silently flip to pass/fail).
+//
+// With no rules it is a plain exit-code success. successPayload is mutated with
+// detection metadata for the success/unsupported paths.
+func applyPostInstallDetection(successPayload map[string]any, exitCode int, output string, rules []DetectionRule, durationMs int64) CommandResult {
+	if len(rules) == 0 {
+		return NewSuccessResult(successPayload, durationMs)
 	}
 
-	return NewSuccessResult(successPayload, time.Since(startTime).Milliseconds())
+	post := EvaluateDetectionRules(rules)
+	if !post.Supported {
+		successPayload["detectionPerformed"] = false
+		successPayload["detail"] = post.Detail
+		return NewSuccessResult(successPayload, durationMs)
+	}
+
+	successPayload["detectionPerformed"] = true
+	successPayload["detectionSatisfied"] = post.Detected
+	if !post.Detected {
+		return CommandResult{
+			Status:     "failed",
+			ExitCode:   exitCode,
+			Stdout:     output,
+			Error:      "installer reported success but detection rule was not satisfied: " + post.Detail,
+			DurationMs: durationMs,
+		}
+	}
+	successPayload["detail"] = post.Detail
+	return NewSuccessResult(successPayload, durationMs)
 }
 
 func validateInstallInputs(fileName, fileType, checksum, silentInstallArgs, softwareName, version string) (string, string, string, string, string, string, error) {

--- a/agent/internal/remote/tools/software_install_detection_test.go
+++ b/agent/internal/remote/tools/software_install_detection_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -39,6 +41,60 @@ func TestInstallerExitIndicatesSuccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyPostInstallDetection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present.txt")
+	if err := os.WriteFile(present, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write present: %v", err)
+	}
+	absent := filepath.Join(dir, "absent.txt")
+
+	t.Run("no rules → plain exit-code success", func(t *testing.T) {
+		r := applyPostInstallDetection(map[string]any{"success": true}, 0, "out", nil, 0)
+		if r.Status != "completed" {
+			t.Fatalf("want completed, got %q", r.Status)
+		}
+	})
+
+	t.Run("supported + detected → success", func(t *testing.T) {
+		rules := []DetectionRule{{Type: "file_exists", Path: present}}
+		r := applyPostInstallDetection(map[string]any{"success": true}, 0, "out", rules, 0)
+		if r.Status != "completed" {
+			t.Fatalf("want completed, got %q (err=%q)", r.Status, r.Error)
+		}
+	})
+
+	t.Run("supported + not detected → failed", func(t *testing.T) {
+		rules := []DetectionRule{{Type: "file_exists", Path: absent}}
+		r := applyPostInstallDetection(map[string]any{"success": true}, 0, "out", rules, 0)
+		if r.Status != "failed" {
+			t.Fatalf("want failed, got %q", r.Status)
+		}
+		if !strings.Contains(r.Error, "detection rule was not satisfied") {
+			t.Fatalf("expected detection-not-satisfied error, got %q", r.Error)
+		}
+	})
+
+	t.Run("unsupported on this platform → keep exit-code success", func(t *testing.T) {
+		// A registry clause is unsupported on the non-Windows CI host, so the
+		// install must remain a success and report detectionPerformed=false.
+		if runtime.GOOS == "windows" {
+			t.Skip("registry clause is supported on Windows")
+		}
+		payload := map[string]any{"success": true}
+		rules := []DetectionRule{{Type: "registry", Path: `SOFTWARE\Acme\App`}}
+		r := applyPostInstallDetection(payload, 0, "out", rules, 0)
+		if r.Status != "completed" {
+			t.Fatalf("want completed, got %q", r.Status)
+		}
+		if payload["detectionPerformed"] != false {
+			t.Fatalf("want detectionPerformed=false, got %v", payload["detectionPerformed"])
+		}
+	})
 }
 
 // When a detection rule already matches the device state, InstallSoftware must

--- a/agent/internal/remote/tools/software_install_detection_test.go
+++ b/agent/internal/remote/tools/software_install_detection_test.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallerExitIndicatesSuccess(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		fileType string
+		exitCode int
+		want     bool
+	}{
+		{"exe success", "exe", 0, true},
+		{"msi success", "msi", 0, true},
+		{"exe reboot required 3010", "exe", 3010, true},
+		{"msi reboot required 3010", "msi", 3010, true},
+		{"exe reboot initiated 1641", "exe", 1641, true},
+		{"msi reboot initiated 1641", "msi", 1641, true},
+		{"exe uppercase filetype still maps", "EXE", 3010, true},
+		{"exe genuine failure", "exe", 1, false},
+		{"msi genuine failure", "msi", 1603, false},
+		// Non-Windows installer types: only 0 is success; reboot codes are
+		// Windows-specific and not treated as success elsewhere.
+		{"deb reboot code not success", "deb", 3010, false},
+		{"pkg success", "pkg", 0, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := installerExitIndicatesSuccess(tc.fileType, tc.exitCode); got != tc.want {
+				t.Fatalf("installerExitIndicatesSuccess(%q, %d) = %v, want %v", tc.fileType, tc.exitCode, got, tc.want)
+			}
+		})
+	}
+}
+
+// When a detection rule already matches the device state, InstallSoftware must
+// skip the download+install and report a skipped success — without ever touching
+// the network. We point a file_exists rule at a real temp file so the pre-install
+// gate fires before validateDownloadURL/download.
+func TestInstallSoftwareSkipsWhenAlreadyDetected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "installed.txt")
+	if err := os.WriteFile(marker, []byte("present"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	payload := map[string]any{
+		// A syntactically valid URL that must never be fetched (the skip returns
+		// before validateDownloadURL/downloadFile).
+		"downloadUrl":  "https://example.invalid/never-fetched.exe",
+		"fileName":     "pkg.exe",
+		"fileType":     "exe",
+		"softwareName": "Acme",
+		"version":      "1.0.0",
+		"detectionRules": []any{
+			map[string]any{"type": "file_exists", "path": marker},
+		},
+	}
+
+	result := InstallSoftware(payload)
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %q (error=%q)", result.Status, result.Error)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		t.Fatalf("unmarshal stdout: %v (stdout=%q)", err, result.Stdout)
+	}
+	if data["skipped"] != true {
+		t.Fatalf("expected skipped=true, got %v", data["skipped"])
+	}
+	if data["detectionSatisfied"] != true {
+		t.Fatalf("expected detectionSatisfied=true, got %v", data["detectionSatisfied"])
+	}
+}
+
+// forceReinstall must defeat the skip gate even when the package is detected, so
+// the install proceeds. With an unfetchable URL the download fails — which is the
+// proof the gate did NOT short-circuit.
+func TestInstallSoftwareForceReinstallBypassesSkip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "installed.txt")
+	if err := os.WriteFile(marker, []byte("present"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	payload := map[string]any{
+		// localhost:0 is a guaranteed-unroutable target; the download attempt
+		// fails fast, proving we did not skip.
+		"downloadUrl":    "https://127.0.0.1:0/pkg.exe",
+		"fileName":       "pkg.exe",
+		"fileType":       "exe",
+		"softwareName":   "Acme",
+		"version":        "1.0.0",
+		"forceReinstall": true,
+		"detectionRules": []any{
+			map[string]any{"type": "file_exists", "path": marker},
+		},
+	}
+
+	result := InstallSoftware(payload)
+	if result.Status != "failed" {
+		t.Fatalf("expected failed (download attempted, not skipped), got %q", result.Status)
+	}
+}

--- a/apps/api/migrations/2026-06-30-software-version-detection-rules.sql
+++ b/apps/api/migrations/2026-06-30-software-version-detection-rules.sql
@@ -1,0 +1,14 @@
+-- Issue #2022: per-package detection rules for the Software Library.
+--
+-- Adds a nullable jsonb column to software_versions holding an array of
+-- detection-rule clauses (registry / file_exists / msi_product_code) that the
+-- agent evaluates against the device's real state to confirm whether the package
+-- is actually installed — independent of the installer's exit code. Null/empty
+-- preserves the prior exit-code-only behavior, so this is a backward-compatible
+-- additive change requiring no backfill.
+--
+-- software_versions is a child of software_catalog (tenant ownership lives on the
+-- catalog row); this column adds no new tenant axis, so no RLS change is needed.
+
+ALTER TABLE software_versions
+  ADD COLUMN IF NOT EXISTS detection_rules jsonb;

--- a/apps/api/src/db/schema/software.ts
+++ b/apps/api/src/db/schema/software.ts
@@ -63,6 +63,11 @@ export const softwareVersions = pgTable('software_versions', {
   silentUninstallArgs: text('silent_uninstall_args'),
   preInstallScript: text('pre_install_script'),
   postInstallScript: text('post_install_script'),
+  // Detection rules (issue #2022): an array of clauses the agent evaluates
+  // against the device's real state to confirm whether the package is actually
+  // present — independent of the installer exit code. Shape validated by
+  // detectionRulesSchema in @breeze/shared. Null/empty = exit-code behavior only.
+  detectionRules: jsonb('detection_rules'),
   isLatest: boolean('is_latest').notNull().default(false)
 }, (table) => ({
   catalogIdx: index('software_versions_catalog_id_idx').on(table.catalogId),

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -419,6 +419,79 @@ describe('software routes', () => {
       expect(uploadBinary).not.toHaveBeenCalled();
     });
 
+    it('rejects malformed detectionRules JSON with a 400 (no silent drop)', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      fd.append('detectionRules', '{not json');
+      fd.append('file', new File(['payload'], 'pkg.exe', { type: 'application/octet-stream' }));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(400);
+      expect(uploadBinary).not.toHaveBeenCalled();
+    });
+
+    it('rejects schema-invalid detectionRules with a 400', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      // Valid JSON but a bad clause (non-GUID product code).
+      fd.append('detectionRules', JSON.stringify([{ type: 'msi_product_code', productCode: 'nope' }]));
+      fd.append('file', new File(['payload'], 'pkg.exe', { type: 'application/octet-stream' }));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(400);
+      expect(uploadBinary).not.toHaveBeenCalled();
+    });
+
+    it('accepts a valid detectionRules array on upload (201)', async () => {
+      vi.mocked(isS3Configured).mockReturnValueOnce(true);
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+      );
+      vi.mocked(db.transaction).mockResolvedValueOnce({
+        id: 'ver-det', catalogId, version: '1.0.0', isLatest: true,
+      } as any);
+
+      const fd = new FormData();
+      fd.append('version', '1.0.0');
+      fd.append(
+        'detectionRules',
+        JSON.stringify([
+          { type: 'registry', path: 'SOFTWARE\\Acme\\App' },
+          { type: 'file_exists', path: 'C:\\Program Files\\Acme\\app.exe' },
+        ]),
+      );
+      fd.append('file', new File(['payload'], 'pkg.exe', { type: 'application/octet-stream' }));
+
+      const res = await app.request(`/software/catalog/${catalogId}/versions/upload`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: fd,
+      });
+
+      expect(res.status).toBe(201);
+      expect(uploadBinary).toHaveBeenCalledTimes(1);
+    });
+
     it('maps a non-MultipartError parse failure to a 500 (not a blank crash)', async () => {
       vi.mocked(isS3Configured).mockReturnValueOnce(true);
       vi.mocked(db.select).mockReturnValueOnce(

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -29,6 +29,7 @@ import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { createSoftwareDeployment } from '../services/softwareDeployment';
+import { detectionRulesSchema } from '@breeze/shared';
 
 export const softwareRoutes = new Hono();
 const requireSoftwareRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -359,7 +360,8 @@ const createVersionSchema = z.object({
   silentInstallArgs: z.string().max(2000).optional(),
   silentUninstallArgs: z.string().max(2000).optional(),
   preInstallScript: z.string().optional(),
-  postInstallScript: z.string().optional()
+  postInstallScript: z.string().optional(),
+  detectionRules: detectionRulesSchema.optional()
 });
 
 const listDeploymentsSchema = z.object({
@@ -724,6 +726,7 @@ softwareRoutes.post(
       silentUninstallArgs: payload.silentUninstallArgs ?? null,
       preInstallScript: payload.preInstallScript ?? null,
       postInstallScript: payload.postInstallScript ?? null,
+      detectionRules: payload.detectionRules ?? null,
     });
 
     if (!version) {
@@ -826,6 +829,25 @@ softwareRoutes.post(
       let silentUninstallArgs = typeof fields.silentUninstallArgs === 'string' ? fields.silentUninstallArgs : null;
       const preInstallScript = typeof fields.preInstallScript === 'string' ? fields.preInstallScript : null;
       const postInstallScript = typeof fields.postInstallScript === 'string' ? fields.postInstallScript : null;
+      // Detection rules arrive as a JSON-encoded field. Unlike supportedOs we do
+      // NOT silently drop a malformed value: detection rules are a deliberate
+      // install-safety config, so a parse/validation failure must surface as a
+      // 400 rather than quietly shipping a version that can't verify itself.
+      let detectionRules: unknown = null;
+      if (typeof fields.detectionRules === 'string' && fields.detectionRules.trim() !== '') {
+        let rawDetection: unknown;
+        try {
+          rawDetection = JSON.parse(fields.detectionRules);
+        } catch {
+          return c.json({ error: 'detectionRules must be valid JSON' }, 400);
+        }
+        const parsedDetection = detectionRulesSchema.safeParse(rawDetection);
+        if (!parsedDetection.success) {
+          return c.json({ error: 'detectionRules is invalid', details: parsedDetection.error.issues }, 400);
+        }
+        detectionRules = parsedDetection.data;
+      }
+
       let supportedOs: string[] | null = null;
       if (typeof fields.supportedOs === 'string') {
         try {
@@ -875,6 +897,7 @@ softwareRoutes.post(
         silentUninstallArgs,
         preInstallScript,
         postInstallScript,
+        detectionRules,
       });
 
       if (!versionRecord) {
@@ -1259,6 +1282,14 @@ softwareRoutes.post(
             inArray(devices.id, resolvedDeviceIds),
           ));
 
+        // Carry detection rules (#2022) so the agent can skip-if-present and
+        // verify real state. This legacy route exposes no force-reinstall toggle,
+        // so forceReinstall is always false here (the canonical /deployments path
+        // honors options.forceReinstall via the softwareDeployment service).
+        const detectionRules = Array.isArray(versionRecord.detectionRules)
+          ? versionRecord.detectionRules
+          : undefined;
+
         for (const device of targetDevices) {
           const command: AgentCommand = {
             id: `sw-install-${deployment!.id}-${device.id}`,
@@ -1272,6 +1303,8 @@ softwareRoutes.post(
               silentInstallArgs: finalSilentInstallArgs,
               softwareName: catalogItem.name,
               version: versionRecord.version,
+              ...(detectionRules ? { detectionRules } : {}),
+              forceReinstall: false,
             },
           };
           sendCommandToAgent(device.agentId, command);

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -146,6 +146,90 @@ describe('createSoftwareDeployment', () => {
     expect(sendCommandMock.mock.calls[0]![1].type).toBe('software_install');
   });
 
+  it('threads detection rules and forceReinstall into the dispatched install payload', async () => {
+    const detectionRules = [
+      { type: 'registry', path: 'SOFTWARE\\Acme\\App' },
+      { type: 'file_exists', path: 'C:\\Program Files\\Acme\\app.exe' },
+    ];
+    const versionRecord = {
+      id: 'ver-det',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: '/S',
+      version: '1.0.0',
+      detectionRules,
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-det', orgId: 'org-1' };
+    const targetDevices = [{ id: 'dev-1', agentId: 'agent-1' }];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock
+      .mockReturnValueOnce(insWithReturning([deployment]))
+      .mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-det',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+      options: { forceReinstall: true },
+    });
+
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    const dispatched = sendCommandMock.mock.calls[0]![1];
+    expect(dispatched.payload.detectionRules).toEqual(detectionRules);
+    expect(dispatched.payload.forceReinstall).toBe(true);
+  });
+
+  it('omits detectionRules and defaults forceReinstall false when version has none', async () => {
+    const versionRecord = {
+      id: 'ver-none',
+      catalogId: 'cat-1',
+      s3Key: 'pkg.key',
+      downloadUrl: null,
+      checksum: null,
+      originalFileName: 'pkg.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '1.0.0',
+      detectionRules: null,
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-none', orgId: 'org-1' };
+    const targetDevices = [{ id: 'dev-1', agentId: 'agent-1' }];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock
+      .mockReturnValueOnce(insWithReturning([deployment]))
+      .mockReturnValueOnce(ins());
+
+    await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-none',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    const dispatched = sendCommandMock.mock.calls[0]![1];
+    expect(dispatched.payload.detectionRules).toBeUndefined();
+    expect(dispatched.payload.forceReinstall).toBe(false);
+  });
+
   it('returns status "failed" with a message when no installer URL is available', async () => {
     // Version has null s3Key AND null downloadUrl — no binary to dispatch
     const versionRecord = {

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -206,6 +206,15 @@ export async function createSoftwareDeployment(
         ),
       );
 
+    // Detection rules (#2022) and the force-reinstall toggle ride along with the
+    // install command so the agent can skip-if-already-present and verify the
+    // real end state. forceReinstall is a per-deployment option (default off);
+    // when set the agent installs even if the package is already detected.
+    const detectionRules = Array.isArray(versionRecord.detectionRules)
+      ? versionRecord.detectionRules
+      : undefined;
+    const forceReinstall = options?.forceReinstall === true;
+
     const dispatchedDeviceIds: string[] = [];
     for (const device of targetDevices) {
       const command: AgentCommand = {
@@ -221,6 +230,8 @@ export async function createSoftwareDeployment(
           silentInstallArgs: finalSilentInstallArgs,
           softwareName: catalogItem.name,
           version: versionRecord.version,
+          ...(detectionRules ? { detectionRules } : {}),
+          forceReinstall,
         },
       };
       sendCommandToAgent(device.agentId, command);

--- a/apps/web/src/components/software/DeploymentWizard.tsx
+++ b/apps/web/src/components/software/DeploymentWizard.tsx
@@ -141,6 +141,9 @@ export default function DeploymentWizard() {
   const [selectedDevices, setSelectedDevices] = useState<Set<string>>(new Set());
   const [scheduleType, setScheduleType] = useState<'immediate' | 'scheduled' | 'maintenance'>('immediate');
   const [scheduledAt, setScheduledAt] = useState('');
+  // When true, the agent installs even if the package's detection rule already
+  // matches (i.e. bypasses skip-if-already-installed). Default off (#2022).
+  const [forceReinstall, setForceReinstall] = useState(false);
   const [targetMode, setTargetMode] = useState<'tree' | 'advanced'>('tree');
   const [targetConfig, setTargetConfig] = useState<DeploymentTargetConfig>({ type: 'devices', deviceIds: [] });
 
@@ -399,6 +402,7 @@ export default function DeploymentWizard() {
               targetFilter: targetConfig.type === 'filter' ? targetConfig.filter : undefined,
               scheduleType,
               scheduledAt: scheduleType === 'scheduled' ? new Date(scheduledAt).toISOString() : undefined,
+              options: forceReinstall ? { forceReinstall: true } : undefined,
             }
           : {
               name: `${selectedSoftware?.name ?? 'Software'} ${selectedVersion?.version ?? ''}`.trim(),
@@ -408,6 +412,7 @@ export default function DeploymentWizard() {
               targetIds: Array.from(selectedDevices),
               scheduleType,
               scheduledAt: scheduleType === 'scheduled' ? new Date(scheduledAt).toISOString() : undefined,
+              options: forceReinstall ? { forceReinstall: true } : undefined,
             };
 
       const result = await runAction<{ id?: string; status?: string; message?: string }>({
@@ -768,6 +773,20 @@ export default function DeploymentWizard() {
               Devices will be queued for the next available maintenance window.
             </div>
           )}
+          <label className="mt-4 flex items-start gap-2 text-sm" data-testid="force-reinstall-toggle">
+            <input
+              type="checkbox"
+              checked={forceReinstall}
+              onChange={(event) => setForceReinstall(event.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Reinstall even if already present
+              <span className="block text-xs text-muted-foreground">
+                Bypasses the package&apos;s detection rule (skip-if-already-installed). Only applies to packages with detection rules.
+              </span>
+            </span>
+          </label>
         </div>
       );
     }

--- a/apps/web/src/components/software/DetectionRulesEditor.test.tsx
+++ b/apps/web/src/components/software/DetectionRulesEditor.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { DetectionRule } from '@breeze/shared';
+import DetectionRulesEditor from './DetectionRulesEditor';
+
+describe('DetectionRulesEditor', () => {
+  it('shows the empty-state hint when there are no rules', () => {
+    render(<DetectionRulesEditor rules={[]} onChange={() => {}} />);
+    expect(screen.getByText(/No detection rules/i)).toBeTruthy();
+  });
+
+  it('adds a registry rule (default type) when Add rule is clicked', () => {
+    const onChange = vi.fn();
+    render(<DetectionRulesEditor rules={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('detection-rule-add'));
+    expect(onChange).toHaveBeenCalledWith([{ type: 'registry', hive: 'HKLM', path: '' }]);
+  });
+
+  it('renders type-specific fields and edits a clause', () => {
+    const rules: DetectionRule[] = [{ type: 'file_exists', path: '' }];
+    const onChange = vi.fn();
+    render(<DetectionRulesEditor rules={rules} onChange={onChange} />);
+
+    const pathInput = screen.getByLabelText('File or folder path') as HTMLInputElement;
+    fireEvent.change(pathInput, { target: { value: 'C:\\Program Files\\Acme\\app.exe' } });
+    expect(onChange).toHaveBeenCalledWith([
+      { type: 'file_exists', path: 'C:\\Program Files\\Acme\\app.exe' },
+    ]);
+  });
+
+  it('switches clause type and resets to a blank clause of the new type', () => {
+    const rules: DetectionRule[] = [{ type: 'file_exists', path: 'C:\\x' }];
+    const onChange = vi.fn();
+    render(<DetectionRulesEditor rules={rules} onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('detection-rule-type'), { target: { value: 'msi_product_code' } });
+    expect(onChange).toHaveBeenCalledWith([{ type: 'msi_product_code', productCode: '' }]);
+  });
+
+  it('removes a clause', () => {
+    const rules: DetectionRule[] = [
+      { type: 'file_exists', path: 'C:\\a' },
+      { type: 'file_exists', path: 'C:\\b' },
+    ];
+    const onChange = vi.fn();
+    render(<DetectionRulesEditor rules={rules} onChange={onChange} />);
+
+    fireEvent.click(screen.getAllByTestId('detection-rule-remove')[0]!);
+    expect(onChange).toHaveBeenCalledWith([{ type: 'file_exists', path: 'C:\\b' }]);
+  });
+});

--- a/apps/web/src/components/software/DetectionRulesEditor.tsx
+++ b/apps/web/src/components/software/DetectionRulesEditor.tsx
@@ -1,0 +1,174 @@
+import type { DetectionRule, RegistryHive } from '@breeze/shared';
+
+interface DetectionRulesEditorProps {
+  rules: DetectionRule[];
+  onChange: (rules: DetectionRule[]) => void;
+}
+
+const REGISTRY_HIVES: RegistryHive[] = ['HKLM', 'HKCU', 'HKCR', 'HKU', 'HKCC'];
+
+const RULE_TYPE_LABELS: Record<DetectionRule['type'], string> = {
+  registry: 'Registry key/value',
+  file_exists: 'File or folder exists',
+  msi_product_code: 'MSI product code',
+};
+
+// A fresh clause for a given type, with sensible defaults.
+function blankRule(type: DetectionRule['type']): DetectionRule {
+  switch (type) {
+    case 'registry':
+      return { type: 'registry', hive: 'HKLM', path: '' };
+    case 'file_exists':
+      return { type: 'file_exists', path: '' };
+    case 'msi_product_code':
+      return { type: 'msi_product_code', productCode: '' };
+  }
+}
+
+const inputClass =
+  'h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring';
+
+/**
+ * Authoring UI for a software version's detection rules (issue #2022). The agent
+ * evaluates these against the device's real state to decide install/uninstall
+ * status independent of the installer exit code, and to skip install when the
+ * package is already present. All clauses must match (AND).
+ */
+export default function DetectionRulesEditor({ rules, onChange }: DetectionRulesEditorProps) {
+  const updateRule = (index: number, next: DetectionRule) => {
+    onChange(rules.map((rule, i) => (i === index ? next : rule)));
+  };
+
+  const removeRule = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  const addRule = () => {
+    onChange([...rules, blankRule('registry')]);
+  };
+
+  return (
+    <div className="mt-4" data-testid="detection-rules-editor">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-semibold uppercase text-muted-foreground">Detection Rules</label>
+        <button
+          type="button"
+          onClick={addRule}
+          data-testid="detection-rule-add"
+          className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted"
+        >
+          + Add rule
+        </button>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Optional. When set, install/uninstall status reflects the device&apos;s real state instead of the
+        installer exit code, and installs are skipped when the package is already present. All rules must match.
+      </p>
+
+      {rules.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground">No detection rules — status falls back to the installer exit code.</p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {rules.map((rule, index) => (
+            <div key={index} className="rounded-md border bg-muted/30 p-3" data-testid="detection-rule-row">
+              <div className="flex items-center gap-2">
+                <select
+                  value={rule.type}
+                  data-testid="detection-rule-type"
+                  onChange={(event) => updateRule(index, blankRule(event.target.value as DetectionRule['type']))}
+                  className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                >
+                  {(Object.keys(RULE_TYPE_LABELS) as DetectionRule['type'][]).map((type) => (
+                    <option key={type} value={type}>
+                      {RULE_TYPE_LABELS[type]}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => removeRule(index)}
+                  data-testid="detection-rule-remove"
+                  className="ml-auto rounded-md border px-2 py-1 text-xs text-destructive hover:bg-muted"
+                  aria-label="Remove detection rule"
+                >
+                  Remove
+                </button>
+              </div>
+
+              {rule.type === 'registry' && (
+                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                  <select
+                    value={rule.hive ?? 'HKLM'}
+                    aria-label="Registry hive"
+                    onChange={(event) => updateRule(index, { ...rule, hive: event.target.value as RegistryHive })}
+                    className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  >
+                    {REGISTRY_HIVES.map((hive) => (
+                      <option key={hive} value={hive}>
+                        {hive}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    value={rule.path}
+                    placeholder="SOFTWARE\\Vendor\\App"
+                    aria-label="Registry key path"
+                    onChange={(event) => updateRule(index, { ...rule, path: event.target.value })}
+                    className={inputClass}
+                  />
+                  <input
+                    type="text"
+                    value={rule.valueName ?? ''}
+                    placeholder="Value name (optional)"
+                    aria-label="Registry value name"
+                    onChange={(event) =>
+                      updateRule(index, { ...rule, valueName: event.target.value || undefined })
+                    }
+                    className={inputClass}
+                  />
+                  <input
+                    type="text"
+                    value={rule.valueData ?? ''}
+                    placeholder="Expected value data (optional)"
+                    aria-label="Registry expected value data"
+                    onChange={(event) =>
+                      updateRule(index, { ...rule, valueData: event.target.value || undefined })
+                    }
+                    className={inputClass}
+                  />
+                </div>
+              )}
+
+              {rule.type === 'file_exists' && (
+                <div className="mt-2">
+                  <input
+                    type="text"
+                    value={rule.path}
+                    placeholder="C:\\Program Files\\Vendor\\App\\app.exe"
+                    aria-label="File or folder path"
+                    onChange={(event) => updateRule(index, { ...rule, path: event.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+              )}
+
+              {rule.type === 'msi_product_code' && (
+                <div className="mt-2">
+                  <input
+                    type="text"
+                    value={rule.productCode}
+                    placeholder="{3F2504E0-4F89-41D3-9A0C-0305E82C3301}"
+                    aria-label="MSI product code"
+                    onChange={(event) => updateRule(index, { ...rule, productCode: event.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown, ChevronUp, Download, Loader2, Plus, Sparkles, CheckCircle, Upload } from 'lucide-react';
+import type { DetectionRule } from '@breeze/shared';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
+import DetectionRulesEditor from './DetectionRulesEditor';
 
 type Architecture = 'x64' | 'arm64' | 'x86';
 
@@ -77,6 +79,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
     silentUninstallArgs: '',
     downloadUrl: '',
     supportedOs: [] as string[],
+    detectionRules: [] as DetectionRule[],
     file: null as File | null,
     fileName: ''
   });
@@ -207,6 +210,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
         if (formState.silentUninstallArgs) formData.append('silentUninstallArgs', formState.silentUninstallArgs);
         if (formState.downloadUrl) formData.append('downloadUrl', formState.downloadUrl);
         if (formState.supportedOs.length > 0) formData.append('supportedOs', JSON.stringify(formState.supportedOs));
+        if (formState.detectionRules.length > 0) formData.append('detectionRules', JSON.stringify(formState.detectionRules));
 
         setUploadProgress(10);
 
@@ -242,6 +246,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
             silentUninstallArgs: formState.silentUninstallArgs || undefined,
             downloadUrl: formState.downloadUrl || undefined,
             supportedOs: formState.supportedOs.length > 0 ? formState.supportedOs : undefined,
+            detectionRules: formState.detectionRules.length > 0 ? formState.detectionRules : undefined,
           })
         });
 
@@ -255,7 +260,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
         setSelectedVersionId(newVersion.id);
       }
 
-      setFormState({ version: '', architecture: 'x64', notes: '', silentInstallArgs: '', silentUninstallArgs: '', downloadUrl: '', supportedOs: [], file: null, fileName: '' });
+      setFormState({ version: '', architecture: 'x64', notes: '', silentInstallArgs: '', silentUninstallArgs: '', downloadUrl: '', supportedOs: [], detectionRules: [], file: null, fileName: '' });
       if (fileInputRef.current) fileInputRef.current.value = '';
       setIsFormOpen(false);
     } catch (err) {
@@ -427,6 +432,11 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
               />
             </div>
           </div>
+
+          <DetectionRulesEditor
+            rules={formState.detectionRules}
+            onChange={(detectionRules) => setFormState(prev => ({ ...prev, detectionRules }))}
+          />
 
           <div className="mt-4">
             <label className="text-xs font-semibold uppercase text-muted-foreground">Release Notes</label>

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -23,6 +23,7 @@ export * from './contracts';
 export * from './mlFeedback';
 export * from './quotes';
 export * from './maintenanceWindow';
+export * from './softwareDetection';
 
 // ============================================
 // Device Roles

--- a/packages/shared/src/validators/softwareDetection.test.ts
+++ b/packages/shared/src/validators/softwareDetection.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { detectionRuleSchema, detectionRulesSchema } from './softwareDetection';
+
+describe('detectionRuleSchema', () => {
+  it('accepts a registry clause with only a key path', () => {
+    const r = detectionRuleSchema.safeParse({
+      type: 'registry',
+      path: 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Foo',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a registry clause with hive, value name and expected data', () => {
+    const r = detectionRuleSchema.safeParse({
+      type: 'registry',
+      hive: 'HKCU',
+      path: 'SOFTWARE\\Acme\\App',
+      valueName: 'Version',
+      valueData: '1.2.3',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects an unknown registry hive', () => {
+    const r = detectionRuleSchema.safeParse({ type: 'registry', hive: 'HKXX', path: 'SOFTWARE\\X' });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a file_exists clause', () => {
+    const r = detectionRuleSchema.safeParse({ type: 'file_exists', path: 'C:\\Program Files\\Acme\\app.exe' });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts an msi_product_code clause with and without braces', () => {
+    expect(
+      detectionRuleSchema.safeParse({
+        type: 'msi_product_code',
+        productCode: '{3F2504E0-4F89-41D3-9A0C-0305E82C3301}',
+      }).success,
+    ).toBe(true);
+    expect(
+      detectionRuleSchema.safeParse({
+        type: 'msi_product_code',
+        productCode: '3F2504E0-4F89-41D3-9A0C-0305E82C3301',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-GUID product code', () => {
+    const r = detectionRuleSchema.safeParse({ type: 'msi_product_code', productCode: 'not-a-guid' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an unknown clause type', () => {
+    const r = detectionRuleSchema.safeParse({ type: 'file_version', path: 'C:\\x', version: '1.0' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an empty path', () => {
+    expect(detectionRuleSchema.safeParse({ type: 'file_exists', path: '' }).success).toBe(false);
+    expect(detectionRuleSchema.safeParse({ type: 'registry', path: '' }).success).toBe(false);
+  });
+});
+
+describe('detectionRulesSchema', () => {
+  it('accepts an empty array', () => {
+    expect(detectionRulesSchema.safeParse([]).success).toBe(true);
+  });
+
+  it('accepts a heterogeneous AND set', () => {
+    const r = detectionRulesSchema.safeParse([
+      { type: 'registry', path: 'SOFTWARE\\Acme\\App' },
+      { type: 'file_exists', path: 'C:\\Program Files\\Acme\\app.exe' },
+      { type: 'msi_product_code', productCode: '{3F2504E0-4F89-41D3-9A0C-0305E82C3301}' },
+    ]);
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a set with one invalid clause', () => {
+    const r = detectionRulesSchema.safeParse([
+      { type: 'file_exists', path: 'C:\\ok' },
+      { type: 'msi_product_code', productCode: 'bad' },
+    ]);
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects more than 20 clauses', () => {
+    const many = Array.from({ length: 21 }, () => ({ type: 'file_exists' as const, path: 'C:\\x' }));
+    expect(detectionRulesSchema.safeParse(many).success).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/softwareDetection.ts
+++ b/packages/shared/src/validators/softwareDetection.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+// ============================================
+// Software Detection Rules (issue #2022, Phase 1)
+// ============================================
+//
+// A software package version can carry a set of detection rules that the agent
+// evaluates against the device's REAL state — independent of the installer's
+// exit code. They serve two purposes:
+//   1. pre-install "skip if already installed" gate, and
+//   2. post-install/uninstall verification (status reflects what is actually on
+//      the box, not just whether the installer returned 0).
+//
+// Composition is implicit AND: every clause must be satisfied for the package to
+// count as "detected" (matches Intune/PDQ semantics). Phase 1 ships three clause
+// types; file-version comparison is deferred (it needs Win32 version-info work).
+//
+// Registry and MSI-product-code clauses are Windows-only. On a platform where a
+// clause type can't be evaluated the agent reports the rule set as "unsupported"
+// and falls back to exit-code behavior — it never silently treats unsupported as
+// pass or fail. See agent/internal/remote/tools/software_detection*.go.
+
+/** Registry hives a registry detection clause may target. */
+export const REGISTRY_HIVES = ['HKLM', 'HKCU', 'HKCR', 'HKU', 'HKCC'] as const;
+export type RegistryHive = (typeof REGISTRY_HIVES)[number];
+
+// A loose GUID matcher accepting the MSI product-code forms with or without
+// surrounding braces, e.g. {3F2504E0-4F89-41D3-9A0C-0305E82C3301} or the bare
+// form. Case-insensitive — the agent normalizes to braced uppercase.
+const MSI_PRODUCT_CODE_REGEX =
+  /^\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}?$/;
+
+export const registryDetectionRuleSchema = z.object({
+  type: z.literal('registry'),
+  hive: z.enum(REGISTRY_HIVES).optional(),
+  // Registry key path WITHOUT the hive prefix, e.g.
+  // "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{...}".
+  path: z.string().min(1).max(1024),
+  // Optional value under the key. Omit to assert only that the key exists.
+  valueName: z.string().max(256).optional(),
+  // Optional expected data for valueName. Omit to assert only that the value
+  // exists (any data). Compared case-insensitively by the agent.
+  valueData: z.string().max(1024).optional(),
+});
+
+export const fileDetectionRuleSchema = z.object({
+  type: z.literal('file_exists'),
+  // Absolute path to a file OR folder; existence of either satisfies the clause.
+  path: z.string().min(1).max(1024),
+});
+
+export const msiProductCodeDetectionRuleSchema = z.object({
+  type: z.literal('msi_product_code'),
+  productCode: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(MSI_PRODUCT_CODE_REGEX, 'Must be a GUID, e.g. {3F2504E0-4F89-41D3-9A0C-0305E82C3301}'),
+});
+
+export const detectionRuleSchema = z.discriminatedUnion('type', [
+  registryDetectionRuleSchema,
+  fileDetectionRuleSchema,
+  msiProductCodeDetectionRuleSchema,
+]);
+
+export type RegistryDetectionRule = z.infer<typeof registryDetectionRuleSchema>;
+export type FileDetectionRule = z.infer<typeof fileDetectionRuleSchema>;
+export type MsiProductCodeDetectionRule = z.infer<typeof msiProductCodeDetectionRuleSchema>;
+export type DetectionRule = z.infer<typeof detectionRuleSchema>;
+
+// The full rule set stored on a software version. An empty array (or null) means
+// "no detection configured" — behavior is unchanged (exit-code only). Capped to
+// keep the agent payload bounded.
+export const detectionRulesSchema = z.array(detectionRuleSchema).max(20);
+export type DetectionRules = z.infer<typeof detectionRulesSchema>;


### PR DESCRIPTION
## Summary

Phase 1 of #2022. `.exe`/`.msi` software deploys were judged only by the installer's exit code, which doesn't reflect whether the app actually landed. This adds per-package **detection rules** so install status reflects the device's **real state**, and makes **skip-if-already-installed** reliable.

Two product asks were in the issue; per scoping with the maintainer, this PR ships **ask 1 (detection rules)** and defers **ask 2 (conditional remediation scripting)** and **file-version (>=) detection** to follow-ups. The issue stays open.

## What's included

- **Shared** (`packages/shared`): `detectionRulesSchema` + types — three clause types (`registry` key/value, `file_exists`, `msi_product_code` GUID), implicit **AND** composition, capped at 20 clauses.
- **DB**: nullable `detection_rules` jsonb on `software_versions` (idempotent `ADD COLUMN`). `software_versions` is a child of `software_catalog` (tenant ownership lives on the catalog row) — no new tenant axis, so no RLS change.
- **API**: create-version and upload routes accept + persist `detectionRules`. The upload path **rejects malformed `detectionRules` with a 400** rather than silently dropping a deliberate safety config. `detectionRules` + `options.forceReinstall` are threaded into the `software_install` dispatch payload (canonical `softwareDeployment` service + the legacy inline `/deploy` route).
- **Agent** (`agent/`): a cross-platform detection evaluator —
  - `file_exists` works on all platforms (`os.Stat`);
  - `registry` + `msi_product_code` are evaluated on Windows via the existing `golang.org/x/sys/windows/registry` idiom;
  - on a platform where a clause type can't be evaluated, the rule set is reported **unsupported** and the agent **falls back to exit-code behavior** — it never silently treats unsupported as pass/fail.
  - `InstallSoftware` now **skips-if-already-detected** before download (unless `forceReinstall`), and **verifies real state post-install** (installer exit 0 but app not detected ⇒ reported failed).
- **Agent bugfix (bundled)**: treat exit **3010** (`ERROR_SUCCESS_REBOOT_REQUIRED`) and **1641** (`ERROR_SUCCESS_REBOOT_INITIATED`) as success for **both `exe` and `msi`**. Previously only MSI 3010 was honored, so a reboot-pending `.exe` install — and any MSI returning 1641 — was wrongly marked failed. (Bundled because this PR rewrites the success-determination path; flagged for visibility.)
- **Web** (`apps/web`): `DetectionRulesEditor` on the software-version form; a **"Reinstall even if already present"** toggle (default off) in the Deployment Wizard.

## Decisions (confirmed during scoping)

- Composition is implicit **AND** (Intune/PDQ semantics); no boolean-tree builder.
- Detection runs at **both** call sites — pre-install skip gate and post-install/uninstall verification (same evaluator).
- **Windows-first**: registry/MSI are Windows-only; unsupported clause types fall back to exit-code, never silent.
- Force-reinstall default **off**.

## Tests

- Shared: `softwareDetection.test.ts` (12) — clause + array validation.
- API: `softwareDeployment.test.ts` (dispatch threads `detectionRules`/`forceReinstall`) + `software.test.ts` (upload 400 on malformed rules, 201 on valid).
- Agent: `software_detection_test.go` (parse + file_exists AND + unsupported fallback), `software_install_detection_test.go` (exit-code mapping incl. 3010/1641, pre-install skip without network, forceReinstall bypass). Full `tools` package green under `-race`; `GOOS=windows go build ./...` OK; `go vet` clean.
- Typecheck: `tsc --noEmit` clean for `apps/api` and `apps/web`.

## Deferred (follow-ups; #2022 stays open)

- File-version `>=` detection (needs Win32 version-info work).
- Conditional if/else **remediation scripting** (the second half of the issue).

Refs #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)