### PR TITLE
feat(unifi): self-hosted controller support (agent-mediated, no cloud key)

### DIFF
--- a/agent/internal/unifi/client.go
+++ b/agent/internal/unifi/client.go
@@ -55,9 +55,15 @@ type Client struct {
 	Raw               json.RawMessage `json:"raw"`
 }
 
+type SiteRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type Snapshot struct {
 	Devices    []Device
 	Clients    []Client
+	Sites      []SiteRef
 	FirmwareOK bool
 }
 
@@ -158,12 +164,11 @@ func (c *APIClient) Poll(ctx context.Context) (Snapshot, error) {
 	if err != nil {
 		return snap, err
 	}
-	var sites []struct {
-		ID string `json:"id"`
-	}
+	var sites []SiteRef
 	if err := json.Unmarshal(sitesData, &sites); err != nil {
 		return snap, fmt.Errorf("decode sites: %w", err)
 	}
+	snap.Sites = sites
 
 	var firstErr error
 	var errCount int

--- a/agent/internal/unifi/client_test.go
+++ b/agent/internal/unifi/client_test.go
@@ -2,8 +2,10 @@ package unifi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -69,6 +71,27 @@ func TestPollParsesDevicesAndClients(t *testing.T) {
 	}
 	if len(snap.Clients) != 1 || snap.Clients[0].Mac != "cc:dd" || snap.Clients[0].SiteID != "s1" {
 		t.Fatalf("unexpected clients: %+v", snap.Clients)
+	}
+}
+
+func TestPoll_ReportsSitesWithNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/sites"):
+			io.WriteString(w, `{"data":[{"id":"s1","name":"HQ"},{"id":"s2","name":"Branch"}]}`)
+		default:
+			io.WriteString(w, `{"data":[]}`)
+		}
+	}))
+	defer srv.Close()
+	c := NewAPIClient(srv.URL, "k", srv.Client())
+	snap, err := c.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(snap.Sites) != 2 || snap.Sites[0].ID != "s1" || snap.Sites[0].Name != "HQ" {
+		t.Fatalf("got sites %+v", snap.Sites)
 	}
 }
 

--- a/agent/internal/unifi/collector.go
+++ b/agent/internal/unifi/collector.go
@@ -73,12 +73,18 @@ type uploadClient struct {
 	Raw               json.RawMessage `json:"raw,omitempty"`
 }
 
+type uploadSite struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
 type telemetryPayload struct {
 	CollectorID string         `json:"collectorId"`
 	PolledAt    string         `json:"polledAt"`
 	FirmwareOK  bool           `json:"firmwareOk"`
 	Devices     []uploadDevice `json:"devices"`
 	Clients     []uploadClient `json:"clients"`
+	Sites       []uploadSite   `json:"sites,omitempty"`
 	Error       string         `json:"error,omitempty"`
 }
 
@@ -114,12 +120,17 @@ func toUploadClients(in []Client) []uploadClient {
 func RunOnce(ctx context.Context, deps CollectorDeps, cfg CollectorConfig, controllerHTTP *http.Client) error {
 	api := NewAPIClient(cfg.ControllerURL, cfg.APIKey, controllerHTTP)
 	snap, pollErr := api.Poll(ctx)
+	sites := make([]uploadSite, len(snap.Sites))
+	for i, s := range snap.Sites {
+		sites[i] = uploadSite{ID: s.ID, Name: s.Name}
+	}
 	payload := telemetryPayload{
 		CollectorID: cfg.CollectorID,
 		PolledAt:    time.Now().UTC().Format(time.RFC3339),
 		FirmwareOK:  snap.FirmwareOK,
 		Devices:     toUploadDevices(snap.Devices),
 		Clients:     toUploadClients(snap.Clients),
+		Sites:       sites,
 	}
 	if pollErr != nil {
 		payload.Error = pollErr.Error()

--- a/agent/internal/unifi/collector_test.go
+++ b/agent/internal/unifi/collector_test.go
@@ -65,6 +65,48 @@ func TestRunOnceUploadsTelemetry(t *testing.T) {
 	}
 }
 
+func TestRunOnceUploadsSites(t *testing.T) {
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/proxy/network/integration/v1/sites":
+			w.Write([]byte(`{"data":[{"id":"s1","name":"HQ"},{"id":"s2","name":"Branch"}]}`))
+		default:
+			w.Write([]byte(`{"data":[]}`))
+		}
+	}))
+	defer controller.Close()
+
+	var mu sync.Mutex
+	var got map[string]any
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/agents/agent-1/unifi-telemetry" {
+			mu.Lock()
+			defer mu.Unlock()
+			_ = json.NewDecoder(r.Body).Decode(&got)
+			w.WriteHeader(202)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer api.Close()
+
+	cfg := CollectorConfig{CollectorID: "c1", ControllerURL: controller.URL, APIKey: "k"}
+	err := RunOnce(context.Background(), CollectorDeps{APIBaseURL: api.URL, AgentID: "agent-1", HTTP: api.Client()}, cfg, controller.Client())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sitesRaw, ok := got["sites"].([]any)
+	if !ok || len(sitesRaw) != 2 {
+		t.Fatalf("expected 2 sites in payload, got %+v", got["sites"])
+	}
+	s0, _ := sitesRaw[0].(map[string]any)
+	if s0["id"] != "s1" || s0["name"] != "HQ" {
+		t.Fatalf("unexpected first site: %+v", sitesRaw[0])
+	}
+}
+
 // fetchConfigs must GET the agent-scoped path /agents/<id>/unifi-collectors, not
 // the bare /agent/unifi-collectors (which 404s and never returns configs — C3).
 func TestFetchConfigsHitsAgentScopedPath(t *testing.T) {

--- a/apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql
+++ b/apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql
@@ -1,0 +1,28 @@
+-- UniFi self-hosted controllers (part a): connection_type discriminator on the
+-- partner integration row. 'cloud' = existing Site Manager (api.ui.com) flow;
+-- 'self_hosted' = agent-mediated local Network controller with no cloud key.
+
+ALTER TABLE unifi_integrations
+  ADD COLUMN IF NOT EXISTS connection_type text NOT NULL DEFAULT 'cloud';
+
+-- Self-hosted integrations carry no cloud API key; relax the NOT NULL and guard
+-- it with a CHECK so cloud rows still require a key.
+ALTER TABLE unifi_integrations ALTER COLUMN api_key_encrypted DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'unifi_integrations_cloud_key_chk'
+  ) THEN
+    ALTER TABLE unifi_integrations
+      ADD CONSTRAINT unifi_integrations_cloud_key_chk
+      CHECK (connection_type <> 'cloud' OR api_key_encrypted IS NOT NULL);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'unifi_integrations_connection_type_chk'
+  ) THEN
+    ALTER TABLE unifi_integrations
+      ADD CONSTRAINT unifi_integrations_connection_type_chk
+      CHECK (connection_type IN ('cloud', 'self_hosted'));
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql
+++ b/apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql
@@ -1,0 +1,17 @@
+-- UniFi self-hosted controllers (part b): one collector row per controller (no
+-- cloud host id), plus the agent-reported controller-site discovery table.
+
+-- 1. Collector host id becomes nullable; a self-hosted controller has no cloud host.
+ALTER TABLE unifi_collectors ALTER COLUMN unifi_host_id DROP NOT NULL;
+
+-- Replace the unconditional unique (integration, host) with a partial that only
+-- governs cloud collectors (host id present). Self-hosted rows (null host id) are
+-- governed by a separate (integration, controller_url) unique index below.
+DROP INDEX IF EXISTS unifi_collectors_integration_host_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_host_idx
+  ON unifi_collectors(integration_id, unifi_host_id)
+  WHERE unifi_host_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_url_idx
+  ON unifi_collectors(integration_id, controller_url)
+  WHERE unifi_host_id IS NULL;

--- a/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
+++ b/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
@@ -46,3 +46,8 @@ CREATE POLICY breeze_org_isolation_update ON unifi_controller_sites
   WITH CHECK (public.breeze_has_org_access(org_id));
 CREATE POLICY breeze_org_isolation_delete ON unifi_controller_sites
   FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- 3. Link telemetry devices to discovered_assets (inventory parity for self-hosted;
+-- harmless for cloud collectors, which simply leave it null).
+ALTER TABLE unifi_device_telemetry
+  ADD COLUMN IF NOT EXISTS discovered_asset_id uuid REFERENCES discovered_assets(id);

--- a/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
+++ b/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
@@ -15,3 +15,34 @@ CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_host_idx
 CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_url_idx
   ON unifi_collectors(integration_id, controller_url)
   WHERE unifi_host_id IS NULL;
