### PR TITLE
fix(api): scope AI manage_patches 'list' to tenant/device, not the global catalog

### DIFF
--- a/apps/api/src/services/aiToolsFleet.test.ts
+++ b/apps/api/src/services/aiToolsFleet.test.ts
@@ -25,6 +25,25 @@ vi.mock('../db', () => ({
             limit: vi.fn(() => Promise.resolve([])),
           })),
         })),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve([])),
+            })),
+            limit: vi.fn(() => Promise.resolve([])),
+          })),
+        })),
+      })),
+    })),
+    selectDistinct: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve([])),
+            })),
+          })),
+        })),
       })),
     })),
     insert: vi.fn(() => ({
@@ -312,6 +331,25 @@ describe('manage_patches handler', () => {
     const result = JSON.parse(await tool.handler({ action: 'setup_auto_approval' }, noOrgAuth));
     expect(result.error).toContain('Action "setup_auto_approval" is disabled');
     expect(result.error).toContain('configuration policies');
+  });
+
+  it('list requires org context (never returns the unscoped global catalog)', async () => {
+    const result = JSON.parse(await tool.handler({ action: 'list' }, noOrgAuth));
+    expect(result.error).toContain('Organization context required');
+    expect(result.patches).toBeUndefined();
+  });
+
+  it('list scopes org-wide to the caller org when no deviceId given', async () => {
+    const result = JSON.parse(await tool.handler({ action: 'list' }, orgAuth));
+    expect(result.scope).toEqual({ orgId: 'org-1' });
+    expect(Array.isArray(result.patches)).toBe(true);
+  });
+
+  it('list scopes to a single device when deviceId is given', async () => {
+    const deviceId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const result = JSON.parse(await tool.handler({ action: 'list', deviceId }, orgAuth));
+    expect(result.scope).toEqual({ deviceId });
+    expect(Array.isArray(result.patches)).toBe(true);
   });
 
   it('approve action calls upsertPatchApproval with correct call shape', async () => {

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -301,7 +301,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
     deviceArgs: ['deviceIds'],
     definition: {
       name: 'manage_patches',
-      description: 'Manage patches: list available patches, check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',
+      description: 'Manage patches: list patches present on the org\'s devices (optionally scoped to a single device via deviceId, which also returns per-device install status), check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -309,6 +309,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           patchId: { type: 'string', description: 'Patch UUID (for approve/decline/defer/rollback)' },
           patchIds: { type: 'array', items: { type: 'string' }, description: 'Patch UUIDs (for bulk_approve/install)' },
           deviceIds: { type: 'array', items: { type: 'string' }, description: 'Device UUIDs (for scan/install)' },
+          deviceId: { type: 'string', description: 'Single device UUID to scope the patch list to one device (for list); returns per-device install status' },
           source: { type: 'string', enum: ['microsoft', 'apple', 'linux', 'third_party', 'custom'], description: 'Filter by source' },
           severity: { type: 'string', enum: ['critical', 'important', 'moderate', 'low', 'unknown'], description: 'Filter by severity' },
           status: { type: 'string', enum: ['pending', 'approved', 'rejected', 'deferred'], description: 'Filter by approval status' },
@@ -337,12 +338,20 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       }
 
       if (action === 'list') {
-        const conditions: SQL[] = [];
-        if (typeof input.source === 'string') conditions.push(eq(patches.source, input.source as any));
-        if (typeof input.severity === 'string') conditions.push(eq(patches.severity, input.severity as any));
+        // `patches` is a global vendor catalog (no org/device columns). Always
+        // scope to the caller's tenant via device_patches so the list reflects
+        // patches actually present on this org's fleet — never the raw catalog,
+        // which would be identical for every device/tenant (issue #2112).
+        if (!orgId) return JSON.stringify({ error: 'Organization context required' });
 
+        const deviceId = typeof input.deviceId === 'string' ? input.deviceId : undefined;
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
-        const rows = await db.select({
+
+        const catalogConds: SQL[] = [];
+        if (typeof input.source === 'string') catalogConds.push(eq(patches.source, input.source as any));
+        if (typeof input.severity === 'string') catalogConds.push(eq(patches.severity, input.severity as any));
+
+        const patchCols = {
           id: patches.id,
           source: patches.source,
           externalId: patches.externalId,
@@ -351,12 +360,31 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           category: patches.category,
           releaseDate: patches.releaseDate,
           requiresReboot: patches.requiresReboot,
-        }).from(patches)
-          .where(conditions.length > 0 ? and(...conditions) : undefined)
+        };
+
+        if (deviceId) {
+          // Per-device: patches on this specific device, with install status.
+          const rows = await db.select({ ...patchCols, status: devicePatches.status })
+            .from(devicePatches)
+            .innerJoin(patches, eq(devicePatches.patchId, patches.id))
+            .where(and(eq(devicePatches.orgId, orgId), eq(devicePatches.deviceId, deviceId), ...catalogConds))
+            .orderBy(desc(patches.createdAt))
+            .limit(limit);
+          return JSON.stringify({ patches: rows, showing: rows.length, scope: { deviceId } });
+        }
+
+        // Org-wide: distinct catalog entries present on any of the org's
+        // devices. selectDistinct collapses the per-device fan-out to one row
+        // per patch; createdAt is in the projection so the DISTINCT + ORDER BY
+        // is valid in Postgres.
+        const rows = await db.selectDistinct({ ...patchCols, createdAt: patches.createdAt })
+          .from(patches)
+          .innerJoin(devicePatches, eq(devicePatches.patchId, patches.id))
+          .where(and(eq(devicePatches.orgId, orgId), ...catalogConds))
           .orderBy(desc(patches.createdAt))
           .limit(limit);
 
-        return JSON.stringify({ patches: rows, showing: rows.length });
+        return JSON.stringify({ patches: rows, showing: rows.length, scope: { orgId } });
       }
 
       if (action === 'compliance') {

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -298,7 +298,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
   registerTool({
     tier: 1,
-    deviceArgs: ['deviceIds'],
+    deviceArgs: ['deviceIds', 'deviceId'],
     definition: {
       name: 'manage_patches',
       description: 'Manage patches: list patches present on the org\'s devices (optionally scoped to a single device via deviceId, which also returns per-device install status), check compliance, trigger scans, approve/decline/defer patches, bulk approve, install on targets, or rollback. To configure patch schedules and auto-approval policies, use manage_policy_feature_link with featureType "patch".',


### PR DESCRIPTION
## Problem

The AI/MCP `manage_patches` `list` action returned rows from the **global vendor `patches` catalog** with no org/device scoping. Because it's naturally used to answer "what patches does this device/org need?", it returned the same rows for every device/tenant — the newest 25 catalog entries, ordered `createdAt desc`. Querying it for two different devices (even one on 25H2 and one on 23H2) returned byte-for-byte identical rows, which reads as a fleet-wide ingestion bug when it's really just an unscoped query.

## Root cause

`action === 'list'` in `apps/api/src/services/aiToolsFleet.ts` selected straight `FROM patches` (a global catalog with no `orgId`/`deviceId`), with only optional source/severity filters. Per-device/org state lives in `device_patches`, which the query never joined. The correctly-scoped per-device data already exists at `GET /devices/:id/patches`.

## Fix

Scope `list` to the caller's tenant:
- Require org context (returns an error otherwise) — never returns the raw catalog.
- Optional `deviceId` input → join `device_patches` and return that device's patches **with install status**.
- Otherwise → org-wide `selectDistinct` of catalog entries actually present on the org's devices.

Also adds the `deviceId` input to the tool schema and updates the tool description so the model understands `list` is tenant/device-scoped.

## Verification

- `tsc --noEmit` — 0 errors
- `eslint` — clean
- `vitest run src/services/aiToolsFleet.test.ts` — **54 passed**, including 3 new tests: org-context required, org-wide scope, single-device scope.

Closes #2112

🤖 Generated with [Claude Code](https://claude.com/claude-code)