### PR TITLE
fix(unifi): correct cloud Site Manager API integration (parsing, paths, mapping UX, safe replace-all)

### DIFF
--- a/apps/api/src/routes/unifi/index.test.ts
+++ b/apps/api/src/routes/unifi/index.test.ts
@@ -287,6 +287,13 @@ describe('unifi routes', () => {
     vi.mocked(db.insert).mockReturnValueOnce({
       values: valuesMock,
     } as any);
+    // Replace-all step: existing-mappings read returns exactly the submitted row, so
+    // the complement is empty and nothing is deleted.
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [{ id: 'existing-1', unifiHostId: 'host-1', unifiSiteId: 'site-1' }]),
+      })),
+    } as any);
 
     const res = await unifiRoutes.request('/mappings', {
       method: 'PUT',
@@ -305,6 +312,188 @@ describe('unifi routes', () => {
     await expect(res.json()).resolves.toMatchObject({ success: true });
     expect(db.insert).toHaveBeenCalled();
     expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_ID }));
+    // Nothing stale → no delete.
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('PUT /mappings replaces all — deletes saved mappings absent from the payload', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    // Site lookup for the single submitted mapping.
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => [{ id: SITE_ID, orgId: ORG_ID }]) })),
+      })),
+    } as any);
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(async () => undefined) })),
+    } as any);
+    // Existing rows: the submitted one (keep) + a stale "undefined" row on the SAME
+    // enumerated host (must delete).
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          { id: 'keep-1', orgId: ORG_ID, siteId: SITE_ID, unifiHostId: 'host-1', unifiSiteId: 'site-1' },
+          { id: 'stale-1', orgId: ORG_ID, siteId: SITE_ID, unifiHostId: 'host-1', unifiSiteId: 'undefined' },
+        ]),
+      })),
+    } as any);
+    const deleteWhere = vi.fn(async () => undefined);
+    vi.mocked(db.delete).mockReturnValueOnce({ where: deleteWhere } as any);
+
+    const res = await unifiRoutes.request('/mappings', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mappings: [{ unifiHostId: 'host-1', unifiSiteId: 'site-1', siteId: SITE_ID }],
+        hostIds: ['host-1'],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('PUT /mappings does NOT delete mappings for hosts absent from hostIds (transient-host guard)', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => [{ id: SITE_ID, orgId: ORG_ID }]) })),
+      })),
+    } as any);
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(async () => undefined) })),
+    } as any);
+    // host-2 has a saved mapping but was NOT enumerated this save (offline/absent) —
+    // it must survive even though it's absent from the submitted set.
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          { id: 'keep-1', orgId: ORG_ID, siteId: SITE_ID, unifiHostId: 'host-1', unifiSiteId: 'site-1' },
+          { id: 'survivor', orgId: ORG_ID, siteId: SITE_ID, unifiHostId: 'host-2', unifiSiteId: 'site-2' },
+        ]),
+      })),
+    } as any);
+    vi.mocked(db.delete).mockReturnValueOnce({ where: vi.fn(async () => undefined) } as any);
+
+    const res = await unifiRoutes.request('/mappings', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mappings: [{ unifiHostId: 'host-1', unifiSiteId: 'site-1', siteId: SITE_ID }],
+        hostIds: ['host-1'], // host-2 deliberately not enumerated
+      }),
+    });
+    expect(res.status).toBe(200);
+    // host-1's set is unchanged and host-2 is out of scope → nothing to delete.
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('PUT /mappings with no hostIds is upsert-only — never deletes (safe fallback)', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => [{ id: SITE_ID, orgId: ORG_ID }]) })),
+      })),
+    } as any);
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(async () => undefined) })),
+    } as any);
+
+    const res = await unifiRoutes.request('/mappings', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mappings: [{ unifiHostId: 'host-1', unifiSiteId: 'site-1', siteId: SITE_ID }],
+        // no hostIds
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('PUT /mappings rejects a literal "undefined" unifiSiteId (the parse-bug guard)', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    const res = await unifiRoutes.request('/mappings', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mappings: [{ unifiHostId: 'host-1', unifiSiteId: 'undefined', siteId: SITE_ID }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    // Must never reach the DB write with a poisoned site id.
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('PUT /mappings also rejects a literal "null" and a poisoned unifiHostId', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    for (const bad of [
+      { unifiHostId: 'host-1', unifiSiteId: 'null', siteId: SITE_ID },
+      { unifiHostId: 'undefined', unifiSiteId: 'site-1', siteId: SITE_ID },
+    ]) {
+      const res = await unifiRoutes.request('/mappings', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mappings: [bad] }),
+      });
+      expect(res.status).toBe(400);
+    }
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it('POST /sync returns 400 when not connected', async () => {
@@ -394,7 +583,7 @@ describe('unifi routes', () => {
     vi.mocked(svc.getDecryptedApiKey).mockResolvedValue('some-key');
     const { createUnifiClient } = await import('../../services/unifi/unifiClient');
     vi.mocked(createUnifiClient).mockReturnValueOnce({
-      listHosts: vi.fn(async () => [{ id: 'host-1', name: 'My Host' }]),
+      listHosts: vi.fn(async () => [{ id: 'host-1', name: 'My Host', type: 'console', model: 'UDM Pro' }]),
       listSites: vi.fn(async () => [{ id: 'usite-1', name: 'My Site', hostId: 'host-1' }]),
       listDevices: vi.fn(async () => []),
       getIspMetrics: vi.fn(async () => null),
@@ -402,8 +591,42 @@ describe('unifi routes', () => {
     const res = await unifiRoutes.request('/hosts', { method: 'GET' });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({
-      hosts: [{ id: 'host-1', name: 'My Host', sites: [{ id: 'usite-1', name: 'My Site' }] }],
+      hosts: [{ id: 'host-1', name: 'My Host', model: 'UDM Pro', sites: [{ id: 'usite-1', name: 'My Site' }] }],
     });
+  });
+
+  it('GET /hosts returns only mappable consoles — drops non-consoles and console without sites', async () => {
+    vi.mocked(svc.getConnection).mockResolvedValue({
+      id: CONN_ID,
+      partnerId: PARTNER_ID,
+      connectionType: 'cloud',
+      baseUrl: 'https://api.ui.com',
+      accountLabel: null,
+      isActive: true,
+      status: 'connected',
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      lastSyncError: null,
+    });
+    vi.mocked(svc.getDecryptedApiKey).mockResolvedValue('some-key');
+    const { createUnifiClient } = await import('../../services/unifi/unifiClient');
+    vi.mocked(createUnifiClient).mockReturnValueOnce({
+      listHosts: vi.fn(async () => [
+        { id: 'console-1', name: 'Mappable UDM', type: 'console', model: 'UDM Pro' },
+        { id: 'server-1', name: 'Cloud Key', type: 'network-server', model: null }, // non-console → drop
+        { id: 'console-2', name: 'No-site UDM', type: 'console', model: 'UDM SE' },  // no sites → drop
+      ]),
+      listSites: vi.fn(async () => [
+        { id: 'usite-1', name: 'HQ', hostId: 'console-1' },
+        { id: 'usite-2', name: 'Orphan', hostId: 'server-1' },
+      ]),
+      listDevices: vi.fn(async () => []),
+      getIspMetrics: vi.fn(async () => null),
+    });
+    const res = await unifiRoutes.request('/hosts', { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { hosts: Array<{ id: string }> };
+    expect(body.hosts.map((h) => h.id)).toEqual(['console-1']);
   });
 
   // PUT /mappings — cross-org security

--- a/apps/api/src/routes/unifi/index.ts
+++ b/apps/api/src/routes/unifi/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { db } from '../../db';
@@ -43,14 +43,27 @@ const connectSchema = z.object({
   accountLabel: z.string().max(200).optional(),
 });
 
+// Reject the stringified-undefined/null ids that a broken upstream parse used to
+// emit — persisting them yields rows whose id matches no real UniFi host/site, so
+// device grouping and ISP-metric lookups silently return nothing.
+const unifiId = z.string().min(1).refine(
+  (v) => v !== 'undefined' && v !== 'null',
+  { message: 'Invalid UniFi id' },
+);
+
 const mappingsSchema = z.object({
   mappings: z.array(z.object({
-    unifiHostId: z.string().min(1),
-    unifiSiteId: z.string().min(1),
+    unifiHostId: unifiId,
+    unifiSiteId: unifiId,
     unifiHostName: z.string().optional(),
     unifiSiteName: z.string().optional(),
     siteId: z.string().guid(),
   })),
+  // The full set of UniFi host ids the client enumerated in this save. The replace-all
+  // cleanup is scoped to these hosts so a host transiently absent from the live list is
+  // never purged, and a failed/empty host list can't trigger a mass delete. Omitted →
+  // upsert-only (no deletes), preserving safe behavior for callers that don't send it.
+  hostIds: z.array(z.string()).optional(),
 });
 
 const collectorSchema = z.object({
@@ -169,6 +182,8 @@ unifiRoutes.get('/hosts', partnerScopes, readPerm, async (c) => {
   try {
     const client = createUnifiClient({ baseUrl: conn.baseUrl, apiKey });
     const [hosts, allSites] = await Promise.all([client.listHosts(), client.listSites()]);
+    // listSites already drops sites with a malformed id, so this map only ever holds
+    // genuinely mappable sites.
     const sitesByHost = new Map<string, Array<{ id: string; name: string }>>();
     for (const s of allSites) {
       const list = sitesByHost.get(s.hostId) ?? [];
@@ -176,7 +191,12 @@ unifiRoutes.get('/hosts', partnerScopes, readPerm, async (c) => {
       sitesByHost.set(s.hostId, list);
     }
     return c.json({
-      hosts: hosts.map((h) => ({ id: h.id, name: h.name, sites: sitesByHost.get(h.id) ?? [] })),
+      // Only surface mappable consoles: a host must have at least one valid site, and
+      // — when its type is known — be a console (drops cloud keys / non-console hosts).
+      // This stops the UI from offering host×site rows that can only save junk mappings.
+      hosts: hosts
+        .filter((h) => (h.type ?? 'console') === 'console' && (sitesByHost.get(h.id)?.length ?? 0) > 0)
+        .map((h) => ({ id: h.id, name: h.name, model: h.model, sites: sitesByHost.get(h.id) ?? [] })),
     });
   } catch (err) {
     return c.json({ success: false, message: err instanceof Error ? err.message : String(err) }, 502);
@@ -190,7 +210,7 @@ unifiRoutes.put('/mappings', partnerScopes, writePerm, requireMfa(), zValidator(
   if ('error' in partner) return c.json({ error: partner.error }, partner.status);
   const conn = await getConnection(db, partner.partnerId);
   if (!conn) return c.json({ success: false, message: 'Not connected' }, 400);
-  const { mappings } = c.req.valid('json');
+  const { mappings, hostIds } = c.req.valid('json');
   // Resolve + authorize EVERY target site before any write. Doing this inline
   // per-iteration would leave earlier mappings persisted when a later cross-org
   // entry hits the 403, so the client sees a failure on a partially-applied batch.
@@ -222,6 +242,46 @@ unifiRoutes.put('/mappings', partnerScopes, writePerm, requireMfa(), zValidator(
         updatedAt: new Date(),
       },
     });
+  }
+  // Replace-all cleanup, scoped to the hosts the client actually enumerated (hostIds).
+  // For each of those hosts, any saved mapping no longer in the submitted set is stale
+  // and removed — this is how poisoned rows (e.g. a legacy unifi_site_id of "undefined")
+  // self-heal when the user re-saves that host. Crucially we DON'T touch mappings for
+  // hosts absent from hostIds: a console transiently missing from the live UniFi list
+  // (or an empty/failed list) must never trigger a destructive delete. unifi_devices
+  // cascade on a mapping delete (FK onDelete: cascade).
+  const hostScope = new Set(hostIds ?? []);
+  if (hostScope.size > 0) {
+    const submitted = new Set(resolved.map(({ m }) => `${m.unifiHostId}::${m.unifiSiteId}`));
+    const existing = await db
+      .select({
+        id: unifiSiteMappings.id,
+        orgId: unifiSiteMappings.orgId,
+        siteId: unifiSiteMappings.siteId,
+        unifiHostId: unifiSiteMappings.unifiHostId,
+        unifiSiteId: unifiSiteMappings.unifiSiteId,
+      })
+      .from(unifiSiteMappings)
+      .where(eq(unifiSiteMappings.integrationId, conn.id));
+    // Only delete rows the caller is actually authorized to modify: scoped to an
+    // enumerated host, deselected, and passing the same org + site-axis gates that
+    // GET /mappings applies on read. Without the site-axis check a site-restricted
+    // caller could wipe mappings they can't even see.
+    const siteGate = auth.canAccessSite;
+    const staleIds = existing
+      .filter((row) =>
+        hostScope.has(row.unifiHostId)
+        && !submitted.has(`${row.unifiHostId}::${row.unifiSiteId}`)
+        && auth.canAccessOrg(row.orgId)
+        && (!siteGate || siteGate(row.siteId)),
+      )
+      .map((row) => row.id);
+    if (staleIds.length > 0) {
+      console.warn(`[unifi] mappings replace-all: removing ${staleIds.length} stale mapping(s) for integration ${conn.id}`);
+      await db
+        .delete(unifiSiteMappings)
+        .where(and(eq(unifiSiteMappings.integrationId, conn.id), inArray(unifiSiteMappings.id, staleIds)));
+    }
   }
   return c.json({ success: true });
 });

--- a/apps/api/src/services/unifi/unifiClient.test.ts
+++ b/apps/api/src/services/unifi/unifiClient.test.ts
@@ -6,16 +6,48 @@ function jsonResponse(body: unknown, status = 200, headers: Record<string, strin
 }
 
 describe('unifiClient', () => {
-  it('sends X-API-KEY and parses the {data} envelope for listHosts', async () => {
+  it('sends X-API-KEY and hits /v1/hosts for listHosts', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
-      jsonResponse({ data: [{ id: 'h1', name: 'Console 1' }] })
+      jsonResponse({ data: [{ id: 'h1', reportedState: { name: 'Console 1' } }] })
     );
     const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
     const hosts = await client.listHosts();
-    expect(hosts).toEqual([{ id: 'h1', name: 'Console 1' }]);
+    expect(hosts).toEqual([{ id: 'h1', name: 'Console 1', type: null, model: null }]);
     const [url, init] = fetchImpl.mock.calls[0]!;
     expect(url).toBe('https://api.ui.com/v1/hosts');
     expect((init.headers as Record<string, string>)['X-API-KEY']).toBe('k');
+  });
+
+  it('reads the console name from reportedState, not a non-existent top-level name', async () => {
+    // Real Site Manager /v1/hosts puts the user-facing name under reportedState;
+    // falling back to the host id here is what produced the "cryptic host IDs" report.
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+      { id: 'h1', reportedState: { name: 'Front Office UDM' } },
+      { id: 'h2', reportedState: { hostname: 'udm-pro' } },
+      { id: 'h3', reportedState: { hardware: { name: 'UDM Pro Max' } } },
+      { id: 'h4' },
+    ] }));
+    const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+    const hosts = await client.listHosts();
+    expect(hosts.map((h) => ({ id: h.id, name: h.name }))).toEqual([
+      { id: 'h1', name: 'Front Office UDM' },
+      { id: 'h2', name: 'udm-pro' },
+      { id: 'h3', name: 'UDM Pro Max' },
+      { id: 'h4', name: 'h4' },
+    ]);
+  });
+
+  it('surfaces host type and hardware model for the mapping UI', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+      { id: 'h1', type: 'console', reportedState: { name: 'UDM', hardware: { name: 'UDM Pro Max', shortname: 'UDMPROMAX' } } },
+      { id: 'h2', type: 'network-server', reportedState: { name: 'Cloud Key' } },
+    ] }));
+    const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+    const hosts = await client.listHosts();
+    expect(hosts).toEqual([
+      { id: 'h1', name: 'UDM', type: 'console', model: 'UDM Pro Max' },
+      { id: 'h2', name: 'Cloud Key', type: 'network-server', model: null },
+    ]);
   });
 
   it('throws UnifiApiError on a non-ok HTTP status', async () => {
@@ -28,10 +60,10 @@ describe('unifiClient', () => {
   it('retries on 429 then succeeds', async () => {
     const fetchImpl = vi.fn()
       .mockResolvedValueOnce(jsonResponse({ message: 'rate limited' }, 429, { 'retry-after': '2' }))
-      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 'h1', name: 'Console 1' }] }));
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 'h1', reportedState: { name: 'Console 1' } }] }));
     const sleepImpl = vi.fn(async () => undefined);
     const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl, sleepImpl });
-    await expect(client.listHosts()).resolves.toEqual([{ id: 'h1', name: 'Console 1' }]);
+    await expect(client.listHosts()).resolves.toEqual([{ id: 'h1', name: 'Console 1', type: null, model: null }]);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(sleepImpl).toHaveBeenCalledTimes(1);
     expect(sleepImpl).toHaveBeenCalledWith(2000);
@@ -49,27 +81,157 @@ describe('unifiClient', () => {
   it('falls back to default delay when Retry-After is absent', async () => {
     const fetchImpl = vi.fn()
       .mockResolvedValueOnce(jsonResponse({ message: 'rate limited' }, 429))
-      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 'h1', name: 'Console 1' }] }));
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 'h1', reportedState: { name: 'Console 1' } }] }));
     const sleepImpl = vi.fn(async () => undefined);
     const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl, sleepImpl });
