### PR TITLE
fix(mcp): resolve owning partner for org-scoped keys under system context (#2108)

### DIFF
--- a/apps/api/src/__tests__/integration/tenantStatusContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantStatusContext.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Real-DB regression test for #2108 (re-report of #2019): the tenant-status
+ * reads in `services/tenantStatus.ts` must resolve under a genuine system
+ * context even when the caller already holds a NARROWER ambient context.
+ *
+ * The manual-API-key MCP path establishes an org-scoped request context with an
+ * EMPTY partner allowlist (`accessiblePartnerIds: []`, see middleware/apiKeyAuth.ts —
+ * partner-axis RLS visibility is withheld from non-`mcp_provisioning` keys). Inside
+ * that context, `routes/mcpServer.ts` calls `getActiveOrgTenant(orgId)` to resolve
+ * the owning partnerId so a Partner Admin's role (which lives in partner_users) can
+ * be threaded into `getUserPermissions`.
+ *
+ * `getActiveOrgTenant` → `getActivePartner` read the `partners` table. Pre-fix they
+ * wrapped the read in `withSystemDbAccessContext`, which no-ops when a context is
+ * already active — so the read ran under the org-scoped context, `breeze_has_partner_access`
+ * returned false for the empty allowlist, the partner row was RLS-filtered to 0 rows,
+ * and `getActiveOrgTenant` returned null → partnerId never resolved → every MCP
+ * `tools/call` died "Insufficient permissions: no role assigned".
+ *
+ * The companion test in `permissionsContext.integration.test.ts` covers the
+ * downstream `getUserPermissions` escalation, but it PASSES the partnerId in
+ * directly — it never exercises the resolution proven here. If `readAsSystem`'s
+ * `runOutsideDbContext` escalation is removed, the first test below fails (null).
+ *
+ * Runs against `breeze_app` (NOBYPASSRLS) so RLS is genuinely enforced — the whole
+ * point of the test. Vacuous under a BYPASSRLS/superuser connection.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { db, withDbAccessContext, withSystemDbAccessContext, hasDbAccessContext } from '../../db';
+import { partners, organizations } from '../../db/schema';
+import { getActiveOrgTenant, getActivePartner } from '../../services/tenantStatus';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface TenantFixture { partnerId: string; orgId: string }
+
+/** Seed an ACTIVE partner and an ACTIVE org under it, committed under a system
+ *  context so the rows exist independent of any request's RLS visibility. */
+async function seedActiveTenant(status: 'active' | 'suspended' = 'active'): Promise<TenantFixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `TS ${sfx}`, slug: `ts-${sfx}`, type: 'msp', plan: 'pro', status })
+      .returning({ id: partners.id });
+    const [o] = await db.insert(organizations)
+      .values({ partnerId: p!.id, name: `TSOrg ${sfx}`, slug: `tso-${sfx}` })
+      .returning({ id: organizations.id });
+    return { partnerId: p!.id, orgId: o!.id };
+  });
+}
+
+/** The manual org-scoped API-key request context: scope='organization', the key's
+ *  single org accessible, and a deliberately EMPTY partner allowlist. */
+function withManualOrgKeyContext<T>(orgId: string, fn: () => Promise<T>): Promise<T> {
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      accessiblePartnerIds: [],
+      currentPartnerId: null,
+    },
+    fn,
+  );
+}
+
+describe('tenantStatus reads escalate past a narrower ambient context (breeze_app, real DB, #2108)', () => {
+  runDb('getActiveOrgTenant resolves the owning partnerId under an org-scoped context with empty partner allowlist', async () => {
+    const f = await seedActiveTenant();
+
+    const tenant = await withManualOrgKeyContext(f.orgId, () => {
+      expect(hasDbAccessContext()).toBe(true); // prove the narrower context is active
+      return getActiveOrgTenant(f.orgId);
+    });
+
+    // Pre-fix: null (partners row RLS-filtered to 0 under the empty partner allowlist).
+    expect(tenant).not.toBeNull();
+    expect(tenant?.orgId).toBe(f.orgId);
+    expect(tenant?.partnerId).toBe(f.partnerId);
+  });
+
+  runDb('getActivePartner resolves an active partner under an org-scoped context with empty partner allowlist', async () => {
+    const f = await seedActiveTenant();
+
+    const partner = await withManualOrgKeyContext(f.orgId, () => getActivePartner(f.partnerId));
+
+    expect(partner).not.toBeNull();
+    expect(partner?.id).toBe(f.partnerId);
+  });
+
+  runDb('still resolves contextless (agent / pre-auth paths keep working)', async () => {
+    const f = await seedActiveTenant();
+
+    // No ambient context — the escalation must not regress the fresh-system-tx path.
+    const tenant = await getActiveOrgTenant(f.orgId);
+
+    expect(tenant?.partnerId).toBe(f.partnerId);
+  });
+
+  runDb('a SUSPENDED partner is still reported inactive (escalation reads truth, does not blanket-allow)', async () => {
+    const f = await seedActiveTenant('suspended');
+
+    // getActiveOrgTenant cascades through getActivePartner (strictly 'active'),
+    // so a suspended partner => null even though the org row itself is active.
+    const tenant = await withManualOrgKeyContext(f.orgId, () => getActiveOrgTenant(f.orgId));
+
+    expect(tenant).toBeNull();
+  });
+});

