### PR TITLE
fix(tenancy): enroll unifi_controller_sites in ORG_CASCADE_DELETE_ORDER

### DIFF
--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -295,6 +295,7 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'tunnel_sessions',
   'unifi_clients',
   'unifi_collectors',
+  'unifi_controller_sites',
   'unifi_device_telemetry',
   'unifi_devices',
   'unifi_site_mappings',


### PR DESCRIPTION
## Description
`main` is currently **red on Integration Tests** (rolls up into `CI Success`), which is blocking every open PR based on it. Found while checking CI on a batch of pending PRs.

Root cause: the self-hosted UniFi controller work (#2097) added the org-scoped table **`unifi_controller_sites`** (with correct RLS — ENABLE+FORCE + all 4 org-isolation policies in `2026-06-29-unifi-self-hosted-collectors-and-sites.sql`), but it was never added to **`ORG_CASCADE_DELETE_ORDER`** in `apps/api/src/services/tenantCascade.ts`. The five sibling unifi tables (`unifi_clients`, `unifi_collectors`, `unifi_device_telemetry`, `unifi_devices`, `unifi_site_mappings`) are all listed; this one was missed.

Failing contract:
```
FAIL src/__tests__/integration/tenantCascade.integration.test.ts
  > every org_id-columned public table is in ORG_CASCADE_DELETE_ORDER
  AssertionError: [ 'unifi_controller_sites' ] to deeply equal []
```

This is also a real **GDPR-cascade completeness gap**: org deletion (`cascadeDeleteOrg`) and tenant export both iterate `ORG_CASCADE_DELETE_ORDER`, so this table was skipped. Rows were only cleaned up incidentally via the `collector_id` FK `ON DELETE CASCADE` from `unifi_collectors`.

## Fix
Add `'unifi_controller_sites'` to `ORG_CASCADE_DELETE_ORDER` in alpha position (between `unifi_collectors` and `unifi_device_telemetry`; `localeCompare` order verified so the sibling "alphabetised" contract also stays green). One-line, declarative — no behavior change beyond making the cascade/export complete.

## Affected Files
- `apps/api/src/services/tenantCascade.ts`

## Reported By
Internal Playwright/CI QA sweep, 2026-06-30. Unblocks PRs #2099, #2102, #2103, #2104, #2105.