-    await expect(client.listHosts()).resolves.toEqual([{ id: 'h1', name: 'Console 1' }]);
+    await expect(client.listHosts()).resolves.toEqual([{ id: 'h1', name: 'Console 1', type: null, model: null }]);
     expect(sleepImpl).toHaveBeenCalledTimes(1);
     expect(sleepImpl).toHaveBeenCalledWith(1000);
   });
 
-  it('maps a raw device payload to UnifiDeviceDto and preserves raw', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [{
-      id: 'd1', mac: 'aa:bb', name: 'AP-1', model: 'U6-Pro', type: 'uap',
-      ipAddress: '10.0.0.5', firmwareVersion: '6.6.0', firmwareUpdatable: true,
-      state: 'CONNECTED', uptime: 1234,
-    }] }));
-    const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
-    const dev = (await client.listDevices('h1'))[0]!;
-    expect(dev.unifiDeviceId).toBe('d1');
-    expect(dev.mac).toBe('aa:bb');
-    expect(dev.deviceType).toBe('uap');
-    expect(dev.uptimeSeconds).toBe(1234);
-    expect(dev.raw).toMatchObject({ id: 'd1', model: 'U6-Pro' });
+  describe('listSites', () => {
+    it('parses siteId + meta.name from the real /v1/sites shape (the "undefined" blocker)', async () => {
+      // Site Manager /v1/sites has NO top-level id/name — only siteId, hostId, and
+      // meta.name. The old String(s.id) parse produced unifi_site_id="undefined".
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { siteId: 'site-abc', hostId: 'h1', meta: { name: 'Default', desc: 'Main' }, statistics: {} },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const sites = await client.listSites();
+      expect(sites).toEqual([{ id: 'site-abc', hostId: 'h1', name: 'Default' }]);
+      expect(fetchImpl.mock.calls[0]![0]).toBe('https://api.ui.com/v1/sites');
+    });
+
+    it('never emits an "undefined"/empty site id, dropping malformed rows', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { siteId: 'good', hostId: 'h1', meta: { name: 'Good' } },
+        { hostId: 'h1', meta: { name: 'Missing siteId' } }, // no siteId → must be dropped
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const sites = await client.listSites();
+      expect(sites).toEqual([{ id: 'good', hostId: 'h1', name: 'Good' }]);
+      expect(sites.every((s) => s.id && s.id !== 'undefined')).toBe(true);
+    });
+
+    it('falls back to the siteId for the display name when meta.name is absent', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { siteId: 'site-xyz', hostId: 'h1', meta: {} },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const sites = await client.listSites();
+      expect(sites).toEqual([{ id: 'site-xyz', hostId: 'h1', name: 'site-xyz' }]);
+    });
+  });
+
+  describe('listDevices', () => {
+    it('fetches /v1/devices and returns only the requested host group', async () => {
+      // The cloud API has no /v1/hosts/{id}/devices endpoint — that 404'd ("non-JSON").
+      // /v1/devices returns every host's devices grouped; we filter to the one host.
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'h1', hostName: 'Console 1', devices: [
+          { id: 'aa:bb:cc:dd:ee:01', mac: 'aa:bb:cc:dd:ee:01', name: 'AP-1', model: 'U6-Pro', status: 'online', version: '6.6.0', firmwareStatus: 'upToDate', productLine: 'network' },
+        ] },
+        { hostId: 'h2', hostName: 'Console 2', devices: [
+          { id: 'aa:bb:cc:dd:ee:99', mac: 'aa:bb:cc:dd:ee:99', name: 'Other', model: 'USW' },
+        ] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const devices = await client.listDevices('h1');
+      expect(fetchImpl.mock.calls[0]![0]).toBe('https://api.ui.com/v1/devices');
+      expect(devices).toHaveLength(1);
+      const dev = devices[0]!;
+      expect(dev.unifiDeviceId).toBe('aa:bb:cc:dd:ee:01');
+      expect(dev.mac).toBe('aa:bb:cc:dd:ee:01');
+      expect(dev.name).toBe('AP-1');
+      expect(dev.model).toBe('U6-Pro');
+      expect(dev.firmwareVersion).toBe('6.6.0');
+      expect(dev.firmwareUpdatable).toBe(false);
+      expect(dev.adoptionState).toBe('online');
+      expect(dev.raw).toMatchObject({ id: 'aa:bb:cc:dd:ee:01', model: 'U6-Pro' });
+    });
+
+    it('derives firmwareUpdatable from an "upgradable" firmwareStatus', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'h1', devices: [{ id: 'd1', mac: 'd1', firmwareStatus: 'upgradable' }] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const dev = (await client.listDevices('h1'))[0]!;
+      expect(dev.firmwareUpdatable).toBe(true);
+    });
+
+    it('throws when the host is absent from the grouped payload (not an empty host)', async () => {
+      // Absent host must error so the sync routes it to the per-mapping failure path
+      // and skips the stale-sweep — returning [] would unlink still-good devices.
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'other', devices: [{ id: 'd1', mac: 'd1' }] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      await expect(client.listDevices('h1')).rejects.toMatchObject({ name: 'UnifiApiError', status: 404 });
+    });
+
+    it('returns [] when the host is present but has zero devices', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'h1', devices: [] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      await expect(client.listDevices('h1')).resolves.toEqual([]);
+    });
+
+    it('drops a device with neither id nor mac instead of writing an "undefined" id', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'h1', devices: [{ id: 'good', mac: 'good' }, { name: 'no-identity' }] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const devices = await client.listDevices('h1');
+      expect(devices.map((d) => d.unifiDeviceId)).toEqual(['good']);
+    });
+
+    it('returns null firmwareUpdatable for an unknown firmwareStatus', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { hostId: 'h1', devices: [{ id: 'd1', mac: 'd1', firmwareStatus: 'checking' }] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const dev = (await client.listDevices('h1'))[0]!;
+      expect(dev.firmwareUpdatable).toBeNull();
+    });
+  });
+
+  describe('getIspMetrics', () => {
+    it('hits /v1/isp-metrics/{type} and selects the entry for the site', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [
+        { siteId: 'other', periods: [] },
+        { siteId: 'site-abc', periods: [
+          { metricTime: '2026-06-30T00:00:00Z', data: { wan: { avgLatency: 12, packetLoss: 0.5, uptime: 99.9, ispName: 'Comcast' } } },
+        ] },
+      ] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const metrics = await client.getIspMetrics('site-abc');
+      expect(fetchImpl.mock.calls[0]![0]).toBe('https://api.ui.com/v1/isp-metrics/5m');
+      expect(metrics).toMatchObject({ latencyMs: 12, packetLoss: 0.5, uptimePercent: 99.9, isp: 'Comcast' });
+      expect(metrics!.raw).toMatchObject({ siteId: 'site-abc' });
+    });
+
+    it('returns an all-null sample (not null) when the matched site has zero periods', async () => {
+      // We found the site but it has no WAN samples yet — distinct from "site not found".
+      // raw is still the entry so wan_metrics records the (empty) sample.
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [{ siteId: 'site-abc', periods: [] }] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      const metrics = await client.getIspMetrics('site-abc');
+      expect(metrics).toMatchObject({ latencyMs: null, packetLoss: null, uptimePercent: null, isp: null });
+      expect(metrics!.raw).toMatchObject({ siteId: 'site-abc' });
+    });
+
+    it('returns null when the site has no metrics entry', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [{ siteId: 'other', periods: [] }] }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      await expect(client.getIspMetrics('site-abc')).resolves.toBeNull();
+    });
+
+    it('returns null on an explicit data:null envelope', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: null }));
+      const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
+      await expect(client.getIspMetrics('s1')).resolves.toBeNull();
+    });
   });
 
   it('throws UnifiApiError on a meta.rc=error envelope (HTTP 200)', async () => {
@@ -79,12 +241,5 @@ describe('unifiClient', () => {
     const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
     // Single call: a Response body can only be read once, so assert both facets at once.
     await expect(client.listHosts()).rejects.toMatchObject({ name: 'UnifiApiError', status: 200 });
-  });
-
-  it('returns null from getIspMetrics on an explicit data:null envelope', async () => {
-    // Regression: `data ?? body` would have returned the whole envelope here.
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: null }));
-    const client = createUnifiClient({ baseUrl: 'https://api.ui.com', apiKey: 'k', fetchImpl });
-    await expect(client.getIspMetrics('s1')).resolves.toBeNull();
   });
 });

