### PR TITLE
fix(alerts): unmuteable resolved alerts + "Forever" suppression + expiry reaper

### DIFF
--- a/apps/api/migrations/2026-06-30-alerts-suppression-expiry-idx.sql
+++ b/apps/api/migrations/2026-06-30-alerts-suppression-expiry-idx.sql
@@ -1,0 +1,7 @@
+-- Partial index backing the suppression-expiry reaper's due-rows scan
+-- (apps/api/src/jobs/suppressionExpiryReaper.ts). Only timed suppressions
+-- (suppressed_until NOT NULL) are ever reaped; Forever suppressions (NULL) are
+-- excluded by design, so they are excluded from the index too.
+CREATE INDEX IF NOT EXISTS idx_alerts_suppressed_expiry
+  ON alerts (suppressed_until)
+  WHERE status = 'suppressed' AND suppressed_until IS NOT NULL;

--- a/apps/api/src/db/schema/alerts.ts
+++ b/apps/api/src/db/schema/alerts.ts
@@ -81,7 +81,12 @@ export const alerts = pgTable('alerts', {
   // Backs the `alerts.critical` device-filter field (#968).
   activeCriticalIdx: index('idx_alerts_active_critical')
     .on(table.deviceId)
-    .where(sql`status = 'active' AND severity = 'critical'`)
+    .where(sql`status = 'active' AND severity = 'critical'`),
+  // Backs the suppression-expiry reaper's due-rows scan
+  // (apps/api/src/jobs/suppressionExpiryReaper.ts).
+  suppressedExpiryIdx: index('idx_alerts_suppressed_expiry')
+    .on(table.suppressedUntil)
+    .where(sql`status = 'suppressed' AND suppressed_until IS NOT NULL`)
 }));
 
 export const alertCorrelations = pgTable('alert_correlations', {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -240,6 +240,7 @@ import { initializePamJobs, shutdownPamJobs } from './jobs/pamJobs';
 import { initializeApprovalExpiryReaper, shutdownApprovalExpiryReaper } from './jobs/approvalExpiryReaper';
 import { initializeStripeReconcileSweep, shutdownStripeReconcileSweep } from './jobs/stripeReconcileSweep';
 import { initializeQuoteExpiryReaper, shutdownQuoteExpiryReaper } from './jobs/quoteExpiryReaper';
+import { initializeSuppressionExpiryReaper, shutdownSuppressionExpiryReaper } from './jobs/suppressionExpiryReaper';
 import { initializeTicketNotifyWorker, shutdownTicketNotifyWorker } from './jobs/ticketNotifyWorker';
 import { initializeTicketSlaWorker, shutdownTicketSlaWorker } from './jobs/ticketSlaWorker';
 import { initializeInboundEmailWorker, shutdownInboundEmailWorker } from './jobs/inboundEmailWorker';
@@ -1191,6 +1192,7 @@ async function initializeWorkers(): Promise<void> {
     ['approvalExpiryReaper', initializeApprovalExpiryReaper],
     ['stripeReconcileSweep', initializeStripeReconcileSweep],
     ['quoteExpiryReaper', initializeQuoteExpiryReaper],
+    ['suppressionExpiryReaper', initializeSuppressionExpiryReaper],
     ['ticketNotifyWorker', initializeTicketNotifyWorker],
     ['ticketSlaWorker', initializeTicketSlaWorker],
     ['inboundEmailWorker', initializeInboundEmailWorker],
@@ -1363,6 +1365,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownApprovalExpiryReaper,
     shutdownStripeReconcileSweep,
     shutdownQuoteExpiryReaper,
+    shutdownSuppressionExpiryReaper,
     shutdownTicketNotifyWorker,
     shutdownTicketSlaWorker,
     shutdownInboundEmailWorker,

--- a/apps/api/src/jobs/suppressionExpiryReaper.integration.test.ts
+++ b/apps/api/src/jobs/suppressionExpiryReaper.integration.test.ts
@@ -1,0 +1,50 @@
+import '../__tests__/integration/setup';
+
+import { expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { alerts, devices, organizations, partners, sites } from '../db/schema';
+import { reapExpiredSuppressions } from './suppressionExpiryReaper';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+runDb('reactivates only past timed suppressions; leaves future, forever, and non-suppressed rows', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const past = new Date(Date.now() - 60_000);
+  const future = new Date(Date.now() + 60 * 60_000);
+
+  const ids = await withSystemDbAccessContext(async () => {
+    const [partner] = await db.insert(partners).values({ name: `SR Partner ${unique}`, slug: `sr-partner-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [org] = await db.insert(organizations).values({ partnerId: partner!.id, name: `SR Org ${unique}`, slug: `sr-org-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [site] = await db.insert(sites).values({ orgId: org!.id, name: `SR Site ${unique}` }).returning({ id: sites.id });
+    const [device] = await db.insert(devices).values({ orgId: org!.id, siteId: site!.id, agentId: `sr-agent-${unique}`, hostname: `sr-host-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'offline' }).returning({ id: devices.id });
+
+    const base = { deviceId: device!.id, orgId: org!.id, severity: 'info' as const, title: 'SR alert', triggeredAt: new Date() };
+    const [pastSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: past }).returning({ id: alerts.id });
+    const [futureSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: future }).returning({ id: alerts.id });
+    const [foreverSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: null }).returning({ id: alerts.id });
+    const [activeAlert] = await db.insert(alerts).values({ ...base, status: 'active', suppressedUntil: null }).returning({ id: alerts.id });
+    return { pastSup: pastSup!.id, futureSup: futureSup!.id, foreverSup: foreverSup!.id, activeAlert: activeAlert!.id };
+  });
+
+  // Other suites may leave suppressed rows behind on the shared DB, so assert on
+  // our specific rows rather than the exact reaped count.
+  const reaped = await withSystemDbAccessContext(() => reapExpiredSuppressions());
+  expect(reaped).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const [pastRow] = await db.select().from(alerts).where(eq(alerts.id, ids.pastSup));
+    expect(pastRow!.status).toBe('active');
+    expect(pastRow!.suppressedUntil).toBeNull();
+
+    const [futureRow] = await db.select().from(alerts).where(eq(alerts.id, ids.futureSup));
+    expect(futureRow!.status).toBe('suppressed');
+
+    const [foreverRow] = await db.select().from(alerts).where(eq(alerts.id, ids.foreverSup));
+    expect(foreverRow!.status).toBe('suppressed'); // Forever stays forever
+    expect(foreverRow!.suppressedUntil).toBeNull();
+
+    const [activeRow] = await db.select().from(alerts).where(eq(alerts.id, ids.activeAlert));
+    expect(activeRow!.status).toBe('active');
+  });
+});

--- a/apps/api/src/jobs/suppressionExpiryReaper.test.ts
+++ b/apps/api/src/jobs/suppressionExpiryReaper.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, alertsTable } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  alertsTable: {
+    status: 'alerts.status',
+    suppressedUntil: 'alerts.suppressed_until',
+  },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      execute: (...args: unknown[]) => executeMock(...(args as [])),
+    },
+    withSystemDbAccessContext: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+vi.mock('../db/schema/alerts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/schema/alerts')>();
+  return {
+    ...actual,
+    alerts: alertsTable,
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { reapExpiredSuppressions } from './suppressionExpiryReaper';
+import { writeAuditEvent } from '../services/auditEvents';
+
+describe('suppressionExpiryReaper.reapExpiredSuppressions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('reactivates expired suppressions and audits each transition', async () => {
+    executeMock.mockResolvedValueOnce({
+      rows: [{ id: 'alert-1', org_id: 'org-1', title: 'Warranty expires' }],
+    });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(1);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-1',
+        action: 'alert.suppression_expired',
+        resourceType: 'alert',
+        resourceId: 'alert-1',
+        actorType: 'system',
+        result: 'success',
+        details: { previousStatus: 'suppressed' },
+      }),
+    );
+  });
+
+  it('returns 0 and audits nothing when no suppressions are due', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(0);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('still transitions when the audit write throws (best-effort audit)', async () => {
+    executeMock.mockResolvedValueOnce({
+      rows: [{ id: 'alert-2', org_id: 'org-2', title: 'CPU high' }],
+    });
+    vi.mocked(writeAuditEvent).mockImplementation(() => {
+      throw new Error('audit sink down');
+    });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(1);
+  });
+});

--- a/apps/api/src/jobs/suppressionExpiryReaper.test.ts
+++ b/apps/api/src/jobs/suppressionExpiryReaper.test.ts
@@ -102,5 +102,23 @@ describe('suppressionExpiryReaper.reapExpiredSuppressions', () => {
     const reaped = await reapExpiredSuppressions();
 
     expect(reaped).toBe(1);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('audits every row even when an earlier row\'s audit write throws (best-effort, per-row)', async () => {
+    executeMock.mockResolvedValueOnce({
+      rows: [
+        { id: 'a1', org_id: 'o1', title: 'A' },
+        { id: 'a2', org_id: 'o2', title: 'B' },
+      ],
+    });
+    vi.mocked(writeAuditEvent).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(2);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/jobs/suppressionExpiryReaper.ts
+++ b/apps/api/src/jobs/suppressionExpiryReaper.ts
@@ -1,0 +1,187 @@
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { alerts } from '../db/schema/alerts';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+
+/**
+ * Reaps `alerts` rows whose timed suppression has elapsed: `status='suppressed'`
+ * with a non-null `suppressed_until` in the past. Flips them back to `active`
+ * and clears the stale deadline so they reappear for triage and stop blocking
+ * new alerts (alertService dedupe counts 'suppressed' as open). Snooze semantics:
+ * no event is published, so notification channels stay silent.
+ *
+ * Indefinite ("Forever", suppressed_until IS NULL) suppressions are never touched.
+ *
+ * Runs every 5 minutes inside `withSystemDbAccessContext` — alerts is org-scoped
+ * RLS, but expiry reaping is a system job.
+ */
+
+const QUEUE_NAME = 'suppression-expiry-reaper';
+const REAP_INTERVAL_MS = 5 * 60 * 1000; // every 5 min
+const MAX_REAP_PER_RUN = 500;
+
+type ReaperJobData = { type: 'reap-expired-suppressions'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[SuppressionExpiryReaper] withSystemDbAccessContext not available — reaper cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+let reaperQueue: Queue<ReaperJobData> | null = null;
+let reaperWorker: Worker<ReaperJobData> | null = null;
+
+function getQueue(): Queue<ReaperJobData> {
+  if (!reaperQueue) {
+    reaperQueue = new Queue<ReaperJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return reaperQueue;
+}
+
+/**
+ * Single pass: flip past-due timed suppressions to `active`, clear their
+ * deadline, and write an audit row per transition. Bounded to MAX_REAP_PER_RUN
+ * via a CTE so a backlog spike can't lock the table for too long. Returns the
+ * number of alerts transitioned.
+ */
+export async function reapExpiredSuppressions(): Promise<number> {
+  const transitioned = await db.execute<{
+    id: string;
+    org_id: string;
+    title: string;
+  }>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${alerts}
+      WHERE ${alerts.status} = 'suppressed'
+        AND ${alerts.suppressedUntil} IS NOT NULL
+        AND ${alerts.suppressedUntil} < now()
+      ORDER BY ${alerts.suppressedUntil} ASC
+      LIMIT ${MAX_REAP_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${alerts} AS a
+    SET status = 'active',
+        suppressed_until = NULL
+    FROM due
+    WHERE a.id = due.id
+      AND a.status = 'suppressed'
+    RETURNING a.id, a.org_id, a.title;
+  `);
+
+  const rows = (transitioned as unknown as { rows?: Array<{ id: string; org_id: string; title: string }> }).rows
+    ?? (transitioned as unknown as Array<{ id: string; org_id: string; title: string }>);
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return 0;
+  }
+
+  // Audit log: one row per reactivated alert. Best-effort — never block a
+  // transition on the audit write. System job, so no IP/UA.
+  const requestLike = requestLikeFromSnapshot({});
+  for (const row of rows) {
+    try {
+      writeAuditEvent(requestLike, {
+        orgId: row.org_id,
+        action: 'alert.suppression_expired',
+        resourceType: 'alert',
+        resourceId: row.id,
+        resourceName: row.title,
+        actorType: 'system',
+        actorId: null,
+        result: 'success',
+        details: { previousStatus: 'suppressed' },
+      });
+    } catch (err) {
+      console.error('[SuppressionExpiryReaper] Failed to write audit event:', err);
+    }
+  }
+
+  if (rows.length === MAX_REAP_PER_RUN) {
+    console.warn(`[SuppressionExpiryReaper] Hit ${MAX_REAP_PER_RUN}-item cap — backlog may be growing`);
+  }
+
+  return rows.length;
+}
+
+function createWorker(): Worker<ReaperJobData> {
+  return new Worker<ReaperJobData>(
+    QUEUE_NAME,
+    async (_job: Job<ReaperJobData>) => {
+      try {
+        const reaped = await runWithSystemDbAccess(reapExpiredSuppressions);
+        if (reaped > 0) {
+          console.log(`[SuppressionExpiryReaper] Reactivated ${reaped} alert(s)`);
+        }
+        return { reaped };
+      } catch (err) {
+        console.error('[SuppressionExpiryReaper] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'reap-expired-suppressions') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(
+    'reap-expired-suppressions',
+    { type: 'reap-expired-suppressions', queuedAt: new Date().toISOString() },
+    {
+      jobId: 'suppression-expiry-reaper',
+      repeat: { every: REAP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeSuppressionExpiryReaper(): Promise<void> {
+  if (reaperWorker) return;
+  reaperWorker = createWorker();
+  reaperWorker.on('error', (error) => {
+    console.error('[SuppressionExpiryReaper] Worker error:', error);
+    captureException(error);
+  });
+  reaperWorker.on('failed', (job, error) => {
+    console.error(`[SuppressionExpiryReaper] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await reaperWorker.close();
+    reaperWorker = null;
+    throw err;
+  }
+  console.log('[SuppressionExpiryReaper] Initialized');
+}
+
+export async function shutdownSuppressionExpiryReaper(): Promise<void> {
+  const worker = reaperWorker;
+  const queue = reaperQueue;
+  reaperWorker = null;
+  reaperQueue = null;
+  if (worker) {
+    try { await worker.close(); } catch (err) { console.error('[SuppressionExpiryReaper] Error closing worker:', err); }
+  }
+  if (queue) {
+    try { await queue.close(); } catch (err) { console.error('[SuppressionExpiryReaper] Error closing queue:', err); }
+  }
+}

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2785,15 +2785,18 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         summary: 'Suppress alert',
         parameters: [{ $ref: '#/components/parameters/idParam' }],
         requestBody: {
-          required: true,
+          required: false,
           content: {
             'application/json': {
               schema: {
                 type: 'object',
                 properties: {
-                  until: { type: 'string', format: 'date-time' }
-                },
-                required: ['until']
+                  until: {
+                    type: 'string',
+                    format: 'date-time',
+                    description: 'Absolute deadline the alert stays muted until. Omit for indefinite ("Forever") suppression.'
+                  }
+                }
               }
             }
           }

--- a/apps/api/src/routes/alerts/alerts.authz.test.ts
+++ b/apps/api/src/routes/alerts/alerts.authz.test.ts
@@ -316,7 +316,8 @@ describe('POST /alerts/bulk site-axis scope (T3)', () => {
 
 // Bulk suppress (PR #2020 follow-up): the bulk endpoint must accept
 // action:'suppress' with a future `until`, set suppressedUntil, skip resolved
-// alerts, and reject a missing/past deadline.
+// alerts, and reject a past deadline. A missing `until` means indefinite
+// ("Forever") suppression — suppressedUntil is left null.
 describe('POST /alerts/bulk suppress', () => {
   const ORG = 'org-1';
   const ALERT_A = 'a1a1a1a1-1111-4111-8111-111111111111';
@@ -368,15 +369,18 @@ describe('POST /alerts/bulk suppress', () => {
     expect(state.alerts.find((x) => x.id === ALERT_RESOLVED)?.status).toBe('resolved');
   });
 
-  it('400 when `until` is omitted', async () => {
+  it('suppresses indefinitely (Forever) when `until` is omitted', async () => {
     const res = await makeApp().request('/alerts/bulk', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ alertIds: [ALERT_A], action: 'suppress' }),
     });
-    expect(res.status).toBe(400);
-    // Nothing was mutated.
-    expect(state.alerts.find((x) => x.id === ALERT_A)?.status).toBe('active');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ updated: 1, skipped: 0 });
+    const a = state.alerts.find((x) => x.id === ALERT_A)!;
+    expect(a.status).toBe('suppressed');
+    // Forever == no deadline: suppressedUntil is left null.
+    expect(a.suppressedUntil).toBeNull();
   });
 
   it('400 when `until` is in the past', async () => {

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -387,9 +387,11 @@ alertsRoutes.post(
 
     // Resolve + validate the suppression deadline once (mirrors the single
     // POST /alerts/:id/suppress contract) so every alert gets the same `until`.
+    // A missing `until` on a suppress action means indefinite ("Forever")
+    // suppression — leave suppressedUntil null.
     let suppressedUntil: Date | null = null;
-    if (action === 'suppress') {
-      suppressedUntil = new Date(until!);
+    if (action === 'suppress' && until !== undefined) {
+      suppressedUntil = new Date(until);
       if (Number.isNaN(suppressedUntil.getTime()) || suppressedUntil <= new Date()) {
         return c.json({ error: 'Suppression time must be in the future' }, 400);
       }
@@ -755,9 +757,13 @@ alertsRoutes.post(
       return c.json({ error: 'Cannot suppress a resolved alert' }, 400);
     }
 
-    const suppressedUntil = new Date(data.until);
-    if (suppressedUntil <= new Date()) {
-      return c.json({ error: 'Suppression time must be in the future' }, 400);
+    // No `until` => indefinite ("Forever") suppression: leave suppressedUntil null.
+    let suppressedUntil: Date | null = null;
+    if (data.until !== undefined) {
+      suppressedUntil = new Date(data.until);
+      if (Number.isNaN(suppressedUntil.getTime()) || suppressedUntil <= new Date()) {
+        return c.json({ error: 'Suppression time must be in the future' }, 400);
+      }
     }
 
     const [updated] = await db
@@ -776,14 +782,14 @@ alertsRoutes.post(
       orgId: alert.orgId,
       alertId: updated.id,
       eventType: 'alert.suppressed',
-      dedupeKey: `suppress:${suppressedUntil.toISOString()}`,
+      dedupeKey: `suppress:${suppressedUntil ? suppressedUntil.toISOString() : 'forever'}`,
       outcome: 'suppressed',
       actorUserId: auth.user.id,
       occurredAt: new Date(),
       metadata: {
         source: 'alerts.route',
         previousStatus: alert.status,
-        suppressedUntil: suppressedUntil.toISOString(),
+        suppressedUntil: suppressedUntil ? suppressedUntil.toISOString() : null,
       },
     });
 
@@ -796,7 +802,7 @@ alertsRoutes.post(
       details: {
         previousStatus: alert.status,
         nextStatus: updated.status,
-        suppressedUntil: suppressedUntil.toISOString(),
+        suppressedUntil: suppressedUntil ? suppressedUntil.toISOString() : null,
       },
     });
 

--- a/apps/api/src/routes/alerts/byid.sitescope.test.ts
+++ b/apps/api/src/routes/alerts/byid.sitescope.test.ts
@@ -188,6 +188,7 @@ const DEVICE_B = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd';
 const ALERT_A = 'a1a1a1a1-1111-4111-8111-111111111111'; // SITE_A device
 const ALERT_B = 'a2a2a2a2-2222-4222-8222-222222222222'; // SITE_B device
 const ALERT_ORGWIDE = 'a3a3a3a3-3333-4333-8333-333333333333'; // deviceless
+const ALERT_RESOLVED = 'a4a4a4a4-4444-4444-8444-444444444444'; // deviceless, already resolved
 const ALERTS_WRITE = 'alerts:write';
 const ALERTS_ACKNOWLEDGE = 'alerts:acknowledge';
 
@@ -200,6 +201,7 @@ function resetState() {
     { id: ALERT_A, orgId: ORG, deviceId: DEVICE_A, status: 'active', ruleId: null, title: 'A' },
     { id: ALERT_B, orgId: ORG, deviceId: DEVICE_B, status: 'active', ruleId: null, title: 'B' },
     { id: ALERT_ORGWIDE, orgId: ORG, deviceId: null, status: 'active', ruleId: null, title: 'org' },
+    { id: ALERT_RESOLVED, orgId: ORG, deviceId: null, status: 'resolved', ruleId: null, title: 'resolved' },
   ];
 }
 
@@ -315,6 +317,45 @@ describe('alert by-id site-axis scope (T9, #1051)', () => {
       });
       expect(res.status).toBe(200);
       expect(state.alerts.find((a) => a.id === ALERT_A)?.status).toBe('suppressed');
+    });
+
+    // `until` omitted => indefinite ("Forever") suppression: 200, status
+    // becomes 'suppressed', suppressedUntil stays null.
+    it('suppresses indefinitely (Forever) when `until` is omitted', async () => {
+      const res = await makeApp().request(`/alerts/${ALERT_A}/suppress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('suppressed');
+      expect(body.suppressedUntil).toBeNull();
+      const a = state.alerts.find((x) => x.id === ALERT_A)!;
+      expect(a.status).toBe('suppressed');
+      expect(a.suppressedUntil).toBeNull();
+    });
+
+    it('400 when `until` is in the past, and leaves the alert unchanged', async () => {
+      const res = await makeApp().request(`/alerts/${ALERT_A}/suppress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ until: '2000-01-01T00:00:00.000Z' }),
+      });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Suppression time must be in the future' });
+      expect(state.alerts.find((x) => x.id === ALERT_A)?.status).toBe('active');
+    });
+
+    it('400 when the target alert is already resolved, and leaves it resolved', async () => {
+      const res = await makeApp().request(`/alerts/${ALERT_RESOLVED}/suppress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ until: '2030-01-01T00:00:00.000Z' }),
+      });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Cannot suppress a resolved alert' });
+      expect(state.alerts.find((x) => x.id === ALERT_RESOLVED)?.status).toBe('resolved');
     });
   });
 });

--- a/apps/api/src/routes/alerts/schemas.ts
+++ b/apps/api/src/routes/alerts/schemas.ts
@@ -90,17 +90,10 @@ export const testAlertRuleSchema = z.object({
 export const bulkAlertActionSchema = z.object({
   action: z.enum(['acknowledge', 'resolve', 'suppress']),
   alertIds: z.array(z.string().guid()).min(1).max(100),
-  // Required only for `suppress` — the absolute deadline the alerts stay muted
-  // until (ISO date string), mirroring POST /alerts/:id/suppress.
+  // Absolute deadline the alerts stay muted until (ISO date string), mirroring
+  // POST /alerts/:id/suppress. Optional even for `suppress`: omit for indefinite
+  // ("Forever") suppression.
   until: z.string().optional()
-}).superRefine((data, ctx) => {
-  if (data.action === 'suppress' && !data.until) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['until'],
-      message: 'until is required when suppressing alerts'
-    });
-  }
 });
 
 // Alerts schemas
@@ -120,7 +113,9 @@ export const resolveAlertSchema = z.object({
 });
 
 export const suppressAlertSchema = z.object({
-  until: z.string() // ISO date string
+  // Absolute ISO deadline the alert stays muted until. Omit for indefinite
+  // ("Forever") suppression — the row's suppressedUntil is then left null.
+  until: z.string().optional()
 });
 
 // Notification Channels schemas

--- a/apps/api/src/services/aiToolsAlerts.feedback.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.feedback.test.ts
@@ -181,6 +181,19 @@ describe('manage_alerts feedback emission', () => {
     }));
   });
 
+  it('refuses to suppress a resolved alert (no write, no feedback)', async () => {
+    mockAlertLookup({ ...ALERT, status: 'resolved' });
+
+    const result = JSON.parse(await handlerFor('manage_alerts')(
+      { action: 'suppress', alertId: ALERT.id },
+      makeAuth()
+    ));
+
+    expect(result.error).toBe('Cannot suppress a resolved alert');
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.emitAlertStateFeedback).not.toHaveBeenCalled();
+  });
+
   it('does not emit feedback when the alert is missing', async () => {
     mockAlertLookup(null);
 

--- a/apps/api/src/services/aiToolsAlerts.feedback.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.feedback.test.ts
@@ -156,6 +156,31 @@ describe('manage_alerts feedback emission', () => {
     }
   });
 
+  it('suppress with suppressDuration:0 suppresses forever (no deadline)', async () => {
+    mockAlertLookup(ALERT);
+    mockUpdate();
+
+    const result = JSON.parse(await handlerFor('manage_alerts')(
+      { action: 'suppress', alertId: ALERT.id, suppressDuration: 0 },
+      makeAuth()
+    ));
+
+    expect(result.success).toBe(true);
+    expect(result.suppressedUntil).toBeNull();
+    expect(result.durationHours).toBeNull();
+    // Forever == no deadline: the dedupe key and metadata carry no timestamp.
+    expect(mocks.emitAlertStateFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'alert.suppressed',
+      dedupeKey: 'suppress:forever',
+      outcome: 'suppressed',
+      metadata: expect.objectContaining({
+        source: 'ai_tools.manage_alerts',
+        suppressedUntil: null,
+        durationHours: null,
+      }),
+    }));
+  });
+
   it('does not emit feedback when the alert is missing', async () => {
     mockAlertLookup(null);
 

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -250,6 +250,12 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const alert = await findAlertWithAccess(input.alertId as string, auth);
         if (!alert) return JSON.stringify({ error: 'Alert not found or access denied' });
 
+        // Mirror the REST endpoints (POST /alerts/:id/suppress): a resolved alert
+        // has nothing to silence, so refuse rather than silently re-open it.
+        if (alert.status === 'resolved') {
+          return JSON.stringify({ error: 'Cannot suppress a resolved alert' });
+        }
+
         // suppressDuration: 0 => indefinite ("Forever") suppression, leaving
         // suppressedUntil null (mirrors POST /alerts/:id/suppress with no `until`).
         const forever = Number(input.suppressDuration) === 0;

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -64,7 +64,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           deviceId: { type: 'string', description: 'Filter by device UUID (for list)' },
           limit: { type: 'number', description: 'Max results (for list, default 25)' },
           resolutionNote: { type: 'string', description: 'Note when resolving or suppressing an alert' },
-          suppressDuration: { type: 'number', description: 'Hours to suppress the alert (default: 24, max: 720)' }
+          suppressDuration: { type: 'number', description: 'Hours to suppress the alert (default: 24, max: 720). Use 0 to suppress forever (indefinitely).' }
         },
         required: ['action']
       }
@@ -250,10 +250,18 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const alert = await findAlertWithAccess(input.alertId as string, auth);
         if (!alert) return JSON.stringify({ error: 'Alert not found or access denied' });
 
-        const durationHours = Math.min(Math.max(1, Number(input.suppressDuration) || 24), 720);
-        const suppressedUntil = new Date(Date.now() + durationHours * 60 * 60 * 1000);
+        // suppressDuration: 0 => indefinite ("Forever") suppression, leaving
+        // suppressedUntil null (mirrors POST /alerts/:id/suppress with no `until`).
+        const forever = Number(input.suppressDuration) === 0;
+        const durationHours = forever
+          ? null
+          : Math.min(Math.max(1, Number(input.suppressDuration) || 24), 720);
+        const suppressedUntil = durationHours === null
+          ? null
+          : new Date(Date.now() + durationHours * 60 * 60 * 1000);
         const occurredAt = new Date();
-        const resolutionNote = (input.resolutionNote as string) ?? `Suppressed for ${durationHours}h via AI assistant`;
+        const resolutionNote = (input.resolutionNote as string)
+          ?? (forever ? 'Suppressed indefinitely via AI assistant' : `Suppressed for ${durationHours}h via AI assistant`);
 
         await db
           .update(alerts)
@@ -274,7 +282,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
               ruleId: alert.ruleId,
               deviceId: alert.deviceId,
               suppressedBy: auth.user.id,
-              suppressedUntil: suppressedUntil.toISOString(),
+              suppressedUntil: suppressedUntil ? suppressedUntil.toISOString() : null,
               durationHours
             },
             'ai-tools',
@@ -289,22 +297,24 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           orgId: alert.orgId,
           alertId: alert.id,
           eventType: 'alert.suppressed',
-          dedupeKey: `suppress:${suppressedUntil.toISOString()}`,
+          dedupeKey: `suppress:${suppressedUntil ? suppressedUntil.toISOString() : 'forever'}`,
           outcome: 'suppressed',
           actorUserId: auth.user.id,
           occurredAt,
           metadata: {
             source: 'ai_tools.manage_alerts',
             previousStatus: alert.status,
-            suppressedUntil: suppressedUntil.toISOString(),
+            suppressedUntil: suppressedUntil ? suppressedUntil.toISOString() : null,
             durationHours,
           },
         });
 
         return JSON.stringify({
           success: true,
-          message: `Alert "${alert.title}" suppressed until ${suppressedUntil.toISOString()}`,
-          suppressedUntil: suppressedUntil.toISOString(),
+          message: suppressedUntil
+            ? `Alert "${alert.title}" suppressed until ${suppressedUntil.toISOString()}`
+            : `Alert "${alert.title}" suppressed indefinitely (Forever)`,
+          suppressedUntil: suppressedUntil ? suppressedUntil.toISOString() : null,
           durationHours,
           warning: suppressEventWarning
         });

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
       'src/services/cpeMap.integration.test.ts',
       'src/services/exploitFeeds.integration.test.ts',
       'src/jobs/vulnerability*.integration.test.ts',
+      // Suppression-expiry reaper real-DB test: imports `__tests__/integration/setup`
+      // (real postgres pool + autoMigrate in its beforeAll), so the unit runner's
+      // no-DB environment fails the suite on connect. Belongs to vitest.integration.config.ts.
+      'src/jobs/suppressionExpiryReaper.integration.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
       'src/services/vulnerabilityRemediationEvents.integration.test.ts',
       // Co-located real-DB integration test for BE-16 Phase 4 AI read tools.
       'src/services/aiToolsVulnerability.integration.test.ts',
+      // Co-located real-DB integration test for the suppression-expiry reaper:
+      // asserts the SQL predicate (incl. the Forever-exclusion invariant)
+      // that mocked unit tests can't cover.
+      'src/jobs/suppressionExpiryReaper.integration.test.ts',
     ],
     exclude: [
       // rls.integration.test.ts is a mocked unit test in integration's

--- a/apps/web/src/components/alerts/AlertList.tsx
+++ b/apps/web/src/components/alerts/AlertList.tsx
@@ -552,7 +552,7 @@ export default function AlertList({
                                 Resolve
                               </button>
                             )}
-                            {alert.status !== 'suppressed' && (
+                            {alert.status !== 'suppressed' && alert.status !== 'resolved' && (
                               <button
                                 type="button"
                                 onClick={e => {

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -552,4 +552,31 @@ describe('AlertsPage — bulk suppress', () => {
       );
     });
   });
+
+  it('sends no "until" in the /alerts/bulk body when Forever is chosen', async () => {
+    bulkMock();
+    render(<AlertsPage />);
+
+    // Select the alert, open the bulk menu, choose Suppress.
+    fireEvent.click(await screen.findByRole('checkbox', { name: /Select High CPU on SRV-01/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Suppress/i }));
+
+    expect(await screen.findByTestId('suppress-confirm')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('suppress-duration-forever'));
+    fireEvent.click(screen.getByTestId('suppress-confirm'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/alerts/bulk',
+        expect.objectContaining({ method: 'POST', body: expect.any(String) }),
+      );
+    });
+
+    const call = fetchMock.mock.calls.find(([url]) => url === '/alerts/bulk')!;
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.action).toBe('suppress');
+    // Forever == no deadline: the body carries no `until` key at all.
+    expect(body).not.toHaveProperty('until');
+  });
 });

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -432,6 +432,27 @@ describe('AlertsPage — suppress duration picker', () => {
     expect(untilMs).toBeLessThanOrEqual(Date.now() + 24 * 60 * 60 * 1000 + 2000);
   });
 