--- a/apps/api/src/services/tenantStatus.test.ts
+++ b/apps/api/src/services/tenantStatus.test.ts
@@ -9,6 +9,10 @@ const { redisGet, redisSet, redisDel } = vi.hoisted(() => ({
 vi.mock('../db', () => ({
   db: { select: vi.fn() },
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  // readAsSystem() consults these: contextless (undefined) → runs the query via
+  // withSystemDbAccessContext, matching these tests' agent/contextless call path.
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/services/tenantStatus.ts
+++ b/apps/api/src/services/tenantStatus.ts
@@ -1,5 +1,5 @@
 import { and, eq, isNull } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { organizations, partners } from '../db/schema';
 import { getRedis } from './redis';
 
@@ -14,8 +14,40 @@ function isUsableOrgStatus(status: string | null | undefined): boolean {
   return status === 'active' || status === 'trial';
 }
 
+/**
+ * Run a tenant-status read under a genuine system-scoped DB context, whatever
+ * the caller's ambient context is.
+ *
+ * Whether a tenant is active is an INFRASTRUCTURE question, not a tenant-data
+ * one — it must not be filtered by the caller's RLS visibility. But
+ * `withSystemDbAccessContext` early-returns (no-ops) when a context is already
+ * active; it does NOT widen a narrower ambient context. So when a request has
+ * already established an org/partner-scoped context whose partner allowlist is
+ * empty — the manual-API-key MCP path is exactly this (`accessiblePartnerIds:
+ * []`, see middleware/apiKeyAuth.ts) — a bare `withSystemDbAccessContext` here
+ * would run the `partners` read under that narrow context, RLS
+ * (`breeze_has_partner_access` → false) filters it to 0 rows, and an active
+ * partner looks unresolvable: `getActiveOrgTenant` returns null → the owning
+ * partnerId is never threaded into `getUserPermissions` → every MCP `tools/call`
+ * dies "no role assigned" (#2108 / re-report of #2019).
+ *
+ * Fix: when the ambient context is narrower than system, exit it FIRST
+ * (`runOutsideDbContext`) then open a fresh system transaction — the same
+ * escalation `services/permissions.ts` (getUserPermissions) already uses.
+ * Contextless callers (agent paths, pre-auth middleware) and already-system
+ * callers are unchanged and acquire no extra connection: the former open a
+ * fresh system tx exactly as before, the latter reuse the active system tx.
+ */
+function readAsSystem<T>(fn: () => Promise<T>): Promise<T> {
+  const ambient = getCurrentDbAccessContext();
+  if (ambient && ambient.scope !== 'system') {
+    return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+  }
+  return withSystemDbAccessContext(fn);
+}
+
 export async function getActivePartner(partnerId: string): Promise<{ id: string } | null> {
-  return withSystemDbAccessContext(async () => {
+  return readAsSystem(async () => {
     const [partner] = await db
       .select({ id: partners.id, status: partners.status, deletedAt: partners.deletedAt })
       .from(partners)
@@ -40,7 +72,7 @@ export async function getActivePartner(partnerId: string): Promise<{ id: string 
 const PARTNER_SESSION_ALLOWED_STATUSES = new Set(['active', 'pending']);
 
 export async function getSessionAllowedPartner(partnerId: string): Promise<{ id: string } | null> {
-  return withSystemDbAccessContext(async () => {
+  return readAsSystem(async () => {
     const [partner] = await db
       .select({ id: partners.id, status: partners.status, deletedAt: partners.deletedAt })
       .from(partners)
@@ -53,7 +85,7 @@ export async function getSessionAllowedPartner(partnerId: string): Promise<{ id:
 }
 
 export async function getActiveOrgTenant(orgId: string): Promise<{ orgId: string; partnerId: string } | null> {
-  return withSystemDbAccessContext(async () => {
+  return readAsSystem(async () => {
     const [org] = await db
       .select({
         orgId: organizations.id,


### PR DESCRIPTION
## Summary

Fixes #2108 (re-report of #2019). A **Partner Admin whose role lives only in `partner_users`** (no `organization_users` row), connecting over MCP with a **manual org-scoped API key**, could `initialize` and `tools/list` but **every `tools/call` failed** `Insufficient permissions: no role assigned`.

#2104 correctly fixed the `getUserPermissions` escalation, but the bug survived: the owning `partnerId` that fix depends on was never resolved, one step upstream.

## Root cause

`routes/mcpServer.ts` (`buildAuthFromApiKey`) resolves the owning partner via `getActiveOrgTenant → getActivePartner` (`services/tenantStatus.ts`). Those wrapped their reads in `withSystemDbAccessContext`, which **no-ops when a context is already active** (it does not widen a narrower one). `buildAuthFromApiKey` runs inside the manual key's org-scoped request context, whose `accessiblePartnerIds` is empty (`apiKeyAuth` withholds partner-axis RLS visibility from non-`mcp_provisioning` keys). So the `partners` read executed under that narrow context, `breeze_has_partner_access()` returned false, the row was RLS-filtered to 0, `getActiveOrgTenant` returned `null`, and the partnerId never reached `getUserPermissions` → partner axis never consulted → "no role assigned".

RLS proof (unprivileged `breeze_app`, the app's GUCs):

```
-- org-scoped context (accessible_partner_ids='')
partners visible: 0     organizations visible: 1
-- system context
partners visible: 1
```

## Fix

`tenantStatus` reads now escalate via `runOutsideDbContext(() => withSystemDbAccessContext(fn))` when the ambient context is **narrower than system** — the identical escalation `services/permissions.ts` already uses. Tenant-status is an infrastructure question, not a tenant-data one, so it must not be filtered by the caller's RLS visibility.

- **Contextless callers** (agent heartbeat/WS/mTLS, pre-auth middleware): `getCurrentDbAccessContext()` is undefined → unchanged (open a fresh system tx as before, **no extra connection**).
- **Already-system callers** (auth token-context helpers, enrollment): unchanged (reuse active system tx, **no extra connection**).
- **Narrower org/partner ambient callers** (only the manual-key MCP path today): now escalate. Correctness-only change; these were silently broken before.

## Testing

- **New real-DB integration test** `tenantStatusContext.integration.test.ts` (runs as `breeze_app`, NOBYPASSRLS): `getActiveOrgTenant`/`getActivePartner` resolve under a narrow org-scoped context with an empty partner allowlist; plus contextless-still-works and suspended-partner-still-inactive guards. **Verified RED without the fix, GREEN with it.**
- Existing `permissionsContext.integration.test.ts` (the #2104 escalation) still green.
- `tenantStatus.test.ts` unit mock updated for the two new `../db` exports.
- Ran 18 tenantStatus-adjacent unit suites (auth/agent/api-key/mcp/oauth): 374 passed. `tsc --noEmit`: clean.
- **Live end-to-end** against a local stack on `main` + this fix: the exact org-scoped Partner-Admin-only key's `tools/call` returns a real result instead of "no role assigned".

Follow-up to #2019 and #2104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)