### PR TITLE
fix(config): reconcile config-policy ownership with the Assignments tab

### DIFF
--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -58,11 +58,13 @@ assignmentRoutes.post(
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
 
-    // For a Partner-Wide assignment the target is the partner itself, derived
-    // server-side (#1724) — never trust a client-supplied partner id. For a
-    // partner-OWNED policy that is its own partner_id; for an org-owned policy
-    // assigned partner-wide it is the owning org's partner (resolved in the
-    // validator). The client may omit targetId for the partner level.
+    // Partner-level assignments are only valid for partner-OWNED policies, and
+    // the target is the partner itself, derived server-side (#1724) — never
+    // trust a client-supplied partner id. It's the policy's own partner_id (or
+    // the caller's, for a fresh partner-owned policy). Org-owned policies are
+    // rejected at the partner level by validateAssignmentTarget below, so the
+    // `auth.partnerId` fallback here only ever serves partner-owned policies.
+    // The client may omit targetId for the partner level.
     let targetId = data.targetId;
     if (data.level === 'partner') {
       if (policy.partnerId) {

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -8,12 +8,14 @@ const {
   getConfigPolicyMock,
   updateConfigPolicyMock,
   deleteConfigPolicyMock,
+  assignPolicyMock,
 } = vi.hoisted(() => ({
   listConfigPoliciesMock: vi.fn(),
   createConfigPolicyMock: vi.fn(),
   getConfigPolicyMock: vi.fn(),
   updateConfigPolicyMock: vi.fn(),
   deleteConfigPolicyMock: vi.fn(),
+  assignPolicyMock: vi.fn(),
 }));
 
 vi.mock('../../services/configurationPolicy', () => ({
@@ -22,6 +24,7 @@ vi.mock('../../services/configurationPolicy', () => ({
   getConfigPolicy: getConfigPolicyMock,
   updateConfigPolicy: updateConfigPolicyMock,
   deleteConfigPolicy: deleteConfigPolicyMock,
+  assignPolicy: assignPolicyMock,
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -73,6 +76,11 @@ describe('configurationPolicies CRUD routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but NOT implementations, so restore the
+    // benign defaults every test — otherwise a mockRejectedValue set by an
+    // auto-assign error-path test leaks into later cases.
+    assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
+    deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
     app = new Hono();
     // Set auth context before mounting routes
     app.use('*', async (c, next) => {
@@ -258,6 +266,68 @@ describe('configurationPolicies CRUD routes', () => {
         expect.objectContaining({ name: 'Partner-wide' }),
         'user-1'
       );
+      // The matching partner-level assignment is seeded automatically so the
+      // policy actually applies to all orgs immediately (no orphaned ownership).
+      expect(assignPolicyMock).toHaveBeenCalledWith(POLICY_ID, 'partner', PARTNER_ID, 0, 'user-1');
+    });
+
+    it('does not auto-assign for an org-owned policy (assignment stays manual)', async () => {
+      const policy = { id: POLICY_ID, name: 'Org policy', orgId: ORG_ID, partnerId: null, status: 'active' };
+      createConfigPolicyMock.mockResolvedValue(policy);
+
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Org policy' }),
+      });
+      expect(res.status).toBe(201);
+      expect(assignPolicyMock).not.toHaveBeenCalled();
+    });
+
+    function partnerCreateApp() {
+      const appPartner = new Hono();
+      appPartner.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+        c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
+        await next();
+      });
+      appPartner.route('/', crudRoutes);
+      return appPartner;
+    }
+
+    it('tolerates a UNIQUE violation on the auto-assign (still 201, no rollback)', async () => {
+      const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
+      createConfigPolicyMock.mockResolvedValue(policy);
+      // Real isPgUniqueViolation is used (not mocked) — SQLSTATE 23505 must be swallowed.
+      assignPolicyMock.mockRejectedValue({ code: '23505' });
+
+      const res = await partnerCreateApp().request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner' }),
+      });
+
+      expect(res.status).toBe(201);
+      // The policy already has its partner assignment — do NOT roll it back.
+      expect(deleteConfigPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the orphaned policy and 500s when the auto-assign fails for a non-unique reason', async () => {
+      const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
+      createConfigPolicyMock.mockResolvedValue(policy);
+      assignPolicyMock.mockRejectedValue(new Error('RLS 0-row write'));
+      deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
+
+      const res = await partnerCreateApp().request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner' }),
+      });
+
+      // A committed-but-unassigned partner-wide policy is the exact failure this
+      // feature prevents, so the orphan is deleted and the failure surfaced.
+      expect(res.status).toBe(500);
+      expect(deleteConfigPolicyMock).toHaveBeenCalledWith(POLICY_ID, expect.anything());
     });
 
     it('rejects ownerScope:partner for an org-scope caller (no partner) (#1724)', async () => {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -4,12 +4,14 @@ import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   createConfigPolicy,
   getConfigPolicy,
   listConfigPolicies,
   updateConfigPolicy,
   deleteConfigPolicy,
+  assignPolicy,
 } from '../../services/configurationPolicy';
 import { invalidateRemoteAccessCache } from '../../services/remoteAccessPolicy';
 import {
@@ -75,13 +77,42 @@ crudRoutes.post(
         return c.json({ error: 'Partner-wide policies require full partner org access (orgAccess must be "all")' }, 403);
       }
       const policy = await createConfigPolicy({ partnerId: auth.partnerId }, data, auth.user.id);
+      // Seed the matching partner-level assignment so the policy actually
+      // applies the moment it's created. Ownership ("Scope: All organizations")
+      // and the assignment that drives resolution are kept in lockstep —
+      // otherwise a partner-wide policy resolves to NO devices until the user
+      // separately discovers the Assignments tab (#1724 follow-up).
+      //
+      // The two inserts aren't in one transaction, so guard the seed: a
+      // UNIQUE(configPolicyId, level, targetId) collision is impossible on a
+      // fresh policy and is tolerated defensively; any OTHER failure would leave
+      // a committed-but-unassigned partner-wide policy (the exact "resolves to no
+      // devices" state this feature prevents), so roll the orphan back and
+      // surface the failure with its id rather than a bare, anonymous 500.
+      try {
+        await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);
+      } catch (err) {
+        if (!isPgUniqueViolation(err)) {
+          console.error(
+            `[ConfigPolicy] Partner-wide auto-assign failed for policy ${policy.id} (partner ${auth.partnerId}); rolling back orphan`,
+            err
+          );
+          await deleteConfigPolicy(policy.id, auth).catch((cleanupErr) => {
+            console.error(
+              `[ConfigPolicy] Failed to roll back orphaned partner-wide policy ${policy.id}`,
+              cleanupErr
+            );
+          });
+          throw err;
+        }
+      }
       writeRouteAudit(c, {
         orgId: null,
         action: 'config_policy.create',
         resourceType: 'configuration_policy',
         resourceId: policy.id,
         resourceName: policy.name,
-        details: { ownerScope: 'partner', partnerId: auth.partnerId },
+        details: { ownerScope: 'partner', partnerId: auth.partnerId, autoAssignedPartnerWide: true },
       });
       return c.json(policy, 201);
     }

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -187,7 +187,7 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
     tier: 2,
     definition: {
       name: 'apply_configuration_policy',
-      description: 'Assign a configuration policy to a target (partner, organization, site, device group, or device). Use roleFilter and osFilter to scope the assignment to specific device types.',
+      description: 'Assign a configuration policy to a target (partner, organization, site, device group, or device). Use roleFilter and osFilter to scope the assignment to specific device types. The "partner" level is reserved for partner-OWNED ("all organizations") policies — an org-owned policy can only be assigned at organization/site/device_group/device level.',
       input_schema: {
         type: 'object' as const,
         properties: {

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1164,15 +1164,16 @@ export async function validateAssignmentTarget(
     }
 
     case 'partner': {
-      const [org] = await db
-        .select({ partnerId: organizations.partnerId })
-        .from(organizations)
-        .where(eq(organizations.id, policyOrgId))
-        .limit(1);
-      if (!org?.partnerId || org.partnerId !== targetId) {
-        return { valid: false, error: 'Partner target does not match the policy organization partner' };
-      }
-      return { valid: true };
+      // An org-owned policy assigned at the partner level is a footgun: it
+      // *looks* partner-wide but resolution still clamps it to its single
+      // owning org (org_id = device.orgId), so it silently reaches only that
+      // one org. True cross-org propagation requires a partner-OWNED policy
+      // (created via the "All organizations" scope). Reject it outright rather
+      // than let it masquerade as fleet-wide (#1724 follow-up).
+      return {
+        valid: false,
+        error: 'Only partner-wide policies can be assigned at the Partner level. This policy is owned by a single organization — assign it at the organization, site, group, or device level instead.',
+      };
     }
 
     default:

--- a/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
+++ b/apps/api/src/services/configurationPolicy.validateAssignment.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// validateAssignmentTarget gates which (level, target) pairs are legal for a
+// given policy ownership. We only need the pure ownership branches here, so the
+// db is mocked; the org-owned + partner rejection must short-circuit BEFORE any
+// query runs.
+const { selectMock } = vi.hoisted(() => ({ selectMock: vi.fn() }));
+vi.mock('../db', () => ({
+  db: { select: selectMock },
+}));
+
+import { validateAssignmentTarget } from './configurationPolicy';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const PARTNER_ID = '22222222-2222-2222-2222-222222222222';
+
+beforeEach(() => {
+  selectMock.mockReset();
+});
+
+describe('validateAssignmentTarget — ownership gating', () => {
+  it('rejects an org-owned policy assigned at the Partner level (footgun) without querying', async () => {
+    const result = await validateAssignmentTarget(
+      { orgId: ORG_ID, partnerId: null },
+      'partner',
+      PARTNER_ID
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Only partner-wide policies can be assigned at the Partner level/i);
+    // Pure early return — no DB lookup for this illegal combination.
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a partner-owned policy assigned below the Partner level', async () => {
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'organization',
+      ORG_ID
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/can only be assigned at the Partner level/i);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a partner-owned policy targeting its own partner', async () => {
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'partner',
+      PARTNER_ID
+    );
+    expect(result.valid).toBe(true);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a partner-owned policy targeting a different partner', async () => {
+    const result = await validateAssignmentTarget(
+      { orgId: null, partnerId: PARTNER_ID },
+      'partner',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/can only target its own partner/i);
+  });
+});

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
@@ -17,6 +17,13 @@ const jsonResponse = (payload: unknown, status = 200): Response =>
 
 const POLICY_ID = '11111111-1111-1111-1111-111111111111';
 const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
+
+const findPost = () =>
+  fetchWithAuth.mock.calls.find(
+    (c) => String(c[0]).endsWith(`/configuration-policies/${POLICY_ID}/assignments`) &&
+      (c[1] as RequestInit | undefined)?.method === 'POST'
+  );
 
 beforeEach(() => {
   fetchWithAuth.mockReset();
@@ -24,51 +31,115 @@ beforeEach(() => {
   fetchWithAuth.mockResolvedValue(jsonResponse({ data: [] }));
 });
 
-describe('AssignmentsTab — Partner-Wide (All Orgs)', () => {
-  it('never calls /orgs/partners when the Partner-Wide level is selected (#1724)', async () => {
-    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} />);
-
-    // Initial load fetches the assignments list + the default (organization)
-    // target options. Wait for that to settle.
+describe('AssignmentsTab — partner-OWNED policy (all organizations)', () => {
+  it('shows the partner-wide banner and no level/target picker', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
 
-    // Switch the Level select to Partner-Wide.
-    const levelSelect = screen.getByDisplayValue('Organization');
-    fireEvent.change(levelSelect, { target: { value: 'partner' } });
-
-    await waitFor(() =>
-      expect(screen.getByText('All organizations in your partner')).toBeInTheDocument()
-    );
-
-    // The old system-scoped partner-list call must NEVER be made.
-    const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
-    expect(urls.some((u) => u.includes('/orgs/partners'))).toBe(false);
+    expect(
+      screen.getByText('This policy applies to all organizations in your partner.')
+    ).toBeInTheDocument();
+    // The org-owned "Level" picker must not exist for a partner-owned policy.
+    expect(screen.queryByText('Level')).not.toBeInTheDocument();
   });
 
-  it('POSTs a partner assignment with no targetId (server-derived) (#1724)', async () => {
-    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} />);
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
-
-    fireEvent.change(screen.getByDisplayValue('Organization'), { target: { value: 'partner' } });
+  it('POSTs a partner assignment with no targetId (server-derived) when re-assigning', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
+    // Wait for the empty-assignments add card to appear.
     await waitFor(() =>
-      expect(screen.getByText('All organizations in your partner')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Assign to all organizations/i })).toBeInTheDocument()
     );
 
-    // The create POST returns a created assignment; the follow-up list refetch
-    // returns empty.
     fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'partner' }, 201));
-
-    fireEvent.click(screen.getByRole('button', { name: /Assign/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Assign to all organizations/i }));
 
     await waitFor(() => {
-      const post = fetchWithAuth.mock.calls.find(
-        (c) => String(c[0]).endsWith(`/configuration-policies/${POLICY_ID}/assignments`) &&
-          (c[1] as RequestInit | undefined)?.method === 'POST'
-      );
+      const post = findPost();
       expect(post).toBeTruthy();
       const body = JSON.parse(String((post![1] as RequestInit).body));
       expect(body.level).toBe('partner');
       expect(body).not.toHaveProperty('targetId');
+    });
+    // The system-scoped partner-list call must NEVER be made.
+    const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/orgs/partners'))).toBe(false);
+  });
+
+  it('hides the re-assign card once a partner assignment exists', async () => {
+    fetchWithAuth.mockResolvedValue(
+      jsonResponse({ data: [{ id: 'a1', level: 'partner', targetId: PARTNER_ID, priority: 0 }] })
+    );
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
+
+    await waitFor(() => expect(screen.getByText('All Organizations')).toBeInTheDocument());
+    expect(
+      screen.queryByRole('button', { name: /Assign to all organizations/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('includes priority and role/OS filters in the partner re-assign POST body', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={null} partnerId={PARTNER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Assign to all organizations/i })).toBeInTheDocument()
+    );
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Workstation' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Windows' }));
+
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'partner' }, 201));
+    fireEvent.click(screen.getByRole('button', { name: /Assign to all organizations/i }));
+
+    await waitFor(() => {
+      const post = findPost();
+      expect(post).toBeTruthy();
+      const body = JSON.parse(String((post![1] as RequestInit).body));
+      expect(body.level).toBe('partner');
+      expect(body).not.toHaveProperty('targetId');
+      expect(body.priority).toBe(5);
+      expect(body.roleFilter).toEqual(['workstation']);
+      expect(body.osFilter).toEqual(['windows']);
+    });
+  });
+});
+
+describe('AssignmentsTab — org-owned policy', () => {
+  it('does not offer the Partner-Wide level (it is a footgun for org-owned policies)', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} partnerId={null} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+
+    const levelSelect = screen.getByDisplayValue('Organization');
+    const optionValues = Array.from(levelSelect.querySelectorAll('option')).map((o) => o.getAttribute('value'));
+    expect(optionValues).toEqual(['organization', 'site', 'device_group', 'device']);
+    expect(optionValues).not.toContain('partner');
+  });
+
+  it('POSTs an organization-level assignment with the selected targetId', async () => {
+    // Route by URL: assignments list is empty, the organization target list has one org.
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (String(url).includes('/orgs/organizations')) {
+        return Promise.resolve(jsonResponse({ data: [{ id: ORG_ID, name: 'Acme Inc' }] }));
+      }
+      return Promise.resolve(jsonResponse({ data: [] }));
+    });
+
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} partnerId={null} />);
+
+    // Open the target dropdown and pick the org once it has loaded.
+    await waitFor(() => expect(screen.getByText(/Select a target/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Select a target/i));
+    await waitFor(() => expect(screen.getByText('Acme Inc')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Acme Inc'));
+
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'organization' }, 201));
+    fireEvent.click(screen.getByRole('button', { name: /^Assign$/i }));
+
+    await waitFor(() => {
+      const post = findPost();
+      expect(post).toBeTruthy();
+      const body = JSON.parse(String((post![1] as RequestInit).body));
+      expect(body.level).toBe('organization');
+      expect(body.targetId).toBe(ORG_ID);
     });
   });
 });

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -17,8 +17,12 @@ type Assignment = {
 
 type TargetOption = { id: string; name: string; extra?: string };
 
-const assignmentLevels = [
-  { value: 'partner', label: 'Partner-Wide (All Orgs)' },
+// Org-owned policies can only narrow within their owning org. The Partner-Wide
+// level is intentionally absent here — assigning an org-owned policy partner-wide
+// is a footgun (resolution still clamps it to the one owning org), so the API
+// rejects it and the picker must not offer it. Partner-OWNED policies use a
+// dedicated, separate flow below (no level picker — they're always all-orgs).
+const orgOwnedAssignmentLevels = [
   { value: 'organization', label: 'Organization' },
   { value: 'site', label: 'Site' },
   { value: 'device_group', label: 'Device Group' },
@@ -37,14 +41,20 @@ function getOsLabel(value: string): string {
 
 type Props = {
   policyId: string;
-  orgId: string;
+  // null for partner-owned ("all organizations") policies.
+  orgId: string | null;
+  // Set when the policy is partner-OWNED (all-orgs). Drives the partner-wide UI.
+  partnerId?: string | null;
 };
 
-export default function AssignmentsTab({ policyId, orgId }: Props) {
+export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
+  const isPartnerOwned = !!partnerId;
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [assignmentsLoading, setAssignmentsLoading] = useState(false);
   const [error, setError] = useState<string>();
-  const [newLevel, setNewLevel] = useState('organization');
+  // Partner-owned policies are always assigned at the partner level (all orgs);
+  // org-owned policies default to the organization level.
+  const [newLevel, setNewLevel] = useState(isPartnerOwned ? 'partner' : 'organization');
   const [newTargetId, setNewTargetId] = useState('');
   const [newPriority, setNewPriority] = useState('0');
   const [newRoleFilter, setNewRoleFilter] = useState<string[]>([]);
@@ -97,6 +107,15 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
     }
     setLoadingTargets(true);
     setTargetOptions([]);
+    // site / device_group targets are scoped to the owning org. This branch is
+    // only reached for org-owned policies (partner-owned uses the no-picker
+    // flow), which always have an orgId — but guard rather than interpolate
+    // `orgId=null` into the URL if the ownership invariant is ever violated.
+    if ((level === 'site' || level === 'device_group') && !orgId) {
+      setLoadingTargets(false);
+      setError('This policy has no organization, so sites and device groups cannot be listed.');
+      return;
+    }
     const endpointMap: Record<string, string> = {
       organization: '/orgs/organizations?limit=200',
       site: `/orgs/sites?orgId=${orgId}&limit=200`,
@@ -252,6 +271,243 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
     }
   };
 
+  // Role + OS filter pickers — shared by the org-owned and partner-wide add cards.
+  const filterFields = (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div>
+        <label className="text-sm font-medium">
+          Role Filter <span className="text-xs text-muted-foreground">(optional)</span>
+          <HelpTooltip text="Restrict this assignment to devices with specific roles. Leave empty to apply to all roles." />
+        </label>
+        <div className="mt-2 flex flex-wrap gap-2 rounded-md border bg-background p-2 min-h-10">
+          {DEVICE_ROLES.map((role) => {
+            const isSelected = newRoleFilter.includes(role);
+            return (
+              <button
+                key={role}
+                type="button"
+                onClick={() => {
+                  setNewRoleFilter((prev) =>
+                    isSelected ? prev.filter((r) => r !== role) : [...prev, role]
+                  );
+                }}
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition',
+                  isSelected
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-muted bg-muted/30 text-muted-foreground hover:bg-muted/60'
+                )}
+              >
+                {getDeviceRoleLabel(role)}
+              </button>
+            );
+          })}
+        </div>
+        {newRoleFilter.length === 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">No restriction - applies to all device roles</p>
+        )}
+      </div>
+      <div>
+        <label className="text-sm font-medium">OS Filter <span className="text-xs text-muted-foreground">(optional)</span></label>
+        <div className="mt-2 flex flex-wrap gap-2 rounded-md border bg-background p-2 min-h-10">
+          {osFilterOptions.map((os) => {
+            const isSelected = newOsFilter.includes(os.value);
+            return (
+              <button
+                key={os.value}
+                type="button"
+                onClick={() => {
+                  setNewOsFilter((prev) =>
+                    isSelected ? prev.filter((o) => o !== os.value) : [...prev, os.value]
+                  );
+                }}
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition',
+                  isSelected
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-muted bg-muted/30 text-muted-foreground hover:bg-muted/60'
+                )}
+              >
+                {os.label}
+              </button>
+            );
+          })}
+        </div>
+        {newOsFilter.length === 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">No restriction - applies to all operating systems</p>
+        )}
+      </div>
+    </div>
+  );
+
+  const priorityField = (
+    <div>
+      <label className="text-sm font-medium">
+        Priority
+        <HelpTooltip text="Higher values override lower ones when multiple policies target the same device at the same level." />
+      </label>
+      <input
+        type="number"
+        min={0}
+        max={1000}
+        value={newPriority}
+        onChange={(e) => setNewPriority(e.target.value)}
+        className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+      />
+    </div>
+  );
+
+  const renderAssignmentsList = () => (
+    <div className="rounded-lg border bg-card p-6 shadow-xs">
+      <h2 className="text-lg font-semibold">Current Assignments</h2>
+      {assignmentsLoading ? (
+        <div className="flex items-center justify-center py-8">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      ) : assignments.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          No assignments yet. Assign this policy to targets above.
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto rounded-md border">
+          <table className="min-w-full divide-y">
+            <thead className="bg-muted/40">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-3">Level</th>
+                <th className="px-4 py-3">Target</th>
+                <th className="px-4 py-3">Priority</th>
+                <th className="px-4 py-3">Filters</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {assignments.map((assignment) => (
+                <tr key={assignment.id} className="text-sm">
+                  <td className="px-4 py-3">
+                    <span className="inline-flex items-center rounded-full border bg-muted/50 px-2.5 py-1 text-xs font-medium capitalize">
+                      {assignment.level.replace('_', ' ')}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div>
+                      {assignment.level === 'partner' ? (
+                        <span className="font-medium">All Organizations</span>
+                      ) : targetNameCache[assignment.targetId] ? (
+                        <>
+                          <span className="font-medium">{targetNameCache[assignment.targetId]}</span>
+                          <span className="ml-2 font-mono text-[10px] text-muted-foreground">
+                            {assignment.targetId.slice(0, 8)}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="font-mono text-xs text-muted-foreground">
+                          {assignment.targetId}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{assignment.priority}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {(!assignment.roleFilter || assignment.roleFilter.length === 0) &&
+                       (!assignment.osFilter || assignment.osFilter.length === 0) && (
+                        <span className="text-xs text-muted-foreground">All devices</span>
+                      )}
+                      {assignment.roleFilter && assignment.roleFilter.length > 0 && (
+                        assignment.roleFilter.map((role) => (
+                          <span
+                            key={role}
+                            className="inline-flex items-center rounded-full border border-purple-500/40 bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-purple-700"
+                          >
+                            {getDeviceRoleLabel(role)}
+                          </span>
+                        ))
+                      )}
+                      {assignment.osFilter && assignment.osFilter.length > 0 && (
+                        assignment.osFilter.map((os) => (
+                          <span
+                            key={os}
+                            className="inline-flex items-center rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-700"
+                          >
+                            {getOsLabel(os)}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAssignment(assignment.id)}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-destructive hover:bg-destructive/10"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+
+  // Partner-OWNED policies ("all organizations"): no level/target picker — the
+  // policy is intrinsically partner-wide. We surface the auto-created partner
+  // assignment in the list below and only show the add card when none exists
+  // (e.g. it was deleted, or the policy predates auto-seeding). Only one partner
+  // row is ever reachable: the server pins the target to the policy's own
+  // partner, and UNIQUE(policy, level, target) then forbids a duplicate.
+  if (isPartnerOwned) {
+    return (
+      <div className="space-y-6">
+        {error && (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="rounded-md border border-primary/30 bg-primary/5 p-4 text-sm">
+          <p className="font-medium">This policy applies to all organizations in your partner.</p>
+          <p className="mt-1 text-muted-foreground">
+            Scope was set to <span className="font-medium">All organizations</span> when the policy was created,
+            so it&apos;s assigned partner-wide automatically — there&apos;s nothing to assign here. To limit it to
+            certain device roles or operating systems, remove the assignment below and re-add it with filters.
+          </p>
+        </div>
+
+        {assignments.length === 0 && !assignmentsLoading && (
+          <div className="rounded-lg border bg-card p-6 shadow-xs">
+            <h2 className="text-lg font-semibold">Assign to all organizations</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              This policy isn&apos;t currently assigned. Re-assign it partner-wide below.
+            </p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              {priorityField}
+            </div>
+            <div className="mt-4">{filterFields}</div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={handleAddAssignment}
+                disabled={addingAssignment}
+                className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              >
+                <Plus className="h-4 w-4" />
+                {addingAssignment ? 'Assigning...' : 'Assign to all organizations'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {renderAssignmentsList()}
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       {error && (
@@ -274,7 +530,7 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
               onChange={(e) => setNewLevel(e.target.value)}
               className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
             >
-              {assignmentLevels.map((level) => (
+              {orgOwnedAssignmentLevels.map((level) => (
                 <option key={level.value} value={level.value}>
                   {level.label}
                 </option>
@@ -283,11 +539,6 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
           </div>
           <div ref={dropdownRef} className="relative">
             <label className="text-sm font-medium">Target</label>
-            {isPartnerLevel ? (
-              <div className="mt-2 flex h-10 w-full items-center rounded-md border bg-muted/40 px-3 text-sm text-muted-foreground">
-                All organizations in your partner
-              </div>
-            ) : (
             <button
               type="button"
               onClick={() => setTargetDropdownOpen(!targetDropdownOpen)}
@@ -298,8 +549,7 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
               </span>
               <ChevronDown className="h-4 w-4 text-muted-foreground" />
             </button>
-            )}
-            {!isPartnerLevel && targetDropdownOpen && (
+            {targetDropdownOpen && (
               <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-lg">
                 <div className="flex items-center border-b px-3 py-2">
                   <Search className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -348,91 +598,14 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
               </div>
             )}
           </div>
-          <div>
-            <label className="text-sm font-medium">
-              Priority
-              <HelpTooltip text="Higher values override lower ones when multiple policies target the same device at the same level." />
-            </label>
-            <input
-              type="number"
-              min={0}
-              max={1000}
-              value={newPriority}
-              onChange={(e) => setNewPriority(e.target.value)}
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-            />
-          </div>
+          {priorityField}
         </div>
-        <div className="mt-4 grid gap-4 sm:grid-cols-2">
-          <div>
-            <label className="text-sm font-medium">
-              Role Filter <span className="text-xs text-muted-foreground">(optional)</span>
-              <HelpTooltip text="Restrict this assignment to devices with specific roles. Leave empty to apply to all roles." />
-            </label>
-            <div className="mt-2 flex flex-wrap gap-2 rounded-md border bg-background p-2 min-h-10">
-              {DEVICE_ROLES.map((role) => {
-                const isSelected = newRoleFilter.includes(role);
-                return (
-                  <button
-                    key={role}
-                    type="button"
-                    onClick={() => {
-                      setNewRoleFilter((prev) =>
-                        isSelected ? prev.filter((r) => r !== role) : [...prev, role]
-                      );
-                    }}
-                    className={cn(
-                      'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition',
-                      isSelected
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-muted bg-muted/30 text-muted-foreground hover:bg-muted/60'
-                    )}
-                  >
-                    {getDeviceRoleLabel(role)}
-                  </button>
-                );
-              })}
-            </div>
-            {newRoleFilter.length === 0 && (
-              <p className="mt-1 text-xs text-muted-foreground">No restriction - applies to all device roles</p>
-            )}
-          </div>
-          <div>
-            <label className="text-sm font-medium">OS Filter <span className="text-xs text-muted-foreground">(optional)</span></label>
-            <div className="mt-2 flex flex-wrap gap-2 rounded-md border bg-background p-2 min-h-10">
-              {osFilterOptions.map((os) => {
-                const isSelected = newOsFilter.includes(os.value);
-                return (
-                  <button
-                    key={os.value}
-                    type="button"
-                    onClick={() => {
-                      setNewOsFilter((prev) =>
-                        isSelected ? prev.filter((o) => o !== os.value) : [...prev, os.value]
-                      );
-                    }}
-                    className={cn(
-                      'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition',
-                      isSelected
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-muted bg-muted/30 text-muted-foreground hover:bg-muted/60'
-                    )}
-                  >
-                    {os.label}
-                  </button>
-                );
-              })}
-            </div>
-            {newOsFilter.length === 0 && (
-              <p className="mt-1 text-xs text-muted-foreground">No restriction - applies to all operating systems</p>
-            )}
-          </div>
-        </div>
+        <div className="mt-4">{filterFields}</div>
         <div className="mt-4 flex justify-end">
           <button
             type="button"
             onClick={handleAddAssignment}
-            disabled={addingAssignment || (!isPartnerLevel && !newTargetId.trim())}
+            disabled={addingAssignment || !newTargetId.trim()}
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
@@ -441,102 +614,7 @@ export default function AssignmentsTab({ policyId, orgId }: Props) {
         </div>
       </div>
 
-      {/* Assignments List */}
-      <div className="rounded-lg border bg-card p-6 shadow-xs">
-        <h2 className="text-lg font-semibold">Current Assignments</h2>
-        {assignmentsLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          </div>
-        ) : assignments.length === 0 ? (
-          <p className="mt-4 text-sm text-muted-foreground">
-            No assignments yet. Assign this policy to targets above.
-          </p>
-        ) : (
-          <div className="mt-4 overflow-x-auto rounded-md border">
-            <table className="min-w-full divide-y">
-              <thead className="bg-muted/40">
-                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  <th className="px-4 py-3">Level</th>
-                  <th className="px-4 py-3">Target</th>
-                  <th className="px-4 py-3">Priority</th>
-                  <th className="px-4 py-3">Filters</th>
-                  <th className="px-4 py-3 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {assignments.map((assignment) => (
-                  <tr key={assignment.id} className="text-sm">
-                    <td className="px-4 py-3">
-                      <span className="inline-flex items-center rounded-full border bg-muted/50 px-2.5 py-1 text-xs font-medium capitalize">
-                        {assignment.level.replace('_', ' ')}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div>
-                        {assignment.level === 'partner' ? (
-                          <span className="font-medium">All Organizations</span>
-                        ) : targetNameCache[assignment.targetId] ? (
-                          <>
-                            <span className="font-medium">{targetNameCache[assignment.targetId]}</span>
-                            <span className="ml-2 font-mono text-[10px] text-muted-foreground">
-                              {assignment.targetId.slice(0, 8)}
-                            </span>
-                          </>
-                        ) : (
-                          <span className="font-mono text-xs text-muted-foreground">
-                            {assignment.targetId}
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">{assignment.priority}</td>
-                    <td className="px-4 py-3">
-                      <div className="flex flex-wrap gap-1">
-                        {(!assignment.roleFilter || assignment.roleFilter.length === 0) &&
-                         (!assignment.osFilter || assignment.osFilter.length === 0) && (
-                          <span className="text-xs text-muted-foreground">All devices</span>
-                        )}
-                        {assignment.roleFilter && assignment.roleFilter.length > 0 && (
-                          assignment.roleFilter.map((role) => (
-                            <span
-                              key={role}
-                              className="inline-flex items-center rounded-full border border-purple-500/40 bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-purple-700"
-                            >
-                              {getDeviceRoleLabel(role)}
-                            </span>
-                          ))
-                        )}
-                        {assignment.osFilter && assignment.osFilter.length > 0 && (
-                          assignment.osFilter.map((os) => (
-                            <span
-                              key={os}
-                              className="inline-flex items-center rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-700"
-                            >
-                              {getOsLabel(os)}
-                            </span>
-                          ))
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveAssignment(assignment.id)}
-                          className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-destructive hover:bg-destructive/10"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      {renderAssignmentsList()}
     </div>
   );
 }

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyCreatePage.tsx
@@ -240,7 +240,7 @@ export default function ConfigPolicyCreatePage() {
 
             {isPartnerScope && (
               <fieldset className="space-y-2 rounded-md border p-4" data-testid="policy-owner">
-                <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Apply to</legend>
+                <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
                 <label className="flex items-center gap-2 text-sm">
                   <input
                     type="radio"
@@ -284,8 +284,9 @@ export default function ConfigPolicyCreatePage() {
                 )}
                 {ownerScope === 'partner' && (
                   <p className="pl-6 text-xs text-muted-foreground">
-                    Applies to every organization under your partner. Backup settings aren&apos;t available on
-                    partner-wide policies.
+                    Applies to every organization under your partner — it&apos;s assigned partner-wide
+                    automatically, so you don&apos;t need to add an assignment (you can still add role or OS
+                    filters on the Assignments tab). Backup settings aren&apos;t available on partner-wide policies.
                   </p>
                 )}
               </fieldset>

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -56,7 +56,8 @@ type PolicyDetail = {
   name: string;
   description?: string;
   status: 'active' | 'inactive' | 'archived';
-  orgId: string;
+  orgId: string | null;
+  partnerId: string | null;
   createdAt?: string;
   updatedAt?: string;
   featureLinks: FeatureLink[];
@@ -437,7 +438,7 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
 
       {/* Assignments Tab */}
       {activeTab === 'assignments' && policyId && policy && (
-        <AssignmentsTab policyId={policyId} orgId={policy.orgId} />
+        <AssignmentsTab policyId={policyId} orgId={policy.orgId} partnerId={policy.partnerId} />
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

The create-page **"Apply to" owner picker** (#2064) collided with the **Assignments tab**. Both surfaced a "partner-wide / all orgs" choice, but they control two independent axes:

- **Ownership** — `configuration_policies.org_id` XOR `partner_id` (DB CHECK), set once at create. The eligibility universe.
- **Assignment** — `config_policy_assignments` rows, what `resolveEffectiveConfig` actually reads.

Three concrete breakages:
1. The create picker **applied nothing** — a partner-owned policy was created with zero assignments, so it resolved to **no devices** until the user separately found the Assignments tab.
2. The Assignments tab was **blind to ownership** — got `orgId=null` for partner-owned policies (breaking target lookups) and offered all 5 levels regardless.
3. **Org-owned + partner-level** validated and saved but silently applied only to the one owning org (footgun).

## Fix — ownership is the single source of truth; the tab is ownership-aware

- **`crud.ts`** — creating a partner-owned policy **auto-seeds the matching partner-level assignment**, so "All organizations" applies immediately. The two inserts aren't transactional, so a non-unique seed failure **rolls back the orphan** and surfaces the error (logged with the policy id) rather than leaving a committed-but-unassigned policy; unique violations are tolerated.
- **`configurationPolicy.ts`** — `validateAssignmentTarget` now **rejects org-owned policies at the Partner level** with an actionable message.
- **`AssignmentsTab.tsx`** — partner-owned shows a banner + a re-assign card only when unassigned; org-owned **drops the Partner-Wide level option**. Guards against a null `orgId` in the site/group target fetch.
- **`ConfigPolicyDetailPage.tsx`** — `PolicyDetail` carries `partnerId` (`orgId` now nullable), passed to the tab.
- **`ConfigPolicyCreatePage.tsx`** — relabeled **"Apply to" → "Scope"**; clarified helper text.
- **`aiToolsConfigPolicy.ts`** — documented the partner-level constraint in the tool description.

## Tests

- New `configurationPolicy.validateAssignment.test.ts` — ownership gating (all four combinations), asserting the illegal combos short-circuit before any DB query.
- `crud.test.ts` — partner auto-assign, org-owned does-not-auto-assign, unique-swallow (still 201), non-unique-rollback (500 + `deleteConfigPolicy` called).
- `AssignmentsTab.test.tsx` — partner banner/no-picker, re-assign POST body (level + priority + role/OS filters, no `targetId`), card hiding, org-owned level list excludes `partner`, org-owned assign POST includes `targetId`.

## Verification

`astro check` 0 errors · API `tsc` clean · eslint clean (both apps) · API 94 config-policy tests + web 14 component tests green.

This is a follow-up to #2064. Reviewed via the pr-review-toolkit (code / tests / silent-failure / comments / types); all surfaced findings were addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)