+  it('sends no "until" in the body when Forever is chosen', async () => {
+    listOnlyMock(() => Promise.resolve(makeJsonResponse({ id: ALERT_ID, status: 'suppressed' })));
+
+    render(<AlertsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /Suppress: High CPU on SRV-01/i }));
+    fireEvent.click(await screen.findByTestId('suppress-duration-forever'));
+    fireEvent.click(await screen.findByTestId('suppress-confirm'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/alerts/${ALERT_ID}/suppress`,
+        expect.objectContaining({ method: 'POST', body: expect.any(String) }),
+      );
+    });
+
+    const call = fetchMock.mock.calls.find(([url]) => url === `/alerts/${ALERT_ID}/suppress`)!;
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    // Forever == no deadline: the body carries no `until` key at all.
+    expect(body).not.toHaveProperty('until');
+  });
+
   it('reverts the optimistic update and surfaces the server error when suppression fails', async () => {
     listOnlyMock(() => Promise.resolve(makeJsonResponse({ error: 'Cannot suppress a resolved alert' }, false, 400)));
 
@@ -447,6 +468,28 @@ describe('AlertsPage — suppress duration picker', () => {
     });
     // Optimistic suppression is rolled back: the row's Suppress button returns.
     expect(await screen.findByRole('button', { name: /Suppress: High CPU on SRV-01/i })).toBeInTheDocument();
+  });
+
+  it('hides the Mute button on resolved alerts (the suppress endpoint rejects them)', async () => {
+    const resolvedAlert = { ...activeAlert, status: 'resolved' };
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [resolvedAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+
+    render(<AlertsPage />);
+    // The row renders...
+    expect(await screen.findByText('High CPU on SRV-01')).toBeInTheDocument();
+    // ...but with no Mute/Suppress action, since the backend returns
+    // "Cannot suppress a resolved alert" for resolved alerts.
+    expect(screen.queryByRole('button', { name: /Suppress: High CPU on SRV-01/i })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/alerts/AlertsPage.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.test.tsx
@@ -579,4 +579,37 @@ describe('AlertsPage — bulk suppress', () => {
     // Forever == no deadline: the body carries no `until` key at all.
     expect(body).not.toHaveProperty('until');
   });
+
+  it('warns (not success) when the bulk suppress changes nothing (all skipped)', async () => {
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/alerts' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+      }
+      if (url === '/devices' && method === 'GET') {
+        return Promise.resolve(makeJsonResponse({ data: [] }));
+      }
+      if (url === '/alerts/bulk' && method === 'POST') {
+        // Server processed the request but nothing changed (e.g. every selected
+        // alert was already resolved, so suppress skipped them all).
+        return Promise.resolve(makeJsonResponse({ updated: 0, skipped: 1, failed: 0 }));
+      }
+      return Promise.resolve(makeJsonResponse({ error: `unexpected ${method} ${url}` }, false, 404));
+    });
+    render(<AlertsPage />);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /Select High CPU on SRV-01/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Suppress/i }));
+    fireEvent.click(await screen.findByTestId('suppress-confirm'));
+
+    // A truthful warning, NOT a green "1 suppressed".
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'warning', message: 'No alerts suppressed — 1 skipped' }),
+      );
+    });
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
 });

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -312,7 +312,11 @@ export default function AlertsPage() {
   const executeBulkAction = async (action: string, selectedAlerts: Alert[], until?: Date | null) => {
     setSubmitting(true);
     try {
-      await runAction({
+      // The bulk endpoint returns HTTP 200 with per-alert counts even when
+      // nothing changed (e.g. every selected alert was already resolved, so
+      // suppress skips them all). Toast from the real counts — never a blanket
+      // "N suppressed" off the selection size — so a no-op isn't shown as success.
+      const result = await runAction<{ updated?: number; skipped?: number; failed?: number }>({
         request: () => fetchWithAuth('/alerts/bulk', {
           method: 'POST',
           body: JSON.stringify({
@@ -322,10 +326,27 @@ export default function AlertsPage() {
           })
         }),
         errorFallback: `Failed to ${action} alerts`,
-        successMessage: `${selectedAlerts.length} alert${selectedAlerts.length > 1 ? 's' : ''} ${BULK_PAST_TENSE[action] ?? `${action}d`}`,
         onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
       await fetchAlerts();
+
+      const past = BULK_PAST_TENSE[action] ?? `${action}d`;
+      const updated = result?.updated ?? 0;
+      const skipped = result?.skipped ?? 0;
+      const failed = result?.failed ?? 0;
+      const extras = [skipped ? `${skipped} skipped` : '', failed ? `${failed} failed` : '']
+        .filter(Boolean).join(', ');
+      if (updated === 0) {
+        showToast({
+          message: `No alerts ${past}${extras ? ` — ${extras}` : ''}`,
+          type: failed > 0 ? 'error' : 'warning',
+        });
+      } else {
+        showToast({
+          message: `${updated} alert${updated > 1 ? 's' : ''} ${past}${extras ? ` (${extras})` : ''}`,
+          type: failed > 0 ? 'warning' : 'success',
+        });
+      }
     } catch (err) {
       if (!(err instanceof ActionError)) {
         showToast({ message: `Failed to ${action} alerts`, type: 'error' });

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -246,13 +246,14 @@ export default function AlertsPage() {
     }
   };
 
-  // One-click Suppress opens the duration picker; the suppress endpoint needs an
-  // absolute `until`, so we can't fire blind — performSuppress runs on confirm.
+  // One-click Suppress opens the duration picker; the picker resolves the chosen
+  // window (or "Forever") — performSuppress runs on confirm.
   const handleSuppress = (alert: Alert) => {
     setSuppressTarget(alert);
   };
 
-  const performSuppress = async (alert: Alert, until: Date) => {
+  // `until === null` means indefinite ("Forever") suppression — send no `until`.
+  const performSuppress = async (alert: Alert, until: Date | null) => {
     setSuppressTarget(null);
 
     // Optimistic update with undo
@@ -283,7 +284,7 @@ export default function AlertsPage() {
       // runAction would double-toast and fight the optimistic flow.
       const response = await fetchWithAuth(`/alerts/${alert.id}/suppress`, {
         method: 'POST',
-        body: JSON.stringify({ until: until.toISOString() }),
+        body: JSON.stringify(until ? { until: until.toISOString() } : {}),
       });
       if (!response.ok) {
         // Surface the server's specific reason (e.g. "Cannot suppress a resolved
@@ -308,7 +309,7 @@ export default function AlertsPage() {
     }
   };
 
-  const executeBulkAction = async (action: string, selectedAlerts: Alert[], until?: Date) => {
+  const executeBulkAction = async (action: string, selectedAlerts: Alert[], until?: Date | null) => {
     setSubmitting(true);
     try {
       await runAction({

--- a/apps/web/src/components/alerts/SuppressAlertDialog.test.tsx
+++ b/apps/web/src/components/alerts/SuppressAlertDialog.test.tsx
@@ -9,12 +9,6 @@ const onCancel = vi.fn();
 const renderDialog = () =>
   render(<SuppressAlertDialog alertTitle="Warranty expires in 5 days: MacBook-Pro-3" onConfirm={onConfirm} onCancel={onCancel} />);
 
-// A local wall-clock string in the datetime-local format (YYYY-MM-DDTHH:mm).
-const localInputValue = (d: Date) => {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-};
-
 describe('SuppressAlertDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -43,38 +37,14 @@ describe('SuppressAlertDialog', () => {
     expect(until.getTime()).toBeLessThanOrEqual(Date.now() + 60 * 60 * 1000 + 1000);
   });
 
-  it('converts a custom local datetime to the matching absolute instant', () => {
+  it('confirms the Forever option as null (indefinite suppression)', () => {
     renderDialog();
-    const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
-    const value = localInputValue(future);
-    fireEvent.change(screen.getByTestId('suppress-duration-custom-input'), { target: { value } });
+    fireEvent.click(screen.getByTestId('suppress-duration-forever'));
     fireEvent.click(screen.getByTestId('suppress-confirm'));
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
-    const until = onConfirm.mock.calls[0][0] as Date;
-    // The emitted instant must equal the local wall-clock the user entered
-    // (this is where a local→UTC off-by-offset bug would surface).
-    expect(until.getTime()).toBe(new Date(value).getTime());
-  });
-
-  it('rejects a past custom time with an inline error and does not confirm', () => {
-    renderDialog();
-    fireEvent.change(screen.getByTestId('suppress-duration-custom-input'), {
-      target: { value: '2000-01-01T00:00' },
-    });
-    fireEvent.click(screen.getByTestId('suppress-confirm'));
-
-    expect(screen.getByTestId('suppress-duration-error')).toHaveTextContent(/future/i);
-    expect(onConfirm).not.toHaveBeenCalled();
-  });
-
-  it('rejects an empty custom selection with an inline error', () => {
-    renderDialog();
-    fireEvent.click(screen.getByTestId('suppress-duration-custom'));
-    fireEvent.click(screen.getByTestId('suppress-confirm'));
-
-    expect(screen.getByTestId('suppress-duration-error')).toBeInTheDocument();
-    expect(onConfirm).not.toHaveBeenCalled();
+    // null signals "no until" — the endpoint leaves suppressedUntil unset.
+    expect(onConfirm.mock.calls[0][0]).toBeNull();
   });
 
   it('cancels without confirming', () => {
@@ -90,12 +60,10 @@ describe('SuppressAlertDialog', () => {
     expect(screen.getByText(/these 5 alerts stay suppressed/i)).toBeInTheDocument();
   });
 
-  it('gives the custom datetime input its own accessible name (not the radio label)', () => {
+  it('offers a Forever radio alongside the timed presets', () => {
     renderDialog();
-    // The radio and the datetime input are distinct, separately-labelled controls.
-    expect(screen.getByRole('radio', { name: /Until/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/Custom suppression date and time/i)).toBe(
-      screen.getByTestId('suppress-duration-custom-input'),
+    expect(screen.getByRole('radio', { name: /Forever/i })).toBe(
+      screen.getByTestId('suppress-duration-forever'),
     );
   });
 

--- a/apps/web/src/components/alerts/SuppressAlertDialog.tsx
+++ b/apps/web/src/components/alerts/SuppressAlertDialog.tsx
@@ -30,19 +30,15 @@ type SuppressAlertDialogProps = {
 
 export default function SuppressAlertDialog({ alertTitle, count = 1, onCancel, onConfirm }: SuppressAlertDialogProps) {
   const [choice, setChoice] = useState<Choice>('24h');
-  const [error, setError] = useState<string | null>(null);
 
   const confirm = () => {
     if (choice === 'forever') {
       onConfirm(null);
       return;
     }
+    // `choice` is a PresetId here, so the preset always resolves.
     const preset = PRESETS.find((p) => p.id === choice);
-    if (!preset) {
-      setError('Pick a suppression duration.');
-      return;
-    }
-    onConfirm(new Date(Date.now() + preset.ms));
+    if (preset) onConfirm(new Date(Date.now() + preset.ms));
   };
 
   return (
@@ -66,7 +62,7 @@ export default function SuppressAlertDialog({ alertTitle, count = 1, onCancel, o
               name="suppress-duration"
               value={p.id}
               checked={choice === p.id}
-              onChange={() => { setChoice(p.id); setError(null); }}
+              onChange={() => setChoice(p.id)}
               data-testid={`suppress-duration-${p.id}`}
             />
             <span>{p.label}</span>
@@ -78,18 +74,12 @@ export default function SuppressAlertDialog({ alertTitle, count = 1, onCancel, o
             name="suppress-duration"
             value="forever"
             checked={choice === 'forever'}
-            onChange={() => { setChoice('forever'); setError(null); }}
+            onChange={() => setChoice('forever')}
             data-testid="suppress-duration-forever"
           />
           <span>Forever</span>
         </label>
       </fieldset>
-
-      {error && (
-        <p className="mt-3 text-sm text-destructive" data-testid="suppress-duration-error">
-          {error}
-        </p>
-      )}
 
       <div className="mt-5 flex justify-end gap-2">
         <button

--- a/apps/web/src/components/alerts/SuppressAlertDialog.tsx
+++ b/apps/web/src/components/alerts/SuppressAlertDialog.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Dialog } from '../shared/Dialog';
 
 // Preset suppression windows offered by the one-click Suppress action. The API
-// (`POST /alerts/:id/suppress`) requires an absolute `until` timestamp, so each
-// preset is resolved to `now + ms` at confirm time. '24h' is the default.
+// (`POST /alerts/:id/suppress`) accepts an absolute `until` timestamp, so each
+// timed preset is resolved to `now + ms` at confirm time. '24h' is the default.
+// The 'forever' choice sends no `until`, leaving the alert muted indefinitely.
 const PRESETS = [
   { id: '1h', label: '1 hour', ms: 60 * 60 * 1000 },
   { id: '8h', label: '8 hours', ms: 8 * 60 * 60 * 1000 },
@@ -12,7 +13,7 @@ const PRESETS = [
 ] as const;
 
 type PresetId = (typeof PRESETS)[number]['id'];
-type Choice = PresetId | 'custom';
+type Choice = PresetId | 'forever';
 
 type SuppressAlertDialogProps = {
   /** Single-alert title. Omit (and pass `count`) when suppressing in bulk. */
@@ -20,49 +21,28 @@ type SuppressAlertDialogProps = {
   /** Number of alerts being suppressed; drives the bulk copy. Defaults to 1. */
   count?: number;
   onCancel: () => void;
-  /** Receives the resolved absolute, strictly-future suppression deadline. */
-  onConfirm: (until: Date) => void;
+  /**
+   * Receives the resolved absolute, strictly-future suppression deadline, or
+   * `null` for indefinite ("Forever") suppression.
+   */
+  onConfirm: (until: Date | null) => void;
 };
-
-// datetime-local renders/parses in the browser's local zone, so a min derived
-// from local-clock parts keeps the picker from offering past times.
-function localDatetimeValue(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
 
 export default function SuppressAlertDialog({ alertTitle, count = 1, onCancel, onConfirm }: SuppressAlertDialogProps) {
   const [choice, setChoice] = useState<Choice>('24h');
-  const [custom, setCustom] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  const minCustom = useMemo(() => localDatetimeValue(new Date(Date.now() + 60 * 1000)), []);
-
   const confirm = () => {
-    let until: Date;
-    if (choice === 'custom') {
-      if (!custom) {
-        setError('Pick a date and time.');
-        return;
-      }
-      until = new Date(custom);
-      if (Number.isNaN(until.getTime())) {
-        setError('That date and time is invalid.');
-        return;
-      }
-    } else {
-      const preset = PRESETS.find((p) => p.id === choice);
-      if (!preset) {
-        setError('Pick a suppression duration.');
-        return;
-      }
-      until = new Date(Date.now() + preset.ms);
-    }
-    if (until.getTime() <= Date.now()) {
-      setError('Suppression time must be in the future.');
+    if (choice === 'forever') {
+      onConfirm(null);
       return;
     }
-    onConfirm(until);
+    const preset = PRESETS.find((p) => p.id === choice);
+    if (!preset) {
+      setError('Pick a suppression duration.');
+      return;
+    }
+    onConfirm(new Date(Date.now() + preset.ms));
   };
 
   return (
@@ -92,31 +72,17 @@ export default function SuppressAlertDialog({ alertTitle, count = 1, onCancel, o
             <span>{p.label}</span>
           </label>
         ))}
-        {/* The radio and the datetime input are two separate controls, so each
-            gets its own accessible name — the <label> wraps only the radio, and
-            the input carries an aria-label — rather than one label spanning both. */}
-        <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted">
-          <label className="flex cursor-pointer items-center gap-2">
-            <input
-              type="radio"
-              name="suppress-duration"
-              value="custom"
-              checked={choice === 'custom'}
-              onChange={() => { setChoice('custom'); setError(null); }}
-              data-testid="suppress-duration-custom"
-            />
-            <span>Until&hellip;</span>
-          </label>
+        <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted">
           <input
-            type="datetime-local"
-            aria-label="Custom suppression date and time"
-            value={custom}
-            min={minCustom}
-            onChange={(e) => { setCustom(e.target.value); setChoice('custom'); setError(null); }}
-            className="ml-auto rounded-md border bg-background px-2 py-1 text-sm"
-            data-testid="suppress-duration-custom-input"
+            type="radio"
+            name="suppress-duration"
+            value="forever"
+            checked={choice === 'forever'}
+            onChange={() => { setChoice('forever'); setError(null); }}
+            data-testid="suppress-duration-forever"
           />
-        </div>
+          <span>Forever</span>
+        </label>
       </fieldset>
 
       {error && (

--- a/docs/superpowers/plans/2026-06-30-alert-suppression-expiry-reaper.md
+++ b/docs/superpowers/plans/2026-06-30-alert-suppression-expiry-reaper.md
@@ -1,0 +1,638 @@
+# Alert Suppression Expiry Reaper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a background reaper that reactivates timed alert suppressions once `suppressed_until` passes, so they reappear for triage and stop blocking new alerts — while leaving indefinite ("Forever", `suppressed_until IS NULL`) suppressions untouched.
+
+**Architecture:** A BullMQ repeatable "reaper" worker, a structural clone of `apps/api/src/jobs/approvalExpiryReaper.ts` / `quoteExpiryReaper.ts`. It runs a single bounded `UPDATE ... FROM (CTE) ... RETURNING` inside `withSystemDbAccessContext`, flipping `suppressed` → `active` and nulling the stale deadline. Snooze semantics: no event published, so notification channels stay silent. A partial index backs the due-rows scan.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL, BullMQ + Redis, Vitest.
+
+## Global Constraints
+
+- **Snooze semantics only:** reactivate to `status = 'active'`, set `suppressed_until = NULL`. NO event-bus publish, NO notification re-fire, NO ML feedback. (Publishing an `alert.*` event risks tripping the `notifications.ts` `alert.triggered` subscriber.)
+- **Forever is sacred:** rows with `suppressed_until IS NULL` must NEVER be reaped. The SQL predicate and the partial index both require `suppressed_until IS NOT NULL`.
+- **System-context DB access:** all DB work runs inside `withSystemDbAccessContext` (alerts is org-scoped RLS; reaping is a system job). No RLS/tenancy-allowlist changes.
+- **Migrations:** idempotent (`CREATE INDEX IF NOT EXISTS`), never edit a shipped migration, no inner `BEGIN;`/`COMMIT;`.
+- **Cadence:** `REAP_INTERVAL_MS = 5 * 60 * 1000` (5 min). Bound each pass to `MAX_REAP_PER_RUN = 500`.
+- **Audit action name:** `alert.suppression_expired` (verbatim), `actorType: 'system'`, best-effort (never blocks a transition).
+
+---
+
+### Task 1: Supporting partial index (migration + schema)
+
+Adds the partial index the reaper's due-rows scan relies on, and keeps `db:check-drift` clean. Independent, idempotent CREATE INDEX on the long-existing `alerts.suppressed_until` column — no cross-migration dependency.
+
+**Files:**
+- Create: `apps/api/migrations/2026-06-30-alerts-suppression-expiry-idx.sql`
+- Modify: `apps/api/src/db/schema/alerts.ts` (the `alerts` table's index block, ~line 80-86)
+
+**Interfaces:**
+- Produces: DB index `idx_alerts_suppressed_expiry` on `alerts(suppressed_until) WHERE status = 'suppressed' AND suppressed_until IS NOT NULL`.
+
+- [ ] **Step 1: Write the migration file**
+
+Create `apps/api/migrations/2026-06-30-alerts-suppression-expiry-idx.sql`:
+
+```sql
+-- Partial index backing the suppression-expiry reaper's due-rows scan
+-- (apps/api/src/jobs/suppressionExpiryReaper.ts). Only timed suppressions
+-- (suppressed_until NOT NULL) are ever reaped; Forever suppressions (NULL) are
+-- excluded by design, so they are excluded from the index too.
+CREATE INDEX IF NOT EXISTS idx_alerts_suppressed_expiry
+  ON alerts (suppressed_until)
+  WHERE status = 'suppressed' AND suppressed_until IS NOT NULL;
+```
+
+- [ ] **Step 2: Add the matching Drizzle index to the schema**
+
+In `apps/api/src/db/schema/alerts.ts`, extend the `alerts` table's index block. Replace:
+
+```ts
+}, (table) => ({
+  // Backs the `alerts.critical` device-filter field (#968).
+  activeCriticalIdx: index('idx_alerts_active_critical')
+    .on(table.deviceId)
+    .where(sql`status = 'active' AND severity = 'critical'`)
+}));
+```
+
+with:
+
+```ts
+}, (table) => ({
+  // Backs the `alerts.critical` device-filter field (#968).
+  activeCriticalIdx: index('idx_alerts_active_critical')
+    .on(table.deviceId)
+    .where(sql`status = 'active' AND severity = 'critical'`),
+  // Backs the suppression-expiry reaper's due-rows scan
+  // (apps/api/src/jobs/suppressionExpiryReaper.ts).
+  suppressedExpiryIdx: index('idx_alerts_suppressed_expiry')
+    .on(table.suppressedUntil)
+    .where(sql`status = 'suppressed' AND suppressed_until IS NOT NULL`)
+}));
+```
+
+(`sql` and `index` are already imported in this file.)
+
+- [ ] **Step 3: Apply the migration and verify no drift**
+
+Run (from repo root):
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate        # runs apps/api src/db/autoMigrate.ts — applies pending migrations idempotently
+pnpm db:check-drift
+```
+
+Expected: migration applies cleanly; `db:check-drift` reports **no drift** (schema index matches the migration).
+
+- [ ] **Step 4: Verify migration ordering regression test still passes**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts
+```
+
+Expected: PASS (confirms the new file sorts safely from-empty).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-06-30-alerts-suppression-expiry-idx.sql apps/api/src/db/schema/alerts.ts
+git commit -m "feat(alerts): partial index for suppression-expiry reaper"
+```
+
+---
+
+### Task 2: The reaper module + unit tests (TDD)
+
+The core worker. TDD: mock-based unit tests for the JS logic (count, audit emission, best-effort audit), then the implementation. The SQL predicate itself is verified in Task 4 against a real DB.
+
+**Files:**
+- Create: `apps/api/src/jobs/suppressionExpiryReaper.ts`
+- Test: `apps/api/src/jobs/suppressionExpiryReaper.test.ts`
+
+**Interfaces:**
+- Consumes: `db.execute`, `withSystemDbAccessContext` (from `../db`); `alerts` (from `../db/schema/alerts`); `getBullMQConnection` (from `../services/redis`); `captureException` (from `../services/sentry`); `writeAuditEvent`, `requestLikeFromSnapshot` (from `../services/auditEvents`).
+- Produces:
+  - `reapExpiredSuppressions(): Promise<number>` — single bounded pass, returns count transitioned.
+  - `initializeSuppressionExpiryReaper(): Promise<void>` / `shutdownSuppressionExpiryReaper(): Promise<void>` — lifecycle (consumed by Task 3).
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `apps/api/src/jobs/suppressionExpiryReaper.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeMock, alertsTable } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  alertsTable: {
+    status: 'alerts.status',
+    suppressedUntil: 'alerts.suppressed_until',
+  },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      execute: (...args: unknown[]) => executeMock(...(args as [])),
+    },
+    withSystemDbAccessContext: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+vi.mock('../db/schema/alerts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/schema/alerts')>();
+  return {
+    ...actual,
+    alerts: alertsTable,
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { reapExpiredSuppressions } from './suppressionExpiryReaper';
+import { writeAuditEvent } from '../services/auditEvents';
+
+describe('suppressionExpiryReaper.reapExpiredSuppressions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('reactivates expired suppressions and audits each transition', async () => {
+    executeMock.mockResolvedValueOnce({
+      rows: [{ id: 'alert-1', org_id: 'org-1', title: 'Warranty expires' }],
+    });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(1);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: 'org-1',
+        action: 'alert.suppression_expired',
+        resourceType: 'alert',
+        resourceId: 'alert-1',
+        actorType: 'system',
+        result: 'success',
+        details: { previousStatus: 'suppressed' },
+      }),
+    );
+  });
+
+  it('returns 0 and audits nothing when no suppressions are due', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(0);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('still transitions when the audit write throws (best-effort audit)', async () => {
+    executeMock.mockResolvedValueOnce({
+      rows: [{ id: 'alert-2', org_id: 'org-2', title: 'CPU high' }],
+    });
+    vi.mocked(writeAuditEvent).mockImplementation(() => {
+      throw new Error('audit sink down');
+    });
+
+    const reaped = await reapExpiredSuppressions();
+
+    expect(reaped).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/jobs/suppressionExpiryReaper.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./suppressionExpiryReaper"` (module not created yet).
+
+- [ ] **Step 3: Write the reaper implementation**
+
+Create `apps/api/src/jobs/suppressionExpiryReaper.ts`:
+
+```ts
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { db } from '../db';
+import { alerts } from '../db/schema/alerts';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+
+/**
+ * Reaps `alerts` rows whose timed suppression has elapsed: `status='suppressed'`
+ * with a non-null `suppressed_until` in the past. Flips them back to `active`
+ * and clears the stale deadline so they reappear for triage and stop blocking
+ * new alerts (alertService dedupe counts 'suppressed' as open). Snooze semantics:
+ * no event is published, so notification channels stay silent.
+ *
+ * Indefinite ("Forever", suppressed_until IS NULL) suppressions are never touched.
+ *
+ * Runs every 5 minutes inside `withSystemDbAccessContext` — alerts is org-scoped
+ * RLS, but expiry reaping is a system job.
+ */
+
+const QUEUE_NAME = 'suppression-expiry-reaper';
+const REAP_INTERVAL_MS = 5 * 60 * 1000; // every 5 min
+const MAX_REAP_PER_RUN = 500;
+
+type ReaperJobData = { type: 'reap-expired-suppressions'; queuedAt: string };
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  if (typeof withSystem !== 'function') {
+    throw new Error(
+      '[SuppressionExpiryReaper] withSystemDbAccessContext not available — reaper cannot run without system DB access',
+    );
+  }
+  return withSystem(fn);
+};
+
+let reaperQueue: Queue<ReaperJobData> | null = null;
+let reaperWorker: Worker<ReaperJobData> | null = null;
+
+function getQueue(): Queue<ReaperJobData> {
+  if (!reaperQueue) {
+    reaperQueue = new Queue<ReaperJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return reaperQueue;
+}
+
+/**
+ * Single pass: flip past-due timed suppressions to `active`, clear their
+ * deadline, and write an audit row per transition. Bounded to MAX_REAP_PER_RUN
+ * via a CTE so a backlog spike can't lock the table for too long. Returns the
+ * number of alerts transitioned.
+ */
+export async function reapExpiredSuppressions(): Promise<number> {
+  const transitioned = await db.execute<{
+    id: string;
+    org_id: string;
+    title: string;
+  }>(sql`
+    WITH due AS (
+      SELECT id
+      FROM ${alerts}
+      WHERE ${alerts.status} = 'suppressed'
+        AND ${alerts.suppressedUntil} IS NOT NULL
+        AND ${alerts.suppressedUntil} < now()
+      ORDER BY ${alerts.suppressedUntil} ASC
+      LIMIT ${MAX_REAP_PER_RUN}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE ${alerts} AS a
+    SET status = 'active',
+        suppressed_until = NULL
+    FROM due
+    WHERE a.id = due.id
+      AND a.status = 'suppressed'
+    RETURNING a.id, a.org_id, a.title;
+  `);
+
+  const rows = (transitioned as unknown as { rows?: Array<{ id: string; org_id: string; title: string }> }).rows
+    ?? (transitioned as unknown as Array<{ id: string; org_id: string; title: string }>);
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return 0;
+  }
+
+  // Audit log: one row per reactivated alert. Best-effort — never block a
+  // transition on the audit write. System job, so no IP/UA.
+  const requestLike = requestLikeFromSnapshot({});
+  for (const row of rows) {
+    try {
+      writeAuditEvent(requestLike, {
+        orgId: row.org_id,
+        action: 'alert.suppression_expired',
+        resourceType: 'alert',
+        resourceId: row.id,
+        resourceName: row.title,
+        actorType: 'system',
+        actorId: null,
+        result: 'success',
+        details: { previousStatus: 'suppressed' },
+      });
+    } catch (err) {
+      console.error('[SuppressionExpiryReaper] Failed to write audit event:', err);
+    }
+  }
+
+  if (rows.length === MAX_REAP_PER_RUN) {
+    console.warn(`[SuppressionExpiryReaper] Hit ${MAX_REAP_PER_RUN}-item cap — backlog may be growing`);
+  }
+
+  return rows.length;
+}
+
+function createWorker(): Worker<ReaperJobData> {
+  return new Worker<ReaperJobData>(
+    QUEUE_NAME,
+    async (_job: Job<ReaperJobData>) => {
+      try {
+        const reaped = await runWithSystemDbAccess(reapExpiredSuppressions);
+        if (reaped > 0) {
+          console.log(`[SuppressionExpiryReaper] Reactivated ${reaped} alert(s)`);
+        }
+        return { reaped };
+      } catch (err) {
+        console.error('[SuppressionExpiryReaper] Run failed:', err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+async function scheduleRepeatableJob(): Promise<void> {
+  const queue = getQueue();
+  const repeatables = await queue.getRepeatableJobs();
+  for (const job of repeatables) {
+    if (job.name === 'reap-expired-suppressions') {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  await queue.add(
+    'reap-expired-suppressions',
+    { type: 'reap-expired-suppressions', queuedAt: new Date().toISOString() },
+    {
+      jobId: 'suppression-expiry-reaper',
+      repeat: { every: REAP_INTERVAL_MS },
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 200 },
+    },
+  );
+}
+
+export async function initializeSuppressionExpiryReaper(): Promise<void> {
+  if (reaperWorker) return;
+  reaperWorker = createWorker();
+  reaperWorker.on('error', (error) => {
+    console.error('[SuppressionExpiryReaper] Worker error:', error);
+    captureException(error);
+  });
+  reaperWorker.on('failed', (job, error) => {
+    console.error(`[SuppressionExpiryReaper] Job ${job?.id} failed:`, error);
+    captureException(error);
+  });
+  try {
+    await scheduleRepeatableJob();
+  } catch (err) {
+    await reaperWorker.close();
+    reaperWorker = null;
+    throw err;
+  }
+  console.log('[SuppressionExpiryReaper] Initialized');
+}
+
+export async function shutdownSuppressionExpiryReaper(): Promise<void> {
+  const worker = reaperWorker;
+  const queue = reaperQueue;
+  reaperWorker = null;
+  reaperQueue = null;
+  if (worker) {
+    try { await worker.close(); } catch (err) { console.error('[SuppressionExpiryReaper] Error closing worker:', err); }
+  }
+  if (queue) {
+    try { await queue.close(); } catch (err) { console.error('[SuppressionExpiryReaper] Error closing queue:', err); }
+  }
+}
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/jobs/suppressionExpiryReaper.test.ts
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/jobs/suppressionExpiryReaper.ts apps/api/src/jobs/suppressionExpiryReaper.test.ts
+git commit -m "feat(alerts): suppression-expiry reaper (reactivate lapsed timed mutes)"
+```
+
+---
+
+### Task 3: Wire the reaper into the API lifecycle
+
+Registers the reaper so it initializes on API boot and shuts down cleanly, alongside the other three reapers.
+
+**Files:**
+- Modify: `apps/api/src/index.ts` (import ~line 242; init array ~line 1193; shutdown array ~line 1365)
+
+**Interfaces:**
+- Consumes: `initializeSuppressionExpiryReaper`, `shutdownSuppressionExpiryReaper` (from Task 2).
+
+- [ ] **Step 1: Add the import**
+
+In `apps/api/src/index.ts`, immediately after the line:
+
+```ts
+import { initializeQuoteExpiryReaper, shutdownQuoteExpiryReaper } from './jobs/quoteExpiryReaper';
+```
+
+add:
+
+```ts
+import { initializeSuppressionExpiryReaper, shutdownSuppressionExpiryReaper } from './jobs/suppressionExpiryReaper';
+```
+
+- [ ] **Step 2: Add to the init array**
+
+Find the initializer array entry:
+
+```ts
+    ['quoteExpiryReaper', initializeQuoteExpiryReaper],
+```
+
+and add immediately after it:
+
+```ts
+    ['suppressionExpiryReaper', initializeSuppressionExpiryReaper],
+```
+
+- [ ] **Step 3: Add to the shutdown array**
+
+Find the shutdown array entry:
+
+```ts
+    shutdownQuoteExpiryReaper,
+```
+
+and add immediately after it:
+
+```ts
+    shutdownSuppressionExpiryReaper,
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run:
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/index.ts
+git commit -m "feat(alerts): register suppression-expiry reaper on API boot"
+```
+
+---
+
+### Task 4: Real-DB integration test (SQL predicate correctness)
+
+Verifies the SQL predicate against a live DB — the guarantee that unit tests can't cover because they mock `db.execute`. Critically asserts the **Forever-exclusion** invariant.
+
+**Files:**
+- Create: `apps/api/src/jobs/suppressionExpiryReaper.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `reapExpiredSuppressions` (from Task 2); `db`, `withSystemDbAccessContext` (from `../db`); `alerts`, `devices`, `organizations`, `partners`, `sites` (from `../db/schema`).
+
+- [ ] **Step 1: Write the integration test**
+
+Create `apps/api/src/jobs/suppressionExpiryReaper.integration.test.ts`:
+
+```ts
+import '../__tests__/integration/setup';
+
+import { expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { alerts, devices, organizations, partners, sites } from '../db/schema';
+import { reapExpiredSuppressions } from './suppressionExpiryReaper';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+runDb('reactivates only past timed suppressions; leaves future, forever, and non-suppressed rows', async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const past = new Date(Date.now() - 60_000);
+  const future = new Date(Date.now() + 60 * 60_000);
+
+  const ids = await withSystemDbAccessContext(async () => {
+    const [partner] = await db.insert(partners).values({ name: `SR Partner ${unique}`, slug: `sr-partner-${unique}`, type: 'msp', plan: 'pro', status: 'active' }).returning({ id: partners.id });
+    const [org] = await db.insert(organizations).values({ partnerId: partner!.id, name: `SR Org ${unique}`, slug: `sr-org-${unique}`, type: 'customer', status: 'active' }).returning({ id: organizations.id });
+    const [site] = await db.insert(sites).values({ orgId: org!.id, name: `SR Site ${unique}` }).returning({ id: sites.id });
+    const [device] = await db.insert(devices).values({ orgId: org!.id, siteId: site!.id, agentId: `sr-agent-${unique}`, hostname: `sr-host-${unique}`, osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'offline' }).returning({ id: devices.id });
+
+    const base = { deviceId: device!.id, orgId: org!.id, severity: 'info' as const, title: 'SR alert', triggeredAt: new Date() };
+    const [pastSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: past }).returning({ id: alerts.id });
+    const [futureSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: future }).returning({ id: alerts.id });
+    const [foreverSup] = await db.insert(alerts).values({ ...base, status: 'suppressed', suppressedUntil: null }).returning({ id: alerts.id });
+    const [activeAlert] = await db.insert(alerts).values({ ...base, status: 'active', suppressedUntil: null }).returning({ id: alerts.id });
+    return { pastSup: pastSup!.id, futureSup: futureSup!.id, foreverSup: foreverSup!.id, activeAlert: activeAlert!.id };
+  });
+
+  // Other suites may leave suppressed rows behind on the shared DB, so assert on
+  // our specific rows rather than the exact reaped count.
+  const reaped = await withSystemDbAccessContext(() => reapExpiredSuppressions());
+  expect(reaped).toBeGreaterThanOrEqual(1);
+
+  await withSystemDbAccessContext(async () => {
+    const [pastRow] = await db.select().from(alerts).where(eq(alerts.id, ids.pastSup));
+    expect(pastRow!.status).toBe('active');
+    expect(pastRow!.suppressedUntil).toBeNull();
+
+    const [futureRow] = await db.select().from(alerts).where(eq(alerts.id, ids.futureSup));
+    expect(futureRow!.status).toBe('suppressed');
+
+    const [foreverRow] = await db.select().from(alerts).where(eq(alerts.id, ids.foreverSup));
+    expect(foreverRow!.status).toBe('suppressed'); // Forever stays forever
+    expect(foreverRow!.suppressedUntil).toBeNull();
+
+    const [activeRow] = await db.select().from(alerts).where(eq(alerts.id, ids.activeAlert));
+    expect(activeRow!.status).toBe('active');
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test against a live DB**
+
+Requires Postgres reachable via `DATABASE_URL` (the integration config loads `../../.env.test`; local DB on `:5433`). From `apps/api`:
+
+```bash
+pnpm exec vitest run --config vitest.integration.config.ts src/jobs/suppressionExpiryReaper.integration.test.ts
+```
+
+Expected: PASS (1 test). If `DATABASE_URL` is unset the test is skipped via `it.runIf` — ensure it actually runs (not skipped) before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/jobs/suppressionExpiryReaper.integration.test.ts
+git commit -m "test(alerts): real-DB coverage for suppression-expiry predicate (forever-exclusion)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Reaper file + bounded CTE UPDATE + snooze semantics → Task 2. ✓
+- Best-effort audit (`alert.suppression_expired`, system actor) → Task 2 (impl + unit test). ✓
+- 5-min cadence + registration in `index.ts` → Task 2 (constants) + Task 3 (wiring). ✓
+- Migration + schema partial index + drift-clean → Task 1. ✓
+- Testing (past→active/null, future untouched, forever untouched, non-suppressed ignored, best-effort audit) → Task 2 (JS logic) + Task 4 (SQL predicate incl. forever-exclusion). ✓
+- Non-goals (no re-notify/escalation, no config, no UI change, reactivate to `active` unconditionally) → enforced by Global Constraints + implementation. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows complete code and exact commands. ✓
+
+**Type consistency:** `reapExpiredSuppressions` / `initializeSuppressionExpiryReaper` / `shutdownSuppressionExpiryReaper` named identically across Tasks 2→3→4. Audit fields (`orgId`, `action`, `resourceType`, `resourceId`, `resourceName`, `actorType`, `actorId`, `result`, `details`) match the `writeAuditEvent` signature used by `approvalExpiryReaper.ts`. RETURNING columns (`id`, `org_id`, `title`) match the `rows` type and the audit-loop usage. ✓

--- a/docs/superpowers/specs/2026-06-30-alert-suppression-expiry-reaper-design.md
+++ b/docs/superpowers/specs/2026-06-30-alert-suppression-expiry-reaper-design.md
@@ -1,0 +1,115 @@
+# Alert Suppression Expiry Reaper — Design
+
+**Date:** 2026-06-30
+**Status:** Approved (pending spec review)
+**Branch context:** follow-up to the mute-UX fix + "Forever" suppression option (same branch introduced `suppressedUntil = null` = indefinite).
+
+## Problem
+
+`alerts.suppressed_until` is written by every suppress path (route, bulk route, AI tool) but **read by nothing**. There is no job that reactivates an alert when its deadline passes, and `alertService` dedupe treats `status = 'suppressed'` as an open alert without consulting `suppressed_until`.
+
+Two consequences:
+
+1. **Timed suppressions never expire.** "Suppress for 1 hour" is functionally identical to "Forever" — the alert stays hidden until someone manually changes it.
+2. **A stale suppression permanently silences its rule+device.** Because dedupe (`apps/api/src/services/alertService.ts`, the `inArray(alerts.status, ['active','acknowledged','suppressed'])` guard) counts a suppressed row as "already open", new occurrences of the same condition are dropped forever — even after the intended mute window elapsed.
+
+The recently shipped "Forever" option made indefinite suppression an *explicit, honest* choice (`suppressed_until IS NULL`). This spec closes the remaining gap so the **timed** presets actually mean something.
+
+## Goal
+
+A background reaper that, on a fixed cadence, flips `suppressed` alerts whose `suppressed_until` has passed back to `active`, so they reappear for triage and stop blocking new alerts. Indefinite ("Forever", `suppressed_until IS NULL`) suppressions are never touched.
+
+## Non-goals (kept separate by intent)
+
+- **No re-notification / re-escalation.** Expiry is a silent "snooze wakes up", not a fresh alert. No event-bus publish, no notification channel fire.
+- No per-org configurability of expiry behavior.
+- No change to the mute UI or the suppress endpoints.
+- No preservation of pre-suppression ack state (reactivate to `active` unconditionally).
+
+## Approach
+
+BullMQ repeatable "reaper" worker, a structural clone of the existing `apps/api/src/jobs/quoteExpiryReaper.ts` (and `approvalExpiryReaper.ts` / `staleCommandReaper.ts`). Rejected alternatives:
+
+- **Lazy read-time un-suppress** (flip on `GET /alerts`): only fixes rows someone reads, and does **not** fix the dedupe-blocking problem for un-read alerts. Rejected.
+- **DB-level pg_cron**: not part of this stack (all scheduling is BullMQ). Rejected.
+
+## Design
+
+### 1. New file: `apps/api/src/jobs/suppressionExpiryReaper.ts`
+
+Mirrors `quoteExpiryReaper.ts`: queue/worker/schedule/shutdown lifecycle, runs inside `withSystemDbAccessContext` (alerts is org-scoped RLS, but the sweep is a system job — same as the quote reaper), Sentry `captureException` on worker/job error, `concurrency: 1`.
+
+Exported `reapExpiredSuppressions(): Promise<number>` runs one bounded pass:
+
+```sql
+WITH due AS (
+  SELECT id FROM alerts
+  WHERE status = 'suppressed'
+    AND suppressed_until IS NOT NULL     -- Forever (NULL) excluded by design
+    AND suppressed_until < now()
+  ORDER BY suppressed_until ASC
+  LIMIT 500                              -- MAX_REAP_PER_RUN
+  FOR UPDATE SKIP LOCKED
+)
+UPDATE alerts AS a
+SET status = 'active',
+    suppressed_until = NULL              -- clear the stale deadline
+FROM due
+WHERE a.id = due.id AND a.status = 'suppressed'
+RETURNING a.id, a.org_id, a.title;
+```
+
+`now()` (DB clock, UTC) is compared directly against the stored `timestamp` — no timezone gymnastics needed (unlike the quote reaper's date-granular UTC-day comparison; suppression deadlines are absolute instants).
+
+The `FOR UPDATE SKIP LOCKED` + `LIMIT 500` bound keeps a backlog spike from locking the table; on hitting the cap, `console.warn` that the backlog may be growing.
+
+### 2. Audit trail (best-effort)
+
+One system audit event per reactivated alert, in a loop over the `RETURNING` rows, mirroring the quote reaper:
+
+- `action: 'alert.suppression_expired'`
+- `actorType: 'system'`, `actorId: null`
+- `resourceType: 'alert'`, `resourceId: <id>`, `resourceName: <title>`
+- `details: { previousStatus: 'suppressed' }`
+
+Wrapped in try/catch — an audit-write failure logs and never blocks the transition. No ML feedback (that tracks *user* outcomes; this is a system transition). No event-bus publish (no consumer, and publishing `alert.*` risks tripping the `notifications.ts` `alert.triggered` subscriber, which would violate the no-re-notify goal).
+
+### 3. Cadence & registration
+
+- `REAP_INTERVAL_MS = 5 * 60 * 1000` (every 5 minutes). Shortest mute preset is 1h, so worst-case overshoot is ~5 min (~8%) — precise enough for a snooze, light on the DB. Tunable. (Quote reaper is 15 min; alerts warrant tighter since durations are shorter.)
+- `QUEUE_NAME = 'suppression-expiry-reaper'`, repeatable `jobId: 'suppression-expiry-reaper'`, `removeOnComplete: { count: 20 }`, `removeOnFail: { count: 200 }`.
+- Wire `initializeSuppressionExpiryReaper` / `shutdownSuppressionExpiryReaper` into `apps/api/src/index.ts` alongside the other three reapers (import; init array near line 1193; shutdown array near line 1365).
+
+### 4. Migration — supporting partial index
+
+New idempotent migration `2026-06-30-alerts-suppression-expiry-idx.sql`:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_alerts_suppressed_expiry
+  ON alerts (suppressed_until)
+  WHERE status = 'suppressed' AND suppressed_until IS NOT NULL;
+```
+
+Matching partial index added to `apps/api/src/db/schema/alerts.ts` (`.where(sql\`status = 'suppressed' AND suppressed_until IS NOT NULL\`)`) so `pnpm db:check-drift` stays clean. No RLS/tenancy-allowlist change (reaper runs system-context; no new table).
+
+### 5. Testing
+
+`apps/api/src/jobs/suppressionExpiryReaper.test.ts`, mirroring `quoteExpiryReaper.test.ts`:
+
+- Reactivates a `suppressed` alert whose `suppressed_until` is in the past → `active`, `suppressed_until` nulled.
+- Leaves a **future** `suppressed_until` untouched.
+- Leaves a **Forever** row (`suppressed_until IS NULL`) untouched.
+- Ignores `active` / `acknowledged` / `resolved` rows.
+- Best-effort audit: a throwing audit write still transitions the alert.
+- Respects the 500-row cap (warns on backlog).
+
+## Interfaces
+
+- `reapExpiredSuppressions(): Promise<number>` — pure-ish single pass, returns count transitioned. Unit-testable without the worker.
+- `initializeSuppressionExpiryReaper(): Promise<void>` / `shutdownSuppressionExpiryReaper(): Promise<void>` — lifecycle, called from `index.ts`.
+
+## Risks & mitigations
+
+- **Reactivating a resolved-by-condition alert:** alerts are not auto-resolved when the underlying condition clears (resolve is manual), so an expired suppression legitimately means "surface it again". Acceptable.
+- **Backlog / table lock:** bounded 500-row `SKIP LOCKED` pass; `console.warn` on cap.
+- **DB load on the US droplet (known conn ceiling):** single bounded UPDATE every 5 min at `concurrency: 1` — negligible.


### PR DESCRIPTION
## Problem

Muting the alert **"Warranty expires in 5 days"** failed with *"Cannot suppress a resolved alert"*. Root cause: `AlertList.tsx` showed the **Mute** row-action whenever `status !== 'suppressed'` — including **resolved** alerts — but `POST /alerts/:id/suppress` rejects resolved alerts. So resolved alerts offered a button that always failed.

While fixing it, two adjacent gaps surfaced: the suppress dialog only offered timed windows (no "mute indefinitely"), and — separately — **timed suppressions never actually expired** (`suppressed_until` was written but read by nothing, so a "1 hour" mute silenced its rule+device forever and blocked new alerts via dedupe).

## What changed

**Mute UX fix**
- Hide the Mute action on resolved alerts (`AlertList.tsx:555`), matching the detail view which already excluded them.

**"Forever" suppression**
- Replace the suppress dialog's custom date picker with a **Forever** option. `until` is now optional across `POST /alerts/:id/suppress`, `POST /alerts/bulk`, and the `manage_alerts` AI tool — omitting it means indefinite suppression (`suppressed_until = NULL`). A present `until` is still validated as a future timestamp.

**Suppression expiry reaper** (`apps/api/src/jobs/suppressionExpiryReaper.ts`)
- New BullMQ repeatable worker (every 5 min), a structural clone of `approvalExpiryReaper`. Reactivates timed suppressions once `suppressed_until` passes: **snooze semantics** — `status → active`, `suppressed_until → NULL`, **no** re-notify (no event/ML side effects). **Forever (`NULL`) suppressions are never touched** — enforced in the SQL predicate, the partial index, and a real-DB integration test. Bounded `LIMIT 500 FOR UPDATE SKIP LOCKED`, best-effort audit (`alert.suppression_expired`), wired into `index.ts` init + shutdown. Backed by partial index `idx_alerts_suppressed_expiry`.

**Reliability fixes (from review)**
- Bulk-action toast now reads the server's `{updated, skipped, failed}` counts instead of the selection size, so bulk-suppressing already-resolved alerts shows a **warning** ("No alerts suppressed — N skipped") rather than a false green success.
- `manage_alerts` AI tool now rejects suppressing a resolved alert, matching the REST endpoints.

## Testing

- Unit: reaper (mocked), suppress route/bulk/AI-tool optional-`until`, single-route functional tests (missing/past `until`, resolved), dialog Forever, bulk Forever + zero-updated warning, AI resolved guard.
- Real-DB integration test asserts the reaper's SQL predicate for past/future/**forever**/active rows.
- `no-silent-mutations` guard passes; `apps/api` + `apps/web` `tsc` clean.

## Notes / follow-ups (not in this PR)

- Design + implementation plan committed under `docs/superpowers/`.
- Deliberately left as follow-ups: reaper internal system-context assertion (matches sibling reaper), bulk-vs-single `suppressedUntil` audit-metadata shape, `suppressDuration` NaN handling in the AI tool.
- Reactivation is to `active` unconditionally (prior ack state not preserved) and silent (no re-notify) — deliberate product choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)