### PR TITLE
fix(mcp): resolve membership-less Partner Admin role on org-scoped MCP keys (#2019)

### DIFF
--- a/apps/api/src/__tests__/authenticated.example.test.ts
+++ b/apps/api/src/__tests__/authenticated.example.test.ts
@@ -47,6 +47,7 @@ vi.mock('../db', () => ({
     }))
   },
   hasDbAccessContext: vi.fn(() => true),
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   withDbAccessContext: vi.fn(async (_ctx: any, fn: any) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: any) => fn()),
   runOutsideDbContext: vi.fn((fn: any) => fn()),

--- a/apps/api/src/__tests__/integration/permissionsContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/permissionsContext.integration.test.ts
@@ -17,13 +17,71 @@
  */
 import './setup';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { db, withSystemDbAccessContext, runOutsideDbContext, hasDbAccessContext } from '../../db';
-import { partners, organizations, users, roles, permissions, rolePermissions, partnerUsers } from '../../db/schema';
+import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext, hasDbAccessContext, getCurrentDbAccessContext } from '../../db';
+import { partners, organizations, users, roles, permissions, rolePermissions, partnerUsers, organizationUsers } from '../../db/schema';
 import { getUserPermissions, clearPermissionCache } from '../../services/permissions';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
 interface Fixture { partnerId: string; userId: string }
