### PR TITLE
fix(patch): reconcile ring 'definition' category with agent 'definitions'

### DIFF
--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -402,6 +402,50 @@ describe('app rules in resolveApprovedPatchesForDevice', () => {
   });
 });
 
+describe('category rule canonicalization (definition/definitions)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  const catRing = (categoryRules: RingConfig['categoryRules']): RingConfig => ({
+    ringId: RING_ID,
+    categoryRules,
+    autoApprove: { enabled: false, severities: [] },
+    deferralDays: 0,
+  });
+
+  it('legacy singular "definition" rule matches the agent\'s "definitions" category', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, devicePatchId: 'dp-1', category: 'definitions', source: 'microsoft' })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(
+      DEVICE_ID,
+      ORG_ID,
+      catRing([{ category: 'definition', autoApprove: true }])
+    );
+
+    expect(result.map((r) => r.patchId)).toEqual([P1]);
+    expect(result[0]?.approvalReason).toBe('category_rule');
+  });
+
+  it('canonical "definitions" rule matches the "definitions" category', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, devicePatchId: 'dp-1', category: 'definitions', source: 'microsoft' })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(
+      DEVICE_ID,
+      ORG_ID,
+      catRing([{ category: 'definitions', autoApprove: true }])
+    );
+
+    expect(result[0]?.approvalReason).toBe('category_rule');
+  });
+});
+
 describe('ring-less path: only manual approvals apply', () => {
   // policyAutoApprove has been removed. With no ring, only partner-wide manual
   // approvals (ring_id NULL) or ring-specific approvals matching null apply.

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -101,6 +101,22 @@ export interface ApprovedPatch {
 // Policy-source → patch-source mapping
 // ============================================
 
+/**
+ * Reconcile category synonyms so ring category rules match the agent's emitted
+ * `patches.category`. The Windows agent emits 'definitions' (plural, see
+ * classifyWindowsUpdateCategory), while older ring rules / the ring UI stored
+ * 'definition' (singular) — without this they never matched and the toggle was
+ * dead. Applied to BOTH the stored rule keys and the patch category at lookup,
+ * so legacy 'definition' rules and new 'definitions' rules both work. Keep in
+ * sync with the agent classifier and the Update Ring category options
+ * (apps/web/src/components/patches/UpdateRingForm.tsx).
+ */
+export function canonicalizePatchCategory(category: string): string {
+  const c = category.toLowerCase();
+  if (c === 'definition') return 'definitions';
+  return c;
+}
+
 /** patches.source values that count as OS updates. Keep in sync with patchSourceEnum (db/schema/patches.ts). */
 const OS_PATCH_SOURCES = ['microsoft', 'apple', 'linux'] as const;
 /** patches.source values that count as third-party application updates. Keep in sync with patchSourceEnum (db/schema/patches.ts). */
@@ -354,7 +370,7 @@ export async function resolveApprovedPatchesForDevice(
   const categoryRuleMap = new Map<string, CategoryRule>();
   for (const rule of categoryRules) {
     if (rule.category) {
-      categoryRuleMap.set(rule.category.toLowerCase(), rule);
+      categoryRuleMap.set(canonicalizePatchCategory(rule.category), rule);
     }
   }
 
@@ -428,7 +444,7 @@ function evaluatePatchApproval(
   // 'third_party_app' is a virtual category — agents report inconsistent
   // category strings for app updates (application/homebrew/homebrew-cask/...),
   // so it matches by patch source instead. An exact category rule wins.
-  let rule = patch.category ? categoryRuleMap.get(patch.category.toLowerCase()) : undefined;
+  let rule = patch.category ? categoryRuleMap.get(canonicalizePatchCategory(patch.category)) : undefined;
   if (!rule && isThirdPartyPatchSource(patch.source)) {
     rule = categoryRuleMap.get('third_party_app');
   }

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -55,13 +55,17 @@ type UpdateRingFormProps = {
 
 type Severity = 'critical' | 'important' | 'moderate' | 'low';
 
+// `value` must match the category strings the agent emits (see the agent's
+// classifyWindowsUpdateCategory) so the approval evaluator's category rules
+// actually match. Note 'definitions' is plural to match the agent; the
+// evaluator also canonicalizes legacy singular 'definition' rules.
 const categoryOptions = [
   { value: 'security', label: 'Security Updates' },
   { value: 'feature', label: 'Feature Updates' },
   { value: 'firmware', label: 'Firmware' },
   { value: 'driver', label: 'Drivers' },
   { value: 'third_party_app', label: 'Third-Party Apps' },
-  { value: 'definition', label: 'Definition Updates' },
+  { value: 'definitions', label: 'Definition Updates' },
 ];
 
 // Severity is a domain-ordered scale (Critical > Important > Moderate > Low),


### PR DESCRIPTION
## Problem

Update Ring category rules match the agent's `patches.category` by exact string, but the ring stored `definition` (singular) while the Windows agent emits `definitions` (plural). So an "auto-approve Definition Updates" rule matched nothing.

## Fix

- **Evaluator** (`patchApprovalEvaluator.ts`): add `canonicalizePatchCategory()` (maps `definition` → `definitions`), applied to **both** the stored rule keys and the patch category at lookup — so legacy singular rules AND new plural rules match.
- **Web** (`UpdateRingForm.tsx`): change the category option value to `definitions` to align with the agent going forward (label unchanged).

## Verification

- `vitest run patchApprovalEvaluator.test.ts` — **63 pass**, including 2 new tests: legacy `definition` rule matches a `definitions` patch, and canonical `definitions` rule matches.
- `tsc --noEmit` (API) — 0 errors.
- `vitest run UpdateRingForm.test.tsx` — 8 pass.

Pairs with the agent-side category classification (PR for the same issue), which is what makes the `firmware` toggle and accurate `security`/`driver` labelling work.

Refs #2117

🤖 Generated with [Claude Code](https://claude.com/claude-code)