### PR TITLE
feat(incidents): EDR-aware Incidents page with unified feed

### DIFF
--- a/apps/api/migrations/2026-06-29-incidents-edr-source-link.sql
+++ b/apps/api/migrations/2026-06-29-incidents-edr-source-link.sql
@@ -1,0 +1,15 @@
+-- Link a tracked incident back to the EDR record it was promoted from, so the
+-- /incidents/feed union can suppress findings that already became incidents.
+-- incidents is org-scoped (RLS shape #1); adding columns does not change tenancy.
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS source_type text;
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS source_ref text;
+
+-- Forward-compat hook for identity-based (ITDR) findings; unused until an ITDR
+-- ingestion path exists. Device-based findings keep using affected_devices.
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS affected_users jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- One tracked incident per (org, EDR source record). Partial: only enforced when
+-- a source_ref is present, so manually-created incidents (no source) are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS incidents_source_ref_unique
+  ON incidents (org_id, source_type, source_ref)
+  WHERE source_ref IS NOT NULL;

--- a/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
+++ b/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Real-Postgres integration coverage for the EDR-aware Incidents feed
+ * (`buildIncidentFeed`). Runs under vitest.integration.config.ts: code-under-
+ * test reaches Postgres through the production `db` pool as the unprivileged
+ * `breeze_app` role, so RLS org-isolation is genuinely enforced (the feed
+ * calls are wrapped in `withDbAccessContext` to set the `breeze.*` GUCs the
+ * org-scoped caller would carry in production).
+ *
+ * Seeding uses the superuser pool (`getTestDb()`), which bypasses RLS. Per
+ * setup.ts cleanupDatabase() TRUNCATEs tenant tables on beforeEach, so each
+ * test re-seeds fresh — no module-scope fixtures (see memory:
+ * rls-forge-test-memoized-fixture-vacuous).
+ *
+ * Fixture topology (two tenants):
+ *   partnerA → orgA   — carries the feed rows under test
+ *   partnerB → orgB   — cross-tenant noise that must be excluded
+ *
+ * Coverage:
+ *   (a) buildIncidentFeed executes against the real union query (this is the
+ *       exact path that threw at query-build time before the `.as()` alias /
+ *       ORDER BY fixes).
+ *   (b) ordering is rank-asc (p1 first) then detectedAt-desc.
+ *   (c) orgB rows are excluded for an orgA-scoped caller (RLS + app filter).
+ *   (d) a huntress finding already promoted to an incident (matching
+ *       source_type/source_ref) is suppressed from the finding legs.
+ *
+ * DEFERRED locally when no integration Postgres is reachable — `it.runIf`
+ * gates every case on DATABASE_URL so the suite no-ops instead of failing.
+ */
+import './setup';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { getTestDb } from './setup';
+import { createPartner, createOrganization } from './db-utils';
+import { withDbAccessContext } from '../../db';
+import {
+  incidents,
+  huntressIncidents,
+  huntressIntegrations,
+  s1Threats,
+  s1Integrations,
+} from '../../db/schema';
+import { buildIncidentFeed, type IncidentFeedParams } from '../../routes/incidents.helpers';
+import type { AuthContext } from '../../middleware/auth';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const FEED_PARAMS: IncidentFeedParams = { limit: 50, offset: 0 };
+
+// Minimal org-scoped auth. buildIncidentFeed only reads scope/orgId via
+// resolveOrgFilter; the rest of AuthContext is never touched on this path.
+function orgAuth(orgId: string): AuthContext {
+  return { scope: 'organization', orgId } as unknown as AuthContext;
+}
+
+// Run the feed with the same RLS GUCs an org-scoped caller carries in prod.
+async function runFeed(orgId: string, params: IncidentFeedParams = FEED_PARAMS) {
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: null,
+      userId: null,
+      currentPartnerId: null,
+    },
+    () => buildIncidentFeed(orgAuth(orgId), params)
+  );
+}
+
+type Tenant = { partnerId: string; orgId: string; huntressIntegrationId: string; s1IntegrationId: string };
+
+async function seedTenant(): Promise<Tenant> {
+  const db = getTestDb();
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+
+  const [hInt] = await db
+    .insert(huntressIntegrations)
+    .values({ partnerId: partner.id, name: 'huntress', apiKeyEncrypted: 'enc' })
+    .returning({ id: huntressIntegrations.id });
+  const [sInt] = await db
+    .insert(s1Integrations)
+    .values({
+      partnerId: partner.id,
+      name: 's1',
+      apiTokenEncrypted: 'enc',
+      managementUrl: 'https://example.sentinelone.net',
+    })
+    .returning({ id: s1Integrations.id });
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    huntressIntegrationId: hInt!.id,
+    s1IntegrationId: sInt!.id,
+  };
+}
+
+describe('buildIncidentFeed (real Postgres)', () => {
+  let orgA: Tenant;
+  let orgB: Tenant;
+
+  beforeEach(async () => {
+    if (!process.env.DATABASE_URL) return;
+    orgA = await seedTenant();
+    orgB = await seedTenant();
+  });
+
+  runDb('orders rank-asc then detectedAt-desc and excludes cross-tenant rows', async () => {
+    const db = getTestDb();
+    const T1 = new Date('2026-06-01T00:00:00Z'); // tracked (p3, rank 3)
+    const T2 = new Date('2026-06-02T00:00:00Z'); // huntress critical (rank 1)
+    const T3 = new Date('2026-06-03T00:00:00Z'); // s1 high (rank 2)
+
+    // orgA rows across all three legs.
+    await db.insert(incidents).values({
+      orgId: orgA.orgId,
+      title: 'Tracked A',
+      classification: 'malware',
+      severity: 'p3',
+      status: 'detected',
+      detectedAt: T1,
+    });
+    await db.insert(huntressIncidents).values({
+      orgId: orgA.orgId,
+      integrationId: orgA.huntressIntegrationId,
+      huntressIncidentId: 'H-A-1',
+      severity: 'critical',
+      title: 'Huntress A',
+      status: 'sent',
+      reportedAt: T2,
+      details: { portalUrl: 'https://huntress.io/a1' },
+    });
+    await db.insert(s1Threats).values({
+      orgId: orgA.orgId,
+      integrationId: orgA.s1IntegrationId,
+      s1ThreatId: 'S-A-1',
+      severity: 'high',
+      threatName: 'S1 A',
+      status: 'mitigated',
+      detectedAt: T3,
+    });
+
+    // orgB cross-tenant noise (must never surface for an orgA caller).
+    await db.insert(huntressIncidents).values({
+      orgId: orgB.orgId,
+      integrationId: orgB.huntressIntegrationId,
+      huntressIncidentId: 'H-B-1',
+      severity: 'critical',
+      title: 'Huntress B',
+      status: 'sent',
+      reportedAt: T2,
+    });
+
+    const { rows, total } = await runFeed(orgA.orgId);
+
+    // (a)+(b): three orgA rows, ordered by rank asc then detectedAt desc.
+    expect(total).toBe(3);
+    expect(rows.map((r) => r.source)).toEqual(['huntress', 's1', 'breeze']);
+    expect(rows.map((r) => r.severity)).toEqual(['p1', 'p2', 'p3']);
+
+    // (c): no orgB row leaks in.
+    expect(rows.some((r) => r.sourceId === 'H-B-1')).toBe(false);
+    expect(rows.every((r) => r.title !== 'Huntress B')).toBe(true);
+  });
+
+  runDb('suppresses a finding already promoted to an incident', async () => {
+    const db = getTestDb();
+
+    await db.insert(huntressIncidents).values({
+      orgId: orgA.orgId,
+      integrationId: orgA.huntressIntegrationId,
+      huntressIncidentId: 'H-A-PROMOTED',
+      severity: 'high',
+      title: 'Promoted finding',
+      status: 'sent',
+      reportedAt: new Date('2026-06-05T00:00:00Z'),
+    });
+    // A tracked incident promoted FROM that finding (matching source link).
+    await db.insert(incidents).values({
+      orgId: orgA.orgId,
+      title: 'Promoted incident',
+      classification: 'malware',
+      severity: 'p2',
+      status: 'analyzing',
+      detectedAt: new Date('2026-06-05T01:00:00Z'),
+      sourceType: 'huntress_incident',
+      sourceRef: 'H-A-PROMOTED',
+    });
+
+    const { rows } = await runFeed(orgA.orgId);
+
+    // The huntress finding is suppressed; only the tracked incident remains.
+    expect(rows.some((r) => r.kind === 'finding' && r.sourceId === 'H-A-PROMOTED')).toBe(false);
+    expect(rows.some((r) => r.kind === 'tracked' && r.title === 'Promoted incident')).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
+++ b/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
@@ -30,9 +30,10 @@
 import './setup';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { getTestDb } from './setup';
-import { createPartner, createOrganization } from './db-utils';
+import { createPartner, createOrganization, createSite } from './db-utils';
 import { withDbAccessContext } from '../../db';
 import {
+  devices,
   incidents,
   huntressIncidents,
   huntressIntegrations,
@@ -193,5 +194,63 @@ describe('buildIncidentFeed (real Postgres)', () => {
     // The huntress finding is suppressed; only the tracked incident remains.
     expect(rows.some((r) => r.kind === 'finding' && r.sourceId === 'H-A-PROMOTED')).toBe(false);
     expect(rows.some((r) => r.kind === 'tracked' && r.title === 'Promoted incident')).toBe(true);
+  });
+
+  // FIX 1 (CRITICAL): site-level RBAC on the EDR legs. A finding bound to a
+  // device in a site OUTSIDE the caller's allowlist must be excluded, while a
+  // provider-level (null-device) finding stays visible. Site is an app-layer
+  // authz axis RLS does not defend, so the feed pushes the allowed-device-id
+  // predicate (resolved by the route via resolveSiteAllowedDeviceIds) onto the
+  // huntress/s1 legs. Here the caller is restricted to a site with no devices
+  // (allowedDeviceIds = []), so only the null-device finding survives.
+  runDb('excludes EDR findings on devices outside the caller site allowlist', async () => {
+    const db = getTestDb();
+
+    // A device in orgA's site that the site-restricted caller may NOT see.
+    const site = await createSite({ orgId: orgA.orgId, name: 'Disallowed Site' });
+    const [device] = await db
+      .insert(devices)
+      .values({
+        orgId: orgA.orgId,
+        siteId: site!.id,
+        agentId: `agent-${Date.now()}`,
+        hostname: 'secret-host',
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'x64',
+        agentVersion: '1.0.0',
+      })
+      .returning({ id: devices.id });
+
+    // Device-bound finding (must be excluded) + provider-level finding (kept).
+    await db.insert(huntressIncidents).values({
+      orgId: orgA.orgId,
+      integrationId: orgA.huntressIntegrationId,
+      huntressIncidentId: 'H-A-DEVICE',
+      severity: 'critical',
+      title: 'Finding on secret-host',
+      status: 'sent',
+      deviceId: device!.id,
+      reportedAt: new Date('2026-06-06T00:00:00Z'),
+    });
+    await db.insert(huntressIncidents).values({
+      orgId: orgA.orgId,
+      integrationId: orgA.huntressIntegrationId,
+      huntressIncidentId: 'H-A-NODEVICE',
+      severity: 'high',
+      title: 'Provider-level finding',
+      status: 'sent',
+      reportedAt: new Date('2026-06-06T01:00:00Z'),
+    });
+
+    // Site-restricted caller with an empty allowed-device set.
+    const { rows } = await runFeed(orgA.orgId, {
+      ...FEED_PARAMS,
+      hasDevicesRead: true,
+      allowedDeviceIds: [],
+    });
+
+    expect(rows.some((r) => r.sourceId === 'H-A-DEVICE')).toBe(false);
+    expect(rows.some((r) => r.sourceId === 'H-A-NODEVICE')).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
+++ b/apps/api/src/__tests__/integration/incidents-feed.integration.test.ts
@@ -45,7 +45,7 @@ import type { AuthContext } from '../../middleware/auth';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
-const FEED_PARAMS: IncidentFeedParams = { limit: 50, offset: 0 };
+const FEED_PARAMS: IncidentFeedParams = { limit: 50, offset: 0, hasDevicesRead: true, allowedDeviceIds: null };
 
 // Minimal org-scoped auth. buildIncidentFeed only reads scope/orgId via
 // resolveOrgFilter; the rest of AuthContext is never touched on this path.

--- a/apps/api/src/db/schema/incidentResponse.ts
+++ b/apps/api/src/db/schema/incidentResponse.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   boolean,
   index,
@@ -6,6 +7,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -56,6 +58,9 @@ export const incidents = pgTable('incidents', {
   summary: text('summary'),
   relatedAlerts: jsonb('related_alerts').$type<string[]>().notNull().default([]),
   affectedDevices: jsonb('affected_devices').$type<string[]>().notNull().default([]),
+  sourceType: text('source_type'),
+  sourceRef: text('source_ref'),
+  affectedUsers: jsonb('affected_users').$type<string[]>().notNull().default([]),
   timeline: jsonb('timeline').$type<IncidentTimelineEntry[]>().notNull().default([]),
   assignedTo: uuid('assigned_to').references(() => users.id),
   detectedAt: timestamp('detected_at').notNull(),
@@ -69,6 +74,9 @@ export const incidents = pgTable('incidents', {
   severityIdx: index('incidents_severity_idx').on(table.severity),
   assignedToIdx: index('incidents_assigned_to_idx').on(table.assignedTo),
   detectedAtIdx: index('incidents_detected_at_idx').on(table.detectedAt),
+  sourceRefIdx: uniqueIndex('incidents_source_ref_unique')
+    .on(table.orgId, table.sourceType, table.sourceRef)
+    .where(sql`source_ref IS NOT NULL`),
 }));
 
 export const incidentEvidence = pgTable('incident_evidence', {

--- a/apps/api/src/routes/incidents.helpers.test.ts
+++ b/apps/api/src/routes/incidents.helpers.test.ts
@@ -41,7 +41,7 @@ describe('resolveFindingLinkOut', () => {
 // exist"). `.toSQL()` builds the statement synchronously without a DB
 // connection, so this runs in the normal unit suite.
 describe('buildIncidentFeedQueries (DB-less build guard)', () => {
-  const params = { limit: 50, offset: 0 } as const;
+  const params = { limit: 50, offset: 0, hasDevicesRead: true, allowedDeviceIds: null } as const;
 
   it('builds the union feed query without throwing', () => {
     expect(() => buildIncidentFeedQueries(orgAuth, params)).not.toThrow();

--- a/apps/api/src/routes/incidents.helpers.test.ts
+++ b/apps/api/src/routes/incidents.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { severityRankToLabel } from './incidents.helpers';
+import { severityRankToLabel, resolveFindingLinkOut } from './incidents.helpers';
 
 describe('severityRankToLabel', () => {
   it('maps rank 1..4 to p1..p4 and clamps unknown to p3', () => {
@@ -8,5 +8,14 @@ describe('severityRankToLabel', () => {
     expect(severityRankToLabel(3)).toBe('p3');
     expect(severityRankToLabel(4)).toBe('p4');
     expect(severityRankToLabel(99)).toBe('p3');
+  });
+});
+
+describe('resolveFindingLinkOut', () => {
+  it('returns the stored portal url when present', () => {
+    expect(resolveFindingLinkOut('huntress', { portalUrl: 'https://huntress.io/x' })).toBe('https://huntress.io/x');
+  });
+  it('returns null when no url is derivable', () => {
+    expect(resolveFindingLinkOut('s1', null)).toBeNull();
   });
 });

--- a/apps/api/src/routes/incidents.helpers.test.ts
+++ b/apps/api/src/routes/incidents.helpers.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { severityRankToLabel } from './incidents.helpers';
+
+describe('severityRankToLabel', () => {
+  it('maps rank 1..4 to p1..p4 and clamps unknown to p3', () => {
+    expect(severityRankToLabel(1)).toBe('p1');
+    expect(severityRankToLabel(2)).toBe('p2');
+    expect(severityRankToLabel(3)).toBe('p3');
+    expect(severityRankToLabel(4)).toBe('p4');
+    expect(severityRankToLabel(99)).toBe('p3');
+  });
+});

--- a/apps/api/src/routes/incidents.helpers.test.ts
+++ b/apps/api/src/routes/incidents.helpers.test.ts
@@ -25,10 +25,10 @@ describe('severityRankToLabel', () => {
 
 describe('resolveFindingLinkOut', () => {
   it('returns the stored portal url when present', () => {
-    expect(resolveFindingLinkOut('huntress', { portalUrl: 'https://huntress.io/x' })).toBe('https://huntress.io/x');
+    expect(resolveFindingLinkOut({ portalUrl: 'https://huntress.io/x' })).toBe('https://huntress.io/x');
   });
   it('returns null when no url is derivable', () => {
-    expect(resolveFindingLinkOut('s1', null)).toBeNull();
+    expect(resolveFindingLinkOut(null)).toBeNull();
   });
 });
 
@@ -84,6 +84,57 @@ describe('buildIncidentFeedQueries (DB-less build guard)', () => {
     const built = buildIncidentFeedQueries(orgAuth, {
       ...params,
       kind: 'tracked',
+      source: 'huntress',
+    });
+    expect(built).toBeNull();
+  });
+
+  // FIX 1 (CRITICAL): site-level RBAC. A site-restricted caller's allowed device
+  // ids must be pushed onto the huntress + s1 legs as the same null-device-OR-
+  // in-list predicate the dedicated EDR routes use, so they cannot read EDR
+  // findings for devices outside their sites via the feed.
+  it('applies the site-allowlist predicate to the huntress and s1 legs when site-restricted', () => {
+    const built = buildIncidentFeedQueries(orgAuth, {
+      ...params,
+      hasDevicesRead: true,
+      allowedDeviceIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    })!;
+    const { sql } = built.rowsQuery.toSQL();
+    // null-device carve-out + device-id IN (...) narrowing (mirrors EDR routes).
+    expect(sql).toContain('"device_id" is null');
+    expect(sql).toMatch(/"device_id" in \(/);
+  });
+
+  it('does not add a site predicate when the caller is not site-restricted', () => {
+    const built = buildIncidentFeedQueries(orgAuth, {
+      ...params,
+      hasDevicesRead: true,
+      allowedDeviceIds: null,
+    })!;
+    const { sql } = built.rowsQuery.toSQL();
+    // The EDR legs still project device_id (select list), but no WHERE predicate
+    // narrows on it — so the broad feed is not over-restricted.
+    expect(sql).not.toContain('"device_id" is null');
+    expect(sql).not.toMatch(/"device_id" in \(/);
+  });
+
+  // FIX 2: devices:read gate. A caller with alerts:read but not devices:read
+  // sees only native tracked incidents — the raw EDR finding legs are omitted.
+  it('omits the huntress and s1 legs entirely when the caller lacks devices:read', () => {
+    const built = buildIncidentFeedQueries(orgAuth, {
+      ...params,
+      hasDevicesRead: false,
+    })!;
+    const { sql } = built.rowsQuery.toSQL();
+    expect(sql).toContain('"incidents"');
+    expect(sql).not.toContain('huntress_incidents');
+    expect(sql).not.toContain('s1_threats');
+  });
+
+  it('yields an empty feed (null) when a no-devices-read caller filters to source=huntress', () => {
+    const built = buildIncidentFeedQueries(orgAuth, {
+      ...params,
+      hasDevicesRead: false,
       source: 'huntress',
     });
     expect(built).toBeNull();

--- a/apps/api/src/routes/incidents.helpers.test.ts
+++ b/apps/api/src/routes/incidents.helpers.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { severityRankToLabel, resolveFindingLinkOut } from './incidents.helpers';
+import {
+  severityRankToLabel,
+  resolveFindingLinkOut,
+  buildIncidentFeedQueries,
+} from './incidents.helpers';
+import type { AuthContext } from '../middleware/auth';
+
+// Minimal org-scoped auth for the DB-less build guard. buildIncidentFeedQueries
+// only reads auth.scope / auth.orgId via resolveOrgFilter, so the rest is unused.
+const orgAuth = {
+  scope: 'organization',
+  orgId: '22222222-2222-4222-8222-222222222222',
+} as unknown as AuthContext;
 
 describe('severityRankToLabel', () => {
   it('maps rank 1..4 to p1..p4 and clamps unknown to p3', () => {
@@ -17,5 +29,63 @@ describe('resolveFindingLinkOut', () => {
   });
   it('returns null when no url is derivable', () => {
     expect(resolveFindingLinkOut('s1', null)).toBeNull();
+  });
+});
+
+// DB-less build guard. This is the exact failure mode that made GET
+// /incidents/feed non-functional: without `.as('<key>')` aliases on the union
+// legs, drizzle throws synchronously at query-BUILD time ("you tried to
+// reference 'kind' field from a subquery ... but it doesn't have an alias");
+// and the old `.orderBy(sql`detected_at desc`)` referenced an unquoted
+// identifier that Postgres folds to lowercase ("column 'detected_at' does not
+// exist"). `.toSQL()` builds the statement synchronously without a DB
+// connection, so this runs in the normal unit suite.
+describe('buildIncidentFeedQueries (DB-less build guard)', () => {
+  const params = { limit: 50, offset: 0 } as const;
+
+  it('builds the union feed query without throwing', () => {
+    expect(() => buildIncidentFeedQueries(orgAuth, params)).not.toThrow();
+    const built = buildIncidentFeedQueries(orgAuth, params);
+    expect(built).not.toBeNull();
+  });
+
+  it('aliases every union-leg field (regression: missing .as() throws at build time)', () => {
+    const built = buildIncidentFeedQueries(orgAuth, params)!;
+    const { sql } = built.rowsQuery.toSQL();
+    for (const key of [
+      'kind',
+      'source',
+      'sourceId',
+      'title',
+      'rank',
+      'edrStatus',
+      'status',
+      'deviceId',
+      'detectedAt',
+      'trackedIncidentId',
+      'details',
+    ]) {
+      expect(sql).toContain(`as "${key}"`);
+    }
+  });
+
+  it('orders by the quoted aliased columns, not unquoted detected_at', () => {
+    const built = buildIncidentFeedQueries(orgAuth, params)!;
+    const { sql } = built.rowsQuery.toSQL();
+    expect(sql).toContain('order by');
+    expect(sql).toContain('"rank"');
+    expect(sql).toContain('"detectedAt"');
+    // The pre-fix bug: an unquoted detected_at identifier in the ORDER BY.
+    expect(sql).not.toMatch(/order by[^()]*\bdetected_at\b/);
+  });
+
+  it('returns null when kind/source filters exclude every leg', () => {
+    // kind=tracked + source=huntress is contradictory → no legs.
+    const built = buildIncidentFeedQueries(orgAuth, {
+      ...params,
+      kind: 'tracked',
+      source: 'huntress',
+    });
+    expect(built).toBeNull();
   });
 });

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -1,9 +1,10 @@
-import { and, eq, inArray, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import { unionAll } from 'drizzle-orm/pg-core';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import { db } from '../db';
-import { incidents, type IncidentTimelineEntry } from '../db/schema';
+import { incidents, huntressIncidents, s1Threats, type IncidentTimelineEntry } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
 import {
   ALLOWED_EVIDENCE_STORAGE_SCHEMES,
@@ -131,4 +132,177 @@ export async function getIncidentWithOrgCheck(incidentId: string, auth: AuthCont
     .limit(1);
 
   return incident ?? null;
+}
+
+export type IncidentFeedRow = {
+  kind: 'tracked' | 'finding';
+  source: 'breeze' | 'huntress' | 's1';
+  sourceId: string;
+  title: string;
+  severity: 'p1' | 'p2' | 'p3' | 'p4';
+  edrStatus: string | null;
+  status: string | null;
+  deviceId: string | null;
+  detectedAt: string;
+  trackedIncidentId: string | null;
+};
+
+export class FeedScopeError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+export function severityRankToLabel(rank: number): IncidentFeedRow['severity'] {
+  return rank === 1 ? 'p1' : rank === 2 ? 'p2' : rank === 4 ? 'p4' : 'p3';
+}
+
+// EDR severity string -> sortable rank (1=p1 highest .. 4=p4). Mirrors the
+// web mapEdrSeverity: critical->1, high->2, medium->3, low->4, else 3.
+function edrSeverityRank(col: SQL<unknown> | PgColumn): SQL<number> {
+  return sql<number>`CASE lower(coalesce(${col}, ''))
+    WHEN 'critical' THEN 1
+    WHEN 'high' THEN 2
+    WHEN 'medium' THEN 3
+    WHEN 'low' THEN 4
+    ELSE 3 END`;
+}
+
+// Native p1..p4 enum -> same rank space.
+function nativeSeverityRank(): SQL<number> {
+  return sql<number>`CASE ${incidents.severity}
+    WHEN 'p1' THEN 1 WHEN 'p2' THEN 2 WHEN 'p4' THEN 4 ELSE 3 END`;
+}
+
+export async function buildIncidentFeed(
+  auth: AuthContext,
+  params: {
+    orgId?: string;
+    kind?: 'tracked' | 'finding';
+    source?: 'breeze' | 'huntress' | 's1';
+    limit: number;
+    offset: number;
+  }
+): Promise<{ rows: IncidentFeedRow[]; total: number }> {
+  const orgIncidents = resolveOrgFilter(auth, params.orgId, incidents.orgId);
+  const orgHuntress = resolveOrgFilter(auth, params.orgId, huntressIncidents.orgId);
+  const orgS1 = resolveOrgFilter(auth, params.orgId, s1Threats.orgId);
+  if (orgIncidents.error) {
+    throw new FeedScopeError(orgIncidents.error.status, orgIncidents.error.message);
+  }
+
+  // Native tracked incidents.
+  const trackedQ = db
+    .select({
+      kind: sql<string>`'tracked'`,
+      source: sql<string>`'breeze'`,
+      sourceId: sql<string>`${incidents.id}::text`,
+      title: sql<string>`${incidents.title}`,
+      rank: nativeSeverityRank(),
+      edrStatus: sql<string | null>`null::text`,
+      status: sql<string | null>`${incidents.status}::text`,
+      deviceId: sql<string | null>`(${incidents.affectedDevices}->>0)`,
+      detectedAt: sql<Date>`${incidents.detectedAt}`,
+      trackedIncidentId: sql<string | null>`${incidents.id}::text`,
+    })
+    .from(incidents)
+    .where(orgIncidents.condition);
+
+  // Huntress findings NOT already promoted.
+  const huntressQ = db
+    .select({
+      kind: sql<string>`'finding'`,
+      source: sql<string>`'huntress'`,
+      sourceId: sql<string>`${huntressIncidents.huntressIncidentId}`,
+      title: sql<string>`${huntressIncidents.title}`,
+      rank: edrSeverityRank(huntressIncidents.severity),
+      edrStatus: sql<string | null>`${huntressIncidents.status}`,
+      status: sql<string | null>`null::text`,
+      deviceId: sql<string | null>`${huntressIncidents.deviceId}::text`,
+      detectedAt: sql<Date>`coalesce(${huntressIncidents.reportedAt}, ${huntressIncidents.createdAt})`,
+      trackedIncidentId: sql<string | null>`null::text`,
+    })
+    .from(huntressIncidents)
+    .where(
+      and(
+        orgHuntress.condition,
+        sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${huntressIncidents.orgId}
+          AND i.source_type = 'huntress_incident' AND i.source_ref = ${huntressIncidents.huntressIncidentId})`
+      )
+    );
+
+  // S1 findings NOT already promoted.
+  const s1Q = db
+    .select({
+      kind: sql<string>`'finding'`,
+      source: sql<string>`'s1'`,
+      sourceId: sql<string>`${s1Threats.s1ThreatId}`,
+      title: sql<string>`coalesce(${s1Threats.threatName}, 'SentinelOne threat')`,
+      rank: edrSeverityRank(s1Threats.severity),
+      edrStatus: sql<string | null>`${s1Threats.status}`,
+      status: sql<string | null>`null::text`,
+      deviceId: sql<string | null>`${s1Threats.deviceId}::text`,
+      detectedAt: sql<Date>`coalesce(${s1Threats.detectedAt}, ${s1Threats.createdAt})`,
+      trackedIncidentId: sql<string | null>`null::text`,
+    })
+    .from(s1Threats)
+    .where(
+      and(
+        orgS1.condition,
+        sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${s1Threats.orgId}
+          AND i.source_type = 's1_threat' AND i.source_ref = ${s1Threats.s1ThreatId})`
+      )
+    );
+
+  // Determine which legs to include based on filters.
+  const includeTracked = params.kind !== 'finding' && params.source !== 'huntress' && params.source !== 's1';
+  const includeHuntress = params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress');
+  const includeS1 = params.kind !== 'tracked' && (params.source === undefined || params.source === 's1');
+  if (!includeTracked && !includeHuntress && !includeS1) return { rows: [], total: 0 };
+
+  // Build UNION ALL explicitly per active combination so Drizzle can infer
+  // each call's table-name union type (dynamic `legs[]` array spreads lose it).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const baseQ: any =
+    includeTracked && includeHuntress && includeS1
+      ? unionAll(trackedQ, huntressQ, s1Q)
+      : includeHuntress && includeS1
+        ? unionAll(huntressQ, s1Q)
+        : includeTracked && includeHuntress
+          ? unionAll(trackedQ, huntressQ)
+          : includeTracked && includeS1
+            ? unionAll(trackedQ, s1Q)
+            : includeTracked
+              ? trackedQ
+              : includeHuntress
+                ? huntressQ
+                : s1Q;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+  const sub = baseQ.as('feed');
+
+  const [countRows, rows] = await Promise.all([
+    db.select({ count: sql<number>`count(*)` }).from(sub),
+    db
+      .select()
+      .from(sub)
+      .orderBy(sql`rank asc`, sql`detected_at desc`)
+      .limit(params.limit)
+      .offset(params.offset),
+  ]);
+
+  return {
+    rows: rows.map((r) => ({
+      kind: r.kind as 'tracked' | 'finding',
+      source: r.source as 'breeze' | 'huntress' | 's1',
+      sourceId: r.sourceId,
+      title: r.title,
+      severity: severityRankToLabel(Number(r.rank)),
+      edrStatus: r.edrStatus,
+      status: r.status,
+      deviceId: r.deviceId,
+      detectedAt: new Date(r.detectedAt as unknown as string).toISOString(),
+      trackedIncidentId: r.trackedIncidentId,
+    })),
+    total: Number(countRows[0]?.count ?? 0),
+  };
 }

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -145,7 +145,20 @@ export type IncidentFeedRow = {
   deviceId: string | null;
   detectedAt: string;
   trackedIncidentId: string | null;
+  linkOut: string | null;
 };
+
+export function resolveFindingLinkOut(
+  source: 'huntress' | 's1',
+  details: unknown
+): string | null {
+  if (details && typeof details === 'object') {
+    const d = details as Record<string, unknown>;
+    const url = d.portalUrl ?? d.url ?? d.link;
+    if (typeof url === 'string' && /^https:\/\//.test(url)) return url;
+  }
+  return null;
+}
 
 export class FeedScopeError extends Error {
   constructor(public status: number, message: string) {
@@ -204,6 +217,7 @@ export async function buildIncidentFeed(
       deviceId: sql<string | null>`(${incidents.affectedDevices}->>0)`,
       detectedAt: sql<Date>`${incidents.detectedAt}`,
       trackedIncidentId: sql<string | null>`${incidents.id}::text`,
+      details: sql<unknown>`null::jsonb`,
     })
     .from(incidents)
     .where(orgIncidents.condition);
@@ -221,6 +235,7 @@ export async function buildIncidentFeed(
       deviceId: sql<string | null>`${huntressIncidents.deviceId}::text`,
       detectedAt: sql<Date>`coalesce(${huntressIncidents.reportedAt}, ${huntressIncidents.createdAt})`,
       trackedIncidentId: sql<string | null>`null::text`,
+      details: sql<unknown>`${huntressIncidents.details}`,
     })
     .from(huntressIncidents)
     .where(
@@ -244,6 +259,7 @@ export async function buildIncidentFeed(
       deviceId: sql<string | null>`${s1Threats.deviceId}::text`,
       detectedAt: sql<Date>`coalesce(${s1Threats.detectedAt}, ${s1Threats.createdAt})`,
       trackedIncidentId: sql<string | null>`null::text`,
+      details: sql<unknown>`${s1Threats.details}`,
     })
     .from(s1Threats)
     .where(
@@ -291,18 +307,22 @@ export async function buildIncidentFeed(
   ]);
 
   return {
-    rows: rows.map((r) => ({
-      kind: r.kind as 'tracked' | 'finding',
-      source: r.source as 'breeze' | 'huntress' | 's1',
-      sourceId: r.sourceId,
-      title: r.title,
-      severity: severityRankToLabel(Number(r.rank)),
-      edrStatus: r.edrStatus,
-      status: r.status,
-      deviceId: r.deviceId,
-      detectedAt: new Date(r.detectedAt as unknown as string).toISOString(),
-      trackedIncidentId: r.trackedIncidentId,
-    })),
+    rows: rows.map((r) => {
+      const source = r.source as 'breeze' | 'huntress' | 's1';
+      return {
+        kind: r.kind as 'tracked' | 'finding',
+        source,
+        sourceId: r.sourceId,
+        title: r.title,
+        severity: severityRankToLabel(Number(r.rank)),
+        edrStatus: r.edrStatus,
+        status: r.status,
+        deviceId: r.deviceId,
+        detectedAt: new Date(r.detectedAt as unknown as string).toISOString(),
+        trackedIncidentId: r.trackedIncidentId,
+        linkOut: source === 'breeze' ? null : resolveFindingLinkOut(source, r.details),
+      };
+    }),
     total: Number(countRows[0]?.count ?? 0),
   };
 }

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { createHash } from 'node:crypto';
@@ -187,16 +187,28 @@ function nativeSeverityRank(): SQL<number> {
     WHEN 'p1' THEN 1 WHEN 'p2' THEN 2 WHEN 'p4' THEN 4 ELSE 3 END`;
 }
 
-export async function buildIncidentFeed(
+export type IncidentFeedParams = {
+  orgId?: string;
+  kind?: 'tracked' | 'finding';
+  source?: 'breeze' | 'huntress' | 's1';
+  limit: number;
+  offset: number;
+};
+
+/**
+ * Build the feed's count + rows queries WITHOUT executing them. Returns null
+ * when the requested kind/source filters exclude every union leg (empty feed).
+ *
+ * Splitting construction from execution lets a DB-less unit test call
+ * `.toSQL()` on the rows query to assert the union legs carry `.as()` aliases
+ * and the ORDER BY references the case-sensitive `"detectedAt"` column —
+ * exactly the two failure modes that made `GET /incidents/feed` throw at
+ * query-build time. May throw {@link FeedScopeError} for an invalid org scope.
+ */
+export function buildIncidentFeedQueries(
   auth: AuthContext,
-  params: {
-    orgId?: string;
-    kind?: 'tracked' | 'finding';
-    source?: 'breeze' | 'huntress' | 's1';
-    limit: number;
-    offset: number;
-  }
-): Promise<{ rows: IncidentFeedRow[]; total: number }> {
+  params: IncidentFeedParams
+) {
   const orgIncidents = resolveOrgFilter(auth, params.orgId, incidents.orgId);
   const orgHuntress = resolveOrgFilter(auth, params.orgId, huntressIncidents.orgId);
   const orgS1 = resolveOrgFilter(auth, params.orgId, s1Threats.orgId);
@@ -204,20 +216,22 @@ export async function buildIncidentFeed(
     throw new FeedScopeError(orgIncidents.error.status, orgIncidents.error.message);
   }
 
-  // Native tracked incidents.
+  // Native tracked incidents. Every raw sql<...> value carries `.as('<key>')`
+  // matching its object key — drizzle requires aliases to reference subquery
+  // fields, and the alias set/order must be identical across all three legs.
   const trackedQ = db
     .select({
-      kind: sql<string>`'tracked'`,
-      source: sql<string>`'breeze'`,
-      sourceId: sql<string>`${incidents.id}::text`,
-      title: sql<string>`${incidents.title}`,
-      rank: nativeSeverityRank(),
-      edrStatus: sql<string | null>`null::text`,
-      status: sql<string | null>`${incidents.status}::text`,
-      deviceId: sql<string | null>`(${incidents.affectedDevices}->>0)`,
-      detectedAt: sql<Date>`${incidents.detectedAt}`,
-      trackedIncidentId: sql<string | null>`${incidents.id}::text`,
-      details: sql<unknown>`null::jsonb`,
+      kind: sql<string>`'tracked'`.as('kind'),
+      source: sql<string>`'breeze'`.as('source'),
+      sourceId: sql<string>`${incidents.id}::text`.as('sourceId'),
+      title: sql<string>`${incidents.title}`.as('title'),
+      rank: nativeSeverityRank().as('rank'),
+      edrStatus: sql<string | null>`null::text`.as('edrStatus'),
+      status: sql<string | null>`${incidents.status}::text`.as('status'),
+      deviceId: sql<string | null>`(${incidents.affectedDevices}->>0)`.as('deviceId'),
+      detectedAt: sql<Date>`${incidents.detectedAt}`.as('detectedAt'),
+      trackedIncidentId: sql<string | null>`${incidents.id}::text`.as('trackedIncidentId'),
+      details: sql<unknown>`null::jsonb`.as('details'),
     })
     .from(incidents)
     .where(orgIncidents.condition);
@@ -225,17 +239,17 @@ export async function buildIncidentFeed(
   // Huntress findings NOT already promoted.
   const huntressQ = db
     .select({
-      kind: sql<string>`'finding'`,
-      source: sql<string>`'huntress'`,
-      sourceId: sql<string>`${huntressIncidents.huntressIncidentId}`,
-      title: sql<string>`${huntressIncidents.title}`,
-      rank: edrSeverityRank(huntressIncidents.severity),
-      edrStatus: sql<string | null>`${huntressIncidents.status}`,
-      status: sql<string | null>`null::text`,
-      deviceId: sql<string | null>`${huntressIncidents.deviceId}::text`,
-      detectedAt: sql<Date>`coalesce(${huntressIncidents.reportedAt}, ${huntressIncidents.createdAt})`,
-      trackedIncidentId: sql<string | null>`null::text`,
-      details: sql<unknown>`${huntressIncidents.details}`,
+      kind: sql<string>`'finding'`.as('kind'),
+      source: sql<string>`'huntress'`.as('source'),
+      sourceId: sql<string>`${huntressIncidents.huntressIncidentId}`.as('sourceId'),
+      title: sql<string>`${huntressIncidents.title}`.as('title'),
+      rank: edrSeverityRank(huntressIncidents.severity).as('rank'),
+      edrStatus: sql<string | null>`${huntressIncidents.status}`.as('edrStatus'),
+      status: sql<string | null>`null::text`.as('status'),
+      deviceId: sql<string | null>`${huntressIncidents.deviceId}::text`.as('deviceId'),
+      detectedAt: sql<Date>`coalesce(${huntressIncidents.reportedAt}, ${huntressIncidents.createdAt})`.as('detectedAt'),
+      trackedIncidentId: sql<string | null>`null::text`.as('trackedIncidentId'),
+      details: sql<unknown>`${huntressIncidents.details}`.as('details'),
     })
     .from(huntressIncidents)
     .where(
@@ -249,17 +263,17 @@ export async function buildIncidentFeed(
   // S1 findings NOT already promoted.
   const s1Q = db
     .select({
-      kind: sql<string>`'finding'`,
-      source: sql<string>`'s1'`,
-      sourceId: sql<string>`${s1Threats.s1ThreatId}`,
-      title: sql<string>`coalesce(${s1Threats.threatName}, 'SentinelOne threat')`,
-      rank: edrSeverityRank(s1Threats.severity),
-      edrStatus: sql<string | null>`${s1Threats.status}`,
-      status: sql<string | null>`null::text`,
-      deviceId: sql<string | null>`${s1Threats.deviceId}::text`,
-      detectedAt: sql<Date>`coalesce(${s1Threats.detectedAt}, ${s1Threats.createdAt})`,
-      trackedIncidentId: sql<string | null>`null::text`,
-      details: sql<unknown>`${s1Threats.details}`,
+      kind: sql<string>`'finding'`.as('kind'),
+      source: sql<string>`'s1'`.as('source'),
+      sourceId: sql<string>`${s1Threats.s1ThreatId}`.as('sourceId'),
+      title: sql<string>`coalesce(${s1Threats.threatName}, 'SentinelOne threat')`.as('title'),
+      rank: edrSeverityRank(s1Threats.severity).as('rank'),
+      edrStatus: sql<string | null>`${s1Threats.status}`.as('edrStatus'),
+      status: sql<string | null>`null::text`.as('status'),
+      deviceId: sql<string | null>`${s1Threats.deviceId}::text`.as('deviceId'),
+      detectedAt: sql<Date>`coalesce(${s1Threats.detectedAt}, ${s1Threats.createdAt})`.as('detectedAt'),
+      trackedIncidentId: sql<string | null>`null::text`.as('trackedIncidentId'),
+      details: sql<unknown>`${s1Threats.details}`.as('details'),
     })
     .from(s1Threats)
     .where(
@@ -274,7 +288,7 @@ export async function buildIncidentFeed(
   const includeTracked = params.kind !== 'finding' && params.source !== 'huntress' && params.source !== 's1';
   const includeHuntress = params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress');
   const includeS1 = params.kind !== 'tracked' && (params.source === undefined || params.source === 's1');
-  if (!includeTracked && !includeHuntress && !includeS1) return { rows: [], total: 0 };
+  if (!includeTracked && !includeHuntress && !includeS1) return null;
 
   // Build UNION ALL explicitly per active combination so Drizzle can infer
   // each call's table-name union type (dynamic `legs[]` array spreads lose it).
@@ -296,15 +310,30 @@ export async function buildIncidentFeed(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   const sub = baseQ.as('feed');
 
-  const [countRows, rows] = await Promise.all([
-    db.select({ count: sql<number>`count(*)` }).from(sub),
-    db
-      .select()
-      .from(sub)
-      .orderBy(sql`rank asc`, sql`detected_at desc`)
-      .limit(params.limit)
-      .offset(params.offset),
-  ]);
+  const countQuery = db.select({ count: sql<number>`count(*)` }).from(sub);
+  const rowsQuery = db
+    .select()
+    .from(sub)
+    // Order by the actual aliased subquery columns. `rank` ascending (p1
+    // first), `detectedAt` descending. Referencing `sub.rank`/`sub.detectedAt`
+    // emits correctly-quoted identifiers — raw unquoted `detected_at` would
+    // fold to lowercase and fail (`column "detected_at" does not exist`).
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    .orderBy(asc(sub.rank), desc(sub.detectedAt))
+    .limit(params.limit)
+    .offset(params.offset);
+
+  return { countQuery, rowsQuery };
+}
+
+export async function buildIncidentFeed(
+  auth: AuthContext,
+  params: IncidentFeedParams
+): Promise<{ rows: IncidentFeedRow[]; total: number }> {
+  const built = buildIncidentFeedQueries(auth, params);
+  if (!built) return { rows: [], total: 0 };
+
+  const [countRows, rows] = await Promise.all([built.countQuery, built.rowsQuery]);
 
   return {
     rows: rows.map((r) => {

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { createHash } from 'node:crypto';
@@ -148,10 +148,7 @@ export type IncidentFeedRow = {
   linkOut: string | null;
 };
 
-export function resolveFindingLinkOut(
-  source: 'huntress' | 's1',
-  details: unknown
-): string | null {
+export function resolveFindingLinkOut(details: unknown): string | null {
   if (details && typeof details === 'object') {
     const d = details as Record<string, unknown>;
     const url = d.portalUrl ?? d.url ?? d.link;
@@ -193,6 +190,24 @@ export type IncidentFeedParams = {
   source?: 'breeze' | 'huntress' | 's1';
   limit: number;
   offset: number;
+  /**
+   * True when the caller holds `devices:read`. The raw EDR finding legs
+   * (huntress + s1) expose device telemetry (device ids + hostnames embedded in
+   * titles), so a caller with only `alerts:read` must not see them — when this
+   * is `false` the huntress/s1 legs are omitted entirely and only native
+   * tracked incidents are returned. Defaults to included when omitted (so
+   * existing callers keep full visibility); the route always sets it explicitly.
+   */
+  hasDevicesRead?: boolean;
+  /**
+   * Site-axis allowlist resolved by the route via `resolveSiteAllowedDeviceIds`
+   * (mirrors GET /huntress/incidents + /sentinelone/threats). `null`/`undefined`
+   * means the caller is NOT site-restricted (no narrowing). A concrete array
+   * narrows the EDR legs to findings on these devices, keeping null-device
+   * (provider-level) findings visible. Site is an app-layer authz axis Postgres
+   * RLS does NOT defend, so this must be applied in the query.
+   */
+  allowedDeviceIds?: string[] | null;
 };
 
 /**
@@ -215,6 +230,22 @@ export function buildIncidentFeedQueries(
   if (orgIncidents.error) {
     throw new FeedScopeError(orgIncidents.error.status, orgIncidents.error.message);
   }
+
+  // Site-axis narrowing for the EDR finding legs. Site is an app-layer authz
+  // axis Postgres RLS cannot see, so a site-restricted caller (org user with
+  // `permissions.allowedSiteIds`) must not read Huntress/S1 findings — deviceId
+  // or hostnames-in-titles — for devices outside their allowed sites. `null`
+  // means the caller is unrestricted (no narrowing). For a restricted caller we
+  // keep null-device (provider-level) findings visible and only exclude rows on
+  // foreign-site devices. Mirrors GET /huntress/incidents (huntress.ts) and GET
+  // /sentinelone/threats (sentinelOne.ts): with no allowed devices the `in (…)`
+  // branch matches nothing, so only the null-device branch survives.
+  const siteDevicePredicate = (deviceIdColumn: PgColumn): SQL | undefined => {
+    if (!params.allowedDeviceIds) return undefined;
+    return params.allowedDeviceIds.length > 0
+      ? (or(isNull(deviceIdColumn), inArray(deviceIdColumn, params.allowedDeviceIds)) as SQL)
+      : isNull(deviceIdColumn);
+  };
 
   // Native tracked incidents. Every raw sql<...> value carries `.as('<key>')`
   // matching its object key — drizzle requires aliases to reference subquery
@@ -255,6 +286,7 @@ export function buildIncidentFeedQueries(
     .where(
       and(
         orgHuntress.condition,
+        siteDevicePredicate(huntressIncidents.deviceId),
         sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${huntressIncidents.orgId}
           AND i.source_type = 'huntress_incident' AND i.source_ref = ${huntressIncidents.huntressIncidentId})`
       )
@@ -279,15 +311,22 @@ export function buildIncidentFeedQueries(
     .where(
       and(
         orgS1.condition,
+        siteDevicePredicate(s1Threats.deviceId),
         sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${s1Threats.orgId}
           AND i.source_type = 's1_threat' AND i.source_ref = ${s1Threats.s1ThreatId})`
       )
     );
 
-  // Determine which legs to include based on filters.
+  // Determine which legs to include based on filters. The raw EDR finding legs
+  // require `devices:read`; a caller with only `alerts:read` (hasDevicesRead ===
+  // false) gets native tracked incidents only. `hasDevicesRead` undefined =
+  // included (back-compat for existing callers/fixtures). This composes with the
+  // kind/source filters: a no-devices-read caller passing source=huntress simply
+  // yields no legs → empty feed (null), not an error.
+  const includeEdr = params.hasDevicesRead !== false;
   const includeTracked = params.kind !== 'finding' && params.source !== 'huntress' && params.source !== 's1';
-  const includeHuntress = params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress');
-  const includeS1 = params.kind !== 'tracked' && (params.source === undefined || params.source === 's1');
+  const includeHuntress = includeEdr && params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress');
+  const includeS1 = includeEdr && params.kind !== 'tracked' && (params.source === undefined || params.source === 's1');
   if (!includeTracked && !includeHuntress && !includeS1) return null;
 
   // Build UNION ALL explicitly per active combination so Drizzle can infer
@@ -349,7 +388,7 @@ export async function buildIncidentFeed(
         deviceId: r.deviceId,
         detectedAt: new Date(r.detectedAt as unknown as string).toISOString(),
         trackedIncidentId: r.trackedIncidentId,
-        linkOut: source === 'breeze' ? null : resolveFindingLinkOut(source, r.details),
+        linkOut: source === 'breeze' ? null : resolveFindingLinkOut(r.details),
       };
     }),
     total: Number(countRows[0]?.count ?? 0),

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -195,19 +195,20 @@ export type IncidentFeedParams = {
    * (huntress + s1) expose device telemetry (device ids + hostnames embedded in
    * titles), so a caller with only `alerts:read` must not see them — when this
    * is `false` the huntress/s1 legs are omitted entirely and only native
-   * tracked incidents are returned. Defaults to included when omitted (so
-   * existing callers keep full visibility); the route always sets it explicitly.
+   * tracked incidents are returned. Required (no default) so omission is a
+   * compile error rather than a fail-open runtime default.
    */
-  hasDevicesRead?: boolean;
+  hasDevicesRead: boolean;
   /**
    * Site-axis allowlist resolved by the route via `resolveSiteAllowedDeviceIds`
-   * (mirrors GET /huntress/incidents + /sentinelone/threats). `null`/`undefined`
-   * means the caller is NOT site-restricted (no narrowing). A concrete array
-   * narrows the EDR legs to findings on these devices, keeping null-device
-   * (provider-level) findings visible. Site is an app-layer authz axis Postgres
-   * RLS does NOT defend, so this must be applied in the query.
+   * (mirrors GET /huntress/incidents + /sentinelone/threats). `null` means the
+   * caller is NOT site-restricted (no narrowing). A concrete array narrows the
+   * EDR legs to findings on these devices, keeping null-device (provider-level)
+   * findings visible. Site is an app-layer authz axis Postgres RLS does NOT
+   * defend, so this must be applied in the query. Required (no default) so
+   * callers must declare their site-restriction posture explicitly.
    */
-  allowedDeviceIds?: string[] | null;
+  allowedDeviceIds: string[] | null;
 };
 
 /**
@@ -319,11 +320,11 @@ export function buildIncidentFeedQueries(
 
   // Determine which legs to include based on filters. The raw EDR finding legs
   // require `devices:read`; a caller with only `alerts:read` (hasDevicesRead ===
-  // false) gets native tracked incidents only. `hasDevicesRead` undefined =
-  // included (back-compat for existing callers/fixtures). This composes with the
+  // false) gets native tracked incidents only. Fail-closed: only include EDR
+  // when the caller explicitly signals devices:read. This composes with the
   // kind/source filters: a no-devices-read caller passing source=huntress simply
   // yields no legs → empty feed (null), not an error.
-  const includeEdr = params.hasDevicesRead !== false;
+  const includeEdr = params.hasDevicesRead === true;
   const includeTracked = params.kind !== 'finding' && params.source !== 'huntress' && params.source !== 's1';
   const includeHuntress = includeEdr && params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress');
   const includeS1 = includeEdr && params.kind !== 'tracked' && (params.source === undefined || params.source === 's1');

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -332,7 +332,6 @@ export function buildIncidentFeedQueries(
 
   // Build UNION ALL explicitly per active combination so Drizzle can infer
   // each call's table-name union type (dynamic `legs[]` array spreads lose it).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const baseQ: any =
     includeTracked && includeHuntress && includeS1
       ? unionAll(trackedQ, huntressQ, s1Q)
@@ -347,7 +346,6 @@ export function buildIncidentFeedQueries(
               : includeHuntress
                 ? huntressQ
                 : s1Q;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   const sub = baseQ.as('feed');
 
   const countQuery = db.select({ count: sql<number>`count(*)` }).from(sub);
@@ -358,7 +356,6 @@ export function buildIncidentFeedQueries(
     // first), `detectedAt` descending. Referencing `sub.rank`/`sub.detectedAt`
     // emits correctly-quoted identifiers — raw unquoted `detected_at` would
     // fold to lowercase and fail (`column "detected_at" does not exist`).
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     .orderBy(asc(sub.rank), desc(sub.detectedAt))
     .limit(params.limit)
     .offset(params.offset);

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -43,9 +43,18 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
 }));
 
+vi.mock('./incidents.helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./incidents.helpers')>();
+  return {
+    ...actual,
+    buildIncidentFeed: vi.fn(),
+  };
+});
+
 import { db } from '../db';
 import { incidentRoutes } from './incidents';
 import { publishEvent } from '../services/eventBus';
+import { buildIncidentFeed, FeedScopeError } from './incidents.helpers';
 
 function mockSelectSingle(row: unknown) {
   return {
@@ -482,6 +491,47 @@ describe('incidentRoutes', () => {
       'incidents-route',
       expect.any(Object),
     );
+  });
+
+  it('GET /incidents/feed returns the unified union with pagination', async () => {
+    vi.mocked(buildIncidentFeed).mockResolvedValueOnce({
+      rows: [
+        {
+          kind: 'tracked',
+          source: 'breeze',
+          sourceId: 'i-1',
+          title: 'Test incident',
+          severity: 'p1',
+          edrStatus: null,
+          status: 'detected',
+          deviceId: null,
+          detectedAt: new Date().toISOString(),
+          trackedIncidentId: 'i-1',
+        },
+      ],
+      total: 1,
+    });
+
+    const res = await app.request('/incidents/feed?limit=25', {
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      data: expect.any(Array),
+      pagination: { page: 1, limit: 25 },
+    });
+  });
+
+  it('GET /incidents/feed surfaces scope errors as their status', async () => {
+    vi.mocked(buildIncidentFeed).mockRejectedValueOnce(
+      new FeedScopeError(403, 'Access to this organization denied')
+    );
+
+    const res = await app.request('/incidents/feed?orgId=00000000-0000-0000-0000-000000000999', {
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(res.status).toBe(403);
   });
 
   it('builds incident report with evidence and action summaries', async () => {

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -208,6 +208,49 @@ describe('incidentRoutes', () => {
     );
   });
 
+  it('persists sourceType/sourceRef when promoting an EDR finding', async () => {
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        {
+          id: '33333333-3333-4333-8333-333333333333',
+          orgId: '22222222-2222-4222-8222-222222222222',
+          title: 'Huntress: Suspicious login',
+          classification: 'huntress-incident',
+          severity: 'p1',
+          status: 'detected',
+          relatedAlerts: [],
+          affectedDevices: [],
+          sourceType: 'huntress_incident',
+          sourceRef: 'hunt-abc-123',
+        },
+      ]),
+    });
+    vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+    const res = await app.request('/incidents', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
+      body: JSON.stringify({
+        title: 'Huntress: Suspicious login',
+        classification: 'huntress-incident',
+        severity: 'p1',
+        sourceType: 'huntress_incident',
+        sourceRef: 'hunt-abc-123',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: 'huntress_incident',
+        sourceRef: 'hunt-abc-123',
+      })
+    );
+  });
+
   it('rejects high-risk containment without approvalRef', async () => {
     const res = await app.request('/incidents/33333333-3333-4333-8333-333333333333/contain', {
       method: 'POST',

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -507,6 +507,7 @@ describe('incidentRoutes', () => {
           deviceId: null,
           detectedAt: new Date().toISOString(),
           trackedIncidentId: 'i-1',
+          linkOut: null,
         },
       ],
       total: 1,

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -260,6 +260,44 @@ describe('incidentRoutes', () => {
     );
   });
 
+  it('returns 409 (not 500) when the same EDR finding is promoted twice', async () => {
+    // postgres.js raises a 23505 PostgresError carrying the constraint name;
+    // Drizzle wraps it in a query error whose real fields live on `.cause`.
+    // isPgUniqueViolation walks that chain, so reproduce both layers here. The
+    // promote handler matches `incidents_source_ref_unique` specifically.
+    const pgError = Object.assign(
+      new Error('duplicate key value violates unique constraint "incidents_source_ref_unique"'),
+      { code: '23505', constraint: 'incidents_source_ref_unique' },
+    );
+    const drizzleError = Object.assign(new Error('Failed query: insert into "incidents"'), {
+      cause: pgError,
+    });
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(drizzleError),
+      }),
+    } as any);
+
+    const res = await app.request('/incidents', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
+      body: JSON.stringify({
+        title: 'Huntress: Suspicious login',
+        classification: 'huntress-incident',
+        severity: 'p1',
+        sourceType: 'huntress_incident',
+        sourceRef: 'hunt-abc-123',
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already been promoted/i);
+  });
+
   it('rejects high-risk containment without approvalRef', async () => {
     const res = await app.request('/incidents/33333333-3333-4333-8333-333333333333/contain', {
       method: 'POST',

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -4,6 +4,7 @@ import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { db } from '../db';
 import {
+  devices,
   incidentActions,
   incidentEvidence,
   incidents,
@@ -12,7 +13,7 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { publishEvent } from '../services/eventBus';
 import { writeRouteAudit } from '../services/auditEvents';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, canAccessSite, hasPermission, type UserPermissions } from '../services/permissions';
 import {
   createIncidentSchema,
   listIncidentFeedSchema,
@@ -38,6 +39,26 @@ const requireIncidentRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, 
 const requireIncidentWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
 incidentRoutes.use('*', authMiddleware);
+
+// Resolve the device IDs a site-restricted caller may read within their org,
+// narrowed by `permissions.allowedSiteIds`. Returns null when the caller has no
+// site restriction (no narrowing needed). Site is an app-layer concept only —
+// Postgres RLS does NOT defend it — so a site-restricted org user must not read
+// EDR finding rows (or device hostnames) for devices in other sites within the
+// same org. Mirrors sentinelOne.ts / browserSecurity.ts `resolveSiteAllowedDeviceIds`.
+async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  permissions: UserPermissions | undefined,
+): Promise<string[] | null> {
+  if (!permissions?.allowedSiteIds) return null;
+  const orgDevices = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.orgId, orgId));
+  return orgDevices
+    .filter((d) => typeof d.siteId === 'string' && canAccessSite(permissions, d.siteId))
+    .map((d) => d.id);
+}
 
 incidentRoutes.post(
   '/',
@@ -101,9 +122,10 @@ incidentRoutes.post(
         .returning();
     } catch (err) {
       // Promoting the same EDR finding twice collides on the partial unique
-      // index (org_id, source_type, source_ref). Surface a clean 409 instead
-      // of leaking the raw Postgres 23505 as a 500.
-      if (isPgUniqueViolation(err)) {
+      // index `incidents_source_ref_unique` (org_id, source_type, source_ref).
+      // Surface a clean 409 instead of leaking the raw Postgres 23505 as a 500.
+      // Match the specific constraint so an unrelated 23505 still throws.
+      if (isPgUniqueViolation(err, 'incidents_source_ref_unique')) {
         return c.json({ error: 'This finding has already been promoted to an incident' }, 409);
       }
       throw err;
@@ -230,6 +252,25 @@ incidentRoutes.get(
     const limit = query.limit;
     const offset = (query.page - 1) * limit;
 
+    // The route-level gate stays `alerts:read` (requireIncidentRead, which also
+    // populated `permissions`). The raw EDR finding legs additionally expose
+    // device telemetry, so they require `devices:read`; a caller with only
+    // alerts:read sees native tracked incidents and no raw Huntress/S1 findings.
+    const perms = c.get('permissions') as UserPermissions | undefined;
+    const hasDevicesRead = perms
+      ? hasPermission(perms, PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action)
+      : false;
+
+    // Site is an app-layer authz axis Postgres RLS cannot defend. A site-
+    // restricted org caller must not read EDR findings for devices outside their
+    // site allowlist via the feed. Resolve the allowed device ids exactly as GET
+    // /huntress/incidents and /sentinelone/threats do; partner/system callers
+    // carry no site restriction (allowedSiteIds undefined → null → no narrowing).
+    let allowedDeviceIds: string[] | null = null;
+    if (hasDevicesRead && perms?.allowedSiteIds && auth.scope === 'organization' && auth.orgId) {
+      allowedDeviceIds = await resolveSiteAllowedDeviceIds(auth.orgId, perms);
+    }
+
     try {
       const { rows, total } = await buildIncidentFeed(auth, {
         orgId: query.orgId,
@@ -237,6 +278,8 @@ incidentRoutes.get(
         source: query.source,
         limit,
         offset,
+        hasDevicesRead,
+        allowedDeviceIds,
       });
       return c.json({
         data: rows,

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -15,13 +15,16 @@ import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
 import {
   createIncidentSchema,
+  listIncidentFeedSchema,
   listIncidentsSchema,
   uuidParamSchema,
   closeIncidentSchema,
 } from './incidents.validation';
 import {
+  buildIncidentFeed,
   canTransitionStatus,
   appendTimeline,
+  FeedScopeError,
   normalizeTimelineWithSort,
   getPagination,
   resolveOrgFilter,
@@ -201,6 +204,38 @@ incidentRoutes.get(
         total: Number(countRows[0]?.count ?? 0),
       },
     });
+  }
+);
+
+incidentRoutes.get(
+  '/feed',
+  requireScope('organization', 'partner', 'system'),
+  requireIncidentRead,
+  zValidator('query', listIncidentFeedSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    const limit = query.limit;
+    const offset = (query.page - 1) * limit;
+
+    try {
+      const { rows, total } = await buildIncidentFeed(auth, {
+        orgId: query.orgId,
+        kind: query.kind,
+        source: query.source,
+        limit,
+        offset,
+      });
+      return c.json({
+        data: rows,
+        pagination: { page: query.page, limit, total },
+      });
+    } catch (err) {
+      if (err instanceof FeedScopeError) {
+        return c.json({ error: err.message }, err.status as ContentfulStatusCode);
+      }
+      throw err;
+    }
   }
 );
 

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -89,6 +89,8 @@ incidentRoutes.post(
         timeline: initialTimeline,
         assignedTo: data.assignedTo,
         detectedAt,
+        sourceType: data.sourceType,
+        sourceRef: data.sourceRef,
       })
       .returning();
 

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -31,6 +31,7 @@ import {
   getIncidentWithOrgCheck,
 } from './incidents.helpers';
 import { incidentActionRoutes } from './incidentActions';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 
 export const incidentRoutes = new Hono();
 const requireIncidentRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
@@ -78,24 +79,35 @@ incidentRoutes.post(
       },
     }];
 
-    const [incident] = await db
-      .insert(incidents)
-      .values({
-        orgId: orgId!,
-        title: data.title,
-        classification: data.classification,
-        severity: data.severity,
-        status: data.status ?? 'detected',
-        summary: data.summary,
-        relatedAlerts: data.relatedAlerts ?? [],
-        affectedDevices: data.affectedDevices ?? [],
-        timeline: initialTimeline,
-        assignedTo: data.assignedTo,
-        detectedAt,
-        sourceType: data.sourceType,
-        sourceRef: data.sourceRef,
-      })
-      .returning();
+    let incident;
+    try {
+      [incident] = await db
+        .insert(incidents)
+        .values({
+          orgId: orgId!,
+          title: data.title,
+          classification: data.classification,
+          severity: data.severity,
+          status: data.status ?? 'detected',
+          summary: data.summary,
+          relatedAlerts: data.relatedAlerts ?? [],
+          affectedDevices: data.affectedDevices ?? [],
+          timeline: initialTimeline,
+          assignedTo: data.assignedTo,
+          detectedAt,
+          sourceType: data.sourceType,
+          sourceRef: data.sourceRef,
+        })
+        .returning();
+    } catch (err) {
+      // Promoting the same EDR finding twice collides on the partial unique
+      // index (org_id, source_type, source_ref). Surface a clean 409 instead
+      // of leaking the raw Postgres 23505 as a 500.
+      if (isPgUniqueViolation(err)) {
+        return c.json({ error: 'This finding has already been promoted to an incident' }, 409);
+      }
+      throw err;
+    }
 
     if (!incident) {
       return c.json({ error: 'Failed to create incident' }, 500);

--- a/apps/api/src/routes/incidents.validation.ts
+++ b/apps/api/src/routes/incidents.validation.ts
@@ -39,6 +39,14 @@ export const listIncidentsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(250).optional(),
 });
 
+export const listIncidentFeedSchema = z.object({
+  orgId: z.string().guid().optional(),
+  kind: z.enum(['tracked', 'finding']).optional(),
+  source: z.enum(['breeze', 'huntress', 's1']).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
 export const containIncidentSchema = z.object({
   actionType: z.string().min(2).max(40),
   description: z.string().min(3).max(10_000),

--- a/apps/api/src/routes/incidents.validation.ts
+++ b/apps/api/src/routes/incidents.validation.ts
@@ -23,6 +23,8 @@ export const createIncidentSchema = z.object({
   assignedTo: z.string().guid().optional(),
   detectedAt: z.string().datetime({ offset: true }).optional(),
   status: z.enum(['detected', 'analyzing']).optional(),
+  sourceType: z.enum(['huntress_incident', 's1_threat']).optional(),
+  sourceRef: z.string().min(1).max(128).optional(),
 });
 
 export const listIncidentsSchema = z.object({

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     'scripts/recover-stuck-agents': 'scripts/recover-stuck-agents.ts',
   },
   format: ['cjs'],
-  dts: true,
+  // @breeze/api is a deployed application, not a consumed library: package.json
+  // declares no `main`/`types`/`exports` and nothing imports `@breeze/api`, so
+  // the emitted declarations have no consumers. Generating them ran the whole
+  // src tree through declaration emit in tsup's lower-heap worker thread, which
+  // OOMed (ERR_WORKER_OUT_OF_MEMORY) on heavy inferred types — e.g. the incident
+  // feed's UNION ALL query builder — failing the build for ~150 bytes of unused
+  // .d.cts. Disable it; the Dockerfile and runbook only ever run dist/*.cjs.
+  dts: false,
   noExternal: ['@breeze/shared', 'dotenv'],
 });

--- a/apps/web/src/components/incidents/IncidentsPage.test.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+import IncidentsPage from './IncidentsPage';
+
+function feed(rows: unknown[]) {
+  return { ok: true, status: 200, json: async () => ({ data: rows, pagination: { page: 1, limit: 25, total: rows.length } }) } as Response;
+}
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('IncidentsPage feed', () => {
+  it('renders source badges for tracked and finding rows', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([
+      { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'i1' },
+      { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null },
+    ]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('War room')).toBeInTheDocument());
+    expect(screen.getByText('Huntress')).toBeInTheDocument();
+    expect(screen.getByText('Bad login', { exact: false })).toBeInTheDocument();
+  });
+
+  it('hits /incidents/feed', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    expect(fetchWithAuth.mock.calls[0][0]).toContain('/incidents/feed');
+  });
+});

--- a/apps/web/src/components/incidents/IncidentsPage.test.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.test.tsx
@@ -1,22 +1,27 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
-vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...a: unknown[]) => navigateTo(...a) }));
 import IncidentsPage from './IncidentsPage';
 
 function feed(rows: unknown[]) {
   return { ok: true, status: 200, json: async () => ({ data: rows, pagination: { page: 1, limit: 25, total: rows.length } }) } as Response;
 }
-beforeEach(() => fetchWithAuth.mockReset());
+
+const trackedRow = { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'inc-123' };
+const findingRow = { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null };
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  navigateTo.mockReset();
+});
 
 describe('IncidentsPage feed', () => {
   it('renders source badges for tracked and finding rows', async () => {
-    fetchWithAuth.mockResolvedValueOnce(feed([
-      { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'i1' },
-      { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null },
-    ]));
+    fetchWithAuth.mockResolvedValueOnce(feed([trackedRow, findingRow]));
     render(<IncidentsPage />);
     await waitFor(() => expect(screen.getByText('War room')).toBeInTheDocument());
     expect(screen.getByText('Huntress')).toBeInTheDocument();
@@ -28,5 +33,47 @@ describe('IncidentsPage feed', () => {
     render(<IncidentsPage />);
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
     expect(fetchWithAuth.mock.calls[0][0]).toContain('/incidents/feed');
+  });
+
+  it('navigates to the tracked incident detail when a tracked row is clicked', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([trackedRow]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('War room')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('War room'));
+    expect(navigateTo).toHaveBeenCalledWith('/incidents/inc-123');
+  });
+
+  it('does not navigate when a finding row is clicked', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([findingRow]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('Bad login', { exact: false })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Bad login', { exact: false }));
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('passes kind=finding to the feed endpoint when the kind filter is set to Findings', async () => {
+    fetchWithAuth.mockResolvedValue(feed([]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'finding' } });
+    await waitFor(() => {
+      const lastUrl = fetchWithAuth.mock.calls[fetchWithAuth.mock.calls.length - 1][0] as string;
+      expect(lastUrl).toContain('kind=finding');
+    });
+  });
+
+  it('passes kind=tracked to the feed endpoint when the kind filter is set to Tracked', async () => {
+    fetchWithAuth.mockResolvedValue(feed([]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'tracked' } });
+    await waitFor(() => {
+      const lastUrl = fetchWithAuth.mock.calls[fetchWithAuth.mock.calls.length - 1][0] as string;
+      expect(lastUrl).toContain('kind=tracked');
+    });
   });
 });

--- a/apps/web/src/components/incidents/IncidentsPage.test.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.test.tsx
@@ -11,8 +11,9 @@ function feed(rows: unknown[]) {
   return { ok: true, status: 200, json: async () => ({ data: rows, pagination: { page: 1, limit: 25, total: rows.length } }) } as Response;
 }
 
-const trackedRow = { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'inc-123' };
-const findingRow = { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null };
+const trackedRow = { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'inc-123', linkOut: null };
+const findingRow = { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null, linkOut: null };
+const findingRowWithLink = { ...findingRow, linkOut: 'https://huntress.io/portal/incident/hunt-1' };
 
 beforeEach(() => {
   fetchWithAuth.mockReset();
@@ -75,5 +76,25 @@ describe('IncidentsPage feed', () => {
       const lastUrl = fetchWithAuth.mock.calls[fetchWithAuth.mock.calls.length - 1][0] as string;
       expect(lastUrl).toContain('kind=tracked');
     });
+  });
+
+  it('renders "View in Huntress" anchor when linkOut is set on a finding row', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([findingRowWithLink]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('Bad login', { exact: false })).toBeInTheDocument());
+
+    const link = screen.getByRole('link', { name: /View in Huntress/ });
+    expect(link).toHaveAttribute('href', 'https://huntress.io/portal/incident/hunt-1');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders the static hint when linkOut is null on a finding row', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([findingRow]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('Bad login', { exact: false })).toBeInTheDocument());
+
+    expect(screen.getByText('Promote from the EDR view')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /View in/ })).toBeNull();
   });
 });

--- a/apps/web/src/components/incidents/IncidentsPage.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.tsx
@@ -4,15 +4,21 @@ import { navigateTo } from '@/lib/navigation';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
-type IncidentStatus = 'detected' | 'analyzing' | 'contained' | 'recovering' | 'closed';
+type IncidentKind = 'tracked' | 'finding';
+type IncidentSource = 'breeze' | 'huntress' | 's1';
+type FeedFilter = '' | IncidentKind;
 
-interface Incident {
-  id: string;
+interface IncidentFeedRow {
+  kind: IncidentKind;
+  source: IncidentSource;
+  sourceId: string;
   title: string;
   severity: IncidentSeverity;
-  status: IncidentStatus;
-  classification: string | null;
+  edrStatus: string | null;
+  status: string | null;
+  deviceId: string | null;
   detectedAt: string;
+  trackedIncidentId: string | null;
 }
 
 interface Pagination {
@@ -28,31 +34,36 @@ const severityColors: Record<IncidentSeverity, string> = {
   p4: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
 };
 
-const statusColors: Record<IncidentStatus, string> = {
-  detected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
-  analyzing: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-  contained: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-  recovering: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
-  closed: 'bg-gray-100 text-gray-800 dark:bg-gray-700/30 dark:text-gray-300',
+const sourceLabels: Record<IncidentSource, string> = {
+  breeze: 'Breeze',
+  huntress: 'Huntress',
+  s1: 'SentinelOne',
 };
 
+const sourceBadge: Record<IncidentSource, string> = {
+  breeze: 'bg-gray-100 text-gray-800 dark:bg-gray-700/40 dark:text-gray-200',
+  huntress: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+  s1: 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300',
+};
+
+const statusBadge = 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+
 export default function IncidentsPage() {
-  const [incidents, setIncidents] = useState<Incident[]>([]);
+  const [rows, setRows] = useState<IncidentFeedRow[]>([]);
   const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 25, total: 0 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [statusFilter, setStatusFilter] = useState<IncidentStatus | ''>('');
+  const [kindFilter, setKindFilter] = useState<FeedFilter>('');
   const [severityFilter, setSeverityFilter] = useState<IncidentSeverity | ''>('');
 
-  const fetchIncidents = useCallback(async (page = 1) => {
+  const fetchFeed = useCallback(async (page = 1) => {
     try {
       setLoading(true);
       setError(undefined);
       const params = new URLSearchParams({ page: String(page), limit: '25' });
-      if (statusFilter) params.set('status', statusFilter);
-      if (severityFilter) params.set('severity', severityFilter);
+      if (kindFilter) params.set('kind', kindFilter);
 
-      const response = await fetchWithAuth(`/incidents?${params.toString()}`);
+      const response = await fetchWithAuth(`/incidents/feed?${params.toString()}`);
       if (!response.ok) {
         if (response.status === 401) {
           void navigateTo('/login', { replace: true });
@@ -61,31 +72,36 @@ export default function IncidentsPage() {
         throw new Error('Failed to fetch incidents');
       }
       const data = await response.json();
-      setIncidents(data.data ?? []);
+      setRows(data.data ?? []);
       setPagination(data.pagination ?? { page: 1, limit: 25, total: 0 });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       setLoading(false);
     }
-  }, [statusFilter, severityFilter]);
+  }, [kindFilter]);
 
   useEffect(() => {
-    fetchIncidents();
-  }, [fetchIncidents]);
+    fetchFeed();
+  }, [fetchFeed]);
 
-  const handleRowClick = (id: string) => {
-    void navigateTo(`/incidents/${id}`);
+  const handleRowClick = (row: IncidentFeedRow) => {
+    if (row.kind === 'tracked' && row.trackedIncidentId) {
+      void navigateTo(`/incidents/${row.trackedIncidentId}`);
+    }
   };
 
   const handlePrevious = () => {
-    if (pagination.page > 1) fetchIncidents(pagination.page - 1);
+    if (pagination.page > 1) fetchFeed(pagination.page - 1);
   };
 
   const handleNext = () => {
     const totalPages = Math.ceil(pagination.total / pagination.limit);
-    if (pagination.page < totalPages) fetchIncidents(pagination.page + 1);
+    if (pagination.page < totalPages) fetchFeed(pagination.page + 1);
   };
+
+  // Client-side severity narrowing — the feed endpoint does not support a severity param.
+  const visibleRows = severityFilter ? rows.filter((r) => r.severity === severityFilter) : rows;
 
   if (loading) {
     return (
@@ -98,13 +114,13 @@ export default function IncidentsPage() {
     );
   }
 
-  if (error && incidents.length === 0) {
+  if (error && rows.length === 0) {
     return (
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
         <p className="text-sm text-destructive">{error}</p>
         <button
           type="button"
-          onClick={() => fetchIncidents()}
+          onClick={() => fetchFeed()}
           className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
         >
           Try again
@@ -121,7 +137,7 @@ export default function IncidentsPage() {
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Incidents</h1>
           <p className="text-muted-foreground">
-            Security and operational incidents across your organization.
+            Tracked incidents and EDR findings across your organization.
           </p>
         </div>
       </div>
@@ -135,16 +151,13 @@ export default function IncidentsPage() {
       {/* Filters */}
       <div className="flex gap-3">
         <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value as IncidentStatus | '')}
+          value={kindFilter}
+          onChange={(e) => setKindFilter(e.target.value as FeedFilter)}
           className="rounded-md border bg-background px-3 py-2 text-sm text-foreground"
         >
-          <option value="">All statuses</option>
-          <option value="detected">Detected</option>
-          <option value="analyzing">Analyzing</option>
-          <option value="contained">Contained</option>
-          <option value="recovering">Recovering</option>
-          <option value="closed">Closed</option>
+          <option value="">All</option>
+          <option value="tracked">Tracked</option>
+          <option value="finding">Findings</option>
         </select>
         <select
           value={severityFilter}
@@ -159,13 +172,13 @@ export default function IncidentsPage() {
         </select>
       </div>
 
-      {incidents.length === 0 ? (
+      {visibleRows.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <h2 className="text-lg font-semibold text-foreground mb-1">No incidents found</h2>
           <p className="text-sm text-muted-foreground max-w-md">
-            {statusFilter || severityFilter
+            {kindFilter || severityFilter
               ? 'No incidents match the current filters.'
-              : 'No incidents have been recorded yet.'}
+              : 'No tracked incidents or EDR findings have been recorded yet.'}
           </p>
         </div>
       ) : (
@@ -175,38 +188,56 @@ export default function IncidentsPage() {
               <thead>
                 <tr className="border-b bg-muted/50">
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">Title</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Source</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">Severity</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
-                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Classification</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">Detected</th>
                 </tr>
               </thead>
               <tbody>
-                {incidents.map((incident) => (
-                  <tr
-                    key={incident.id}
-                    onClick={() => handleRowClick(incident.id)}
-                    className="border-b cursor-pointer hover:bg-muted/30 transition-colors"
-                  >
-                    <td className="px-4 py-3 font-medium text-foreground">{incident.title}</td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${severityColors[incident.severity]}`}>
-                        {incident.severity.toUpperCase()}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusColors[incident.status]}`}>
-                        {incident.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {incident.classification ?? '-'}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {formatDateTime(incident.detectedAt)}
-                    </td>
-                  </tr>
-                ))}
+                {visibleRows.map((row) => {
+                  const isTracked = row.kind === 'tracked';
+                  return (
+                    <tr
+                      key={`${row.source}:${row.sourceId}`}
+                      onClick={() => handleRowClick(row)}
+                      className={`border-b transition-colors ${
+                        isTracked ? 'cursor-pointer hover:bg-muted/30' : ''
+                      }`}
+                    >
+                      <td className="px-4 py-3 font-medium text-foreground">{row.title}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${sourceBadge[row.source]}`}>
+                          {sourceLabels[row.source]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${severityColors[row.severity]}`}>
+                          {row.severity.toUpperCase()}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        {isTracked ? (
+                          row.status ? (
+                            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusBadge}`}>
+                              {row.status}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )
+                        ) : (
+                          <div className="flex flex-col gap-0.5">
+                            <span className="capitalize text-muted-foreground">{row.edrStatus ?? '-'}</span>
+                            <span className="text-xs text-muted-foreground">Promote from the EDR view</span>
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {formatDateTime(row.detectedAt)}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/apps/web/src/components/incidents/IncidentsPage.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.tsx
@@ -4,6 +4,7 @@ import { navigateTo } from '@/lib/navigation';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
 type IncidentSeverity = 'p1' | 'p2' | 'p3' | 'p4';
+type IncidentStatus = 'detected' | 'analyzing' | 'contained' | 'recovering' | 'closed';
 type IncidentKind = 'tracked' | 'finding';
 type IncidentSource = 'breeze' | 'huntress' | 's1';
 type FeedFilter = '' | IncidentKind;
@@ -46,7 +47,15 @@ const sourceBadge: Record<IncidentSource, string> = {
   s1: 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300',
 };
 
-const statusBadge = 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+const statusColors: Record<IncidentStatus, string> = {
+  detected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  analyzing: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  contained: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  recovering: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+  closed: 'bg-gray-100 text-gray-800 dark:bg-gray-700/30 dark:text-gray-300',
+};
+
+const fallbackStatusBadge = 'bg-gray-100 text-gray-800 dark:bg-gray-700/40 dark:text-gray-200';
 
 export default function IncidentsPage() {
   const [rows, setRows] = useState<IncidentFeedRow[]>([]);
@@ -54,7 +63,6 @@ export default function IncidentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [kindFilter, setKindFilter] = useState<FeedFilter>('');
-  const [severityFilter, setSeverityFilter] = useState<IncidentSeverity | ''>('');
 
   const fetchFeed = useCallback(async (page = 1) => {
     try {
@@ -99,9 +107,6 @@ export default function IncidentsPage() {
     const totalPages = Math.ceil(pagination.total / pagination.limit);
     if (pagination.page < totalPages) fetchFeed(pagination.page + 1);
   };
-
-  // Client-side severity narrowing — the feed endpoint does not support a severity param.
-  const visibleRows = severityFilter ? rows.filter((r) => r.severity === severityFilter) : rows;
 
   if (loading) {
     return (
@@ -159,24 +164,13 @@ export default function IncidentsPage() {
           <option value="tracked">Tracked</option>
           <option value="finding">Findings</option>
         </select>
-        <select
-          value={severityFilter}
-          onChange={(e) => setSeverityFilter(e.target.value as IncidentSeverity | '')}
-          className="rounded-md border bg-background px-3 py-2 text-sm text-foreground"
-        >
-          <option value="">All severities</option>
-          <option value="p1">P1 - Critical</option>
-          <option value="p2">P2 - High</option>
-          <option value="p3">P3 - Medium</option>
-          <option value="p4">P4 - Low</option>
-        </select>
       </div>
 
-      {visibleRows.length === 0 ? (
+      {rows.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <h2 className="text-lg font-semibold text-foreground mb-1">No incidents found</h2>
           <p className="text-sm text-muted-foreground max-w-md">
-            {kindFilter || severityFilter
+            {kindFilter
               ? 'No incidents match the current filters.'
               : 'No tracked incidents or EDR findings have been recorded yet.'}
           </p>
@@ -195,7 +189,7 @@ export default function IncidentsPage() {
                 </tr>
               </thead>
               <tbody>
-                {visibleRows.map((row) => {
+                {rows.map((row) => {
                   const isTracked = row.kind === 'tracked';
                   return (
                     <tr
@@ -219,7 +213,7 @@ export default function IncidentsPage() {
                       <td className="px-4 py-3">
                         {isTracked ? (
                           row.status ? (
-                            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusBadge}`}>
+                            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusColors[row.status as IncidentStatus] ?? fallbackStatusBadge}`}>
                               {row.status}
                             </span>
                           ) : (

--- a/apps/web/src/components/incidents/IncidentsPage.tsx
+++ b/apps/web/src/components/incidents/IncidentsPage.tsx
@@ -20,6 +20,7 @@ interface IncidentFeedRow {
   deviceId: string | null;
   detectedAt: string;
   trackedIncidentId: string | null;
+  linkOut: string | null;
 }
 
 interface Pagination {
@@ -222,7 +223,19 @@ export default function IncidentsPage() {
                         ) : (
                           <div className="flex flex-col gap-0.5">
                             <span className="capitalize text-muted-foreground">{row.edrStatus ?? '-'}</span>
-                            <span className="text-xs text-muted-foreground">Promote from the EDR view</span>
+                            {row.linkOut ? (
+                              <a
+                                href={row.linkOut}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-xs text-primary hover:underline"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                View in {sourceLabels[row.source]}
+                              </a>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">Promote from the EDR view</span>
+                            )}
                           </div>
                         )}
                       </td>

--- a/apps/web/src/lib/incidents.test.ts
+++ b/apps/web/src/lib/incidents.test.ts
@@ -64,6 +64,22 @@ describe('mappers', () => {
     expect(input.affectedDevices).toEqual([]);
     expect(input.classification).toBe('huntress-incident');
   });
+
+  it('s1ThreatToIncident sets the s1 source link', () => {
+    const input = s1ThreatToIncident({ id: 't1', orgId: 'org-1', deviceId: 'dev-9', deviceName: 'PC',
+      s1ThreatId: 's1-xyz', threatName: 'Emotet', severity: 'critical', status: 'active',
+      detectedAt: '2026-06-20T00:00:00Z' } as any);
+    expect(input.sourceType).toBe('s1_threat');
+    expect(input.sourceRef).toBe('s1-xyz');
+  });
+
+  it('huntressIncidentToIncident sets the huntress source link', () => {
+    const input = huntressIncidentToIncident({ id: 'i1', orgId: 'org-1', deviceId: 'dev-9',
+      huntressIncidentId: 'hunt-1', title: 'Bad login', severity: 'high', status: 'open',
+      reportedAt: '2026-06-20T00:00:00Z' } as any);
+    expect(input.sourceType).toBe('huntress_incident');
+    expect(input.sourceRef).toBe('hunt-1');
+  });
 });
 
 describe('promoteToIncident', () => {

--- a/apps/web/src/lib/incidents.ts
+++ b/apps/web/src/lib/incidents.ts
@@ -12,6 +12,8 @@ export interface CreateIncidentInput {
   summary?: string;
   affectedDevices?: string[];
   detectedAt?: string;
+  sourceType?: 'huntress_incident' | 's1_threat';
+  sourceRef?: string;
 }
 
 const SEVERITY_MAP: Record<string, IncidentSeverity> = {
@@ -39,6 +41,8 @@ export function s1ThreatToIncident(t: S1Threat): CreateIncidentInput {
     summary: `Promoted from SentinelOne threat "${t.threatName ?? 'Unknown threat'}" on ${device}.`,
     affectedDevices: t.deviceId ? [t.deviceId] : [],
     detectedAt: t.detectedAt ?? undefined,
+    sourceType: 's1_threat',
+    sourceRef: t.s1ThreatId,
   };
 }
 
@@ -53,6 +57,8 @@ export function huntressIncidentToIncident(i: HuntressIncident): CreateIncidentI
     summary: `Promoted from Huntress incident "${i.title}" on ${device}.${body ? ` ${body}` : ''}`.slice(0, 10000),
     affectedDevices: i.deviceId ? [i.deviceId] : [],
     detectedAt: i.reportedAt ?? undefined,
+    sourceType: 'huntress_incident',
+    sourceRef: i.huntressIncidentId,
   };
 }
 

--- a/docs/superpowers/plans/2026-06-29-edr-incidents-feed.md
+++ b/docs/superpowers/plans/2026-06-29-edr-incidents-feed.md
@@ -1,0 +1,806 @@
+# EDR-aware Incidents Page (Unified Feed) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface all Huntress incidents and SentinelOne threats on the Incidents page alongside native tracked incidents, with a source-link so manually-promoted findings dedupe out of the feed.
+
+**Architecture:** Add a `source_type`/`source_ref` link (and a forward-compat `affected_users`) to the `incidents` table. A new `GET /incidents/feed` endpoint returns a normalized `UNION ALL` of native incidents + Huntress incidents + S1 threats, scoped via the existing `resolveOrgFilter`, suppressing any finding already promoted. The web Incidents page renders the union as one list with source badges + a filter. The existing `GET /incidents` (tracked-only) is untouched.
+
+**Tech Stack:** Hono + Drizzle (Postgres, RLS-forced as `breeze_app`), Vitest, Astro/React islands, Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-edr-incidents-feed-design.md`
+
+## Global Constraints
+
+- **No auto-file, no config gating.** All findings show; sensitivity stays EDR-side. Findings become tracked incidents only via the existing manual Promote button.
+- **RLS:** `incidents` stays org-scoped (shape #1, direct `org_id`). This plan adds **columns only** — no new tenant-scoped table, so no `rls-coverage` allowlist change. All DB reads go through the request DB-access context (never the bare pool).
+- **Migrations:** hand-written SQL in `apps/api/migrations/`, filename `YYYY-MM-DD-<slug>.sql`, idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), no inner `BEGIN/COMMIT`. Never edit a shipped migration.
+- **Severity map (verbatim):** `critical→p1, high→p2, medium→p3, low→p4`, anything else → `p3`.
+- **Promote contract unchanged:** `POST /incidents` still requires `alerts:write` + MFA.
+- **File-size guideline:** keep route/helper files focused; the feed projection lives in `incidents.helpers.ts`, not inline in the route.
+
+---
+
+### Task 1: Migration + schema — source link & affected_users columns
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-29-incidents-edr-source-link.sql`
+- Modify: `apps/api/src/db/schema/incidentResponse.ts` (incidents table, ~line 49-72)
+
+**Interfaces:**
+- Produces: `incidents.sourceType` (`text`, nullable), `incidents.sourceRef` (`text`, nullable), `incidents.affectedUsers` (`jsonb`, `$type<string[]>`, not null, default `[]`); partial unique index `incidents_source_ref_unique (org_id, source_type, source_ref) WHERE source_ref IS NOT NULL`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-29-incidents-edr-source-link.sql`:
+
+```sql
+-- Link a tracked incident back to the EDR record it was promoted from, so the
+-- /incidents/feed union can suppress findings that already became incidents.
+-- incidents is org-scoped (RLS shape #1); adding columns does not change tenancy.
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS source_type text;
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS source_ref text;
+
+-- Forward-compat hook for identity-based (ITDR) findings; unused until an ITDR
+-- ingestion path exists. Device-based findings keep using affected_devices.
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS affected_users jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- One tracked incident per (org, EDR source record). Partial: only enforced when
+-- a source_ref is present, so manually-created incidents (no source) are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS incidents_source_ref_unique
+  ON incidents (org_id, source_type, source_ref)
+  WHERE source_ref IS NOT NULL;
+```
+
+- [ ] **Step 2: Update the Drizzle schema**
+
+In `apps/api/src/db/schema/incidentResponse.ts`, inside the `incidents = pgTable('incidents', {...})` column block (after `affectedDevices`, before `timeline`), add:
+
+```ts
+  sourceType: text('source_type'),
+  sourceRef: text('source_ref'),
+  affectedUsers: jsonb('affected_users').$type<string[]>().notNull().default([]),
+```
+
+And in the table's index callback (after `detectedAtIdx`), add:
+
+```ts
+  sourceRefIdx: uniqueIndex('incidents_source_ref_unique')
+    .on(table.orgId, table.sourceType, table.sourceRef)
+    .where(sql`source_ref IS NOT NULL`),
+```
+
+Ensure `uniqueIndex` and `sql` are imported from `drizzle-orm/pg-core` and `drizzle-orm` respectively at the top of the file (add to the existing import lists if missing).
+
+- [ ] **Step 3: Run drift check to verify schema matches migration**
+
+Run: `export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift`
+Expected: no drift reported (schema matches the migration).
+
+- [ ] **Step 4: Verify migration idempotency**
+
+Run: `cd apps/api && pnpm vitest run src/db/autoMigrate.test.ts`
+Expected: PASS (migration ordering/idempotency regression test green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-29-incidents-edr-source-link.sql apps/api/src/db/schema/incidentResponse.ts
+git commit -m "feat(incidents): add source_type/source_ref + affected_users to incidents"
+```
+
+---
+
+### Task 2: Accept & persist the source link on `POST /incidents`
+
+**Files:**
+- Modify: `apps/api/src/routes/incidents.validation.ts` (`createIncidentSchema`)
+- Modify: `apps/api/src/routes/incidents.ts` (POST handler insert, ~line 78-92)
+- Test: `apps/api/src/routes/incidents.test.ts`
+
+**Interfaces:**
+- Consumes: `incidents.sourceType` / `incidents.sourceRef` columns (Task 1).
+- Produces: `createIncidentSchema` accepts optional `sourceType: 'huntress_incident' | 's1_threat'` and `sourceRef: string (1..128)`; POST persists both.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/routes/incidents.test.ts`, add (follow the file's existing Drizzle-mock + auth-context patterns; mirror the values asserted by an existing create test):
+
+```ts
+it('persists sourceType/sourceRef when promoting an EDR finding', async () => {
+  // Arrange: org-scoped auth with alerts:write + MFA satisfied (reuse the
+  // helper the other create tests in this file use).
+  const body = {
+    title: 'Huntress: Suspicious login',
+    classification: 'huntress-incident',
+    severity: 'p1',
+    sourceType: 'huntress_incident',
+    sourceRef: 'hunt-abc-123',
+  };
+
+  const res = await postIncident(body); // existing test helper in this file
+
+  expect(res.status).toBe(201);
+  // The insert .values(...) must have received the source link:
+  expect(insertValuesArg).toMatchObject({
+    sourceType: 'huntress_incident',
+    sourceRef: 'hunt-abc-123',
+  });
+});
+```
+
+(If the file lacks an `insertValuesArg` capture, capture it the same way the existing create test asserts inserted columns — assert on the mock `.values` call argument.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.test.ts -t "persists sourceType"`
+Expected: FAIL — schema rejects unknown keys or the insert omits the fields.
+
+- [ ] **Step 3: Extend the validation schema**
+
+In `apps/api/src/routes/incidents.validation.ts`, add to `createIncidentSchema` (after `status`):
+
+```ts
+  sourceType: z.enum(['huntress_incident', 's1_threat']).optional(),
+  sourceRef: z.string().min(1).max(128).optional(),
+```
+
+- [ ] **Step 4: Persist in the POST handler**
+
+In `apps/api/src/routes/incidents.ts`, in the `.insert(incidents).values({...})` object (after `detectedAt,`), add:
+
+```ts
+        sourceType: data.sourceType,
+        sourceRef: data.sourceRef,
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.test.ts -t "persists sourceType"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/incidents.validation.ts apps/api/src/routes/incidents.ts apps/api/src/routes/incidents.test.ts
+git commit -m "feat(incidents): accept and persist source link on create"
+```
+
+---
+
+### Task 3: Feed projection helper (severity map + union builder)
+
+**Files:**
+- Modify: `apps/api/src/routes/incidents.helpers.ts`
+- Test: `apps/api/src/routes/incidents.helpers.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: `resolveOrgFilter(auth, queryOrgId, column)` (already in this file); `huntressIncidents`, `s1Threats`, `incidents` from `../db/schema`.
+- Produces:
+  - `type IncidentFeedRow = { kind: 'tracked' | 'finding'; source: 'breeze' | 'huntress' | 's1'; sourceId: string; title: string; severity: 'p1'|'p2'|'p3'|'p4'; edrStatus: string | null; status: string | null; deviceId: string | null; detectedAt: string; trackedIncidentId: string | null }`
+  - `mapEdrSeverityRank(sev): SQL<number>` — SQL CASE producing 1..4 (p1..p4) for sorting.
+  - `buildIncidentFeed(auth, params): Promise<{ rows: IncidentFeedRow[]; total: number }>` where `params = { orgId?: string; kind?: 'tracked'|'finding'; source?: 'breeze'|'huntress'|'s1'; limit: number; offset: number }`. Throws `FeedScopeError` (carrying `{ message, status }`) when `resolveOrgFilter` returns an error.
+
+- [ ] **Step 1: Write the failing test (severity rank + suppression shape)**
+
+Create `apps/api/src/routes/incidents.helpers.test.ts` (mock `../db` so no real DB; assert the builder issues a query with the suppression `NOT EXISTS` and the org filter). Start with the pure pieces:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { severityRankToLabel } from './incidents.helpers';
+
+describe('severityRankToLabel', () => {
+  it('maps rank 1..4 to p1..p4 and clamps unknown to p3', () => {
+    expect(severityRankToLabel(1)).toBe('p1');
+    expect(severityRankToLabel(2)).toBe('p2');
+    expect(severityRankToLabel(3)).toBe('p3');
+    expect(severityRankToLabel(4)).toBe('p4');
+    expect(severityRankToLabel(99)).toBe('p3');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.helpers.test.ts`
+Expected: FAIL — `severityRankToLabel` not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+In `apps/api/src/routes/incidents.helpers.ts`:
+
+Add imports at the top (extend existing import lines):
+
+```ts
+import { and, eq, inArray, sql, unionAll, type SQL } from 'drizzle-orm';
+import { incidents, huntressIncidents, s1Threats } from '../db/schema';
+```
+
+Add the types + helpers:
+
+```ts
+export type IncidentFeedRow = {
+  kind: 'tracked' | 'finding';
+  source: 'breeze' | 'huntress' | 's1';
+  sourceId: string;
+  title: string;
+  severity: 'p1' | 'p2' | 'p3' | 'p4';
+  edrStatus: string | null;
+  status: string | null;
+  deviceId: string | null;
+  detectedAt: string;
+  trackedIncidentId: string | null;
+};
+
+export class FeedScopeError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+export function severityRankToLabel(rank: number): IncidentFeedRow['severity'] {
+  return rank === 1 ? 'p1' : rank === 2 ? 'p2' : rank === 4 ? 'p4' : 'p3';
+}
+
+// EDR severity string -> sortable rank (1=p1 highest .. 4=p4). Mirrors the
+// web mapEdrSeverity: critical->1, high->2, medium->3, low->4, else 3.
+function edrSeverityRank(col: SQL | PgColumn): SQL<number> {
+  return sql<number>`CASE lower(coalesce(${col}, ''))
+    WHEN 'critical' THEN 1
+    WHEN 'high' THEN 2
+    WHEN 'medium' THEN 3
+    WHEN 'low' THEN 4
+    ELSE 3 END`;
+}
+
+// Native p1..p4 enum -> same rank space.
+function nativeSeverityRank(): SQL<number> {
+  return sql<number>`CASE ${incidents.severity}
+    WHEN 'p1' THEN 1 WHEN 'p2' THEN 2 WHEN 'p4' THEN 4 ELSE 3 END`;
+}
+```
+
+Add the builder:
+
+```ts
+export async function buildIncidentFeed(
+  auth: AuthContext,
+  params: {
+    orgId?: string;
+    kind?: 'tracked' | 'finding';
+    source?: 'breeze' | 'huntress' | 's1';
+    limit: number;
+    offset: number;
+  }
+): Promise<{ rows: IncidentFeedRow[]; total: number }> {
+  const orgIncidents = resolveOrgFilter(auth, params.orgId, incidents.orgId);
+  const orgHuntress = resolveOrgFilter(auth, params.orgId, huntressIncidents.orgId);
+  const orgS1 = resolveOrgFilter(auth, params.orgId, s1Threats.orgId);
+  if (orgIncidents.error) {
+    throw new FeedScopeError(orgIncidents.error.status, orgIncidents.error.message);
+  }
+
+  // Native tracked incidents.
+  const trackedQ = db
+    .select({
+      kind: sql<'tracked'>`'tracked'`,
+      source: sql<'breeze'>`'breeze'`,
+      sourceId: sql<string>`${incidents.id}::text`,
+      title: incidents.title,
+      rank: nativeSeverityRank(),
+      edrStatus: sql<string | null>`null::text`,
+      status: sql<string | null>`${incidents.status}::text`,
+      deviceId: sql<string | null>`(${incidents.affectedDevices}->>0)`,
+      detectedAt: incidents.detectedAt,
+      trackedIncidentId: incidents.id,
+    })
+    .from(incidents)
+    .where(orgIncidents.condition);
+
+  // Huntress findings NOT already promoted.
+  const huntressQ = db
+    .select({
+      kind: sql<'finding'>`'finding'`,
+      source: sql<'huntress'>`'huntress'`,
+      sourceId: huntressIncidents.huntressIncidentId,
+      title: huntressIncidents.title,
+      rank: edrSeverityRank(huntressIncidents.severity),
+      edrStatus: huntressIncidents.status,
+      status: sql<string | null>`null::text`,
+      deviceId: huntressIncidents.deviceId,
+      detectedAt: sql<Date>`coalesce(${huntressIncidents.reportedAt}, ${huntressIncidents.createdAt})`,
+      trackedIncidentId: sql<string | null>`null::uuid`,
+    })
+    .from(huntressIncidents)
+    .where(
+      and(
+        orgHuntress.condition,
+        sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${huntressIncidents.orgId}
+          AND i.source_type = 'huntress_incident' AND i.source_ref = ${huntressIncidents.huntressIncidentId})`
+      )
+    );
+
+  // S1 findings NOT already promoted.
+  const s1Q = db
+    .select({
+      kind: sql<'finding'>`'finding'`,
+      source: sql<'s1'>`'s1'`,
+      sourceId: s1Threats.s1ThreatId,
+      title: sql<string>`coalesce(${s1Threats.threatName}, 'SentinelOne threat')`,
+      rank: edrSeverityRank(s1Threats.severity),
+      edrStatus: s1Threats.status,
+      status: sql<string | null>`null::text`,
+      deviceId: s1Threats.deviceId,
+      detectedAt: sql<Date>`coalesce(${s1Threats.detectedAt}, ${s1Threats.createdAt})`,
+      trackedIncidentId: sql<string | null>`null::uuid`,
+    })
+    .from(s1Threats)
+    .where(
+      and(
+        orgS1.condition,
+        sql`NOT EXISTS (SELECT 1 FROM incidents i WHERE i.org_id = ${s1Threats.orgId}
+          AND i.source_type = 's1_threat' AND i.source_ref = ${s1Threats.s1ThreatId})`
+      )
+    );
+
+  // Apply kind/source filtering by selecting only the relevant legs.
+  const legs = [];
+  if (params.kind !== 'finding' && params.source !== 'huntress' && params.source !== 's1') legs.push(trackedQ);
+  if (params.kind !== 'tracked' && (params.source === undefined || params.source === 'huntress')) legs.push(huntressQ);
+  if (params.kind !== 'tracked' && (params.source === undefined || params.source === 's1')) legs.push(s1Q);
+  if (legs.length === 0) return { rows: [], total: 0 };
+
+  const union = legs.length === 1 ? legs[0]! : unionAll(legs[0]!, ...legs.slice(1));
+  const sub = union.as('feed');
+
+  const [countRows, rows] = await Promise.all([
+    db.select({ count: sql<number>`count(*)` }).from(sub),
+    db
+      .select()
+      .from(sub)
+      .orderBy(sql`rank asc`, sql`detected_at desc`)
+      .limit(params.limit)
+      .offset(params.offset),
+  ]);
+
+  return {
+    rows: rows.map((r) => ({
+      kind: r.kind,
+      source: r.source,
+      sourceId: r.sourceId,
+      title: r.title,
+      severity: severityRankToLabel(Number(r.rank)),
+      edrStatus: r.edrStatus,
+      status: r.status,
+      deviceId: r.deviceId,
+      detectedAt: new Date(r.detectedAt as unknown as string).toISOString(),
+      trackedIncidentId: r.trackedIncidentId,
+    })),
+    total: Number(countRows[0]?.count ?? 0),
+  };
+}
+```
+
+(`PgColumn` is already imported at the top of this file; `db` and `AuthContext` too.)
+
+- [ ] **Step 4: Run to verify the pure helper passes**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.helpers.test.ts`
+Expected: PASS for `severityRankToLabel`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/incidents.helpers.ts apps/api/src/routes/incidents.helpers.test.ts
+git commit -m "feat(incidents): feed projection helper (severity rank + union builder)"
+```
+
+---
+
+### Task 4: `GET /incidents/feed` route
+
+**Files:**
+- Modify: `apps/api/src/routes/incidents.validation.ts` (add `listIncidentFeedSchema`)
+- Modify: `apps/api/src/routes/incidents.ts` (mount `GET /feed` **before** `GET /:id`)
+- Test: `apps/api/src/routes/incidents.test.ts`
+
+**Interfaces:**
+- Consumes: `buildIncidentFeed`, `FeedScopeError`, `IncidentFeedRow` (Task 3).
+- Produces: `GET /incidents/feed` → `{ data: IncidentFeedRow[]; pagination: { page, limit, total } }`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/routes/incidents.test.ts` add (mock `buildIncidentFeed` from the helpers module, or assert against seeded Drizzle mocks consistent with the file's style):
+
+```ts
+it('GET /incidents/feed returns the unified union with pagination', async () => {
+  const res = await app.request('/incidents/feed?limit=25', { headers: orgAuthHeaders });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    data: expect.any(Array),
+    pagination: { page: 1, limit: 25 },
+  });
+});
+
+it('GET /incidents/feed surfaces scope errors as their status', async () => {
+  // org-scoped token requesting a foreign orgId -> 403 from resolveOrgFilter
+  const res = await app.request('/incidents/feed?orgId=00000000-0000-0000-0000-000000000999', {
+    headers: orgAuthHeaders,
+  });
+  expect(res.status).toBe(403);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.test.ts -t "incidents/feed"`
+Expected: FAIL — route returns 404 (not mounted).
+
+- [ ] **Step 3: Add the query schema**
+
+In `apps/api/src/routes/incidents.validation.ts`:
+
+```ts
+export const listIncidentFeedSchema = z.object({
+  orgId: z.string().guid().optional(),
+  kind: z.enum(['tracked', 'finding']).optional(),
+  source: z.enum(['breeze', 'huntress', 's1']).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+```
+
+- [ ] **Step 4: Add the route**
+
+In `apps/api/src/routes/incidents.ts`, **above** the existing `incidentRoutes.get('/:id', ...)` (so `/feed` is not captured by `/:id`), add — importing `buildIncidentFeed`, `FeedScopeError`, and `listIncidentFeedSchema`:
+
+```ts
+incidentRoutes.get(
+  '/feed',
+  requireScope('organization', 'partner', 'system'),
+  requireIncidentRead,
+  zValidator('query', listIncidentFeedSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const query = c.req.valid('query');
+    const limit = query.limit;
+    const offset = (query.page - 1) * limit;
+
+    try {
+      const { rows, total } = await buildIncidentFeed(auth, {
+        orgId: query.orgId,
+        kind: query.kind,
+        source: query.source,
+        limit,
+        offset,
+      });
+      return c.json({
+        data: rows,
+        pagination: { page: query.page, limit, total },
+      });
+    } catch (err) {
+      if (err instanceof FeedScopeError) {
+        return c.json({ error: err.message }, err.status as ContentfulStatusCode);
+      }
+      throw err;
+    }
+  }
+);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.test.ts -t "incidents/feed"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/incidents.validation.ts apps/api/src/routes/incidents.ts apps/api/src/routes/incidents.test.ts
+git commit -m "feat(incidents): GET /incidents/feed unified EDR + tracked union"
+```
+
+---
+
+### Task 5: Web — promote mappers set the source link
+
+**Files:**
+- Modify: `apps/web/src/lib/incidents.ts`
+- Test: `apps/web/src/lib/incidents.test.ts`
+
+**Interfaces:**
+- Consumes: `POST /incidents` now accepting `sourceType`/`sourceRef` (Task 2).
+- Produces: `CreateIncidentInput` gains optional `sourceType: 'huntress_incident' | 's1_threat'` and `sourceRef: string`; both mappers populate them.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/web/src/lib/incidents.test.ts`, extend the mapper describe block:
+
+```ts
+it('s1ThreatToIncident sets the s1 source link', () => {
+  const input = s1ThreatToIncident({ id: 't1', orgId: 'org-1', deviceId: 'dev-9', deviceName: 'PC',
+    s1ThreatId: 's1-xyz', threatName: 'Emotet', severity: 'critical', status: 'active',
+    detectedAt: '2026-06-20T00:00:00Z' } as any);
+  expect(input.sourceType).toBe('s1_threat');
+  expect(input.sourceRef).toBe('s1-xyz');
+});
+
+it('huntressIncidentToIncident sets the huntress source link', () => {
+  const input = huntressIncidentToIncident({ id: 'i1', orgId: 'org-1', deviceId: 'dev-9',
+    huntressIncidentId: 'hunt-1', title: 'Bad login', severity: 'high', status: 'open',
+    reportedAt: '2026-06-20T00:00:00Z' } as any);
+  expect(input.sourceType).toBe('huntress_incident');
+  expect(input.sourceRef).toBe('hunt-1');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/lib/incidents.test.ts -t "source link"`
+Expected: FAIL — `sourceType`/`sourceRef` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `apps/web/src/lib/incidents.ts`, extend the interface:
+
+```ts
+export interface CreateIncidentInput {
+  orgId: string;
+  title: string;
+  classification: string;
+  severity: IncidentSeverity;
+  summary?: string;
+  affectedDevices?: string[];
+  detectedAt?: string;
+  sourceType?: 'huntress_incident' | 's1_threat';
+  sourceRef?: string;
+}
+```
+
+In `s1ThreatToIncident`'s returned object add:
+
+```ts
+    sourceType: 's1_threat',
+    sourceRef: t.s1ThreatId,
+```
+
+In `huntressIncidentToIncident`'s returned object add:
+
+```ts
+    sourceType: 'huntress_incident',
+    sourceRef: i.huntressIncidentId,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/lib/incidents.test.ts`
+Expected: PASS (existing mapper tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/incidents.ts apps/web/src/lib/incidents.test.ts
+git commit -m "feat(web): promote mappers set EDR source link"
+```
+
+---
+
+### Task 6: Web — Incidents page renders the unified feed
+
+**Files:**
+- Modify: `apps/web/src/components/incidents/IncidentsPage.tsx`
+- Test: `apps/web/src/components/incidents/IncidentsPage.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `GET /incidents/feed` → `{ data: IncidentFeedRow[]; pagination }` (Task 4).
+- Produces: list rows with a source badge (`Breeze`/`Huntress`/`SentinelOne`), a `All · Tracked · Findings` filter, Promote affordance hint on findings, and a link-out for findings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/incidents/IncidentsPage.test.tsx` (mock `fetchWithAuth` to return a feed payload; follow the jsdom + Toast-mock conventions used by sibling component tests):
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+import IncidentsPage from './IncidentsPage';
+
+function feed(rows: unknown[]) {
+  return { ok: true, status: 200, json: async () => ({ data: rows, pagination: { page: 1, limit: 25, total: rows.length } }) } as Response;
+}
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('IncidentsPage feed', () => {
+  it('renders source badges for tracked and finding rows', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([
+      { kind: 'tracked', source: 'breeze', sourceId: 'i1', title: 'War room', severity: 'p1', edrStatus: null, status: 'analyzing', deviceId: null, detectedAt: '2026-06-20T00:00:00Z', trackedIncidentId: 'i1' },
+      { kind: 'finding', source: 'huntress', sourceId: 'hunt-1', title: 'Huntress: Bad login', severity: 'p2', edrStatus: 'open', status: null, deviceId: 'd1', detectedAt: '2026-06-19T00:00:00Z', trackedIncidentId: null },
+    ]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(screen.getByText('War room')).toBeInTheDocument());
+    expect(screen.getByText('Huntress')).toBeInTheDocument();
+    expect(screen.getByText('Bad login', { exact: false })).toBeInTheDocument();
+  });
+
+  it('hits /incidents/feed', async () => {
+    fetchWithAuth.mockResolvedValueOnce(feed([]));
+    render(<IncidentsPage />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    expect(fetchWithAuth.mock.calls[0][0]).toContain('/incidents/feed');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/incidents/IncidentsPage.test.tsx`
+Expected: FAIL — page still calls `/incidents` and has no badge.
+
+- [ ] **Step 3: Rework the page to the feed**
+
+In `apps/web/src/components/incidents/IncidentsPage.tsx`:
+- Replace the `Incident` interface with the `IncidentFeedRow` shape (`kind`, `source`, `sourceId`, `severity`, `edrStatus`, `status`, `deviceId`, `detectedAt`, `trackedIncidentId`).
+- Change the fetch URL from `/incidents?...` to `/incidents/feed?...`, keeping the `page`/`limit` params; add an optional `kind` param driven by a new filter state (`'' | 'tracked' | 'finding'`) replacing the old status/severity filters (severity filter may stay).
+- Render per row: a **source badge** mapping `source` → label (`breeze`→`Breeze`, `huntress`→`Huntress`, `s1`→`SentinelOne`) with the existing `severityColors` chip for `severity`.
+- For `kind === 'tracked'`: clicking the row calls `navigateTo('/incidents/' + row.trackedIncidentId)`; show `status` chip.
+- For `kind === 'finding'`: show `edrStatus` text and a "View in {source}" external link (`linkOut` if present on the row — see Task 4 note; until link-out URLs are wired, render the badge + a non-link "Promote from the EDR view" hint). Do not make finding rows navigate to `/incidents/:id`.
+
+Concretely, add the badge map near the existing `severityColors`:
+
+```tsx
+const sourceLabels: Record<'breeze' | 'huntress' | 's1', string> = {
+  breeze: 'Breeze',
+  huntress: 'Huntress',
+  s1: 'SentinelOne',
+};
+const sourceBadge: Record<'breeze' | 'huntress' | 's1', string> = {
+  breeze: 'bg-gray-100 text-gray-800 dark:bg-gray-700/40 dark:text-gray-200',
+  huntress: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+  s1: 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300',
+};
+```
+
+and render `<span className={...sourceBadge[row.source]}>{sourceLabels[row.source]}</span>` in each row.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/incidents/IncidentsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check the web app**
+
+Run: `cd apps/web && pnpm astro check`
+Expected: no new type errors in `IncidentsPage.tsx`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/incidents/IncidentsPage.tsx apps/web/src/components/incidents/IncidentsPage.test.tsx
+git commit -m "feat(web): Incidents page renders unified EDR + tracked feed"
+```
+
+---
+
+### Task 7: Link-out URL resolution (findings → EDR console)
+
+**Files:**
+- Modify: `apps/api/src/routes/incidents.helpers.ts` (`buildIncidentFeed` projection — add `linkOut`)
+- Modify: `apps/web/src/components/incidents/IncidentsPage.tsx` (render the link)
+- Test: `apps/api/src/routes/incidents.helpers.test.ts`
+
+**Interfaces:**
+- Produces: `IncidentFeedRow.linkOut: string | null` — a Huntress/S1 console URL when derivable from the row, else `null`.
+
+> **Plan-time decision (from spec §4):** Neither EDR table stores a portal URL. First check whether `details` jsonb on `huntress_incidents` / `s1_threats` already carries a `portalUrl`/`url` field (grep the sync writers `huntressSync.ts` / `s1Sync.ts` for what they put in `details`). If yes, surface it. If no, derive a best-effort console root URL and accept that it links to the console rather than the specific record. Do NOT block the feature on exact deep-links.
+
+- [ ] **Step 1: Investigate what `details` contains**
+
+Run: `grep -n "details" apps/api/src/jobs/huntressSync.ts apps/api/src/jobs/s1Sync.ts`
+Record whether a per-record URL is stored. This determines Step 3's implementation.
+
+- [ ] **Step 2: Write the failing test**
+
+In `apps/api/src/routes/incidents.helpers.test.ts`:
+
+```ts
+import { resolveFindingLinkOut } from './incidents.helpers';
+
+describe('resolveFindingLinkOut', () => {
+  it('returns the stored portal url when present', () => {
+    expect(resolveFindingLinkOut('huntress', { portalUrl: 'https://huntress.io/x' })).toBe('https://huntress.io/x');
+  });
+  it('returns null when no url is derivable', () => {
+    expect(resolveFindingLinkOut('s1', null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Implement `resolveFindingLinkOut` and wire it into the projection**
+
+In `apps/api/src/routes/incidents.helpers.ts`:
+
+```ts
+export function resolveFindingLinkOut(
+  source: 'huntress' | 's1',
+  details: unknown
+): string | null {
+  if (details && typeof details === 'object') {
+    const d = details as Record<string, unknown>;
+    const url = d.portalUrl ?? d.url ?? d.link;
+    if (typeof url === 'string' && /^https:\/\//.test(url)) return url;
+  }
+  return null;
+}
+```
+
+Add `details` to the huntress/s1 select legs (`details: huntressIncidents.details` / `s1Threats.details`) and `linkOut: sql<null>\`null\`` to the tracked leg so the union columns line up; in the final `rows.map`, compute `linkOut: r.source === 'breeze' ? null : resolveFindingLinkOut(r.source, r.details)`. Add `linkOut: string | null` to `IncidentFeedRow`.
+
+- [ ] **Step 4: Render the link on findings**
+
+In `IncidentsPage.tsx`, for `kind === 'finding'` rows, when `row.linkOut` is set render an anchor `<a href={row.linkOut} target="_blank" rel="noopener noreferrer">View in {sourceLabels[row.source]}</a>`; otherwise render the static hint text.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.helpers.test.ts && cd ../web && pnpm vitest run src/components/incidents/IncidentsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/incidents.helpers.ts apps/api/src/routes/incidents.helpers.test.ts apps/web/src/components/incidents/IncidentsPage.tsx
+git commit -m "feat(incidents): derive EDR console link-out for findings"
+```
+
+---
+
+### Task 8: RLS verification + full suite
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Verify the feed honors RLS as `breeze_app`**
+
+With the worktree stack up, confirm a cross-tenant probe: query `/incidents/feed` as an org-A token and confirm no org-B Huntress/S1 rows appear. Spot-check directly:
+
+Run: `docker exec -it breeze-postgres psql -U breeze_app -d breeze -c "SELECT count(*) FROM huntress_incidents;"`
+Expected: governed by RLS context (0 without a set org context) — confirms the union legs can't leak across tenants.
+
+- [ ] **Step 2: Run the affected suites**
+
+Run: `cd apps/api && pnpm vitest run src/routes/incidents.test.ts src/routes/incidents.helpers.test.ts src/db/autoMigrate.test.ts`
+Run: `cd apps/web && pnpm vitest run src/lib/incidents.test.ts src/components/incidents/IncidentsPage.test.tsx`
+Expected: all PASS.
+
+- [ ] **Step 3: Type-check both apps**
+
+Run: `cd apps/api && pnpm typecheck && cd ../web && pnpm astro check`
+Expected: no new errors.
+
+- [ ] **Step 4: Final commit (if any cleanup)**
+
+```bash
+git add -A && git commit -m "test(incidents): verify EDR feed RLS + suites" --allow-empty
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two-tier model / unified list → Tasks 4, 6. ✅
+- Show all Huntress + S1, no gating → Task 3 builder (no severity filter). ✅
+- Source-link dedup/suppression → Tasks 1, 2, 3 (`NOT EXISTS`), 5 (promote sets link). ✅
+- Scope via `resolveOrgFilter` (org + partner/fleet) → Task 3. ✅
+- Severity normalization → Task 3 (`edrSeverityRank` + `severityRankToLabel`). ✅
+- `affected_users` ITDR hook → Task 1. ✅
+- Existing `GET /incidents` untouched → confirmed (new `/feed` route only). ✅
+- Link-out with fallback → Task 7. ✅
+- Out of scope (auto-file, config gating, resolve client, ITDR ingestion) → none added. ✅
+- Testing (projection, route, migration idempotency, RLS, component) → Tasks 1,3,4,6,8. ✅
+
+**Placeholder scan:** Task 7 carries an explicit investigate-first step with a concrete fallback (console-root link), not a TODO — acceptable per spec §4. No bare "add validation"/"handle edge cases" steps.
+
+**Type consistency:** `IncidentFeedRow` defined in Task 3 is consumed verbatim in Tasks 4/6/7; `sourceType`/`sourceRef` names match across schema (Task 1), validation+insert (Task 2), mappers (Task 5), and suppression predicate (Task 3). `severityRankToLabel`/`edrSeverityRank` names consistent.

--- a/docs/superpowers/specs/2026-06-29-edr-incidents-feed-design.md
+++ b/docs/superpowers/specs/2026-06-29-edr-incidents-feed-design.md
@@ -1,0 +1,149 @@
+# EDR-aware Incidents Page (Unified Feed) — Design
+
+> **Status:** Approved design. Next step is an implementation plan via `writing-plans`.
+> **Branch:** `ToddHebebrand/Incidents-Tab`
+> **Date:** 2026-06-29
+
+## Problem
+
+The Incidents page (`IncidentsPage.tsx` → `GET /incidents`) reads only the BE-32 `incidents`
+table, which is populated solely by manual create, the AI brain, and audit-chain tamper detection.
+Meanwhile Huntress incidents and SentinelOne (S1) threats sync into their **own** tables
+(`huntress_incidents`, `s1_threats`) and are shown only under the integration / EDR pages. The two
+systems were never connected, so the Incidents page looks empty even when EDR integrations are
+syncing healthily (observed on the OliveTech / DO-US tenant).
+
+Pillar 4a (PR #1946) shipped a manual **"Promote to Incident"** button on the EDR surfaces, but it
+creates an `incidents` row with **no trace of its origin** — there is no link from the EDR record to
+the resulting incident.
+
+## Goal
+
+Make the Incidents page the single pane for security incidents: surface **all** Huntress incidents
+and S1 threats alongside native tracked incidents, while keeping proper incident management for the
+ones a human chooses to work — without rebuilding the Huntress/S1 console inside Breeze.
+
+## Decisions (locked with the product owner)
+
+- **Two-tier model**, not auto-file. EDR findings appear read-only; they become tracked incidents
+  only via manual **Promote** (the shipped Pillar 4a button).
+- **Show everything.** All Huntress incidents and all S1 threats surface. Breeze does **no**
+  severity filtering or config-policy gating — sensitivity is configured on the EDR side.
+- **Don't duplicate Huntress.** Findings render as thin summary rows with a **link-out** to the EDR
+  console for forensic detail. Tracked incidents **reference** their EDR origin (do not copy it).
+- **Manual promote only.** No auto-file, no auto-promote rules.
+- **Forward-compat for ITDR** (identity-based, user- not device-scoped): add the schema hook now,
+  build the ingestion later. The Huntress **resolve** write-back API client is a separate follow-up.
+
+## Architecture
+
+### 1. Page layout (web)
+
+A single **interleaved list** with two row kinds, distinguished by a **source badge**
+(`Breeze` / `Huntress` / `SentinelOne`) and a filter (`All · Tracked · Findings`, plus by source):
+
+- **Finding rows** (read-only): title, normalized severity, affected device/user, EDR status,
+  detected time, **"View in Huntress/S1"** link-out, and a **Promote** button.
+- **Tracked rows**: native `incidents` with full lifecycle; click opens the existing
+  `IncidentDetailPage`.
+
+Rationale for one list over tabs: the owner's mental model is "one place to see all incidents." The
+badge + the Promote-vs-status affordance make the two kinds visually obvious.
+
+### 2. API
+
+- **New** `GET /incidents/feed` returns a **normalized union** of three projections — native
+  `incidents`, `huntress_incidents`, `s1_threats` — into a common row shape:
+
+  ```ts
+  {
+    kind: 'tracked' | 'finding';
+    source: 'breeze' | 'huntress' | 's1';
+    sourceId: string;            // incident id, or EDR external id
+    title: string;
+    severity: 'p1' | 'p2' | 'p3' | 'p4';
+    edrStatus: string | null;    // raw EDR status for findings; null for tracked
+    status: IncidentStatus | null; // BE-32 lifecycle for tracked; null for findings
+    deviceId: string | null;
+    detectedAt: string;          // ISO
+    linkOut: string | null;      // EDR console deep-link (findings only)
+    trackedIncidentId: string | null; // set if a finding was promoted (suppressed from feed)
+  }
+  ```
+
+  Sorted (severity, then `detectedAt` desc) and **paginated server-side**.
+
+- The existing `GET /incidents` (tracked-only) is **unchanged** — AI tools and other consumers keep
+  working.
+- **Scope** reuses the existing `resolveOrgFilter(auth, orgId, col)` helper against each table's
+  `org_id`, so org users see their org and partner users get the fleet view — identical to today's
+  incidents list behavior.
+- **Severity normalization**: a server-side `mapEdrSeverity` (mirror of the one in
+  `apps/web/src/lib/incidents.ts`) maps Huntress/S1 severity strings → `p1–p4`
+  (`critical→p1, high→p2, medium→p3, low→p4`, else `p3`).
+- **Dedup / suppression**: the feed `LEFT JOIN`s `incidents` on `(source_type, source_ref)` and
+  **excludes any finding already promoted**, so a promoted finding shows exactly once — as its
+  tracked incident.
+
+#### Implementation approach for the union
+
+Project each source to the common shape and `UNION ALL`, then sort + paginate. Prefer a query (or a
+`security_invoker` SQL view) so each underlying table's RLS still applies under `breeze_app`. Avoid
+app-level merge across capped per-source fetches (breaks clean pagination). RLS must be verified as
+`breeze_app` for the view/query path.
+
+### 3. Schema (one idempotent migration)
+
+`incidents` has no source link today. Add:
+
+- `source_type` text — `'huntress_incident' | 's1_threat' | null`.
+- `source_ref` text — the EDR external id (`huntress_incident_id` / `s1_threat_id`).
+- Partial unique index `(org_id, source_type, source_ref) WHERE source_ref IS NOT NULL`.
+- `affected_users jsonb NOT NULL DEFAULT '[]'` — **forward-compat hook for ITDR**, unused for now,
+  so identity-based findings slot in later without another migration.
+
+RLS shape is unchanged — `incidents` stays org-scoped (shape #1, direct `org_id`). No new
+tenant-scoped table is introduced; the migration only adds columns + an index.
+
+Also:
+
+- Extend `createIncidentSchema` + the `POST /incidents` handler to accept and persist
+  `source_type` / `source_ref`.
+- Update the **shipped Pillar 4a mappers** (`apps/web/src/lib/incidents.ts`:
+  `s1ThreatToIncident`, `huntressIncidentToIncident`) to pass `source_type` / `source_ref` so
+  promote dedups against the feed.
+
+### 4. Link-out detail
+
+Neither EDR table stores a portal URL. The link-out URL is **derived** from the external id (+ the
+integration's base) or pulled from the `details` jsonb if present. Exact URL shape is resolved during
+the plan; worst case is linking to the Huntress/S1 console root rather than the specific record.
+
+## Out of scope (deferred)
+
+- **Auto-file / auto-promote** — manual promote only.
+- **Config-policy gating** — none; sensitivity stays EDR-side.
+- **Resolve API client** (Huntress write-back, `HuntressClient` POST methods + UI) — separate spec.
+- **ITDR ingestion** (no sync exists) — only the `affected_users` schema hook is added now.
+
+## Testing
+
+- **Feed projection unit tests**: severity mapping; suppression of promoted findings; org-vs-partner
+  scope filtering; sort/pagination ordering.
+- **Route test** for `GET /incidents/feed` (org scope, partner/fleet scope, suppression).
+- **Migration idempotency** test (re-apply is a no-op) + RLS verification as `breeze_app`.
+- **Web component test** for the unified list: source badges, `All · Tracked · Findings` filter,
+  Promote affordance on findings, link-out rendering.
+- Update `no-silent-mutations` count if any new mutation handler is enrolled.
+
+## Affected files (indicative)
+
+- New migration: `apps/api/migrations/2026-06-29-incidents-edr-source-link.sql`.
+- `apps/api/src/db/schema/incidentResponse.ts` — new columns.
+- `apps/api/src/routes/incidents.ts` + `incidents.validation.ts` — feed endpoint, source link on POST.
+- `apps/api/src/routes/incidents.helpers.ts` — feed projection / union builder + server-side
+  `mapEdrSeverity`.
+- `apps/web/src/components/incidents/IncidentsPage.tsx` — unified list, badge, filter.
+- `apps/web/src/lib/incidents.ts` — mappers pass source link.
+- `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — no new table, but
+  re-verify if the union view is added.


### PR DESCRIPTION
## Summary

Makes the Incidents page **EDR-aware**: it now renders a unified feed that unions live EDR detections (from connected endpoint-security providers) with manually-tracked incident-response records, instead of showing only tracked incidents.

- **New `GET /incidents/feed`** endpoint returns a severity-ranked union of EDR findings + tracked incidents
- **Schema**: adds `source_type` / `source_ref` and `affected_users` to incidents; create-path accepts and persists an EDR source link
- **EDR console link-out**: findings derive a deep link back to the originating EDR console
- **Web**: Incidents page renders the unified feed with per-status colors; removed the misleading client-side severity filter

## Security / tenant isolation

- EDR feed legs are gated on **site-RBAC + `devices:read`** — a user without device read or outside the site scope cannot see EDR findings (#8)
- `hasDevicesRead` + `allowedDeviceIds` are **required** on `IncidentFeedParams` so the gate can't be bypassed by omission
- Integration coverage added for the site-RBAC exclusion path

## Migration

`2026-06-29-incidents-edr-source-link.sql` — idempotent add of source-link columns.

## Tests

- API: `incidents.helpers.test.ts`, `incidents.test.ts`, plus `incidents-feed.integration.test.ts` (real-DB RBAC exclusion)
- Web: `IncidentsPage.test.tsx`, `incidents.test.ts`

Spec: `docs/superpowers/specs/2026-06-29-edr-incidents-feed-design.md`
Plan: `docs/superpowers/plans/2026-06-29-edr-incidents-feed.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
