### PR TITLE
feat(ticketing): drop-unknown-sender mode + DMARC-fail drop; inbound review queue → Tickets tab

### DIFF
--- a/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
+++ b/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
@@ -117,11 +117,23 @@ describe('findOrCreateEmailContact', () => {
 });
 
 describe('loadPartnerInboundPolicy', () => {
-  it('reads triage flags from partners.settings JSONB, defaulting absent to off', async () => {
+  it('reads routing policy from partners.settings JSONB, defaulting absent to quarantine', async () => {
     const { p } = await seedPartnerOrg();
     const defaults = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
-    expect(defaults).toEqual({ triageUnknownSenders: false, defaultTriageOrgId: null });
+    expect(defaults).toEqual({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
+    const adminDb = getTestDb() as any;
+    await adminDb
+      .update(partners)
+      .set({ settings: { ticketing: { inbound: { unknownSenderMode: 'drop', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: true } } } })
+      .where(eq(partners.id, p.id));
+
+    const set = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
+    expect(set).toEqual({ unknownSenderMode: 'drop', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: true });
+  });
+
+  it('maps the legacy triageUnknownSenders boolean to unknownSenderMode for back-compat', async () => {
+    const { p } = await seedPartnerOrg();
     const adminDb = getTestDb() as any;
     await adminDb
       .update(partners)
@@ -129,6 +141,6 @@ describe('loadPartnerInboundPolicy', () => {
       .where(eq(partners.id, p.id));
 
     const set = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
-    expect(set).toEqual({ triageUnknownSenders: true, defaultTriageOrgId: 'org-triage' });
+    expect(set).toEqual({ unknownSenderMode: 'triage', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: false });
   });
 });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -468,10 +468,16 @@ const partnerSettingsSchema = z.object({
       address: z.string().email().optional().or(z.literal('')),
       defaultTriageOrgId: z.string().guid().nullable().optional(),
       autoresponderEnabled: z.boolean().optional(),
-      // NOTE: triageUnknownSenders was already sent by InboundEmailCard but missing
-      // from this schema (closed object → stripped). Add it here while we're in the
-      // object so it actually persists, alongside the new auto-reply fields.
+      // Unknown-sender routing. `unknownSenderMode` is the current 3-way control;
+      // `triageUnknownSenders` is the legacy boolean still accepted for back-compat
+      // (loadPartnerInboundPolicy maps it true→'triage'). The card now sends
+      // `unknownSenderMode`, which retires the legacy key on the next save (the
+      // inbound sub-object is replaced wholesale).
+      unknownSenderMode: z.enum(['quarantine', 'triage', 'drop']).optional(),
       triageUnknownSenders: z.boolean().optional(),
+      // When true, senders failing the SPF/DKIM/DMARC gate are dropped silently
+      // instead of quarantined. Default-off; applies to all unverified senders.
+      dropUnverifiedSenders: z.boolean().optional(),
       autoresponseSubject: z.string().max(200).nullable().optional(),
       autoresponseBody: z.string().max(5000).nullable().optional(),
     }).optional(),

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -227,7 +227,7 @@ beforeEach(() => {
   resolveOrgMock.mockResolvedValue(null);
   findOrCreateContactMock.mockReset();
   loadPolicyMock.mockReset();
-  loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
+  loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 });
 
 describe('processInboundEmail', () => {
@@ -721,6 +721,22 @@ describe('processInboundEmail', () => {
     expect(log[0]!.parseStatus).toBe('quarantined');
   });
 
+  it('R4: dropUnverifiedSenders DROPS an unverified sender instead of quarantining (audit row only)', async () => {
+    resolveMock.mockResolvedValue('p-1');
+    state.selectRows['ticket_email_inbound'] = [];
+    state.selectRows['tickets'] = [];
+    state.selectRows['portal_users'] = [];
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: true });
+
+    await processInboundEmail(email({ senderAuth: { spf: 'fail', dkim: 'fail', dmarc: 'fail', verified: false } }));
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    const log = inboundOf();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.parseStatus).toBe('ignored');
+    expect(log[0]!.ticketId).toBeNull();
+  });
+
   it('R4: a VERIFIED sender still appends/reopens, and stamps authorName from the stored portal-user name', async () => {
     resolveMock.mockResolvedValue('p-1');
     state.selectRows['ticket_email_inbound'] = [];
@@ -763,9 +779,9 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
     resolveOrgMock.mockReset();
     findOrCreateContactMock.mockReset();
     loadPolicyMock.mockReset();
-    // Safe defaults: no domain match, triage off.
+    // Safe defaults: no domain match, quarantine unknown senders.
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
   });
 
   it('routes a mapped domain (autoCreateContact true) -> creates ticket in the org + onboards a contact', async () => {
@@ -801,7 +817,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
   it('falls back to the triage org when enabled and no domain matches (no contact onboarding)', async () => {
     state.selectRows['organizations'] = [{ id: 'o-triage' }];
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: true, defaultTriageOrgId: 'o-triage' });
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'triage', defaultTriageOrgId: 'o-triage', dropUnverifiedSenders: false });
     createTicketMock.mockResolvedValue({ id: 't-t', internalNumber: 'T-2026-0100' });
 
     await processInboundEmail(email());
@@ -812,14 +828,37 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
     expect(inboundOf()[0]!.parseStatus).toBe('created');
   });
 
-  it('quarantines when nothing matches and triage is disabled', async () => {
+  it('quarantines when nothing matches and mode is quarantine (default)', async () => {
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ triageUnknownSenders: false, defaultTriageOrgId: null });
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
     await processInboundEmail(email());
 
     expect(createTicketMock).not.toHaveBeenCalled();
     expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
+  });
+
+  it('triage mode with NO triage org configured falls through to quarantine (never a no-org create)', async () => {
+    resolveOrgMock.mockResolvedValue(null);
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'triage', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+
+    await processInboundEmail(email());
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
+  });
+
+  it("'drop' mode silently ignores an unknown sender — no ticket, no quarantine (audit row only)", async () => {
+    resolveOrgMock.mockResolvedValue(null);
+    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'drop', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+
+    await processInboundEmail(email());
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    const rows = inboundOf();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.parseStatus).toBe('ignored');
+    expect(rows[0]!.ticketId).toBeNull();
   });
 
   it('does NOT reach domain routing for an unverified sender (existing DMARC gate wins)', async () => {

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -171,7 +171,17 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
     // boundary (aligned SPF+DKIM, or DMARC pass). When NOT verified, route the message to
     // the EXISTING quarantine/review path instead of auto-acting — mail is never dropped.
     if (!n.senderAuth?.verified) {
-      await logInbound(n, partnerId, 'quarantined', null, 'unverified sender (SPF/DKIM/DMARC)');
+      // Default: route to the review queue. If the partner opted into dropping
+      // unverified mail, silently ignore it instead (audit row only, no review
+      // queue, no autoresponse). This gate runs before any sender matching, so
+      // the drop applies to ALL unverified senders — known or not (see
+      // PartnerInboundPolicy.dropUnverifiedSenders).
+      const policy = await loadPartnerInboundPolicy(partnerId);
+      if (policy.dropUnverifiedSenders) {
+        await logInbound(n, partnerId, 'ignored', null, 'drop: unverified sender (SPF/DKIM/DMARC)');
+      } else {
+        await logInbound(n, partnerId, 'quarantined', null, 'unverified sender (SPF/DKIM/DMARC)');
+      }
       return;
     }
 
@@ -230,17 +240,28 @@ export async function processInboundEmail(n: NormalizedInboundEmail): Promise<vo
       return;
     }
 
-    // (7) Triage fallback for unknown senders, only if the partner opted in
-    // (settings.ticketing.inbound). No contact is onboarded — the customer is
-    // unknown. Default-off: absent settings keep the Phase 4 quarantine behavior.
+    // (7) Unknown sender (no thread, no portal user, no mapped domain). The
+    // partner's policy (settings.ticketing.inbound) decides the fate. No contact
+    // is onboarded — the customer is unknown. Default-off: absent settings keep
+    // the Phase 4 quarantine behavior.
     const policy = await loadPartnerInboundPolicy(partnerId);
-    if (policy.triageUnknownSenders && policy.defaultTriageOrgId) {
+
+    // 'drop' — silently ignore: no ticket, no review-queue row, no autoresponse.
+    // Distinct from quarantine so unmapped spam doesn't fill the review queue.
+    if (policy.unknownSenderMode === 'drop') {
+      await logInbound(n, partnerId, 'ignored', null, 'drop: unknown sender');
+      return;
+    }
+
+    // 'triage' — auto-create in the partner's default triage org (only when one
+    // is configured; otherwise fall through to quarantine).
+    if (policy.unknownSenderMode === 'triage' && policy.defaultTriageOrgId) {
       const t = await createFromEmail(n, partnerId, policy.defaultTriageOrgId, null, null);
       await logInbound(n, partnerId, 'created', t.id);
       return;
     }
 
-    // (8) Nothing matched -> quarantine for manual review.
+    // (8) 'quarantine' (default) -> review queue for manual handling.
     await logInbound(n, partnerId, 'quarantined', null);
   } catch (err) {
     // (9) Any guard/error -> failed, logged under the RESOLVED partner (or null if

--- a/apps/api/src/services/inboundEmail/resolveOrg.ts
+++ b/apps/api/src/services/inboundEmail/resolveOrg.ts
@@ -74,12 +74,41 @@ export async function findOrCreateEmailContact(
 }
 
 /**
- * Read the partner's inbound triage policy from partners.settings JSONB
- * (settings.ticketing.inbound). Absent fields read as disabled.
+ * How an inbound email from an UNKNOWN sender (no live thread, no closed-ticket
+ * reply, no portal user, no mapped customer domain) is handled:
+ *  - 'quarantine' — route to the review queue for manual convert/dismiss (default)
+ *  - 'triage'     — auto-create a ticket in the partner's default triage org
+ *                   (only effective when defaultTriageOrgId is set)
+ *  - 'drop'       — silently ignore: no ticket, no review-queue row, no
+ *                   autoresponse (an 'ignored' audit row is still written)
+ */
+export type UnknownSenderMode = 'quarantine' | 'triage' | 'drop';
+
+const UNKNOWN_SENDER_MODES: readonly UnknownSenderMode[] = ['quarantine', 'triage', 'drop'];
+
+export interface PartnerInboundPolicy {
+  unknownSenderMode: UnknownSenderMode;
+  defaultTriageOrgId: string | null;
+  /**
+   * When true, an inbound email whose sender fails the SPF/DKIM/DMARC gate is
+   * silently dropped ('ignored' audit row) instead of quarantined. Applies to
+   * ALL unverified senders (known or not), since the auth gate runs before any
+   * sender matching. Default false (preserves the quarantine-for-review behavior).
+   */
+  dropUnverifiedSenders: boolean;
+}
+
+/**
+ * Read the partner's inbound routing policy from partners.settings JSONB
+ * (settings.ticketing.inbound). Absent fields read as the safe default
+ * (quarantine; never drop). Back-compat: a partner that only has the legacy
+ * `triageUnknownSenders` boolean (set before the 3-way mode existed) maps
+ * true -> 'triage', false/absent -> 'quarantine'. The first save from the UI
+ * replaces the inbound object wholesale, retiring the legacy key.
  */
 export async function loadPartnerInboundPolicy(
   partnerId: string,
-): Promise<{ triageUnknownSenders: boolean; defaultTriageOrgId: string | null }> {
+): Promise<PartnerInboundPolicy> {
   const rows = await db
     .select({ settings: partners.settings })
     .from(partners)
@@ -88,10 +117,25 @@ export async function loadPartnerInboundPolicy(
   const settings = (rows[0]?.settings ?? {}) as Record<string, unknown>;
   const inbound =
     (((settings.ticketing as Record<string, unknown> | undefined)?.inbound) as
-      | { defaultTriageOrgId?: string | null; triageUnknownSenders?: boolean }
+      | {
+          defaultTriageOrgId?: string | null;
+          triageUnknownSenders?: boolean;
+          unknownSenderMode?: string;
+          dropUnverifiedSenders?: boolean;
+        }
       | undefined) ?? {};
+
+  // Prefer the explicit 3-way mode; fall back to the legacy boolean. An
+  // unrecognized stored value falls through to the safe 'quarantine' default.
+  const mode = UNKNOWN_SENDER_MODES.includes(inbound.unknownSenderMode as UnknownSenderMode)
+    ? (inbound.unknownSenderMode as UnknownSenderMode)
+    : inbound.triageUnknownSenders === true
+      ? 'triage'
+      : 'quarantine';
+
   return {
-    triageUnknownSenders: inbound.triageUnknownSenders === true,
+    unknownSenderMode: mode,
     defaultTriageOrgId: inbound.defaultTriageOrgId ?? null,
+    dropUnverifiedSenders: inbound.dropUnverifiedSenders === true,
   };
 }

--- a/apps/api/src/services/ticketConfigService.test.ts
+++ b/apps/api/src/services/ticketConfigService.test.ts
@@ -269,6 +269,26 @@ describe('getTicketConfig inbound block', () => {
     expect(cfg.inbound.domainConfigured).toBe(false);
     expect(cfg.inbound.address).toBe('');
   });
+  it('defaults unknownSenderMode=quarantine and dropUnverifiedSenders=false when absent', async () => {
+    enqueueForInbound({ slug: 'acme', settings: {} });
+    const cfg = await getTicketConfig('p-1');
+    expect(cfg.inbound.unknownSenderMode).toBe('quarantine');
+    expect(cfg.inbound.dropUnverifiedSenders).toBe(false);
+    expect(cfg.inbound.triageUnknownSenders).toBe(false);
+  });
+  it('surfaces an explicit unknownSenderMode=drop and dropUnverifiedSenders=true', async () => {
+    enqueueForInbound({ slug: 'acme', settings: { ticketing: { inbound: { unknownSenderMode: 'drop', dropUnverifiedSenders: true } } } });
+    const cfg = await getTicketConfig(PARTNER);
+    expect(cfg.inbound.unknownSenderMode).toBe('drop');
+    expect(cfg.inbound.dropUnverifiedSenders).toBe(true);
+    expect(cfg.inbound.triageUnknownSenders).toBe(false);
+  });
+  it('maps legacy triageUnknownSenders=true -> unknownSenderMode=triage (back-compat)', async () => {
+    enqueueForInbound({ slug: 'acme', settings: { ticketing: { inbound: { triageUnknownSenders: true } } } });
+    const cfg = await getTicketConfig(PARTNER);
+    expect(cfg.inbound.unknownSenderMode).toBe('triage');
+    expect(cfg.inbound.triageUnknownSenders).toBe(true);
+  });
 });
 
 describe('createTicketStatus', () => {

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -368,6 +368,7 @@ export async function getTicketConfig(partnerId: string) {
     {
       enabled?: boolean; address?: string; defaultTriageOrgId?: string | null;
       autoresponderEnabled?: boolean; triageUnknownSenders?: boolean;
+      unknownSenderMode?: string; dropUnverifiedSenders?: boolean;
       autoresponseSubject?: string | null; autoresponseBody?: string | null;
     } | undefined) ?? {};
   const domain = getConfig().TICKETS_INBOUND_DOMAIN ?? '';
@@ -376,13 +377,26 @@ export async function getTicketConfig(partnerId: string) {
   const derived = domainConfigured && effectiveLocalPart ? `${effectiveLocalPart}@${domain}` : '';
   const addressOverride = (inboundCfg.address && inboundCfg.address.length > 0) ? inboundCfg.address : null;
 
+  // Resolve the 3-way unknown-sender mode with the same back-compat rule as
+  // loadPartnerInboundPolicy: explicit mode wins, else the legacy boolean maps
+  // true→'triage', else 'quarantine'. `triageUnknownSenders` is still emitted
+  // (derived) so any older client keeps working.
+  const unknownSenderMode: 'quarantine' | 'triage' | 'drop' =
+    inboundCfg.unknownSenderMode === 'triage' || inboundCfg.unknownSenderMode === 'drop' || inboundCfg.unknownSenderMode === 'quarantine'
+      ? inboundCfg.unknownSenderMode
+      : inboundCfg.triageUnknownSenders === true
+        ? 'triage'
+        : 'quarantine';
+
   const inbound = {
     enabled: inboundCfg.enabled ?? false,
     address: addressOverride ?? derived,
     addressOverride,
     defaultTriageOrgId: inboundCfg.defaultTriageOrgId ?? null,
     autoresponderEnabled: inboundCfg.autoresponderEnabled ?? true,
-    triageUnknownSenders: inboundCfg.triageUnknownSenders ?? false,
+    unknownSenderMode,
+    triageUnknownSenders: unknownSenderMode === 'triage',
+    dropUnverifiedSenders: inboundCfg.dropUnverifiedSenders ?? false,
     autoresponseSubject: inboundCfg.autoresponseSubject ?? null,
     autoresponseBody: inboundCfg.autoresponseBody ?? null,
     slug,

--- a/apps/web/src/components/settings/InboundEmailCard.test.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.test.tsx
@@ -14,6 +14,8 @@ vi.mock('../../lib/runAction', () => ({
   },
   handleActionError: vi.fn(),
 }));
+// CustomerDomainsCard does its own fetches; stub it out — not under test here.
+vi.mock('./CustomerDomainsCard', () => ({ CustomerDomainsCard: () => null }));
 
 import InboundEmailCard from './InboundEmailCard';
 
@@ -28,7 +30,8 @@ interface CfgShape {
   addressOverride: string | null;
   defaultTriageOrgId: string | null;
   autoresponderEnabled: boolean;
-  triageUnknownSenders: boolean;
+  unknownSenderMode: 'quarantine' | 'triage' | 'drop';
+  dropUnverifiedSenders: boolean;
   autoresponseSubject: string | null;
   autoresponseBody: string | null;
   slug: string;
@@ -42,25 +45,27 @@ const CFG: CfgShape = {
   addressOverride: null,
   defaultTriageOrgId: null,
   autoresponderEnabled: true,
-  triageUnknownSenders: false,
+  unknownSenderMode: 'quarantine',
+  dropUnverifiedSenders: false,
   autoresponseSubject: null,
   autoresponseBody: null,
   slug: 'acme',
   domainConfigured: true,
 };
 
-function routeFetch(queue: unknown[], cfg: CfgShape = CFG) {
+function routeFetch(cfg: CfgShape = CFG) {
   fetchWithAuth.mockImplementation((url: string) => {
     if (url === '/ticket-config') return Promise.resolve(jsonRes({ data: { inbound: cfg } }));
-    if (url.startsWith('/ticket-config/email-inbound?'))
-      return Promise.resolve(jsonRes({ data: queue, pagination: { page: 1, limit: 50, total: queue.length } }));
     if (url === '/orgs/organizations?limit=100')
       return Promise.resolve(jsonRes({ data: [{ id: 'o-1', name: 'Acme Org' }] }));
-    if (url.includes('/convert')) return Promise.resolve(jsonRes({ data: { id: 'r-1', parseStatus: 'created' } }));
-    if (url.includes('/dismiss')) return Promise.resolve(jsonRes({ data: { id: 'r-1', parseStatus: 'ignored' } }));
     if (url === '/orgs/partners/me') return Promise.resolve(jsonRes({ id: 'p-1' }));
     return Promise.resolve(jsonRes({ data: [] }));
   });
+}
+
+function lastInboundPatch() {
+  const call = fetchWithAuth.mock.calls.find((c) => c[0] === '/orgs/partners/me')!;
+  return JSON.parse((call[1] as { body: string }).body).settings.ticketing.inbound;
 }
 
 beforeEach(() => {
@@ -68,109 +73,86 @@ beforeEach(() => {
 });
 
 describe('InboundEmailCard', () => {
-  it('renders the inbound address and review queue', async () => {
-    routeFetch([
-      {
-        id: 'r-1',
-        fromAddress: 'jane@x.com',
-        subject: 'printer',
-        parseStatus: 'quarantined',
-        error: null,
-        ticketId: null,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
+  it('renders the inbound address and the unknown-sender mode control', async () => {
+    routeFetch();
     render(<InboundEmailCard />);
     expect(await screen.findByTestId('inbound-email-card')).toBeTruthy();
     expect((screen.getByTestId('inbound-localpart') as HTMLInputElement).value).toBe('acme');
-    expect(screen.getByTestId('inbound-row-r-1')).toBeTruthy();
+    expect(screen.getByTestId('inbound-unknown-sender-mode')).toBeTruthy();
+    // The review queue no longer lives in settings (moved to the Tickets area).
+    expect(screen.queryByTestId('inbound-review-queue')).toBeNull();
+  });
+
+  it('quarantine is selected by default; triage is disabled until a triage org is set', async () => {
+    routeFetch();
+    render(<InboundEmailCard />);
+    await screen.findByTestId('inbound-email-card');
+    expect((screen.getByTestId('inbound-unknown-quarantine') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('inbound-unknown-triage') as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('triage becomes selectable once a default triage org is configured', async () => {
+    routeFetch({ ...CFG, defaultTriageOrgId: 'o-1', unknownSenderMode: 'triage' });
+    render(<InboundEmailCard />);
+    await screen.findByTestId('inbound-email-card');
+    expect((screen.getByTestId('inbound-unknown-triage') as HTMLInputElement).disabled).toBe(false);
+    expect((screen.getByTestId('inbound-unknown-triage') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('selecting "Drop silently" PATCHes unknownSenderMode=drop in the complete inbound object', async () => {
+    routeFetch();
+    render(<InboundEmailCard />);
+    await screen.findByTestId('inbound-email-card');
+    fireEvent.click(screen.getByTestId('inbound-unknown-drop'));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/partners/me', expect.objectContaining({ method: 'PATCH' })),
+    );
+    const inbound = lastInboundPatch();
+    expect(inbound.unknownSenderMode).toBe('drop');
+    expect(inbound).not.toHaveProperty('triageUnknownSenders'); // legacy key retired
+    expect(inbound).toHaveProperty('dropUnverifiedSenders');
+  });
+
+  it('toggling "drop unverified senders" PATCHes dropUnverifiedSenders=true', async () => {
+    routeFetch();
+    render(<InboundEmailCard />);
+    await screen.findByTestId('inbound-email-card');
+    fireEvent.click(screen.getByTestId('inbound-drop-unverified-toggle'));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/partners/me', expect.objectContaining({ method: 'PATCH' })),
+    );
+    expect(lastInboundPatch().dropUnverifiedSenders).toBe(true);
   });
 
   it('toggling enable PATCHes /orgs/partners/me with the COMPLETE ticketing.inbound (no address when override is null)', async () => {
-    routeFetch([]);
+    routeFetch();
     render(<InboundEmailCard />);
     await screen.findByTestId('inbound-email-card');
     fireEvent.click(screen.getByTestId('inbound-enabled-toggle'));
     await waitFor(() =>
       expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/partners/me', expect.objectContaining({ method: 'PATCH' })),
     );
-    const body = JSON.parse(
-      (fetchWithAuth.mock.calls.find((c) => c[0] === '/orgs/partners/me')![1] as { body: string }).body,
-    );
-    expect(body.settings.ticketing.inbound.enabled).toBe(true);
-    expect(body.settings.ticketing.inbound).toHaveProperty('defaultTriageOrgId');
-    expect(body.settings.ticketing.inbound).toHaveProperty('autoresponderEnabled');
-    expect(body.settings.ticketing.inbound).not.toHaveProperty('address'); // derived address is NOT re-sent as an override
+    const inbound = lastInboundPatch();
+    expect(inbound.enabled).toBe(true);
+    expect(inbound).toHaveProperty('defaultTriageOrgId');
+    expect(inbound).toHaveProperty('autoresponderEnabled');
+    expect(inbound).toHaveProperty('unknownSenderMode');
+    expect(inbound).not.toHaveProperty('address'); // derived address is NOT re-sent as an override
   });
 
   it('re-sends a self-hosted address override on save so the merge does not destroy it (blocker #1)', async () => {
-    routeFetch([], { ...CFG, address: 'support@tickets.acme.com', addressOverride: 'support@tickets.acme.com' });
+    routeFetch({ ...CFG, address: 'support@tickets.acme.com', addressOverride: 'support@tickets.acme.com' });
     render(<InboundEmailCard />);
     await screen.findByTestId('inbound-email-card');
     fireEvent.click(screen.getByTestId('inbound-autoresponder-toggle'));
     await waitFor(() =>
       expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/partners/me', expect.objectContaining({ method: 'PATCH' })),
     );
-    const body = JSON.parse(
-      (fetchWithAuth.mock.calls.find((c) => c[0] === '/orgs/partners/me')![1] as { body: string }).body,
-    );
-    expect(body.settings.ticketing.inbound.address).toBe('support@tickets.acme.com');
-  });
-
-  it('Convert opens the org picker and POSTs convert with the chosen orgId', async () => {
-    routeFetch([
-      {
-        id: 'r-1',
-        fromAddress: 'jane@x.com',
-        subject: 'printer',
-        parseStatus: 'quarantined',
-        error: null,
-        ticketId: null,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
-    render(<InboundEmailCard />);
-    await screen.findByTestId('inbound-row-r-1');
-    fireEvent.click(screen.getByTestId('inbound-convert-r-1'));
-    fireEvent.change(screen.getByTestId('inbound-convert-org-r-1'), { target: { value: 'o-1' } });
-    fireEvent.click(screen.getByTestId('inbound-convert-submit-r-1'));
-    await waitFor(() =>
-      expect(fetchWithAuth).toHaveBeenCalledWith(
-        '/ticket-config/email-inbound/r-1/convert',
-        expect.objectContaining({ method: 'POST' }),
-      ),
-    );
-    const body = JSON.parse(
-      (fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/convert'))![1] as { body: string }).body,
-    );
-    expect(body.orgId).toBe('o-1');
-  });
-
-  it('Dismiss PATCHes the dismiss route and refetches', async () => {
-    routeFetch([
-      {
-        id: 'r-1',
-        fromAddress: 'jane@x.com',
-        subject: 'printer',
-        parseStatus: 'failed',
-        error: 'boom',
-        ticketId: null,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
-    render(<InboundEmailCard />);
-    await screen.findByTestId('inbound-row-r-1');
-    fireEvent.click(screen.getByTestId('inbound-dismiss-r-1'));
-    await waitFor(() =>
-      expect(fetchWithAuth).toHaveBeenCalledWith(
-        '/ticket-config/email-inbound/r-1/dismiss',
-        expect.objectContaining({ method: 'PATCH' }),
-      ),
-    );
+    expect(lastInboundPatch().address).toBe('support@tickets.acme.com');
   });
 
   it('shows a live preview of the custom auto-reply body with sample variables', async () => {
-    routeFetch([], { ...CFG, autoresponseBody: 'Hi {{requester_name}}' });
+    routeFetch({ ...CFG, autoresponseBody: 'Hi {{requester_name}}' });
     render(<InboundEmailCard />);
     await screen.findByTestId('inbound-email-card');
     const preview = await screen.findByTestId('inbound-autoreply-preview');
@@ -178,7 +160,7 @@ describe('InboundEmailCard', () => {
   });
 
   it('saves the complete inbound object including auto-reply subject + body', async () => {
-    routeFetch([]);
+    routeFetch();
     render(<InboundEmailCard />);
     await screen.findByTestId('inbound-email-card');
     fireEvent.change(screen.getByTestId('inbound-autoreply-subject'), {
@@ -191,42 +173,26 @@ describe('InboundEmailCard', () => {
     await waitFor(() =>
       expect(fetchWithAuth).toHaveBeenCalledWith('/orgs/partners/me', expect.objectContaining({ method: 'PATCH' })),
     );
-    const body = JSON.parse(
-      (fetchWithAuth.mock.calls.find((c) => c[0] === '/orgs/partners/me')![1] as { body: string }).body,
-    );
-    const inbound = body.settings.ticketing.inbound;
+    const inbound = lastInboundPatch();
     expect(inbound.autoresponseSubject).toBe('Re: {{ticket_subject}}');
     expect(inbound.autoresponseBody).toBe('Thanks {{requester_name}}');
     // No sibling field destroyed by the shallow-replace of `ticketing`.
     expect(inbound).toHaveProperty('enabled');
     expect(inbound).toHaveProperty('autoresponderEnabled');
-    expect(inbound).toHaveProperty('triageUnknownSenders');
+    expect(inbound).toHaveProperty('unknownSenderMode');
+    expect(inbound).toHaveProperty('dropUnverifiedSenders');
   });
 
   it('hides the auto-reply editor when the autoresponder is disabled', async () => {
-    routeFetch([], { ...CFG, autoresponderEnabled: false });
+    routeFetch({ ...CFG, autoresponderEnabled: false });
     render(<InboundEmailCard />);
     await screen.findByTestId('inbound-email-card');
     expect(screen.queryByTestId('inbound-autoreply-body')).toBeNull();
   });
 
   it('shows the unconfigured-domain hint when domainConfigured is false', async () => {
-    routeFetch([], { ...CFG, address: '', domainConfigured: false });
+    routeFetch({ ...CFG, address: '', domainConfigured: false });
     render(<InboundEmailCard />);
     expect(await screen.findByTestId('inbound-address-unconfigured')).toBeTruthy();
-  });
-
-  it('renders the admin-only notice when the queue fetch 403s but keeps settings usable', async () => {
-    fetchWithAuth.mockImplementation((url: string) => {
-      if (url === '/ticket-config') return Promise.resolve(jsonRes({ data: { inbound: CFG } }));
-      if (url.startsWith('/ticket-config/email-inbound?'))
-        return Promise.resolve(jsonRes({ error: 'admin' }, false, 403));
-      if (url === '/orgs/organizations?limit=100') return Promise.resolve(jsonRes({ data: [] }));
-      return Promise.resolve(jsonRes({ data: [] }));
-    });
-    render(<InboundEmailCard />);
-    expect(await screen.findByTestId('inbound-email-card')).toBeTruthy();
-    expect(screen.getByTestId('inbound-review-forbidden')).toBeTruthy();
-    expect(screen.getByTestId('inbound-enabled-toggle')).toBeTruthy(); // settings still rendered
   });
 });

--- a/apps/web/src/components/settings/InboundEmailCard.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { renderTemplate, variablesForContext, type TicketTemplateVars } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
 import { showToast } from '../shared/Toast';
-import { formatDateTime } from '@/lib/dateTimeFormat';
 import { CustomerDomainsCard } from './CustomerDomainsCard';
 
 // Sample values so the admin can preview how merge variables resolve in the
@@ -20,6 +19,10 @@ const AUTORESPONSE_SAMPLE: TicketTemplateVars = {
   partner_name: 'Your Company',
 };
 
+// How inbound mail from an unmatched ("unknown") sender is handled. Mirrors the
+// API's PartnerInboundPolicy union (settings.ticketing.inbound.unknownSenderMode).
+type UnknownSenderMode = 'quarantine' | 'triage' | 'drop';
+
 interface InboundConfig {
   enabled: boolean;
   address: string;
@@ -27,26 +30,12 @@ interface InboundConfig {
   inboundLocalPart: string | null;
   defaultTriageOrgId: string | null;
   autoresponderEnabled: boolean;
-  triageUnknownSenders: boolean;
+  unknownSenderMode: UnknownSenderMode;
+  dropUnverifiedSenders: boolean;
   autoresponseSubject: string | null;
   autoresponseBody: string | null;
   slug: string;
   domainConfigured: boolean;
-}
-
-interface QueueRow {
-  id: string;
-  fromAddress: string | null;
-  toAddress: string | null;
-  subject: string | null;
-  // The list endpoint only ever returns review-queue rows, so the union is the
-  // two review statuses. convert/dismiss responses carry the resolved status
-  // ('created'/'ignored') but the card intentionally discards those bodies and
-  // reloads the queue, so they never widen this type.
-  parseStatus: 'quarantined' | 'failed';
-  error: string | null;
-  ticketId: string | null;
-  createdAt: string;
 }
 
 interface OrgOption {
@@ -56,30 +45,19 @@ interface OrgOption {
 
 const FRIENDLY_CODES: Record<string, string> = {
   ORG_NOT_ACCESSIBLE: 'That organization is not available under your partner.',
-  INBOUND_ROW_NOT_FOUND: 'That inbound email is no longer available.',
-  INBOUND_ROW_ALREADY_RESOLVED: 'That inbound email was already handled. Refreshing the list.',
-  INBOUND_ROW_NO_SENDER:
-    'This email has no usable sender address, so it cannot become a ticket. Dismiss it or follow up out-of-band.',
 };
 const friendlyCode = (code: string): string | undefined => FRIENDLY_CODES[code];
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
-const PAGE_SIZE = 50;
 const SAVE_ERROR =
   'Could not save inbound email settings — your session may need MFA re-verification. Retry.';
 
 export default function InboundEmailCard() {
   const [cfg, setCfg] = useState<InboundConfig | null>(null);
   const [orgs, setOrgs] = useState<OrgOption[]>([]);
-  const [rows, setRows] = useState<QueueRow[]>([]);
-  const [page, setPage] = useState(1);
-  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  const [queueForbidden, setQueueForbidden] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [convertOpenId, setConvertOpenId] = useState<string | null>(null);
-  const [convertOrgId, setConvertOrgId] = useState('');
   const [localPartDraft, setLocalPartDraft] = useState('');
   // Draft state for the auto-reply editor — kept separate from `cfg` so typing
   // doesn't auto-save; persisted explicitly via the Save button.
@@ -103,23 +81,6 @@ export default function InboundEmailCard() {
     setAutoBody(nextCfg.autoresponseBody ?? '');
   }, []);
 
-  const loadQueue = useCallback(async (p: number) => {
-    const res = await fetchWithAuth(`/ticket-config/email-inbound?page=${p}&limit=${PAGE_SIZE}`);
-    // The queue is an admin-only surface; a 403 must not break the settings.
-    if (res.status === 403) {
-      setQueueForbidden(true);
-      return;
-    }
-    if (!res.ok) {
-      setError(true);
-      return;
-    }
-    setQueueForbidden(false);
-    const body = (await res.json()) as { data: QueueRow[]; pagination: { total: number } };
-    setRows(body.data);
-    setTotal(body.pagination.total);
-  }, []);
-
   const loadOrgs = useCallback(async () => {
     const res = await fetchWithAuth('/orgs/organizations?limit=100');
     if (res.ok) {
@@ -129,21 +90,21 @@ export default function InboundEmailCard() {
   }, []);
 
   const loadAll = useCallback(
-    async (p: number) => {
+    async () => {
       setLoading(true);
       setError(false);
       try {
-        await Promise.all([loadConfig(), loadQueue(p), loadOrgs()]);
+        await Promise.all([loadConfig(), loadOrgs()]);
       } catch {
         setError(true);
       }
       setLoading(false);
     },
-    [loadConfig, loadQueue, loadOrgs],
+    [loadConfig, loadOrgs],
   );
 
   useEffect(() => {
-    void loadAll(1);
+    void loadAll();
   }, [loadAll]);
 
   const saveConfig = useCallback(
@@ -154,7 +115,8 @@ export default function InboundEmailCard() {
           | 'enabled'
           | 'defaultTriageOrgId'
           | 'autoresponderEnabled'
-          | 'triageUnknownSenders'
+          | 'unknownSenderMode'
+          | 'dropUnverifiedSenders'
           | 'autoresponseSubject'
           | 'autoresponseBody'
         >
@@ -164,14 +126,16 @@ export default function InboundEmailCard() {
       const next = { ...cfg, ...patch };
       // Send the COMPLETE ticketing.inbound object — PATCH /partners/me deep-merges
       // `ticketing` one level but replaces the `inbound` sub-object wholesale, so any
-      // omitted inbound field is destroyed.
+      // omitted inbound field is destroyed (this also retires the legacy
+      // `triageUnknownSenders` key, which we no longer send).
       // Include `address` ONLY when there is a real self-hosted override (never the
       // derived value, which would persist a derived address as a spurious override).
       const inbound: Record<string, unknown> = {
         enabled: next.enabled,
         defaultTriageOrgId: next.defaultTriageOrgId,
         autoresponderEnabled: next.autoresponderEnabled,
-        triageUnknownSenders: next.triageUnknownSenders,
+        unknownSenderMode: next.unknownSenderMode,
+        dropUnverifiedSenders: next.dropUnverifiedSenders,
         autoresponseSubject: next.autoresponseSubject,
         autoresponseBody: next.autoresponseBody,
       };
@@ -230,70 +194,12 @@ export default function InboundEmailCard() {
     }
   }, [cfg, localPartDraft]);
 
-  const convert = useCallback(
-    async (id: string) => {
-      if (!convertOrgId) {
-        showToast({ type: 'error', message: 'Pick an organization first.' });
-        return;
-      }
-      try {
-        await runAction({
-          request: () =>
-            fetchWithAuth(`/ticket-config/email-inbound/${id}/convert`, {
-              method: 'POST',
-              body: JSON.stringify({ orgId: convertOrgId }),
-            }),
-          errorFallback: 'Convert to ticket failed. Retry.',
-          successMessage: 'Ticket created from email',
-          friendly: friendlyCode,
-          onUnauthorized: UNAUTHORIZED,
-        });
-        setConvertOpenId(null);
-        await loadQueue(page);
-      } catch (err) {
-        handleActionError(err, 'Convert to ticket failed. Retry.');
-        // An already-resolved row (409) means the list is stale — refresh so it clears.
-        await loadQueue(page);
-      }
-    },
-    [convertOrgId, page, loadQueue],
-  );
-
-  const dismiss = useCallback(
-    async (id: string) => {
-      try {
-        await runAction({
-          request: () =>
-            fetchWithAuth(`/ticket-config/email-inbound/${id}/dismiss`, { method: 'PATCH' }),
-          errorFallback: 'Dismiss failed. Retry.',
-          successMessage: 'Inbound email dismissed',
-          friendly: friendlyCode,
-          onUnauthorized: UNAUTHORIZED,
-        });
-        await loadQueue(page);
-      } catch (err) {
-        handleActionError(err, 'Dismiss failed. Retry.');
-        await loadQueue(page);
-      }
-    },
-    [page, loadQueue],
-  );
-
   const copyAddress = useCallback(() => {
     if (cfg?.address) {
       void navigator.clipboard?.writeText(cfg.address);
       showToast({ type: 'success', message: 'Inbound address copied' });
     }
   }, [cfg]);
-
-  const totalPages = useMemo(() => Math.max(1, Math.ceil(total / PAGE_SIZE)), [total]);
-  const goPage = useCallback(
-    (p: number) => {
-      setPage(p);
-      void loadQueue(p);
-    },
-    [loadQueue],
-  );
 
   if (loading)
     return (
@@ -307,7 +213,7 @@ export default function InboundEmailCard() {
         Inbound email settings failed to load.{' '}
         <button
           type="button"
-          onClick={() => void loadAll(1)}
+          onClick={() => void loadAll()}
           className="underline hover:text-foreground"
           data-testid="inbound-email-retry"
         >
@@ -393,15 +299,84 @@ export default function InboundEmailCard() {
           </select>
         </div>
 
-        <label className="mt-3 flex items-center gap-2 text-sm">
+        <fieldset className="mt-4" data-testid="inbound-unknown-sender-mode">
+          <legend className="text-xs font-medium">Unknown senders</legend>
+          <p className="mb-1.5 text-xs text-muted-foreground">
+            What to do with mail whose sender isn&apos;t a portal user, a mapped customer
+            domain, or a reply to an existing ticket.
+          </p>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="unknown-sender-mode"
+              className="mt-0.5"
+              checked={cfg.unknownSenderMode === 'quarantine'}
+              disabled={saving}
+              onChange={() => void saveConfig({ unknownSenderMode: 'quarantine' })}
+              data-testid="inbound-unknown-quarantine"
+            />
+            <span>
+              Quarantine for review <span className="text-muted-foreground">(default)</span>
+              <span className="block text-xs text-muted-foreground">
+                Held in the Tickets → Review queue for manual convert or dismiss.
+              </span>
+            </span>
+          </label>
+          <label className="mt-2 flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="unknown-sender-mode"
+              className="mt-0.5"
+              checked={cfg.unknownSenderMode === 'triage'}
+              disabled={saving || !cfg.defaultTriageOrgId}
+              onChange={() => void saveConfig({ unknownSenderMode: 'triage' })}
+              data-testid="inbound-unknown-triage"
+            />
+            <span>
+              Route to the triage organization
+              <span className="block text-xs text-muted-foreground">
+                Auto-creates a ticket in the triage org above.
+                {!cfg.defaultTriageOrgId && ' Select a triage organization first.'}
+              </span>
+            </span>
+          </label>
+          <label className="mt-2 flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="unknown-sender-mode"
+              className="mt-0.5"
+              checked={cfg.unknownSenderMode === 'drop'}
+              disabled={saving}
+              onChange={() => void saveConfig({ unknownSenderMode: 'drop' })}
+              data-testid="inbound-unknown-drop"
+            />
+            <span>
+              Drop silently
+              <span className="block text-xs text-muted-foreground">
+                No ticket, no review-queue entry, no autoresponse. An audit row is still
+                recorded. Use this to keep unmapped spam out of triage and the review queue.
+              </span>
+            </span>
+          </label>
+        </fieldset>
+
+        <label className="mt-4 flex items-start gap-2 text-sm">
           <input
             type="checkbox"
-            checked={cfg.triageUnknownSenders ?? false}
-            disabled={saving || !cfg.defaultTriageOrgId}
-            onChange={(e) => void saveConfig({ triageUnknownSenders: e.target.checked })}
-            data-testid="inbound-triage-toggle"
+            className="mt-0.5"
+            checked={cfg.dropUnverifiedSenders}
+            disabled={saving}
+            onChange={(e) => void saveConfig({ dropUnverifiedSenders: e.target.checked })}
+            data-testid="inbound-drop-unverified-toggle"
           />
-          Route unknown senders to the triage org instead of quarantining
+          <span>
+            Drop mail that fails sender authentication (SPF/DKIM/DMARC)
+            <span className="block text-xs text-muted-foreground">
+              When off, unverified mail is quarantined for review. When on, it&apos;s dropped
+              silently. This applies to <em>all</em> unverified senders — including mapped
+              customers whose individual message fails the check.
+            </span>
+          </span>
         </label>
 
         <label className="mt-3 flex items-center gap-2 text-sm">
@@ -505,127 +480,6 @@ export default function InboundEmailCard() {
       </section>
 
       <CustomerDomainsCard />
-
-      <section className="rounded-lg border p-4" data-testid="inbound-review-queue">
-        <h2 className="mb-1 text-sm font-semibold">Review queue</h2>
-        <p className="mb-3 text-xs text-muted-foreground">
-          Quarantined (unknown sender) and failed inbound emails. Convert to a ticket or dismiss.
-        </p>
-        {queueForbidden ? (
-          <p className="text-sm text-muted-foreground" data-testid="inbound-review-forbidden">
-            The review queue is available to admins only.
-          </p>
-        ) : rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground" data-testid="inbound-review-empty">
-            Nothing to review.
-          </p>
-        ) : (
-          <table className="min-w-full divide-y text-sm">
-            <tbody className="divide-y">
-              {rows.map((r) => (
-                <tr key={r.id} data-testid={`inbound-row-${r.id}`}>
-                  <td className="px-2 py-2 align-top">
-                    <div className="font-medium">{r.fromAddress ?? '(unknown sender)'}</div>
-                    <div className="text-muted-foreground">{r.subject ?? '(no subject)'}</div>
-                    <div className="mt-0.5 text-xs text-muted-foreground">
-                      <span className="rounded border px-1 py-0.5">{r.parseStatus}</span>{' '}
-                      {formatDateTime(r.createdAt)}
-                      {r.parseStatus === 'failed' && r.error && (
-                        <span className="ml-2 text-red-600">{r.error}</span>
-                      )}
-                    </div>
-                    {convertOpenId === r.id && (
-                      <div
-                        className="mt-2 flex items-center gap-2"
-                        data-testid={`inbound-convert-form-${r.id}`}
-                      >
-                        <select
-                          value={convertOrgId}
-                          onChange={(e) => setConvertOrgId(e.target.value)}
-                          className="rounded-md border bg-background px-2 py-1 text-sm"
-                          data-testid={`inbound-convert-org-${r.id}`}
-                        >
-                          <option value="">Select organization…</option>
-                          {orgs.map((o) => (
-                            <option key={o.id} value={o.id}>
-                              {o.name}
-                            </option>
-                          ))}
-                        </select>
-                        <button
-                          type="button"
-                          onClick={() => void convert(r.id)}
-                          disabled={!convertOrgId}
-                          className="rounded-md bg-primary px-2.5 py-1 text-sm text-white disabled:opacity-50"
-                          data-testid={`inbound-convert-submit-${r.id}`}
-                        >
-                          Create ticket
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setConvertOpenId(null)}
-                          className="rounded-md border px-2.5 py-1 text-sm"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    )}
-                  </td>
-                  <td className="px-2 py-2 text-right align-top space-x-2 whitespace-nowrap">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setConvertOpenId(r.id);
-                        setConvertOrgId(cfg.defaultTriageOrgId ?? '');
-                      }}
-                      className="text-muted-foreground hover:text-foreground"
-                      data-testid={`inbound-convert-${r.id}`}
-                    >
-                      Convert to ticket
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void dismiss(r.id)}
-                      className="text-muted-foreground hover:text-foreground"
-                      data-testid={`inbound-dismiss-${r.id}`}
-                    >
-                      Dismiss
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-        {!queueForbidden && totalPages > 1 && (
-          <div
-            className="mt-3 flex items-center justify-between text-sm"
-            data-testid="inbound-pagination"
-          >
-            <button
-              type="button"
-              onClick={() => goPage(page - 1)}
-              disabled={page <= 1}
-              className="rounded-md border px-2.5 py-1 disabled:opacity-40"
-              data-testid="inbound-page-prev"
-            >
-              Prev
-            </button>
-            <span className="text-muted-foreground">
-              Page {page} of {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => goPage(page + 1)}
-              disabled={page >= totalPages}
-              className="rounded-md border px-2.5 py-1 disabled:opacity-40"
-              data-testid="inbound-page-next"
-            >
-              Next
-            </button>
-          </div>
-        )}
-      </section>
     </div>
   );
 }

--- a/apps/web/src/components/tickets/InboundReviewQueue.test.tsx
+++ b/apps/web/src/components/tickets/InboundReviewQueue.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../lib/authScope', () => ({ loginPathWithNext: () => '/login' }));
+// pass-through runAction so the request fn (and thus fetchWithAuth) runs
+vi.mock('../../lib/runAction', () => ({
+  runAction: async (o: { request: () => Promise<Response> }) => {
+    const r = await o.request();
+    return r.json().catch(() => null);
+  },
+  handleActionError: vi.fn(),
+}));
+
+import InboundReviewQueue from './InboundReviewQueue';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body, blob: async () => new Blob() } as unknown as Response;
+}
+
+const ROW = {
+  id: 'r-1',
+  fromAddress: 'jane@x.com',
+  toAddress: 'acme@tickets.example.com',
+  subject: 'printer',
+  parseStatus: 'quarantined' as const,
+  error: null,
+  ticketId: null,
+  createdAt: new Date().toISOString(),
+};
+
+function routeFetch(rows: unknown[]) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url.startsWith('/ticket-config/email-inbound?'))
+      return Promise.resolve(jsonRes({ data: rows, pagination: { page: 1, limit: 50, total: rows.length } }));
+    if (url === '/orgs/organizations?limit=100')
+      return Promise.resolve(jsonRes({ data: [{ id: 'o-1', name: 'Acme Org' }] }));
+    if (url.includes('/convert')) return Promise.resolve(jsonRes({ data: { id: 'r-1', parseStatus: 'created' } }));
+    if (url.includes('/dismiss')) return Promise.resolve(jsonRes({ data: { id: 'r-1', parseStatus: 'ignored' } }));
+    return Promise.resolve(jsonRes({ data: [] }));
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('InboundReviewQueue', () => {
+  it('renders quarantined/failed rows', async () => {
+    routeFetch([ROW]);
+    render(<InboundReviewQueue />);
+    expect(await screen.findByTestId('inbound-review-queue')).toBeTruthy();
+    expect(screen.getByTestId('inbound-row-r-1')).toBeTruthy();
+  });
+
+  it('reports the pending total via onTotalChange', async () => {
+    routeFetch([ROW]);
+    const onTotalChange = vi.fn();
+    render(<InboundReviewQueue onTotalChange={onTotalChange} />);
+    await screen.findByTestId('inbound-row-r-1');
+    expect(onTotalChange).toHaveBeenCalledWith(1);
+  });
+
+  it('shows the empty state when there is nothing to review', async () => {
+    routeFetch([]);
+    render(<InboundReviewQueue />);
+    expect(await screen.findByTestId('inbound-review-empty')).toBeTruthy();
+  });
+
+  it('Convert opens the org picker and POSTs convert with the chosen orgId', async () => {
+    routeFetch([ROW]);
+    render(<InboundReviewQueue />);
+    await screen.findByTestId('inbound-row-r-1');
+    fireEvent.click(screen.getByTestId('inbound-convert-r-1'));
+    fireEvent.change(screen.getByTestId('inbound-convert-org-r-1'), { target: { value: 'o-1' } });
+    fireEvent.click(screen.getByTestId('inbound-convert-submit-r-1'));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        '/ticket-config/email-inbound/r-1/convert',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    const body = JSON.parse(
+      (fetchWithAuth.mock.calls.find((c) => String(c[0]).includes('/convert'))![1] as { body: string }).body,
+    );
+    expect(body.orgId).toBe('o-1');
+  });
+
+  it('Dismiss PATCHes the dismiss route', async () => {
+    routeFetch([{ ...ROW, parseStatus: 'failed', error: 'boom' }]);
+    render(<InboundReviewQueue />);
+    await screen.findByTestId('inbound-row-r-1');
+    fireEvent.click(screen.getByTestId('inbound-dismiss-r-1'));
+    await waitFor(() =>
+      expect(fetchWithAuth).toHaveBeenCalledWith(
+        '/ticket-config/email-inbound/r-1/dismiss',
+        expect.objectContaining({ method: 'PATCH' }),
+      ),
+    );
+  });
+
+  it('renders the admin-only notice when the queue fetch 403s', async () => {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url.startsWith('/ticket-config/email-inbound?')) return Promise.resolve(jsonRes({ error: 'admin' }, false, 403));
+      if (url === '/orgs/organizations?limit=100') return Promise.resolve(jsonRes({ data: [] }));
+      return Promise.resolve(jsonRes({ data: [] }));
+    });
+    render(<InboundReviewQueue />);
+    expect(await screen.findByTestId('inbound-review-forbidden')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/tickets/InboundReviewQueue.tsx
+++ b/apps/web/src/components/tickets/InboundReviewQueue.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { loginPathWithNext } from '../../lib/authScope';
+import { showToast } from '../shared/Toast';
+import { formatDateTime } from '@/lib/dateTimeFormat';
+
+// Inbound review queue: quarantined (unknown sender) and failed inbound emails.
+// Convert to a ticket or dismiss. Admin-only surface — the backing routes carry
+// writePerm + adminMiddleware, so a non-admin gets a 403 and the graceful
+// "admins only" message (the parent tab also hides itself for non-admins).
+//
+// Extracted out of settings/InboundEmailCard so it can live under the Tickets
+// area (the dismiss/convert workflow is a ticketing task, not a settings task).
+
+interface QueueRow {
+  id: string;
+  fromAddress: string | null;
+  toAddress: string | null;
+  subject: string | null;
+  // The list endpoint only ever returns review-queue rows, so the union is the
+  // two review statuses. convert/dismiss responses carry the resolved status
+  // ('created'/'ignored') but this component discards those bodies and reloads
+  // the queue, so they never widen this type.
+  parseStatus: 'quarantined' | 'failed';
+  error: string | null;
+  ticketId: string | null;
+  createdAt: string;
+}
+
+interface OrgOption {
+  id: string;
+  name: string;
+}
+
+const FRIENDLY_CODES: Record<string, string> = {
+  ORG_NOT_ACCESSIBLE: 'That organization is not available under your partner.',
+  INBOUND_ROW_NOT_FOUND: 'That inbound email is no longer available.',
+  INBOUND_ROW_ALREADY_RESOLVED: 'That inbound email was already handled. Refreshing the list.',
+  INBOUND_ROW_NO_SENDER:
+    'This email has no usable sender address, so it cannot become a ticket. Dismiss it or follow up out-of-band.',
+};
+const friendlyCode = (code: string): string | undefined => FRIENDLY_CODES[code];
+const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+const PAGE_SIZE = 50;
+
+interface InboundReviewQueueProps {
+  /** Notified with the authoritative pending total after every (re)load, so the
+   *  parent's tab badge stays in sync as rows are converted/dismissed. */
+  onTotalChange?: (total: number) => void;
+}
+
+export default function InboundReviewQueue({ onTotalChange }: InboundReviewQueueProps) {
+  const [rows, setRows] = useState<QueueRow[]>([]);
+  const [orgs, setOrgs] = useState<OrgOption[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [forbidden, setForbidden] = useState(false);
+  const [convertOpenId, setConvertOpenId] = useState<string | null>(null);
+  const [convertOrgId, setConvertOrgId] = useState('');
+
+  const loadQueue = useCallback(
+    async (p: number) => {
+      const res = await fetchWithAuth(`/ticket-config/email-inbound?page=${p}&limit=${PAGE_SIZE}`);
+      // The queue is an admin-only surface; a 403 must not break the page.
+      if (res.status === 403) {
+        setForbidden(true);
+        return;
+      }
+      if (!res.ok) {
+        setError(true);
+        return;
+      }
+      setForbidden(false);
+      const body = (await res.json()) as { data: QueueRow[]; pagination: { total: number } };
+      setRows(body.data);
+      setTotal(body.pagination.total);
+      onTotalChange?.(body.pagination.total);
+    },
+    [onTotalChange],
+  );
+
+  const loadOrgs = useCallback(async () => {
+    const res = await fetchWithAuth('/orgs/organizations?limit=100');
+    if (res.ok) {
+      const body = (await res.json()) as { data?: OrgOption[] };
+      if (body.data) setOrgs(body.data);
+    }
+  }, []);
+
+  const loadAll = useCallback(
+    async (p: number) => {
+      setLoading(true);
+      setError(false);
+      try {
+        await Promise.all([loadQueue(p), loadOrgs()]);
+      } catch {
+        setError(true);
+      }
+      setLoading(false);
+    },
+    [loadQueue, loadOrgs],
+  );
+
+  useEffect(() => {
+    void loadAll(1);
+  }, [loadAll]);
+
+  const convert = useCallback(
+    async (id: string) => {
+      if (!convertOrgId) {
+        showToast({ type: 'error', message: 'Pick an organization first.' });
+        return;
+      }
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/ticket-config/email-inbound/${id}/convert`, {
+              method: 'POST',
+              body: JSON.stringify({ orgId: convertOrgId }),
+            }),
+          errorFallback: 'Convert to ticket failed. Retry.',
+          successMessage: 'Ticket created from email',
+          friendly: friendlyCode,
+          onUnauthorized: UNAUTHORIZED,
+        });
+        setConvertOpenId(null);
+        await loadQueue(page);
+      } catch (err) {
+        handleActionError(err, 'Convert to ticket failed. Retry.');
+        // An already-resolved row (409) means the list is stale — refresh so it clears.
+        await loadQueue(page);
+      }
+    },
+    [convertOrgId, page, loadQueue],
+  );
+
+  const dismiss = useCallback(
+    async (id: string) => {
+      try {
+        await runAction({
+          request: () =>
+            fetchWithAuth(`/ticket-config/email-inbound/${id}/dismiss`, { method: 'PATCH' }),
+          errorFallback: 'Dismiss failed. Retry.',
+          successMessage: 'Inbound email dismissed',
+          friendly: friendlyCode,
+          onUnauthorized: UNAUTHORIZED,
+        });
+        await loadQueue(page);
+      } catch (err) {
+        handleActionError(err, 'Dismiss failed. Retry.');
+        await loadQueue(page);
+      }
+    },
+    [page, loadQueue],
+  );
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(total / PAGE_SIZE)), [total]);
+  const goPage = useCallback(
+    (p: number) => {
+      setPage(p);
+      void loadQueue(p);
+    },
+    [loadQueue],
+  );
+
+  if (loading)
+    return (
+      <p className="mt-6 text-center text-sm text-muted-foreground" data-testid="inbound-review-loading">
+        Loading.
+      </p>
+    );
+  if (error)
+    return (
+      <p className="mt-6 text-center text-sm text-muted-foreground" data-testid="inbound-review-error">
+        Review queue failed to load.{' '}
+        <button
+          type="button"
+          onClick={() => void loadAll(1)}
+          className="underline hover:text-foreground"
+          data-testid="inbound-review-retry"
+        >
+          Retry
+        </button>
+      </p>
+    );
+
+  return (
+    <section className="rounded-lg border p-4" data-testid="inbound-review-queue">
+      <h2 className="mb-1 text-sm font-semibold">Review queue</h2>
+      <p className="mb-3 text-xs text-muted-foreground">
+        Quarantined (unknown sender) and failed inbound emails. Convert to a ticket or dismiss.
+      </p>
+      {forbidden ? (
+        <p className="text-sm text-muted-foreground" data-testid="inbound-review-forbidden">
+          The review queue is available to admins only.
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="inbound-review-empty">
+          Nothing to review.
+        </p>
+      ) : (
+        <table className="min-w-full divide-y text-sm">
+          <tbody className="divide-y">
+            {rows.map((r) => (
+              <tr key={r.id} data-testid={`inbound-row-${r.id}`}>
+                <td className="px-2 py-2 align-top">
+                  <div className="font-medium">{r.fromAddress ?? '(unknown sender)'}</div>
+                  <div className="text-muted-foreground">{r.subject ?? '(no subject)'}</div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    <span className="rounded border px-1 py-0.5">{r.parseStatus}</span>{' '}
+                    {formatDateTime(r.createdAt)}
+                    {r.parseStatus === 'failed' && r.error && (
+                      <span className="ml-2 text-red-600">{r.error}</span>
+                    )}
+                  </div>
+                  {convertOpenId === r.id && (
+                    <div
+                      className="mt-2 flex items-center gap-2"
+                      data-testid={`inbound-convert-form-${r.id}`}
+                    >
+                      <select
+                        value={convertOrgId}
+                        onChange={(e) => setConvertOrgId(e.target.value)}
+                        className="rounded-md border bg-background px-2 py-1 text-sm"
+                        data-testid={`inbound-convert-org-${r.id}`}
+                      >
+                        <option value="">Select organization…</option>
+                        {orgs.map((o) => (
+                          <option key={o.id} value={o.id}>
+                            {o.name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => void convert(r.id)}
+                        disabled={!convertOrgId}
+                        className="rounded-md bg-primary px-2.5 py-1 text-sm text-white disabled:opacity-50"
+                        data-testid={`inbound-convert-submit-${r.id}`}
+                      >
+                        Create ticket
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConvertOpenId(null)}
+                        className="rounded-md border px-2.5 py-1 text-sm"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </td>
+                <td className="px-2 py-2 text-right align-top space-x-2 whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setConvertOpenId(r.id);
+                      setConvertOrgId('');
+                    }}
+                    className="text-muted-foreground hover:text-foreground"
+                    data-testid={`inbound-convert-${r.id}`}
+                  >
+                    Convert to ticket
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void dismiss(r.id)}
+                    className="text-muted-foreground hover:text-foreground"
+                    data-testid={`inbound-dismiss-${r.id}`}
+                  >
+                    Dismiss
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {!forbidden && totalPages > 1 && (
+        <div
+          className="mt-3 flex items-center justify-between text-sm"
+          data-testid="inbound-pagination"
+        >
+          <button
+            type="button"
+            onClick={() => goPage(page - 1)}
+            disabled={page <= 1}
+            className="rounded-md border px-2.5 py-1 disabled:opacity-40"
+            data-testid="inbound-page-prev"
+          >
+            Prev
+          </button>
+          <span className="text-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => goPage(page + 1)}
+            disabled={page >= totalPages}
+            className="rounded-md border px-2.5 py-1 disabled:opacity-40"
+            data-testid="inbound-page-next"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -44,6 +44,16 @@ vi.mock('./TicketWorkbench', () => ({
   }
 }));
 
+// The review-queue surface has its own suite (InboundReviewQueue.test.tsx); here
+// we only verify the tab gating/badge and that selecting it swaps in the pane.
+const capturedReviewProps: Array<{ onTotalChange?: (n: number) => void }> = [];
+vi.mock('./InboundReviewQueue', () => ({
+  default: (props: { onTotalChange?: (n: number) => void }) => {
+    capturedReviewProps.push(props);
+    return <div data-testid="inbound-review-queue-mock" />;
+  }
+}));
+
 const fetchMock = vi.mocked(fetchWithAuth);
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
@@ -103,7 +113,7 @@ const BULK_RESULT = { data: { updated: 2, skipped: 0, failed: 0, total: 2 } };
 
 function mockListApi(
   tickets: TicketSummary[] | ((url: string) => TicketSummary[]),
-  opts: { usersFail?: boolean; bulkResult?: typeof BULK_RESULT; stats?: unknown } = {}
+  opts: { usersFail?: boolean; bulkResult?: typeof BULK_RESULT; stats?: unknown; reviewTotal?: number } = {}
 ) {
   fetchMock.mockImplementation(async (input) => {
     const url = String(input);
@@ -112,6 +122,13 @@ function mockListApi(
     if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
     if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
+    // The inbound review-queue probe. Default: 403 (non-admin) so the tab stays
+    // hidden, matching the bulk of these tests. opts.reviewTotal opts it in.
+    if (url.startsWith('/ticket-config/email-inbound')) {
+      return opts.reviewTotal === undefined
+        ? makeJsonResponse({ error: 'admin' }, false, 403)
+        : makeJsonResponse({ data: [], pagination: { page: 1, limit: 1, total: opts.reviewTotal } });
+    }
     if (url === '/users') {
       return opts.usersFail ? makeJsonResponse({ error: 'forbidden' }, false, 403) : makeJsonResponse(USERS);
     }
@@ -787,6 +804,46 @@ describe('TicketsPage', () => {
         const tokenAfter = Number(screen.getByTestId('ticket-workbench-mock').getAttribute('data-refresh') ?? '0');
         expect(tokenAfter).toBeGreaterThan(tokenBefore);
       });
+    });
+  });
+
+  describe('inbound review queue tab', () => {
+    it('hides the Review queue tab when the queue probe is forbidden (non-admin)', async () => {
+      mockListApi([healthy]); // default: probe 403s
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+      // Give the probe a tick to resolve before asserting absence.
+      await waitFor(() => expect(screen.getByTestId('tickets-tab-open')).toBeInTheDocument());
+      expect(screen.queryByTestId('tickets-tab-review')).toBeNull();
+    });
+
+    it('shows the Review queue tab with a pending-count badge when the probe succeeds', async () => {
+      mockListApi([healthy], { reviewTotal: 3 });
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+      await screen.findByTestId('tickets-tab-review');
+      expect(screen.getByTestId('tickets-tab-review-badge')).toHaveTextContent('3');
+    });
+
+    it('omits the badge when there is nothing pending', async () => {
+      mockListApi([healthy], { reviewTotal: 0 });
+      render(<TicketsPage />);
+      await screen.findByTestId('tickets-tab-review');
+      expect(screen.queryByTestId('tickets-tab-review-badge')).toBeNull();
+    });
+
+    it('selecting the Review queue tab swaps in the review pane and hides the ticket filters', async () => {
+      mockListApi([healthy], { reviewTotal: 2 });
+      render(<TicketsPage />);
+      await screen.findByTestId('ticket-row-tk-healthy');
+
+      fireEvent.click(await screen.findByTestId('tickets-tab-review'));
+
+      await screen.findByTestId('tickets-review-pane');
+      expect(screen.getByTestId('inbound-review-queue-mock')).toBeInTheDocument();
+      // The ticket filter bar and queue list are not rendered on the review tab.
+      expect(screen.queryByTestId('tickets-filter-bar')).toBeNull();
+      expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -8,6 +8,7 @@ import { navigateTo } from '@/lib/navigation';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
 import TicketWorkbench from './TicketWorkbench';
+import InboundReviewQueue from './InboundReviewQueue';
 import { useQueueKeyboard } from './useQueueKeyboard';
 import { type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
 import { fetchTicketConfig, priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
@@ -23,7 +24,10 @@ const SKIP_REASON_LABELS: Record<string, string> = {
   OTHER: 'other errors'
 };
 
-type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed';
+// 'review' is the inbound email review queue — a sibling surface, not a ticket
+// query. It renders InboundReviewQueue instead of the queue/workbench split, and
+// is only present for admins (visibility gated by a 200 from the queue endpoint).
+type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed' | 'review';
 type TicketSort = 'triage' | 'newest' | 'oldest' | 'due';
 
 const SORT_OPTIONS: Array<{ value: TicketSort; label: string }> = [
@@ -50,7 +54,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'closed', label: 'Closed' }
 ];
 
-function tabQuery(tab: Tab): string {
+function tabQuery(tab: Exclude<Tab, 'review'>): string {
   switch (tab) {
     case 'mine': return 'statusGroup=open&assignee=me';
     case 'unassigned': return 'statusGroup=open&assignee=unassigned';
@@ -125,6 +129,11 @@ export default function TicketsPage() {
   // Ticket config (custom statuses + priority labels). null = not loaded / fetch
   // failed; chips and bulk-status options fall back to the static core config.
   const [config, setConfig] = useState<TicketConfig | null>(null);
+  // Inbound review queue: only admins can read it, so the tab is hidden unless a
+  // probe of the queue endpoint returns 200 (non-admins / org-scoped users 403).
+  // `reviewTotal` drives the tab's pending-count badge.
+  const [reviewAvailable, setReviewAvailable] = useState(false);
+  const [reviewTotal, setReviewTotal] = useState(0);
   const fetchSeq = useRef(0);
 
   // 'mine'/'unassigned' tabs already pin the assignee param; the filter select is locked there.
@@ -175,6 +184,9 @@ export default function TicketsPage() {
   }, []);
 
   const fetchTickets = useCallback(async () => {
+    // The review tab isn't a ticket query — it renders InboundReviewQueue, which
+    // loads its own data. Skip the /tickets fetch so tabQuery never sees 'review'.
+    if (tab === 'review') { setLoading(false); return; }
     const seq = ++fetchSeq.current;
     setLoading(true);
     setError(undefined);
@@ -255,6 +267,23 @@ export default function TicketsPage() {
     return () => { cancelled = true; };
   }, []);
 
+  // Probe the inbound review queue once: a 200 means the caller is an admin who
+  // can act on it, so we reveal the tab + seed its badge count. A 403 (non-admin
+  // / org-scoped) or any error leaves the tab hidden. This is UX-only gating —
+  // the endpoint re-enforces admin access server-side.
+  const refreshReviewBadge = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth('/ticket-config/email-inbound?page=1&limit=1');
+      if (!res.ok) return;
+      setReviewAvailable(true);
+      const body = (await res.json()) as { pagination?: { total?: number } };
+      setReviewTotal(body.pagination?.total ?? 0);
+    } catch {
+      // Network error — leave the tab hidden rather than risk a broken surface.
+    }
+  }, []);
+  useEffect(() => { void refreshReviewBadge(); }, [refreshReviewBadge]);
+
   // Selection survives tab switches (POST /tickets/bulk takes raw ids; the bar's
   // count chip reports off-view rows) but clears when a filter or the search
   // changes — those genuinely change what the result set means.
@@ -286,13 +315,14 @@ export default function TicketsPage() {
 
   // Auto-select first row when nothing valid is selected (UI brief: no-selection state auto-selects)
   useEffect(() => {
+    if (tab === 'review') return; // the review tab has no ticket selection
     if (!loading && tickets.length > 0 && !selected) {
       const first = tickets[0];
       const key = first.internalNumber ?? first.id;
       writeHash(key, sort);
       setSelectedNumber(key);
     }
-  }, [loading, tickets, selected, sort, writeHash]);
+  }, [tab, loading, tickets, selected, sort, writeHash]);
 
   const select = useCallback((t: TicketSummary) => {
     // Below the split-pane breakpoint the workbench pane is hidden; navigate
@@ -403,6 +433,8 @@ export default function TicketsPage() {
   });
 
   const tabCount = (id: Tab): number | null => {
+    // The review badge is independent of /tickets/stats; show it only when non-empty.
+    if (id === 'review') return reviewTotal > 0 ? reviewTotal : null;
     if (!stats) return null;
     if (id === 'mine') return stats.mine;
     if (id === 'unassigned') return stats.unassigned;
@@ -453,6 +485,24 @@ export default function TicketsPage() {
             {tabCount(t.id) !== null && <span className="ml-1.5 text-xs text-muted-foreground">{tabCount(t.id)}</span>}
           </button>
         ))}
+        {reviewAvailable && (
+          <button
+            type="button"
+            onClick={() => setTab('review')}
+            data-testid="tickets-tab-review"
+            className={cn(
+              'border-b-2 px-3 py-2 text-sm font-medium -mb-px',
+              tab === 'review' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Review queue
+            {tabCount('review') !== null && (
+              <span className="ml-1.5 rounded-full bg-amber-500/20 px-1.5 text-xs font-semibold text-amber-800 dark:bg-amber-500/30 dark:text-amber-200" data-testid="tickets-tab-review-badge">
+                {tabCount('review')}
+              </span>
+            )}
+          </button>
+        )}
         <input
           type="search"
           value={search}
@@ -463,6 +513,7 @@ export default function TicketsPage() {
         />
       </div>
 
+      {tab !== 'review' && (
       <div className="mb-3 flex flex-wrap items-center gap-2" data-testid="tickets-filter-bar">
         {!orgScoped && orgs.length > 1 && (
           <select
@@ -535,8 +586,13 @@ export default function TicketsPage() {
           ))}
         </select>
       </div>
+      )}
 
-      {trueEmpty ? (
+      {tab === 'review' ? (
+        <div className="min-h-0 flex-1 overflow-y-auto" data-testid="tickets-review-pane">
+          <InboundReviewQueue onTotalChange={setReviewTotal} />
+        </div>
+      ) : trueEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center text-center" data-testid="tickets-empty">
           <h2 className="text-base font-medium">No tickets yet</h2>
           <p className="mt-1 max-w-md text-sm text-muted-foreground">


### PR DESCRIPTION
Implements two inbound email-to-ticket requests from a self-hosted partner (SemoTech).

## 1. Drop unknown senders + DMARC-fail drop

Adds a third option for unmatched ("unknown") senders. The single `triageUnknownSenders` boolean becomes a 3-way **`unknownSenderMode`**:

- **`quarantine`** (default) — review queue, as today
- **`triage`** — auto-create in the default triage org (only when one is set)
- **`drop`** (new) — silently ignore: no ticket, no review-queue entry, no autoresponse. Writes an `ignored` audit row so the trail is preserved. Keeps unmapped spam out of triage *and* the review queue.

A separate **`dropUnverifiedSenders`** toggle makes the existing SPF/DKIM/DMARC gate **drop** (rather than quarantine) unverified mail.

Stored in `partners.settings` JSONB — **no migration**. `loadPartnerInboundPolicy` reads the new shape with **back-compat**: a partner carrying only the legacy boolean maps `true→'triage'`, `false`/absent→`'quarantine'`. The legacy key is still accepted on write and emitted (derived) on read; the card's first save retires it via the wholesale `inbound`-object replace.

### Ordering caveat (handled + surfaced in the UI)
The DMARC gate runs **before** sender matching, so:
- DMARC-passing cold spam (e.g. Gmail) reaches the fork → dropped by `unknownSenderMode: drop`.
- DMARC-failing mail is caught by the gate → needs `dropUnverifiedSenders` to drop vs quarantine.

`dropUnverifiedSenders` applies to **all** unverified senders, including a mapped customer whose individual message fails the check — the checkbox carries an explicit warning, and dropped mail always leaves an audit row.

## 2. Review queue → Tickets tab

The inbound review queue moves out of **Settings → Partner → Ticketing → Inbound Email** into a **"Review queue" tab** on the Tickets page (admin-gated via an endpoint probe; pending-count badge). Extracted into `InboundReviewQueue` (convert/dismiss/pagination intact) and removed from the settings card.

## Files
- API: `inboundEmailService.ts`, `resolveOrg.ts`, `orgs.ts` (Zod), `ticketConfigService.ts`
- Web: new `tickets/InboundReviewQueue.tsx`, `TicketsPage.tsx` (review tab), `settings/InboundEmailCard.tsx` (3-way control + DMARC toggle; queue removed)

## Tests
- API: inbound service / ticketConfig / orgs suites pass, incl. new drop-unknown, drop-unverified, and back-compat cases. `resolveOrg.integration.test.ts` updated to the new shape.
- Web: 4 affected suites pass + new `InboundReviewQueue.test.tsx`.
- `tsc --noEmit` clean for both `apps/web` and `apps/api`.

## Out of scope
The `/webhooks/tickets` mount-order fix for self-hosted (separate issue SemoTech also mentioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)