### PR TITLE
fix(shared): reject firmware/drivers-only patch sources (fail loud)

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -508,6 +508,14 @@ const patchSourceValueSchema = z.enum([
   'linux',
 ]);
 
+/**
+ * Patch sources with no backing patch provider yet: they expand to an empty
+ * allow-set at approval time (see patchApprovalEvaluator.buildAllowedPatchSources).
+ * A selection made up ONLY of these would silently approve zero patches, so it
+ * is rejected rather than saved as a no-op. Keep in sync with that expander.
+ */
+const PROVIDERLESS_PATCH_SOURCES = new Set<string>(['firmware', 'drivers']);
+
 export const policyAppRuleSchema = z.object({
   source: z.enum(['third_party', 'custom']),
   packageId: z.string().min(1).max(256),
@@ -582,6 +590,14 @@ export const patchInlineSettingsSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ['autoApproveSeverities'],
       message: 'Select at least one severity for auto-approval.',
+    });
+  }
+
+  if (data.sources.length > 0 && data.sources.every((s) => PROVIDERLESS_PATCH_SOURCES.has(s))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['sources'],
+      message: 'The selected patch sources (firmware/drivers) have no patch provider yet and would approve nothing. Include at least one of: os, third_party, custom.',
     });
   }
 

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -84,6 +84,19 @@ describe('patchInlineSettingsSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('rejects a firmware/drivers-only selection (no provider — would approve nothing)', () => {
+    const result = patchInlineSettingsSchema.safeParse({ sources: ['firmware', 'drivers'] });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('sources'))).toBe(true);
+    }
+  });
+
+  it('accepts firmware/drivers when combined with a provider-backed source', () => {
+    const result = patchInlineSettingsSchema.safeParse({ sources: ['os', 'drivers'] });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('patchInlineSettingsSchema app rules + deferral', () => {


### PR DESCRIPTION
## Problem

The config-policy patch `sources` selection accepts `firmware` and `drivers`, but these have **no backing patch provider**. At approval time `buildAllowedPatchSources` (`patchApprovalEvaluator.ts`) expands them to nothing, so a policy whose sources are *only* firmware/drivers silently approves **zero** patches — a fail-closed no-op with no signal to the admin.

(Context: driver/firmware approval is governed by Update Ring **categories**, not the policy `sources` array — #1317. The `sources` firmware/drivers values are vestigial.)

## Fix

Add a `superRefine` to `patchInlineSettingsSchema` that rejects a `sources` array whose values are **all** provider-less (`firmware`/`drivers`), with a message pointing to `os` / `third_party` / `custom`. This is fail-*loud* hardening:

- `['firmware', 'drivers']` → rejected at save.
- `['os', 'drivers']` and other mixed selections → still save; the provider-less entries are simply inert.
- Default (`['os']`) and existing rows are unaffected.

This does **not** add driver/firmware approval to `sources` (that's intentionally Update Rings' job) — it only stops the silent no-op.

## Verification

- `tsc --noEmit` (shared) — 0 errors
- `vitest run src/validators/index_inline_settings.test.ts` — **51 passed**, including 2 new tests: firmware/drivers-only rejected, os+drivers accepted.

## Follow-ups (not in this PR)

The related default asymmetry (OS on by default, third-party "other software" off) is intentional/opt-in and left as-is; see #2113 for the fuller discussion.

Closes #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)