+
+interface OrgFixture { partnerId: string; orgId: string; userId: string }
+
+/** Seed a Partner Admin with a partner-scope role holding `devices:read`, an org
+ *  under that partner, and the partner_users membership — but deliberately NO
+ *  organization_users row. This is the #2019 self-hoster shape: a membership-less
+ *  Partner Admin whose role lives only on the partner axis. */
+async function seedMembershiplessPartnerAdmin(): Promise<OrgFixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `MP ${sfx}`, slug: `mp-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'MOrg', slug: `mo-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `mp-${sfx}@x.io`, name: 'MP', status: 'active' })
+      .returning({ id: users.id });
+    const [r] = await db.insert(roles)
+      .values({ partnerId: p!.id, scope: 'partner', name: `Admin ${sfx}` })
+      .returning({ id: roles.id });
+    const [perm] = await db.insert(permissions)
+      .values({ resource: 'devices', action: 'read' })
+      .returning({ id: permissions.id });
+    await db.insert(rolePermissions).values({ roleId: r!.id, permissionId: perm!.id });
+    await db.insert(partnerUsers)
+      .values({ partnerId: p!.id, userId: u!.id, roleId: r!.id, orgAccess: 'all' });
+    // NB: NO organization_users row — the role is partner-axis only.
+    return { partnerId: p!.id, orgId: o!.id, userId: u!.id };
+  });
+}
+
+/** Seed a user with a real organization_users row holding an org-scope role with
+ *  devices:read — the common dashboard shape (org membership on the org axis). */
+async function seedOrgMemberUser(): Promise<OrgFixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `OM ${sfx}`, slug: `om-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: 'OMOrg', slug: `omo-${sfx}` })
+      .returning({ id: organizations.id });
+    const [u] = await db.insert(users)
+      .values({ partnerId: p!.id, orgId: o!.id, email: `om-${sfx}@x.io`, name: 'OM', status: 'active' })
+      .returning({ id: users.id });
+    const [r] = await db.insert(roles)
+      .values({ orgId: o!.id, scope: 'organization', name: `OrgRole ${sfx}` })
+      .returning({ id: roles.id });
+    const [perm] = await db.insert(permissions)
+      .values({ resource: 'devices', action: 'read' })
+      .returning({ id: permissions.id });
+    await db.insert(rolePermissions).values({ roleId: r!.id, permissionId: perm!.id });
+    await db.insert(organizationUsers).values({ orgId: o!.id, userId: u!.id, roleId: r!.id });
+    return { partnerId: p!.id, orgId: o!.id, userId: u!.id };
+  });
+}
 
 /** Seed a partner, a user, a partner-scope role holding invoices:send, and the
  *  partner_users membership linking them. All under a system context so the rows
@@ -56,6 +114,31 @@ async function seedPartnerUserWithSendPerm(): Promise<Fixture> {
 describe('getUserPermissions DB access context (breeze_app, real DB, #1448)', () => {
   beforeEach(async () => {
     await clearPermissionCache();
+  });
+
+  runDb('getCurrentDbAccessContext mirrors the active context and clears under runOutsideDbContext', async () => {
+    // Plumbing proof for the conditional-escalation getter: the metadata store must
+    // surface the live context (so canSee() can read accessibleOrgIds/Partners) and must
+    // be cleared when we exit via runOutsideDbContext (so the escalated read is genuinely
+    // contextless). Uses synthetic ids — no rows queried, just GUC propagation.
+    const orgId = '00000000-0000-0000-0000-0000000000aa';
+    const { inside, outside } = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId,
+        accessibleOrgIds: [orgId],
+        accessiblePartnerIds: [],
+        currentPartnerId: null,
+      },
+      async () => ({
+        inside: getCurrentDbAccessContext(),
+        outside: runOutsideDbContext(() => getCurrentDbAccessContext()),
+      }),
+    );
+
+    expect(inside?.scope).toBe('organization');
+    expect(inside?.accessibleOrgIds).toEqual([orgId]);
+    expect(outside).toBeUndefined();
   });
 
   runDb('resolves the real permission set when called contextless on a cold cache (the pay-link route condition)', async () => {
@@ -92,16 +175,70 @@ describe('getUserPermissions DB access context (breeze_app, real DB, #1448)', ()
     expect(perms).toBeNull();
   });
 
-  runDb('resolves the same permission set when already inside an ambient context (no-op nest)', async () => {
+  runDb('resolves a membership-less Partner Admin role under a NARROWER org-scope ambient context (#2019 MCP org-key path)', async () => {
+    const f = await seedMembershiplessPartnerAdmin();
+
+    // Reproduce the manual org-scoped MCP/API-key request context exactly:
+    // scope='organization', single accessible org, and an EMPTY partner allowlist
+    // (apiKeyAuth withholds partner-axis RLS visibility from manual keys). The
+    // caller passes BOTH the org and the resolved owning partnerId (the #2019 fix
+    // threads partnerId in) — but the role lives in partner_users, which RLS hides
+    // unless the read escalates to system scope. Pre-fix this returned null →
+    // "Insufficient permissions: no role assigned" on every tools/call.
+    const perms = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId: f.orgId,
+        accessibleOrgIds: [f.orgId],
+        accessiblePartnerIds: [], // the deliberately-narrow manual-key context
+        currentPartnerId: null,
+      },
+      () => {
+        expect(hasDbAccessContext()).toBe(true); // prove the narrower context is active
+        return getUserPermissions(f.userId, { partnerId: f.partnerId, orgId: f.orgId });
+      },
+    );
+
+    expect(perms).not.toBeNull();
+    expect(perms?.scope).toBe('partner');
+    expect(perms?.permissions).toContainEqual({ resource: 'devices', action: 'read' });
+  });
+
+  runDb('reuses an ambient SYSTEM context (which sees every row) without escalating', async () => {
     const f = await seedPartnerUserWithSendPerm();
 
-    // Normal-route path: an ambient system context is active; getUserPermissions must
-    // NOT open a second context and must resolve the same row.
+    // A system-scope context already grants visibility to every row, so canSee() is true
+    // and getUserPermissions resolves the partner role in-place — no exit/re-enter. The
+    // assertion here is the resolved row; the no-escalation behavior for this case is
+    // pinned at the unit level (permissions.test.ts reuse test).
     const perms = await withSystemDbAccessContext(() => {
       expect(hasDbAccessContext()).toBe(true);
       return getUserPermissions(f.userId, { partnerId: f.partnerId });
     });
 
     expect(perms?.permissions).toContainEqual({ resource: 'invoices', action: 'send' });
+  });
+
+  runDb('resolves an org member under their own org-scope ambient context (reuse path, real RLS)', async () => {
+    // The common dashboard shape the unit tests can only mock: a user with a real
+    // organization_users row, resolved inside the org-scope context authMiddleware would
+    // open for them (accessibleOrgIds = [their org]). canSee('org') is true → the
+    // org-axis read is reused against real Postgres RLS and must return the org role.
+    const f = await seedOrgMemberUser();
+
+    const perms = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId: f.orgId,
+        accessibleOrgIds: [f.orgId],
+        accessiblePartnerIds: [],
+        currentPartnerId: null,
+      },
+      () => getUserPermissions(f.userId, { orgId: f.orgId, partnerId: f.partnerId }),
+    );
+
+    expect(perms).not.toBeNull();
+    expect(perms?.scope).toBe('organization');
+    expect(perms?.permissions).toContainEqual({ resource: 'devices', action: 'read' });
   });
 });

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -38,6 +38,14 @@ const client = postgres(connectionString, {
 });
 const baseDb = drizzle(client, { schema });
 const dbContextStorage = new AsyncLocalStorage<typeof baseDb>();
+// Parallel store holding the DbAccessContext METADATA (scope + allowlists) for
+// the active request transaction. Kept separate from dbContextStorage (which
+// resolves to the tx for query routing) so the tx-resolution hot path is
+// untouched. Set/cleared in lockstep with dbContextStorage. Lets callers cheaply
+// ask "does the active context already grant visibility to row X?" before
+// deciding whether they must escalate to a system context (see
+// getCurrentDbAccessContext + permissions.getUserPermissions).
+const dbContextMetaStorage = new AsyncLocalStorage<DbAccessContext>();
 
 function getCurrentDb(): typeof baseDb {
   return dbContextStorage.getStore() ?? baseDb;
@@ -194,7 +202,9 @@ export async function withDbAccessContext<T>(
     const warnMs = getHeldContextWarnMs();
     const startedAt = warnMs > 0 ? Date.now() : 0;
     try {
-      return await dbContextStorage.run(tx as unknown as typeof baseDb, fn);
+      return await dbContextStorage.run(tx as unknown as typeof baseDb, () =>
+        dbContextMetaStorage.run(context, fn),
+      );
     } finally {
       // The whole point of this block is to SURFACE problems, so it must never
       // BECOME one: any throw here (e.g. a Sentry transport hiccup) would, from
@@ -241,16 +251,32 @@ export function hasDbAccessContext(): boolean {
   return dbContextStorage.getStore() !== undefined;
 }
 
+/**
+ * The DbAccessContext metadata (scope + org/partner allowlists) of the active
+ * request transaction, or undefined when no context is established. Use this to
+ * decide whether the ambient context already grants RLS visibility to a specific
+ * row BEFORE deciding to escalate to a system context — its `scope`,
+ * `accessibleOrgIds`, and `accessiblePartnerIds` mirror exactly what
+ * `breeze_has_org_access` / `breeze_has_partner_access` evaluate, so an
+ * allowlist hit here means RLS will return the row. Returns the same object
+ * passed to `withDbAccessContext`; do not mutate it.
+ */
+export function getCurrentDbAccessContext(): DbAccessContext | undefined {
+  return dbContextMetaStorage.getStore();
+}
+
 export type RunOutsideDbContextFn = <T>(fn: () => T) => T;
 
 /**
  * Runs a function outside any active AsyncLocalStorage DB context,
  * ensuring `db` resolves to `baseDb` (the connection pool) rather
  * than a request-scoped transaction. Use this for long-lived background
- * tasks that outlive the originating HTTP request.
+ * tasks that outlive the originating HTTP request. Exits BOTH the tx-routing
+ * store and the metadata store so a nested withSystemDbAccessContext opens a
+ * genuinely fresh context and getCurrentDbAccessContext reflects reality.
  */
 export const runOutsideDbContext: RunOutsideDbContextFn = <T>(fn: () => T): T => {
-  return dbContextStorage.exit(fn);
+  return dbContextStorage.exit(() => dbContextMetaStorage.exit(fn));
 };
 
 // Query-builder write methods that, when invoked on the bare pool (no active

--- a/apps/api/src/routes/mcpServer.bearer.test.ts
+++ b/apps/api/src/routes/mcpServer.bearer.test.ts
@@ -50,6 +50,7 @@ vi.mock('../db', () => {
       select: () => ({ from: () => ({ where: makeWhere }) }),
     },
     hasDbAccessContext: vi.fn(() => true),
+    getCurrentDbAccessContext: vi.fn(() => undefined),
     withDbAccessContext: vi.fn(),
     withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
     runOutsideDbContext: vi.fn((fn: () => any) => fn()),

--- a/apps/api/src/services/permissions.test.ts
+++ b/apps/api/src/services/permissions.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// hasDbAccessContext defaults to false (simulating a contextless caller, e.g. the
-// #1448 self-managed-DB-context pay routes whose permission read runs with no
-// ambient transaction). withSystemDbAccessContext is a transparent pass-through so
-// the wrapped reads still run against the mocked db. Individual tests can override
-// hasDbAccessContext to assert the no-op-nest path when a context is already active.
-const mockHasDbAccessContext = vi.fn(() => false);
+// getUserPermissions resolves a user's role per-axis on a cache miss, escalating to a
+// fresh SYSTEM RLS context only for the axis the ambient context can't see: it
+// runOutsideDbContext (to exit the narrower ambient context, e.g. the org-scoped
+// MCP/API-key context from #2019) then withSystemDbAccessContext. When the ambient
+// context (getCurrentDbAccessContext) already grants visibility it reuses it — no
+// escalation. Both wrappers are transparent pass-throughs here so the wrapped reads
+// still run against the mocked db; the spies + the mocked ambient context let tests
+// assert when escalation happens vs. when the request transaction is reused.
 const mockWithSystemDbAccessContext = vi.fn(<T>(fn: () => Promise<T>) => fn());
+const mockRunOutsideDbContext = vi.fn(<T>(fn: () => T) => fn());
+const mockGetCurrentDbAccessContext = vi.fn<() => unknown>(() => undefined);
 vi.mock('../db', () => ({
   db: {
     select: vi.fn()
   },
-  hasDbAccessContext: () => mockHasDbAccessContext(),
-  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => mockWithSystemDbAccessContext(fn)
+  withSystemDbAccessContext: <T>(fn: () => Promise<T>) => mockWithSystemDbAccessContext(fn),
+  runOutsideDbContext: <T>(fn: () => T) => mockRunOutsideDbContext(fn),
+  getCurrentDbAccessContext: () => mockGetCurrentDbAccessContext()
 }));
 
 vi.mock('../db/schema', () => ({
@@ -63,8 +68,9 @@ describe('permissions service', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(getRedis).mockReturnValue(null);
-    mockHasDbAccessContext.mockReturnValue(false);
     mockWithSystemDbAccessContext.mockImplementation(<T>(fn: () => Promise<T>) => fn());
+    mockRunOutsideDbContext.mockImplementation(<T>(fn: () => T) => fn());
+    mockGetCurrentDbAccessContext.mockReturnValue(undefined); // contextless by default
     await clearPermissionCache();
   });
 
@@ -428,34 +434,123 @@ describe('permissions service', () => {
         } as any);
     }
 
-    it('establishes a system context for its RLS-protected reads when none is active (the #1448 pay-route path)', async () => {
-      // The self-managed-DB-context pay routes run requirePermission with NO ambient
-      // transaction. Without the wrapper the membership reads would RLS-filter to 0
-      // rows under breeze_app → null → 403 (the #1375 class). Assert it wraps instead.
-      mockHasDbAccessContext.mockReturnValue(false);
+    it('escalates RLS reads to a fresh system context, runOutsideDbContext BEFORE withSystemDbAccessContext (#1448 contextless + #2019 narrower-ctx)', async () => {
+      // On a cache miss the membership reads must resolve under SYSTEM scope so they
+      // aren't RLS-filtered to 0 rows → null → 403 / "no role assigned". This covers
+      // both failure classes the wrap exists for: NO ambient context (#1448 pay-route)
+      // and a NARROWER ambient context (#2019 org-scoped MCP key, accessiblePartnerIds=[]).
+      // The mock layer can't distinguish the two (production no longer reads
+      // hasDbAccessContext) — the real per-scenario RLS proof lives in
+      // permissionsContext.integration.test.ts. What this unit test pins that the
+      // integration test can't run cheaply is the ORDER: withDbAccessContext is a no-op
+      // while a context is active, so runOutsideDbContext MUST run first. A swapped
+      // wrap (withSystemDbAccessContext(() => runOutsideDbContext(fn))) would keep the
+      // call COUNTS identical but silently reintroduce #2019 — the order assertion is
+      // the only unit-level guard against that regression.
       mockMembershipAndRoleReads();
 
       const perms = await getUserPermissions('user-123', { orgId: 'org-123' });
 
       expect(perms).not.toBeNull();
       expect(perms?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      expect(mockRunOutsideDbContext).toHaveBeenCalledTimes(1);
       expect(mockWithSystemDbAccessContext).toHaveBeenCalledTimes(1);
+      // runOutsideDbContext must be entered before withSystemDbAccessContext.
+      expect(mockRunOutsideDbContext.mock.invocationCallOrder[0]!)
+        .toBeLessThan(mockWithSystemDbAccessContext.mock.invocationCallOrder[0]!);
     });
 
-    it('does NOT open a redundant context when one is already active (no-op nest on normal routes)', async () => {
-      // Normal routes already run inside an org/partner withDbAccessContext; opening a
-      // second system context there would override the request scope. Assert pass-through.
-      mockHasDbAccessContext.mockReturnValue(true);
+    it('does NOT open the system-context wrapper on a warm cache hit (conn-hold guard, #1105 class)', async () => {
+      // The wrap runs only on a cache MISS — the comment in permissions.ts promises the
+      // extra context churn stays off the warm path. A regression that re-escalates on
+      // every hit would, under a cluster-wide cache bump, hold 2 pooled connections per
+      // request and risk pool starvation (the documented #1105 conn-hold class). Pin it:
+      // a second call for the same key must be served from cache with zero wrap calls.
+      mockMembershipAndRoleReads();
+
+      await getUserPermissions('user-123', { orgId: 'org-123' }); // miss → escalates once
+      const before = mockRunOutsideDbContext.mock.calls.length;
+      const cached = await getUserPermissions('user-123', { orgId: 'org-123' }); // hit
+
+      expect(cached?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      expect(mockRunOutsideDbContext.mock.calls.length).toBe(before); // no new escalation
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2); // both reads only on the miss
+    });
+
+    it('propagates (does NOT swallow into null) when the system-context read throws', async () => {
+      // The whole point of the fix is that RLS-filtered-0-rows must not look like a DB
+      // error AND a real DB error (pool exhausted, txn timeout) must not look like
+      // "no role". A future careless `try { ... } catch { return null }` around the wrap
+      // would silently turn infra faults into 403s — assert the throw reaches the caller.
+      mockRunOutsideDbContext.mockImplementationOnce(() => {
+        throw new Error('pool exhausted');
+      });
+
+      await expect(getUserPermissions('user-123', { orgId: 'org-123' }))
+        .rejects.toThrow('pool exhausted');
+    });
+
+    it('REUSES the ambient transaction (no escalation) when it already grants the axis visibility', async () => {
+      // The common dashboard path: an org user inside their own org-scope context. The
+      // ambient context's accessibleOrgIds already covers the org, so canSee('org') is
+      // true and the org-membership read must run in-place — NO runOutsideDbContext, NO
+      // extra pooled connection. This is the conn-hold mitigation (#1105) made concrete.
+      mockGetCurrentDbAccessContext.mockReturnValue({
+        scope: 'organization',
+        accessibleOrgIds: ['org-123'],
+        accessiblePartnerIds: [],
+      });
       mockMembershipAndRoleReads();
 
       const perms = await getUserPermissions('user-123', { orgId: 'org-123' });
 
       expect(perms?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      expect(mockRunOutsideDbContext).not.toHaveBeenCalled();
       expect(mockWithSystemDbAccessContext).not.toHaveBeenCalled();
     });
 
+    it('escalates ONLY the blind partner-axis fallback, reusing the ambient txn for the org read (#2019 MCP org-key)', async () => {
+      // The exact #2019 shape at unit level: org-scope context (sees its org) with an
+      // empty partner allowlist. A membership-less Partner Admin has NO org_users row,
+      // so the org read is reused-but-empty, then the partner fallback — which the
+      // ambient context is blind to — must escalate. Proves escalation is scoped to the
+      // blind axis, not applied wholesale.
+      mockGetCurrentDbAccessContext.mockReturnValue({
+        scope: 'organization',
+        accessibleOrgIds: ['org-123'],
+        accessiblePartnerIds: [], // blind to the partner axis
+      });
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ // org_users read → empty (no org membership)
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+          })
+        } as any)
+        .mockReturnValueOnce({ // partner_users read → the partner role
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ roleId: 'role-partner', orgAccess: 'all', orgIds: null }])
+            })
+          })
+        } as any)
+        .mockReturnValueOnce({ // role_permissions read
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ resource: 'devices', action: 'read' }])
+            })
+          })
+        } as any);
+
+      const perms = await getUserPermissions('user-123', { orgId: 'org-123', partnerId: 'partner-1' });
+
+      expect(perms?.scope).toBe('partner');
+      expect(perms?.permissions).toEqual([{ resource: 'devices', action: 'read' }]);
+      // Exactly one escalation — for the partner fallback only; the org read was reused.
+      expect(mockRunOutsideDbContext).toHaveBeenCalledTimes(1);
+      expect(mockWithSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    });
+
     it('returns null (→ 403) when the user has no membership, regardless of context', async () => {
-      mockHasDbAccessContext.mockReturnValue(false);
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -1,4 +1,4 @@
-import { db, hasDbAccessContext, withSystemDbAccessContext } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { roles, permissions, rolePermissions, partnerUsers, organizationUsers } from '../db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getRedis } from './redis';
@@ -97,95 +97,100 @@ export async function getUserPermissions(
   }
 
   // The membership/role reads below hit RLS-protected tables (organization_users,
-  // partner_users, role_permissions). They must run under an RLS access context or
-  // the unprivileged breeze_app role silently filters them to 0 rows — returning a
-  // spurious `null` (→ 403) instead of the real permission set (the #1375 class).
-  // Most callers (normal routes via authMiddleware) already have an org/partner
-  // context active, in which case this is a no-op nest that keeps that context.
-  // The self-managed-DB-context pay routes (#1448) run requirePermission with NO
-  // ambient context, so without this wrapper getUserPermissions would 403 on a
-  // cold/expired permission cache. The explicit userId + orgId/partnerId equality
-  // filters mean a system-scope read returns the same single row a narrower scope
-  // would, so widening the read scope here doesn't change the result set.
-  const wrap = hasDbAccessContext()
-    ? <T>(fn: () => Promise<T>) => fn()
-    : withSystemDbAccessContext;
+  // partner_users, role_permissions). If they run under a context that can't SEE the
+  // role row, forced RLS silently filters them to 0 rows → a spurious `null`
+  // (→ 403 / "no role assigned") instead of the real permission set. Resolving a
+  // user's role is an IDENTITY question, not a tenant-data one, so it must not be
+  // filtered by the request's tenant visibility. Two failure classes:
+  //   - #1375/#1448: NO ambient context (contextless pay-link route) → bare breeze_app
+  //     pool, RLS denies, cold-cache 403.
+  //   - #2019: a NARROWER ambient context — an org-scoped MCP/API-key request runs
+  //     inside withDbAccessContext with scope='organization' + accessiblePartnerIds=[]
+  //     (apiKeyAuth withholds partner-axis visibility from manual keys). A Partner
+  //     Admin's role lives in partner_users (FORCE-RLS gated by
+  //     breeze_has_partner_access() → false for an empty partner allowlist) → the role
+  //     row is filtered to 0 rows → every tools/call dies "no role assigned".
+  //
+  // Fix: resolve each axis under a context that can read it, escalating to a fresh
+  // system transaction ONLY for the axis the ambient context is blind to. `canSee`
+  // mirrors breeze_has_org_access / breeze_has_partner_access exactly, so an allowlist
+  // hit ⇒ RLS returns the row (reuse the ambient txn — zero extra connection); a miss
+  // (or no ambient context) ⇒ escalate. Because the reads are equality-keyed by the
+  // explicit userId + orgId/partnerId args, a system-scope read can only surface that
+  // one pinned row or nothing — never another user's/tenant's row — so over-escalation
+  // is at worst a perf miss, never a leak. Escalation runs only on a cache MISS, and
+  // only for the blind axis: org-members and same-tenant callers keep reusing their
+  // request transaction (no extra pooled connection on the hot path — the #1105 class).
+  //
+  // withDbAccessContext early-returns (no-op) when a context is already active, so
+  // withSystemDbAccessContext alone can't widen a narrower ambient context — we must
+  // runOutsideDbContext FIRST to exit it, then open a fresh system-scoped transaction.
+  const ambient = getCurrentDbAccessContext();
+  const canSee = (axis: 'org' | 'partner', id: string): boolean => {
+    if (!ambient) return false; // contextless → must escalate
+    if (ambient.scope === 'system') return true; // system reads every row
+    const ids = axis === 'org' ? ambient.accessibleOrgIds : ambient.accessiblePartnerIds;
+    return ids?.includes(id) ?? false;
+  };
+  const runForAxis = <T>(visible: boolean, fn: () => Promise<T>): Promise<T> =>
+    visible ? fn() : runOutsideDbContext(() => withSystemDbAccessContext(fn));
 
-  const userPerms = await wrap(async (): Promise<UserPermissions | null> => {
-    let roleId: string | null = null;
-    let scope: 'system' | 'partner' | 'organization' = 'system';
-    let orgAccess: 'all' | 'selected' | 'none' | undefined;
-    let allowedOrgIds: string[] | undefined;
-    let allowedSiteIds: string[] | undefined;
-
-    // Check organization-level access first
-    if (context.orgId) {
-      const [orgUser] = await db
-        .select()
-        .from(organizationUsers)
-        .where(
-          and(
-            eq(organizationUsers.userId, userId),
-            eq(organizationUsers.orgId, context.orgId)
-          )
-        )
-        .limit(1);
-
-      if (orgUser) {
-        roleId = orgUser.roleId;
-        scope = 'organization';
-        allowedSiteIds = orgUser.siteIds || undefined;
-      }
-    }
-
-    // Check partner-level access
-    if (!roleId && context.partnerId) {
-      const [partnerUser] = await db
-        .select()
-        .from(partnerUsers)
-        .where(
-          and(
-            eq(partnerUsers.userId, userId),
-            eq(partnerUsers.partnerId, context.partnerId)
-          )
-        )
-        .limit(1);
-
-      if (partnerUser) {
-        roleId = partnerUser.roleId;
-        scope = 'partner';
-        orgAccess = partnerUser.orgAccess;
-        allowedOrgIds = partnerUser.orgIds || undefined;
-      }
-    }
-
-    if (!roleId) {
-      return null;
-    }
-
-    // Get role permissions
+  const buildPerms = async (
+    roleId: string,
+    scope: 'partner' | 'organization',
+    extra: Pick<UserPermissions, 'orgAccess' | 'allowedOrgIds' | 'allowedSiteIds'>,
+  ): Promise<UserPermissions> => {
     const rolePerms = await db
-      .select({
-        resource: permissions.resource,
-        action: permissions.action
-      })
+      .select({ resource: permissions.resource, action: permissions.action })
       .from(rolePermissions)
       .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
       .where(eq(rolePermissions.roleId, roleId));
-
-    const perms = rolePerms.map(p => ({ resource: p.resource, action: p.action }));
-
     return {
-      permissions: perms,
+      permissions: rolePerms.map(p => ({ resource: p.resource, action: p.action })),
       partnerId: context.partnerId || null,
       orgId: context.orgId || null,
       roleId,
       scope,
-      orgAccess,
-      allowedOrgIds,
-      allowedSiteIds
+      ...extra,
     };
-  });
+  };
+
+  // Org-axis first (org membership takes precedence over partner membership).
+  const resolveOrgAxis = async (): Promise<UserPermissions | null> => {
+    const [orgUser] = await db
+      .select()
+      .from(organizationUsers)
+      .where(and(eq(organizationUsers.userId, userId), eq(organizationUsers.orgId, context.orgId!)))
+      .limit(1);
+    // No membership row, or one without a usable role, means "nothing on this
+    // axis" — fall through to the partner axis (mirrors the original
+    // `if (orgUser) roleId = ...; if (!roleId && partnerId) ...` precedence).
+    if (!orgUser?.roleId) return null;
+    return buildPerms(orgUser.roleId, 'organization', {
+      allowedSiteIds: orgUser.siteIds || undefined,
+    });
+  };
+
+  const resolvePartnerAxis = async (): Promise<UserPermissions | null> => {
+    const [partnerUser] = await db
+      .select()
+      .from(partnerUsers)
+      .where(and(eq(partnerUsers.userId, userId), eq(partnerUsers.partnerId, context.partnerId!)))
+      .limit(1);
+    if (!partnerUser?.roleId) return null;
+    return buildPerms(partnerUser.roleId, 'partner', {
+      orgAccess: partnerUser.orgAccess,
+      allowedOrgIds: partnerUser.orgIds || undefined,
+    });
+  };
+
+  let userPerms: UserPermissions | null = null;
+  if (context.orgId) {
+    userPerms = await runForAxis(canSee('org', context.orgId), resolveOrgAxis);
+  }
+  if (!userPerms && context.partnerId) {
+    userPerms = await runForAxis(canSee('partner', context.partnerId), resolvePartnerAxis);
+  }
 
   if (!userPerms) {
     return null;


### PR DESCRIPTION
## Summary

Self-hoster **SemoTech re-reported #2019 on 0.87.0**: Cursor → `/api/v1/mcp/sse` with an org-scoped manual API key (Partner Admin user). Connect + `tools/list` work; every `tools/call` fails `Insufficient permissions: no role assigned`. The 0.87.0 fix (`8c2743b7`) was **incomplete**.

## Root cause

`8c2743b7` correctly threaded the owning `partnerId` into `getUserPermissions`, but the `partner_users` role lookup runs under the request's own DB access context. For a manual (non-`mcp_provisioning`) org-scoped key, `apiKeyAuth` deliberately establishes that context as `scope='organization'` with `accessiblePartnerIds: []` (it withholds partner-axis RLS visibility from manual keys). `partner_users` is FORCE-RLS gated by `breeze_has_partner_access(partner_id)`, which returns **false** for an empty partner allowlist → the Partner Admin's role row is filtered to **0 rows** → `null` → 403. A membership-less Partner Admin (no `organization_users` row) has nowhere else for the role to come from. `tools/list` works because it has no RBAC gate.

The original regression test passed **vacuously** — it mocked `getUserPermissions`, `checkToolPermission`, and every DB-context helper, so it never exercised real RLS.

## Fix

Resolve each axis (`organization_users`, then `partner_users`) under a context that can actually read it, escalating to a fresh **system** transaction **only for the axis the ambient context is blind to**:

- New `getCurrentDbAccessContext()` — a parallel `AsyncLocalStorage` in `db/index.ts` holding the `DbAccessContext` metadata (the tx-routing path is untouched).
- `canSee(axis, id)` mirrors `breeze_has_org_access` / `breeze_has_partner_access` **exactly** (`scope==='system' || accessible{Org,Partner}Ids.includes(id)`). An allowlist hit ⇒ RLS will return the row ⇒ **reuse the request transaction** (zero extra connection); a miss or no context ⇒ escalate via `runOutsideDbContext(() => withSystemDbAccessContext(fn))`.

This keeps the dominant dashboard paths (org-members, same-tenant callers) on their existing transaction — avoiding a second pooled connection per cache-miss permission check (the #1105 conn-hold / connection-ceiling class) — while fixing the blind MCP partner-axis fallback.

**Safety:** reads are equality-keyed by `userId` + `orgId`/`partnerId`, so system-scope resolution can only surface that one pinned row or nothing — never a cross-tenant/cross-user row. Over-escalation is at worst a perf miss, never a leak.

## Tests

- **`permissionsContext.integration.test.ts`** (real DB, unprivileged `breeze_app` = NOSUPERUSER/NOBYPASSRLS): membership-less Partner Admin under a narrow org-scope context (#2019), contextless cold cache (#1448), **org-member reuse path**, system-context reuse, and `getCurrentDbAccessContext` plumbing. Verified **RED** when escalation is forced off — non-vacuous.
- **`permissions.test.ts`** (unit): call-order (`runOutsideDbContext` before `withSystemDbAccessContext`), cache-hit-no-escalation, throw-propagation (an infra fault must reject, not become a silent `null`/403), and per-axis escalate-only-the-blind-axis.
- Full API suite: **896 files / 10,971 tests green**; typecheck clean.

Reported by SemoTech (self-hosted, Cursor MCP). Follow-up to #2019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)