+
+-- 2. unifi_controller_sites: the local sites the agent discovered on a self-hosted
+-- controller, so the mapping UI can list them. org-axis = collector agent's org.
+CREATE TABLE IF NOT EXISTS unifi_controller_sites (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  collector_id  uuid NOT NULL REFERENCES unifi_collectors(id) ON DELETE CASCADE,
+  org_id        uuid NOT NULL REFERENCES organizations(id),
+  local_site_id text NOT NULL,
+  name          text,
+  last_seen_at  timestamptz NOT NULL DEFAULT now(),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_controller_sites_collector_site_idx
+  ON unifi_controller_sites(collector_id, local_site_id);
+
+ALTER TABLE unifi_controller_sites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE unifi_controller_sites FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON unifi_controller_sites;
+CREATE POLICY breeze_org_isolation_select ON unifi_controller_sites
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON unifi_controller_sites
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON unifi_controller_sites
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON unifi_controller_sites
+  FOR DELETE USING (public.breeze_has_org_access(org_id));

--- a/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
+++ b/apps/api/migrations/2026-06-29-unifi-self-hosted-collectors-and-sites.sql
@@ -1,5 +1,5 @@
--- UniFi self-hosted controllers (part b): one collector row per controller (no
--- cloud host id), plus the agent-reported controller-site discovery table.
+-- UniFi self-hosted controllers: one collector row per controller (no cloud
+-- host id), plus the agent-reported controller-site discovery table.
 
 -- 1. Collector host id becomes nullable; a self-hosted controller has no cloud host.
 ALTER TABLE unifi_collectors ALTER COLUMN unifi_host_id DROP NOT NULL;

--- a/apps/api/src/db/schema/unifi.ts
+++ b/apps/api/src/db/schema/unifi.ts
@@ -150,6 +150,7 @@ export const unifiDeviceTelemetry = pgTable('unifi_device_telemetry', {
   txBytes: bigint('tx_bytes', { mode: 'number' }),
   rxBytes: bigint('rx_bytes', { mode: 'number' }),
   numClients: integer('num_clients'),
+  discoveredAssetId: uuid('discovered_asset_id').references(() => discoveredAssets.id),
   poePorts: jsonb('poe_ports'),
   raw: jsonb('raw').notNull(),
   isStale: boolean('is_stale').notNull().default(false),

--- a/apps/api/src/db/schema/unifi.ts
+++ b/apps/api/src/db/schema/unifi.ts
@@ -112,7 +112,7 @@ export const unifiCollectors = pgTable('unifi_collectors', {
   integrationId: uuid('integration_id').notNull().references(() => unifiIntegrations.id, { onDelete: 'cascade' }),
   orgId: uuid('org_id').notNull().references(() => organizations.id),
   siteId: uuid('site_id').notNull().references(() => sites.id),
-  unifiHostId: text('unifi_host_id').notNull(),
+  unifiHostId: text('unifi_host_id'),
   collectorDeviceId: uuid('collector_device_id').notNull().references(() => devices.id),
   controllerUrl: text('controller_url').notNull(),
   localApiKeyEncrypted: text('local_api_key_encrypted').notNull(),
@@ -127,7 +127,12 @@ export const unifiCollectors = pgTable('unifi_collectors', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({
-  integrationHostIdx: uniqueIndex('unifi_collectors_integration_host_idx').on(table.integrationId, table.unifiHostId),
+  integrationHostIdx: uniqueIndex('unifi_collectors_integration_host_idx')
+    .on(table.integrationId, table.unifiHostId)
+    .where(sql`${table.unifiHostId} IS NOT NULL`),
+  integrationUrlIdx: uniqueIndex('unifi_collectors_integration_url_idx')
+    .on(table.integrationId, table.controllerUrl)
+    .where(sql`${table.unifiHostId} IS NULL`),
   deviceIdx: index('unifi_collectors_device_idx').on(table.collectorDeviceId).where(sql`${table.isEnabled}`),
 }));
 

--- a/apps/api/src/db/schema/unifi.ts
+++ b/apps/api/src/db/schema/unifi.ts
@@ -22,8 +22,9 @@ import { devices } from './devices';
 export const unifiIntegrations = pgTable('unifi_integrations', {
   id: uuid('id').primaryKey().defaultRandom(),
   partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  connectionType: text('connection_type').notNull().default('cloud'),
   baseUrl: text('base_url').notNull().default('https://api.ui.com'),
-  apiKeyEncrypted: text('api_key_encrypted').notNull(),
+  apiKeyEncrypted: text('api_key_encrypted'),
   accountLabel: text('account_label'),
   isActive: boolean('is_active').notNull().default(true),
   status: varchar('status', { length: 20 }).notNull().default('connected'),

--- a/apps/api/src/db/schema/unifi.ts
+++ b/apps/api/src/db/schema/unifi.ts
@@ -191,3 +191,17 @@ export const unifiClients = pgTable('unifi_clients', {
   collectorMacIdx: uniqueIndex('unifi_clients_collector_mac_idx').on(table.collectorId, table.mac),
   orgMacIdx: index('unifi_clients_org_mac_idx').on(table.orgId, table.mac),
 }));
+
+export const unifiControllerSites = pgTable('unifi_controller_sites', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  collectorId: uuid('collector_id').notNull().references(() => unifiCollectors.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  localSiteId: text('local_site_id').notNull(),
+  name: text('name'),
+  lastSeenAt: timestamp('last_seen_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  collectorSiteIdx: uniqueIndex('unifi_controller_sites_collector_site_idx')
+    .on(table.collectorId, table.localSiteId),
+}));

--- a/apps/api/src/routes/agents/unifiTelemetry.ts
+++ b/apps/api/src/routes/agents/unifiTelemetry.ts
@@ -58,6 +58,7 @@ const telemetrySchema = z.object({
   firmwareOk: z.boolean(),
   devices: z.array(deviceDto),
   clients: z.array(clientDto),
+  sites: z.array(z.object({ id: z.string().min(1), name: z.string().nullable().optional() })).optional(),
   error: z.string().optional(),
 });
 

--- a/apps/api/src/routes/unifi/index.test.ts
+++ b/apps/api/src/routes/unifi/index.test.ts
@@ -151,6 +151,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: 'My UniFi',
       isActive: true,
@@ -228,6 +229,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.upsertConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -261,6 +263,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -345,6 +348,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -378,6 +382,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -417,6 +422,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -457,6 +463,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -492,6 +499,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,
@@ -621,6 +629,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getConnection).mockResolvedValue({
       id: CONN_ID,
       partnerId: PARTNER_ID,
+      connectionType: 'cloud',
       baseUrl: 'https://api.ui.com',
       accountLabel: null,
       isActive: true,

--- a/apps/api/src/routes/unifi/index.ts
+++ b/apps/api/src/routes/unifi/index.ts
@@ -8,6 +8,7 @@ import { db } from '../../db';
 import { devices, unifiCollectors, unifiDeviceTelemetry, unifiClients, unifiSiteMappings, unifiSyncRuns, sites } from '../../db/schema';
 import { createUnifiClient, UnifiApiError } from '../../services/unifi/unifiClient';
 import { getConnection, getDecryptedApiKey, upsertConnection, deleteConnection, createSelfHostedIntegration } from '../../services/unifi/unifiConnectionService';
+import { listControllerSitesForIntegration } from '../../services/unifi/unifiControllerSiteService';
 import { listCollectors, upsertCollector, deleteCollector, upsertSelfHostedController } from '../../services/unifi/unifiCollectorService';
 import { enqueueUnifiSync } from '../../jobs/unifiWorker';
 
@@ -389,4 +390,15 @@ unifiRoutes.get('/sync-runs', partnerScopes, readPerm, async (c) => {
     .orderBy(desc(unifiSyncRuns.startedAt))
     .limit(20);
   return c.json({ runs });
+});
+
+// GET /unifi/controller-sites — agent-discovered local sites for the mapping UI
+unifiRoutes.get('/controller-sites', partnerScopes, readPerm, async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const conn = await getConnection(db, partner.partnerId);
+  if (!conn) return c.json({ sites: [] });
+  const sitesOut = await listControllerSitesForIntegration(db, conn.id);
+  return c.json({ sites: sitesOut });
 });

--- a/apps/api/src/routes/unifi/index.ts
+++ b/apps/api/src/routes/unifi/index.ts
@@ -7,7 +7,7 @@ import { PERMISSIONS } from '../../services/permissions';
 import { db } from '../../db';
 import { devices, unifiCollectors, unifiDeviceTelemetry, unifiClients, unifiSiteMappings, unifiSyncRuns, sites } from '../../db/schema';
 import { createUnifiClient, UnifiApiError } from '../../services/unifi/unifiClient';
-import { getConnection, getDecryptedApiKey, upsertConnection, deleteConnection } from '../../services/unifi/unifiConnectionService';
+import { getConnection, getDecryptedApiKey, upsertConnection, deleteConnection, createSelfHostedIntegration } from '../../services/unifi/unifiConnectionService';
 import { listCollectors, upsertCollector, deleteCollector } from '../../services/unifi/unifiCollectorService';
 import { enqueueUnifiSync } from '../../jobs/unifiWorker';
 
@@ -72,6 +72,7 @@ unifiRoutes.get('/', partnerScopes, readPerm, async (c) => {
   if (!conn) return c.json({ connected: false });
   return c.json({
     connected: true,
+    connectionType: conn.connectionType,
     status: conn.status,
     accountLabel: conn.accountLabel,
     lastSyncAt: conn.lastSyncAt,
@@ -106,6 +107,23 @@ unifiRoutes.post('/connect', partnerScopes, writePerm, requireMfa(), zValidator(
     createdBy: auth.user.id,
   });
   return c.json({ connected: true, status: conn.status });
+});
+
+const connectSelfHostedSchema = z.object({
+  accountLabel: z.string().max(200).optional(),
+});
+
+// POST /unifi/connect-self-hosted — create a self-hosted integration (no cloud key)
+unifiRoutes.post('/connect-self-hosted', partnerScopes, writePerm, requireMfa(), zValidator('json', connectSelfHostedSchema), async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const { accountLabel } = c.req.valid('json');
+  const integration = await createSelfHostedIntegration(db, partner.partnerId, {
+    accountLabel: accountLabel ?? null,
+    createdBy: auth.user.id,
+  });
+  return c.json({ connected: true, connectionType: integration.connectionType });
 });
 
 // POST /unifi/test — live connection test against stored credentials

--- a/apps/api/src/routes/unifi/index.ts
+++ b/apps/api/src/routes/unifi/index.ts
@@ -8,7 +8,7 @@ import { db } from '../../db';
 import { devices, unifiCollectors, unifiDeviceTelemetry, unifiClients, unifiSiteMappings, unifiSyncRuns, sites } from '../../db/schema';
 import { createUnifiClient, UnifiApiError } from '../../services/unifi/unifiClient';
 import { getConnection, getDecryptedApiKey, upsertConnection, deleteConnection, createSelfHostedIntegration } from '../../services/unifi/unifiConnectionService';
-import { listCollectors, upsertCollector, deleteCollector } from '../../services/unifi/unifiCollectorService';
+import { listCollectors, upsertCollector, deleteCollector, upsertSelfHostedController } from '../../services/unifi/unifiCollectorService';
 import { enqueueUnifiSync } from '../../jobs/unifiWorker';
 
 export const unifiRoutes = new Hono();
@@ -282,6 +282,44 @@ unifiRoutes.put('/collectors', partnerScopes, writePerm, requireMfa(), zValidato
     orgId: site.orgId,
     siteId: site.id,
     unifiHostId: body.unifiHostId,
+    collectorDeviceId: body.collectorDeviceId,
+    controllerUrl: body.controllerUrl,
+    apiKey: body.apiKey,
+    pollIntervalSeconds: body.pollIntervalSeconds,
+    createdBy: auth.user.id,
+  });
+  return c.json({ success: true, collectorId: collector.id });
+});
+
+const controllerSchema = z.object({
+  siteId: z.string().guid(),
+  collectorDeviceId: z.string().guid(),
+  controllerUrl: z.string().url().max(300),
+  apiKey: z.string().min(1),
+  pollIntervalSeconds: z.number().int().min(15).max(3600).optional(),
+});
+
+// PUT /unifi/controllers — register/update a self-hosted controller (no cloud host)
+unifiRoutes.put('/controllers', partnerScopes, writePerm, requireMfa(), zValidator('json', controllerSchema), async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const conn = await getConnection(db, partner.partnerId);
+  if (!conn) return c.json({ success: false, message: 'Not connected' }, 400);
+  if (conn.connectionType !== 'self_hosted') {
+    return c.json({ success: false, message: 'Controllers can only be registered on a self-hosted integration' }, 400);
+  }
+  const body = c.req.valid('json');
+  const [site] = await db.select({ id: sites.id, orgId: sites.orgId }).from(sites).where(eq(sites.id, body.siteId)).limit(1);
+  if (!site) return c.json({ success: false, message: `Unknown Breeze site: ${body.siteId}` }, 400);
+  if (!auth.canAccessOrg(site.orgId)) return c.json({ success: false, message: 'Access to target organization denied' }, 403);
+  const [dev] = await db.select({ id: devices.id, orgId: devices.orgId }).from(devices).where(eq(devices.id, body.collectorDeviceId)).limit(1);
+  if (!dev) return c.json({ success: false, message: 'Unknown collector agent' }, 400);
+  if (dev.orgId !== site.orgId) return c.json({ success: false, message: 'Collector agent must belong to the site\'s organization' }, 400);
+  const collector = await upsertSelfHostedController(db, {
+    integrationId: conn.id,
+    orgId: site.orgId,
+    siteId: site.id,
     collectorDeviceId: body.collectorDeviceId,
     controllerUrl: body.controllerUrl,
     apiKey: body.apiKey,

--- a/apps/api/src/services/unifi/unifiCollectorService.test.ts
+++ b/apps/api/src/services/unifi/unifiCollectorService.test.ts
@@ -75,7 +75,7 @@ describe('upsertSelfHostedController', () => {
       controllerUrl: 'https://192.168.1.1', apiKey: 'secret',
     });
     expect(out.id).toBe('col-1');
-    const inserted = values.mock.calls[0][0];
+    const inserted = values.mock.calls[0]![0];
     expect(inserted.unifiHostId ?? null).toBeNull();
     expect(inserted.localApiKeyEncrypted).toBe('ENC');
   });

--- a/apps/api/src/services/unifi/unifiCollectorService.test.ts
+++ b/apps/api/src/services/unifi/unifiCollectorService.test.ts
@@ -55,3 +55,28 @@ describe('unifiCollectorService', () => {
     await expect(svc.getCollectorOwnerDeviceId(dbWith([]), 'c1')).resolves.toBeNull();
   });
 });
+
+function mockInsertDb(returning: any[]) {
+  const onConflictDoUpdate = vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(returning) });
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { db: { insert } as any, insert, values, onConflictDoUpdate };
+}
+
+describe('upsertSelfHostedController', () => {
+  it('inserts a collector with null host id keyed on controller_url', async () => {
+    const { db, values } = mockInsertDb([{
+      id: 'col-1', integrationId: 'int-1', orgId: 'org-1', siteId: 'site-1', unifiHostId: null,
+      collectorDeviceId: 'dev-1', controllerUrl: 'https://192.168.1.1', isEnabled: true,
+      pollIntervalSeconds: 60, status: 'pending', firmwareOk: null, lastPollAt: null, lastPollStatus: null, lastPollError: null,
+    }]);
+    const out = await svc.upsertSelfHostedController(db, {
+      integrationId: 'int-1', orgId: 'org-1', siteId: 'site-1', collectorDeviceId: 'dev-1',
+      controllerUrl: 'https://192.168.1.1', apiKey: 'secret',
+    });
+    expect(out.id).toBe('col-1');
+    const inserted = values.mock.calls[0][0];
+    expect(inserted.unifiHostId ?? null).toBeNull();
+    expect(inserted.localApiKeyEncrypted).toBe('ENC');
+  });
+});

--- a/apps/api/src/services/unifi/unifiCollectorService.ts
+++ b/apps/api/src/services/unifi/unifiCollectorService.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { unifiCollectors } from '../../db/schema';
 import { encryptSecret, decryptForColumn } from '../secretCrypto';
 import type { DbExecutor } from './unifiConnectionService';
@@ -15,7 +15,7 @@ export interface UnifiCollector {
   integrationId: string;
   orgId: string;
   siteId: string;
-  unifiHostId: string;
+  unifiHostId: string | null;
   collectorDeviceId: string;
   controllerUrl: string;
   isEnabled: boolean;
@@ -29,7 +29,7 @@ export interface UnifiCollector {
 
 export interface AgentCollectorConfig {
   collectorId: string;
-  unifiHostId: string;
+  unifiHostId: string | null;
   controllerUrl: string;
   apiKey: string;
   pollIntervalSeconds: number;
@@ -104,6 +104,53 @@ export async function upsertCollector(
     })
     .returning();
   if (!rows[0]) throw new Error('upsertCollector returned no unifi_collectors row');
+  return toCollector(rows[0]);
+}
+
+export async function upsertSelfHostedController(
+  db: DbExecutor,
+  fields: {
+    integrationId: string;
+    orgId: string;
+    siteId: string;
+    collectorDeviceId: string;
+    controllerUrl: string;
+    apiKey: string;
+    pollIntervalSeconds?: number;
+    createdBy?: string | null;
+  },
+): Promise<UnifiCollector> {
+  const localApiKeyEncrypted = encryptSecret(fields.apiKey, { aad: 'unifi_collectors.local_api_key_encrypted' });
+  const rows = await db
+    .insert(unifiCollectors)
+    .values({
+      integrationId: fields.integrationId,
+      orgId: fields.orgId,
+      siteId: fields.siteId,
+      unifiHostId: null,
+      collectorDeviceId: fields.collectorDeviceId,
+      controllerUrl: fields.controllerUrl,
+      localApiKeyEncrypted,
+      pollIntervalSeconds: fields.pollIntervalSeconds ?? 60,
+      createdBy: fields.createdBy ?? null,
+      status: 'pending',
+    })
+    .onConflictDoUpdate({
+      target: [unifiCollectors.integrationId, unifiCollectors.controllerUrl],
+      targetWhere: sql`${unifiCollectors.unifiHostId} IS NULL`,
+      set: {
+        orgId: fields.orgId,
+        siteId: fields.siteId,
+        collectorDeviceId: fields.collectorDeviceId,
+        localApiKeyEncrypted,
+        pollIntervalSeconds: fields.pollIntervalSeconds ?? 60,
+        status: 'pending',
+        lastPollError: null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  if (!rows[0]) throw new Error('upsertSelfHostedController returned no unifi_collectors row');
   return toCollector(rows[0]);
 }
 

--- a/apps/api/src/services/unifi/unifiConnectionService.test.ts
+++ b/apps/api/src/services/unifi/unifiConnectionService.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as svc from './unifiConnectionService';
+
+vi.mock('../secretCrypto', () => ({
+  encryptSecret: vi.fn(() => 'enc-key'),
+  decryptForColumn: vi.fn(() => null),
+}));
 
 // Minimal chainable db mock: each method returns an object exposing the next
 function makeDb(overrides: Partial<Record<string, any>> = {}) {
@@ -37,5 +42,29 @@ describe('unifiConnectionService', () => {
   it('deleteConnection returns false on 0 rows (idempotent) and true when a row is deleted', async () => {
     await expect(svc.deleteConnection(makeDb({ deleteRows: [] }), 'partner-1')).resolves.toBe(false);
     await expect(svc.deleteConnection(makeDb({ deleteRows: [{ id: 'conn-1' }] }), 'partner-1')).resolves.toBe(true);
+  });
+});
+
+describe('upsertConnection (cloud path)', () => {
+  function spyDb(returning: any[]) {
+    const onConflictDoUpdate = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(returning),
+    });
+    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+    const insert = vi.fn().mockReturnValue({ values });
+    return { db: { insert } as unknown as svc.DbExecutor, onConflictDoUpdate };
+  }
+
+  it('onConflictDoUpdate set block includes connectionType: cloud', async () => {
+    const row = {
+      id: 'int-1', partnerId: 'partner-1', connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com', accountLabel: null,
+      isActive: true, status: 'connected',
+      lastSyncAt: null, lastSyncStatus: null, lastSyncError: null,
+    };
+    const { db, onConflictDoUpdate } = spyDb([row]);
+    await svc.upsertConnection(db, 'partner-1', { baseUrl: 'https://api.ui.com', apiKey: 'k' });
+    const arg = onConflictDoUpdate.mock.calls[0][0] as { set: Record<string, unknown> };
+    expect(arg.set.connectionType).toBe('cloud');
   });
 });

--- a/apps/api/src/services/unifi/unifiConnectionService.test.ts
+++ b/apps/api/src/services/unifi/unifiConnectionService.test.ts
@@ -64,7 +64,7 @@ describe('upsertConnection (cloud path)', () => {
     };
     const { db, onConflictDoUpdate } = spyDb([row]);
     await svc.upsertConnection(db, 'partner-1', { baseUrl: 'https://api.ui.com', apiKey: 'k' });
-    const arg = onConflictDoUpdate.mock.calls[0][0] as { set: Record<string, unknown> };
+    const arg = onConflictDoUpdate.mock.calls[0]![0] as { set: Record<string, unknown> };
     expect(arg.set.connectionType).toBe('cloud');
   });
 });

--- a/apps/api/src/services/unifi/unifiConnectionService.ts
+++ b/apps/api/src/services/unifi/unifiConnectionService.ts
@@ -15,6 +15,7 @@ export type IntegrationStatus = 'pending' | 'connected' | 'reauth_required' | 'e
 export interface UnifiConnection {
   id: string;
   partnerId: string;
+  connectionType: 'cloud' | 'self_hosted';
   baseUrl: string;
   accountLabel: string | null;
   isActive: boolean;
@@ -28,6 +29,7 @@ function toConnection(row: any): UnifiConnection {
   return {
     id: row.id,
     partnerId: row.partnerId,
+    connectionType: row.connectionType === 'self_hosted' ? 'self_hosted' : 'cloud',
     baseUrl: row.baseUrl,
     accountLabel: row.accountLabel ?? null,
     isActive: row.isActive,
@@ -116,6 +118,37 @@ export async function upsertConnection(
     .returning();
   if (!inserted[0]) throw new Error('upsertConnection returned no unifi_integrations row');
   return toConnection(inserted[0]);
+}
+
+export async function createSelfHostedIntegration(
+  db: DbExecutor,
+  partnerId: string,
+  fields: { accountLabel?: string | null; createdBy?: string | null },
+): Promise<{ id: string; connectionType: 'self_hosted' }> {
+  const rows = await db
+    .insert(unifiIntegrations)
+    .values({
+      partnerId,
+      connectionType: 'self_hosted',
+      apiKeyEncrypted: null,
+      accountLabel: fields.accountLabel ?? null,
+      createdBy: fields.createdBy ?? null,
+      status: 'connected',
+      isActive: true,
+    })
+    .onConflictDoUpdate({
+      target: unifiIntegrations.partnerId,
+      targetWhere: eq(unifiIntegrations.isActive, true),
+      set: {
+        connectionType: 'self_hosted',
+        accountLabel: fields.accountLabel ?? null,
+        status: 'connected',
+        updatedAt: new Date(),
+      },
+    })
+    .returning({ id: unifiIntegrations.id, connectionType: unifiIntegrations.connectionType });
+  if (!rows[0]) throw new Error('createSelfHostedIntegration returned no row');
+  return { id: rows[0].id, connectionType: 'self_hosted' };
 }
 
 export async function markStatus(

--- a/apps/api/src/services/unifi/unifiConnectionService.ts
+++ b/apps/api/src/services/unifi/unifiConnectionService.ts
@@ -107,6 +107,7 @@ export async function upsertConnection(
       target: unifiIntegrations.partnerId,
       targetWhere: eq(unifiIntegrations.isActive, true),
       set: {
+        connectionType: 'cloud',
         baseUrl: fields.baseUrl,
         apiKeyEncrypted,
         accountLabel: fields.accountLabel ?? null,

--- a/apps/api/src/services/unifi/unifiControllerSiteService.test.ts
+++ b/apps/api/src/services/unifi/unifiControllerSiteService.test.ts
@@ -13,8 +13,8 @@ describe('upsertControllerSites', () => {
     const { db, values } = mockDb();
     await upsertControllerSites(db, 'col-1', 'org-1', [{ id: 's1', name: 'HQ' }, { id: 's2' }]);
     expect(values).toHaveBeenCalledTimes(2);
-    expect(values.mock.calls[0][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's1', name: 'HQ' });
-    expect(values.mock.calls[1][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's2', name: null });
+    expect(values.mock.calls[0]![0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's1', name: 'HQ' });
+    expect(values.mock.calls[1]![0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's2', name: null });
   });
 
   it('no-ops on an empty list', async () => {

--- a/apps/api/src/services/unifi/unifiControllerSiteService.test.ts
+++ b/apps/api/src/services/unifi/unifiControllerSiteService.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { upsertControllerSites } from './unifiControllerSiteService';
+
+function mockDb() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { db: { insert } as any, values };
+}
+
+describe('upsertControllerSites', () => {
+  it('upserts one row per reported site with the collector org', async () => {
+    const { db, values } = mockDb();
+    await upsertControllerSites(db, 'col-1', 'org-1', [{ id: 's1', name: 'HQ' }, { id: 's2' }]);
+    expect(values).toHaveBeenCalledTimes(2);
+    expect(values.mock.calls[0][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's1', name: 'HQ' });
+    expect(values.mock.calls[1][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's2', name: null });
+  });
+
+  it('no-ops on an empty list', async () => {
+    const { db, values } = mockDb();
+    await upsertControllerSites(db, 'col-1', 'org-1', []);
+    expect(values).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/unifi/unifiControllerSiteService.ts
+++ b/apps/api/src/services/unifi/unifiControllerSiteService.ts
@@ -1,0 +1,49 @@
+import { eq, inArray } from 'drizzle-orm';
+import { unifiControllerSites, unifiCollectors, unifiSiteMappings } from '../../db/schema';
+import type { DbExecutor } from './unifiConnectionService';
+
+export interface ReportedSite { id: string; name?: string | null }
+
+// Upsert the agent-reported local sites for a self-hosted controller. Keyed on
+// (collector_id, local_site_id). org comes from the collector (caller resolves it).
+export async function upsertControllerSites(
+  db: DbExecutor,
+  collectorId: string,
+  orgId: string,
+  sites: ReportedSite[],
+): Promise<void> {
+  const now = new Date();
+  for (const s of sites) {
+    await db.insert(unifiControllerSites).values({
+      collectorId, orgId, localSiteId: s.id, name: s.name ?? null, lastSeenAt: now,
+    }).onConflictDoUpdate({
+      target: [unifiControllerSites.collectorId, unifiControllerSites.localSiteId],
+      set: { name: s.name ?? null, lastSeenAt: now, updatedAt: now },
+    });
+  }
+}
+
+// List discovered sites for a self-hosted integration's collectors, flagging which
+// already have a Phase-1-style mapping row (unifi_host_id = collectorId sentinel).
+export async function listControllerSitesForIntegration(
+  db: DbExecutor,
+  integrationId: string,
+): Promise<Array<{ collectorId: string; localSiteId: string; name: string | null; mapped: boolean }>> {
+  const collectors = await db.select({ id: unifiCollectors.id })
+    .from(unifiCollectors).where(eq(unifiCollectors.integrationId, integrationId));
+  const collectorIds = collectors.map((c: any) => c.id);
+  if (collectorIds.length === 0) return [];
+  const rows = await db.select({
+    collectorId: unifiControllerSites.collectorId,
+    localSiteId: unifiControllerSites.localSiteId,
+    name: unifiControllerSites.name,
+  }).from(unifiControllerSites).where(inArray(unifiControllerSites.collectorId, collectorIds));
+  const mappings = await db.select({
+    unifiHostId: unifiSiteMappings.unifiHostId, unifiSiteId: unifiSiteMappings.unifiSiteId,
+  }).from(unifiSiteMappings).where(eq(unifiSiteMappings.integrationId, integrationId));
+  const mappedKeys = new Set(mappings.map((m: any) => `${m.unifiHostId}::${m.unifiSiteId}`));
+  return rows.map((r: any) => ({
+    collectorId: r.collectorId, localSiteId: r.localSiteId, name: r.name,
+    mapped: mappedKeys.has(`${r.collectorId}::${r.localSiteId}`),
+  }));
+}

--- a/apps/api/src/services/unifi/unifiSelfHostedService.test.ts
+++ b/apps/api/src/services/unifi/unifiSelfHostedService.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSelfHostedIntegration } from './unifiConnectionService';
+
+function mockDb(returning: any[]) {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue(returning),
+        }),
+      }),
+    }),
+  } as any;
+}
+
+describe('createSelfHostedIntegration', () => {
+  it('inserts a self_hosted integration with no api key', async () => {
+    const db = mockDb([{ id: 'int-1', connectionType: 'self_hosted' }]);
+    const out = await createSelfHostedIntegration(db, 'partner-1', { accountLabel: 'HQ VM', createdBy: 'user-1' });
+    expect(out).toEqual({ id: 'int-1', connectionType: 'self_hosted' });
+    const values = (db.insert as any).mock.results[0].value.values.mock.calls[0][0];
+    expect(values.connectionType).toBe('self_hosted');
+    expect(values.apiKeyEncrypted ?? null).toBeNull();
+    expect(values.partnerId).toBe('partner-1');
+  });
+});

--- a/apps/api/src/services/unifi/unifiTelemetryService.test.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.test.ts
@@ -109,8 +109,9 @@ function scriptedDb(opts: {
 describe('reconcileTelemetry', () => {
   it('upserts device + client telemetry and resolves site via mapping', async () => {
     const { db, writes } = scriptedDb({
-      collector: { id: 'c1', orgId: 'org-fallback', siteId: 'site-fallback', integrationId: 'int-1' },
-      mappings: [{ unifiSiteId: 's1', siteId: 'site-mapped', orgId: 'org-mapped' }],
+      // unifiHostId: null = self-hosted; sentinel mapping row carries unifiHostId = collector.id ('c1').
+      collector: { id: 'c1', orgId: 'org-fallback', siteId: 'site-fallback', integrationId: 'int-1', unifiHostId: null },
+      mappings: [{ unifiSiteId: 's1', siteId: 'site-mapped', orgId: 'org-mapped', unifiHostId: 'c1' }],
       assetByMac: { 'cc:dd': { id: 'asset-1' } },
     });
 
@@ -253,6 +254,34 @@ describe('reconcileTelemetry', () => {
     expect(deviceInserts).toHaveLength(1);
     expect(deviceInserts[0]!.values.discoveredAssetId).toBe('asset-new-1');
     expect(deviceInserts[0]!.conflict.set.discoveredAssetId).toBe('asset-new-1');
+  });
+
+  it('REGRESSION: per-controller isolation — identical local site id on two self-hosted controllers routes to the correct org', async () => {
+    // Pre-fix: siteByUnifi.set("default", …) is called for BOTH mapping rows; last-write-wins
+    // picks collA's row (it is last in iteration order), so collB's device is mis-routed to org-A.
+    // Post-fix: the filter `m.unifiHostId === hostKey` limits the map to collB's own row only.
+    //
+    // Mapping rows ordered [B first, A last] so that without the host-axis filter the last write
+    // (A) wins — proving the test is RED on pre-fix code.
+    const { db, writes } = scriptedDb({
+      collector: { id: 'collB', orgId: 'org-Bhome', siteId: 'site-Bhome', integrationId: 'int-1', unifiHostId: null },
+      mappings: [
+        { unifiHostId: 'collB', unifiSiteId: 'default', orgId: 'org-B', siteId: 'site-B' },
+        { unifiHostId: 'collA', unifiSiteId: 'default', orgId: 'org-A', siteId: 'site-A' },
+      ],
+    });
+
+    await reconcileTelemetry(db, {
+      collectorId: 'collB', polledAt: '2026-06-30T00:00:00Z', firmwareOk: true,
+      devices: [{ unifiDeviceId: 'dev-1', unifiSiteId: 'default', raw: {} }],
+      clients: [],
+    });
+
+    const deviceInserts = writes.inserts.filter((w) => w.table === unifiDeviceTelemetry);
+    expect(deviceInserts).toHaveLength(1);
+    // Must resolve to collB's org/site, NOT collA's — cross-tenant mis-routing would write org-A here.
+    expect(deviceInserts[0]!.values.orgId).toBe('org-B');
+    expect(deviceInserts[0]!.values.siteId).toBe('site-B');
   });
 
   it('skips asset creation and leaves discoveredAssetId null when device raw has no ip', async () => {

--- a/apps/api/src/services/unifi/unifiTelemetryService.test.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.test.ts
@@ -42,6 +42,7 @@ function scriptedDb(opts: {
     insertValues?: any;
     setValues?: any;
     conflict?: any;
+    returning?: boolean;
   }) {
     const chain: any = {
       from(table: any) {

--- a/apps/api/src/services/unifi/unifiTelemetryService.test.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.test.ts
@@ -7,7 +7,9 @@ type WriteRecord = { table: any; values: any; conflict?: any };
 
 // Build a DbExecutor that returns canned select rows per table and records inserts/updates.
 function scriptedDb(opts: {
-  collector: any; mappings: any[]; existingDevices?: any[]; existingClients?: any[]; assetByMac?: Record<string, any>;
+  collector: any; mappings: any[]; existingDevices?: any[]; existingClients?: any[];
+  assetByMac?: Record<string, any>;
+  assetInsertReturn?: { id: string }; // canned return for discoveredAssets insert().returning()
 }) {
   const writes = { inserts: [] as WriteRecord[], updates: [] as WriteRecord[] };
 
@@ -61,6 +63,10 @@ function scriptedDb(opts: {
         ctx.conflict = conflict;
         return chain;
       },
+      returning(_col: any) {
+        ctx.returning = true;
+        return chain;
+      },
       set(v: any) {
         ctx.setValues = v;
         return chain;
@@ -69,7 +75,11 @@ function scriptedDb(opts: {
         try {
           if (ctx.op === 'insert' && ctx.insertValues !== undefined) {
             writes.inserts.push({ table: ctx.table, values: ctx.insertValues, conflict: ctx.conflict });
-            resolve([]);
+            if (ctx.table === discoveredAssets && opts.assetInsertReturn) {
+              resolve([opts.assetInsertReturn]);
+            } else {
+              resolve([]);
+            }
             return;
           }
           if (ctx.op === 'update' && ctx.setValues !== undefined) {
@@ -218,5 +228,50 @@ describe('reconcileTelemetry', () => {
     // Stored canonical (lowercase, colon-separated) and linked despite the source casing.
     expect(clientInserts[0]!.values.mac).toBe('aa:bb:cc:dd:ee:ff');
     expect(clientInserts[0]!.values.discoveredAssetId).toBe('asset-9');
+  });
+
+  it('reconciles device ip+mac into discovered_assets and stamps discoveredAssetId on the telemetry row', async () => {
+    const { db, writes } = scriptedDb({
+      collector: { id: 'c1', orgId: 'org-a', siteId: 'site-a', integrationId: 'int-1' },
+      mappings: [],
+      assetInsertReturn: { id: 'asset-new-1' },
+    });
+
+    await reconcileTelemetry(db, {
+      collectorId: 'c1', polledAt: '2026-06-29T00:00:00Z', firmwareOk: true,
+      devices: [{ unifiDeviceId: 'd1', mac: 'AA:BB:CC:00:11:22', raw: { ipAddress: '10.0.0.5', name: 'sw1' } }],
+      clients: [],
+    });
+
+    const assetInserts = writes.inserts.filter((w) => w.table === discoveredAssets);
+    expect(assetInserts).toHaveLength(1);
+    expect(assetInserts[0]!.values.orgId).toBe('org-a');
+    expect(assetInserts[0]!.values.ipAddress).toBe('10.0.0.5');
+    expect(assetInserts[0]!.values.manufacturer).toBe('Ubiquiti');
+
+    const deviceInserts = writes.inserts.filter((w) => w.table === unifiDeviceTelemetry);
+    expect(deviceInserts).toHaveLength(1);
+    expect(deviceInserts[0]!.values.discoveredAssetId).toBe('asset-new-1');
+    expect(deviceInserts[0]!.conflict.set.discoveredAssetId).toBe('asset-new-1');
+  });
+
+  it('skips asset creation and leaves discoveredAssetId null when device raw has no ip', async () => {
+    const { db, writes } = scriptedDb({
+      collector: { id: 'c1', orgId: 'org-a', siteId: 'site-a', integrationId: 'int-1' },
+      mappings: [],
+    });
+
+    await reconcileTelemetry(db, {
+      collectorId: 'c1', polledAt: '2026-06-29T00:00:00Z', firmwareOk: true,
+      devices: [{ unifiDeviceId: 'd1', mac: 'AA:BB:CC:00:11:22', raw: { name: 'sw1' } }],
+      clients: [],
+    });
+
+    const assetInserts = writes.inserts.filter((w) => w.table === discoveredAssets);
+    expect(assetInserts).toHaveLength(0);
+
+    const deviceInserts = writes.inserts.filter((w) => w.table === unifiDeviceTelemetry);
+    expect(deviceInserts).toHaveLength(1);
+    expect(deviceInserts[0]!.values.discoveredAssetId).toBeNull();
   });
 });

--- a/apps/api/src/services/unifi/unifiTelemetryService.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.ts
@@ -1,6 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 import { unifiCollectors, unifiSiteMappings, unifiDeviceTelemetry, unifiClients, discoveredAssets } from '../../db/schema';
 import type { DbExecutor } from './unifiConnectionService';
+import { upsertControllerSites } from './unifiControllerSiteService';
 
 // Fields the wire schema marks optional are `T | null | undefined` here, matching
 // what the zod validator infers (the agent omits zero-value fields via omitempty).
@@ -20,6 +21,7 @@ export interface TelemetryClientDto {
 export interface TelemetryPayload {
   collectorId: string; polledAt: string; firmwareOk: boolean;
   devices: TelemetryDeviceDto[]; clients: TelemetryClientDto[]; error?: string;
+  sites?: Array<{ id: string; name?: string | null }>;
   // Server-authoritative: the posting agent's token-resolved deviceId, stamped by
   // the ingest route. The worker rejects the payload unless it matches the
   // collector's collector_device_id, so an agent cannot write another org's
@@ -50,6 +52,10 @@ export async function reconcileTelemetry(
     integrationId: unifiCollectors.integrationId,
   }).from(unifiCollectors).where(eq(unifiCollectors.id, payload.collectorId)).limit(1);
   if (!collector) throw new Error(`reconcileTelemetry: unknown collector ${payload.collectorId}`);
+
+  if (payload.sites && payload.sites.length > 0) {
+    await upsertControllerSites(db, collector.id, collector.orgId, payload.sites);
+  }
 
   // Build unifiSiteId -> {orgId, siteId} from the Phase 1 mappings for this integration.
   const mappings = await db.select({

--- a/apps/api/src/services/unifi/unifiTelemetryService.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.ts
@@ -37,6 +37,65 @@ function normalizeMac(mac: string): string {
   return mac.trim().toLowerCase().replace(/-/g, ':');
 }
 
+// Extract IP from a telemetry device's raw payload.
+// UniFi device JSON uses `ipAddress`; guard against other field names too.
+function deviceIp(raw: unknown): string | null {
+  if (raw && typeof raw === 'object') {
+    const r = raw as Record<string, unknown>;
+    const ip = r.ipAddress ?? r.ip;
+    if (typeof ip === 'string' && ip.length > 0) return ip;
+  }
+  return null;
+}
+
+// Find-or-create a discovered_assets row for a telemetry device; return its id.
+// Mirrors reconcileDiscoveredAsset in unifiSyncService.ts but uses the telemetry
+// device DTO which exposes IP only inside `raw`.
+async function linkTelemetryDeviceToAsset(
+  db: DbExecutor,
+  orgId: string,
+  siteId: string,
+  device: TelemetryDeviceDto,
+): Promise<string | null> {
+  const ip = deviceIp(device.raw);
+  if (!ip) return null;
+
+  const enrich = {
+    macAddress: device.mac ?? undefined,
+    hostname: device.name ?? undefined,
+    manufacturer: 'Ubiquiti',
+    isOnline: true,
+    lastSeenAt: new Date(),
+  };
+
+  // 1. Match by (org_id, mac) first — the stable identifier.
+  let existing: { id: string } | null = null;
+  if (device.mac) {
+    const byMac = await db.select({ id: discoveredAssets.id }).from(discoveredAssets)
+      .where(and(eq(discoveredAssets.orgId, orgId), eq(discoveredAssets.macAddress, device.mac))).limit(1);
+    existing = byMac[0] ?? null;
+  }
+
+  // 2. Fall back to the (org_id, ip_address) unique key.
+  if (!existing) {
+    const byIp = await db.select({ id: discoveredAssets.id }).from(discoveredAssets)
+      .where(and(eq(discoveredAssets.orgId, orgId), eq(discoveredAssets.ipAddress, ip))).limit(1);
+    existing = byIp[0] ?? null;
+  }
+
+  if (existing) {
+    await db.update(discoveredAssets).set(enrich).where(eq(discoveredAssets.id, existing.id));
+    return existing.id;
+  }
+
+  // Net-new: insert, absorbing a race with agent discovery via the (org,ip) unique key.
+  const inserted = await db.insert(discoveredAssets)
+    .values({ orgId, siteId, ipAddress: ip, ...enrich })
+    .onConflictDoUpdate({ target: [discoveredAssets.orgId, discoveredAssets.ipAddress], set: enrich })
+    .returning({ id: discoveredAssets.id });
+  return inserted[0]?.id ?? null;
+}
+
 export async function reconcileTelemetry(
   db: DbExecutor,
   payload: TelemetryPayload,
@@ -82,16 +141,17 @@ export async function reconcileTelemetry(
   for (const d of payload.devices) {
     seenDeviceIds.add(d.unifiDeviceId);
     const { orgId, siteId } = resolveSite(d.unifiSiteId);
+    const discoveredAssetId = await linkTelemetryDeviceToAsset(db, orgId, siteId, d);
     await db.insert(unifiDeviceTelemetry).values({
       collectorId: collector.id, orgId, siteId, unifiDeviceId: d.unifiDeviceId, mac: d.mac, name: d.name,
       uptimeSeconds: d.uptimeSeconds, cpuPct: d.cpuPct, memPct: d.memPct, txBytes: d.txBytes, rxBytes: d.rxBytes,
-      numClients: d.numClients, poePorts: d.poePorts ?? null, raw: rawOrEmpty(d.raw), isStale: false, lastSeenAt: seenAt,
+      numClients: d.numClients, discoveredAssetId, poePorts: d.poePorts ?? null, raw: rawOrEmpty(d.raw), isStale: false, lastSeenAt: seenAt,
       lastSyncedAt: now, updatedAt: now,
     }).onConflictDoUpdate({
       target: [unifiDeviceTelemetry.collectorId, unifiDeviceTelemetry.unifiDeviceId],
       set: {
         orgId, siteId, mac: d.mac, name: d.name, uptimeSeconds: d.uptimeSeconds, cpuPct: d.cpuPct, memPct: d.memPct,
-        txBytes: d.txBytes, rxBytes: d.rxBytes, numClients: d.numClients, poePorts: d.poePorts ?? null, raw: rawOrEmpty(d.raw),
+        txBytes: d.txBytes, rxBytes: d.rxBytes, numClients: d.numClients, discoveredAssetId, poePorts: d.poePorts ?? null, raw: rawOrEmpty(d.raw),
         isStale: false, lastSeenAt: seenAt, lastSyncedAt: now, updatedAt: now,
       },
     });

--- a/apps/api/src/services/unifi/unifiTelemetryService.ts
+++ b/apps/api/src/services/unifi/unifiTelemetryService.ts
@@ -108,7 +108,7 @@ export async function reconcileTelemetry(
 
   const [collector] = await db.select({
     id: unifiCollectors.id, orgId: unifiCollectors.orgId, siteId: unifiCollectors.siteId,
-    integrationId: unifiCollectors.integrationId,
+    integrationId: unifiCollectors.integrationId, unifiHostId: unifiCollectors.unifiHostId,
   }).from(unifiCollectors).where(eq(unifiCollectors.id, payload.collectorId)).limit(1);
   if (!collector) throw new Error(`reconcileTelemetry: unknown collector ${payload.collectorId}`);
 
@@ -116,12 +116,18 @@ export async function reconcileTelemetry(
     await upsertControllerSites(db, collector.id, collector.orgId, payload.sites);
   }
 
-  // Build unifiSiteId -> {orgId, siteId} from the Phase 1 mappings for this integration.
+  // Build unifiSiteId -> {orgId, siteId} from the Phase 1 mappings for this integration,
+  // scoped to this collector's host axis so that identical local site ids on different
+  // self-hosted controllers (e.g. every controller has a "default" site) cannot collide.
+  // Cloud collectors carry a real unifiHostId; self-hosted collectors have NULL and their
+  // mapping rows use the sentinel unifi_host_id = collector.id.
+  const hostKey = collector.unifiHostId ?? collector.id;
   const mappings = await db.select({
-    unifiSiteId: unifiSiteMappings.unifiSiteId, siteId: unifiSiteMappings.siteId, orgId: unifiSiteMappings.orgId,
+    unifiSiteId: unifiSiteMappings.unifiSiteId, siteId: unifiSiteMappings.siteId,
+    orgId: unifiSiteMappings.orgId, unifiHostId: unifiSiteMappings.unifiHostId,
   }).from(unifiSiteMappings).where(eq(unifiSiteMappings.integrationId, collector.integrationId));
   const siteByUnifi = new Map<string, { orgId: string; siteId: string }>();
-  for (const m of mappings) if (m.unifiSiteId) siteByUnifi.set(m.unifiSiteId, { orgId: m.orgId, siteId: m.siteId });
+  for (const m of mappings) if (m.unifiSiteId && m.unifiHostId === hostKey) siteByUnifi.set(m.unifiSiteId, { orgId: m.orgId, siteId: m.siteId });
   // Fallback to the collector's own org/site when a device reports no/unknown unifi site.
   const resolveSite = (unifiSiteId: string | null | undefined) =>
     (unifiSiteId && siteByUnifi.get(unifiSiteId)) || { orgId: collector.orgId, siteId: collector.siteId };

--- a/apps/web/src/components/integrations/UnifiIntegration.test.tsx
+++ b/apps/web/src/components/integrations/UnifiIntegration.test.tsx
@@ -37,6 +37,68 @@ function routeFetch(telemetry: Response) {
 
 afterEach(() => vi.clearAllMocks());
 
+describe('UnifiIntegration connection-type chooser (not connected)', () => {
+  it('offers cloud + self-hosted modes, and selecting self-hosted reveals the account label + Connect button', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/unifi') return Promise.resolve(res({ connected: false }));
+      return Promise.resolve(res({}));
+    });
+    render(<UnifiIntegration />);
+
+    // Both mode toggles render on the not-connected screen; cloud is the default.
+    await screen.findByTestId('unifi-connect-mode');
+    expect(screen.getByTestId('unifi-connect-mode-cloud')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('unifi-connect-mode-self-hosted')).toHaveAttribute('aria-checked', 'false');
+    // Cloud form is shown by default; the self-hosted form is not.
+    expect(screen.getByTestId('unifi-connect-cloud')).toBeInTheDocument();
+    expect(screen.queryByTestId('unifi-connect-self-hosted')).toBeNull();
+
+    // Switch to self-hosted → account label input + Connect button appear; cloud form hides.
+    fireEvent.click(screen.getByTestId('unifi-connect-mode-self-hosted'));
+    expect(screen.getByTestId('unifi-connect-self-hosted')).toBeInTheDocument();
+    expect(screen.getByTestId('unifi-account-label-input')).toBeInTheDocument();
+    expect(screen.getByTestId('unifi-connect-self-hosted-submit')).toBeInTheDocument();
+    expect(screen.queryByTestId('unifi-connect-cloud')).toBeNull();
+  });
+
+  it('POSTs the account label to /unifi/connect-self-hosted and reloads status', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/unifi') return Promise.resolve(res({ connected: false }));
+      if (url === '/unifi/connect-self-hosted') return Promise.resolve(res({ connected: true, connectionType: 'self_hosted' }));
+      return Promise.resolve(res({}));
+    });
+    render(<UnifiIntegration />);
+
+    await screen.findByTestId('unifi-connect-mode');
+    fireEvent.click(screen.getByTestId('unifi-connect-mode-self-hosted'));
+    fireEvent.change(screen.getByTestId('unifi-account-label-input'), { target: { value: 'Acme HQ' } });
+    fireEvent.click(screen.getByTestId('unifi-connect-self-hosted-submit'));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/unifi/connect-self-hosted');
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toEqual({ accountLabel: 'Acme HQ' });
+    });
+  });
+});
+
+describe('UnifiIntegration self-hosted connected view', () => {
+  it('hides cloud-only Sync now / mapping / history affordances when connectionType is self_hosted', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/unifi') return Promise.resolve(res({ connected: true, status: 'connected', connectionType: 'self_hosted' }));
+      return Promise.resolve(res({}));
+    });
+    render(<UnifiIntegration />);
+
+    await screen.findByTestId('unifi-connected');
+    expect(screen.queryByTestId('unifi-sync')).toBeNull();
+    expect(screen.queryByTestId('unifi-mapping-card')).toBeNull();
+    expect(screen.queryByTestId('unifi-history-card')).toBeNull();
+    // Disconnect stays available for both connection types.
+    expect(screen.getByTestId('unifi-disconnect')).toBeInTheDocument();
+  });
+});
+
 describe('UnifiIntegration deep-telemetry error surfacing', () => {
   it('shows the backend error message on a failed telemetry load (not a silent empty panel)', async () => {
     routeFetch(res({ error: 'Access to this site denied' }, false, 403));

--- a/apps/web/src/components/integrations/UnifiIntegration.test.tsx
+++ b/apps/web/src/components/integrations/UnifiIntegration.test.tsx
@@ -99,6 +99,96 @@ describe('UnifiIntegration self-hosted connected view', () => {
   });
 });
 
+describe('UnifiIntegration self-hosted controller mapping (Task D2)', () => {
+  // Self-hosted connected view with one agent-discovered controller site.
+  function routeSelfHosted() {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/unifi') return Promise.resolve(res({ connected: true, status: 'connected', connectionType: 'self_hosted' }));
+      if (url.startsWith('/orgs/sites')) return Promise.resolve(res({ data: [{ id: 'site-1', name: 'HQ', orgId: 'org-1' }] }));
+      if (url.startsWith('/orgs/organizations')) return Promise.resolve(res({ data: [{ id: 'org-1', name: 'Acme' }] }));
+      if (url === '/unifi/mappings') return Promise.resolve(res({ mappings: [] }));
+      if (url === '/unifi/collectors') return Promise.resolve(res({ collectors: [] }));
+      if (url.startsWith('/devices')) return Promise.resolve(res({ data: [{ id: 'agent-1', name: 'Edge', siteId: 'site-1' }] }));
+      if (url === '/unifi/controller-sites') return Promise.resolve(res({ sites: [{ collectorId: 'col-1', localSiteId: 'default', name: 'Default', mapped: false }] }));
+      return Promise.resolve(res({ success: true }));
+    });
+  }
+
+  it('renders a mapping row for each agent-discovered controller site', async () => {
+    routeSelfHosted();
+    render(<UnifiIntegration />);
+
+    await screen.findByTestId('unifi-controller-mapping-card');
+    const rows = await screen.findAllByTestId('unifi-controller-mapping-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('Default');
+    expect(rows[0]).toHaveTextContent('default');
+    // Empty-state copy must not be showing when a site exists.
+    expect(screen.queryByTestId('unifi-controller-mapping-empty')).toBeNull();
+  });
+
+  it('shows the empty-state copy when no controller sites are discovered yet', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/unifi') return Promise.resolve(res({ connected: true, status: 'connected', connectionType: 'self_hosted' }));
+      if (url === '/unifi/controller-sites') return Promise.resolve(res({ sites: [] }));
+      if (url.startsWith('/orgs/sites')) return Promise.resolve(res({ data: [] }));
+      if (url.startsWith('/orgs/organizations')) return Promise.resolve(res({ data: [] }));
+      if (url === '/unifi/mappings') return Promise.resolve(res({ mappings: [] }));
+      if (url === '/unifi/collectors') return Promise.resolve(res({ collectors: [] }));
+      if (url.startsWith('/devices')) return Promise.resolve(res({ data: [] }));
+      return Promise.resolve(res({ success: true }));
+    });
+    render(<UnifiIntegration />);
+
+    const empty = await screen.findByTestId('unifi-controller-mapping-empty');
+    expect(empty).toHaveTextContent('No sites discovered yet');
+  });
+
+  it('saves a mapping with the collector id as the sentinel unifiHostId', async () => {
+    routeSelfHosted();
+    render(<UnifiIntegration />);
+
+    await screen.findByTestId('unifi-controller-mapping-card');
+    // Wait for the Breeze-site <option> to populate before selecting.
+    await screen.findAllByRole('option', { name: 'HQ' });
+    fireEvent.change(screen.getByTestId('unifi-controller-mapping-select'), { target: { value: 'site-1' } });
+    fireEvent.click(screen.getByTestId('unifi-controller-mapping-save'));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/unifi/mappings' && (c[1] as RequestInit)?.method === 'PUT');
+      expect(call).toBeTruthy();
+      const body = JSON.parse((call![1] as RequestInit).body as string);
+      expect(body.mappings).toEqual([
+        { unifiHostId: 'col-1', unifiSiteId: 'default', unifiSiteName: 'Default', siteId: 'site-1' },
+      ]);
+    });
+  });
+
+  it('registers a controller via PUT /unifi/controllers with the chosen site, agent, url, and key', async () => {
+    routeSelfHosted();
+    render(<UnifiIntegration />);
+
+    await screen.findByTestId('unifi-controller-form');
+    await screen.findAllByRole('option', { name: 'HQ' });
+    fireEvent.change(screen.getByTestId('unifi-controller-url'), { target: { value: 'https://192.168.1.1' } });
+    fireEvent.change(screen.getByTestId('unifi-controller-site'), { target: { value: 'site-1' } });
+    fireEvent.change(screen.getByTestId('unifi-controller-agent'), { target: { value: 'agent-1' } });
+    fireEvent.change(screen.getByTestId('unifi-controller-key'), { target: { value: 'secret-key' } });
+    fireEvent.click(screen.getByTestId('unifi-controller-register'));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/unifi/controllers');
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toEqual({
+        siteId: 'site-1',
+        collectorDeviceId: 'agent-1',
+        controllerUrl: 'https://192.168.1.1',
+        apiKey: 'secret-key',
+      });
+    });
+  });
+});
+
 describe('UnifiIntegration deep-telemetry error surfacing', () => {
   it('shows the backend error message on a failed telemetry load (not a silent empty panel)', async () => {
     routeFetch(res({ error: 'Access to this site denied' }, false, 403));

--- a/apps/web/src/components/integrations/UnifiIntegration.tsx
+++ b/apps/web/src/components/integrations/UnifiIntegration.tsx
@@ -64,9 +64,11 @@ interface SyncRun {
 }
 
 // Per-console deep-telemetry collector config (from GET /unifi/collectors).
+// `unifiHostId` is null for self-hosted controllers (no cloud host) — they're
+// keyed on their own row id instead.
 interface UnifiCollector {
   id: string;
-  unifiHostId: string;
+  unifiHostId: string | null;
   siteId: string;
   collectorDeviceId: string;
   controllerUrl: string;
@@ -91,6 +93,12 @@ interface TelemetryClient {
 }
 // Per-host draft for the collector config form.
 interface CollectorDraft { siteId: string; collectorDeviceId: string; controllerUrl: string; apiKey: string }
+// Agent-discovered local site on a self-hosted controller (from GET /unifi/controller-sites).
+// `collectorId` is the unifi_collectors row id, used as the sentinel host id when mapping.
+interface ControllerSite { collectorId: string; localSiteId: string; name: string | null; mapped: boolean }
+// Registration draft for a self-hosted controller (Task D2).
+interface ControllerDraft { controllerUrl: string; collectorDeviceId: string; siteId: string; apiKey: string }
+const emptyControllerDraft: ControllerDraft = { controllerUrl: '', collectorDeviceId: '', siteId: '', apiKey: '' };
 
 // Stable key for a discovered UniFi site within a host (host ids repeat across hosts otherwise).
 const mapKey = (hostId: string, unifiSiteId: string) => `${hostId}::${unifiSiteId}`;
@@ -126,6 +134,14 @@ export default function UnifiIntegration() {
   const [agents, setAgents] = useState<AgentDevice[]>([]);
   const [collectorDrafts, setCollectorDrafts] = useState<Record<string, CollectorDraft>>({});
   const [savingCollector, setSavingCollector] = useState<string | null>(null);
+
+  // Self-hosted controller state (Task D2): registered controllers, agent-discovered
+  // local sites to map, and the registration form draft.
+  const [selfHostedCollectors, setSelfHostedCollectors] = useState<UnifiCollector[]>([]);
+  const [controllerSites, setControllerSites] = useState<ControllerSite[] | null>(null);
+  const [controllerDraft, setControllerDraft] = useState<ControllerDraft>(emptyControllerDraft);
+  const [registeringController, setRegisteringController] = useState(false);
+  const [savingControllerMappings, setSavingControllerMappings] = useState(false);
   // Telemetry viewer state.
   const [telemetrySite, setTelemetrySite] = useState<string>('');
   const [telemetry, setTelemetry] = useState<{ devices: TelemetryDevice[]; clients: TelemetryClient[] } | null>(null);
@@ -247,11 +263,17 @@ export default function UnifiIntegration() {
       const collectorsJson = await collectorsRes.json().catch(() => ({}));
       if (collectorsRes.ok) {
         const list = (collectorsJson as { collectors?: UnifiCollector[] }).collectors ?? [];
-        setCollectors(Object.fromEntries(list.map((col) => [col.unifiHostId, col])));
+        // These maps are keyed by UniFi host id (cloud collectors only). Self-hosted
+        // collectors have a null host id and are managed by the Controllers card, so
+        // exclude them here to keep the cloud collectors card behaving as before.
+        const cloudList = list.filter(
+          (col): col is UnifiCollector & { unifiHostId: string } => col.unifiHostId != null,
+        );
+        setCollectors(Object.fromEntries(cloudList.map((col) => [col.unifiHostId, col])));
         // Pre-fill each host's draft from its saved collector (key stays blank — never echoed back).
         setCollectorDrafts((prev) => {
           const next = { ...prev };
-          for (const col of list) {
+          for (const col of cloudList) {
             next[col.unifiHostId] = {
               siteId: col.siteId,
               collectorDeviceId: col.collectorDeviceId,
@@ -280,12 +302,64 @@ export default function UnifiIntegration() {
     }
   }, [onUnauthorized, loadHosts]);
 
+  // Self-hosted controller view: load the Breeze sites/orgs (for the pickers), agents
+  // (for the collector select), registered controllers, saved mappings, and the
+  // agent-discovered controller sites. No live api.ui.com /hosts call — sites come from
+  // the on-network agent's poll (GET /unifi/controller-sites).
+  const loadSelfHosted = useCallback(async () => {
+    setDetailsError(null);
+    try {
+      const [sitesRes, orgsRes, mappingsRes, collectorsRes, devicesRes, controllerSitesRes] = await Promise.all([
+        fetchWithAuth('/orgs/sites?limit=500'),
+        fetchWithAuth('/orgs/organizations?limit=500'),
+        fetchWithAuth('/unifi/mappings'),
+        fetchWithAuth('/unifi/collectors'),
+        fetchWithAuth('/devices?limit=500'),
+        fetchWithAuth('/unifi/controller-sites'),
+      ]);
+      if ([sitesRes, orgsRes, mappingsRes, collectorsRes, devicesRes, controllerSitesRes].some((r) => r.status === 401)) {
+        onUnauthorized();
+        return;
+      }
+      const failed: string[] = [];
+      const sitesJson = await sitesRes.json().catch(() => ({}));
+      if (sitesRes.ok) setBreezeSites((sitesJson as { data?: BreezeSiteOption[] }).data ?? []); else failed.push('sites');
+      const orgsJson = await orgsRes.json().catch(() => ({}));
+      if (orgsRes.ok) setOrgs((orgsJson as { data?: OrgOption[] }).data ?? []); else failed.push('organizations');
+      const mappingsJson = await mappingsRes.json().catch(() => ({}));
+      if (mappingsRes.ok) {
+        const saved = (mappingsJson as { mappings?: SavedMapping[] }).mappings ?? [];
+        setSelection(Object.fromEntries(saved.map((m) => [mapKey(m.unifiHostId, m.unifiSiteId), m.siteId])));
+      } else failed.push('mappings');
+      const collectorsJson = await collectorsRes.json().catch(() => ({}));
+      if (collectorsRes.ok) setSelfHostedCollectors((collectorsJson as { collectors?: UnifiCollector[] }).collectors ?? []); else failed.push('controllers');
+      const devicesJson = await devicesRes.json().catch(() => ({}));
+      if (devicesRes.ok) {
+        const list = (devicesJson as { data?: AgentDevice[]; devices?: AgentDevice[] }).data
+          ?? (devicesJson as { devices?: AgentDevice[] }).devices
+          ?? (Array.isArray(devicesJson) ? (devicesJson as AgentDevice[]) : []);
+        setAgents(list);
+      } else failed.push('agent devices');
+      const controllerSitesJson = await controllerSitesRes.json().catch(() => ({}));
+      if (controllerSitesRes.ok) setControllerSites((controllerSitesJson as { sites?: ControllerSite[] }).sites ?? []); else failed.push('controller sites');
+      if (failed.length > 0) {
+        setDetailsError(`Some UniFi configuration data failed to load (${failed.join(', ')}). Refresh to retry.`);
+      }
+    } catch {
+      setDetailsError('Could not load UniFi configuration data. Check your connection and refresh.');
+    }
+  }, [onUnauthorized]);
+
   // Load mapping/history detail once the connection status resolves to connected.
   // Only cloud connections have api.ui.com hosts/sites to map — the self-hosted
   // controller view (Task D2) is driven separately, so skip the cloud fetches.
   useEffect(() => {
     if (status?.connected === true && status?.connectionType !== 'self_hosted') void loadDetails();
   }, [status?.connected, status?.connectionType, loadDetails]);
+
+  useEffect(() => {
+    if (status?.connected === true && status?.connectionType === 'self_hosted') void loadSelfHosted();
+  }, [status?.connected, status?.connectionType, loadSelfHosted]);
 
   const handleSaveMappings = useCallback(async () => {
     if (!hosts) return;
@@ -312,6 +386,66 @@ export default function UnifiIntegration() {
       setSavingMappings(false);
     }
   }, [hosts, selection, onUnauthorized, loadDetails]);
+
+  // Register/update a self-hosted controller, then reload collectors + controller sites.
+  const handleRegisterController = useCallback(async () => {
+    const { controllerUrl, collectorDeviceId, siteId, apiKey } = controllerDraft;
+    if (!siteId || !collectorDeviceId || !controllerUrl.trim() || !apiKey.trim()) {
+      setLoadError('Pick the site this controller serves, a collector agent, and enter the controller URL and local API key.');
+      return;
+    }
+    setRegisteringController(true);
+    setLoadError(null);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/unifi/controllers', {
+          method: 'PUT',
+          body: JSON.stringify({
+            siteId,
+            collectorDeviceId,
+            controllerUrl: controllerUrl.trim(),
+            apiKey: apiKey.trim(),
+          }),
+        }),
+        errorFallback: 'Failed to register the controller.',
+        successMessage: 'Controller registered',
+        onUnauthorized,
+      });
+      setControllerDraft(emptyControllerDraft);
+      await loadSelfHosted();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) handleActionError(err, 'Failed to register the controller.');
+    } finally {
+      setRegisteringController(false);
+    }
+  }, [controllerDraft, onUnauthorized, loadSelfHosted]);
+
+  // Map each agent-discovered controller site to a Breeze site via the shared
+  // PUT /unifi/mappings, using the collector id as the sentinel unifiHostId.
+  const handleSaveControllerMappings = useCallback(async () => {
+    if (!controllerSites) return;
+    const mappings = controllerSites.flatMap((s) => {
+      const siteId = selection[mapKey(s.collectorId, s.localSiteId)];
+      if (!siteId) return [];
+      return [{ unifiHostId: s.collectorId, unifiSiteId: s.localSiteId, unifiSiteName: s.name ?? undefined, siteId }];
+    });
+    setSavingControllerMappings(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/unifi/mappings', { method: 'PUT', body: JSON.stringify({ mappings }) }),
+        errorFallback: 'Failed to save site mappings.',
+        successMessage: 'Site mappings saved',
+        onUnauthorized,
+      });
+      await loadSelfHosted();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) handleActionError(err, 'Failed to save site mappings.');
+    } finally {
+      setSavingControllerMappings(false);
+    }
+  }, [controllerSites, selection, onUnauthorized, loadSelfHosted]);
 
   const updateDraft = useCallback((hostId: string, patch: Partial<CollectorDraft>) => {
     setCollectorDrafts((prev) => {
@@ -716,6 +850,189 @@ export default function UnifiIntegration() {
               Disconnect
             </button>
           </div>
+        </div>
+      )}
+
+      {isSelfHosted && (
+        <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-controllers-card">
+          <h2 className="text-lg font-semibold">Controllers</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Register each self-hosted UniFi Network controller. A Breeze agent on the controller&apos;s
+            network polls its local Integration API (firmware&nbsp;≥&nbsp;9.3) directly — no UniFi cloud account
+            needed. The local API key is stored encrypted and pushed to the chosen agent.
+          </p>
+
+          {selfHostedCollectors.length > 0 && (
+            <ul className="mb-4 space-y-2" data-testid="unifi-controller-list">
+              {selfHostedCollectors.map((col) => (
+                <li key={col.id} className="flex items-center gap-2 rounded-lg border p-3 text-sm" data-testid="unifi-controller-item">
+                  <span className="font-medium break-all">{col.controllerUrl}</span>
+                  <span
+                    className={`ml-auto inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${collectorStatusClasses(col.status)}`}
+                    title={col.lastPollError ?? undefined}
+                    data-testid="unifi-controller-status"
+                  >
+                    {col.status}
+                    {col.lastPollAt ? ` · ${formatDateTime(col.lastPollAt)}` : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="rounded-lg border p-4" data-testid="unifi-controller-form">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-sm">
+                <span className="text-muted-foreground">Controller URL</span>
+                <input
+                  type="text"
+                  value={controllerDraft.controllerUrl}
+                  onChange={(e) => setControllerDraft((prev) => ({ ...prev, controllerUrl: e.target.value }))}
+                  placeholder="https://192.168.1.1"
+                  className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+                  data-testid="unifi-controller-url"
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-muted-foreground">Site this controller serves</span>
+                <select
+                  value={controllerDraft.siteId}
+                  onChange={(e) => setControllerDraft((prev) => ({ ...prev, siteId: e.target.value, collectorDeviceId: '' }))}
+                  className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+                  data-testid="unifi-controller-site"
+                >
+                  <option value="">— Select site —</option>
+                  {sitesByOrg.map((group) => (
+                    <optgroup key={group.id} label={group.name}>
+                      {group.sites.map((site) => (
+                        <option key={site.id} value={site.id}>{site.name}</option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
+              </label>
+              <label className="text-sm">
+                <span className="text-muted-foreground">Collector agent</span>
+                <select
+                  value={controllerDraft.collectorDeviceId}
+                  onChange={(e) => setControllerDraft((prev) => ({ ...prev, collectorDeviceId: e.target.value }))}
+                  disabled={!controllerDraft.siteId}
+                  className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm disabled:opacity-50"
+                  data-testid="unifi-controller-agent"
+                >
+                  <option value="">{controllerDraft.siteId ? '— Select agent —' : 'Pick a site first'}</option>
+                  {agents.filter((a) => !controllerDraft.siteId || a.siteId === controllerDraft.siteId).map((a) => (
+                    <option key={a.id} value={a.id}>{a.name ?? a.id}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-sm">
+                <span className="text-muted-foreground">Local API key</span>
+                <input
+                  type="password"
+                  autoComplete="off"
+                  value={controllerDraft.apiKey}
+                  onChange={(e) => setControllerDraft((prev) => ({ ...prev, apiKey: e.target.value }))}
+                  placeholder="Network Integration API key"
+                  className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+                  data-testid="unifi-controller-key"
+                />
+              </label>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleRegisterController()}
+              disabled={registeringController}
+              className="mt-3 inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              data-testid="unifi-controller-register"
+            >
+              {registeringController ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+              Register controller
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isSelfHosted && (
+        <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-controller-mapping-card">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Site mapping</h2>
+            <button
+              type="button"
+              onClick={() => void loadSelfHosted()}
+              className="ml-auto inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium hover:bg-muted"
+              data-testid="unifi-controller-mapping-refresh"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Refresh
+            </button>
+          </div>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Map each agent-discovered controller site to a Breeze site. Devices polled from that site are
+            reconciled into the chosen site&apos;s discovered assets.
+          </p>
+
+          {!controllerSites || controllerSites.length === 0 ? (
+            <p className="py-6 text-sm text-muted-foreground" data-testid="unifi-controller-mapping-empty">
+              No sites discovered yet. Once the assigned agent reaches the controller (within ~1 minute), its
+              sites appear here to map.
+            </p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y text-sm" data-testid="unifi-controller-mapping-table">
+                  <thead>
+                    <tr className="text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Controller site</th>
+                      <th className="px-3 py-2 font-medium">Breeze site</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {controllerSites.map((s) => {
+                      const key = mapKey(s.collectorId, s.localSiteId);
+                      return (
+                        <tr key={key} data-testid="unifi-controller-mapping-row">
+                          <td className="px-3 py-2">
+                            <span className="font-medium">{s.name ?? s.localSiteId}</span>
+                            <span className="ml-1 text-xs text-muted-foreground">{s.localSiteId}</span>
+                          </td>
+                          <td className="px-3 py-2">
+                            <select
+                              value={selection[key] ?? ''}
+                              onChange={(e) => setSelection((prev) => ({ ...prev, [key]: e.target.value }))}
+                              className="h-9 w-full max-w-xs rounded-md border bg-background px-2 text-sm"
+                              data-testid="unifi-controller-mapping-select"
+                            >
+                              <option value="">— Not mapped —</option>
+                              {sitesByOrg.map((group) => (
+                                <optgroup key={group.id} label={group.name}>
+                                  {group.sites.map((site) => (
+                                    <option key={site.id} value={site.id}>{site.name}</option>
+                                  ))}
+                                </optgroup>
+                              ))}
+                            </select>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <div className="mt-4 flex items-center gap-3 border-t pt-4">
+                <button
+                  type="button"
+                  onClick={() => void handleSaveControllerMappings()}
+                  disabled={savingControllerMappings}
+                  className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                  data-testid="unifi-controller-mapping-save"
+                >
+                  {savingControllerMappings ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+                  Save mappings
+                </button>
+              </div>
+            </>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/integrations/UnifiIntegration.tsx
+++ b/apps/web/src/components/integrations/UnifiIntegration.tsx
@@ -17,9 +17,11 @@ import { formatDateTime } from '@/lib/dateTimeFormat';
 type ConnectionStatus = 'connected' | 'error' | 'reauth_required';
 
 // Mirrors the GET /unifi contract: `{ connected: false }` when not connected, otherwise
-// `{ connected: true, status, accountLabel, lastSyncAt, lastSyncStatus, lastSyncError }`.
+// `{ connected: true, connectionType, status, accountLabel, lastSyncAt, lastSyncStatus, lastSyncError }`.
+type UnifiConnectionType = 'cloud' | 'self_hosted';
 interface UnifiStatus {
   connected: boolean;
+  connectionType?: UnifiConnectionType;
   status?: ConnectionStatus;
   accountLabel?: string | null;
   lastSyncAt?: string | null;
@@ -99,6 +101,10 @@ export default function UnifiIntegration() {
 
   const [status, setStatus] = useState<UnifiStatus | null>(null);
   const [apiKey, setApiKey] = useState('');
+  // Not-connected screen: choose between a UniFi cloud account vs a self-hosted
+  // controller polled by an on-network Breeze agent. Cloud is the default.
+  const [connectMode, setConnectMode] = useState<UnifiConnectionType>('cloud');
+  const [accountLabel, setAccountLabel] = useState('');
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -275,9 +281,11 @@ export default function UnifiIntegration() {
   }, [onUnauthorized, loadHosts]);
 
   // Load mapping/history detail once the connection status resolves to connected.
+  // Only cloud connections have api.ui.com hosts/sites to map — the self-hosted
+  // controller view (Task D2) is driven separately, so skip the cloud fetches.
   useEffect(() => {
-    if (status?.connected === true) void loadDetails();
-  }, [status?.connected, loadDetails]);
+    if (status?.connected === true && status?.connectionType !== 'self_hosted') void loadDetails();
+  }, [status?.connected, status?.connectionType, loadDetails]);
 
   const handleSaveMappings = useCallback(async () => {
     if (!hosts) return;
@@ -404,6 +412,30 @@ export default function UnifiIntegration() {
     }
   }, [apiKey, load, onUnauthorized]);
 
+  const handleConnectSelfHosted = useCallback(async () => {
+    const label = accountLabel.trim();
+    setConnecting(true);
+    setLoadError(null);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/unifi/connect-self-hosted', {
+          method: 'POST',
+          body: JSON.stringify({ accountLabel: label || undefined }),
+        }),
+        errorFallback: 'Failed to connect the self-hosted UniFi controller.',
+        successMessage: 'Self-hosted UniFi controller connected',
+        onUnauthorized,
+      });
+      setAccountLabel('');
+      await load();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) handleActionError(err, 'Failed to connect the self-hosted UniFi controller.');
+    } finally {
+      setConnecting(false);
+    }
+  }, [accountLabel, load, onUnauthorized]);
+
   const handleSync = useCallback(async () => {
     setSyncing(true);
     try {
@@ -463,6 +495,10 @@ export default function UnifiIntegration() {
   // Connected vs. not is the API's `connected` boolean. The `status` string then
   // distinguishes healthy ('connected') from degraded ('error' / 'reauth_required').
   const isConnected = status?.connected === true;
+  // Cloud connections expose api.ui.com-backed affordances (Sync now, host/site mapping,
+  // collectors, sync history). Self-hosted controllers (Task D2) don't, so those are hidden.
+  const isSelfHosted = isConnected && status?.connectionType === 'self_hosted';
+  const isCloud = isConnected && !isSelfHosted;
   const needsReauth = isConnected && status?.status === 'reauth_required';
   const hasError = isConnected && status?.status === 'error';
 
@@ -515,34 +551,98 @@ export default function UnifiIntegration() {
 
       {!isConnected && (
         <div className="rounded-lg border bg-card p-5" data-testid="unifi-disconnected">
-          <p className="text-sm text-muted-foreground">
-            Connect your UniFi Site Manager account with a cloud API key to discover sites,
-            gateways, switches, and access points across your hosts. Breeze maps UniFi sites to
-            your Breeze sites and reconciles discovered network assets.
-          </p>
-          <label className="mt-4 block text-sm font-medium" htmlFor="unifi-api-key">
-            UniFi Site Manager API key
-          </label>
-          <input
-            id="unifi-api-key"
-            type="password"
-            autoComplete="off"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="Paste your API key"
-            className="mt-2 h-10 w-full max-w-md rounded-md border bg-background px-3 text-sm"
-            data-testid="unifi-api-key"
-          />
-          <button
-            type="button"
-            onClick={() => void handleConnect()}
-            disabled={connecting || !apiKey.trim()}
-            className="mt-4 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-            data-testid="unifi-connect"
+          {/* Connection-type chooser: a UniFi cloud account (Site Manager API key) vs a
+              self-hosted Network controller polled directly by an on-network Breeze agent. */}
+          <div
+            className="inline-flex rounded-md border bg-muted/40 p-1"
+            role="radiogroup"
+            aria-label="UniFi connection type"
+            data-testid="unifi-connect-mode"
           >
-            {connecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
-            Connect to UniFi
-          </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={connectMode === 'cloud'}
+              onClick={() => setConnectMode('cloud')}
+              className={`inline-flex h-8 items-center rounded px-3 text-sm font-medium ${connectMode === 'cloud' ? 'bg-background shadow-xs' : 'text-muted-foreground hover:text-foreground'}`}
+              data-testid="unifi-connect-mode-cloud"
+            >
+              Cloud (Site Manager API key)
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={connectMode === 'self_hosted'}
+              onClick={() => setConnectMode('self_hosted')}
+              className={`inline-flex h-8 items-center rounded px-3 text-sm font-medium ${connectMode === 'self_hosted' ? 'bg-background shadow-xs' : 'text-muted-foreground hover:text-foreground'}`}
+              data-testid="unifi-connect-mode-self-hosted"
+            >
+              Self-hosted controller
+            </button>
+          </div>
+
+          {connectMode === 'cloud' ? (
+            <div data-testid="unifi-connect-cloud">
+              <p className="mt-4 text-sm text-muted-foreground">
+                Connect your UniFi Site Manager account with a cloud API key to discover sites,
+                gateways, switches, and access points across your hosts. Breeze maps UniFi sites to
+                your Breeze sites and reconciles discovered network assets.
+              </p>
+              <label className="mt-4 block text-sm font-medium" htmlFor="unifi-api-key">
+                UniFi Site Manager API key
+              </label>
+              <input
+                id="unifi-api-key"
+                type="password"
+                autoComplete="off"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Paste your API key"
+                className="mt-2 h-10 w-full max-w-md rounded-md border bg-background px-3 text-sm"
+                data-testid="unifi-api-key"
+              />
+              <button
+                type="button"
+                onClick={() => void handleConnect()}
+                disabled={connecting || !apiKey.trim()}
+                className="mt-4 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                data-testid="unifi-connect"
+              >
+                {connecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+                Connect to UniFi
+              </button>
+            </div>
+          ) : (
+            <div data-testid="unifi-connect-self-hosted">
+              <p className="mt-4 text-sm text-muted-foreground">
+                Connect a self-hosted UniFi Network controller. A Breeze agent on the controller&apos;s
+                network polls it directly — no UniFi cloud account needed.
+              </p>
+              <label className="mt-4 block text-sm font-medium" htmlFor="unifi-account-label">
+                Account label <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                id="unifi-account-label"
+                type="text"
+                autoComplete="off"
+                value={accountLabel}
+                onChange={(e) => setAccountLabel(e.target.value)}
+                placeholder="e.g. Acme HQ controllers"
+                className="mt-2 h-10 w-full max-w-md rounded-md border bg-background px-3 text-sm"
+                data-testid="unifi-account-label-input"
+              />
+              <button
+                type="button"
+                onClick={() => void handleConnectSelfHosted()}
+                disabled={connecting}
+                className="mt-4 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                data-testid="unifi-connect-self-hosted-submit"
+              >
+                {connecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+                Connect
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -593,16 +693,18 @@ export default function UnifiIntegration() {
           </dl>
 
           <div className="flex items-center gap-3 border-t pt-4">
-            <button
-              type="button"
-              onClick={() => void handleSync()}
-              disabled={syncing}
-              className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              data-testid="unifi-sync"
-            >
-              {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-              Sync now
-            </button>
+            {isCloud && (
+              <button
+                type="button"
+                onClick={() => void handleSync()}
+                disabled={syncing}
+                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                data-testid="unifi-sync"
+              >
+                {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Sync now
+              </button>
+            )}
             <button
               type="button"
               onClick={() => void handleDisconnect()}
@@ -617,7 +719,7 @@ export default function UnifiIntegration() {
         </div>
       )}
 
-      {isConnected && (
+      {isCloud && (
         <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-mapping-card">
           <div className="flex items-center gap-2">
             <h2 className="text-lg font-semibold">Site mapping</h2>
@@ -709,7 +811,7 @@ export default function UnifiIntegration() {
         </div>
       )}
 
-      {isConnected && hosts && hosts.length > 0 && (
+      {isCloud && hosts && hosts.length > 0 && (
         <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-collectors-card">
           <h2 className="text-lg font-semibold">Deep telemetry collectors</h2>
           <p className="mb-4 text-sm text-muted-foreground">
@@ -815,7 +917,7 @@ export default function UnifiIntegration() {
         </div>
       )}
 
-      {isConnected && (
+      {isCloud && (
         <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-telemetry-card">
           <h2 className="text-lg font-semibold">Deep telemetry</h2>
           <p className="mb-4 text-sm text-muted-foreground">Live per-device PoE/health and connected clients for a mapped site.</p>
@@ -917,7 +1019,7 @@ export default function UnifiIntegration() {
         </div>
       )}
 
-      {isConnected && (
+      {isCloud && (
         <div className="rounded-xl border bg-card p-5 shadow-xs" data-testid="unifi-history-card">
           <div className="flex items-center gap-2">
             <History className="h-4 w-4 text-muted-foreground" />

--- a/docs/superpowers/plans/2026-06-29-unifi-self-hosted-controller.md
+++ b/docs/superpowers/plans/2026-06-29-unifi-self-hosted-controller.md
@@ -1,0 +1,1147 @@
+# UniFi Self-Hosted Controller Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP register a single self-hosted UniFi Network controller (one VM serving many customer sites) by URL + collector agent + local API key — with no UniFi cloud (`api.ui.com`) involvement — and have that one controller deliver both inventory and deep telemetry, routed to the correct customer org per site.
+
+**Architecture:** Add a `connection_type` discriminator (`'cloud' | 'self_hosted'`) to `unifi_integrations`. For self-hosted, the existing agent collector loop and telemetry-ingest pipeline are reused almost verbatim — the agent already enumerates every site on the controller and tags each device/client with its `unifi_site_id`, and `reconcileTelemetry` already routes rows to the right Breeze site via `unifi_site_mappings`. The work is: relax the host-id-keyed collector constraints so one controller (no cloud host) can exist and fan out to many site mappings; add an agent-reported controller-site discovery list so the mapping UI has something to map; reconcile telemetry devices into `discovered_assets` for inventory parity; and add the self-hosted connect/register/map UI.
+
+**Tech Stack:** PostgreSQL + Drizzle ORM, Hono (TypeScript) API, BullMQ workers, Go agent, Astro + React (web). Tests: Vitest (API/web), `go test -race` (agent), RLS integration test (`vitest.config.rls.ts` / `rls-coverage.integration.test.ts`).
+
+## Global Constraints
+
+- **Design spec:** `docs/superpowers/specs/2026-06-29-unifi-self-hosted-controller-design.md`. Every task implements part of it.
+- **Migrations:** hand-written SQL in `apps/api/migrations/`, named `2026-06-29-<slug>.sql`. **Idempotent** (`IF NOT EXISTS`, `DROP ... IF EXISTS` then recreate, `DO $$ ... pg_policies` checks). **No inner `BEGIN;`/`COMMIT;`** (the runner wraps each file). Never edit a shipped migration. Same-day dependent migrations use `-a-`/`-b-` infixes.
+- **RLS:** every tenant-scoped table has RLS enabled + forced + policies created in the same migration. New tables added to the matching allowlist in `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` in this PR. `unifi_controller_sites` is org-axis (direct `org_id` column) → auto-discovered, no allowlist entry needed, but must have policies.
+- **DB context:** request paths use `db` under `withDbAccessContext` (middleware-provided); agent/worker paths use `withSystemDbAccessContext`. Never use a bare pool in request code.
+- **Drizzle:** type-safe queries only. Do NOT run `drizzle-kit generate/push`. After schema edits run `pnpm db:check-drift`.
+- **Web mutations:** new POST/PUT handlers wrap requests in `runAction` (`apps/web/src/lib/runAction.ts`).
+- **Partner scope:** all `/unifi/*` routes are `requireScope('partner','system')` + `BILLING_MANAGE`. Keep that.
+- **Self-hosted invariants (non-goals):** one `connection_type` per partner integration (no mixed cloud+self-hosted simultaneously); one collector agent per controller (no HA).
+- **Local site ids:** the UniFi Network *integration* API returns an opaque per-site `id` (not the `default` slug). `reconcileTelemetry` keys the site map on `unifi_site_id` alone; self-hosted mapping rows store `unifi_host_id = <collectorId>` as a stable sentinel so the existing `(integration_id, unifi_host_id, unifi_site_id)` unique index still applies.
+
+---
+
+## File map
+
+**Create:**
+- `apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql` — `connection_type`, nullable cloud key + CHECK.
+- `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql` — collector host-id nullability + index surgery; new `unifi_controller_sites` table + RLS.
+- `apps/api/src/services/unifi/unifiControllerSiteService.ts` — upsert/list agent-reported controller sites.
+- `apps/api/src/services/unifi/unifiControllerSiteService.test.ts`
+- `apps/api/src/services/unifi/unifiSelfHostedService.test.ts` (self-hosted integration + controller upsert)
+
+**Modify:**
+- `apps/api/src/db/schema/unifi.ts` — `connectionType` col; nullable `unifiHostId`; `unifiControllerSites` table.
+- `apps/api/src/services/unifi/unifiConnectionService.ts` — `createSelfHostedIntegration`, expose `connectionType`.
+- `apps/api/src/services/unifi/unifiCollectorService.ts` — self-hosted upsert keyed on `controller_url`; null host id in `AgentCollectorConfig`.
+- `apps/api/src/routes/unifi/index.ts` — `POST /unifi/connect-self-hosted`, `PUT /unifi/controllers`, `GET /unifi/controller-sites`.
+- `apps/api/src/routes/unifi/index.test.ts` (create if absent) — route tests.
+- `apps/api/src/routes/agents/unifiTelemetry.ts` — accept optional `sites: [{id,name}]` in `telemetrySchema`.
+- `apps/api/src/services/unifi/unifiTelemetryService.ts` — upsert `unifi_controller_sites` from payload; reconcile devices into `discovered_assets`.
+- `apps/api/src/services/unifi/unifiTelemetryService.test.ts`
+- `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — allowlist note for `unifi_controller_sites` (auto-discovered org-axis; assert policies present).
+- `agent/internal/unifi/client.go` — capture site `name`; return discovered sites from `Poll`.
+- `agent/internal/unifi/client_test.go`
+- `agent/internal/unifi/collector.go` — carry `Sites` into `telemetryPayload`.
+- `agent/internal/unifi/collector_test.go`
+- `apps/web/src/components/integrations/UnifiIntegration.tsx` — connection-type choice; self-hosted register + map from controller sites.
+
+---
+
+## Phase A — Schema & migration
+
+### Task A1: `connection_type` on `unifi_integrations`
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql`
+- Modify: `apps/api/src/db/schema/unifi.ts:22-40`
+- Test: `apps/api/src/db/autoMigrate.test.ts` (existing ordering regression test — just runs; no new test code here, verified via drift + migrate)
+
+**Interfaces:**
+- Produces: `unifi_integrations.connection_type text NOT NULL DEFAULT 'cloud'`; `api_key_encrypted` becomes nullable with CHECK that it is non-null when `connection_type='cloud'`. Drizzle: `unifiIntegrations.connectionType`, `unifiIntegrations.apiKeyEncrypted` (now nullable).
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql`:
+
+```sql
+-- UniFi self-hosted controllers (part a): connection_type discriminator on the
+-- partner integration row. 'cloud' = existing Site Manager (api.ui.com) flow;
+-- 'self_hosted' = agent-mediated local Network controller with no cloud key.
+
+ALTER TABLE unifi_integrations
+  ADD COLUMN IF NOT EXISTS connection_type text NOT NULL DEFAULT 'cloud';
+
+-- Self-hosted integrations carry no cloud API key; relax the NOT NULL and guard
+-- it with a CHECK so cloud rows still require a key.
+ALTER TABLE unifi_integrations ALTER COLUMN api_key_encrypted DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'unifi_integrations_cloud_key_chk'
+  ) THEN
+    ALTER TABLE unifi_integrations
+      ADD CONSTRAINT unifi_integrations_cloud_key_chk
+      CHECK (connection_type <> 'cloud' OR api_key_encrypted IS NOT NULL);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'unifi_integrations_connection_type_chk'
+  ) THEN
+    ALTER TABLE unifi_integrations
+      ADD CONSTRAINT unifi_integrations_connection_type_chk
+      CHECK (connection_type IN ('cloud', 'self_hosted'));
+  END IF;
+END $$;
+```
+
+- [ ] **Step 2: Update the Drizzle schema**
+
+In `apps/api/src/db/schema/unifi.ts`, edit the `unifiIntegrations` table (lines 22-35). Change `apiKeyEncrypted` to nullable and add `connectionType`:
+
+```ts
+export const unifiIntegrations = pgTable('unifi_integrations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id),
+  connectionType: text('connection_type').notNull().default('cloud'),
+  baseUrl: text('base_url').notNull().default('https://api.ui.com'),
+  apiKeyEncrypted: text('api_key_encrypted'),
+  accountLabel: text('account_label'),
+  isActive: boolean('is_active').notNull().default(true),
+  status: varchar('status', { length: 20 }).notNull().default('connected'),
+  lastSyncAt: timestamp('last_sync_at'),
+  lastSyncStatus: varchar('last_sync_status', { length: 20 }),
+  lastSyncError: text('last_sync_error'),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  partnerActiveIdx: uniqueIndex('unifi_integrations_partner_active_idx')
+    .on(table.partnerId)
+    .where(sql`${table.isActive}`),
+}));
+```
+
+- [ ] **Step 3: Apply migration + verify no drift**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts
+pnpm db:check-drift
+```
+Expected: autoMigrate test passes (ordering OK); `db:check-drift` reports no drift between schema and migrations.
+
+- [ ] **Step 4: Verify idempotency**
+
+Run the migration test a second time (re-apply must be a no-op — the runner skips already-applied files, and the SQL is guarded). Confirm no error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-29-a-unifi-self-hosted-connection.sql apps/api/src/db/schema/unifi.ts
+git commit -m "feat(unifi): add connection_type to unifi_integrations for self-hosted"
+```
+
+---
+
+### Task A2: nullable collector host id + index surgery
+
+**Files:**
+- Modify: `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql` (created here; controller-sites table added in A3 to the same file)
+- Modify: `apps/api/src/db/schema/unifi.ts:109-131`
+
+**Interfaces:**
+- Produces: `unifi_collectors.unifi_host_id` nullable. Unique index `unifi_collectors_integration_host_idx` becomes partial (`WHERE unifi_host_id IS NOT NULL`). New partial unique index `unifi_collectors_integration_url_idx` on `(integration_id, controller_url) WHERE unifi_host_id IS NULL`. Drizzle: `unifiCollectors.unifiHostId` nullable.
+
+- [ ] **Step 1: Start the part-b migration with collector changes**
+
+Create `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql`:
+
+```sql
+-- UniFi self-hosted controllers (part b): one collector row per controller (no
+-- cloud host id), plus the agent-reported controller-site discovery table.
+
+-- 1. Collector host id becomes nullable; a self-hosted controller has no cloud host.
+ALTER TABLE unifi_collectors ALTER COLUMN unifi_host_id DROP NOT NULL;
+
+-- Replace the unconditional unique (integration, host) with a partial that only
+-- governs cloud collectors (host id present). Self-hosted rows (null host id) are
+-- governed by a separate (integration, controller_url) unique index below.
+DROP INDEX IF EXISTS unifi_collectors_integration_host_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_host_idx
+  ON unifi_collectors(integration_id, unifi_host_id)
+  WHERE unifi_host_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_collectors_integration_url_idx
+  ON unifi_collectors(integration_id, controller_url)
+  WHERE unifi_host_id IS NULL;
+```
+
+> Note: dropping and recreating `unifi_collectors_integration_host_idx` as a partial index is safe because no production self-hosted rows exist yet; all existing rows have a non-null host id and remain covered.
+
+- [ ] **Step 2: Update the Drizzle schema**
+
+In `apps/api/src/db/schema/unifi.ts`, edit `unifiCollectors` (lines 109-131): make `unifiHostId` nullable and update the index definitions:
+
+```ts
+  unifiHostId: text('unifi_host_id'),
+```
+and replace the table-config block (lines 128-131):
+```ts
+}, (table) => ({
+  integrationHostIdx: uniqueIndex('unifi_collectors_integration_host_idx')
+    .on(table.integrationId, table.unifiHostId)
+    .where(sql`${table.unifiHostId} IS NOT NULL`),
+  integrationUrlIdx: uniqueIndex('unifi_collectors_integration_url_idx')
+    .on(table.integrationId, table.controllerUrl)
+    .where(sql`${table.unifiHostId} IS NULL`),
+  deviceIdx: index('unifi_collectors_device_idx').on(table.collectorDeviceId).where(sql`${table.isEnabled}`),
+}));
+```
+
+- [ ] **Step 3: Apply + drift check**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts
+pnpm db:check-drift
+```
+Expected: passes, no drift. (Schema `.where()` partial-index predicates must match the SQL exactly or drift will flag.)
+
+- [ ] **Step 4: Commit** (combined with A3; if committing separately:)
+
+```bash
+git add apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql apps/api/src/db/schema/unifi.ts
+git commit -m "feat(unifi): nullable collector host id + controller_url uniqueness"
+```
+
+---
+
+### Task A3: `unifi_controller_sites` discovery table
+
+**Files:**
+- Modify: `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql` (append)
+- Modify: `apps/api/src/db/schema/unifi.ts` (append table)
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`
+
+**Interfaces:**
+- Produces: table `unifi_controller_sites` (`id`, `collector_id`, `org_id`, `local_site_id`, `name`, `last_seen_at`, timestamps), unique `(collector_id, local_site_id)`, org-axis RLS. Drizzle export `unifiControllerSites`.
+
+- [ ] **Step 1: Append the table to the part-b migration**
+
+Append to `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql`:
+
+```sql
+-- 2. unifi_controller_sites: the local sites the agent discovered on a self-hosted
+-- controller, so the mapping UI can list them. org-axis = collector agent's org.
+CREATE TABLE IF NOT EXISTS unifi_controller_sites (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  collector_id  uuid NOT NULL REFERENCES unifi_collectors(id) ON DELETE CASCADE,
+  org_id        uuid NOT NULL REFERENCES organizations(id),
+  local_site_id text NOT NULL,
+  name          text,
+  last_seen_at  timestamptz NOT NULL DEFAULT now(),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_controller_sites_collector_site_idx
+  ON unifi_controller_sites(collector_id, local_site_id);
+
+ALTER TABLE unifi_controller_sites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE unifi_controller_sites FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON unifi_controller_sites;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON unifi_controller_sites;
+CREATE POLICY breeze_org_isolation_select ON unifi_controller_sites
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON unifi_controller_sites
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON unifi_controller_sites
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON unifi_controller_sites
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+- [ ] **Step 2: Add the Drizzle table**
+
+Append to `apps/api/src/db/schema/unifi.ts`:
+
+```ts
+export const unifiControllerSites = pgTable('unifi_controller_sites', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  collectorId: uuid('collector_id').notNull().references(() => unifiCollectors.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  localSiteId: text('local_site_id').notNull(),
+  name: text('name'),
+  lastSeenAt: timestamp('last_seen_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  collectorSiteIdx: uniqueIndex('unifi_controller_sites_collector_site_idx')
+    .on(table.collectorId, table.localSiteId),
+}));
+```
+
+- [ ] **Step 3: Confirm RLS contract test discovers the table**
+
+`unifi_controller_sites` has a direct `org_id` column (tenancy shape #1), so the RLS coverage test auto-discovers it — no allowlist edit. Run the contract test (needs a real DB):
+
+```bash
+pnpm --filter @breeze/api exec vitest run --config vitest.config.rls.ts src/__tests__/integration/rls-coverage.integration.test.ts
+```
+Expected: PASS, with `unifi_controller_sites` covered (RLS enabled + forced + 4 policies). If it reports the table as missing policies, the migration didn't apply — re-run migrate.
+
+- [ ] **Step 4: Forge a cross-tenant insert as `breeze_app`**
+
+```bash
+docker exec -it breeze-postgres psql -U breeze_app -d breeze \
+  -c "INSERT INTO unifi_controller_sites (collector_id, org_id, local_site_id) VALUES (gen_random_uuid(), gen_random_uuid(), 'x');"
+```
+Expected: `ERROR: new row violates row-level security policy for table "unifi_controller_sites"`.
+
+- [ ] **Step 5: Drift check + commit**
+
+```bash
+pnpm db:check-drift
+git add apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql apps/api/src/db/schema/unifi.ts apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "feat(unifi): unifi_controller_sites discovery table with org-axis RLS"
+```
+
+---
+
+## Phase B — API services & routes
+
+### Task B1: self-hosted integration creation
+
+**Files:**
+- Modify: `apps/api/src/services/unifi/unifiConnectionService.ts`
+- Modify: `apps/api/src/routes/unifi/index.ts` (add `POST /unifi/connect-self-hosted`; surface `connectionType` in `GET /unifi`)
+- Test: `apps/api/src/services/unifi/unifiSelfHostedService.test.ts`
+
+**Interfaces:**
+- Consumes: `db`, `partnerId`.
+- Produces: `createSelfHostedIntegration(db, partnerId, { accountLabel, createdBy }): Promise<{ id: string; connectionType: 'self_hosted' }>`. `getConnection` result gains `connectionType: 'cloud' | 'self_hosted'`. Route `POST /unifi/connect-self-hosted` body `{ accountLabel?: string }` → `{ connected: true, connectionType: 'self_hosted' }`.
+
+- [ ] **Step 1: Write the failing service test**
+
+Create `apps/api/src/services/unifi/unifiSelfHostedService.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createSelfHostedIntegration } from './unifiConnectionService';
+
+function mockDb(returning: any[]) {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue(returning),
+        }),
+      }),
+    }),
+  } as any;
+}
+
+describe('createSelfHostedIntegration', () => {
+  it('inserts a self_hosted integration with no api key', async () => {
+    const db = mockDb([{ id: 'int-1', connectionType: 'self_hosted' }]);
+    const out = await createSelfHostedIntegration(db, 'partner-1', { accountLabel: 'HQ VM', createdBy: 'user-1' });
+    expect(out).toEqual({ id: 'int-1', connectionType: 'self_hosted' });
+    const values = (db.insert as any).mock.results[0].value.values.mock.calls[0][0];
+    expect(values.connectionType).toBe('self_hosted');
+    expect(values.apiKeyEncrypted ?? null).toBeNull();
+    expect(values.partnerId).toBe('partner-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiSelfHostedService.test.ts`
+Expected: FAIL — `createSelfHostedIntegration is not a function`.
+
+- [ ] **Step 3: Implement the service function**
+
+In `apps/api/src/services/unifi/unifiConnectionService.ts`, add (mirror the existing `upsertConnection`, but with no key and `connectionType: 'self_hosted'`; reuse the same `unifi_integrations_partner_active_idx` conflict target). Add near the existing exports:
+
+```ts
+export async function createSelfHostedIntegration(
+  db: DbExecutor,
+  partnerId: string,
+  fields: { accountLabel?: string | null; createdBy?: string | null },
+): Promise<{ id: string; connectionType: 'self_hosted' }> {
+  const rows = await db
+    .insert(unifiIntegrations)
+    .values({
+      partnerId,
+      connectionType: 'self_hosted',
+      apiKeyEncrypted: null,
+      accountLabel: fields.accountLabel ?? null,
+      createdBy: fields.createdBy ?? null,
+      status: 'connected',
+      isActive: true,
+    })
+    .onConflictDoUpdate({
+      target: unifiIntegrations.partnerId,
+      targetWhere: sql`${unifiIntegrations.isActive}`,
+      set: {
+        connectionType: 'self_hosted',
+        accountLabel: fields.accountLabel ?? null,
+        status: 'connected',
+        updatedAt: new Date(),
+      },
+    })
+    .returning({ id: unifiIntegrations.id, connectionType: unifiIntegrations.connectionType });
+  if (!rows[0]) throw new Error('createSelfHostedIntegration returned no row');
+  return { id: rows[0].id, connectionType: 'self_hosted' };
+}
+```
+
+Ensure `sql` is imported from `drizzle-orm` and `connectionType` is included in the `getConnection` select (add `connectionType: unifiIntegrations.connectionType` to its returned object so the route can branch).
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiSelfHostedService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the route**
+
+In `apps/api/src/routes/unifi/index.ts`, import `createSelfHostedIntegration`, and after the `POST /unifi/connect` handler add:
+
+```ts
+const connectSelfHostedSchema = z.object({
+  accountLabel: z.string().max(200).optional(),
+});
+
+// POST /unifi/connect-self-hosted — create a self-hosted integration (no cloud key)
+unifiRoutes.post('/connect-self-hosted', partnerScopes, writePerm, requireMfa(), zValidator('json', connectSelfHostedSchema), async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const { accountLabel } = c.req.valid('json');
+  const integration = await createSelfHostedIntegration(db, partner.partnerId, {
+    accountLabel: accountLabel ?? null,
+    createdBy: auth.user.id,
+  });
+  return c.json({ connected: true, connectionType: integration.connectionType });
+});
+```
+
+Also extend `GET /unifi` (lines 73-80) to include `connectionType: conn.connectionType` in the response.
+
+- [ ] **Step 6: Run the API unit suite for the route file**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/unifi/`
+Expected: PASS (existing tests still green; new route compiles).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/unifi/unifiConnectionService.ts apps/api/src/services/unifi/unifiSelfHostedService.test.ts apps/api/src/routes/unifi/index.ts
+git commit -m "feat(unifi): self-hosted integration creation endpoint"
+```
+
+---
+
+### Task B2: self-hosted controller registration
+
+**Files:**
+- Modify: `apps/api/src/services/unifi/unifiCollectorService.ts`
+- Modify: `apps/api/src/routes/unifi/index.ts` (add `PUT /unifi/controllers`)
+- Test: `apps/api/src/services/unifi/unifiCollectorService.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: `db`, validated body.
+- Produces: `upsertSelfHostedController(db, { integrationId, orgId, siteId, collectorDeviceId, controllerUrl, apiKey, pollIntervalSeconds?, createdBy? }): Promise<UnifiCollector>` — inserts with `unifiHostId: null`, conflict target `(integration_id, controller_url)`. `AgentCollectorConfig.unifiHostId` becomes `string | null`. Route `PUT /unifi/controllers` body `{ siteId, collectorDeviceId, controllerUrl, apiKey, pollIntervalSeconds? }` → `{ success, collectorId }`.
+
+- [ ] **Step 1: Write the failing service test**
+
+Create/append `apps/api/src/services/unifi/unifiCollectorService.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { upsertSelfHostedController } from './unifiCollectorService';
+
+vi.mock('../secretCrypto', () => ({
+  encryptSecret: (v: string) => `enc(${v})`,
+  decryptForColumn: (_t: string, _c: string, v: string) => v.replace(/^enc\(|\)$/g, ''),
+}));
+
+function mockInsertDb(returning: any[]) {
+  const onConflictDoUpdate = vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(returning) });
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { db: { insert } as any, insert, values, onConflictDoUpdate };
+}
+
+describe('upsertSelfHostedController', () => {
+  it('inserts a collector with null host id keyed on controller_url', async () => {
+    const { db, values } = mockInsertDb([{
+      id: 'col-1', integrationId: 'int-1', orgId: 'org-1', siteId: 'site-1', unifiHostId: null,
+      collectorDeviceId: 'dev-1', controllerUrl: 'https://192.168.1.1', isEnabled: true,
+      pollIntervalSeconds: 60, status: 'pending', firmwareOk: null, lastPollAt: null, lastPollStatus: null, lastPollError: null,
+    }]);
+    const out = await upsertSelfHostedController(db, {
+      integrationId: 'int-1', orgId: 'org-1', siteId: 'site-1', collectorDeviceId: 'dev-1',
+      controllerUrl: 'https://192.168.1.1', apiKey: 'secret',
+    });
+    expect(out.id).toBe('col-1');
+    const inserted = values.mock.calls[0][0];
+    expect(inserted.unifiHostId ?? null).toBeNull();
+    expect(inserted.localApiKeyEncrypted).toBe('enc(secret)');
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiCollectorService.test.ts`
+Expected: FAIL — `upsertSelfHostedController is not a function`.
+
+- [ ] **Step 3: Implement the service function**
+
+In `apps/api/src/services/unifi/unifiCollectorService.ts`: change `AgentCollectorConfig.unifiHostId` and `UnifiCollector.unifiHostId` to `string | null`. Add:
+
+```ts
+export async function upsertSelfHostedController(
+  db: DbExecutor,
+  fields: {
+    integrationId: string;
+    orgId: string;
+    siteId: string;
+    collectorDeviceId: string;
+    controllerUrl: string;
+    apiKey: string;
+    pollIntervalSeconds?: number;
+    createdBy?: string | null;
+  },
+): Promise<UnifiCollector> {
+  const localApiKeyEncrypted = encryptSecret(fields.apiKey, { aad: 'unifi_collectors.local_api_key_encrypted' });
+  const rows = await db
+    .insert(unifiCollectors)
+    .values({
+      integrationId: fields.integrationId,
+      orgId: fields.orgId,
+      siteId: fields.siteId,
+      unifiHostId: null,
+      collectorDeviceId: fields.collectorDeviceId,
+      controllerUrl: fields.controllerUrl,
+      localApiKeyEncrypted,
+      pollIntervalSeconds: fields.pollIntervalSeconds ?? 60,
+      createdBy: fields.createdBy ?? null,
+      status: 'pending',
+    })
+    .onConflictDoUpdate({
+      target: [unifiCollectors.integrationId, unifiCollectors.controllerUrl],
+      targetWhere: sql`${unifiCollectors.unifiHostId} IS NULL`,
+      set: {
+        orgId: fields.orgId,
+        siteId: fields.siteId,
+        collectorDeviceId: fields.collectorDeviceId,
+        localApiKeyEncrypted,
+        pollIntervalSeconds: fields.pollIntervalSeconds ?? 60,
+        status: 'pending',
+        lastPollError: null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  if (!rows[0]) throw new Error('upsertSelfHostedController returned no unifi_collectors row');
+  return toCollector(rows[0]);
+}
+```
+
+Add `import { sql } from 'drizzle-orm';` (the file currently imports only `and, eq`). The partial-index conflict target requires `targetWhere` to match the index predicate.
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiCollectorService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the route**
+
+In `apps/api/src/routes/unifi/index.ts`, import `upsertSelfHostedController`, add a schema and handler after `PUT /unifi/collectors`:
+
+```ts
+const controllerSchema = z.object({
+  siteId: z.string().guid(),
+  collectorDeviceId: z.string().guid(),
+  controllerUrl: z.string().url().max(300),
+  apiKey: z.string().min(1),
+  pollIntervalSeconds: z.number().int().min(15).max(3600).optional(),
+});
+
+// PUT /unifi/controllers — register/update a self-hosted controller (no cloud host)
+unifiRoutes.put('/controllers', partnerScopes, writePerm, requireMfa(), zValidator('json', controllerSchema), async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const conn = await getConnection(db, partner.partnerId);
+  if (!conn) return c.json({ success: false, message: 'Not connected' }, 400);
+  if (conn.connectionType !== 'self_hosted') {
+    return c.json({ success: false, message: 'Controllers can only be registered on a self-hosted integration' }, 400);
+  }
+  const body = c.req.valid('json');
+  const [site] = await db.select({ id: sites.id, orgId: sites.orgId }).from(sites).where(eq(sites.id, body.siteId)).limit(1);
+  if (!site) return c.json({ success: false, message: `Unknown Breeze site: ${body.siteId}` }, 400);
+  if (!auth.canAccessOrg(site.orgId)) return c.json({ success: false, message: 'Access to target organization denied' }, 403);
+  const [dev] = await db.select({ id: devices.id, orgId: devices.orgId }).from(devices).where(eq(devices.id, body.collectorDeviceId)).limit(1);
+  if (!dev) return c.json({ success: false, message: 'Unknown collector agent' }, 400);
+  if (dev.orgId !== site.orgId) return c.json({ success: false, message: 'Collector agent must belong to the site\'s organization' }, 400);
+  const collector = await upsertSelfHostedController(db, {
+    integrationId: conn.id,
+    orgId: site.orgId,
+    siteId: site.id,
+    collectorDeviceId: body.collectorDeviceId,
+    controllerUrl: body.controllerUrl,
+    apiKey: body.apiKey,
+    pollIntervalSeconds: body.pollIntervalSeconds,
+    createdBy: auth.user.id,
+  });
+  return c.json({ success: true, collectorId: collector.id });
+});
+```
+
+- [ ] **Step 6: Run the API suite**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/routes/unifi/ src/services/unifi/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/unifi/unifiCollectorService.ts apps/api/src/services/unifi/unifiCollectorService.test.ts apps/api/src/routes/unifi/index.ts
+git commit -m "feat(unifi): register self-hosted controllers keyed on controller_url"
+```
+
+---
+
+### Task B3: controller-site discovery (ingest + list)
+
+**Files:**
+- Create: `apps/api/src/services/unifi/unifiControllerSiteService.ts`
+- Test: `apps/api/src/services/unifi/unifiControllerSiteService.test.ts`
+- Modify: `apps/api/src/routes/agents/unifiTelemetry.ts` (accept `sites`)
+- Modify: `apps/api/src/services/unifi/unifiTelemetryService.ts` (`TelemetryPayload.sites`, call upsert)
+- Modify: `apps/api/src/routes/unifi/index.ts` (`GET /unifi/controller-sites`)
+
+**Interfaces:**
+- Consumes: collector `orgId` (resolved in `reconcileTelemetry`), payload `sites: [{ id, name }]`.
+- Produces: `upsertControllerSites(db, collectorId, orgId, sites): Promise<void>`; `listControllerSitesForIntegration(db, integrationId): Promise<Array<{ collectorId, localSiteId, name, mapped: boolean }>>`. `TelemetryPayload.sites?: Array<{ id: string; name?: string | null }>`. Route `GET /unifi/controller-sites` → `{ sites: [...] }`.
+
+- [ ] **Step 1: Write the failing service test**
+
+Create `apps/api/src/services/unifi/unifiControllerSiteService.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { upsertControllerSites } from './unifiControllerSiteService';
+
+function mockDb() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { db: { insert } as any, values };
+}
+
+describe('upsertControllerSites', () => {
+  it('upserts one row per reported site with the collector org', async () => {
+    const { db, values } = mockDb();
+    await upsertControllerSites(db, 'col-1', 'org-1', [{ id: 's1', name: 'HQ' }, { id: 's2' }]);
+    expect(values).toHaveBeenCalledTimes(2);
+    expect(values.mock.calls[0][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's1', name: 'HQ' });
+    expect(values.mock.calls[1][0]).toMatchObject({ collectorId: 'col-1', orgId: 'org-1', localSiteId: 's2', name: null });
+  });
+
+  it('no-ops on an empty list', async () => {
+    const { db, values } = mockDb();
+    await upsertControllerSites(db, 'col-1', 'org-1', []);
+    expect(values).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiControllerSiteService.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service**
+
+Create `apps/api/src/services/unifi/unifiControllerSiteService.ts`:
+
+```ts
+import { eq, inArray } from 'drizzle-orm';
+import { unifiControllerSites, unifiCollectors, unifiSiteMappings } from '../../db/schema';
+import type { DbExecutor } from './unifiConnectionService';
+
+export interface ReportedSite { id: string; name?: string | null }
+
+// Upsert the agent-reported local sites for a self-hosted controller. Keyed on
+// (collector_id, local_site_id). org comes from the collector (caller resolves it).
+export async function upsertControllerSites(
+  db: DbExecutor,
+  collectorId: string,
+  orgId: string,
+  sites: ReportedSite[],
+): Promise<void> {
+  const now = new Date();
+  for (const s of sites) {
+    await db.insert(unifiControllerSites).values({
+      collectorId, orgId, localSiteId: s.id, name: s.name ?? null, lastSeenAt: now,
+    }).onConflictDoUpdate({
+      target: [unifiControllerSites.collectorId, unifiControllerSites.localSiteId],
+      set: { name: s.name ?? null, lastSeenAt: now, updatedAt: now },
+    });
+  }
+}
+
+// List discovered sites for a self-hosted integration's collectors, flagging which
+// already have a Phase-1-style mapping row (unifi_host_id = collectorId sentinel).
+export async function listControllerSitesForIntegration(
+  db: DbExecutor,
+  integrationId: string,
+): Promise<Array<{ collectorId: string; localSiteId: string; name: string | null; mapped: boolean }>> {
+  const collectors = await db.select({ id: unifiCollectors.id })
+    .from(unifiCollectors).where(eq(unifiCollectors.integrationId, integrationId));
+  const collectorIds = collectors.map((c: any) => c.id);
+  if (collectorIds.length === 0) return [];
+  const rows = await db.select({
+    collectorId: unifiControllerSites.collectorId,
+    localSiteId: unifiControllerSites.localSiteId,
+    name: unifiControllerSites.name,
+  }).from(unifiControllerSites).where(inArray(unifiControllerSites.collectorId, collectorIds));
+  const mappings = await db.select({
+    unifiHostId: unifiSiteMappings.unifiHostId, unifiSiteId: unifiSiteMappings.unifiSiteId,
+  }).from(unifiSiteMappings).where(eq(unifiSiteMappings.integrationId, integrationId));
+  const mappedKeys = new Set(mappings.map((m: any) => `${m.unifiHostId}::${m.unifiSiteId}`));
+  return rows.map((r: any) => ({
+    collectorId: r.collectorId, localSiteId: r.localSiteId, name: r.name,
+    mapped: mappedKeys.has(`${r.collectorId}::${r.localSiteId}`),
+  }));
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiControllerSiteService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `sites` through the ingest schema + payload type**
+
+In `apps/api/src/routes/agents/unifiTelemetry.ts`, add to `telemetrySchema` (after `clients`):
+```ts
+  sites: z.array(z.object({ id: z.string().min(1), name: z.string().nullable().optional() })).optional(),
+```
+In `apps/api/src/services/unifi/unifiTelemetryService.ts`, add to `TelemetryPayload`:
+```ts
+  sites?: Array<{ id: string; name?: string | null }>;
+```
+
+- [ ] **Step 6: Call the upsert from reconcile**
+
+In `reconcileTelemetry` (`unifiTelemetryService.ts`), after the collector is loaded (right after line 52, the `if (!collector) throw`), add:
+```ts
+  if (payload.sites && payload.sites.length > 0) {
+    await upsertControllerSites(db, collector.id, collector.orgId, payload.sites);
+  }
+```
+Add the import at the top: `import { upsertControllerSites } from './unifiControllerSiteService';`
+
+- [ ] **Step 7: Add the list route**
+
+In `apps/api/src/routes/unifi/index.ts`, import `listControllerSitesForIntegration`, add:
+```ts
+// GET /unifi/controller-sites — agent-discovered local sites for the mapping UI
+unifiRoutes.get('/controller-sites', partnerScopes, readPerm, async (c) => {
+  const auth = c.get('auth');
+  const partner = resolvePartnerId(auth, requestedPartnerId(c));
+  if ('error' in partner) return c.json({ error: partner.error }, partner.status);
+  const conn = await getConnection(db, partner.partnerId);
+  if (!conn) return c.json({ sites: [] });
+  const sitesOut = await listControllerSitesForIntegration(db, conn.id);
+  return c.json({ sites: sitesOut });
+});
+```
+
+- [ ] **Step 8: Run API suites**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/ src/routes/unifi/ src/routes/agents/`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/services/unifi/unifiControllerSiteService.ts apps/api/src/services/unifi/unifiControllerSiteService.test.ts apps/api/src/routes/agents/unifiTelemetry.ts apps/api/src/services/unifi/unifiTelemetryService.ts apps/api/src/routes/unifi/index.ts
+git commit -m "feat(unifi): agent-reported controller-site discovery + list endpoint"
+```
+
+---
+
+### Task B4: inventory parity — reconcile telemetry devices into `discovered_assets`
+
+**Files:**
+- Modify: `apps/api/src/services/unifi/unifiTelemetryService.ts`
+- Test: `apps/api/src/services/unifi/unifiTelemetryService.test.ts`
+
+**Interfaces:**
+- Consumes: per-device resolved `{ orgId, siteId }`, device `mac`/`ip`/`name`.
+- Produces: in the device loop, find-or-create a `discovered_assets` row by `(org_id, mac)` then `(org_id, ip_address)`, and set `unifi_device_telemetry.discoveredAssetId`. New helper `linkTelemetryDeviceToAsset(db, orgId, siteId, device): Promise<string | null>`. (Telemetry devices expose IP only inside `raw`; extract `ip` from `raw` when present — UniFi integration device JSON carries `ipAddress`/`ip`. When no IP is available, skip asset creation, matching the cloud path which requires an IP.)
+
+> Note: `unifi_device_telemetry` has no `discovered_asset_id` column today. Add it in a follow-on migration step below so device inventory links the same way clients already do.
+
+- [ ] **Step 1: Migration — add `discovered_asset_id` to `unifi_device_telemetry`**
+
+Append to `apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql`:
+```sql
+-- 3. Link telemetry devices to discovered_assets (inventory parity for self-hosted;
+-- harmless for cloud collectors, which simply leave it null).
+ALTER TABLE unifi_device_telemetry
+  ADD COLUMN IF NOT EXISTS discovered_asset_id uuid REFERENCES discovered_assets(id);
+```
+And in `apps/api/src/db/schema/unifi.ts`, add to `unifiDeviceTelemetry` (after `numClients`):
+```ts
+  discoveredAssetId: uuid('discovered_asset_id').references(() => discoveredAssets.id),
+```
+Run `pnpm db:check-drift` — expect no drift.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `apps/api/src/services/unifi/unifiTelemetryService.test.ts` a test asserting that a device with a mac+ip in `raw` creates/links a `discovered_assets` row and stamps `discoveredAssetId` on the telemetry upsert. Use the existing mock-db harness in that file (follow its established pattern for `select().from().where().limit()` and `insert().values().onConflictDoUpdate()`); assert:
+```ts
+// after reconcileTelemetry with one device { unifiDeviceId:'d1', mac:'AA:BB:CC:00:11:22', raw:{ ipAddress:'10.0.0.5', name:'sw1' } }
+// expect a discoveredAssets insert/update happened with orgId of the resolved site
+// expect the unifiDeviceTelemetry upsert `set`/`values` carried discoveredAssetId
+```
+
+- [ ] **Step 3: Run it — expect failure**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiTelemetryService.test.ts`
+Expected: FAIL — `discoveredAssetId` not set / no asset reconcile.
+
+- [ ] **Step 4: Implement device→asset linking**
+
+In `unifiTelemetryService.ts`, add a helper modeled on `reconcileDiscoveredAsset` from `unifiSyncService.ts` (find by `(org,mac)` then `(org,ip)`, else insert with `onConflictDoUpdate` on `(org_id, ip_address)`; `manufacturer: 'Ubiquiti'`). Extract the IP from the device DTO's `raw` (`raw.ipAddress ?? raw.ip`), skip when absent. Then in the device loop set `discoveredAssetId` on both the insert `values` and the `onConflictDoUpdate` `set`. Keep the asset type mapping minimal (`'access_point' | 'switch' | 'router' | 'firewall' | 'unknown'`) reusing the device `raw.type`/`raw.model` when present, else `'unknown'`.
+
+```ts
+function deviceIp(raw: unknown): string | null {
+  if (raw && typeof raw === 'object') {
+    const r = raw as Record<string, unknown>;
+    const ip = r.ipAddress ?? r.ip;
+    if (typeof ip === 'string' && ip.length > 0) return ip;
+  }
+  return null;
+}
+
+async function linkTelemetryDeviceToAsset(
+  db: DbExecutor,
+  orgId: string,
+  siteId: string,
+  device: TelemetryDeviceDto,
+): Promise<string | null> {
+  const ip = deviceIp(device.raw);
+  if (!ip) return null;
+  const enrich = {
+    macAddress: device.mac ?? undefined,
+    hostname: device.name ?? undefined,
+    manufacturer: 'Ubiquiti',
+    isOnline: true,
+    lastSeenAt: new Date(),
+  };
+  let existing: { id: string } | null = null;
+  if (device.mac) {
+    const byMac = await db.select({ id: discoveredAssets.id }).from(discoveredAssets)
+      .where(and(eq(discoveredAssets.orgId, orgId), eq(discoveredAssets.macAddress, device.mac))).limit(1);
+    existing = byMac[0] ?? null;
+  }
+  if (!existing) {
+    const byIp = await db.select({ id: discoveredAssets.id }).from(discoveredAssets)
+      .where(and(eq(discoveredAssets.orgId, orgId), eq(discoveredAssets.ipAddress, ip))).limit(1);
+    existing = byIp[0] ?? null;
+  }
+  if (existing) {
+    await db.update(discoveredAssets).set(enrich).where(eq(discoveredAssets.id, existing.id));
+    return existing.id;
+  }
+  const inserted = await db.insert(discoveredAssets)
+    .values({ orgId, siteId, ipAddress: ip, ...enrich })
+    .onConflictDoUpdate({ target: [discoveredAssets.orgId, discoveredAssets.ipAddress], set: enrich })
+    .returning({ id: discoveredAssets.id });
+  return inserted[0]?.id ?? null;
+}
+```
+In the device loop (line 76+), after resolving `{ orgId, siteId }`, add `const discoveredAssetId = await linkTelemetryDeviceToAsset(db, orgId, siteId, d);` and include `discoveredAssetId` in both the `values` and the `onConflictDoUpdate` `set`.
+
+- [ ] **Step 5: Run the test — expect pass**
+
+Run: `pnpm --filter @breeze/api exec vitest run src/services/unifi/unifiTelemetryService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-29-b-unifi-self-hosted-collectors-and-sites.sql apps/api/src/db/schema/unifi.ts apps/api/src/services/unifi/unifiTelemetryService.ts apps/api/src/services/unifi/unifiTelemetryService.test.ts
+git commit -m "feat(unifi): reconcile telemetry devices into discovered_assets (inventory parity)"
+```
+
+---
+
+## Phase C — Agent
+
+### Task C1: report discovered sites in the telemetry payload
+
+**Files:**
+- Modify: `agent/internal/unifi/client.go`
+- Modify: `agent/internal/unifi/collector.go`
+- Test: `agent/internal/unifi/client_test.go`, `agent/internal/unifi/collector_test.go`
+
+**Interfaces:**
+- Produces: `Snapshot.Sites []SiteRef` where `type SiteRef struct { ID string; Name string }`; `telemetryPayload.Sites []uploadSite` with JSON `sites: [{ id, name }]`. The agent now reports every site it enumerated even when a site has zero devices/clients, so the server can populate `unifi_controller_sites`.
+
+- [ ] **Step 1: Write the failing client test**
+
+In `agent/internal/unifi/client_test.go`, add a test that stands up an `httptest` server returning two sites (with `name`) from `/proxy/network/integration/v1/sites` and empty device/client arrays, then asserts `snap.Sites` has both site ids and names:
+
+```go
+func TestPoll_ReportsSitesWithNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/sites"):
+			io.WriteString(w, `{"data":[{"id":"s1","name":"HQ"},{"id":"s2","name":"Branch"}]}`)
+		default:
+			io.WriteString(w, `{"data":[]}`)
+		}
+	}))
+	defer srv.Close()
+	c := NewAPIClient(srv.URL, "k", srv.Client())
+	snap, err := c.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(snap.Sites) != 2 || snap.Sites[0].ID != "s1" || snap.Sites[0].Name != "HQ" {
+		t.Fatalf("got sites %+v", snap.Sites)
+	}
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `cd agent && go test -race ./internal/unifi/ -run TestPoll_ReportsSitesWithNames`
+Expected: FAIL — `snap.Sites undefined`.
+
+- [ ] **Step 3: Implement in `client.go`**
+
+Add the type and field, and capture names in `Poll`:
+```go
+type SiteRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+```
+Add `Sites []SiteRef` to `Snapshot`. Change the `sites` decode struct in `Poll` (lines 161-163) to include `Name`, and after decoding, populate `snap.Sites`:
+```go
+	var sites []SiteRef
+	if err := json.Unmarshal(sitesData, &sites); err != nil {
+		return snap, fmt.Errorf("decode sites: %w", err)
+	}
+	snap.Sites = sites
+```
+(The loop below still iterates `sites` by `.ID`; add `.ID` references remain valid since `SiteRef` has `ID`.)
+
+- [ ] **Step 4: Run client test — expect pass**
+
+Run: `cd agent && go test -race ./internal/unifi/ -run TestPoll_ReportsSitesWithNames`
+Expected: PASS.
+
+- [ ] **Step 5: Carry sites into the upload (collector.go)**
+
+In `agent/internal/unifi/collector.go`, add:
+```go
+type uploadSite struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+```
+Add `Sites []uploadSite \`json:"sites,omitempty"\`` to `telemetryPayload`. In `RunOnce`, populate it:
+```go
+	sites := make([]uploadSite, len(snap.Sites))
+	for i, s := range snap.Sites {
+		sites[i] = uploadSite{ID: s.ID, Name: s.Name}
+	}
+	payload := telemetryPayload{
+		CollectorID: cfg.CollectorID,
+		PolledAt:    time.Now().UTC().Format(time.RFC3339),
+		FirmwareOK:  snap.FirmwareOK,
+		Devices:     toUploadDevices(snap.Devices),
+		Clients:     toUploadClients(snap.Clients),
+		Sites:       sites,
+	}
+```
+
+- [ ] **Step 6: Write + run a collector test asserting `sites` is in the posted body**
+
+In `agent/internal/unifi/collector_test.go`, add a test (or extend an existing upload test) that captures the POST body to `/unifi-telemetry` and asserts it contains `"sites":[{"id":"s1"`. Run:
+```bash
+cd agent && go test -race ./internal/unifi/
+```
+Expected: PASS (all unifi package tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/internal/unifi/client.go agent/internal/unifi/collector.go agent/internal/unifi/client_test.go agent/internal/unifi/collector_test.go
+git commit -m "feat(agent): report discovered UniFi sites in telemetry upload"
+```
+
+---
+
+## Phase D — Web UI
+
+### Task D1: connection-type choice + self-hosted connect
+
+**Files:**
+- Modify: `apps/web/src/components/integrations/UnifiIntegration.tsx`
+
+**Interfaces:**
+- Consumes: `GET /unifi` now returns `connectionType`. New `POST /unifi/connect-self-hosted` `{ accountLabel? }`.
+- Produces: connect screen offers **Cloud (Site Manager API key)** vs **Self-hosted controller**; selecting self-hosted + submitting calls `connect-self-hosted` via `runAction` and transitions to the connected (self-hosted) view.
+
+- [ ] **Step 1: Read the current component**
+
+Read `apps/web/src/components/integrations/UnifiIntegration.tsx` fully to learn its state shape (`isConnected`, the connect form at ~523-535, `handleConnect` at ~391, the `runAction` usage, and how `GET /unifi` status is loaded). Match its existing patterns.
+
+- [ ] **Step 2: Add connection-type state + a mode toggle on the connect screen**
+
+In the not-connected branch, add a two-option selector (radio or segmented control) bound to a `connectMode: 'cloud' | 'self_hosted'` state (default `'cloud'`). When `'cloud'`, render the existing API-key form unchanged. When `'self_hosted'`, render an optional **Account label** text input and a **Connect** button. Keep copy concrete: cloud = "Connect your UniFi Site Manager account with a cloud API key"; self-hosted = "Connect a self-hosted UniFi Network controller. A Breeze agent on the controller's network polls it directly — no UniFi cloud account needed."
+
+- [ ] **Step 3: Add the self-hosted connect handler**
+
+Mirror `handleConnect`, wrapping in `runAction`:
+```ts
+async function handleConnectSelfHosted() {
+  await runAction({
+    action: () => fetch('/api/unifi/connect-self-hosted', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountLabel: accountLabel || undefined }),
+    }),
+    successMessage: 'Self-hosted UniFi controller connected',
+  });
+  await reloadStatus(); // existing function that re-fetches GET /unifi
+}
+```
+(Use the file's actual `runAction` signature and status-reload function names discovered in Step 1; the catch pattern from CLAUDE.md applies — let runAction toast non-401 failures.)
+
+- [ ] **Step 4: Branch the connected view on `connectionType`**
+
+Store `connectionType` from `GET /unifi`. When `'self_hosted'`, hide the cloud-only "Sync now"/host-mapping affordances that depend on `api.ui.com`, and show the self-hosted controllers section (Task D2). When `'cloud'`, the existing UI is unchanged.
+
+- [ ] **Step 5: Run the web unit tests**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/integrations/`
+Expected: PASS (existing tests green; add a render test asserting the self-hosted toggle appears when not connected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/integrations/UnifiIntegration.tsx
+git commit -m "feat(web): UniFi connect screen offers self-hosted controller mode"
+```
+
+---
+
+### Task D2: self-hosted controller register + map from controller sites
+
+**Files:**
+- Modify: `apps/web/src/components/integrations/UnifiIntegration.tsx`
+
+**Interfaces:**
+- Consumes: `PUT /unifi/controllers`, `GET /unifi/controller-sites`, `PUT /unifi/mappings` (existing), `GET /devices?limit=500` (existing agent list).
+- Produces: a self-hosted controllers panel: register controller(s) (Controller URL, Collector agent, Local API key), then map each agent-discovered local site → a Breeze site.
+
+- [ ] **Step 1: Controller registration form**
+
+In the self-hosted connected view, render a "Controllers" card with fields: **Controller URL** (`placeholder="https://192.168.1.1"`), **Collector agent** (`<select>` sourced from the existing `agents` list loaded via `GET /devices?limit=500`), **Site this controller serves** (a Breeze `<select>` grouped by org from the existing `sitesByOrg`), and **Local API key** (password). Submit via `runAction` to `PUT /unifi/controllers` with `{ siteId, collectorDeviceId, controllerUrl, apiKey }`. On success, reload controllers + controller-sites.
+
+> The "Site this controller serves" picks the collector's *own* org/site (the fallback used by `reconcileTelemetry` for any site that isn't explicitly mapped). Per-customer sites are mapped in Step 2.
+
+- [ ] **Step 2: Load + render agent-discovered sites for mapping**
+
+Add a fetch of `GET /unifi/controller-sites` into state (`controllerSites: Array<{ collectorId, localSiteId, name, mapped }>`). Render one mapping row per discovered site: show the site name/id, and a Breeze-site `<select>` (grouped by org, from `sitesByOrg`). This replaces the cloud `GET /unifi/hosts` source for self-hosted.
+
+- [ ] **Step 3: Save mappings (reuse existing endpoint, sentinel host id)**
+
+On save, call the existing `PUT /unifi/mappings` with each row mapped as:
+```ts
+{
+  unifiHostId: row.collectorId,   // sentinel: self-hosted has no cloud host
+  unifiSiteId: row.localSiteId,
+  unifiSiteName: row.name ?? undefined,
+  siteId: selectedBreezeSiteId,
+}
+```
+This writes a `unifi_site_mappings` row whose `(integration_id, unifi_host_id=collectorId, unifi_site_id=localSiteId)` is unique, and which `reconcileTelemetry` consumes (it keys the site map on `unifi_site_id`).
+
+- [ ] **Step 4: Empty-state copy**
+
+When `controllerSites` is empty, show: "No sites discovered yet. Once the assigned agent reaches the controller (within ~1 minute), its sites appear here to map." (The agent reports sites on its next poll via Task C1.)
+
+- [ ] **Step 5: Run web tests**
+
+Run: `pnpm --filter @breeze/web exec vitest run src/components/integrations/`
+Expected: PASS. Add a test that, given a mocked `GET /unifi/controller-sites` with one site, the mapping row renders and saving posts the sentinel `unifiHostId`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/integrations/UnifiIntegration.tsx
+git commit -m "feat(web): register self-hosted controllers and map discovered sites"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full API + web + agent test pass**
+
+Run:
+```bash
+pnpm test --filter=@breeze/api
+pnpm test --filter=@breeze/web
+cd agent && go test -race ./... && cd ..
+```
+Expected: all green.
+
+- [ ] **Step 2: RLS contract + drift**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:check-drift
+pnpm --filter @breeze/api exec vitest run --config vitest.config.rls.ts src/__tests__/integration/rls-coverage.integration.test.ts
+```
+Expected: no drift; RLS coverage passes including `unifi_controller_sites`.
+
+- [ ] **Step 3: Manual end-to-end smoke (optional, needs a controller or a stub)**
+
+Connect a self-hosted integration, register a controller pointed at a UniFi Network integration API (or a stub returning `/sites`, `/sites/:id/devices`, `/sites/:id/clients`), confirm: collector status flips to `connected`, discovered sites appear under controller-sites, a mapped site routes device telemetry + a `discovered_assets` row to the right org, and `unifi_device_telemetry`/`unifi_clients` populate.
+
+---
+
+## Self-review notes (coverage vs spec)
+
+- **`connection_type` discriminator** → Task A1. ✅
+- **Nullable host id + revised indexes** → Task A2. ✅
+- **`unifi_controller_sites` + RLS** → Task A3. ✅
+- **Self-hosted connect (no cloud key)** → Task B1. ✅
+- **Controller registration fanning to many sites** → Task B2 (one collector per controller) + D2 (many mappings). ✅
+- **Agent multi-site discovery + `local_site_id` tagging** → already present (`client.go` Poll tags `SiteID`, `collector.go` uploads `unifiSiteId`); only the empty-site discovery list is added → Task C1. ✅
+- **Server inventory reconcile + telemetry routing** → routing already in `reconcileTelemetry` (keys on `unifiSiteId`); device→`discovered_assets` parity added in Task B4. ✅
+- **UI: connection-type choice, self-hosted register, mapping from controller sites** → Tasks D1, D2. ✅
+- **Tenancy/security** → partner-scoped routes preserved; org-axis RLS on new table; ownership gate in ingest unchanged; agent self-signed TLS + redirect-refusal unchanged. ✅
+- **Non-goals** (mixed mode, collector HA) → not implemented, by design. ✅

--- a/docs/superpowers/specs/2026-06-29-unifi-self-hosted-controller-design.md
+++ b/docs/superpowers/specs/2026-06-29-unifi-self-hosted-controller-design.md
@@ -1,0 +1,112 @@
+# UniFi Self-Hosted Controller Support — Design
+
+**Date:** 2026-06-29
+**Status:** Draft (design)
+**Related:** `2026-06-28-unifi-network-integration-design.md` (Phase 1 cloud inventory), `2026-06-29-unifi-phase2a-agent-telemetry-design.md` (Phase 2a agent telemetry)
+
+## Problem
+
+The UniFi integration as shipped assumes **cloud-registered UniFi-OS consoles**. Both the inventory path and the deep-telemetry path are anchored to a `unifi_host_id` that originates exclusively from Ubiquiti's Site Manager cloud (`https://api.ui.com/v1/hosts`, see `apps/api/src/services/unifi/unifiClient.ts:87`). This excludes a common MSP topology:
+
+> A single **self-hosted UniFi Network application** running in one VM, with each customer represented as a *site* inside that one controller.
+
+Two independent walls block that topology today:
+
+1. **A self-hosted controller is never listed as a host.** Site Manager (`api.ui.com`) only returns cloud-adopted UniFi-OS consoles. A self-hosted software controller is, per the Phase-1 spec, explicitly out of scope: *"Self-hosted (non-UniFi-OS) Network Applications are not reachable via Site Manager; they are out of scope and surfaced as such in the UI"* (`2026-06-28-unifi-network-integration-design.md:35`). With zero hosts, the "Deep telemetry collectors" card never renders — it is gated on `hosts.length > 0` (`apps/web/src/components/integrations/UnifiIntegration.tsx:712`).
+
+2. **One controller can only map to one site.** `unifi_collectors` has `unifi_host_id text NOT NULL` (`apps/api/src/db/schema/unifi.ts:114`) and a unique index `unifi_collectors_integration_host_idx` on `(integration_id, unifi_host_id)` (`schema/unifi.ts:129`). The upsert keys on exactly that tuple (`apps/api/src/services/unifi/unifiCollectorService.ts:91-92`), so a second collector for the same controller overwrites the first. A single VM = a single (at most) host id, so it cannot fan out to many customer sites.
+
+The pieces that *would* scale already work: one agent can back many collectors (no unique constraint on `collector_device_id`; `listCollectorsForDevice` returns an array — `unifiCollectorService.ts:119-137`), and the agent loop iterates all assigned collectors (`agent/internal/unifi/collector.go:170`). The bottleneck is the host-centric config/discovery model upstream.
+
+## Goal
+
+Let a partner register a **self-hosted UniFi controller** by URL + collector agent + local API key, with **no cloud (`api.ui.com`) involvement**, and have that one controller fan out to **many customer sites and orgs**. The agent — the only component that reaches the controller, over the LAN — delivers **both inventory and deep telemetry**, achieving full parity with the cloud path.
+
+### Non-goals
+
+- **Mixed mode** (a single partner integration holding *both* cloud-adopted consoles *and* a self-hosted VM at the same time). One `connection_type` per integration. Revisit only if a real need appears.
+- **Collector HA / failover** (multiple agents polling the same controller). One collector agent per controller for now.
+- Changing the cloud path's behavior. Cloud integrations continue to work exactly as today.
+
+## Approach
+
+Extend the **existing** UniFi integration with a connection-type discriminator rather than introducing a parallel "self-hosted controller" subsystem. This reuses the agent collector loop, the telemetry ingest pipeline, the `discovered_assets` reconciliation, and the integrations UI — swapping only the host-id-keyed assumptions for controller-id-keyed ones.
+
+## Data model
+
+### `unifi_integrations`
+- Add `connection_type text NOT NULL DEFAULT 'cloud'` — allowed values `'cloud' | 'self_hosted'`.
+- For `self_hosted`, the cloud fields (`base_url`, `api_key_encrypted`) are unused; make them nullable. (They are currently `base_url text default 'https://api.ui.com'` and `api_key_encrypted text not null` — `schema/unifi.ts:25,30`. The migration relaxes `api_key_encrypted` to nullable and adds a `CHECK` that it is non-null when `connection_type = 'cloud'`.)
+- Remains **partner-scoped** (one active row per partner; `requireScope('partner','system')`, `routes/unifi/index.ts:37`).
+
+### `unifi_collectors` (becomes the controller registration for self-hosted)
+- Make `unifi_host_id` **nullable** (currently `NOT NULL`, `schema/unifi.ts:114`). Null = self-hosted controller; non-null = cloud console (unchanged).
+- Replace the unconditional unique index `(integration_id, unifi_host_id)` with a **partial** unique index `WHERE unifi_host_id IS NOT NULL` (preserves the cloud invariant only).
+- Add a partial unique index `(integration_id, controller_url) WHERE unifi_host_id IS NULL` to prevent registering the same self-hosted controller twice.
+- For self-hosted, **one row = one VM** (one controller), not one-per-site. Existing columns reused: `collector_device_id`, `controller_url`, `local_api_key_encrypted`, `poll_interval_seconds`, status fields.
+
+### `unifi_controller_sites` (new)
+The agent enumerates the controller's local sites so the UI has something to map.
+- Columns: `id`, `collector_id` (FK → `unifi_collectors`), `local_site_id` (the controller's site id), `name`, `last_seen_at`, timestamps.
+- Unique `(collector_id, local_site_id)`. Upserted by the server from the agent's reported site list.
+- Tenancy shape: scoped through `collector_id → integration → partner`. Add to `PARTNER_TENANT_TABLES` (or the appropriate shape) in `rls-coverage.integration.test.ts` with policies created in the same migration. (See CLAUDE.md RLS workflow.)
+
+### `unifi_site_mappings`
+- Today keyed on cloud `unifi_host_id` + `unifi_site_id` → Breeze `site_id`. Extend so that when `unifi_host_id` is null, the mapping keys on `(collector_id, local_site_id) → site_id`.
+- Add nullable `collector_id` and `local_site_id` columns; a `CHECK` enforces exactly one of {cloud host/site pair, self-hosted collector/local-site pair} is populated.
+- Mapping a local site to a Breeze site **auto-assigns the org** (site → org), which is the mechanism that lets one MSP controller cleanly span many customers.
+
+## Agent changes (`agent/internal/unifi`)
+
+The agent is ~90% there. `collector.go:170` already iterates all assigned collectors; `client.go` already polls `/sites`, `/sites/{id}/devices`, `/sites/{id}/clients` over self-signed TLS with redirect refusal.
+
+Changes:
+1. **Self-hosted collector (no host id):** enumerate **all** sites on the controller and include the full discovered-site list (id + name) in the upload, so the server can populate `unifi_controller_sites`.
+2. **Tag rows with `local_site_id`:** every device/client/telemetry row carries its `local_site_id` so the server routes it to the correct mapping/org.
+3. No new static config on the agent — it continues to fetch assignments from `GET /agents/:id/unifi-collectors` and post to `POST /agents/:id/unifi-telemetry` (`routes/agents/unifiTelemetry.ts`). The collector config payload gains a flag/marker that this is a self-hosted controller (host id absent) so the agent knows to enumerate all sites.
+
+## Server ingest = full parity
+
+Extend the telemetry ingest worker so that for self-hosted uploads it additionally:
+1. **Upserts `unifi_controller_sites`** from the reported site list (drives the mapping UI).
+2. **Reconciles devices into `discovered_assets`**, reusing the cloud `reconcileDiscoveredAsset()` logic (`apps/api/src/services/unifi/unifiSyncService.ts:64+`) — match by MAC/IP within the mapped org, upsert, mark stale on disappearance.
+3. **Routes telemetry and clients** to the correct org/site via the `(collector_id, local_site_id)` mapping.
+
+Net result: a self-hosted controller populates **both** inventory (`discovered_assets`, plus the UniFi device/client tables) **and** deep telemetry, each routed to the right customer org.
+
+Ingest must continue to enforce that the posting agent owns the collector — `getCollectorOwnerDeviceId` already does this (`unifiCollectorService.ts:143`). Self-hosted changes nothing about that check.
+
+## UI (`/integrations` → UniFi tab)
+
+`apps/web/src/components/integrations/UnifiIntegration.tsx` (partner-scoped; org-scoped users see the "partner accounts only" message — `IntegrationsPage.tsx:267-273`).
+
+- **Connect step** gains a choice: **Cloud (Site Manager API key)** vs **Self-hosted controller**.
+- **Self-hosted flow:** register a controller (Controller URL, Collector agent dropdown, Local API key — no cloud key). The agent's discovered sites then populate the mapping card.
+- **Mapping card:** same UX as cloud, but sourced from `unifi_controller_sites` (agent-discovered) instead of cloud `/v1/sites`. Map each local site → Breeze site (→ org).
+- For self-hosted, deep telemetry is **inherent**, not a separately gated card. The existing `hosts.length > 0` gate (`UnifiIntegration.tsx:712`) is replaced by a connection-type-aware condition.
+
+## Tenancy / security
+
+- Integration stays **partner-scoped**; site mappings fan out across multiple orgs; telemetry and inventory rows resolve their owning org through the mapping. No cross-tenant leakage provided ingest validates collector ownership (already enforced).
+- `unifi_controller_sites` and any new columns get RLS policies in the same migration, with allowlist entries in `rls-coverage.integration.test.ts` (CLAUDE.md RLS workflow). Verify a cross-tenant insert fails as `breeze_app`.
+- Local API key stored encrypted with the existing `aad` pattern (`unifiConnectionService.ts:92` style), pushed only to the assigned agent (existing collector-config delivery).
+- Agent → local controller already uses `InsecureSkipVerify` for self-signed console certs plus explicit redirect refusal to prevent key leakage via SSRF (`client.go:88-101`). Unchanged.
+
+## Migration notes
+
+- Date-prefixed, idempotent migration(s) per CLAUDE.md. If altering `unifi_collectors` constraints and adding `unifi_controller_sites` in dependent steps on the same day, use `-a-` / `-b-` infixes.
+- Dropping/recreating the `(integration_id, unifi_host_id)` unique index as a partial index must be idempotent (`DROP INDEX IF EXISTS` then `CREATE UNIQUE INDEX IF NOT EXISTS ... WHERE ...`).
+- Relaxing `unifi_integrations.api_key_encrypted` to nullable + adding the `connection_type` CHECK must tolerate existing cloud rows (all have a key and default `connection_type='cloud'`).
+
+## Phasing
+
+Single spec; implementable in sequence:
+1. Schema: `connection_type`, nullable host id + revised indexes, `unifi_controller_sites`, mapping columns + RLS.
+2. Controller registration API + service (reuse `PUT /unifi/collectors`, drop the host-id requirement for self-hosted).
+3. Agent: multi-site discovery + `local_site_id` tagging.
+4. Server ingest: controller-site upsert + `discovered_assets` reconcile + telemetry routing.
+5. UI: connection-type choice, self-hosted register flow, mapping sourced from controller sites.
+
+## Open questions
+
+- None blocking. Mixed-mode and collector HA are deliberately deferred (see Non-goals).


### PR DESCRIPTION
## Summary

Adds support for a **self-hosted UniFi Network controller** (one VM serving many customer sites) to the UniFi integration. Previously the integration only worked with cloud-registered (api.ui.com Site Manager) consoles, which excludes the common MSP topology of one self-hosted controller with each customer as a *site* inside it. This routes a self-hosted controller entirely through a Breeze agent on the controller's LAN — no UniFi cloud key — and fans that one controller out to many customer orgs for both **inventory and deep telemetry**.

Spec: `docs/superpowers/specs/2026-06-29-unifi-self-hosted-controller-design.md`
Plan: `docs/superpowers/plans/2026-06-29-unifi-self-hosted-controller.md`

## End-to-end flow
1. Partner connects a `self_hosted` integration (no cloud key) — `POST /unifi/connect-self-hosted`.
2. Registers a controller (LAN URL + collector agent + local API key) — `PUT /unifi/controllers` → one `unifi_collectors` row with NULL `unifi_host_id`.
3. The agent polls the local controller, reports all sites (id+name) and per-site devices/clients — `POST /agents/:id/unifi-telemetry`.
4. Server upserts discovered sites into `unifi_controller_sites`, routes telemetry to the right Breeze site/org, and reconciles devices into `discovered_assets` (inventory parity).
5. Partner maps each agent-discovered local site → a Breeze site in the UI (sentinel mapping `unifi_host_id = collectorId`, since self-hosted has no cloud host id).

## Data model
- `unifi_integrations.connection_type` (`'cloud' | 'self_hosted'`); cloud key nullable, guarded by a CHECK.
- `unifi_collectors.unifi_host_id` nullable; disjoint partial unique indexes (cloud host-keyed vs self-hosted URL-keyed) so the two types can't collide.
- New `unifi_controller_sites` table (agent-discovered sites) with forced org-axis RLS.
- `unifi_device_telemetry.discovered_asset_id` link column.

## Backward compatibility / deploy
- Existing cloud integrations are unaffected (`connection_type` defaults `'cloud'`; cloud collectors keep their host-keyed index and UI card).
- Migrations are idempotent and auto-applied by `autoMigrate`. **No new required env vars.**
- The agent change is backward-compatible (`sites` is `omitempty`; older agents/cloud collectors never send it).

## Design decision to confirm before/after merge
Devices on a self-hosted site that **isn't mapped yet** fall back to the controller's registration org/site (as the plan specified). For a one-customer controller this is fine; for the many-customers-per-controller model, unmapped sites' devices are attributed to the registration customer until mapped. Open to switching to "skip unmapped self-hosted sites" if preferred — happy to do it here or as a follow-up.

## Notable fixes made during review
- Migration ordering: renamed the self-hosted migration to sort **after** `unifi-phase2a` (avoids ALTER-before-CREATE on a from-empty DB).
- `upsertConnection` now stamps `connectionType='cloud'` on its conflict path (prevents a self_hosted→cloud reconnect from keeping the wrong type).
- **Multi-controller telemetry isolation:** `reconcileTelemetry` now scopes its site-mapping lookup to the posting controller (`hostKey = collector.unifiHostId ?? collector.id`) instead of keying on local site id across the whole integration — fixes potential wrong-org attribution when two self-hosted controllers share a `"default"` site.

## Test plan
- API: unifi services/routes/agents/worker — 77/77.
- Web: integrations + no-silent-mutations — 158/158; `astro check` 0 errors.
- Go agent: `go test -race ./internal/unifi/` green.
- DB (live stack): migrations apply cleanly + correct order (autoMigrate ordering 43/43), drift clean, RLS coverage 50/50, cross-tenant forge on `unifi_controller_sites` rejected as `breeze_app`.

## Follow-ups (non-blocking, logged in review)
- `linkTelemetryDeviceToAsset` matches `discovered_assets` on raw MAC while the telemetry client path normalizes — worth a normalization pass to avoid dup assets.
- Minor UI polish (per-row test-id, empty-state load flash, save-button icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)