--- a/apps/api/src/services/unifi/unifiClient.ts
+++ b/apps/api/src/services/unifi/unifiClient.ts
@@ -9,7 +9,7 @@ export class UnifiApiError extends Error {
   }
 }
 
-export interface UnifiHost { id: string; name: string }
+export interface UnifiHost { id: string; name: string; type: string | null; model: string | null }
 export interface UnifiSite { id: string; hostId: string; name: string }
 export interface UnifiDeviceDto {
   unifiDeviceId: string;
@@ -46,7 +46,24 @@ const DEFAULT_RETRY_DELAY_MS = 1000;
 
 const str = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null);
 const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
-const bool = (v: unknown): boolean | null => (typeof v === 'boolean' ? v : null);
+const obj = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' ? (v as Record<string, unknown>) : {});
+
+// The Site Manager (cloud) /v1/devices payload reports firmware as a status string
+// ("upToDate" | "upgradable" | …), not the boolean the local API uses. Normalize
+// to the boolean our schema stores, tolerating the local field names too.
+function firmwareUpdatable(d: Record<string, unknown>): boolean | null {
+  if (typeof d.firmwareUpdatable === 'boolean') return d.firmwareUpdatable;
+  if (typeof d.upgradable === 'boolean') return d.upgradable;
+  const status = str(d.firmwareStatus)?.toLowerCase();
+  if (status === 'uptodate') return false;
+  if (status === 'upgradable' || status === 'updatable') return true;
+  // Unknown/indeterminate status ("checking", "pending", a new enum, …) must stay
+  // null — coercing it to `true` would raise false "update available" alerts.
+  return null;
+}
+
+// 5-minute granularity (24h retention) — the freshest ISP samples for "latest WAN".
+const ISP_METRIC_TYPE = '5m';
 
 export function createUnifiClient(cfg: UnifiClientConfig): UnifiClient {
   const fetchImpl = cfg.fetchImpl ?? fetch;
@@ -85,37 +102,100 @@ export function createUnifiClient(cfg: UnifiClientConfig): UnifiClient {
       // Coerce a `data: null` / 204 empty result to [] so the .map() can't throw
       // an opaque 500 ("Cannot read properties of null").
       const rows = (await get<Array<Record<string, unknown>> | null>('/v1/hosts')) ?? [];
-      return rows.map((h) => ({ id: String(h.id), name: str(h.name) ?? String(h.id) }));
+      return rows.map((h) => {
+        const id = String(h.id);
+        // The console's user-facing name lives under reportedState, not top-level —
+        // reading h.name fell straight through to the host id ("cryptic host IDs").
+        const rs = obj(h.reportedState);
+        const hw = obj(rs.hardware);
+        const name = str(rs.name) ?? str(rs.hostname) ?? str(hw.name) ?? str(h.name) ?? id;
+        return {
+          id,
+          name,
+          // `type` ("console" | "network-server" | …) lets the UI keep only mappable
+          // consoles; `model` (hardware name) replaces showing a raw host id.
+          type: str(h.type) ?? str(rs.type),
+          model: str(hw.name) ?? str(hw.shortname),
+        };
+      });
     },
     async listSites() {
       const rows = (await get<Array<Record<string, unknown>> | null>('/v1/sites')) ?? [];
-      return rows.map((s) => ({ id: String(s.id), hostId: String(s.hostId ?? s.host_id ?? ''), name: str(s.name) ?? String(s.id) }));
+      const mapped = rows
+        .map((s) => {
+          // /v1/sites identifies the site by `siteId` (no top-level id) and carries
+          // its name under `meta.name`. The old String(s.id) parse is what wrote
+          // unifi_site_id="undefined" and 404'd every downstream sync call.
+          const id = str(s.siteId) ?? str(s.id) ?? '';
+          const name = str(obj(s.meta).name) ?? str(s.name) ?? id;
+          return { id, hostId: String(s.hostId ?? s.host_id ?? ''), name };
+        })
+        // Never persist a malformed site id — a missing siteId must drop the row,
+        // not become the literal "undefined"/"null" string.
+        .filter((s) => s.id.length > 0 && s.id !== 'undefined' && s.id !== 'null');
+      // Dropping every row (while the API returned some) almost certainly means the
+      // payload shape changed under us — surface it instead of silently reporting an
+      // empty account, which reads to the user as "no sites".
+      if (rows.length > 0 && mapped.length === 0) {
+        console.warn(`[unifi] listSites: dropped all ${rows.length} site row(s) as malformed — /v1/sites shape may have changed`);
+      }
+      return mapped;
     },
     async listDevices(hostId: string) {
-      const rows = (await get<Array<Record<string, unknown>> | null>(`/v1/hosts/${encodeURIComponent(hostId)}/devices`)) ?? [];
-      return rows.map((d) => ({
-        unifiDeviceId: String(d.id),
-        mac: str(d.mac),
-        name: str(d.name),
-        model: str(d.model),
-        deviceType: str(d.type),
-        ip: str(d.ipAddress ?? d.ip),
-        firmwareVersion: str(d.firmwareVersion ?? d.version),
-        firmwareUpdatable: bool(d.firmwareUpdatable ?? d.upgradable),
-        adoptionState: str(d.state ?? d.adoptionState),
-        uptimeSeconds: num(d.uptime),
-        raw: d,
-      }));
+      // The cloud API exposes devices via /v1/devices grouped by host (there is no
+      // /v1/hosts/{id}/devices — that path 404'd and returned non-JSON). Fetch the
+      // grouped list and return only the requested host's devices.
+      const groups = (await get<Array<Record<string, unknown>> | null>('/v1/devices')) ?? [];
+      const group = groups.find((g) => String(g.hostId ?? '') === hostId);
+      // A host *absent* from the grouped payload (offline/non-reporting console, or a
+      // host-id keying mismatch) is NOT an empty host. Returning [] here would let the
+      // sync stale-sweep unlink every still-good device on that mapping while reporting
+      // success — throw so the caller routes it to the per-mapping error path instead.
+      if (!group) {
+        throw new UnifiApiError(`UniFi host ${hostId} not present in /v1/devices`, 404);
+      }
+      const rows = (group.devices as Array<Record<string, unknown>> | undefined) ?? [];
+      return rows.flatMap((d) => {
+        // Cloud device `id` is the MAC. Skip a device with no usable identity rather
+        // than coercing to the string "undefined"/"null" — that id is the upsert key,
+        // so a sentinel would collide id-less devices into one phantom row.
+        const id = str(d.id) ?? str(d.mac);
+        if (!id) return [];
+        return [{
+          unifiDeviceId: id,
+          mac: str(d.mac) ?? str(d.id),
+          name: str(d.name),
+          model: str(d.model),
+          deviceType: str(d.type),
+          // IP/uptime are absent from the cloud payload (local/agent telemetry only) —
+          // read them anyway so a richer source feeding this mapper works.
+          ip: str(d.ip ?? d.ipAddress),
+          firmwareVersion: str(d.version ?? d.firmwareVersion),
+          firmwareUpdatable: firmwareUpdatable(d),
+          adoptionState: str(d.status ?? d.state ?? d.adoptionState),
+          uptimeSeconds: num(d.uptime),
+          raw: d,
+        }];
+      });
     },
     async getIspMetrics(siteId: string) {
-      const data = await get<Record<string, unknown> | null>(`/v1/sites/${encodeURIComponent(siteId)}/isp-metrics`);
-      if (!data) return null;
+      // /v1/isp-metrics/{type} returns samples for every site on the account; select
+      // the requested site and take its latest WAN sample. (The old per-site path
+      // /v1/sites/{id}/isp-metrics does not exist and 404'd.)
+      const rows = (await get<Array<Record<string, unknown>> | null>(`/v1/isp-metrics/${ISP_METRIC_TYPE}`)) ?? [];
+      const entry = rows.find((r) => String(r.siteId ?? '') === siteId);
+      if (!entry) return null;
+      const periods = (entry.periods as Array<Record<string, unknown>> | undefined) ?? [];
+      const wan = obj(obj(periods[periods.length - 1]).data).wan;
+      const w = obj(wan);
       return {
-        latencyMs: num(data.latencyMs ?? data.latency),
-        packetLoss: num(data.packetLoss ?? data.loss),
-        uptimePercent: num(data.uptimePercent ?? data.uptime),
-        isp: str(data.isp ?? data.provider),
-        raw: data,
+        latencyMs: num(w.avgLatency ?? w.latencyAvg ?? w.latency),
+        packetLoss: num(w.packetLoss ?? w.loss),
+        uptimePercent: num(w.uptime ?? w.uptimePercent),
+        isp: str(w.ispName ?? w.isp ?? w.provider),
+        // Persist the whole site entry — wan_metrics stores `.raw`, and the cloud
+        // metric shape is a time series we don't want to flatten away.
+        raw: entry,
       };
     },
   };

--- a/apps/api/src/services/unifi/unifiSyncService.test.ts
+++ b/apps/api/src/services/unifi/unifiSyncService.test.ts
@@ -10,7 +10,7 @@ import type { DbExecutor } from './unifiConnectionService';
 
 function fakeClient(devices: any[]): UnifiClient {
   return {
-    listHosts: async () => [{ id: 'h1', name: 'Console' }],
+    listHosts: async () => [{ id: 'h1', name: 'Console', type: 'console', model: 'UDM' }],
     listSites: async () => [{ id: 's1', hostId: 'h1', name: 'Site' }],
     listDevices: async () => devices,
     getIspMetrics: async () => ({
@@ -285,7 +285,7 @@ describe('unifiSyncService.syncIntegration', () => {
     // map-1 (h1): succeeds with no devices this run
     // map-2 (h2): listDevices throws → failedMappingIds captures 'map-2'
     const staledClient: UnifiClient = {
-      listHosts: async () => [{ id: 'h1', name: 'C1' }, { id: 'h2', name: 'C2' }],
+      listHosts: async () => [{ id: 'h1', name: 'C1', type: 'console', model: null }, { id: 'h2', name: 'C2', type: 'console', model: null }],
       listSites: async () => [],
       listDevices: async (hostId) => {
         if (hostId === 'h2') throw new Error('timeout');

--- a/apps/web/src/components/integrations/UnifiIntegration.tsx
+++ b/apps/web/src/components/integrations/UnifiIntegration.tsx
@@ -33,6 +33,7 @@ interface UnifiStatus {
 interface UnifiHostOption {
   id: string;
   name: string;
+  model?: string | null;
   sites: Array<{ id: string; name: string }>;
 }
 // Breeze sites/orgs that a UniFi site can be mapped onto (from GET /orgs/*).
@@ -373,7 +374,10 @@ export default function UnifiIntegration() {
     setSavingMappings(true);
     try {
       await runAction({
-        request: () => fetchWithAuth('/unifi/mappings', { method: 'PUT', body: JSON.stringify({ mappings }) }),
+        // Send the full enumerated host set so the server's replace-all cleanup is
+        // scoped to hosts the user actually saw — a host transiently missing from this
+        // live list must not have its mapping (and synced devices) deleted.
+        request: () => fetchWithAuth('/unifi/mappings', { method: 'PUT', body: JSON.stringify({ mappings, hostIds: hosts.map((h) => h.id) }) }),
         errorFallback: 'Failed to save site mappings.',
         successMessage: 'Site mappings saved',
         onUnauthorized,
@@ -433,7 +437,9 @@ export default function UnifiIntegration() {
     setSavingControllerMappings(true);
     try {
       await runAction({
-        request: () => fetchWithAuth('/unifi/mappings', { method: 'PUT', body: JSON.stringify({ mappings }) }),
+        // Scope replace-all to the controller sites enumerated here (keyed by collector
+        // id, the sentinel host id), so other controllers' mappings are never purged.
+        request: () => fetchWithAuth('/unifi/mappings', { method: 'PUT', body: JSON.stringify({ mappings, hostIds: controllerSites.map((s) => s.collectorId) }) }),
         errorFallback: 'Failed to save site mappings.',
         successMessage: 'Site mappings saved',
         onUnauthorized,
@@ -1085,7 +1091,12 @@ export default function UnifiIntegration() {
                         const key = mapKey(h.id, s.id);
                         return (
                           <tr key={key} data-testid="unifi-mapping-row">
-                            <td className="px-3 py-2 font-medium">{h.name}</td>
+                            <td className="px-3 py-2">
+                              <span className="font-medium">{h.name}</span>
+                              {h.model && (
+                                <span className="ml-2 text-xs text-muted-foreground" data-testid="unifi-mapping-host-model">{h.model}</span>
+                              )}
+                            </td>
                             <td className="px-3 py-2 text-muted-foreground">{s.name}</td>
                             <td className="px-3 py-2">
                               <select
@@ -1145,6 +1156,7 @@ export default function UnifiIntegration() {
                 <div key={h.id} className="rounded-lg border p-4" data-testid="unifi-collector-row">
                   <div className="flex items-center gap-2">
                     <span className="font-medium">{h.name}</span>
+                    {h.model && <span className="text-xs text-muted-foreground">{h.model}</span>}
                     {collector && (
                       <span
                         className={`ml-auto inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${collectorStatusClasses(collector.status)}`}


### PR DESCRIPTION
## Why

SemoTech reported on v0.87.0 that the UniFi cloud (Site Manager) integration connects fine but **mapping + sync fail**: `unifi_site_id = "undefined"`, sync calls `/v1/sites/undefined/isp-metrics` → 404, **0 devices imported**.

Root cause: `unifiClient` was coded against the **local Network Integration API** shape, but the partner cloud key talks to the **Site Manager API** (`https://api.ui.com/v1`). Three of its four endpoints were wrong (path and/or parsing). Verified shapes against the [official Site Manager API docs](https://developer.ui.com/site-manager-api/) ([list-sites](https://developer.ui.com/site-manager-api/list-sites), [list-devices](https://developer.ui.com/site-manager-api/listdevices/), [get-isp-metrics](https://developer.ui.com/site-manager-api/get-isp-metrics)).

## What changed

**`unifiClient.ts` — rewrite for the real cloud API**
- `listSites`: read `siteId` + `meta.name` (was `String(s.id)` → `"undefined"`); drop malformed-id rows; warn on a total drop (shape change).
- `listDevices`: grouped `/v1/devices` filtered by host (was non-existent `/v1/hosts/{id}/devices`). **Throws when the host is absent** from the payload so sync routes it to the per-mapping error path instead of stale-sweeping still-good devices; returns `[]` only for a present-but-empty host. Drops id-less devices.
- `getIspMetrics`: `/v1/isp-metrics/{type}` filtered by `siteId` (was non-existent `/v1/sites/{id}/isp-metrics`).
- `listHosts`: name from `reportedState`; adds `type` + `model`.
- `firmwareUpdatable`: whitelist statuses (unknown → `null`, no false "update available").

**`routes/unifi/index.ts`**
- `GET /hosts`: surface only **mappable consoles** (≥1 valid site, console type when known) + model, so the UI can't offer junk host×site rows.
- `PUT /mappings`: **replace-all** cleanup so poisoned/stale rows self-heal — but **scoped to the `hostIds` the client enumerated** and filtered by `canAccessOrg`/`canAccessSite`, so a transiently-absent host, an empty/failed host list, or a site-restricted caller can never trigger a destructive delete. Rejects literal `"undefined"`/`"null"` ids.

**`web/UnifiIntegration.tsx`**: renders console model; sends enumerated `hostIds` on save so replace-all is correctly scoped.

## Review

Ran the pr-review-toolkit (5 agents). They caught two **data-loss bugs introduced in the first pass** of the replace-all/`listDevices` work — both now fixed and covered by tests:
1. Replace-all deleting good mappings (+ cascaded devices) on a transient/filtered/empty host list, and skipping the site-axis gate.
2. `listDevices` returning `[]` for a missing host → stale-sweep unlinking every device while reporting success.

## Not included (deferred)
- **Deep telemetry via local Network keys** — genuine upstream Ubiquiti limitation (local keys appear Protect-only on current firmware); SemoTech has a UniFi support ticket open. Not a Breeze bug.
- Host **online/offline status** in the mapping UI — couldn't pin the cloud field name without a live response; won't guess (that caused the original bug).
- Broader Sentry/`errorIds` logging and a few type-design polish items — noted for a follow-up.

## Testing
API **96** UniFi tests + web **9** pass; `tsc` + `eslint` clean in both packages.

> ⚠️ Shapes are doc/struct-derived, not from a live key. `wan_metrics` persists the whole `raw` entry and all reads have fallbacks, so nothing 404s or loses data even if a nested field name is slightly off — but a smoke test against a real cloud key before release is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)