### PR TITLE
Partner-wide first: patch enablement, capability gate, and dual-ownership software + security policies

### DIFF
--- a/apps/api/migrations/2026-07-01-alert-rules-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-alert-rules-partner-ownership.sql
@@ -1,0 +1,77 @@
+-- Partner-owned alert rules (epic #2135, issue #2128).
+--
+-- Until now an alert_rules row was always owned by exactly one org (org_id
+-- NOT NULL), so a standalone alert pack could not be defined once and applied
+-- across every org under a partner. This migration makes an alert rule ownable
+-- by EITHER an org (org_id set, partner_id NULL — the existing shape) OR a
+-- partner (partner_id set, org_id NULL — the "partner-wide / all orgs" shape),
+-- enforced by an exactly-one-axis CHECK. Mirrors software_policies (#2126) and
+-- security_policies (#2127).
+--
+-- Invariants for partner-wide rules (enforced app-side at the routes):
+--   - targetType is always 'all' with targetId = partner_id (targetId is
+--     NOT NULL; the 'all' match ignores the value)
+--   - no org-scoped notification-channel/escalation bindings — dispatch falls
+--     back to each firing device's OWN org routing (notificationDispatcher
+--     resolves everything from alerts.org_id, which always carries the
+--     device's org, never the rule's)
+--
+-- alerts (fired rows) stay org-only: an alert always belongs to the device's
+-- org. alert_templates are already dual-ownership (2026-06-13). The
+-- config-policy INLINE alert path (config_policy_alert_rules) was already
+-- partner-safe via the 2026-06-27 dual-axis join policies.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE alert_rules
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE alert_rules
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'alert_rules_one_owner_chk'
+      AND conrelid = 'alert_rules'::regclass
+  ) THEN
+    ALTER TABLE alert_rules
+      ADD CONSTRAINT alert_rules_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS alert_rules_partner_id_idx
+  ON alert_rules(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+
+ALTER TABLE alert_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE alert_rules FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON alert_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON alert_rules;
+DROP POLICY IF EXISTS alert_rules_isolation ON alert_rules;
+CREATE POLICY alert_rules_isolation
+  ON alert_rules
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/migrations/2026-07-01-security-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-security-policies-partner-ownership.sql
@@ -1,0 +1,78 @@
+-- Partner-owned security policies (epic #2135, issue #2127).
+--
+-- Until now a security_policies row was always owned by exactly one org
+-- (org_id NOT NULL), so an AV/EDR baseline (scan schedule, real-time
+-- protection, quarantine, severity threshold, exclusions) could not be defined
+-- once and applied across every org under a partner. This migration makes a
+-- security policy ownable by EITHER an org (org_id set, partner_id NULL — the
+-- existing shape) OR a partner (partner_id set, org_id NULL — the
+-- "partner-wide / all orgs" template shape), enforced by an exactly-one-axis
+-- CHECK. Mirrors software_policies (2026-07-01-software-policies-partner-
+-- ownership.sql) and configuration_policies (#1724).
+--
+-- Simpler than the software_policies migration: security_policies is a LEAF —
+-- no child/audit table FK-references it, and the posture tables
+-- (security_status/threats/scans/posture_snapshots) reach tenancy through the
+-- device's own org, never through a policy row, so they are unchanged.
+--
+-- RLS: replaces the four legacy per-command breeze_org_isolation_* policies
+-- (0001-baseline) with a single dual-axis policy + system short-circuit,
+-- matching the software_policies / configuration_policies shape. FORCE was not
+-- asserted for this table in the baseline; assert ENABLE + FORCE here.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE security_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE security_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+-- Exactly one ownership axis must be set. (org_id IS NULL) <> (partner_id IS NULL)
+-- is true iff exactly one of the two is NULL — i.e. exactly one is set.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'security_policies_one_owner_chk'
+      AND conrelid = 'security_policies'::regclass
+  ) THEN
+    ALTER TABLE security_policies
+      ADD CONSTRAINT security_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS security_policies_partner_id_idx
+  ON security_policies(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+
+ALTER TABLE security_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE security_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON security_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON security_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON security_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON security_policies;
+DROP POLICY IF EXISTS security_policies_isolation ON security_policies;
+CREATE POLICY security_policies_isolation
+  ON security_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/migrations/2026-07-01-security-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-security-policies-partner-ownership.sql
@@ -17,8 +17,8 @@
 --
 -- RLS: replaces the four legacy per-command breeze_org_isolation_* policies
 -- (0001-baseline) with a single dual-axis policy + system short-circuit,
--- matching the software_policies / configuration_policies shape. FORCE was not
--- asserted for this table in the baseline; assert ENABLE + FORCE here.
+-- matching the software_policies / configuration_policies shape. ENABLE/FORCE
+-- are re-asserted here for idempotence (0001-baseline already set both).
 --
 -- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
 -- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate

--- a/apps/api/migrations/2026-07-01-software-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-software-policies-partner-ownership.sql
@@ -1,0 +1,134 @@
+-- Partner-owned software policies (epic #2135, issue #2126).
+--
+-- Until now a software_policies row was always owned by exactly one org
+-- (org_id NOT NULL), so a software blocklist/allowlist could not be defined
+-- once and applied across every org under a partner — an MSP had to recreate
+-- and maintain a copy per customer. This migration makes a software policy
+-- ownable by EITHER an org (org_id set, partner_id NULL — the existing shape)
+-- OR a partner (partner_id set, org_id NULL — the "partner-wide / all orgs"
+-- template shape), enforced by an exactly-one-axis CHECK. This mirrors
+-- configuration_policies (2026-06-27-config-policies-partner-ownership.sql)
+-- and patch_policies (partner-axis update rings).
+--
+-- software_policy_audit is dual-owned but NOT XOR: an event for a partner-wide
+-- policy acting on a device carries BOTH the device's org_id (org admin
+-- visibility) and the policy's partner_id (partner admin visibility);
+-- policy-level events carry whichever axis owns the policy. CHECK requires at
+-- least one axis.
+--
+-- software_compliance_status is unchanged: it reaches its tenant through the
+-- device join (devices are always org-owned), which is correct for partner-wide
+-- policies too — each compliance row belongs to the device's own org.
+--
+-- RLS: both tables move from pure org-axis (0039-software-policies-rls.sql) to
+-- dual-axis (org OR partner) with the system short-circuit, matching the
+-- configuration_policies precedent.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECKs, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — software_policies: add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE software_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE software_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+-- Exactly one ownership axis must be set. (org_id IS NULL) <> (partner_id IS NULL)
+-- is true iff exactly one of the two is NULL — i.e. exactly one is set.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'software_policies_one_owner_chk'
+      AND conrelid = 'software_policies'::regclass
+  ) THEN
+    ALTER TABLE software_policies
+      ADD CONSTRAINT software_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS software_policies_partner_id_idx
+  ON software_policies(partner_id);
+
+-- ============================================
+-- Step 2: schema — software_policy_audit: add partner_id, relax org_id,
+--         at-least-one-owner CHECK (NOT XOR — see header)
+-- ============================================
+
+ALTER TABLE software_policy_audit
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE software_policy_audit
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'software_policy_audit_owner_chk'
+      AND conrelid = 'software_policy_audit'::regclass
+  ) THEN
+    ALTER TABLE software_policy_audit
+      ADD CONSTRAINT software_policy_audit_owner_chk
+      CHECK (org_id IS NOT NULL OR partner_id IS NOT NULL);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS software_policy_audit_partner_id_idx
+  ON software_policy_audit(partner_id);
+
+-- ============================================
+-- Step 3: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+-- Replaces the four pure org-axis policies per table from
+-- 0039-software-policies-rls.sql with a single dual-axis policy each,
+-- matching the configuration_policies shape. ENABLE/FORCE are re-asserted
+-- for idempotence (0039 already set them).
+
+ALTER TABLE software_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE software_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON software_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON software_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON software_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON software_policies;
+DROP POLICY IF EXISTS software_policies_isolation ON software_policies;
+CREATE POLICY software_policies_isolation
+  ON software_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+ALTER TABLE software_policy_audit ENABLE ROW LEVEL SECURITY;
+ALTER TABLE software_policy_audit FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON software_policy_audit;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON software_policy_audit;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON software_policy_audit;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON software_policy_audit;
+DROP POLICY IF EXISTS software_policy_audit_isolation ON software_policy_audit;
+CREATE POLICY software_policy_audit_isolation
+  ON software_policy_audit
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/src/__tests__/integration/alertRulesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertRulesPartnerRls.integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * alert_rules RLS — dual-axis (org OR partner) enforcement (#2128, epic #2135).
+ *
+ * Migration under test: 2026-07-01-alert-rules-partner-ownership.sql.
+ *
+ * An alert rule is owned by EITHER an org (org_id set, partner_id NULL) OR a
+ * partner (partner_id set, org_id NULL — partner-wide, targetType 'all' with
+ * targetId = partner id). Fired alerts always carry the DEVICE's org — the
+ * `alerts` table stays org-only. Same dual-axis contract-test blindspot as the
+ * sibling suites: this functional test through the REAL postgres.js driver
+ * (breeze_app role) is the guard that a partner cannot forge a partner_id for
+ * another partner.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { alertRules, alertTemplates } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdRules: string[] = [];
+const createdTemplates: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdRules.length === 0 && createdTemplates.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdRules) {
+      await db.delete(alertRules).where(eq(alertRules.id, id));
+    }
+    for (const id of createdTemplates) {
+      await db.delete(alertTemplates).where(eq(alertTemplates.id, id));
+    }
+  });
+  createdRules.length = 0;
+  createdTemplates.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+/** Partner-owned template (alert_templates is already dual-ownership). */
+async function seedPartnerTemplate(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(alertTemplates)
+      .values({
+        orgId: null,
+        partnerId,
+        name: 'Partner-wide CPU template',
+        conditions: { type: 'metric', metric: 'cpu', operator: '>', threshold: 95 },
+        severity: 'high',
+        titleTemplate: 'High CPU on {{hostname}}',
+        messageTemplate: 'CPU exceeded threshold on {{hostname}}',
+      })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdTemplates.push(id);
+  return id;
+}
+
+async function seedPartnerRule(partnerId: string, templateId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(alertRules)
+      .values({
+        orgId: null,
+        partnerId,
+        templateId,
+        name: 'Partner-wide CPU rule',
+        targetType: 'all',
+        targetId: partnerId, // NOT NULL anchor; the 'all' match ignores it
+      })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdRules.push(id);
+  return id;
+}
+
+describe('alert_rules RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide rule (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+    const templateId = await seedPartnerTemplate(partner.id);
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(alertRules)
+        .values({
+          orgId: null,
+          partnerId: partner.id,
+          templateId,
+          name: 'All-orgs rule',
+          targetType: 'all',
+          targetId: partner.id,
+        })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdRules.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge a rule attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const templateId = await seedPartnerTemplate(partnerA.id);
+    const ruleId = await seedPartnerRule(partnerA.id, templateId);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: alertRules.id }).from(alertRules).where(eq(alertRules.id, ruleId)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge (Postgres 42501 on the cause).
+    // The template is RLS-invisible to partner B too, but the row-security
+    // check fires before the FK lookup, so 42501 is still the signal.
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(alertRules)
+          .values({
+            orgId: null,
+            partnerId: partnerA.id,
+            templateId,
+            name: 'Forged rule',
+            targetType: 'all',
+            targetId: partnerA.id,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide rule owned by its partner (evaluation still covers its devices via the worker)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const templateId = await seedPartnerTemplate(partner.id);
+    const ruleId = await seedPartnerRule(partner.id, templateId);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: alertRules.id }).from(alertRules).where(eq(alertRules.id, ruleId)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('org scope can still INSERT and SELECT an org-scoped rule (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const templateId = await seedPartnerTemplate(partner.id);
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(alertRules)
+        .values({
+          orgId: org.id,
+          partnerId: null,
+          templateId, // partner-shared template readable? RLS on templates allows org read of built-in/org rows only — use system-seeded org template instead if this fails
+          name: 'Org rule',
+          targetType: 'org',
+          targetId: org.id,
+        })
+        .returning(),
+    );
+    if (inserted[0]) createdRules.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: alertRules.id }).from(alertRules).where(eq(alertRules.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('the one-owner CHECK rejects a rule that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const templateId = await seedPartnerTemplate(partner.id);
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(alertRules)
+          .values({
+            orgId: org.id,
+            partnerId: partner.id,
+            templateId,
+            name: 'Both axes',
+            targetType: 'all',
+            targetId: org.id,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(alertRules)
+          .values({
+            orgId: null,
+            partnerId: null,
+            templateId,
+            name: 'No axis',
+            targetType: 'all',
+            targetId: partner.id,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide rule', async () => {
+    const partner = await createPartner();
+    const templateId = await seedPartnerTemplate(partner.id);
+    const ruleId = await seedPartnerRule(partner.id, templateId);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(alertRules)
+        .set({ name: 'Renamed rule', isActive: false })
+        .where(eq(alertRules.id, ruleId))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.isActive).toBe(false);
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(alertRules).where(eq(alertRules.id, ruleId)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdRules.splice(createdRules.indexOf(ruleId), 1);
+  });
+});

--- a/apps/api/src/__tests__/integration/alertRulesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/alertRulesPartnerRls.integration.test.ts
@@ -15,11 +15,14 @@ import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { alertRules, alertTemplates } from '../../db/schema';
+import { alertRules, alertTemplates, devices, sites } from '../../db/schema';
+import { getApplicableRules } from '../../services/alertService';
 import { createOrganization, createPartner } from './db-utils';
 
 const createdRules: string[] = [];
 const createdTemplates: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
 
 const SYSTEM_CTX: DbAccessContext = {
   scope: 'system',
@@ -30,7 +33,7 @@ const SYSTEM_CTX: DbAccessContext = {
 };
 
 afterEach(async () => {
-  if (createdRules.length === 0 && createdTemplates.length === 0) return;
+  if (createdRules.length === 0 && createdTemplates.length === 0 && createdDevices.length === 0) return;
   await withDbAccessContext(SYSTEM_CTX, async () => {
     for (const id of createdRules) {
       await db.delete(alertRules).where(eq(alertRules.id, id));
@@ -38,9 +41,17 @@ afterEach(async () => {
     for (const id of createdTemplates) {
       await db.delete(alertTemplates).where(eq(alertTemplates.id, id));
     }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
   });
   createdRules.length = 0;
   createdTemplates.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
 });
 
 function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
@@ -258,5 +269,75 @@ describe('alert_rules RLS — dual-axis (2026-07-01 migration)', () => {
     );
     expect(deleted).toHaveLength(1);
     createdRules.splice(createdRules.indexOf(ruleId), 1);
+  });
+});
+
+
+// ============================================================
+// Evaluation fan-out (#2128): the load-bearing SQL that makes a stored
+// partner-wide rule actually FIRE. Every unit test mocks
+// alertRuleOwnershipConditionForOrg away, so this is the only place the
+// real query shape is proven against Postgres.
+// ============================================================
+
+describe('getApplicableRules — partner-wide evaluation fan-out (#2128)', () => {
+  async function seedDevice(orgId: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname: 'fanout-test-host',
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  it('a partner-wide rule matches devices in a member org; a FOREIGN partner-wide rule does not', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const deviceId = await seedDevice(orgA.id);
+
+    const templateA = await seedPartnerTemplate(partnerA.id);
+    const templateB = await seedPartnerTemplate(partnerB.id);
+    const partnerWideRuleA = await seedPartnerRule(partnerA.id, templateA);
+    const partnerWideRuleB = await seedPartnerRule(partnerB.id, templateB);
+
+    // Also an org-owned rule, to prove both axes coexist.
+    const [orgRule] = await withDbAccessContext(orgContext(orgA.id), () =>
+      db
+        .insert(alertRules)
+        .values({
+          orgId: orgA.id,
+          partnerId: null,
+          templateId: templateA,
+          name: 'Org-owned rule',
+          targetType: 'all',
+          targetId: orgA.id,
+        })
+        .returning(),
+    );
+    createdRules.push(orgRule!.id);
+
+    // The worker evaluates under system context (RLS bypass) — mirror that.
+    const applicable = await withDbAccessContext(SYSTEM_CTX, () => getApplicableRules(deviceId));
+    const ids = applicable.map((r) => r.rule.id);
+
+    expect(ids).toContain(partnerWideRuleA); // partner-wide rule FIRES for member-org device
+    expect(ids).toContain(orgRule!.id); // org-owned rule still fires
+    expect(ids).not.toContain(partnerWideRuleB); // another partner's rule NEVER matches
   });
 });

--- a/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
@@ -17,9 +17,11 @@
  */
 import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
-import { eq } from 'drizzle-orm';
+import { eq, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { configurationPolicies } from '../../db/schema';
+import { listConfigPolicies } from '../../services/configurationPolicy';
 import { createOrganization, createPartner } from './db-utils';
 
 const created: string[] = [];
@@ -192,6 +194,63 @@ describe('configuration_policies RLS — dual-axis (2026-06-27 migration)', () =
             .returning(),
       ),
     ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('listConfigPolicies filtered by orgId ALSO returns the partner-wide policies that govern that org (#1724 follow-up)', async () => {
+    // A partner admin viewing org X should see both X's own policies AND the
+    // partner-wide policies that also apply to X — otherwise the org-filtered
+    // list hides policies that genuinely govern the org's devices.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const orgPolicyId = (
+      await withDbAccessContext(orgContext(org.id), () =>
+        db
+          .insert(configurationPolicies)
+          .values({ orgId: org.id, partnerId: null, name: 'Org-owned' })
+          .returning(),
+      )
+    )[0]!.id;
+    created.push(orgPolicyId);
+    const partnerPolicyId = await seedPartnerPolicy(partner.id);
+
+    // Minimal AuthContext surface listConfigPolicies actually reads: orgCondition
+    // (single accessible org) + partnerId (partner axis).
+    const auth = {
+      scope: 'partner',
+      partnerId: partner.id,
+      orgId: null,
+      accessibleOrgIds: [org.id],
+      orgCondition: (col: PgColumn): SQL | undefined => eq(col, org.id),
+    } as never;
+
+    const result = await withDbAccessContext(partnerContext(partner.id, [org.id]), () =>
+      listConfigPolicies(auth, { orgId: org.id }, { page: 1, limit: 50 }),
+    );
+    const ids = result.data.map((p) => p.id);
+
+    expect(ids).toContain(orgPolicyId); // org-owned still shows
+    expect(ids).toContain(partnerPolicyId); // partner-wide ALSO shows (the fix)
+  });
+
+  it('an org-filtered list does NOT surface another partner\'s partner-wide policy', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const foreignPartnerPolicyId = await seedPartnerPolicy(partnerB.id);
+
+    const authA = {
+      scope: 'partner',
+      partnerId: partnerA.id,
+      orgId: null,
+      accessibleOrgIds: [orgA.id],
+      orgCondition: (col: PgColumn): SQL | undefined => eq(col, orgA.id),
+    } as never;
+
+    const result = await withDbAccessContext(partnerContext(partnerA.id, [orgA.id]), () =>
+      listConfigPolicies(authA, { orgId: orgA.id }, { page: 1, limit: 50 }),
+    );
+    expect(result.data.map((p) => p.id)).not.toContain(foreignPartnerPolicyId);
   });
 
   it('partner scope can UPDATE and DELETE its own partner-wide policy', async () => {

--- a/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts
@@ -233,6 +233,35 @@ describe('configuration_policies RLS — dual-axis (2026-06-27 migration)', () =
     expect(ids).toContain(partnerPolicyId); // partner-wide ALSO shows (the fix)
   });
 
+  it('a SYSTEM-scope org-filtered list only includes the filtered org\'s partner\'s partner-wide policies', async () => {
+    // System scope has no access condition at all, so the org filter itself
+    // must bound the org_id IS NULL branch to the filtered org's own partner —
+    // a bare `OR org_id IS NULL` would return every partner's partner-wide
+    // policies platform-wide.
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const aPolicyId = await seedPartnerPolicy(partnerA.id);
+    const bPolicyId = await seedPartnerPolicy(partnerB.id);
+
+    const systemAuth = {
+      scope: 'system',
+      partnerId: null,
+      orgId: null,
+      accessibleOrgIds: null,
+      orgCondition: (): SQL | undefined => undefined,
+    } as never;
+
+    const result = await withDbAccessContext(
+      { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+      () => listConfigPolicies(systemAuth, { orgId: orgA.id }, { page: 1, limit: 100 }),
+    );
+    const ids = result.data.map((p) => p.id);
+
+    expect(ids).toContain(aPolicyId); // orgA's partner's partner-wide policy
+    expect(ids).not.toContain(bPolicyId); // unrelated partner's must NOT appear
+  });
+
   it('an org-filtered list does NOT surface another partner\'s partner-wide policy', async () => {
     const partnerA = await createPartner();
     const partnerB = await createPartner();

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -256,6 +256,12 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // security_policies_one_owner_chk enforces exactly one axis. Functional
   // cross-partner forge proof: securityPoliciesPartnerRls.integration.test.ts.
   'security_policies',
+  // alert_rules (#2128, epic #2135): org-scoped OR partner-wide standalone
+  // alert rule (fired alerts always carry the DEVICE's org — alerts stays
+  // org-only). Converted in 2026-07-01-alert-rules-partner-ownership. CHECK
+  // alert_rules_one_owner_chk enforces exactly one axis. Functional
+  // cross-partner forge proof: alertRulesPartnerRls.integration.test.ts.
+  'alert_rules',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -236,6 +236,20 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // branch; this entry asserts the breeze_has_partner_access (built-in) branch.
   // A CHECK constraint (software_catalog_one_owner_chk) enforces exactly one axis.
   'software_catalog',
+  // software_policies (#2126, epic #2135): a policy is org-scoped (org_id set,
+  // partner_id NULL) OR a partner-wide template (partner_id set, org_id NULL —
+  // "all orgs"). Converted from org-only to dual-axis in
+  // 2026-07-01-software-policies-partner-ownership. Same auto-discovery
+  // blindspot as configuration_policies: this entry asserts the
+  // breeze_has_partner_access branch. CHECK software_policies_one_owner_chk
+  // enforces exactly one axis. Functional cross-partner forge proof:
+  // softwarePoliciesPartnerRls.integration.test.ts.
+  'software_policies',
+  // software_policy_audit (#2126): dual-owned but NOT XOR — a device-level
+  // event under a partner-wide policy carries BOTH the device's org_id and the
+  // policy's partner_id so both admins can see it; CHECK
+  // software_policy_audit_owner_chk requires at least one axis.
+  'software_policy_audit',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -250,6 +250,12 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // policy's partner_id so both admins can see it; CHECK
   // software_policy_audit_owner_chk requires at least one axis.
   'software_policy_audit',
+  // security_policies (#2127, epic #2135): org-scoped OR partner-wide AV/EDR
+  // baseline template. Converted from org-only to dual-axis in
+  // 2026-07-01-security-policies-partner-ownership. CHECK
+  // security_policies_one_owner_chk enforces exactly one axis. Functional
+  // cross-partner forge proof: securityPoliciesPartnerRls.integration.test.ts.
+  'security_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/securityPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/securityPoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * security_policies RLS — dual-axis (org OR partner) enforcement (#2127, epic #2135).
+ *
+ * Migration under test: 2026-07-01-security-policies-partner-ownership.sql.
+ *
+ * A security policy is owned by EITHER an org (org_id set, partner_id NULL —
+ * the original shape) OR a partner (partner_id set, org_id NULL — the
+ * "partner-wide / all orgs" template shape). The dual-axis policy is:
+ *   system OR (org_id IS NOT NULL AND breeze_has_org_access(org_id))
+ *          OR (partner_id IS NOT NULL AND breeze_has_partner_access(partner_id))
+ *
+ * Same dual-axis blindspot as software_policies/configuration_policies: the
+ * rls-coverage contract test does NOT prove the partner branch, so this
+ * functional test through the REAL postgres.js driver (breeze_app role) is the
+ * required guard that a partner cannot forge a partner_id for another partner.
+ * security_policies is a LEAF (no FK children), so there is no audit/child
+ * suite here.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { securityPolicies } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of created) {
+      await db.delete(securityPolicies).where(eq(securityPolicies.id, id));
+    }
+  });
+  created.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_POLICY = {
+  name: 'Partner-wide security baseline',
+  settings: { scanSchedule: 'daily', realTimeProtection: true },
+};
+
+async function seedPartnerPolicy(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(securityPolicies)
+      .values({ ...BASE_POLICY, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  created.push(id);
+  return id;
+}
+
+describe('security_policies RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide security policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(securityPolicies)
+        .values({ ...BASE_POLICY, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) created.push(rows[0].id);
+  });
+
+  it('partner scope can SELECT back its own partner-wide security policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: securityPolicies.id })
+        .from(securityPolicies)
+        .where(eq(securityPolicies.partnerId, partner.id)),
+    );
+
+    expect(visible.map((r) => r.id)).toContain(id);
+  });
+
+  it('a different partner can neither see nor forge a security policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .select({ id: securityPolicies.id })
+        .from(securityPolicies)
+        .where(eq(securityPolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge (Postgres 42501 on the cause).
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(securityPolicies)
+          .values({ ...BASE_POLICY, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('org scope can INSERT and SELECT an org-scoped security policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(securityPolicies)
+        .values({ ...BASE_POLICY, name: 'Org policy', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) created.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: securityPolicies.id })
+        .from(securityPolicies)
+        .where(eq(securityPolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('an org-scope caller cannot see a partner-wide security policy owned by its partner', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: securityPolicies.id })
+        .from(securityPolicies)
+        .where(eq(securityPolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('the one-owner CHECK rejects a row that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(securityPolicies)
+          .values({ ...BASE_POLICY, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(securityPolicies)
+          .values({ ...BASE_POLICY, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide security policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(securityPolicies)
+        .set({ name: 'Renamed baseline' })
+        .where(eq(securityPolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.name).toBe('Renamed baseline');
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .delete(securityPolicies)
+        .where(eq(securityPolicies.id, id))
+        .returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    created.splice(created.indexOf(id), 1);
+  });
+});

--- a/apps/api/src/__tests__/integration/softwarePoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwarePoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * software_policies RLS — dual-axis (org OR partner) enforcement (#2126, epic #2135).
+ *
+ * Migration under test: 2026-07-01-software-policies-partner-ownership.sql.
+ *
+ * A software policy is owned by EITHER an org (org_id set, partner_id NULL —
+ * the original shape) OR a partner (partner_id set, org_id NULL — the
+ * "partner-wide / all orgs" template shape). The dual-axis policy is:
+ *   system OR (org_id IS NOT NULL AND breeze_has_org_access(org_id))
+ *          OR (partner_id IS NOT NULL AND breeze_has_partner_access(partner_id))
+ *
+ * Same blindspot as configuration_policies: the rls-coverage contract test does
+ * NOT prove the partner branch (it accepts an org-only policy), so this
+ * functional test through the REAL postgres.js driver (breeze_app role) is the
+ * required guard that a partner cannot forge a partner_id for another partner.
+ *
+ * software_policy_audit is dual-owned but NOT XOR (a device event under a
+ * partner-wide policy carries both axes); its CHECK requires at least one axis.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { softwarePolicies, softwarePolicyAudit } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdPolicies: string[] = [];
+const createdAudit: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdPolicies.length === 0 && createdAudit.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdAudit) {
+      await db.delete(softwarePolicyAudit).where(eq(softwarePolicyAudit.id, id));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(softwarePolicies).where(eq(softwarePolicies.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+  createdAudit.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_POLICY = {
+  name: 'Partner-wide blocklist',
+  mode: 'blocklist' as const,
+  rules: { software: [{ name: 'BitTorrent' }] },
+};
+
+async function seedPartnerPolicy(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(softwarePolicies)
+      .values({ ...BASE_POLICY, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdPolicies.push(id);
+  return id;
+}
+
+describe('software_policies RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide software policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(softwarePolicies)
+        .values({ ...BASE_POLICY, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdPolicies.push(rows[0].id);
+  });
+
+  it('partner scope can SELECT back its own partner-wide software policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: softwarePolicies.id })
+        .from(softwarePolicies)
+        .where(eq(softwarePolicies.partnerId, partner.id)),
+    );
+
+    expect(visible.map((r) => r.id)).toContain(id);
+  });
+
+  it('a different partner can neither see nor forge a software policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .select({ id: softwarePolicies.id })
+        .from(softwarePolicies)
+        .where(eq(softwarePolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge. Drizzle wraps the driver error,
+    // so the RLS signal is Postgres code 42501 on the cause.
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(softwarePolicies)
+          .values({ ...BASE_POLICY, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('org scope can INSERT and SELECT an org-scoped software policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(softwarePolicies)
+        .values({ ...BASE_POLICY, name: 'Org policy', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) createdPolicies.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: softwarePolicies.id })
+        .from(softwarePolicies)
+        .where(eq(softwarePolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('an org-scope caller cannot see a partner-wide software policy owned by its partner', async () => {
+    // Org scope is intentionally narrower: partner-wide templates belong to the
+    // partner axis, which org-scope tokens don't hold. Devices still receive
+    // the policy via config-policy resolution (system context), and compliance
+    // rows are visible per-device — only the template itself is partner-side.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: softwarePolicies.id })
+        .from(softwarePolicies)
+        .where(eq(softwarePolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('the one-owner CHECK rejects a policy row that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(softwarePolicies)
+          .values({ ...BASE_POLICY, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(softwarePolicies)
+          .values({ ...BASE_POLICY, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and soft-DELETE its own partner-wide software policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(softwarePolicies)
+        .set({ name: 'Renamed template' })
+        .where(eq(softwarePolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.name).toBe('Renamed template');
+
+    const deactivated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(softwarePolicies)
+        .set({ isActive: false })
+        .where(eq(softwarePolicies.id, id))
+        .returning(),
+    );
+    expect(deactivated).toHaveLength(1);
+    expect(deactivated[0]?.isActive).toBe(false);
+  });
+});
+
+describe('software_policy_audit RLS — dual-owned, at-least-one-axis (2026-07-01 migration)', () => {
+  it('a dual-owned audit row (device org + policy partner) is visible to BOTH the org and the partner', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const policyId = await seedPartnerPolicy(partner.id);
+
+    // System (worker) writes the dual-owned row, as the compliance worker does.
+    const [audit] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(softwarePolicyAudit)
+        .values({
+          orgId: org.id,
+          partnerId: partner.id,
+          policyId,
+          action: 'violation_detected',
+          actor: 'system',
+        })
+        .returning(),
+    );
+    expect(audit).toBeTruthy();
+    createdAudit.push(audit!.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: softwarePolicyAudit.id }).from(softwarePolicyAudit).where(eq(softwarePolicyAudit.id, audit!.id)),
+    );
+    expect(visibleToOrg).toHaveLength(1);
+
+    const visibleToPartner = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.select({ id: softwarePolicyAudit.id }).from(softwarePolicyAudit).where(eq(softwarePolicyAudit.id, audit!.id)),
+    );
+    expect(visibleToPartner).toHaveLength(1);
+  });
+
+  it('the owner CHECK rejects an audit row with NEITHER axis set', async () => {
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(softwarePolicyAudit)
+          .values({ orgId: null, partnerId: null, action: 'policy_created', actor: 'system' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('a different partner cannot see a partner-owned audit row', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const policyId = await seedPartnerPolicy(partnerA.id);
+
+    const [audit] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(softwarePolicyAudit)
+        .values({ orgId: null, partnerId: partnerA.id, policyId, action: 'policy_created', actor: 'system' })
+        .returning(),
+    );
+    createdAudit.push(audit!.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: softwarePolicyAudit.id }).from(softwarePolicyAudit).where(eq(softwarePolicyAudit.id, audit!.id)),
+    );
+    expect(visibleToB).toEqual([]);
+  });
+});

--- a/apps/api/src/db/schema/alerts.ts
+++ b/apps/api/src/db/schema/alerts.ts
@@ -42,9 +42,17 @@ export const alertTemplates = pgTable('alert_templates', {
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });
 
+// An alert rule is owned by EITHER an org (orgId set, partnerId NULL — the
+// original shape) OR a partner (partnerId set, orgId NULL — "partner-wide /
+// all orgs", epic #2135 / #2128). Exactly one axis is set per row; the CHECK
+// constraint `alert_rules_one_owner_chk` (migration 2026-07-01) enforces it.
+// Partner-wide rules always use targetType 'all' with targetId = partnerId
+// (targetId is NOT NULL; the 'all' match ignores it). Fired alerts ALWAYS
+// carry the device's org (alerts.org_id NOT NULL), never the rule's.
 export const alertRules = pgTable('alert_rules', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   templateId: uuid('template_id').notNull().references(() => alertTemplates.id),
   name: varchar('name', { length: 200 }).notNull(),
   targetType: varchar('target_type', { length: 50 }).notNull(),
@@ -54,6 +62,7 @@ export const alertRules = pgTable('alert_rules', {
   createdAt: timestamp('created_at').defaultNow().notNull()
 }, (table) => ({
   orgIdIdx: index('alert_rules_org_id_idx').on(table.orgId),
+  partnerIdIdx: index('alert_rules_partner_id_idx').on(table.partnerId),
   templateIdIdx: index('alert_rules_template_id_idx').on(table.templateId)
 }));
 

--- a/apps/api/src/db/schema/security.ts
+++ b/apps/api/src/db/schema/security.ts
@@ -13,7 +13,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { devices } from './devices';
 import { users } from './users';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 
 export const securityProviderEnum = pgEnum('security_provider', [
   'windows_defender',
@@ -112,15 +112,22 @@ export const securityScans = pgTable('security_scans', {
   statusIdx: index('security_scans_status_idx').on(table.status)
 }));
 
+// A security policy is owned by EITHER an org (orgId set, partnerId NULL — the
+// original shape) OR a partner (partnerId set, orgId NULL — "partner-wide /
+// all orgs" template, epic #2135 / #2127). Exactly one axis is set per row;
+// the CHECK constraint `security_policies_one_owner_chk` (migration
+// 2026-07-01) enforces it. Mirrors software_policies (#2126).
 export const securityPolicies = pgTable('security_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   settings: jsonb('settings').notNull().default({}),
   isDefault: boolean('is_default').notNull().default(false),
   createdAt: timestamp('created_at').defaultNow().notNull()
 }, (table) => ({
-  orgIdx: index('security_policies_org_id_idx').on(table.orgId)
+  orgIdx: index('security_policies_org_id_idx').on(table.orgId),
+  partnerIdx: index('security_policies_partner_id_idx').on(table.partnerId)
 }));
 
 export const securityPostureSnapshots = pgTable('security_posture_snapshots', {

--- a/apps/api/src/db/schema/softwarePolicies.ts
+++ b/apps/api/src/db/schema/softwarePolicies.ts
@@ -11,7 +11,7 @@ import {
   index,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 import { devices } from './devices';
 
@@ -74,9 +74,15 @@ export type RemediationError = {
   message: string;
 };
 
+// A software policy is owned by EITHER an org (orgId set, partnerId NULL — the
+// original shape) OR a partner (partnerId set, orgId NULL — "partner-wide /
+// all orgs" template, epic #2135 / #2126). Exactly one axis is set per row;
+// the CHECK constraint `software_policies_one_owner_chk` (migration
+// 2026-07-01) enforces it. Mirrors configuration_policies (#1724).
 export const softwarePolicies = pgTable('software_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 200 }).notNull(),
   description: text('description'),
   mode: softwarePolicyModeEnum('mode').notNull(),
@@ -92,6 +98,7 @@ export const softwarePolicies = pgTable('software_policies', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({
   orgIdIdx: index('software_policies_org_id_idx').on(table.orgId),
+  partnerIdIdx: index('software_policies_partner_id_idx').on(table.partnerId),
   targetTypeIdx: index('software_policies_target_type_idx').on(table.targetType),
   activePriorityIdx: index('software_policies_active_priority_idx').on(table.isActive, table.priority),
 }));
@@ -113,9 +120,15 @@ export const softwareComplianceStatus = pgTable('software_compliance_status', {
   devicePolicyUnique: uniqueIndex('software_compliance_device_policy_unique').on(table.deviceId, table.policyId),
 }));
 
+// Audit rows are dual-owned but NOT XOR (unlike the policy table): an event for
+// a partner-wide policy acting on a device carries BOTH the device's org_id
+// (so the org admin sees it) and the policy's partner_id (so the partner admin
+// sees it). Policy-level events with no device carry whichever axis owns the
+// policy. CHECK `software_policy_audit_owner_chk` requires at least one axis.
 export const softwarePolicyAudit = pgTable('software_policy_audit', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   policyId: uuid('policy_id').references(() => softwarePolicies.id, { onDelete: 'set null' }),
   deviceId: uuid('device_id').references(() => devices.id, { onDelete: 'set null' }),
   action: varchar('action', { length: 50 }).notNull(),
@@ -125,6 +138,7 @@ export const softwarePolicyAudit = pgTable('software_policy_audit', {
   timestamp: timestamp('timestamp').defaultNow().notNull(),
 }, (table) => ({
   orgIdIdx: index('software_policy_audit_org_id_idx').on(table.orgId),
+  partnerIdIdx: index('software_policy_audit_partner_id_idx').on(table.partnerId),
   policyIdIdx: index('software_policy_audit_policy_id_idx').on(table.policyId),
   deviceIdIdx: index('software_policy_audit_device_id_idx').on(table.deviceId),
   timestampIdx: index('software_policy_audit_timestamp_idx').on(table.timestamp),

--- a/apps/api/src/jobs/offlineDetector.test.ts
+++ b/apps/api/src/jobs/offlineDetector.test.ts
@@ -45,6 +45,8 @@ vi.mock('../services/eventBus', () => ({
 }));
 
 vi.mock('../services/alertService', () => ({
+  // #2128: and() drops undefined, so this stub keeps the mocked rule query unchanged
+  alertRuleOwnershipConditionForOrg: vi.fn(async () => undefined),
   createAlert: vi.fn(),
 }));
 

--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -11,7 +11,7 @@ import { devices, alertRules, alertTemplates, alerts } from '../db/schema';
 import { eq, and, lt, gt, asc, inArray, or } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { publishEvent } from '../services/eventBus';
-import { createAlert, evaluateDeviceAlertsFromPolicy } from '../services/alertService';
+import { createAlert, evaluateDeviceAlertsFromPolicy, alertRuleOwnershipConditionForOrg } from '../services/alertService';
 import { interpolateTemplate } from '../services/alertConditions';
 import { resolveReevalHorizonMinutes } from '../services/alertConditions/offlineDuration';
 import { isReusableState } from '../services/bullmqUtils';
@@ -361,13 +361,15 @@ export async function triggerOfflineAlerts(
   // Find legacy standalone alert rules that have offline conditions
   // We need to find rules where the template conditions include type: 'offline'
 
-  // Get all active rules for this device's org
+  // Get all active rules for this device's org, plus its partner's
+  // partner-wide rules (#2128).
+  const ownershipCondition = await alertRuleOwnershipConditionForOrg(device.orgId);
   const rules = await db
     .select()
     .from(alertRules)
     .where(
       and(
-        eq(alertRules.orgId, device.orgId),
+        ownershipCondition,
         eq(alertRules.isActive, true),
         or(
           eq(alertRules.targetType, 'all'),

--- a/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
+++ b/apps/api/src/jobs/offlineDetector_configPolicy.test.ts
@@ -48,6 +48,8 @@ vi.mock('../services/redis', () => ({
 vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));
 
 vi.mock('../services/alertService', () => ({
+  // #2128: and() drops undefined, so this stub keeps the mocked rule query unchanged
+  alertRuleOwnershipConditionForOrg: vi.fn(async () => undefined),
   createAlert: vi.fn(),
   evaluateDeviceAlertsFromPolicy: evaluateFromPolicyMock,
 }));

--- a/apps/api/src/jobs/offlineDetector_fanout.test.ts
+++ b/apps/api/src/jobs/offlineDetector_fanout.test.ts
@@ -89,6 +89,8 @@ vi.mock('../services/eventBus', () => ({
 }));
 
 vi.mock('../services/alertService', () => ({
+  // #2128: and() drops undefined, so this stub keeps the mocked rule query unchanged
+  alertRuleOwnershipConditionForOrg: vi.fn(async () => undefined),
   createAlert: vi.fn()
 }));
 

--- a/apps/api/src/jobs/offlineDetector_reeval.test.ts
+++ b/apps/api/src/jobs/offlineDetector_reeval.test.ts
@@ -86,6 +86,8 @@ vi.mock('../services/redis', () => ({
 vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));
 
 vi.mock('../services/alertService', () => ({
+  // #2128: and() drops undefined, so this stub keeps the mocked rule query unchanged
+  alertRuleOwnershipConditionForOrg: vi.fn(async () => undefined),
   createAlert: vi.fn(),
   evaluateDeviceAlertsFromPolicy: evaluateFromPolicyMock,
 }));

--- a/apps/api/src/jobs/patchSchedulerWorker.test.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.test.ts
@@ -19,7 +19,10 @@ vi.mock('../db', () => {
   const where = vi.fn(() => Promise.resolve(mockRows));
   const leftJoinSites = vi.fn(() => ({ where }));
   const leftJoinPartners = vi.fn(() => ({ leftJoin: leftJoinSites }));
-  const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners }));
+  // innerJoinOrgs terminates two shapes: loadDeviceSchedulingContexts chains
+  // two more leftJoins; resolveDeviceIdsForAssignment's partner branch calls
+  // .where() directly after the single innerJoin.
+  const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners, where }));
   const from = vi.fn(() => ({ innerJoin: innerJoinOrgs }));
   const select = vi.fn(() => ({ from }));
   return {
@@ -65,7 +68,39 @@ import { __testOnly } from './patchSchedulerWorker';
 import { enqueuePatchJob, filterOrphanedJobIds } from './patchJobExecutor';
 import { captureException } from '../services/sentry';
 
-const { loadDeviceSchedulingContexts, enqueueScanResults } = __testOnly;
+const { loadDeviceSchedulingContexts, enqueueScanResults, resolveDeviceIdsForAssignment } = __testOnly;
+
+describe('resolveDeviceIdsForAssignment (partner-wide patch, #1724)', () => {
+  beforeEach(() => {
+    mockRows = [];
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves every device under the partner when the policy has no owning org (partner-wide)', async () => {
+    // A partner-wide patch policy carries policyOrgId === null and is assigned
+    // at the partner level. Resolution must NOT early-return or clamp to an org
+    // — it returns all the partner's devices for the scheduler to group by org.
+    mockRows = [{ id: 'dev-a' }, { id: 'dev-b' }];
+    const ids = await resolveDeviceIdsForAssignment(
+      'partner',
+      '88888888-8888-4888-8888-888888888888',
+      null
+    );
+    expect(ids).toEqual(['dev-a', 'dev-b']);
+  });
+
+  it('returns [] without querying for an org-scoped level when the policy has no owning org', async () => {
+    // Org/site/group/device levels are never carried by a partner-wide policy
+    // (validateAssignmentTarget rejects them); a null policyOrgId here is a
+    // no-op, guarded before the org-equality queries run.
+    const { db } = await import('../db');
+    const ids = await resolveDeviceIdsForAssignment('organization', 'org-x', null);
+    expect(ids).toEqual([]);
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+});
 
 describe('loadDeviceSchedulingContexts (#1318 partner tz)', () => {
   beforeEach(() => {

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -185,8 +185,37 @@ function getDueOccurrenceKey(settings: PatchInlineSettings, timezone: string, no
 async function resolveDeviceIdsForAssignment(
   assignmentLevel: string,
   assignmentTargetId: string,
-  policyOrgId: string
+  // null for partner-wide policies (#1724) — they have no owning org and can
+  // only carry a partner-level assignment, resolved across all the partner's orgs.
+  policyOrgId: string | null
 ): Promise<string[]> {
+  if (assignmentLevel === 'partner') {
+    // A partner-wide policy (policyOrgId null, #1724) resolves EVERY device
+    // under the assigned partner. A legacy org-owned policy at partner level
+    // (now rejected at assign time) still clamps to its own org as a backstop.
+    //
+    // NOTE: this deliberately does NOT filter organizations by billing status,
+    // unlike the auth-layer visibility scope (computeAccessibleOrgIds, which
+    // limits to active/trial). Scheduling patches for a device is a security
+    // action we want to keep running even for orgs in a lapsed billing state,
+    // so the scheduling scope is intentionally broader than the visibility
+    // scope. If product decides suspended orgs should stop receiving patches,
+    // add the organizations.status filter here.
+    const conditions = [eq(organizations.partnerId, assignmentTargetId)];
+    if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId));
+    const partnerDevices = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(...conditions));
+    return partnerDevices.map((d) => d.id);
+  }
+
+  // Every remaining level is org-scoped and clamps to the policy's owning org.
+  // A partner-wide policy never carries one (validateAssignmentTarget rejects),
+  // so a null policyOrgId here means there is nothing to resolve.
+  if (!policyOrgId) return [];
+
   switch (assignmentLevel) {
     case 'device': {
       const [device] = await db
@@ -224,20 +253,6 @@ async function resolveDeviceIdsForAssignment(
         .from(devices)
         .where(and(eq(devices.orgId, assignmentTargetId), eq(devices.orgId, policyOrgId)));
       return orgDevices.map((d) => d.id);
-    }
-
-    case 'partner': {
-      const partnerDevices = await db
-        .select({ id: devices.id })
-        .from(devices)
-        .innerJoin(organizations, eq(devices.orgId, organizations.id))
-        .where(
-          and(
-            eq(organizations.partnerId, assignmentTargetId),
-            eq(devices.orgId, policyOrgId)
-          )
-        );
-      return partnerDevices.map((d) => d.id);
     }
 
     default:
@@ -360,13 +375,11 @@ async function scanAndCreateJobs(): Promise<{
 
   for (const row of patchPoliciesWithSchedules) {
     try {
-      // Partner-owned policies (org_id NULL, #1724) cannot carry a patch
-      // feature link — the feature-link route rejects 'patch' on partner-wide
-      // policies (ORG_SCOPED_ONLY_FEATURES), so this query never returns one.
-      // The guard is a defensive backstop; it never skips real work.
-      if (row.policyOrgId === null) continue;
-      // Bind the non-null org id locally: the post-guard narrowing of
-      // `row.policyOrgId` does not survive into the closures below.
+      // Partner-wide policies (org_id NULL, #1724) DO carry patch feature links —
+      // rings are partner-axis and the scheduler groups jobs by each device's own
+      // org, so a partner-wide policy schedules across every org under the partner.
+      // policyOrgId is null for those; resolveDeviceIdsForAssignment resolves the
+      // partner-level assignment across all the partner's devices.
       const policyOrgId = row.policyOrgId;
 
       const policyLocal = await runWithSystemDbAccess(() => loadPolicyLocalPatchConfig(row.configPolicyId));
@@ -698,4 +711,5 @@ export const __testOnly = {
   loadDeviceSchedulingContexts,
   enqueueScanResults,
   scanAndCreateJobs,
+  resolveDeviceIdsForAssignment,
 };

--- a/apps/api/src/jobs/patchSchedulerWorker.ts
+++ b/apps/api/src/jobs/patchSchedulerWorker.ts
@@ -213,8 +213,16 @@ async function resolveDeviceIdsForAssignment(
 
   // Every remaining level is org-scoped and clamps to the policy's owning org.
   // A partner-wide policy never carries one (validateAssignmentTarget rejects),
-  // so a null policyOrgId here means there is nothing to resolve.
-  if (!policyOrgId) return [];
+  // so a null policyOrgId here should be unreachable — but if a future path
+  // bypasses assignment validation, silently scheduling ZERO patch jobs is a
+  // patch-compliance hole, so make the no-op loud.
+  if (!policyOrgId) {
+    console.warn(
+      `[PatchScheduler] ${assignmentLevel}-level assignment on a policy with no owning org — resolving no devices`,
+      { assignmentLevel, assignmentTargetId }
+    );
+    return [];
+  }
 
   switch (assignmentLevel) {
     case 'device': {

--- a/apps/api/src/jobs/softwareComplianceWorker.ts
+++ b/apps/api/src/jobs/softwareComplianceWorker.ts
@@ -1,7 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { and, eq, inArray } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { softwareComplianceStatus, softwarePolicies } from '../db/schema';
+import { devices, softwareComplianceStatus, softwarePolicies } from '../db/schema';
 import {
   recordSoftwarePolicyEvaluation,
   recordSoftwarePolicyViolation,
@@ -316,6 +316,18 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
   const existingByDevice = await readComplianceStateByDevice(policy.id, deviceIds);
   const inventoryByDevice = await getSoftwareInventoryByDeviceIds(deviceIds);
 
+  // Device→org map for the dual-owner audit rows (#2126): a per-device event
+  // under a partner-wide policy (policy.orgId NULL) must carry the DEVICE's
+  // org so the org admin can see it, alongside the policy's partnerId.
+  const orgByDevice = new Map<string, string>();
+  for (const chunk of chunkArray(deviceIds)) {
+    const rows = await db
+      .select({ id: devices.id, orgId: devices.orgId })
+      .from(devices)
+      .where(inArray(devices.id, chunk));
+    for (const row of rows) orgByDevice.set(row.id, row.orgId);
+  }
+
   let violations = 0;
   const remediationTargets = new Set<string>();
   const complianceUpserts: Parameters<typeof upsertSoftwareComplianceStatuses>[0] = [];
@@ -361,7 +373,7 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
         recordSoftwarePolicyViolation(policy.mode, violationsWithStableTimestamps.length);
 
         fireAudit({
-          orgId: policy.orgId,
+          orgId: policy.orgId ?? orgByDevice.get(deviceId) ?? null,
           partnerId: policy.partnerId,
           policyId: policy.id,
           deviceId,
@@ -413,7 +425,7 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
       recordSoftwarePolicyEvaluation(policy.mode, 'unknown', Date.now() - startedAt, 'error');
 
       fireAudit({
-        orgId: policy.orgId,
+        orgId: policy.orgId ?? orgByDevice.get(deviceId) ?? null,
         partnerId: policy.partnerId,
         policyId: policy.id,
         deviceId,

--- a/apps/api/src/jobs/softwareComplianceWorker.ts
+++ b/apps/api/src/jobs/softwareComplianceWorker.ts
@@ -362,6 +362,7 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
 
         fireAudit({
           orgId: policy.orgId,
+          partnerId: policy.partnerId,
           policyId: policy.id,
           deviceId,
           action: 'violation_detected',
@@ -413,6 +414,7 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
 
       fireAudit({
         orgId: policy.orgId,
+        partnerId: policy.partnerId,
         policyId: policy.id,
         deviceId,
         action: 'compliance_check_failed',
@@ -451,6 +453,7 @@ async function processCheckPolicy(data: CheckPolicyJobData): Promise<{
 
     fireAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'remediation_scheduled',
       actor: 'system',

--- a/apps/api/src/jobs/softwareRemediationWorker.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.ts
@@ -100,6 +100,7 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
     .select({
       id: softwarePolicies.id,
       orgId: softwarePolicies.orgId,
+      partnerId: softwarePolicies.partnerId,
       name: softwarePolicies.name,
       isActive: softwarePolicies.isActive,
       remediationOptions: softwarePolicies.remediationOptions,
@@ -159,6 +160,7 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
 
       fireAudit({
         orgId: policy.orgId,
+        partnerId: policy.partnerId,
         policyId: policy.id,
         deviceId: data.deviceId,
         action: 'remediation_deferred',
@@ -295,6 +297,7 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
       : (skippedInFlight > 0 && commandsQueued === 0 ? 'remediation_deferred' : 'remediation_queued');
     fireAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       deviceId: data.deviceId,
       action,

--- a/apps/api/src/jobs/softwareRemediationWorker.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.ts
@@ -1,7 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
 import { and, eq, gte, sql } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { deviceCommands, softwareComplianceStatus, softwarePolicies, type RemediationError } from '../db/schema';
+import { deviceCommands, devices, softwareComplianceStatus, softwarePolicies, type RemediationError } from '../db/schema';
 import { recordSoftwareRemediationDecision } from '../routes/metrics';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
@@ -122,6 +122,16 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
     };
   }
 
+  // Dual-owner audit rows (#2126): per-device events under a partner-wide
+  // policy (policy.orgId NULL) must carry the DEVICE's org so the org admin
+  // can see them, alongside the policy's partnerId.
+  const [deviceRow] = await db
+    .select({ orgId: devices.orgId })
+    .from(devices)
+    .where(eq(devices.id, data.deviceId))
+    .limit(1);
+  const auditOrgId = policy.orgId ?? deviceRow?.orgId ?? null;
+
   const [compliance] = await db
     .select()
     .from(softwareComplianceStatus)
@@ -159,7 +169,7 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
         .where(eq(softwareComplianceStatus.id, compliance.id));
 
       fireAudit({
-        orgId: policy.orgId,
+        orgId: auditOrgId,
         partnerId: policy.partnerId,
         policyId: policy.id,
         deviceId: data.deviceId,
@@ -296,7 +306,7 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
       ? (commandsQueued > 0 ? 'remediation_partial' : 'remediation_failed')
       : (skippedInFlight > 0 && commandsQueued === 0 ? 'remediation_deferred' : 'remediation_queued');
     fireAudit({
-      orgId: policy.orgId,
+      orgId: auditOrgId,
       partnerId: policy.partnerId,
       policyId: policy.id,
       deviceId: data.deviceId,

--- a/apps/api/src/jobs/suppressionExpiryReaper.ts
+++ b/apps/api/src/jobs/suppressionExpiryReaper.ts
@@ -102,6 +102,7 @@ export async function reapExpiredSuppressions(): Promise<number> {
       });
     } catch (err) {
       console.error('[SuppressionExpiryReaper] Failed to write audit event:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
   }
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -35,6 +35,20 @@ export interface AuthContext {
   accessibleOrgIds: string[] | null;
 
   /**
+   * The caller's `partner_users.org_access` flag ('all' | 'selected' | 'none'),
+   * set for partner-scope requests that resolved a partner membership.
+   * This is the capability gate for PARTNER-WIDE writes (policies that apply
+   * to every org under the partner): only 'all' may create/modify them —
+   * see canManagePartnerWidePolicies in services/configurationPolicy.
+   * Deliberately not derivable from `accessibleOrgIds`: a 'selected' user
+   * whose selection covers every current org still must not administer
+   * partner-wide state (it also governs orgs created later). Undefined for
+   * contexts that never resolve a membership (org scope, agent, helper, MCP
+   * keys) — those fail closed at the gate.
+   */
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
+
+  /**
    * Helper to get the org filter condition for any table.
    * Returns undefined for system scope (no filter needed).
    *
@@ -178,20 +192,33 @@ function isMfaEnrollmentExemptPath(path: string): boolean {
  * Compute which org IDs a user can access based on their scope.
  * Called once per request in authMiddleware.
  */
+interface OrgReach {
+  /** null = unrestricted (system scope); string[] = the concrete allowlist. */
+  orgIds: string[] | null;
+  /**
+   * The caller's partner_users.org_access flag, when the caller is a partner
+   * member. Distinct from `orgIds`: a 'selected' user whose selection happens
+   * to cover every current org still must NOT pass 'all'-gated actions
+   * (partner-wide writes apply to future orgs too). null for system/org scope
+   * and for membership-less partner tokens.
+   */
+  partnerOrgAccess: 'all' | 'selected' | 'none' | null;
+}
+
 async function computeAccessibleOrgIds(
   scope: 'system' | 'partner' | 'organization',
   partnerId: string | null,
   orgId: string | null,
   userId: string
-): Promise<string[] | null> {
+): Promise<OrgReach> {
   if (scope === 'system') {
-    // System users can access all orgs - return null to indicate no filter
-    return null;
+    // System users can access all orgs - null indicates no filter
+    return { orgIds: null, partnerOrgAccess: null };
   }
 
   if (scope === 'organization') {
     // Org users can only access their org
-    return orgId ? [orgId] : [];
+    return { orgIds: orgId ? [orgId] : [], partnerOrgAccess: null };
   }
 
   if (scope === 'partner' && partnerId) {
@@ -201,7 +228,7 @@ async function computeAccessibleOrgIds(
     // denies everything. Run the whole lookup under a system-scope context
     // so the pre-auth read works; the returned list is only used to build
     // the real (non-system) context the request then runs under.
-    return withSystemDbAccessContext(async () => {
+    return withSystemDbAccessContext(async (): Promise<OrgReach> => {
       const [partnerMembership] = await db
         .select({
           orgAccess: partnerUsers.orgAccess,
@@ -217,11 +244,11 @@ async function computeAccessibleOrgIds(
         .limit(1);
 
       if (!partnerMembership) {
-        return [];
+        return { orgIds: [], partnerOrgAccess: null };
       }
 
       if (partnerMembership.orgAccess === 'none') {
-        return [];
+        return { orgIds: [], partnerOrgAccess: 'none' };
       }
 
       if (partnerMembership.orgAccess === 'selected') {
@@ -230,7 +257,7 @@ async function computeAccessibleOrgIds(
         );
 
         if (selectedOrgIds.length === 0) {
-          return [];
+          return { orgIds: [], partnerOrgAccess: 'selected' };
         }
 
         const partnerOrgs = await db
@@ -245,7 +272,7 @@ async function computeAccessibleOrgIds(
             )
           );
 
-        return partnerOrgs.map(o => o.id);
+        return { orgIds: partnerOrgs.map(o => o.id), partnerOrgAccess: 'selected' };
       }
 
       // orgAccess=all: partner users can access all orgs under their partner.
@@ -260,11 +287,11 @@ async function computeAccessibleOrgIds(
           )
         );
 
-      return partnerOrgs.map(o => o.id);
+      return { orgIds: partnerOrgs.map(o => o.id), partnerOrgAccess: 'all' };
     });
   }
 
-  return [];
+  return { orgIds: [], partnerOrgAccess: null };
 }
 
 /**
@@ -437,7 +464,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
   }
 
   // Pre-compute accessible org IDs
-  const accessibleOrgIds = await computeAccessibleOrgIds(
+  const { orgIds: accessibleOrgIds, partnerOrgAccess } = await computeAccessibleOrgIds(
     payload.scope,
     payload.partnerId,
     payload.orgId,
@@ -490,6 +517,7 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
     orgId: payload.orgId,
     scope: payload.scope,
     accessibleOrgIds,
+    partnerOrgAccess,
     orgCondition,
     canAccessOrg,
     allowedSiteIds,

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db';
-import { alertRules, alertTemplates } from '../../db/schema';
-import { eq, and, like, or, desc } from 'drizzle-orm';
+import { alertRules, alertTemplates, organizations } from '../../db/schema';
+import { eq, and, like, or, desc, isNull, type SQL } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { listRulesSchema, createRuleSchema, updateRuleSchema, toggleRuleSchema } from './schemas';
@@ -13,6 +13,28 @@ import { PERMISSIONS } from '../../services/permissions';
 export const ruleRoutes = new Hono();
 
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
+
+// Dual-axis rule condition for this legacy org-pinned route (#2128): the org's
+// own rules PLUS the partner-wide rules (org_id NULL) of the org's partner —
+// those govern this org's devices too, so hiding them here would misrepresent
+// what alerting applies. Partner-wide rules are read-only on this route; they
+// are managed via /alerts/rules at partner scope.
+async function ruleOwnershipConditionForOrg(orgId: string): Promise<SQL> {
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const partnerId = orgRow?.partnerId ?? null;
+  if (!partnerId) return eq(alertRules.orgId, orgId) as unknown as SQL;
+  return or(
+    eq(alertRules.orgId, orgId),
+    and(isNull(alertRules.orgId), eq(alertRules.partnerId, partnerId))
+  ) as SQL;
+}
+
+const PARTNER_WIDE_RULE_READONLY_HERE =
+  'This is a partner-wide alert rule; manage it via /alerts/rules at partner scope';
 
 ruleRoutes.get(
   '/rules',
@@ -31,7 +53,7 @@ ruleRoutes.get(
         return c.json({ error: 'Forbidden' }, 403);
       }
 
-      const conditions: ReturnType<typeof eq>[] = [eq(alertRules.orgId, orgId)];
+      const conditions: SQL[] = [await ruleOwnershipConditionForOrg(orgId)];
 
       const enabled = parseBoolean(query.enabled);
       if (enabled !== undefined) {
@@ -86,7 +108,8 @@ ruleRoutes.get(
         limit,
         total: filtered.length
       });
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] list failed:', err);
       return c.json({ error: 'Failed to list rules' }, 500);
     }
   }
@@ -182,7 +205,8 @@ ruleRoutes.post(
         },
       });
       return c.json({ data: { ...rule, templateName: template.name, enabled: rule.isActive } }, 201);
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] create failed:', err);
       return c.json({ error: 'Failed to create rule' }, 500);
     }
   }
@@ -204,7 +228,7 @@ ruleRoutes.get(
         .select({ rule: alertRules, templateName: alertTemplates.name })
         .from(alertRules)
         .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
-        .where(and(eq(alertRules.id, ruleId), eq(alertRules.orgId, orgId)))
+        .where(and(eq(alertRules.id, ruleId), await ruleOwnershipConditionForOrg(orgId)))
         .limit(1);
 
       if (!row) {
@@ -212,7 +236,8 @@ ruleRoutes.get(
       }
 
       return c.json({ data: { ...row.rule, templateName: row.templateName, enabled: row.rule.isActive } });
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] fetch failed:', err);
       return c.json({ error: 'Failed to fetch rule' }, 500);
     }
   }
@@ -238,11 +263,15 @@ ruleRoutes.patch(
       const [existing] = await db
         .select()
         .from(alertRules)
-        .where(and(eq(alertRules.id, ruleId), eq(alertRules.orgId, orgId)))
+        .where(and(eq(alertRules.id, ruleId), await ruleOwnershipConditionForOrg(orgId)))
         .limit(1);
 
       if (!existing) {
         return c.json({ error: 'Rule not found' }, 404);
+      }
+
+      if (existing.orgId === null) {
+        return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
       }
 
       if (Object.keys(updates).length === 0) {
@@ -276,7 +305,8 @@ ruleRoutes.patch(
         details: { updatedFields: Object.keys(updates) },
       });
       return c.json({ data: { ...updated, enabled: updated?.isActive } });
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] update failed:', err);
       return c.json({ error: 'Failed to update rule' }, 500);
     }
   }
@@ -299,11 +329,15 @@ ruleRoutes.delete(
       const [existing] = await db
         .select()
         .from(alertRules)
-        .where(and(eq(alertRules.id, ruleId), eq(alertRules.orgId, orgId)))
+        .where(and(eq(alertRules.id, ruleId), await ruleOwnershipConditionForOrg(orgId)))
         .limit(1);
 
       if (!existing) {
         return c.json({ error: 'Rule not found' }, 404);
+      }
+
+      if (existing.orgId === null) {
+        return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
       }
 
       await db.delete(alertRules).where(eq(alertRules.id, ruleId));
@@ -316,7 +350,8 @@ ruleRoutes.delete(
         resourceName: existing.name,
       });
       return c.json({ data: { id: ruleId, deleted: true } });
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] delete failed:', err);
       return c.json({ error: 'Failed to delete rule' }, 500);
     }
   }
@@ -342,11 +377,15 @@ ruleRoutes.post(
       const [existing] = await db
         .select()
         .from(alertRules)
-        .where(and(eq(alertRules.id, ruleId), eq(alertRules.orgId, orgId)))
+        .where(and(eq(alertRules.id, ruleId), await ruleOwnershipConditionForOrg(orgId)))
         .limit(1);
 
       if (!existing) {
         return c.json({ error: 'Rule not found' }, 404);
+      }
+
+      if (existing.orgId === null) {
+        return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
       }
 
       const [updated] = await db
@@ -364,7 +403,8 @@ ruleRoutes.post(
         details: { enabled },
       });
       return c.json({ data: { ...updated, enabled: updated?.isActive } });
-    } catch {
+    } catch (err) {
+      console.error('[alertTemplates/rules] toggle failed:', err);
       return c.json({ error: 'Failed to toggle rule' }, 500);
     }
   }

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -97,7 +97,10 @@ export function resolveWriteOrgId(
   return { error: 'orgId is required when the caller can access multiple organizations', status: 400 };
 }
 
-export async function getAlertRuleWithOrgCheck(ruleId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {
+export async function getAlertRuleWithOrgCheck(
+  ruleId: string,
+  auth: { canAccessOrg: (orgId: string) => boolean; scope?: string; partnerId?: string | null }
+) {
   const [rule] = await db
     .select()
     .from(alertRules)
@@ -108,7 +111,12 @@ export async function getAlertRuleWithOrgCheck(ruleId: string, auth: { canAccess
     return null;
   }
 
-  const hasAccess = ensureOrgAccess(rule.orgId, auth);
+  // Dual-axis access (#2128): org-owned rules via org access; partner-wide
+  // rules (orgId NULL) via the caller's own partner (or system scope). Writes
+  // are additionally gated on canManagePartnerWidePolicies at the routes.
+  const hasAccess = rule.orgId !== null
+    ? ensureOrgAccess(rule.orgId, auth)
+    : auth.scope === 'system' || (!!auth.partnerId && rule.partnerId === auth.partnerId);
   if (!hasAccess) {
     return null;
   }
@@ -447,7 +455,10 @@ export function formatAlertRuleResponse(rule: AlertRuleRow, template?: AlertTemp
 
 export async function resolveAlertTemplate(params: {
   templateId?: string;
-  orgId: string;
+  // Owner of any template CREATED here: org-owned for org rules, partner-owned
+  // for partner-wide rules (#2128; alert_templates are already dual-ownership).
+  orgId: string | null;
+  partnerId?: string | null;
   name?: string;
   description?: string;
   severity?: string;
@@ -477,6 +488,7 @@ export async function resolveAlertTemplate(params: {
       .values({
         id: params.templateId,
         orgId: params.orgId,
+        partnerId: params.partnerId ?? null,
         name: templateName,
         description: params.description,
         conditions: templateConditions,
@@ -496,6 +508,7 @@ export async function resolveAlertTemplate(params: {
     .insert(alertTemplates)
     .values({
       orgId: params.orgId,
+      partnerId: params.partnerId ?? null,
       name: templateName,
       description: params.description,
       conditions: templateConditions,

--- a/apps/api/src/routes/alerts/rules.authz.test.ts
+++ b/apps/api/src/routes/alerts/rules.authz.test.ts
@@ -42,7 +42,9 @@ vi.mock('../../middleware/auth', () => ({
 
 vi.mock('../../db', () => ({ db: {} }));
 vi.mock('../../db/schema', () => ({
-  alertRules: {}, alertTemplates: {}, alerts: {}, devices: {},
+  alertRules: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', isActive: 'isActive', createdAt: 'createdAt', templateId: 'templateId' },
+  alertTemplates: {}, alerts: {}, devices: {},
+  organizations: { id: 'id', partnerId: 'partnerId' },
 }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('./helpers', () => ({
@@ -55,6 +57,7 @@ vi.mock('./helpers', () => ({
 }));
 
 import { rulesRoutes } from './rules';
+import * as helpers from './helpers';
 
 function makeApp() {
   const app = new Hono();
@@ -127,5 +130,94 @@ describe('alert rules authz (Finding #6)', () => {
     grantedRef.current.add(ALERTS_WRITE);
     const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, { method: 'DELETE' });
     expect(res.status).not.toBe(403);
+  });
+});
+
+// ============================================================
+// Partner-wide alert rules (#2128, epic #2135)
+// ============================================================
+
+describe('partner-wide alert rules (#2128)', () => {
+  const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+
+  function setPartnerAuth(partnerOrgAccess?: 'all' | 'selected' | 'none') {
+    grantedRef.current = new Set<string>([ALERTS_WRITE]);
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Partner Admin', email: 'admin@msp.example' },
+      partnerId: PARTNER_ID,
+      partnerOrgAccess,
+      orgId: null,
+      accessibleOrgIds: ['org-1'],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('denies partner-wide create without full partner org access (orgAccess selected)', async () => {
+    setPartnerAuth('selected');
+    const res = await makeApp().request('/alerts/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ownerScope: 'partner', name: 'Fleet CPU rule', severity: 'high', conditions: { type: 'metric' } }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('rejects a non-"all" target on partner-wide create', async () => {
+    setPartnerAuth('all');
+    const res = await makeApp().request('/alerts/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ownerScope: 'partner', name: 'Fleet rule', severity: 'high', conditions: { type: 'metric' }, targetType: 'site', targetId: '5d4c3b2a-1111-4222-8333-444455556666' }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toMatch(/only support the "all" target/);
+  });
+
+  it('rejects org-scoped notification bindings on partner-wide create', async () => {
+    setPartnerAuth('all');
+    const res = await makeApp().request('/alerts/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ownerScope: 'partner',
+        name: 'Fleet rule',
+        severity: 'high',
+        conditions: { type: 'metric' },
+        notificationChannelIds: ['5d4c3b2a-1111-4222-8333-444455556666'],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toMatch(/notification channels/i);
+  });
+
+  it('denies DELETE of a partner-wide rule without the partner-wide capability', async () => {
+    setPartnerAuth('selected');
+    vi.mocked(helpers.getAlertRuleWithOrgCheck).mockResolvedValue({
+      id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet rule', overrideSettings: null,
+    } as never);
+
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('denies PUT of a partner-wide rule without the partner-wide capability', async () => {
+    setPartnerAuth('none');
+    vi.mocked(helpers.getAlertRuleWithOrgCheck).mockResolvedValue({
+      id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet rule', overrideSettings: null,
+    } as never);
+
+    const res = await makeApp().request(`/alerts/rules/${RULE_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -1,8 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { alertRules, alertTemplates, alerts, devices } from '../../db/schema';
+import { alertRules, alertTemplates, alerts, devices, organizations } from '../../db/schema';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
@@ -41,33 +42,65 @@ rulesRoutes.get(
     const { page, limit, offset } = getPagination(query);
 
     // Build conditions array
-    const conditions: ReturnType<typeof eq>[] = [];
+    const conditions: SQL[] = [];
 
-    // Filter by org access based on scope
+    // Filter by org access based on scope. Partner callers also see their
+    // partner-wide rules (org_id NULL, #2128) — including in org-filtered
+    // views, since those rules govern that org's devices too. For system
+    // callers the NULL branch is scoped to the QUERIED org's own partner
+    // (mirrors listConfigPolicies) so it never returns unrelated partners'
+    // rules platform-wide.
     if (auth.scope === 'organization') {
       if (!auth.orgId) {
         return c.json({ error: 'Organization context required' }, 403);
       }
       conditions.push(eq(alertRules.orgId, auth.orgId));
     } else if (auth.scope === 'partner') {
+      const partnerWideMine = auth.partnerId
+        ? and(isNull(alertRules.orgId), eq(alertRules.partnerId, auth.partnerId))
+        : undefined;
       if (query.orgId) {
         const hasAccess = ensureOrgAccess(query.orgId, auth);
         if (!hasAccess) {
           return c.json({ error: 'Access to this organization denied' }, 403);
         }
-        conditions.push(eq(alertRules.orgId, query.orgId));
+        conditions.push(
+          partnerWideMine
+            ? (or(eq(alertRules.orgId, query.orgId), partnerWideMine) as SQL)
+            : eq(alertRules.orgId, query.orgId)
+        );
       } else {
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        if (orgIds.length === 0 && !partnerWideMine) {
           return c.json({
             data: [],
             pagination: { page, limit, total: 0 }
           });
         }
-        conditions.push(inArray(alertRules.orgId, orgIds));
+        const orgOwned = orgIds.length > 0 ? inArray(alertRules.orgId, orgIds) : undefined;
+        if (orgOwned && partnerWideMine) {
+          conditions.push(or(orgOwned, partnerWideMine) as SQL);
+        } else if (orgOwned) {
+          conditions.push(orgOwned);
+        } else if (partnerWideMine) {
+          conditions.push(partnerWideMine as SQL);
+        }
       }
     } else if (auth.scope === 'system' && query.orgId) {
-      conditions.push(eq(alertRules.orgId, query.orgId));
+      const [orgRow] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, query.orgId))
+        .limit(1);
+      const orgPartnerId = orgRow?.partnerId ?? null;
+      conditions.push(
+        orgPartnerId
+          ? (or(
+              eq(alertRules.orgId, query.orgId),
+              and(isNull(alertRules.orgId), eq(alertRules.partnerId, orgPartnerId))
+            ) as SQL)
+          : eq(alertRules.orgId, query.orgId)
+      );
     }
 
     // Additional filters
@@ -140,31 +173,68 @@ rulesRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    const orgId = data.orgId ?? auth.orgId;
-    if (!orgId) {
-      return c.json({ error: 'Organization context required' }, 403);
+    // Ownership axis (#2128). Partner-wide rules evaluate against devices in
+    // ALL orgs under the partner (including orgs created later), so creation
+    // is gated on the partner-wide capability — same gate as software/security
+    // policies. The partner is ALWAYS derived from the caller's own token.
+    const isPartnerWide = data.ownerScope === 'partner';
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (isPartnerWide) {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner-wide alert rules require partner scope' }, 403);
+      }
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: 'Partner-wide alert rules require full partner org access (orgAccess must be "all")' }, 403);
+      }
+      // Partner-wide rules always target 'all' (every device under the
+      // partner); org/site/group/device targets have no meaning without an
+      // owning org. targetId carries the partner id to satisfy NOT NULL — the
+      // 'all' match ignores it.
+      const requestedTargetType = data.targets?.type ?? data.targetType;
+      if (requestedTargetType && requestedTargetType !== 'all') {
+        return c.json({ error: 'Partner-wide alert rules only support the "all" target — scope narrower rules to an organization instead' }, 400);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgId = data.orgId ?? auth.orgId;
+      if (!orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      if (!auth.canAccessOrg(orgId)) {
+        return c.json({ error: 'Access to this organization denied' }, 403);
+      }
+      owner = { orgId, partnerId: null };
     }
 
-    if (!auth.canAccessOrg(orgId)) {
-      return c.json({ error: 'Access to this organization denied' }, 403);
-    }
-
-    const { targetType, targetId, targetIds, targets } = normalizeTargetsForRule(
-      {
-        targets: data.targets,
-        targetType: data.targetType,
-        targetId: data.targetId
-      },
-      orgId
-    );
+    const { targetType, targetId, targetIds, targets } = isPartnerWide
+      ? { targetType: 'all', targetId: owner.partnerId!, targetIds: [], targets: { type: 'all', ids: [] } }
+      : normalizeTargetsForRule(
+          {
+            targets: data.targets,
+            targetType: data.targetType,
+            targetId: data.targetId
+          },
+          owner.orgId!
+        );
 
     if (!targetId) {
       return c.json({ error: 'Target is required' }, 400);
     }
 
+    // Notification channels and escalation policies are org-scoped (#2130);
+    // a partner-wide rule cannot bind them. Dispatch falls back to each firing
+    // device's OWN org routing (the alert always carries the device's org).
+    if (isPartnerWide) {
+      const requestedChannels = data.notificationChannelIds ?? data.notificationChannels;
+      if ((Array.isArray(requestedChannels) && requestedChannels.length > 0) || data.escalationPolicyId) {
+        return c.json({ error: 'Partner-wide alert rules cannot bind org-scoped notification channels or escalation policies; each organization\'s default routing is used instead' }, 400);
+      }
+    }
+
     const { template, created } = await resolveAlertTemplate({
       templateId: data.templateId,
-      orgId,
+      orgId: owner.orgId,
+      partnerId: owner.partnerId,
       name: data.name,
       description: data.description,
       severity: data.severity,
@@ -176,8 +246,16 @@ rulesRoutes.post(
       return c.json({ error: 'Failed to resolve alert template' }, 500);
     }
 
-    if (!created && template.orgId && template.orgId !== orgId) {
-      return c.json({ error: 'Access to this alert template denied' }, 403);
+    if (!created) {
+      // Org rules may use built-in, partner-shared, or same-org templates
+      // (unchanged). Partner-wide rules may use built-in or OWN-partner
+      // templates — never another tenant's org template.
+      const templateDenied = isPartnerWide
+        ? Boolean(template.orgId) || (template.partnerId ? template.partnerId !== owner.partnerId : !template.isBuiltIn)
+        : Boolean(template.orgId && template.orgId !== owner.orgId);
+      if (templateDenied) {
+        return c.json({ error: 'Access to this alert template denied' }, 403);
+      }
     }
 
     const baseOverrides: Record<string, unknown> = {
@@ -200,12 +278,14 @@ rulesRoutes.post(
       baseOverrides.notificationChannelIds = notificationChannelIds;
     }
 
-    const createNotificationBindingError = await validateAlertRuleNotificationBindings(
-      orgId,
-      getOverrides(baseOverrides)
-    );
-    if (createNotificationBindingError) {
-      return c.json({ error: createNotificationBindingError }, 400);
+    if (!isPartnerWide) {
+      const createNotificationBindingError = await validateAlertRuleNotificationBindings(
+        owner.orgId!,
+        getOverrides(baseOverrides)
+      );
+      if (createNotificationBindingError) {
+        return c.json({ error: createNotificationBindingError }, 400);
+      }
     }
 
     baseOverrides.targets = targets;
@@ -221,7 +301,8 @@ rulesRoutes.post(
     const [rule] = await db
       .insert(alertRules)
       .values({
-        orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         templateId: template.id,
         name: ruleName,
         targetType,
@@ -235,7 +316,7 @@ rulesRoutes.post(
     }
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: owner.orgId,
       action: 'alert_rule.create',
       resourceType: 'alert_rule',
       resourceId: rule.id,
@@ -273,6 +354,14 @@ rulesRoutes.put(
       return c.json({ error: 'Alert rule not found' }, 404);
     }
 
+    // Partner-wide rules are READABLE by any member of the partner but
+    // administrable only with the partner-wide capability — editing them
+    // changes alerting across every org under the partner (#2128).
+    const isPartnerWide = rule.orgId === null;
+    if (isPartnerWide && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const updates: Record<string, unknown> = {};
     let templateOwned = getOverrides(rule.overrideSettings).templateOwned;
 
@@ -280,6 +369,7 @@ rulesRoutes.put(
       const resolved = await resolveAlertTemplate({
         templateId: data.templateId,
         orgId: rule.orgId,
+        partnerId: rule.partnerId,
         name: data.name,
         description: data.description,
         severity: data.severity,
@@ -292,7 +382,11 @@ rulesRoutes.put(
       }
       const resolvedTemplate = resolved.template;
 
-      if (!resolved.created && resolvedTemplate.orgId && resolvedTemplate.orgId !== rule.orgId) {
+      const templateDenied = isPartnerWide
+        ? !resolved.created && (Boolean(resolvedTemplate.orgId)
+            || (resolvedTemplate.partnerId ? resolvedTemplate.partnerId !== rule.partnerId : !resolvedTemplate.isBuiltIn))
+        : !resolved.created && Boolean(resolvedTemplate.orgId && resolvedTemplate.orgId !== rule.orgId);
+      if (templateDenied) {
         return c.json({ error: 'Access to this alert template denied' }, 403);
       }
 
@@ -303,14 +397,22 @@ rulesRoutes.put(
     if (data.name !== undefined) updates.name = data.name;
 
     if (data.targets || data.targetType || data.targetId) {
-      const resolvedTargets = normalizeTargetsForRule(
-        {
-          targets: data.targets,
-          targetType: data.targetType,
-          targetId: data.targetId
-        },
-        rule.orgId
-      );
+      if (isPartnerWide) {
+        const requestedTargetType = data.targets?.type ?? data.targetType;
+        if (requestedTargetType && requestedTargetType !== 'all') {
+          return c.json({ error: 'Partner-wide alert rules only support the "all" target — scope narrower rules to an organization instead' }, 400);
+        }
+      }
+      const resolvedTargets = isPartnerWide
+        ? { targetType: 'all', targetId: rule.partnerId!, targetIds: [], targets: { type: 'all', ids: [] } }
+        : normalizeTargetsForRule(
+            {
+              targets: data.targets,
+              targetType: data.targetType,
+              targetId: data.targetId
+            },
+            rule.orgId!
+          );
 
       if (!resolvedTargets.targetId) {
         return c.json({ error: 'Target is required' }, 400);
@@ -354,8 +456,13 @@ rulesRoutes.put(
       || containsNotificationBindingOverride(data.overrides);
 
     if (shouldValidateNotificationBindings) {
+      if (isPartnerWide) {
+        // Channels/escalation are org-scoped (#2130); partner-wide rules use
+        // each firing device's own org routing instead.
+        return c.json({ error: 'Partner-wide alert rules cannot bind org-scoped notification channels or escalation policies; each organization\'s default routing is used instead' }, 400);
+      }
       const updateNotificationBindingError = await validateAlertRuleNotificationBindings(
-        rule.orgId,
+        rule.orgId!,
         getOverrides(baseOverrides)
       );
       if (updateNotificationBindingError) {
@@ -449,6 +556,11 @@ rulesRoutes.delete(
       return c.json({ error: 'Alert rule not found' }, 404);
     }
 
+    // Same partner-wide administration gate as PUT (#2128).
+    if (rule.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     // Check for active alerts using this rule
     const activeAlerts = await db
       .select({ count: sql<number>`count(*)` })
@@ -502,16 +614,16 @@ rulesRoutes.post(
       return c.json({ error: 'Alert rule not found' }, 404);
     }
 
-    // Verify device exists and belongs to same org
+    // Verify device exists and is governed by this rule: same org for
+    // org-owned rules; any org under the rule's partner for partner-wide
+    // rules (#2128).
+    const deviceScope = rule.orgId !== null
+      ? [eq(devices.orgId, rule.orgId)]
+      : [sql`${devices.orgId} IN (SELECT id FROM ${organizations} WHERE ${organizations.partnerId} = ${rule.partnerId})`];
     const [device] = await db
       .select()
       .from(devices)
-      .where(
-        and(
-          eq(devices.id, data.deviceId),
-          eq(devices.orgId, rule.orgId)
-        )
-      )
+      .where(and(eq(devices.id, data.deviceId), ...deviceScope))
       .limit(1);
 
     if (!device) {

--- a/apps/api/src/routes/alerts/schemas.ts
+++ b/apps/api/src/routes/alerts/schemas.ts
@@ -12,6 +12,10 @@ export const listAlertRulesSchema = z.object({
 
 export const createAlertRuleSchema = z.object({
   orgId: z.string().guid().optional(),
+  // Ownership axis (#2128, mirrors software/security policies). 'organization'
+  // (default) = classic org-scoped rule. 'partner' = partner-wide / all-orgs;
+  // the server derives the partner from the caller's own token. Create-only.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   templateId: z.string().guid().optional(),
   name: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -17,14 +17,20 @@ const {
   validateAssignmentTargetMock: vi.fn(),
 }));
 
-vi.mock('../../services/configurationPolicy', () => ({
-  getConfigPolicy: getConfigPolicyMock,
-  assignPolicy: assignPolicyMock,
-  unassignPolicy: unassignPolicyMock,
-  listAssignments: listAssignmentsMock,
-  listAssignmentsForTarget: listAssignmentsForTargetMock,
-  validateAssignmentTarget: validateAssignmentTargetMock,
-}));
+vi.mock('../../services/configurationPolicy', async (importOriginal) => {
+  // Spread the original so canManagePartnerWidePolicies (the real capability
+  // gate) and PARTNER_WIDE_WRITE_DENIED_MESSAGE flow through unmocked.
+  const original = await importOriginal<typeof import('../../services/configurationPolicy')>();
+  return {
+    ...original,
+    getConfigPolicy: getConfigPolicyMock,
+    assignPolicy: assignPolicyMock,
+    unassignPolicy: unassignPolicyMock,
+    listAssignments: listAssignmentsMock,
+    listAssignmentsForTarget: listAssignmentsForTargetMock,
+    validateAssignmentTarget: validateAssignmentTargetMock,
+  };
+});
 
 vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
@@ -151,7 +157,7 @@ describe('configurationPolicies assignment routes', () => {
 
     const appPartnerAll = new Hono();
     appPartnerAll.use('*', async (c, next) => {
-      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
       // requirePermission populates permissions; simulate orgAccess='all' (full partner admin)
       c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
       await next();
@@ -194,7 +200,7 @@ describe('configurationPolicies assignment routes', () => {
 
     const appPartnerSelected = new Hono();
     appPartnerSelected.use('*', async (c, next) => {
-      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID] }));
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID], partnerOrgAccess: 'selected' }));
       c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'selected', allowedOrgIds: [ORG_ID] }));
       await next();
     });
@@ -217,7 +223,7 @@ describe('configurationPolicies assignment routes', () => {
 
     const appPartnerNone = new Hono();
     appPartnerNone.use('*', async (c, next) => {
-      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [] }));
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [], partnerOrgAccess: 'none' }));
       c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'none' }));
       await next();
     });
@@ -245,7 +251,7 @@ describe('configurationPolicies assignment routes', () => {
 
     const appPartnerAll = new Hono();
     appPartnerAll.use('*', async (c, next) => {
-      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
       c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
       await next();
     });
@@ -298,5 +304,46 @@ describe('configurationPolicies assignment routes', () => {
     // orgAccess guard does not apply to device-level assignments
     expect(res.status).toBe(201);
     expect(assignPolicyMock).toHaveBeenCalled();
+  });
+
+  it('denies UNASSIGNING a partner-wide policy without full partner org access', async () => {
+    // Removing the partner-level assignment strips config from every org under
+    // the partner — same blast radius as assigning, same capability gate.
+    const AID = '77777777-7777-7777-7777-777777777777';
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+
+    const appPartnerSelected = new Hono();
+    appPartnerSelected.use('*', async (c, next) => {
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID], partnerOrgAccess: 'selected' }));
+      await next();
+    });
+    appPartnerSelected.route('/', assignmentRoutes);
+
+    const res = await appPartnerSelected.request(`/${POLICY_ID}/assignments/${AID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(403);
+    expect(unassignPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it('allows unassigning a partner-wide policy with full partner org access', async () => {
+    const AID = '77777777-7777-7777-7777-777777777777';
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide' });
+    unassignPolicyMock.mockResolvedValue({ id: AID, level: 'partner', targetId: PARTNER_ID });
+
+    const appPartnerAll = new Hono();
+    appPartnerAll.use('*', async (c, next) => {
+      c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
+      await next();
+    });
+    appPartnerAll.route('/', assignmentRoutes);
+
+    const res = await appPartnerAll.request(`/${POLICY_ID}/assignments/${AID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    expect(unassignPolicyMock).toHaveBeenCalledWith(AID, POLICY_ID);
   });
 });

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { PERMISSIONS } from '../../services/permissions';
 import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   getConfigPolicy,
@@ -12,6 +12,8 @@ import {
   listAssignments,
   listAssignmentsForTarget,
   validateAssignmentTarget,
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../../services/configurationPolicy';
 import { invalidateRemoteAccessCache } from '../../services/remoteAccessPolicy';
 import {
@@ -79,10 +81,9 @@ assignmentRoutes.post(
       // of orgs — permitting a partner-level assignment would silently propagate
       // config (remote_access, PAM, monitoring, patch) to orgs they cannot access.
       // Only orgAccess='all' partner users (and system scope) may assign at
-      // partner level. requireConfigPolicyWrite (requirePermission) already
-      // populated c.get('permissions') with the caller's orgAccess.
-      const userPerms = c.get('permissions') as UserPermissions | undefined;
-      if (auth.scope !== 'system' && userPerms?.orgAccess !== 'all') {
+      // partner level — the same capability that gates partner-wide policy
+      // create/update/delete and feature-link writes.
+      if (!canManagePartnerWidePolicies(auth)) {
         return c.json({ error: 'Partner-level assignments require full partner org access (orgAccess must be "all")' }, 403);
       }
     }
@@ -144,6 +145,13 @@ assignmentRoutes.delete(
 
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
+
+    // Unassigning a partner-wide policy strips config from ALL orgs under the
+    // partner (its only assignment is the partner-level one) — the same blast
+    // radius as assigning, so the same capability gate applies.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
 
     const deleted = await unassignPolicy(aid, id);
     if (!deleted) return c.json({ error: 'Assignment not found' }, 404);

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -20,18 +20,30 @@ const {
   dbSelectMock: vi.fn(),
 }));
 
-vi.mock('../../services/configurationPolicy', () => ({
-  listConfigPolicies: listConfigPoliciesMock,
-  createConfigPolicy: createConfigPolicyMock,
-  getConfigPolicy: getConfigPolicyMock,
-  updateConfigPolicy: updateConfigPolicyMock,
-  deleteConfigPolicy: deleteConfigPolicyMock,
-  assignPolicy: assignPolicyMock,
-}));
+vi.mock('../../services/configurationPolicy', async (importOriginal) => {
+  // Spread the original so canManagePartnerWidePolicies (the real capability
+  // gate) and PartnerWideWriteDeniedError flow through unmocked.
+  const original = await importOriginal<typeof import('../../services/configurationPolicy')>();
+  return {
+    ...original,
+    listConfigPolicies: listConfigPoliciesMock,
+    createConfigPolicy: createConfigPolicyMock,
+    getConfigPolicy: getConfigPolicyMock,
+    updateConfigPolicy: updateConfigPolicyMock,
+    deleteConfigPolicy: deleteConfigPolicyMock,
+    assignPolicy: assignPolicyMock,
+  };
+});
 
-// crud.ts uses db.select only for the system-scope org-existence check.
-vi.mock('../../db', () => ({ db: { select: dbSelectMock } }));
-vi.mock('../../db/schema', () => ({ organizations: { id: 'organizations.id' } }));
+// crud.ts uses db.select only for the system-scope org-existence check. The
+// real db/schema module loads fine (importOriginal of the service needs its
+// tables); only the db driver itself is mocked.
+vi.mock('../../db', () => ({
+  db: { select: dbSelectMock, insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
 
 // Configure the db.select().from().where().limit() chain to report whether the
 // target org exists (system-scope create path).
@@ -54,6 +66,8 @@ vi.mock('../../middleware/auth', () => ({
 import { crudRoutes } from './crud';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { requireScope } from '../../middleware/auth';
+// Real class via the importOriginal spread in the service mock above.
+import { PartnerWideWriteDeniedError } from '../../services/configurationPolicy';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const POLICY_ID = '22222222-2222-2222-2222-222222222222';
@@ -261,7 +275,7 @@ describe('configurationPolicies CRUD routes', () => {
 
       const appPartner = new Hono();
       appPartner.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
         // requirePermission populates permissions; simulate orgAccess='all' (full partner admin)
         c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
         await next();
@@ -397,7 +411,7 @@ describe('configurationPolicies CRUD routes', () => {
     function partnerCreateApp() {
       const appPartner = new Hono();
       appPartner.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID }));
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, partnerOrgAccess: 'all' }));
         c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
         await next();
       });
@@ -451,7 +465,7 @@ describe('configurationPolicies CRUD routes', () => {
       // they cannot access.
       const appPartnerSelected = new Hono();
       appPartnerSelected.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID] }));
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID], partnerOrgAccess: 'selected' }));
         // permissions reflect orgAccess='selected' — as set by requirePermission
         c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'selected', allowedOrgIds: [ORG_ID] }));
         await next();
@@ -472,7 +486,7 @@ describe('configurationPolicies CRUD routes', () => {
     it('denies partner-wide policy create when orgAccess is "none"', async () => {
       const appPartnerNone = new Hono();
       appPartnerNone.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [] }));
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [], partnerOrgAccess: 'none' }));
         c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'none' }));
         await next();
       });
@@ -494,7 +508,7 @@ describe('configurationPolicies CRUD routes', () => {
 
       const appPartnerAll = new Hono();
       appPartnerAll.use('*', async (c, next) => {
-        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID, ORG_B] }));
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID, ORG_B], partnerOrgAccess: 'all' }));
         c.set('permissions', makePermissions({ scope: 'partner', partnerId: PARTNER_ID, orgId: null, orgAccess: 'all' }));
         await next();
       });
@@ -610,6 +624,22 @@ describe('configurationPolicies CRUD routes', () => {
       });
       expect(res.status).toBe(404);
     });
+
+    it('maps PartnerWideWriteDeniedError from the service to a 403', async () => {
+      // The service throws when a partner-wide policy is visible but not
+      // administrable (orgAccess != 'all') — the route must surface 403, not 500.
+      updateConfigPolicyMock.mockRejectedValue(new PartnerWideWriteDeniedError());
+
+      const res = await app.request(`/${POLICY_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Updated' }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error).toMatch(/full partner org access/);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================
@@ -633,6 +663,14 @@ describe('configurationPolicies CRUD routes', () => {
 
       const res = await app.request(`/${POLICY_ID}`, { method: 'DELETE' });
       expect(res.status).toBe(404);
+    });
+
+    it('maps PartnerWideWriteDeniedError from the service to a 403', async () => {
+      deleteConfigPolicyMock.mockRejectedValue(new PartnerWideWriteDeniedError());
+
+      const res = await app.request(`/${POLICY_ID}`, { method: 'DELETE' });
+      expect(res.status).toBe(403);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/configurationPolicies/crud.test.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.test.ts
@@ -9,6 +9,7 @@ const {
   updateConfigPolicyMock,
   deleteConfigPolicyMock,
   assignPolicyMock,
+  dbSelectMock,
 } = vi.hoisted(() => ({
   listConfigPoliciesMock: vi.fn(),
   createConfigPolicyMock: vi.fn(),
@@ -16,6 +17,7 @@ const {
   updateConfigPolicyMock: vi.fn(),
   deleteConfigPolicyMock: vi.fn(),
   assignPolicyMock: vi.fn(),
+  dbSelectMock: vi.fn(),
 }));
 
 vi.mock('../../services/configurationPolicy', () => ({
@@ -26,6 +28,18 @@ vi.mock('../../services/configurationPolicy', () => ({
   deleteConfigPolicy: deleteConfigPolicyMock,
   assignPolicy: assignPolicyMock,
 }));
+
+// crud.ts uses db.select only for the system-scope org-existence check.
+vi.mock('../../db', () => ({ db: { select: dbSelectMock } }));
+vi.mock('../../db/schema', () => ({ organizations: { id: 'organizations.id' } }));
+
+// Configure the db.select().from().where().limit() chain to report whether the
+// target org exists (system-scope create path).
+function mockOrgExists(exists: boolean) {
+  dbSelectMock.mockReturnValue({
+    from: () => ({ where: () => ({ limit: () => Promise.resolve(exists ? [{ id: ORG_ID }] : []) }) }),
+  });
+}
 
 vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
@@ -81,6 +95,7 @@ describe('configurationPolicies CRUD routes', () => {
     // auto-assign error-path test leaks into later cases.
     assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
     deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
+    mockOrgExists(true); // default: system-scope org-existence check passes
     app = new Hono();
     // Set auth context before mounting routes
     app.use('*', async (c, next) => {
@@ -284,6 +299,101 @@ describe('configurationPolicies CRUD routes', () => {
       expect(assignPolicyMock).not.toHaveBeenCalled();
     });
 
+    function systemCreateApp() {
+      const appSystem = new Hono();
+      appSystem.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'system', orgId: null, accessibleOrgIds: null, canAccessOrg: () => true }));
+        await next();
+      });
+      appSystem.route('/', crudRoutes);
+      return appSystem;
+    }
+
+    it('system scope: returns 404 (not a raw 500) when the target org does not exist', async () => {
+      mockOrgExists(false);
+
+      const res = await systemCreateApp().request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Policy', orgId: ORG_ID }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('system scope: creates the policy when the target org exists', async () => {
+      mockOrgExists(true);
+      createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Policy', orgId: ORG_ID, partnerId: null, status: 'active' });
+
+      const res = await systemCreateApp().request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Policy', orgId: ORG_ID }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(createConfigPolicyMock).toHaveBeenCalledWith({ orgId: ORG_ID }, expect.objectContaining({ name: 'Policy' }), 'user-1');
+    });
+
+    it('partner scope: distinct message when the partner has NO accessible orgs', async () => {
+      const appPartnerNoOrg = new Hono();
+      appPartnerNoOrg.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [], canAccessOrg: () => false }));
+        await next();
+      });
+      appPartnerNoOrg.route('/', crudRoutes);
+
+      const res = await appPartnerNoOrg.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Policy' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/No accessible organization/i);
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('partner scope: distinct message when the partner has MULTIPLE orgs and no orgId given', async () => {
+      const ORG_B = '55555555-5555-5555-5555-555555555555';
+      const appPartnerMulti = new Hono();
+      appPartnerMulti.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID, ORG_B], canAccessOrg: (o: string) => o === ORG_ID || o === ORG_B }));
+        await next();
+      });
+      appPartnerMulti.route('/', crudRoutes);
+
+      const res = await appPartnerMulti.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Policy' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/multiple organizations/i);
+      expect(createConfigPolicyMock).not.toHaveBeenCalled();
+    });
+
+    it('partner scope: defaults to the single accessible org when none is supplied', async () => {
+      createConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, name: 'Policy', orgId: ORG_ID, partnerId: null, status: 'active' });
+      const appPartnerSingle = new Hono();
+      appPartnerSingle.use('*', async (c, next) => {
+        c.set('auth', makeAuth({ scope: 'partner', orgId: null, partnerId: PARTNER_ID, accessibleOrgIds: [ORG_ID], canAccessOrg: (o: string) => o === ORG_ID }));
+        await next();
+      });
+      appPartnerSingle.route('/', crudRoutes);
+
+      const res = await appPartnerSingle.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Policy' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(createConfigPolicyMock).toHaveBeenCalledWith({ orgId: ORG_ID }, expect.objectContaining({ name: 'Policy' }), 'user-1');
+    });
+
     function partnerCreateApp() {
       const appPartner = new Hono();
       appPartner.use('*', async (c, next) => {
@@ -295,28 +405,10 @@ describe('configurationPolicies CRUD routes', () => {
       return appPartner;
     }
 
-    it('tolerates a UNIQUE violation on the auto-assign (still 201, no rollback)', async () => {
-      const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
-      createConfigPolicyMock.mockResolvedValue(policy);
-      // Real isPgUniqueViolation is used (not mocked) — SQLSTATE 23505 must be swallowed.
-      assignPolicyMock.mockRejectedValue({ code: '23505' });
-
-      const res = await partnerCreateApp().request('/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner' }),
-      });
-
-      expect(res.status).toBe(201);
-      // The policy already has its partner assignment — do NOT roll it back.
-      expect(deleteConfigPolicyMock).not.toHaveBeenCalled();
-    });
-
-    it('rolls back the orphaned policy and 500s when the auto-assign fails for a non-unique reason', async () => {
+    it('surfaces a 500 when the auto-assign fails, WITHOUT a compensating delete (request transaction rolls back)', async () => {
       const policy = { id: POLICY_ID, name: 'Partner-wide', orgId: null, partnerId: PARTNER_ID, status: 'active' };
       createConfigPolicyMock.mockResolvedValue(policy);
       assignPolicyMock.mockRejectedValue(new Error('RLS 0-row write'));
-      deleteConfigPolicyMock.mockResolvedValue({ id: POLICY_ID });
 
       const res = await partnerCreateApp().request('/', {
         method: 'POST',
@@ -324,10 +416,12 @@ describe('configurationPolicies CRUD routes', () => {
         body: JSON.stringify({ name: 'Partner-wide', ownerScope: 'partner' }),
       });
 
-      // A committed-but-unassigned partner-wide policy is the exact failure this
-      // feature prevents, so the orphan is deleted and the failure surfaced.
+      // Both inserts share the request-level withDbAccessContext transaction, so
+      // the failed seed rolls the policy insert back automatically — the handler
+      // must NOT issue an explicit compensating delete (which would double-handle
+      // rollback and, on a UNIQUE violation, run against an already-aborted txn).
       expect(res.status).toBe(500);
-      expect(deleteConfigPolicyMock).toHaveBeenCalledWith(POLICY_ID, expect.anything());
+      expect(deleteConfigPolicyMock).not.toHaveBeenCalled();
     });
 
     it('rejects ownerScope:partner for an org-scope caller (no partner) (#1724)', async () => {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -1,10 +1,12 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
-import { isPgUniqueViolation } from '../../utils/pgErrors';
+import { db } from '../../db';
+import { organizations } from '../../db/schema';
 import {
   createConfigPolicy,
   getConfigPolicy,
@@ -83,29 +85,13 @@ crudRoutes.post(
       // otherwise a partner-wide policy resolves to NO devices until the user
       // separately discovers the Assignments tab (#1724 follow-up).
       //
-      // The two inserts aren't in one transaction, so guard the seed: a
-      // UNIQUE(configPolicyId, level, targetId) collision is impossible on a
-      // fresh policy and is tolerated defensively; any OTHER failure would leave
-      // a committed-but-unassigned partner-wide policy (the exact "resolves to no
-      // devices" state this feature prevents), so roll the orphan back and
-      // surface the failure with its id rather than a bare, anonymous 500.
-      try {
-        await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);
-      } catch (err) {
-        if (!isPgUniqueViolation(err)) {
-          console.error(
-            `[ConfigPolicy] Partner-wide auto-assign failed for policy ${policy.id} (partner ${auth.partnerId}); rolling back orphan`,
-            err
-          );
-          await deleteConfigPolicy(policy.id, auth).catch((cleanupErr) => {
-            console.error(
-              `[ConfigPolicy] Failed to roll back orphaned partner-wide policy ${policy.id}`,
-              cleanupErr
-            );
-          });
-          throw err;
-        }
-      }
+      // Both writes run inside the request-level transaction: authMiddleware
+      // wraps the handler in withDbAccessContext, which is a single
+      // baseDb.transaction. If this seed throws, the policy insert above rolls
+      // back with it — a committed-but-unassigned partner-wide policy (the exact
+      // "resolves to no devices" state this feature prevents) can't be left
+      // behind, and no compensating delete is needed.
+      await assignPolicy(policy.id, 'partner', auth.partnerId, 0, auth.user.id);
       writeRouteAudit(c, {
         orgId: null,
         action: 'config_policy.create',
@@ -119,22 +105,48 @@ crudRoutes.post(
 
     let orgId = data.orgId;
     if (auth.scope === 'organization') {
+      // Org scope always owns the policy in its own org — a client-supplied
+      // orgId is ignored so an org user can't create a policy in another org.
       if (!auth.orgId) return c.json({ error: 'Organization context required' }, 403);
       orgId = auth.orgId;
     } else if (auth.scope === 'partner') {
       if (!orgId) {
-        const singleOrg = auth.accessibleOrgIds?.[0];
-        if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
-          orgId = singleOrg;
+        const accessibleOrgs = auth.accessibleOrgIds ?? [];
+        const [onlyOrg] = accessibleOrgs;
+        if (accessibleOrgs.length === 1 && onlyOrg) {
+          orgId = onlyOrg;
         } else {
-          return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+          // Distinguish "nothing to own it" from "ambiguous which org" so the
+          // caller gets an actionable message rather than a misleading one.
+          return c.json(
+            {
+              error:
+                accessibleOrgs.length === 0
+                  ? 'No accessible organization to own this policy'
+                  : 'orgId is required when the partner has multiple organizations',
+            },
+            400
+          );
         }
       }
       if (!auth.canAccessOrg(orgId)) return c.json({ error: 'Access to this organization denied' }, 403);
-    } else if (auth.scope === 'system' && !orgId) {
-      return c.json({ error: 'orgId is required' }, 400);
+    } else if (auth.scope === 'system') {
+      if (!orgId) return c.json({ error: 'orgId is required' }, 400);
+      // System scope bypasses the org-access checks above, so a non-existent
+      // orgId would otherwise fail as a raw FK 500 at insert time. Surface a
+      // clean 404 instead. (System context sees all orgs — no RLS filter.)
+      const [org] = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, orgId))
+        .limit(1);
+      if (!org) return c.json({ error: 'Organization not found' }, 404);
     }
 
+    // Org-owned policies are intentionally NOT auto-assigned (unlike partner-wide
+    // above): an org policy is commonly meant for a specific site/group/device,
+    // so auto-assigning it at the org level would silently over-apply to every
+    // device in the org. The user picks the assignment target explicitly.
     const policy = await createConfigPolicy({ orgId: orgId as string }, data, auth.user.id);
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/configurationPolicies/crud.ts
+++ b/apps/api/src/routes/configurationPolicies/crud.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import { PERMISSIONS } from '../../services/permissions';
 import { db } from '../../db';
 import { organizations } from '../../db/schema';
 import {
@@ -14,6 +14,8 @@ import {
   updateConfigPolicy,
   deleteConfigPolicy,
   assignPolicy,
+  canManagePartnerWidePolicies,
+  PartnerWideWriteDeniedError,
 } from '../../services/configurationPolicy';
 import { invalidateRemoteAccessCache } from '../../services/remoteAccessPolicy';
 import {
@@ -72,10 +74,9 @@ crudRoutes.post(
       // subset of orgs — granting them partner-wide policy create would silently
       // push config (remote_access, PAM, monitoring, patch) to orgs they cannot
       // access. Only orgAccess='all' partner users (and system scope) may create
-      // partner-wide policies. requireConfigPolicyWrite (requirePermission)
-      // already populated c.get('permissions') with the caller's orgAccess.
-      const userPerms = c.get('permissions') as UserPermissions | undefined;
-      if (auth.scope !== 'system' && userPerms?.orgAccess !== 'all') {
+      // partner-wide policies. The same gate protects update/delete (enforced in
+      // the service) and feature-link/assignment writes (route gates).
+      if (!canManagePartnerWidePolicies(auth)) {
         return c.json({ error: 'Partner-wide policies require full partner org access (orgAccess must be "all")' }, 403);
       }
       const policy = await createConfigPolicy({ partnerId: auth.partnerId }, data, auth.user.id);
@@ -194,7 +195,13 @@ crudRoutes.patch(
       return c.json({ error: 'No updates provided' }, 400);
     }
 
-    const updated = await updateConfigPolicy(id, data, auth);
+    let updated;
+    try {
+      updated = await updateConfigPolicy(id, data, auth);
+    } catch (err) {
+      if (err instanceof PartnerWideWriteDeniedError) return c.json({ error: err.message }, 403);
+      throw err;
+    }
     if (!updated) return c.json({ error: 'Configuration policy not found' }, 404);
 
     invalidateRemoteAccessCache();
@@ -222,7 +229,13 @@ crudRoutes.delete(
     const auth = c.get('auth') as AuthContext;
     const { id } = c.req.valid('param');
 
-    const deleted = await deleteConfigPolicy(id, auth);
+    let deleted;
+    try {
+      deleted = await deleteConfigPolicy(id, auth);
+    } catch (err) {
+      if (err instanceof PartnerWideWriteDeniedError) return c.json({ error: err.message }, 403);
+      throw err;
+    }
     if (!deleted) return c.json({ error: 'Configuration policy not found' }, 404);
 
     invalidateRemoteAccessCache();

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -404,6 +404,27 @@ describe('featureLinks routes', () => {
       expect(addFeatureLinkMock).toHaveBeenCalled();
     });
 
+    it('ALLOWS linking a partner-owned SOFTWARE POLICY template on a partner-owned policy → 201 (#2126)', async () => {
+      validateFeaturePolicyExistsMock.mockResolvedValue({ valid: true });
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'software_policy' });
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'software_policy',
+          featurePolicyId: '55555555-5555-4555-8555-555555555555',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(validateFeaturePolicyExistsMock).toHaveBeenCalledWith(
+        'software_policy',
+        '55555555-5555-4555-8555-555555555555',
+        expect.objectContaining({ orgId: null, partnerId: PARTNER_POLICY.partnerId })
+      );
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
     it('still rejects linking an org-scoped feature policy (non-patch) on a partner-owned policy → 400', async () => {
       const res = await app.request(`/${POLICY_ID}/features`, {
         method: 'POST',

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -281,6 +281,71 @@ describe('featureLinks routes', () => {
     beforeEach(() => {
       getConfigPolicyMock.mockResolvedValue(PARTNER_POLICY);
       addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'backup' });
+      // Writes on a partner-wide policy require the partner-wide capability —
+      // rebuild the app with a full-partner-admin auth so the tests below
+      // exercise the per-feature-type behavior, not the capability gate.
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_POLICY.partnerId,
+          partnerOrgAccess: 'all',
+        }));
+        await next();
+      });
+      app.route('/', featureLinkRoutes);
+    });
+
+    it('denies ANY feature-link write on a partner-wide policy without full partner org access → 403', async () => {
+      // A 'selected'-access partner user can SEE the partner-wide policy but
+      // must not edit its feature links (all-orgs blast radius, same rationale
+      // as the create/assign guards).
+      const appSelected = new Hono();
+      appSelected.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_POLICY.partnerId,
+          partnerOrgAccess: 'selected',
+        }));
+        await next();
+      });
+      appSelected.route('/', featureLinkRoutes);
+
+      const res = await appSelected.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureType: 'patch', inlineSettings: { scheduleTime: '02:00' } }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(String(body.error)).toMatch(/full partner org access/);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('denies feature-link DELETE on a partner-wide policy without full partner org access → 403', async () => {
+      getConfigPolicyMock.mockResolvedValue({
+        ...PARTNER_POLICY,
+        featureLinks: [{ id: LINK_ID, featureType: 'patch' }],
+      });
+      const appSelected = new Hono();
+      appSelected.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_POLICY.partnerId,
+          partnerOrgAccess: 'selected',
+        }));
+        await next();
+      });
+      appSelected.route('/', featureLinkRoutes);
+
+      const res = await appSelected.request(`/${POLICY_ID}/features/${LINK_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(403);
+      expect(removeFeatureLinkMock).not.toHaveBeenCalled();
     });
 
     // onedrive_helper is also in ORG_SCOPED_ONLY_FEATURES but isn't accepted by

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -446,8 +446,9 @@ describe('featureLinks routes', () => {
     });
 
     it('still rejects linking an org-scoped feature policy (compliance) on a partner-owned policy → 400', async () => {
-      // compliance links automationPolicies, which is still org-only (#2129
-      // will migrate it). security graduated to PARTNER_LINKABLE in #2127.
+      // TODO(#2129): compliance links automationPolicies, which is still
+      // org-only — when #2129 migrates it, switch this test to another
+      // org-only linked type. security graduated to PARTNER_LINKABLE in #2127.
       const res = await app.request(`/${POLICY_ID}/features`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -285,24 +285,75 @@ describe('featureLinks routes', () => {
 
     // onedrive_helper is also in ORG_SCOPED_ONLY_FEATURES but isn't accepted by
     // addFeatureLinkSchema's enum, so it can't reach the route at all — only
-    // backup and patch are exercisable here.
-    it.each(['backup', 'patch'])(
-      'rejects the %s feature on a partner-owned policy → 400 (no insert)',
-      async (featureType) => {
-        const res = await app.request(`/${POLICY_ID}/features`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          // Valid body (passes the schema refine) so we exercise the
-          // partner-wide guard, not the generic validator.
-          body: JSON.stringify({ featureType, inlineSettings: { enabled: true } }),
-        });
+    // backup is exercisable here. patch is deliberately NOT rejected: rings are
+    // partner-axis and the scheduler groups by device org (#1724 follow-up).
+    it('rejects the backup feature on a partner-owned policy → 400 (no insert)', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // Valid body (passes the schema refine) so we exercise the
+        // partner-wide guard, not the generic validator.
+        body: JSON.stringify({ featureType: 'backup', inlineSettings: { enabled: true } }),
+      });
 
-        expect(res.status).toBe(400);
-        const body = await res.json();
-        expect(String(body.error)).toContain('partner-wide');
-        expect(addFeatureLinkMock).not.toHaveBeenCalled();
-      }
-    );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(String(body.error)).toContain('partner-wide');
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('ALLOWS the patch feature on a partner-owned policy → 201 (rings are partner-axis)', async () => {
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'patch' });
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // Minimal valid patch inline settings (defaults fill the rest).
+        body: JSON.stringify({ featureType: 'patch', inlineSettings: { scheduleTime: '02:00' } }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('ALLOWS linking a patch update ring (featurePolicyId) on a partner-owned policy → 201', async () => {
+      validateFeaturePolicyExistsMock.mockResolvedValue({ valid: true });
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'patch' });
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'patch',
+          featurePolicyId: '44444444-4444-4444-4444-444444444444',
+          inlineSettings: { scheduleTime: '02:00' },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      // Validation must receive the policy's partnerId so it resolves the
+      // partner-axis ring without an owning org.
+      expect(validateFeaturePolicyExistsMock).toHaveBeenCalledWith(
+        'patch',
+        '44444444-4444-4444-4444-444444444444',
+        expect.objectContaining({ orgId: null, partnerId: PARTNER_POLICY.partnerId })
+      );
+      expect(addFeatureLinkMock).toHaveBeenCalled();
+    });
+
+    it('still rejects linking an org-scoped feature policy (non-patch) on a partner-owned policy → 400', async () => {
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'security',
+          featurePolicyId: '44444444-4444-4444-4444-444444444444',
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(String(body.error)).toContain('partner-owned');
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
 
     it('still allows an org-derived feature (security) on a partner-owned policy', async () => {
       addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'security' });

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -425,12 +425,34 @@ describe('featureLinks routes', () => {
       expect(addFeatureLinkMock).toHaveBeenCalled();
     });
 
-    it('still rejects linking an org-scoped feature policy (non-patch) on a partner-owned policy → 400', async () => {
+    it('ALLOWS linking a partner-owned SECURITY policy template on a partner-owned policy → 201 (#2127)', async () => {
+      validateFeaturePolicyExistsMock.mockResolvedValue({ valid: true });
+      addFeatureLinkMock.mockResolvedValue({ id: LINK_ID, featureType: 'security' });
       const res = await app.request(`/${POLICY_ID}/features`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           featureType: 'security',
+          featurePolicyId: '66666666-6666-4666-8666-666666666666',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(validateFeaturePolicyExistsMock).toHaveBeenCalledWith(
+        'security',
+        '66666666-6666-4666-8666-666666666666',
+        expect.objectContaining({ orgId: null, partnerId: PARTNER_POLICY.partnerId })
+      );
+    });
+
+    it('still rejects linking an org-scoped feature policy (compliance) on a partner-owned policy → 400', async () => {
+      // compliance links automationPolicies, which is still org-only (#2129
+      // will migrate it). security graduated to PARTNER_LINKABLE in #2127.
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'compliance',
           featurePolicyId: '44444444-4444-4444-4444-444444444444',
         }),
       });

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -18,6 +18,7 @@ import {
   remoteAccessInlineSettingsSchema,
   canManagePartnerWidePolicies,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  PARTNER_LINKABLE_FEATURE_TYPES,
 } from '../../services/configurationPolicy';
 import {
   addFeatureLinkSchema,
@@ -98,10 +99,11 @@ featureLinkRoutes.post(
 
     // Validate the referenced feature policy exists (only when a policy ID is provided)
     if (data.featurePolicyId) {
-      // Referenced feature policies are org-scoped and can't be linked to a
-      // partner-owned policy (org_id NULL, #1724) — EXCEPT patch update rings,
-      // which are partner-axis and belong on a partner-wide policy.
-      if (policy.orgId === null && data.featureType !== 'patch') {
+      // Most referenced feature policies are org-scoped and can't be linked to
+      // a partner-owned policy (org_id NULL, #1724) — EXCEPT the feature types
+      // whose standalone table supports partner ownership (update rings,
+      // software policies, ... — see PARTNER_LINKABLE_FEATURE_TYPES).
+      if (policy.orgId === null && !PARTNER_LINKABLE_FEATURE_TYPES.has(data.featureType)) {
         return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
       }
       const validation = await validateFeaturePolicyExists(
@@ -224,10 +226,8 @@ featureLinkRoutes.patch(
     }
 
     if (data.featurePolicyId !== undefined && data.featurePolicyId !== null) {
-      // Referenced feature policies are org-scoped and can't be linked to a
-      // partner-owned policy (org_id NULL, #1724) — EXCEPT patch update rings,
-      // which are partner-axis and belong on a partner-wide policy.
-      if (policy.orgId === null && existingLink.featureType !== 'patch') {
+      // Same partner-linkable exception as the POST route above.
+      if (policy.orgId === null && !PARTNER_LINKABLE_FEATURE_TYPES.has(existingLink.featureType as any)) {
         return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
       }
       const validation = await validateFeaturePolicyExists(

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -16,6 +16,8 @@ import {
   validateFeaturePolicyExists,
   pamInlineSettingsSchema,
   remoteAccessInlineSettingsSchema,
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../../services/configurationPolicy';
 import {
   addFeatureLinkSchema,
@@ -73,6 +75,13 @@ featureLinkRoutes.post(
 
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
+
+    // Feature links carry the policy's actual settings (patch schedules, PAM,
+    // remote access...), so editing them on a partner-wide policy has the same
+    // all-orgs blast radius as creating one — gate on the same capability.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
 
     // Partner-wide policies (org_id NULL, #1724) can't carry org-scoped feature
     // settings. Reject at write time so the scheduler/read-side stay consistent.
@@ -198,6 +207,12 @@ featureLinkRoutes.patch(
 
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
+
+    // Same all-orgs blast radius as the POST gate above.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const existingLink = policy.featureLinks.find((l: any) => l.id === linkId);
 
     if (!existingLink) {
@@ -302,6 +317,12 @@ featureLinkRoutes.delete(
 
     const policy = await getConfigPolicy(id, auth);
     if (!policy) return c.json({ error: 'Configuration policy not found' }, 404);
+
+    // Same all-orgs blast radius as the POST/PATCH gates above.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const existingLink = policy.featureLinks.find((l: any) => l.id === linkId);
     if (!existingLink) return c.json({ error: 'Feature link not found' }, 404);
     if (existingLink.featureType === 'patch' && !hasSatisfiedMfa(auth)) {

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -30,12 +30,16 @@ const requireConfigPolicyWrite = requirePermission(PERMISSIONS.DEVICES_WRITE.res
 
 // Feature types whose per-feature config is fundamentally org-scoped and cannot
 // be authored on a partner-wide policy (#1724): backup/onedrive_helper settings
-// carry a concrete org_id FK, and patch scheduling is org-batch only (the
-// scheduler iterates orgs, not partners). Rejecting these at the feature-link
-// write layer keeps the read side (effective-config resolution) and the write
-// side consistent — a partner-wide policy never advertises coverage the
-// scheduler won't deliver. See the PR scope note.
-const ORG_SCOPED_ONLY_FEATURES = new Set(['backup', 'onedrive_helper', 'patch']);
+// carry a concrete org_id FK, so a partner-wide policy has no owning org to
+// anchor them to. Rejecting these at the feature-link write layer keeps the
+// read side (effective-config resolution) and the write side consistent — a
+// partner-wide policy never advertises coverage that can't be delivered.
+//
+// patch is deliberately NOT here: update rings are partner-axis (partner_id, no
+// org_id) and the patch scheduler groups by each device's own org, so a
+// partner-wide patch policy resolves and schedules end-to-end across every org
+// under the partner. See configPolicyPatching.ts.
+const ORG_SCOPED_ONLY_FEATURES = new Set(['backup', 'onedrive_helper']);
 
 // GET /:id/features — list feature links for a policy
 featureLinkRoutes.get(
@@ -85,15 +89,16 @@ featureLinkRoutes.post(
 
     // Validate the referenced feature policy exists (only when a policy ID is provided)
     if (data.featurePolicyId) {
-      // Referenced feature policies are org-scoped; a partner-owned config
-      // policy (org_id NULL, #1724) cannot link one.
-      if (policy.orgId === null) {
+      // Referenced feature policies are org-scoped and can't be linked to a
+      // partner-owned policy (org_id NULL, #1724) — EXCEPT patch update rings,
+      // which are partner-axis and belong on a partner-wide policy.
+      if (policy.orgId === null && data.featureType !== 'patch') {
         return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
       }
       const validation = await validateFeaturePolicyExists(
         data.featureType,
         data.featurePolicyId,
-        policy.orgId
+        { orgId: policy.orgId, partnerId: policy.partnerId }
       );
       if (!validation.valid) {
         return c.json({ error: validation.error }, 400);
@@ -204,15 +209,16 @@ featureLinkRoutes.patch(
     }
 
     if (data.featurePolicyId !== undefined && data.featurePolicyId !== null) {
-      // Referenced feature policies are org-scoped; a partner-owned config
-      // policy (org_id NULL, #1724) cannot link one.
-      if (policy.orgId === null) {
+      // Referenced feature policies are org-scoped and can't be linked to a
+      // partner-owned policy (org_id NULL, #1724) — EXCEPT patch update rings,
+      // which are partner-axis and belong on a partner-wide policy.
+      if (policy.orgId === null && existingLink.featureType !== 'patch') {
         return c.json({ error: 'Cannot link an org-scoped feature policy to a partner-owned policy' }, 400);
       }
       const validation = await validateFeaturePolicyExists(
         existingLink.featureType as any,
         data.featurePolicyId,
-        policy.orgId
+        { orgId: policy.orgId, partnerId: policy.partnerId }
       );
       if (!validation.valid) {
         return c.json({ error: validation.error }, 400);

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -72,6 +72,10 @@ vi.mock('../../db/schema', () => ({
     siteId: 'devices.siteId',
     hostname: 'devices.hostname',
   },
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
 }));
 
 import { db } from '../../db';
@@ -451,6 +455,134 @@ describe('configurationPolicies patchJob routes', () => {
       expect(res.status).toBe(403);
       const json = await res.json();
       expect(json.error).toContain('policy organization');
+      expect(json.skipped.crossOrgDeviceIds).toEqual([device2]);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // ── Partner-wide policies (#1724 follow-up): one policy patches every org
+    //    under the partner. Scope guard verifies device.org.partnerId matches. ──
+    const PARTNER_ID = '88888888-8888-4888-8888-888888888888';
+
+    it('creates a partner-wide patch job spanning multiple orgs under the partner', async () => {
+      const orgA = ORG_ID;
+      const orgB = '99999999-9999-4999-8999-999999999999';
+      const device2 = '66666666-6666-4666-8666-666666666666';
+      getConfigPolicyMock.mockResolvedValue({
+        id: POLICY_ID,
+        status: 'active',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        name: 'Partner-wide',
+      });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({ orgId: null }));
+      vi.mocked(db.select)
+        // 1) device select
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: DEVICE_ID, orgId: orgA, hostname: 'host-a' },
+              { id: device2, orgId: orgB, hostname: 'host-b' },
+            ]),
+          }),
+        } as any)
+        // 2) organizations→partner select (partner-wide scope guard)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: orgA, partnerId: PARTNER_ID },
+              { id: orgB, partnerId: PARTNER_ID },
+            ]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+
+      const insertValuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'job-1' }]),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValuesMock } as any);
+
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          partnerId: PARTNER_ID,
+          accessibleOrgIds: [orgA, orgB],
+          canAccessOrg: (orgId: string) => orgId === orgA || orgId === orgB,
+        }));
+        await next();
+      });
+      app.route('/', patchJobRoutes);
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID, device2] }),
+      });
+
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.totalDevices).toBe(2);
+      // One patch_jobs row per device org (job insert grouped by org).
+      expect(insertValuesMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('denies a partner-wide patch job for a device whose org belongs to another partner', async () => {
+      const orgA = ORG_ID;
+      const foreignOrg = '99999999-9999-4999-8999-999999999999';
+      const foreignPartner = '55555555-5555-4555-8555-555555555555';
+      const device2 = '66666666-6666-4666-8666-666666666666';
+      getConfigPolicyMock.mockResolvedValue({
+        id: POLICY_ID,
+        status: 'active',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        name: 'Partner-wide',
+      });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({ orgId: null }));
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: DEVICE_ID, orgId: orgA, hostname: 'host-a' },
+              { id: device2, orgId: foreignOrg, hostname: 'host-foreign' },
+            ]),
+          }),
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: orgA, partnerId: PARTNER_ID },
+              { id: foreignOrg, partnerId: foreignPartner },
+            ]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          partnerId: PARTNER_ID,
+          // Caller can technically reach both orgs; the partner-scope guard is
+          // what must reject the foreign-partner device, not just RLS/access.
+          accessibleOrgIds: [orgA, foreignOrg],
+          canAccessOrg: () => true,
+        }));
+        await next();
+      });
+      app.route('/', patchJobRoutes);
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID, device2] }),
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error).toContain('policy partner');
       expect(json.skipped.crossOrgDeviceIds).toEqual([device2]);
       expect(db.insert).not.toHaveBeenCalled();
     });

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -6,7 +6,7 @@ import type { AuthContext } from '../../middleware/auth';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { db } from '../../db';
-import { patchJobs, devices } from '../../db/schema';
+import { patchJobs, devices, organizations } from '../../db/schema';
 import {
   checkDeviceMaintenanceWindow,
   resolvePatchConfigDetailsForDevice,
@@ -138,9 +138,6 @@ patchJobRoutes.post(
     const inaccessibleDeviceIds = targetDevices
       .filter((d) => !auth.canAccessOrg(d.orgId))
       .map((d) => d.id);
-    const crossOrgDeviceIds = accessibleDevices
-      .filter((d) => d.orgId !== policy.orgId)
-      .map((d) => d.id);
 
     if (accessibleDevices.length === 0) {
       return c.json({
@@ -149,9 +146,34 @@ patchJobRoutes.post(
       }, 404);
     }
 
+    // Scope guard: an org-owned policy can only patch devices in its own org. A
+    // partner-wide policy (org_id NULL, #1724) may patch devices across every
+    // org under its partner, but never another partner's — so each device's org
+    // must resolve to policy.partnerId. This is the partner-axis equivalent of
+    // the org check, layered on top of auth.canAccessOrg + RLS above.
+    let crossOrgDeviceIds: string[];
+    if (policy.orgId === null) {
+      const uniqueOrgIds = [...new Set(accessibleDevices.map((d) => d.orgId))];
+      const orgRows = await db
+        .select({ id: organizations.id, partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(inArray(organizations.id, uniqueOrgIds));
+      const orgPartner = new Map(orgRows.map((r) => [r.id, r.partnerId]));
+      crossOrgDeviceIds = accessibleDevices
+        .filter((d) => orgPartner.get(d.orgId) !== policy.partnerId)
+        .map((d) => d.id);
+    } else {
+      crossOrgDeviceIds = accessibleDevices
+        .filter((d) => d.orgId !== policy.orgId)
+        .map((d) => d.id);
+    }
+
     if (crossOrgDeviceIds.length > 0) {
       return c.json({
-        error: 'Configuration policy patch jobs can only target devices in the policy organization',
+        error:
+          policy.orgId === null
+            ? 'Configuration policy patch jobs can only target devices belonging to the policy partner'
+            : 'Configuration policy patch jobs can only target devices in the policy organization',
         skipped: { missingDeviceIds, inaccessibleDeviceIds, crossOrgDeviceIds },
       }, 403);
     }

--- a/apps/api/src/routes/security.test.ts
+++ b/apps/api/src/routes/security.test.ts
@@ -79,6 +79,7 @@ vi.mock('../services/permissions', () => ({
 }));
 
 import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
 import { queueCommand } from '../services/commandQueue';
 import {
   getLatestSecurityPostureForDevice,
@@ -909,5 +910,162 @@ describe('security routes', () => {
       expect(body.data.status).toBe('completed');
       expect(db.insert).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// ============================================================
+// Partner-wide security policies (#2127, epic #2135)
+// ============================================================
+
+describe('partner-wide security policies (#2127)', () => {
+  const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+  const POLICY_ID = '9b0ce8f4-21c0-4f65-8b0a-0b9f8bbf9a11';
+
+  let app: Hono;
+
+  function setPartnerAuth(partnerOrgAccess?: 'all' | 'selected' | 'none') {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        partnerOrgAccess,
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+        orgCondition: () => undefined,
+        canAccessOrg: () => true,
+      });
+      return next();
+    });
+  }
+
+  const CREATE_BODY = {
+    ownerScope: 'partner',
+    name: 'Fleet security baseline',
+    scanSchedule: 'daily',
+    realTimeProtection: true,
+    autoQuarantine: true,
+    severityThreshold: 'high',
+    exclusions: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).__denyPermission = false;
+    app = new Hono();
+    app.route('/security', securityRoutes);
+  });
+
+  it('creates a partner-wide policy (org NULL, partner from token) for a full partner admin', async () => {
+    setPartnerAuth('all');
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet security baseline', settings: {}, createdAt: new Date() },
+      ]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request('/security/policies', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: null, partnerId: PARTNER_ID })
+    );
+  });
+
+  it('denies partner-wide create without full partner org access (orgAccess selected)', async () => {
+    setPartnerAuth('selected');
+
+    const res = await app.request('/security/policies', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/full partner org access/);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('denies PUT on a partner-wide policy without the partner-wide capability', async () => {
+    setPartnerAuth('selected');
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet baseline', settings: {}, createdAt: new Date() },
+          ]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/security/policies/${POLICY_ID}`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/full partner org access/);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('allows PUT on a partner-wide policy for a full partner admin', async () => {
+    setPartnerAuth('all');
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet baseline', settings: {}, createdAt: new Date() },
+          ]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Renamed', settings: {}, createdAt: new Date() },
+          ]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request(`/security/policies/${POLICY_ID}`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('denies partner-wide create for an org-scope caller (no partner)', async () => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: '11111111-1111-1111-1111-111111111111',
+        partnerId: null,
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        user: { id: 'user-1' },
+        orgCondition: () => undefined,
+        canAccessOrg: () => true,
+      });
+      return next();
+    });
+
+    const res = await app.request('/security/policies', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/security/policies.ts
+++ b/apps/api/src/routes/security/policies.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { securityPolicies } from '../../db/schema';
-import { requirePermission, requireScope } from '../../middleware/auth';
+import { requirePermission, requireScope, type AuthContext } from '../../middleware/auth';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
 import {
   listPoliciesQuerySchema,
   createPolicySchema,
@@ -15,6 +16,22 @@ import { getPolicyOrgId } from './helpers';
 
 export const policiesRoutes = new Hono();
 
+// Dual-axis access condition (#2127): org-owned rows the caller can reach OR
+// partner-wide rows (org_id NULL) owned by the caller's own partner. RLS
+// enforces the same at the DB layer; this app-layer condition keeps
+// partner-owned templates visible to reads that filter by auth.orgCondition
+// (which would otherwise exclude org_id IS NULL rows). Mirrors
+// softwarePolicyAccessCondition in routes/softwarePolicies.ts (#2126).
+function securityPolicyAccessCondition(auth: AuthContext): SQL | undefined {
+  const orgCond = auth.orgCondition(securityPolicies.orgId);
+  // System scope: no filter on either axis.
+  if (!orgCond) return undefined;
+  if (auth.partnerId) {
+    return sql`(${orgCond} OR (${securityPolicies.orgId} IS NULL AND ${securityPolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return orgCond;
+}
+
 policiesRoutes.get(
   '/policies',
   requireScope('organization', 'partner', 'system'),
@@ -24,8 +41,8 @@ policiesRoutes.get(
     const query = c.req.valid('query');
 
     const conditions = [];
-    const orgCondition = auth.orgCondition(securityPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const accessCondition = securityPolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     const rows = await db
       .select()
@@ -37,7 +54,9 @@ policiesRoutes.get(
       const settings = (row.settings ?? {}) as Record<string, unknown>;
       return {
         id: row.id,
+        // null orgId = partner-wide ("All organizations") template (#2127)
         orgId: row.orgId,
+        partnerId: row.partnerId,
         name: row.name,
         description: typeof settings.description === 'string' ? settings.description : undefined,
         providerId: typeof settings.providerId === 'string' ? settings.providerId : undefined,
@@ -85,16 +104,33 @@ policiesRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const payload = c.req.valid('json');
-    const orgId = getPolicyOrgId(auth);
 
-    if (!orgId) {
-      return c.json({ error: 'Unable to determine target organization for policy creation' }, 400);
+    // Ownership axis (#2127). Partner-wide templates apply to devices in ALL
+    // orgs under the partner, so creation is gated on the partner-wide
+    // capability — same gate as software/config policies. The partner is
+    // ALWAYS derived from the caller's own token.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (payload.ownerScope === 'partner') {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner-wide security policies require partner scope' }, 403);
+      }
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: 'Partner-wide security policies require full partner org access (orgAccess must be "all")' }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgId = getPolicyOrgId(auth);
+      if (!orgId) {
+        return c.json({ error: 'Unable to determine target organization for policy creation' }, 400);
+      }
+      owner = { orgId, partnerId: null };
     }
 
     const [policy] = await db
       .insert(securityPolicies)
       .values({
-        orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: payload.name,
         settings: {
           description: payload.description,
@@ -113,6 +149,8 @@ policiesRoutes.post(
 
     return c.json({ data: {
       id: policy.id,
+      orgId: policy.orgId,
+      partnerId: policy.partnerId,
       name: policy.name,
       description: payload.description,
       providerId: payload.providerId,
@@ -139,9 +177,9 @@ policiesRoutes.put(
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
 
-    const conditions = [eq(securityPolicies.id, id)];
-    const orgCondition = auth.orgCondition(securityPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const conditions: SQL[] = [eq(securityPolicies.id, id)];
+    const accessCondition = securityPolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     const [existing] = await db
       .select()
@@ -151,6 +189,13 @@ policiesRoutes.put(
 
     if (!existing) {
       return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    // Partner-wide templates are READABLE by any member of the partner but
+    // administrable only with the partner-wide capability — editing the AV/EDR
+    // baseline changes enforcement across every org under the partner.
+    if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const existingSettings = (existing.settings ?? {}) as Record<string, unknown>;

--- a/apps/api/src/routes/security/policies.ts
+++ b/apps/api/src/routes/security/policies.ts
@@ -17,16 +17,17 @@ import { getPolicyOrgId } from './helpers';
 export const policiesRoutes = new Hono();
 
 // Dual-axis access condition (#2127): org-owned rows the caller can reach OR
-// partner-wide rows (org_id NULL) owned by the caller's own partner. RLS
-// enforces the same at the DB layer; this app-layer condition keeps
-// partner-owned templates visible to reads that filter by auth.orgCondition
-// (which would otherwise exclude org_id IS NULL rows). Mirrors
-// softwarePolicyAccessCondition in routes/softwarePolicies.ts (#2126).
+// partner-wide rows (org_id NULL) owned by the caller's own partner. This
+// app-layer condition keeps partner-owned templates visible to reads that
+// filter by auth.orgCondition (which would otherwise exclude org_id IS NULL
+// rows). RLS is STRICTER, not identical: breeze_has_partner_access only passes
+// for partner-scope callers, so the branch is gated on partner scope to keep
+// app and DB in agreement. Mirrors softwarePolicyAccessCondition (#2126).
 function securityPolicyAccessCondition(auth: AuthContext): SQL | undefined {
   const orgCond = auth.orgCondition(securityPolicies.orgId);
   // System scope: no filter on either axis.
   if (!orgCond) return undefined;
-  if (auth.partnerId) {
+  if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${orgCond} OR (${securityPolicies.orgId} IS NULL AND ${securityPolicies.partnerId} = ${auth.partnerId}))`;
   }
   return orgCond;

--- a/apps/api/src/routes/security/schemas.ts
+++ b/apps/api/src/routes/security/schemas.ts
@@ -168,6 +168,13 @@ export const listPoliciesQuerySchema = z.object({
 
 export const createPolicySchema = z.object({
   name: z.string().min(1).max(255),
+  // Ownership axis (#2127, mirrors software/config policies). 'organization'
+  // (default) = classic org-scoped policy. 'partner' = partner-wide / all-orgs
+  // template; the server derives the partner from the caller's own token — a
+  // client-supplied partner id is NEVER trusted. Create-only: ownership is
+  // immutable, so updatePolicySchema omits it (which also keeps it out of the
+  // settings JSONB the PUT handler spreads the payload into).
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   description: z.string().optional(),
   providerId: z.string().optional(),
   scanSchedule: z.enum(['daily', 'weekly', 'monthly', 'manual']).default('weekly'),
@@ -181,7 +188,8 @@ export const createPolicySchema = z.object({
 // v3), which would silently reset protection settings (realTimeProtection,
 // autoQuarantine, …) whenever a client patches an unrelated field. Strip the
 // create-time defaults from the defaulted fields so omitted keys stay absent.
-export const updatePolicySchema = createPolicySchema.partial().extend({
+// ownerScope is omitted: ownership is create-only (see createPolicySchema).
+export const updatePolicySchema = createPolicySchema.omit({ ownerScope: true }).partial().extend({
   scanSchedule: createPolicySchema.shape.scanSchedule.removeDefault().optional(),
   realTimeProtection: createPolicySchema.shape.realTimeProtection.removeDefault().optional(),
   autoQuarantine: createPolicySchema.shape.autoQuarantine.removeDefault().optional(),

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -124,9 +124,23 @@ function resolveOrgReadScope(auth: AuthContext, requestedOrgId?: string): OrgRea
 
 type PolicyStatus = 'allowed' | 'blocked' | 'audit' | 'no_policy';
 
-async function getPolicyStatusMap(orgFilter: SQL | undefined): Promise<Map<string, PolicyStatus>> {
+async function getPolicyStatusMap(
+  auth: AuthContext,
+  orgFilter: SQL | undefined
+): Promise<Map<string, PolicyStatus>> {
   const conditions: SQL[] = [eq(softwarePolicies.isActive, true)];
-  if (orgFilter) conditions.push(orgFilter);
+  // Dual-axis (#2126): software policies can be partner-wide templates
+  // (org_id NULL). Those govern every org under the partner, so the badge
+  // must include them — otherwise titles blocked by a partner-wide blocklist
+  // render as no_policy. Partner-scope callers only; RLS hides partner rows
+  // from org-scope tokens regardless.
+  if (orgFilter) {
+    conditions.push(
+      auth.scope === 'partner' && auth.partnerId
+        ? (sql`(${orgFilter} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))` as SQL)
+        : orgFilter
+    );
+  }
   const policies = await db
     .select({
       mode: softwarePolicies.mode,
@@ -302,7 +316,7 @@ softwareInventoryRoutes.get('/', requireSoftwareInventoryRead, zValidator('query
   `);
 
   // Build policy status map
-  const policyStatusMap = await getPolicyStatusMap(orgScope.applyTo(softwarePolicies.orgId));
+  const policyStatusMap = await getPolicyStatusMap(auth, orgScope.applyTo(softwarePolicies.orgId));
 
   // Process results
   const data = (rows as unknown as Array<{

--- a/apps/api/src/routes/softwarePolicies.test.ts
+++ b/apps/api/src/routes/softwarePolicies.test.ts
@@ -33,7 +33,7 @@ vi.mock('../db/schema', () => ({
     remediationStatus: 'softwareComplianceStatus.remediationStatus',
     lastRemediationAttempt: 'softwareComplianceStatus.lastRemediationAttempt',
   },
-  softwarePolicies: { id: 'id', orgId: 'orgId', mode: 'mode', name: 'name', isActive: 'isActive' },
+  softwarePolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', mode: 'mode', name: 'name', isActive: 'isActive', updatedAt: 'updatedAt' },
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -533,5 +533,166 @@ describe('GET /violations — site scope', () => {
     expect((await res.json()).total).toBe(2);
     expect(whereArgs).toHaveLength(1);
     expect(dumpSql(whereArgs[0])).not.toContain('devices.siteId');
+  });
+});
+
+// ============================================================
+// Partner-wide ownership (#2126, epic #2135)
+// ============================================================
+
+describe('partner-wide software policies (#2126)', () => {
+  const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+  const ORG_ID = '11111111-1111-1111-1111-111111111111';
+  const POLICY_ID = '22222222-2222-2222-2222-222222222222';
+
+  let app: Hono;
+
+  function setPartnerAuth(partnerOrgAccess?: 'all' | 'selected' | 'none') {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        partnerOrgAccess,
+        accessibleOrgIds: [ORG_ID],
+        canAccessOrg: (orgId: string) => orgId === ORG_ID,
+        orgCondition: () => undefined,
+        user: { id: 'user-123', email: 'test@example.com' },
+      });
+      return next();
+    });
+  }
+
+  function mockPartnerPolicyLookup() {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, mode: 'blocklist', name: 'Partner template' },
+          ]),
+        }),
+      }),
+    } as any);
+  }
+
+  const CREATE_BODY = {
+    ownerScope: 'partner',
+    name: 'Fleet blocklist',
+    mode: 'blocklist',
+    rules: { software: [{ name: 'BitTorrent' }] },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/', softwarePoliciesRoutes);
+  });
+
+  it('creates a partner-wide policy (org NULL, partner from token) for a full partner admin', async () => {
+    setPartnerAuth('all');
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([
+        { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet blocklist', mode: 'blocklist', enforceMode: false },
+      ]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: null, partnerId: PARTNER_ID })
+    );
+  });
+
+  it('denies partner-wide create without full partner org access (orgAccess selected)', async () => {
+    setPartnerAuth('selected');
+
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/full partner org access/);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('denies partner-wide create for an org-scope caller (no partner)', async () => {
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: ORG_ID,
+        partnerId: null,
+        accessibleOrgIds: [ORG_ID],
+        canAccessOrg: (orgId: string) => orgId === ORG_ID,
+        orgCondition: () => undefined,
+        user: { id: 'user-123' },
+      });
+      return next();
+    });
+
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(CREATE_BODY),
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('denies PATCH on a partner-wide policy without the partner-wide capability', async () => {
+    setPartnerAuth('selected');
+    mockPartnerPolicyLookup();
+
+    const res = await app.request(`/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/full partner org access/);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('denies DELETE on a partner-wide policy without the partner-wide capability', async () => {
+    setPartnerAuth('none');
+    mockPartnerPolicyLookup();
+
+    const res = await app.request(`/${POLICY_ID}`, { method: 'DELETE' });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/full partner org access/);
+  });
+
+  it('allows PATCH on a partner-wide policy for a full partner admin', async () => {
+    setPartnerAuth('all');
+    mockPartnerPolicyLookup();
+    const updateChain: any = {
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            { id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Renamed', mode: 'blocklist' },
+          ]),
+        }),
+      }),
+    };
+    vi.mocked(db.update).mockReturnValue(updateChain);
+
+    const res = await app.request(`/${POLICY_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(db.update).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -158,16 +158,19 @@ export function resolveOrgIdForWrite(
 }
 
 // Dual-axis access condition (#2126): org-owned rows the caller can reach OR
-// partner-wide rows (org_id NULL) owned by the caller's own partner. RLS
-// enforces the same at the DB layer; this app-layer condition keeps
-// partner-owned templates visible to reads that filter by auth.orgCondition
-// (which would otherwise exclude org_id IS NULL rows). Mirrors
-// policyAccessCondition in services/configurationPolicy.ts.
+// partner-wide rows (org_id NULL) owned by the caller's own partner. This
+// app-layer condition keeps partner-owned templates visible to reads that
+// filter by auth.orgCondition (which would otherwise exclude org_id IS NULL
+// rows). RLS is STRICTER, not identical: breeze_has_partner_access only passes
+// for partner-scope callers, so org-scope tokens (which also carry a
+// partnerId) never see partner-wide rows regardless of the app condition —
+// proven by softwarePoliciesPartnerRls.integration.test.ts. Gate the branch on
+// partner scope so app and DB agree.
 function softwarePolicyAccessCondition(auth: AuthContext): SQL | undefined {
   const orgCond = auth.orgCondition(softwarePolicies.orgId);
   // System scope: no filter on either axis.
   if (!orgCond) return undefined;
-  if (auth.partnerId) {
+  if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${orgCond} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`;
   }
   return orgCond;

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -16,6 +16,7 @@ import {
   normalizeSoftwarePolicyRules,
   recordSoftwarePolicyAudit,
 } from '../services/softwarePolicyService';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { captureException } from '../services/sentry';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 
@@ -90,6 +91,12 @@ const listPoliciesQuerySchema = z.object({
 
 const createPolicySchema = z.object({
   orgId: z.string().guid().optional(),
+  // Ownership axis (#2126, mirroring config policies #1724). 'organization'
+  // (default) = classic org-scoped policy. 'partner' = partner-wide / all-orgs
+  // template; the server derives the partner from the caller's own token —
+  // a client-supplied partner id is NEVER trusted. orgId is ignored when
+  // ownerScope is 'partner'.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(200),
   description: z.string().max(4000).optional(),
   mode: z.enum(['allowlist', 'blocklist', 'audit']),
@@ -150,10 +157,26 @@ export function resolveOrgIdForWrite(
   return { error: 'orgId is required for this scope' };
 }
 
+// Dual-axis access condition (#2126): org-owned rows the caller can reach OR
+// partner-wide rows (org_id NULL) owned by the caller's own partner. RLS
+// enforces the same at the DB layer; this app-layer condition keeps
+// partner-owned templates visible to reads that filter by auth.orgCondition
+// (which would otherwise exclude org_id IS NULL rows). Mirrors
+// policyAccessCondition in services/configurationPolicy.ts.
+function softwarePolicyAccessCondition(auth: AuthContext): SQL | undefined {
+  const orgCond = auth.orgCondition(softwarePolicies.orgId);
+  // System scope: no filter on either axis.
+  if (!orgCond) return undefined;
+  if (auth.partnerId) {
+    return sql`(${orgCond} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return orgCond;
+}
+
 async function getPolicyWithAccess(policyId: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(softwarePolicies.id, policyId)];
-  const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-  if (orgCondition) conditions.push(orgCondition);
+  const accessCondition = softwarePolicyAccessCondition(auth);
+  if (accessCondition) conditions.push(accessCondition);
 
   const [policy] = await db
     .select()
@@ -193,8 +216,8 @@ softwarePoliciesRoutes.get(
     const query = c.req.valid('query');
 
     const conditions: SQL[] = [];
-    const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const accessCondition = softwarePolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
     if (query.mode) conditions.push(eq(softwarePolicies.mode, query.mode));
     conditions.push(eq(softwarePolicies.isActive, query.isActive === undefined ? true : query.isActive === 'true'));
 
@@ -235,16 +258,32 @@ softwarePoliciesRoutes.post(
     const auth = c.get('auth');
     const payload = c.req.valid('json');
 
-    // The frontend always sends ?orgId=<currentOrgId> on partner-scope POSTs,
-    // not in the JSON body. Reading only from payload.orgId left partner-scope
-    // users with no resolvable org (#808: "orgId is required for this scope"
-    // after the underlying 500 from #807 was fixed).
-    const resolvedOrg = resolveOrgIdForWrite(
-      auth,
-      payload.orgId ?? c.req.query('orgId') ?? undefined
-    );
-    if (!resolvedOrg.orgId) {
-      return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+    // Ownership axis (#2126). Partner-wide templates push rules to devices in
+    // ALL orgs under the partner (including orgs created later), so creation is
+    // gated on the partner-wide capability — same gate as configuration
+    // policies. The partner is ALWAYS derived from the caller's own token.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (payload.ownerScope === 'partner') {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner-wide software policies require partner scope' }, 403);
+      }
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: 'Partner-wide software policies require full partner org access (orgAccess must be "all")' }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      // The frontend always sends ?orgId=<currentOrgId> on partner-scope POSTs,
+      // not in the JSON body. Reading only from payload.orgId left partner-scope
+      // users with no resolvable org (#808: "orgId is required for this scope"
+      // after the underlying 500 from #807 was fixed).
+      const resolvedOrg = resolveOrgIdForWrite(
+        auth,
+        payload.orgId ?? c.req.query('orgId') ?? undefined
+      );
+      if (!resolvedOrg.orgId) {
+        return c.json({ error: resolvedOrg.error ?? 'Organization resolution failed' }, 400);
+      }
+      owner = { orgId: resolvedOrg.orgId, partnerId: null };
     }
 
     const rules = normalizeSoftwarePolicyRules(payload.rules);
@@ -255,7 +294,8 @@ softwarePoliciesRoutes.post(
     const [policy] = await db
       .insert(softwarePolicies)
       .values({
-        orgId: resolvedOrg.orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: payload.name,
         description: payload.description ?? null,
         mode: payload.mode,
@@ -280,6 +320,7 @@ softwarePoliciesRoutes.post(
 
     recordSoftwarePolicyAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'policy_created',
       actor: 'user',
@@ -440,6 +481,13 @@ softwarePoliciesRoutes.patch(
       return c.json({ error: 'Policy not found' }, 404);
     }
 
+    // Partner-wide templates are READABLE by any member of the partner but
+    // administrable only with the partner-wide capability — editing rules
+    // changes enforcement across every org under the partner.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const updates: Partial<typeof softwarePolicies.$inferInsert> = {
       updatedAt: new Date(),
     };
@@ -476,6 +524,7 @@ softwarePoliciesRoutes.patch(
 
     recordSoftwarePolicyAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'policy_updated',
       actor: 'user',
@@ -518,6 +567,12 @@ softwarePoliciesRoutes.delete(
       return c.json({ error: 'Policy not found' }, 404);
     }
 
+    // Same partner-wide administration gate as PATCH: deleting a partner-wide
+    // template strips enforcement from every org under the partner.
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     try {
       await db.transaction(async (tx) => {
         await tx
@@ -536,6 +591,7 @@ softwarePoliciesRoutes.delete(
 
     recordSoftwarePolicyAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'policy_deleted',
       actor: 'user',
@@ -593,6 +649,7 @@ softwarePoliciesRoutes.post(
 
     recordSoftwarePolicyAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'compliance_check_requested',
       actor: 'user',
@@ -651,8 +708,13 @@ softwarePoliciesRoutes.post(
     // their allowlist — whether named explicitly via body.deviceIds or
     // selected implicitly from the policy's violations. `allowedSiteIds` is
     // only ever set for org-scope users, so `policy.orgId` is the relevant org.
+    // A partner-wide policy (orgId NULL, #2126) is RLS-invisible to org-scope
+    // callers, so a site-restricted caller can't normally reach this branch —
+    // if one somehow does, fail closed (empty allowlist = no devices).
     const perms = c.get('permissions') as UserPermissions | undefined;
-    const siteAllowedDeviceIds = await resolveSiteAllowedDeviceIds(policy.orgId, perms);
+    const siteAllowedDeviceIds = policy.orgId
+      ? await resolveSiteAllowedDeviceIds(policy.orgId, perms)
+      : (perms?.allowedSiteIds ? [] : null);
 
     if (targetDeviceIds.length > 0) {
       // Deny the whole batch (matching sentinelOne.ts hasDeniedDeviceSite) if
@@ -730,6 +792,7 @@ softwarePoliciesRoutes.post(
 
     recordSoftwarePolicyAudit({
       orgId: policy.orgId,
+      partnerId: policy.partnerId,
       policyId: policy.id,
       action: 'remediation_requested',
       actor: 'user',

--- a/apps/api/src/scripts/migrateToConfigPolicies.ts
+++ b/apps/api/src/scripts/migrateToConfigPolicies.ts
@@ -202,7 +202,9 @@ async function migrate() {
     ...orgFromAutomationPolicies,
     ...orgFromMaintenanceWindows,
   ]) {
-    orgIdSet.add(row.orgId);
+    // Partner-wide alert rules (org_id NULL, #2128) are not legacy org data —
+    // this migrator only sweeps per-org rows.
+    if (row.orgId !== null) orgIdSet.add(row.orgId);
   }
 
   if (orgIdSet.size === 0) {

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -209,7 +209,7 @@ registerTool({
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
       if (orgCondition) {
         conditions.push(
-          auth.partnerId
+          auth.scope === 'partner' && auth.partnerId
             ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
             : orgCondition
         );
@@ -236,7 +236,7 @@ registerTool({
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
       if (orgCondition) {
         conditions.push(
-          auth.partnerId
+          auth.scope === 'partner' && auth.partnerId
             ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
             : orgCondition
         );
@@ -300,7 +300,7 @@ registerTool({
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
       if (orgCondition) {
         conditions.push(
-          auth.partnerId
+          auth.scope === 'partner' && auth.partnerId
             ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
             : orgCondition
         );
@@ -364,7 +364,7 @@ registerTool({
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
       if (orgCondition) {
         conditions.push(
-          auth.partnerId
+          auth.scope === 'partner' && auth.partnerId
             ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
             : orgCondition
         );

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -23,6 +23,7 @@ import type { AiTool } from './aiTools';
 import { scheduleSoftwareComplianceCheck } from '../jobs/softwareComplianceWorker';
 import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
 import { normalizeSoftwarePolicyRules } from './softwarePolicyService';
+import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
@@ -203,8 +204,16 @@ registerTool({
 
     if (action === 'list') {
       const conditions: SQL[] = [];
+      // Dual-axis (#2126): org-owned rows the caller can reach OR partner-wide
+      // rows (org_id NULL) owned by the caller's own partner.
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-      if (orgCondition) conditions.push(orgCondition);
+      if (orgCondition) {
+        conditions.push(
+          auth.partnerId
+            ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
+            : orgCondition
+        );
+      }
       if (typeof input.mode === 'string') conditions.push(eq(softwarePolicies.mode, input.mode as 'allowlist' | 'blocklist' | 'audit'));
       if (typeof input.isActive === 'boolean') conditions.push(eq(softwarePolicies.isActive, input.isActive));
 
@@ -222,8 +231,16 @@ registerTool({
     if (action === 'get') {
       if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
       const conditions: SQL[] = [eq(softwarePolicies.id, input.policyId as string)];
+      // Dual-axis (#2126): org-owned rows the caller can reach OR partner-wide
+      // rows (org_id NULL) owned by the caller's own partner.
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-      if (orgCondition) conditions.push(orgCondition);
+      if (orgCondition) {
+        conditions.push(
+          auth.partnerId
+            ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
+            : orgCondition
+        );
+      }
 
       const [policy] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
       if (!policy) return JSON.stringify({ error: 'Policy not found or access denied' });
@@ -278,11 +295,25 @@ registerTool({
       if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
 
       const conditions: SQL[] = [eq(softwarePolicies.id, input.policyId as string)];
+      // Dual-axis (#2126): org-owned rows the caller can reach OR partner-wide
+      // rows (org_id NULL) owned by the caller's own partner.
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-      if (orgCondition) conditions.push(orgCondition);
+      if (orgCondition) {
+        conditions.push(
+          auth.partnerId
+            ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
+            : orgCondition
+        );
+      }
 
       const [existing] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
       if (!existing) return JSON.stringify({ error: 'Policy not found or access denied' });
+
+      // Partner-wide templates are administrable only with the partner-wide
+      // capability (same gate as the HTTP route).
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+      }
 
       const updates: Partial<typeof softwarePolicies.$inferInsert> = { updatedAt: new Date() };
       if (typeof input.name === 'string') updates.name = input.name;
@@ -328,11 +359,24 @@ registerTool({
       if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
 
       const conditions: SQL[] = [eq(softwarePolicies.id, input.policyId as string)];
+      // Dual-axis (#2126): org-owned rows the caller can reach OR partner-wide
+      // rows (org_id NULL) owned by the caller's own partner.
       const orgCondition = auth.orgCondition(softwarePolicies.orgId);
-      if (orgCondition) conditions.push(orgCondition);
+      if (orgCondition) {
+        conditions.push(
+          auth.partnerId
+            ? sql`(${orgCondition} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`
+            : orgCondition
+        );
+      }
 
       const [existing] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
       if (!existing) return JSON.stringify({ error: 'Policy not found or access denied' });
+
+      // Same partner-wide administration gate as update.
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+      }
 
       await db.transaction(async (tx) => {
         await tx

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -19,6 +19,8 @@ import {
   listFeatureLinks,
   listAssignments,
   validateAssignmentTarget,
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from './configurationPolicy';
 import {
   getConfigPolicyComplianceRuleInfo,
@@ -590,6 +592,14 @@ For link-only types, set featurePolicyId instead of inlineSettings:
       if (action === 'list') {
         const links = await listFeatureLinks(configPolicyId);
         return JSON.stringify({ configPolicyId, policyName: policy.name, featureLinks: links });
+      }
+
+      // Feature-link writes on a partner-wide policy (org_id NULL) push config
+      // to every org under the partner — same capability gate as the HTTP
+      // routes. (The add/update/remove services below don't take auth, so this
+      // handler is the enforcement point for the AI path.)
+      if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return JSON.stringify({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
       }
 
       if (action === 'add') {

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -79,6 +79,17 @@ function orgWhere(auth: AuthContext, orgIdCol: ReturnType<typeof sql.raw> | any)
   return auth.orgCondition(orgIdCol) ?? undefined;
 }
 
+// Dual-axis access for alert_rules (#2128): org-owned rules the caller can
+// reach OR partner-wide rules (org_id NULL) owned by the caller's own partner.
+function alertRuleWhere(auth: AuthContext): SQL | undefined {
+  const oc = alertRuleWhere(auth);
+  if (!oc) return undefined; // system scope
+  if (auth.partnerId) {
+    return sql`(${oc} OR (${alertRules.orgId} IS NULL AND ${alertRules.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
 /** Wrap handler in try-catch so DB/runtime errors return JSON instead of crashing */
 function safeHandler(toolName: string, fn: FleetHandler): FleetHandler {
   return async (input, auth) => {
@@ -1338,7 +1349,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list_rules') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, alertRules.orgId);
+        const oc = alertRuleWhere(auth);
         if (oc) conditions.push(oc);
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
@@ -1361,7 +1372,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'get_rule') {
         if (!input.ruleId) return JSON.stringify({ error: 'ruleId is required' });
         const conditions: SQL[] = [eq(alertRules.id, input.ruleId as string)];
-        const oc = orgWhere(auth, alertRules.orgId);
+        const oc = alertRuleWhere(auth);
         if (oc) conditions.push(oc);
 
         const [rule] = await db.select().from(alertRules).where(and(...conditions)).limit(1);
@@ -1391,7 +1402,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'test_rule') {
         if (!input.ruleId) return JSON.stringify({ error: 'ruleId is required' });
         const conditions: SQL[] = [eq(alertRules.id, input.ruleId as string)];
-        const oc = orgWhere(auth, alertRules.orgId);
+        const oc = alertRuleWhere(auth);
         if (oc) conditions.push(oc);
 
         const [rule] = await db.select().from(alertRules).where(and(...conditions)).limit(1);

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -82,9 +82,12 @@ function orgWhere(auth: AuthContext, orgIdCol: ReturnType<typeof sql.raw> | any)
 // Dual-axis access for alert_rules (#2128): org-owned rules the caller can
 // reach OR partner-wide rules (org_id NULL) owned by the caller's own partner.
 function alertRuleWhere(auth: AuthContext): SQL | undefined {
-  const oc = alertRuleWhere(auth);
+  const oc = orgWhere(auth, alertRules.orgId);
   if (!oc) return undefined; // system scope
-  if (auth.partnerId) {
+  // Only partner-scope callers hold the partner axis — RLS's
+  // breeze_has_partner_access is false for org-scope tokens even when they
+  // carry a partnerId, so adding the branch for them would be dead code.
+  if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${oc} OR (${alertRules.orgId} IS NULL AND ${alertRules.partnerId} = ${auth.partnerId}))`;
   }
   return oc;

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -16,6 +16,7 @@ import { eq, and, desc, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { ringAutoApproveSchema } from '@breeze/shared/validators';
+import { canManagePartnerWidePolicies } from './partnerWideAccess';
 
 /**
  * Defense-in-depth (#1317): the manage_update_rings AI tool writes `autoApprove`
@@ -60,6 +61,18 @@ function partnerWhere(auth: AuthContext, partnerIdCol: any): SQL | undefined {
   if (auth.partnerId) return eq(partnerIdCol, auth.partnerId);
   // org scope or partnerless: match nothing
   return sql`false`;
+}
+
+// Dual-axis access for software_policies (#2126): org-owned rows the caller can
+// reach OR partner-wide rows (org_id NULL) owned by the caller's own partner.
+// Mirrors softwarePolicyAccessCondition in routes/softwarePolicies.ts.
+function softwarePolicyWhere(auth: AuthContext): SQL | undefined {
+  const oc = orgWhere(auth, softwarePolicies.orgId);
+  if (!oc) return undefined; // system scope
+  if (auth.partnerId) {
+    return sql`(${oc} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
 }
 
 function safeHandler(toolName: string, fn: Handler): Handler {
@@ -259,6 +272,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         properties: {
           action: { type: 'string', enum: ['list', 'get', 'create', 'update'], description: 'Action to perform' },
           policyId: { type: 'string', description: 'Software policy UUID (required for get/update)' },
+          ownerScope: { type: 'string', enum: ['organization', 'partner'], description: 'Ownership for create: "organization" (default, owned by the current org) or "partner" (partner-wide "all orgs" template usable by every org under the partner; requires full partner org access)' },
           name: { type: 'string', description: 'Policy name (required for create)' },
           description: { type: 'string', description: 'Policy description' },
           mode: { type: 'string', enum: ['allowlist', 'blocklist', 'audit'], description: 'Policy mode (required for create)' },
@@ -277,8 +291,8 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, softwarePolicies.orgId);
-        if (oc) conditions.push(oc);
+        const access = softwarePolicyWhere(auth);
+        if (access) conditions.push(access);
         if (typeof input.mode === 'string') conditions.push(eq(softwarePolicies.mode, input.mode as any));
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
@@ -305,8 +319,8 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
       if (action === 'get') {
         if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
         const conditions: SQL[] = [eq(softwarePolicies.id, input.policyId as string)];
-        const oc = orgWhere(auth, softwarePolicies.orgId);
-        if (oc) conditions.push(oc);
+        const access = softwarePolicyWhere(auth);
+        if (access) conditions.push(access);
 
         const [policy] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
         if (!policy) return JSON.stringify({ error: 'Software policy not found or access denied' });
@@ -314,12 +328,26 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
       }
 
       if (action === 'create') {
-        if (!orgId) return JSON.stringify({ error: 'Organization context required' });
+        // Ownership axis (#2126): partner-wide templates apply to every org
+        // under the partner, so creation is gated on the same capability as
+        // the HTTP route. The partner is derived from the caller's own token.
+        let owner: { orgId: string | null; partnerId: string | null };
+        if (input.ownerScope === 'partner') {
+          if (!auth.partnerId) return JSON.stringify({ error: 'Partner-wide software policies require partner scope' });
+          if (!canManagePartnerWidePolicies(auth)) {
+            return JSON.stringify({ error: 'Partner-wide software policies require full partner org access (orgAccess must be "all")' });
+          }
+          owner = { orgId: null, partnerId: auth.partnerId };
+        } else {
+          if (!orgId) return JSON.stringify({ error: 'Organization context required' });
+          owner = { orgId, partnerId: null };
+        }
         if (!input.name) return JSON.stringify({ error: 'name is required' });
         if (!input.mode) return JSON.stringify({ error: 'mode is required (allowlist, blocklist, or audit)' });
 
         const rows = await db.insert(softwarePolicies).values({
-          orgId,
+          orgId: owner.orgId,
+          partnerId: owner.partnerId,
           name: input.name as string,
           description: (input.description as string) ?? null,
           mode: input.mode as any,
@@ -343,11 +371,17 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
       if (action === 'update') {
         if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
         const conditions: SQL[] = [eq(softwarePolicies.id, input.policyId as string)];
-        const oc = orgWhere(auth, softwarePolicies.orgId);
-        if (oc) conditions.push(oc);
+        const access = softwarePolicyWhere(auth);
+        if (access) conditions.push(access);
 
         const [existing] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Software policy not found or access denied' });
+
+        // Partner-wide templates are readable partner-wide but administrable
+        // only with the partner-wide capability (same gate as the HTTP route).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide software policy requires full partner org access (orgAccess must be "all")' });
+        }
 
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -69,7 +69,9 @@ function partnerWhere(auth: AuthContext, partnerIdCol: any): SQL | undefined {
 function softwarePolicyWhere(auth: AuthContext): SQL | undefined {
   const oc = orgWhere(auth, softwarePolicies.orgId);
   if (!oc) return undefined; // system scope
-  if (auth.partnerId) {
+  // Partner scope only — RLS's breeze_has_partner_access is false for
+  // org-scope tokens even when they carry a partnerId.
+  if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${oc} OR (${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${auth.partnerId}))`;
   }
   return oc;

--- a/apps/api/src/services/alertCorrelationRca.ts
+++ b/apps/api/src/services/alertCorrelationRca.ts
@@ -604,7 +604,15 @@ export async function buildAlertCorrelationRca(options: BuildRcaOptions): Promis
         })
         .from(alertRules)
         .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
-        .where(and(eq(alertRules.orgId, options.orgId), inArray(alertRules.id, ruleIds)))
+        .where(
+        and(
+          // ruleIds come from THIS org's own alerts, so a NULL-org row here can
+          // only be a partner-wide rule that legitimately fired for this org
+          // (#2128) — include it so the RCA narrative keeps the rule name.
+          or(eq(alertRules.orgId, options.orgId), isNull(alertRules.orgId)),
+          inArray(alertRules.id, ruleIds)
+        )
+      )
     : [];
   const ruleSources = new Map(ruleSourceRows.map((row) => [row.ruleId, row]));
   const configPolicyAlertRuleIds = [

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -16,10 +16,11 @@ import {
   devices,
   deviceGroups,
   deviceGroupMemberships,
+  organizations,
   sites,
   configPolicyAlertRules
 } from '../db/schema';
-import { eq, and, inArray, isNull, isNotNull, or } from 'drizzle-orm';
+import { eq, and, inArray, isNull, isNotNull, or, sql, type SQL } from 'drizzle-orm';
 import { evaluateConditions, evaluateAutoResolveConditions, interpolateTemplate } from './alertConditions';
 import { isCooldownActive, setCooldown, isConfigPolicyRuleCooling, markConfigPolicyRuleCooldown, recordStateTransition, isFlapping } from './alertCooldown';
 import { resolveAlertRulesForDevice, resolveMaintenanceConfigForDevice, isInMaintenanceWindow } from './featureConfigResolver';
@@ -349,6 +350,26 @@ export async function resolveAlert(
  * This function remains for legacy/backward compatibility with standalone alertRules.
  * New alert evaluation should use getApplicableRulesFromPolicy() instead.
  */
+/**
+ * Rule-ownership condition for EVALUATION (#2128): a device is governed by the
+ * standalone rules owned by its OWN org, plus the partner-wide rules (org_id
+ * NULL) owned by that org's partner. Exported for the offline detector, which
+ * runs the same standalone-rule sweep.
+ */
+export async function alertRuleOwnershipConditionForOrg(orgId: string): Promise<SQL> {
+  const [ownerOrg] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const partnerId = ownerOrg?.partnerId ?? null;
+  if (!partnerId) {
+    // Orphaned org (no partner): only its own rules apply.
+    return eq(alertRules.orgId, orgId) as unknown as SQL;
+  }
+  return sql`(${alertRules.orgId} = ${orgId} OR (${alertRules.orgId} IS NULL AND ${alertRules.partnerId} = ${partnerId}))`;
+}
+
 export async function getApplicableRules(deviceId: string): Promise<RuleWithTemplate[]> {
   // Get device info
   const [device] = await db
@@ -384,13 +405,15 @@ export async function getApplicableRules(deviceId: string): Promise<RuleWithTemp
     );
   }
 
-  // Get all active rules that apply to this device
+  // Get all active rules that apply to this device: the device org's own
+  // rules plus its partner's partner-wide rules (#2128).
+  const ownershipCondition = await alertRuleOwnershipConditionForOrg(device.orgId);
   const rules = await db
     .select()
     .from(alertRules)
     .where(
       and(
-        eq(alertRules.orgId, device.orgId),
+        ownershipCondition,
         eq(alertRules.isActive, true),
         or(...targetConditions)
       )
@@ -477,11 +500,14 @@ export async function evaluateDeviceAlerts(deviceId: string): Promise<string[]> 
         const title = interpolateTemplate(template.titleTemplate, templateContext);
         const message = interpolateTemplate(template.messageTemplate, templateContext);
 
-        // Create alert
+        // Create alert — ALWAYS in the DEVICE's org (alerts.org_id NOT NULL):
+        // a partner-wide rule (#2128) has no org of its own, and for org-owned
+        // rules device.orgId is identical to rule.orgId by the ownership match
+        // above. Notifications then route via the firing org's own channels.
         const alertId = await createAlert({
           ruleId: rule.id,
           deviceId,
-          orgId: rule.orgId,
+          orgId: device.orgId,
           severity: effectiveSeverity,
           title,
           message,

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -301,16 +301,6 @@ export async function loadPolicyLocalPatchConfig(
       })
     : storedInline;
 
-  // Patch feature links are rejected on partner-wide policies (org_id NULL) at the
-  // featureLinks route (#1724), so reaching this load path with a patch link and no
-  // org is a misconfiguration that escaped the write-side gate. Warn rather than
-  // silently resolving so it surfaces instead of masking. (Defense-in-depth: the
-  // ring still resolves from partnerId below since patch_policies is partner-axis.)
-  if (row.featurePolicyId && !row.orgId) {
-    console.warn(
-      `[configPolicyPatching] patch feature link ${row.featurePolicyId} on partner-wide config policy ${row.configPolicyId} (no org) — should have been blocked at write time`
-    );
-  }
   // Partner-wide config policies (#1724) carry partnerId directly and orgId === null;
   // org-scoped policies derive the partner from their org. Prefer the explicit
   // partnerId so partner-wide policies still resolve their (partner-axis) patch ring.

--- a/apps/api/src/services/configurationPolicy.onedrive.test.ts
+++ b/apps/api/src/services/configurationPolicy.onedrive.test.ts
@@ -6,13 +6,13 @@ import { validateFeaturePolicyExists } from './configurationPolicy';
 
 describe('onedrive_helper feature type', () => {
   it('rejects a featurePolicyId (inline-only feature)', async () => {
-    const res = await validateFeaturePolicyExists('onedrive_helper', 'some-id', 'org-1');
+    const res = await validateFeaturePolicyExists('onedrive_helper', 'some-id', { orgId: 'org-1', partnerId: null });
     expect(res.valid).toBe(false);
     expect(res.error).toMatch(/does not support featurePolicyId/);
   });
 
   it('accepts inline-only (no featurePolicyId)', async () => {
-    const res = await validateFeaturePolicyExists('onedrive_helper', null, 'org-1');
+    const res = await validateFeaturePolicyExists('onedrive_helper', null, { orgId: 'org-1', partnerId: null });
     expect(res.valid).toBe(true);
   });
 });

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -602,12 +602,12 @@ describe('updateFeatureLink — vulnerability inlineSettings service-layer valid
 
 describe('validateFeaturePolicyExists — vulnerability is inline-only', () => {
   it('rejects a featurePolicyId (vulnerability has no standalone policy table)', async () => {
-    const result = await validateFeaturePolicyExists('vulnerability', 'some-uuid', 'org-1');
+    const result = await validateFeaturePolicyExists('vulnerability', 'some-uuid', { orgId: 'org-1', partnerId: null });
     expect(result.valid).toBe(false);
   });
 
   it('accepts inline-only (no featurePolicyId)', async () => {
-    const result = await validateFeaturePolicyExists('vulnerability', null, 'org-1');
+    const result = await validateFeaturePolicyExists('vulnerability', null, { orgId: 'org-1', partnerId: null });
     expect(result.valid).toBe(true);
   });
 });

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -720,3 +720,41 @@ describe('updateConfigPolicy / deleteConfigPolicy — partner-wide administratio
     expect(updated?.name).toBe('Renamed');
   });
 });
+
+// ============================================================
+// validateFeaturePolicyExists — software_policy dual-axis (#2126)
+// ============================================================
+
+describe('validateFeaturePolicyExists — software_policy dual-axis linking (#2126)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  function mockLookupReturns(rows: unknown[]) {
+    vi.mocked(db.select).mockReturnValue(selectLimitRows(rows) as never);
+  }
+
+  it('accepts inline-only (no featurePolicyId)', async () => {
+    const result = await validateFeaturePolicyExists('software_policy', null, { orgId: 'org-1', partnerId: null });
+    expect(result.valid).toBe(true);
+  });
+
+  it('a PARTNER-WIDE config policy can link a partner-owned software template', async () => {
+    mockLookupReturns([{ id: 'sw-1' }]);
+    const result = await validateFeaturePolicyExists('software_policy', 'sw-1', { orgId: null, partnerId: 'partner-1' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('an ORG-owned config policy can link a software policy (own org or its partner template)', async () => {
+    mockLookupReturns([{ id: 'sw-1' }]);
+    const result = await validateFeaturePolicyExists('software_policy', 'sw-1', { orgId: 'org-1', partnerId: null });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a software policy id that resolves to neither axis', async () => {
+    mockLookupReturns([]);
+    const result = await validateFeaturePolicyExists('software_policy', 'missing', { orgId: null, partnerId: 'partner-1' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -13,7 +13,17 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
-import { addFeatureLink, updateFeatureLink, listFeatureLinks, pamInlineSettingsSchema, validateFeaturePolicyExists } from './configurationPolicy';
+import {
+  addFeatureLink,
+  updateFeatureLink,
+  listFeatureLinks,
+  pamInlineSettingsSchema,
+  validateFeaturePolicyExists,
+  canManagePartnerWidePolicies,
+  updateConfigPolicy,
+  deleteConfigPolicy,
+  PartnerWideWriteDeniedError,
+} from './configurationPolicy';
 import { db } from '../db';
 
 // Chain for `db.select().from(...).where(...)` awaited directly (links query)
@@ -609,5 +619,104 @@ describe('validateFeaturePolicyExists — vulnerability is inline-only', () => {
   it('accepts inline-only (no featurePolicyId)', async () => {
     const result = await validateFeaturePolicyExists('vulnerability', null, { orgId: 'org-1', partnerId: null });
     expect(result.valid).toBe(true);
+  });
+});
+
+// ============================================================
+// Partner-wide administration capability (single source of truth)
+// ============================================================
+
+describe('canManagePartnerWidePolicies', () => {
+  it.each([
+    // [scope, partnerOrgAccess, expected]
+    ['system', undefined, true],
+    ['system', 'none', true], // system short-circuits regardless of flag
+    ['partner', 'all', true],
+    ['partner', 'selected', false],
+    ['partner', 'none', false],
+    ['partner', undefined, false], // membership-less / MCP-key contexts fail closed
+    ['organization', undefined, false],
+    ['organization', 'all', false], // org scope never administers partner-wide state
+  ] as const)('scope=%s partnerOrgAccess=%s → %s', (scope, partnerOrgAccess, expected) => {
+    expect(canManagePartnerWidePolicies({ scope, partnerOrgAccess } as never)).toBe(expected);
+  });
+});
+
+describe('updateConfigPolicy / deleteConfigPolicy — partner-wide administration gate', () => {
+  // policyAccessCondition treats an undefined orgCondition as "no app-layer
+  // filter" — irrelevant here since db is fully mocked; only the fetched row's
+  // orgId and the auth capability drive the gate under test.
+  const partnerAuth = (partnerOrgAccess?: 'all' | 'selected' | 'none'): never =>
+    ({
+      scope: 'partner',
+      partnerId: 'partner-1',
+      orgId: null,
+      partnerOrgAccess,
+      orgCondition: () => undefined,
+      user: { id: 'user-1' },
+    }) as never;
+
+  const PARTNER_WIDE_ROW = { id: 'policy-1', orgId: null, partnerId: 'partner-1', name: 'Wide', status: 'active' };
+
+  function mockSelectExisting(row: Record<string, unknown> | null) {
+    vi.mocked(db.select).mockReturnValue(selectLimitRows(row ? [row] : []) as never);
+  }
+
+  function mockUpdateReturning(row: Record<string, unknown>) {
+    const chain: any = {};
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([row]));
+    vi.mocked(db.update).mockReturnValue(chain);
+  }
+
+  function mockDeleteReturning(row: Record<string, unknown>) {
+    const chain: any = {};
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([row]));
+    vi.mocked(db.delete).mockReturnValue(chain);
+  }
+
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.update).mockReset();
+    vi.mocked(db.delete).mockReset();
+  });
+
+  it('updateConfigPolicy throws PartnerWideWriteDeniedError for a partner-wide policy without orgAccess=all', async () => {
+    mockSelectExisting(PARTNER_WIDE_ROW);
+    await expect(
+      updateConfigPolicy('policy-1', { name: 'Renamed' }, partnerAuth('selected'))
+    ).rejects.toBeInstanceOf(PartnerWideWriteDeniedError);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('deleteConfigPolicy throws PartnerWideWriteDeniedError for a partner-wide policy without orgAccess=all', async () => {
+    mockSelectExisting(PARTNER_WIDE_ROW);
+    await expect(deleteConfigPolicy('policy-1', partnerAuth('none'))).rejects.toBeInstanceOf(
+      PartnerWideWriteDeniedError
+    );
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('updateConfigPolicy proceeds for a partner-wide policy with orgAccess=all', async () => {
+    mockSelectExisting(PARTNER_WIDE_ROW);
+    mockUpdateReturning({ ...PARTNER_WIDE_ROW, name: 'Renamed' });
+    const updated = await updateConfigPolicy('policy-1', { name: 'Renamed' }, partnerAuth('all'));
+    expect(updated?.name).toBe('Renamed');
+  });
+
+  it('deleteConfigPolicy proceeds for a partner-wide policy with orgAccess=all', async () => {
+    mockSelectExisting(PARTNER_WIDE_ROW);
+    mockDeleteReturning(PARTNER_WIDE_ROW);
+    const deleted = await deleteConfigPolicy('policy-1', partnerAuth('all'));
+    expect(deleted?.id).toBe('policy-1');
+  });
+
+  it('org-owned policies are NOT gated (a selected-access partner user may still edit them)', async () => {
+    mockSelectExisting({ ...PARTNER_WIDE_ROW, orgId: 'org-1', partnerId: null });
+    mockUpdateReturning({ ...PARTNER_WIDE_ROW, orgId: 'org-1', partnerId: null, name: 'Renamed' });
+    const updated = await updateConfigPolicy('policy-1', { name: 'Renamed' }, partnerAuth('selected'));
+    expect(updated?.name).toBe('Renamed');
   });
 });

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -757,4 +757,17 @@ describe('validateFeaturePolicyExists — software_policy dual-axis linking (#21
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/not found/i);
   });
+
+  it('a PARTNER-WIDE config policy can link a partner-owned SECURITY policy (#2127)', async () => {
+    mockLookupReturns([{ id: 'sec-1' }]);
+    const result = await validateFeaturePolicyExists('security', 'sec-1', { orgId: null, partnerId: 'partner-1' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a security policy id that resolves to neither axis', async () => {
+    mockLookupReturns([]);
+    const result = await validateFeaturePolicyExists('security', 'missing', { orgId: 'org-1', partnerId: null });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Security policy .* not found/i);
+  });
 });

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1536,11 +1536,10 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch, software_policy, and security are handled separately in
+  // patch, software_policy, security, and alert_rule are handled separately in
   // validateFeaturePolicyExists: rings are pure partner-axis, and software /
-  // security policies are dual-ownership (org XOR partner, #2126/#2127) —
-  // none fits the org-only lookup below.
-  alert_rule: { table: alertRules, orgIdCol: alertRules.orgId },
+  // security / alert-rule policies are dual-ownership (org XOR partner,
+  // #2126/#2127/#2128) — none fits the org-only lookup below.
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
   compliance: { table: automationPolicies, orgIdCol: automationPolicies.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
@@ -1559,6 +1558,7 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
   'patch',
   'software_policy',
   'security',
+  'alert_rule',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1598,13 +1598,13 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  if (featureType === 'software_policy' || featureType === 'security') {
+  if (featureType === 'software_policy' || featureType === 'security' || featureType === 'alert_rule') {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
-    // Software (#2126) and security (#2127) policies are dual-ownership. A
-    // config policy may link:
+    // Software (#2126), security (#2127), and alert-rule (#2128) policies are
+    // dual-ownership. A config policy may link:
     //  - an org-owned policy belonging to the config policy's own org
     //  - a partner-owned ("all orgs") template belonging to the config
     //    policy's partner (derived from its org for org-owned config policies)
@@ -1612,7 +1612,9 @@ export async function validateFeaturePolicyExists(
     // templates — there is no owning org to anchor an org-owned one.
     const dualAxis = featureType === 'software_policy'
       ? { table: softwarePolicies, label: 'Software policy' }
-      : { table: securityPolicies, label: 'Security policy' };
+      : featureType === 'security'
+        ? { table: securityPolicies, label: 'Security policy' }
+        : { table: alertRules, label: 'Alert rule' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -153,6 +153,34 @@ function policyAccessCondition(auth: AuthContext): SQL | undefined {
   return orgCond;
 }
 
+/**
+ * Capability gate for creating/modifying PARTNER-WIDE ("all organizations")
+ * policies. Partner-wide state pushes config to every org under the partner —
+ * including orgs created later — so only full-partner admins (orgAccess='all')
+ * and system scope qualify. Contexts that never resolved a partner membership
+ * (org scope, agent, helper, MCP keys) have no partnerOrgAccess and fail closed.
+ *
+ * This is the single source of truth: HTTP routes gate with it directly, and
+ * updateConfigPolicy/deleteConfigPolicy enforce it via
+ * PartnerWideWriteDeniedError so non-route callers (AI tools) are covered too.
+ */
+export function canManagePartnerWidePolicies(
+  auth: Pick<AuthContext, 'scope' | 'partnerOrgAccess'>
+): boolean {
+  return auth.scope === 'system' || (auth.scope === 'partner' && auth.partnerOrgAccess === 'all');
+}
+
+export const PARTNER_WIDE_WRITE_DENIED_MESSAGE =
+  'Modifying a partner-wide policy requires full partner org access (orgAccess must be "all")';
+
+/** Thrown by update/delete when a partner-wide policy is visible to the caller but not administrable. Routes map it to 403. */
+export class PartnerWideWriteDeniedError extends Error {
+  constructor() {
+    super(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+    this.name = 'PartnerWideWriteDeniedError';
+  }
+}
+
 export async function createConfigPolicy(
   owner: { orgId: string; partnerId?: null } | { orgId?: null; partnerId: string },
   data: { name: string; description?: string; status?: 'active' | 'inactive' | 'archived' },
@@ -201,16 +229,26 @@ export async function listConfigPolicies(
   if (accessCond) conditions.push(accessCond);
 
   if (filters.orgId) {
-    // Include the caller's partner-wide policies (org_id NULL) alongside the
-    // org-owned ones. A partner-wide policy applies to EVERY org under the
-    // partner, so an org-filtered list that hid them would misrepresent which
-    // policies actually govern that org's devices (and the UI has no separate
-    // surface for them). policyAccessCondition already bounds the org_id IS NULL
-    // rows to the caller's own partner, so this cannot leak another partner's
-    // policies; for org-scope callers (no partner axis) the NULL branch matches
-    // nothing, leaving their behavior unchanged. (#1724 follow-up)
+    // Include the partner-wide policies (org_id NULL) that govern the filtered
+    // org alongside its org-owned ones — a partner-wide policy applies to EVERY
+    // org under its partner, so an org-filtered list that hid them would
+    // misrepresent which policies actually apply (and the UI has no separate
+    // surface for them). The NULL branch is scoped to THE FILTERED ORG'S OWN
+    // partner, not merely the caller's visibility: for a system-scope caller
+    // policyAccessCondition is no filter at all, and a bare `OR org_id IS NULL`
+    // would return every partner's partner-wide policies platform-wide. If the
+    // org row is missing (or RLS-invisible to the caller), fall back to the
+    // plain org filter — fail-closed, never fail-open. (#1724 follow-up)
+    const [orgRow] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, filters.orgId))
+      .limit(1);
+    const orgPartnerId = orgRow?.partnerId ?? null;
     conditions.push(
-      sql`(${configurationPolicies.orgId} = ${filters.orgId} OR ${configurationPolicies.orgId} IS NULL)`
+      orgPartnerId
+        ? sql`(${configurationPolicies.orgId} = ${filters.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${orgPartnerId}))`
+        : eq(configurationPolicies.orgId, filters.orgId)
     );
   }
   if (filters.status) {
@@ -255,6 +293,14 @@ export async function updateConfigPolicy(
   const [existing] = await db.select().from(configurationPolicies).where(and(...conditions)).limit(1);
   if (!existing) return null;
 
+  // Partner-wide policies are READABLE by any member of the partner but
+  // administrable only with orgAccess='all' — same blast-radius rationale as
+  // the create-time guard. Enforced here (not just in routes) so every caller,
+  // including AI tool handlers, hits the same gate.
+  if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+    throw new PartnerWideWriteDeniedError();
+  }
+
   const updates: Record<string, unknown> = { updatedAt: new Date() };
   if (data.name !== undefined) updates.name = data.name;
   if (data.description !== undefined) updates.description = data.description;
@@ -274,6 +320,18 @@ export async function deleteConfigPolicy(id: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(configurationPolicies.id, id)];
   const accessCond = policyAccessCondition(auth);
   if (accessCond) conditions.push(accessCond);
+
+  // Pre-fetch to apply the partner-wide administration gate (see
+  // updateConfigPolicy) before the destructive statement.
+  const [existing] = await db
+    .select({ orgId: configurationPolicies.orgId })
+    .from(configurationPolicies)
+    .where(and(...conditions))
+    .limit(1);
+  if (!existing) return null;
+  if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+    throw new PartnerWideWriteDeniedError();
+  }
 
   const [deleted] = await db
     .delete(configurationPolicies)

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -29,7 +29,8 @@ import {
   sensitiveDataPolicies,
   peripheralPolicies,
 } from '../db/schema';
-import { and, eq, desc, sql, inArray, asc, SQL } from 'drizzle-orm';
+import { and, eq, desc, or, sql, inArray, asc, SQL } from 'drizzle-orm';
+import { canManagePartnerWidePolicies, PartnerWideWriteDeniedError } from './partnerWideAccess';
 import { z } from 'zod';
 import { eventLogInlineSettingsSchema, monitoringInlineSettingsSchema } from '@breeze/shared/validators';
 import type { AuthContext } from '../middleware/auth';
@@ -153,33 +154,17 @@ function policyAccessCondition(auth: AuthContext): SQL | undefined {
   return orgCond;
 }
 
-/**
- * Capability gate for creating/modifying PARTNER-WIDE ("all organizations")
- * policies. Partner-wide state pushes config to every org under the partner —
- * including orgs created later — so only full-partner admins (orgAccess='all')
- * and system scope qualify. Contexts that never resolved a partner membership
- * (org scope, agent, helper, MCP keys) have no partnerOrgAccess and fail closed.
- *
- * This is the single source of truth: HTTP routes gate with it directly, and
- * updateConfigPolicy/deleteConfigPolicy enforce it via
- * PartnerWideWriteDeniedError so non-route callers (AI tools) are covered too.
- */
-export function canManagePartnerWidePolicies(
-  auth: Pick<AuthContext, 'scope' | 'partnerOrgAccess'>
-): boolean {
-  return auth.scope === 'system' || (auth.scope === 'partner' && auth.partnerOrgAccess === 'all');
-}
-
-export const PARTNER_WIDE_WRITE_DENIED_MESSAGE =
-  'Modifying a partner-wide policy requires full partner org access (orgAccess must be "all")';
-
-/** Thrown by update/delete when a partner-wide policy is visible to the caller but not administrable. Routes map it to 403. */
-export class PartnerWideWriteDeniedError extends Error {
-  constructor() {
-    super(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
-    this.name = 'PartnerWideWriteDeniedError';
-  }
-}
+// The partner-wide capability gate lives in the dependency-free leaf module
+// services/partnerWideAccess.ts (so routes/workers/AI tools can import it
+// without this service's schema graph). Re-exported here for back-compat:
+// HTTP routes gate with it directly, and updateConfigPolicy/deleteConfigPolicy
+// enforce it via PartnerWideWriteDeniedError so non-route callers (AI tools)
+// are covered too.
+export {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  PartnerWideWriteDeniedError,
+} from './partnerWideAccess';
 
 export async function createConfigPolicy(
   owner: { orgId: string; partnerId?: null } | { orgId?: null; partnerId: string },
@@ -1551,16 +1536,30 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch is handled separately in validateFeaturePolicyExists (partner-scoped, not org-scoped)
+  // patch and software_policy are handled separately in
+  // validateFeaturePolicyExists: rings are pure partner-axis, and software
+  // policies are dual-ownership (org XOR partner, #2126) — neither fits the
+  // org-only lookup below.
   alert_rule: { table: alertRules, orgIdCol: alertRules.orgId },
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
   security: { table: securityPolicies, orgIdCol: securityPolicies.orgId },
   compliance: { table: automationPolicies, orgIdCol: automationPolicies.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
-  software_policy: { table: softwarePolicies, orgIdCol: softwarePolicies.orgId },
   sensitive_data: { table: sensitiveDataPolicies, orgIdCol: sensitiveDataPolicies.orgId },
   peripheral_control: { table: peripheralPolicies, orgIdCol: peripheralPolicies.orgId },
 };
+
+/**
+ * Feature types whose LINKED standalone table supports partner ownership, and
+ * may therefore carry a featurePolicyId on a PARTNER-WIDE config policy:
+ * update rings are pure partner-axis; software policies are dual-ownership
+ * (#2126). Grows as more template tables migrate to dual-axis (epic #2135).
+ * The featureLinks routes consult this set instead of hardcoding 'patch'.
+ */
+export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = new Set([
+  'patch',
+  'software_policy',
+]);
 
 export async function validateFeaturePolicyExists(
   featureType: ConfigFeatureType,
@@ -1594,6 +1593,46 @@ export async function validateFeaturePolicyExists(
 
     if (!ring) {
       return { valid: false, error: `Update ring "${featurePolicyId}" not found for this partner` };
+    }
+
+    return { valid: true };
+  }
+
+  if (featureType === 'software_policy') {
+    if (!featurePolicyId) {
+      return { valid: true };
+    }
+
+    // Software policies are dual-ownership (#2126). A config policy may link:
+    //  - an org-owned software policy belonging to the config policy's own org
+    //  - a partner-owned ("all orgs") software policy belonging to the config
+    //    policy's partner (derived from its org for org-owned config policies)
+    // A partner-wide config policy (orgId null) can only link partner-owned
+    // templates — there is no owning org to anchor an org-owned one.
+    const partnerId =
+      owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
+
+    const ownershipConditions: SQL[] = [];
+    if (owner.orgId) {
+      ownershipConditions.push(eq(softwarePolicies.orgId, owner.orgId));
+    }
+    if (partnerId) {
+      ownershipConditions.push(
+        sql`(${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${partnerId})`
+      );
+    }
+    if (ownershipConditions.length === 0) {
+      return { valid: false, error: `Software policy "${featurePolicyId}" not found — no owning organization or partner` };
+    }
+
+    const [row] = await db
+      .select({ id: softwarePolicies.id })
+      .from(softwarePolicies)
+      .where(and(eq(softwarePolicies.id, featurePolicyId), or(...ownershipConditions)))
+      .limit(1);
+
+    if (!row) {
+      return { valid: false, error: `Software policy "${featurePolicyId}" not found for this organization or partner` };
     }
 
     return { valid: true };

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -201,7 +201,17 @@ export async function listConfigPolicies(
   if (accessCond) conditions.push(accessCond);
 
   if (filters.orgId) {
-    conditions.push(eq(configurationPolicies.orgId, filters.orgId));
+    // Include the caller's partner-wide policies (org_id NULL) alongside the
+    // org-owned ones. A partner-wide policy applies to EVERY org under the
+    // partner, so an org-filtered list that hid them would misrepresent which
+    // policies actually govern that org's devices (and the UI has no separate
+    // surface for them). policyAccessCondition already bounds the org_id IS NULL
+    // rows to the caller's own partner, so this cannot leak another partner's
+    // policies; for org-scope callers (no partner axis) the NULL branch matches
+    // nothing, leaving their behavior unchanged. (#1724 follow-up)
+    conditions.push(
+      sql`(${configurationPolicies.orgId} = ${filters.orgId} OR ${configurationPolicies.orgId} IS NULL)`
+    );
   }
   if (filters.status) {
     conditions.push(eq(configurationPolicies.status, filters.status as 'active' | 'inactive' | 'archived'));
@@ -1497,15 +1507,17 @@ const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCo
 export async function validateFeaturePolicyExists(
   featureType: ConfigFeatureType,
   featurePolicyId: string | undefined | null,
-  orgId: string
+  owner: { orgId: string | null; partnerId: string | null }
 ): Promise<{ valid: boolean; error?: string }> {
   if (featureType === 'patch') {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
-    // Rings are partner-scoped: derive the partner from the config policy's org.
-    const partnerId = await resolvePartnerIdForOrg(orgId);
+    // Rings are partner-axis. A partner-wide policy (#1724) carries partnerId
+    // directly (orgId null); an org-scoped policy derives it from its org.
+    const partnerId =
+      owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
     if (!partnerId) {
       return { valid: false, error: `Update ring "${featurePolicyId}" not found — organization has no partner` };
     }
@@ -1547,6 +1559,18 @@ export async function validateFeaturePolicyExists(
 
   if (!featurePolicyId) {
     return { valid: true }; // inline-only is allowed; schema ensures inlineSettings is present
+  }
+
+  // Every remaining feature type references an org-scoped policy table. A
+  // partner-wide policy (orgId null, #1724) cannot link one — patch (rings,
+  // partner-axis) is the only linked feature valid partner-wide and returned
+  // above. The route blocks this upstream; guard here as defense-in-depth.
+  const orgId = owner.orgId;
+  if (!orgId) {
+    return {
+      valid: false,
+      error: `The "${featureType}" feature policy is organization-scoped and cannot be linked to a partner-wide configuration policy`,
+    };
   }
 
   // Check if it's a reference to another Configuration Policy (whole-policy linking)

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1536,13 +1536,12 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch and software_policy are handled separately in
-  // validateFeaturePolicyExists: rings are pure partner-axis, and software
-  // policies are dual-ownership (org XOR partner, #2126) — neither fits the
-  // org-only lookup below.
+  // patch, software_policy, and security are handled separately in
+  // validateFeaturePolicyExists: rings are pure partner-axis, and software /
+  // security policies are dual-ownership (org XOR partner, #2126/#2127) —
+  // none fits the org-only lookup below.
   alert_rule: { table: alertRules, orgIdCol: alertRules.orgId },
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
-  security: { table: securityPolicies, orgIdCol: securityPolicies.orgId },
   compliance: { table: automationPolicies, orgIdCol: automationPolicies.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
   sensitive_data: { table: sensitiveDataPolicies, orgIdCol: sensitiveDataPolicies.orgId },
@@ -1559,6 +1558,7 @@ const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCo
 export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = new Set([
   'patch',
   'software_policy',
+  'security',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1598,41 +1598,45 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  if (featureType === 'software_policy') {
+  if (featureType === 'software_policy' || featureType === 'security') {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
-    // Software policies are dual-ownership (#2126). A config policy may link:
-    //  - an org-owned software policy belonging to the config policy's own org
-    //  - a partner-owned ("all orgs") software policy belonging to the config
+    // Software (#2126) and security (#2127) policies are dual-ownership. A
+    // config policy may link:
+    //  - an org-owned policy belonging to the config policy's own org
+    //  - a partner-owned ("all orgs") template belonging to the config
     //    policy's partner (derived from its org for org-owned config policies)
     // A partner-wide config policy (orgId null) can only link partner-owned
     // templates — there is no owning org to anchor an org-owned one.
+    const dualAxis = featureType === 'software_policy'
+      ? { table: softwarePolicies, label: 'Software policy' }
+      : { table: securityPolicies, label: 'Security policy' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 
     const ownershipConditions: SQL[] = [];
     if (owner.orgId) {
-      ownershipConditions.push(eq(softwarePolicies.orgId, owner.orgId));
+      ownershipConditions.push(eq(dualAxis.table.orgId, owner.orgId));
     }
     if (partnerId) {
       ownershipConditions.push(
-        sql`(${softwarePolicies.orgId} IS NULL AND ${softwarePolicies.partnerId} = ${partnerId})`
+        sql`(${dualAxis.table.orgId} IS NULL AND ${dualAxis.table.partnerId} = ${partnerId})`
       );
     }
     if (ownershipConditions.length === 0) {
-      return { valid: false, error: `Software policy "${featurePolicyId}" not found — no owning organization or partner` };
+      return { valid: false, error: `${dualAxis.label} "${featurePolicyId}" not found — no owning organization or partner` };
     }
 
     const [row] = await db
-      .select({ id: softwarePolicies.id })
-      .from(softwarePolicies)
-      .where(and(eq(softwarePolicies.id, featurePolicyId), or(...ownershipConditions)))
+      .select({ id: dualAxis.table.id })
+      .from(dualAxis.table)
+      .where(and(eq(dualAxis.table.id, featurePolicyId), or(...ownershipConditions)))
       .limit(1);
 
     if (!row) {
-      return { valid: false, error: `Software policy "${featurePolicyId}" not found for this organization or partner` };
+      return { valid: false, error: `${dualAxis.label} "${featurePolicyId}" not found for this organization or partner` };
     }
 
     return { valid: true };

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -135,18 +135,19 @@ export interface EffectiveConfiguration {
  * access (the original shape) OR owned by their own partner (partner-wide /
  * all-orgs policies, org_id NULL). System scope returns undefined (no filter).
  *
- * RLS already enforces this at the DB layer; this app-layer condition keeps
- * partner-owned policies visible to org/partner-scoped reads that filter by
- * `auth.orgCondition` (which would otherwise exclude org_id IS NULL rows).
+ * This app-layer condition keeps partner-owned policies visible to
+ * partner-scoped reads that filter by `auth.orgCondition` (which would
+ * otherwise exclude org_id IS NULL rows). RLS is STRICTER, not identical:
+ * breeze_has_partner_access only passes for partner-scope callers, so
+ * org-scope tokens (which also carry a partnerId) never see partner-wide
+ * rows — see configurationPoliciesPartnerRls.integration.test.ts. The branch
+ * is therefore gated on partner scope so app and DB agree.
  */
 function policyAccessCondition(auth: AuthContext): SQL | undefined {
   const orgCond = auth.orgCondition(configurationPolicies.orgId);
   // System scope: no filter on either axis.
   if (!orgCond) return undefined;
-  // Org-owned rows the caller can reach, OR partner-owned rows for the caller's
-  // own partner. partner-scope callers have a partnerId; org-scope callers do
-  // not own partner-wide policies, so the partner branch is a no-op for them.
-  if (auth.partnerId) {
+  if (auth.scope === 'partner' && auth.partnerId) {
     return and(
       sql`(${orgCond} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${auth.partnerId}))`
     );

--- a/apps/api/src/services/partnerWideAccess.ts
+++ b/apps/api/src/services/partnerWideAccess.ts
@@ -1,0 +1,40 @@
+/**
+ * Partner-wide administration capability (epic #2135).
+ *
+ * Partner-wide ("all organizations") state — configuration policies, software
+ * policy templates, and every future dual-ownership table — pushes config to
+ * EVERY org under the partner, including orgs created later. Only full-partner
+ * admins (partner_users.org_access = 'all') and system scope may create or
+ * modify it.
+ *
+ * This is a deliberately dependency-free leaf module (types only) so routes,
+ * services, workers, and AI tools can all import the ONE capability check
+ * without pulling in the configurationPolicy service graph — test files that
+ * mock db/schema stay unaffected. configurationPolicy re-exports these for
+ * back-compat.
+ */
+import type { AuthContext } from '../middleware/auth';
+
+/**
+ * True when the caller may create/modify partner-wide state. Contexts that
+ * never resolved a partner membership (org scope, agent, helper, MCP keys)
+ * have no partnerOrgAccess and fail closed. Deliberately NOT derivable from
+ * accessibleOrgIds: a 'selected' user whose selection happens to cover every
+ * current org still must not administer partner-wide state.
+ */
+export function canManagePartnerWidePolicies(
+  auth: Pick<AuthContext, 'scope' | 'partnerOrgAccess'>
+): boolean {
+  return auth.scope === 'system' || (auth.scope === 'partner' && auth.partnerOrgAccess === 'all');
+}
+
+export const PARTNER_WIDE_WRITE_DENIED_MESSAGE =
+  'Modifying a partner-wide policy requires full partner org access (orgAccess must be "all")';
+
+/** Thrown by service mutators when a partner-wide row is visible to the caller but not administrable. Routes map it to 403. */
+export class PartnerWideWriteDeniedError extends Error {
+  constructor() {
+    super(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+    this.name = 'PartnerWideWriteDeniedError';
+  }
+}

--- a/apps/api/src/services/softwarePolicyService.ts
+++ b/apps/api/src/services/softwarePolicyService.ts
@@ -470,7 +470,12 @@ export async function upsertSoftwareComplianceStatus(params: {
 }
 
 export async function recordSoftwarePolicyAudit(input: {
-  orgId: string;
+  // Dual-owner audit (#2126): a device-level event under a partner-wide policy
+  // carries BOTH the device's orgId (org-admin visibility) and the policy's
+  // partnerId (partner-admin visibility); policy-level events carry whichever
+  // axis owns the policy. At least one must be set (DB CHECK enforces it).
+  orgId: string | null;
+  partnerId?: string | null;
   policyId?: string | null;
   deviceId?: string | null;
   action: string;
@@ -479,8 +484,12 @@ export async function recordSoftwarePolicyAudit(input: {
   details?: Record<string, unknown> | null;
 }): Promise<void> {
   try {
+    if (!input.orgId && !input.partnerId) {
+      throw new Error('software policy audit requires at least one owner axis (orgId or partnerId)');
+    }
     await db.insert(softwarePolicyAudit).values({
       orgId: input.orgId,
+      partnerId: input.partnerId ?? null,
       policyId: input.policyId ?? null,
       deviceId: input.deviceId ?? null,
       action: input.action,
@@ -491,6 +500,7 @@ export async function recordSoftwarePolicyAudit(input: {
   } catch (err) {
     console.error('[softwarePolicyService] Failed to write policy audit record', {
       orgId: input.orgId,
+      partnerId: input.partnerId,
       policyId: input.policyId,
       deviceId: input.deviceId,
       action: input.action,

--- a/apps/api/src/services/softwarePolicyService.ts
+++ b/apps/api/src/services/softwarePolicyService.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';
+import { captureException } from './sentry';
 import {
   devices,
   softwareComplianceStatus,
@@ -498,6 +499,9 @@ export async function recordSoftwarePolicyAudit(input: {
       details: input.details ?? null,
     });
   } catch (err) {
+    // Audit rows exist for accountability — losing one silently defeats the
+    // point, so surface to Sentry (mirrors auditService's exhausted-retry
+    // posture) in addition to the structured log.
     console.error('[softwarePolicyService] Failed to write policy audit record', {
       orgId: input.orgId,
       partnerId: input.partnerId,
@@ -506,5 +510,6 @@ export async function recordSoftwarePolicyAudit(input: {
       action: input.action,
       error: err,
     });
+    captureException(err);
   }
 }

--- a/apps/web/src/components/alerts/AlertRuleEditPage.tsx
+++ b/apps/web/src/components/alerts/AlertRuleEditPage.tsx
@@ -4,6 +4,7 @@ import AlertRuleForm, { type AlertRuleFormValues } from './AlertRuleForm';
 import type { NotificationChannel } from './NotificationChannelList';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 import { extractApiError } from '@/lib/apiError';
 
@@ -26,6 +27,17 @@ export default function AlertRuleEditPage({ ruleId, isNew = false }: AlertRuleEd
   const [devices, setDevices] = useState<Device[]>([]);
   const [notificationChannels, setNotificationChannels] = useState<NotificationChannel[]>([]);
   const { currentOrgId } = useOrgStore();
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+
+  // Ownership axis (#2128, mirrors software/security policies): partner-scope
+  // creators may own the rule partner-wide ("all orgs" — targets every device
+  // under the partner, uses each org's default alert routing). Gate on the
+  // JWT scope; default to partner-wide when viewing All orgs. Create-only.
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const [ownerScope, setOwnerScope] = useState<'organization' | 'partner'>(
+    isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization'
+  );
 
   const fetchRule = useCallback(async () => {
     if (!ruleId || isNew) return;
@@ -146,7 +158,21 @@ export default function AlertRuleEditPage({ ruleId, isNew = false }: AlertRuleEd
         autoResolve: values.autoResolve,
         enabled: true
       };
-      const requestPayload = isNew && currentOrgId ? { ...payload, orgId: currentOrgId } : payload;
+      const partnerWideCreate = isNew && isPartnerScope && ownerScope === 'partner';
+      const requestPayload = partnerWideCreate
+        ? {
+            ...payload,
+            ownerScope: 'partner',
+            // Partner-wide rules always target 'all' and use each org's own
+            // default notification routing — org-scoped bindings are rejected
+            // by the API.
+            targetType: 'all',
+            targets: { type: 'all', ids: [] },
+            notificationChannelIds: undefined,
+          }
+        : isNew && currentOrgId
+          ? { ...payload, orgId: currentOrgId }
+          : payload;
 
       const url = isNew ? '/alerts/rules' : `/alerts/rules/${ruleId}`;
       const method = isNew ? 'POST' : 'PUT';
@@ -228,6 +254,34 @@ export default function AlertRuleEditPage({ ruleId, isNew = false }: AlertRuleEd
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
         </div>
+      )}
+
+      {isNew && isPartnerScope && (
+        <fieldset className="space-y-2 rounded-md border p-4" data-testid="alert-rule-owner">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="alertRuleOwnerScope"
+              value="partner"
+              checked={ownerScope === 'partner'}
+              onChange={() => setOwnerScope('partner')}
+              data-testid="alert-rule-owner-partner"
+            />
+            All organizations <span className="text-muted-foreground">(partner-wide — targets every device; each org's default notification routing applies)</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="alertRuleOwnerScope"
+              value="organization"
+              checked={ownerScope === 'organization'}
+              onChange={() => setOwnerScope('organization')}
+              data-testid="alert-rule-owner-org"
+            />
+            This organization only
+          </label>
+        </fieldset>
       )}
 
       <AlertRuleForm

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Search, ChevronLeft, ChevronRight, Pencil, Trash2 } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, Pencil, Trash2, Globe } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export type ConfigPolicyStatus = 'active' | 'inactive' | 'archived';
@@ -9,7 +9,8 @@ export type ConfigPolicy = {
   name: string;
   description?: string;
   status: ConfigPolicyStatus;
-  orgId: string;
+  // null = partner-wide ("All organizations") policy (#1724)
+  orgId: string | null;
   createdAt?: string;
   updatedAt?: string;
   featureLinks?: { id: string; featureType: string }[];
@@ -131,7 +132,21 @@ export default function ConfigPolicyList({
             ) : (
               paginatedPolicies.map((policy) => (
                 <tr key={policy.id} className="text-sm">
-                  <td className="px-4 py-3 font-medium text-foreground">{policy.name}</td>
+                  <td className="px-4 py-3 font-medium text-foreground">
+                    <div className="flex items-center gap-2">
+                      <span>{policy.name}</span>
+                      {policy.orgId === null && (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                          title="Partner-wide policy — applies to every organization"
+                          data-testid="partner-wide-badge"
+                        >
+                          <Globe className="h-3 w-3" />
+                          All orgs
+                        </span>
+                      )}
+                    </div>
+                  </td>
                   <td className="px-4 py-3">
                     <span
                       className={cn(

--- a/apps/web/src/components/security/SecurityPolicyEditor.tsx
+++ b/apps/web/src/components/security/SecurityPolicyEditor.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalendarClock, Loader2, Plus, Save, Trash2 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 
 type ToggleRowProps = {
   label: string;
@@ -89,6 +91,18 @@ export default function SecurityPolicyEditor({ policyId, onSave }: SecurityPolic
   const [exclusions, setExclusions] = useState<string[]>([]);
   const [newExclusion, setNewExclusion] = useState('');
 
+  // Ownership axis (#2127, mirrors software/config policies): partner-scope
+  // creators may own the baseline partner-wide ("all orgs"). Gate on the JWT
+  // scope; default to partner-wide when viewing All orgs. Create-only —
+  // ownership is immutable after create.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const [ownerScope, setOwnerScope] = useState<'organization' | 'partner'>(
+    isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization'
+  );
+
   const fetchPolicy = useCallback(async () => {
     if (!policyId) return;
 
@@ -133,6 +147,8 @@ export default function SecurityPolicyEditor({ policyId, onSave }: SecurityPolic
 
     const payload = {
       name: policyName,
+      // Create-only intent; the server derives the partner from the token.
+      ...(policyId ? {} : { ownerScope: isPartnerScope ? ownerScope : undefined }),
       description,
       scanSchedule,
       realTimeProtection: realTimeEnabled,
@@ -188,6 +204,33 @@ export default function SecurityPolicyEditor({ policyId, onSave }: SecurityPolic
       </div>
 
       <div className="rounded-lg border bg-card p-6 shadow-xs">
+        {!policyId && isPartnerScope && (
+          <fieldset className="mb-4 space-y-2 rounded-md border p-4" data-testid="security-policy-owner">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="securityPolicyOwnerScope"
+                value="partner"
+                checked={ownerScope === 'partner'}
+                onChange={() => setOwnerScope('partner')}
+                data-testid="security-policy-owner-partner"
+              />
+              All organizations <span className="text-muted-foreground">(partner-wide template)</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="securityPolicyOwnerScope"
+                value="organization"
+                checked={ownerScope === 'organization'}
+                onChange={() => setOwnerScope('organization')}
+                data-testid="security-policy-owner-org"
+              />
+              This organization only
+            </label>
+          </fieldset>
+        )}
         <div className="grid gap-4 md:grid-cols-2">
           <div>
             <label className="text-xs uppercase text-muted-foreground">Policy name</label>

--- a/apps/web/src/components/software/ComplianceDashboard.tsx
+++ b/apps/web/src/components/software/ComplianceDashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   AlertTriangle,
+  Globe,
   Pencil,
   Plus,
   ShieldCheck,
@@ -9,6 +10,8 @@ import {
   X,
 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { showToast } from '../shared/Toast';
 import PolicyForm, { type PolicyFormValues } from './PolicyForm';
 import { formatDateTime } from '@/lib/dateTimeFormat';
@@ -17,6 +20,10 @@ type Policy = {
   id: string;
   name: string;
   description?: string;
+  // null = partner-wide ("All organizations") template (#2126). Optional
+  // because client-side prefill drafts (not yet server rows) omit it.
+  orgId?: string | null;
+  partnerId?: string | null;
   mode: 'allowlist' | 'blocklist' | 'audit';
   rules?: {
     software: Array<{
@@ -83,6 +90,16 @@ export default function ComplianceDashboard({ prefill }: ComplianceDashboardProp
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedPolicy, setSelectedPolicy] = useState<Policy | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  // Ownership axis (#2126, mirrors ConfigPolicyCreatePage #1724): partner-scope
+  // creators may own a policy partner-wide ("all orgs"). Gate on the JWT scope,
+  // not useOrgStore().partners; default to partner-wide when viewing All orgs.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const defaultOwnerScope: PolicyFormValues['ownerScope'] =
+    isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization';
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -189,6 +206,9 @@ export default function ComplianceDashboard({ prefill }: ComplianceDashboardProp
         name: values.name,
         description: values.description || undefined,
         mode: values.mode,
+        // Ownership is immutable after create — only send the intent on create.
+        // The server derives the partner from the caller's own token (#2126).
+        ownerScope: modalMode === 'create' ? values.ownerScope : undefined,
         rules: {
           software: values.software.map((s) => ({
             name: s.name,
@@ -394,7 +414,21 @@ export default function ComplianceDashboard({ prefill }: ComplianceDashboardProp
             <tbody>
               {policies.map((policy) => (
                 <tr key={policy.id} className="border-t">
-                  <td className="px-4 py-3 font-medium">{policy.name}</td>
+                  <td className="px-4 py-3 font-medium">
+                    <div className="flex items-center gap-2">
+                      <span>{policy.name}</span>
+                      {policy.orgId === null && (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                          title="Partner-wide template — applies to every organization"
+                          data-testid="software-policy-partner-wide-badge"
+                        >
+                          <Globe className="h-3 w-3" />
+                          All orgs
+                        </span>
+                      )}
+                    </div>
+                  </td>
                   <td className="px-4 py-3 capitalize">{policy.mode}</td>
                   <td className="px-4 py-3">
                     <span
@@ -514,10 +548,11 @@ export default function ComplianceDashboard({ prefill }: ComplianceDashboardProp
                 defaultValues={
                   modalMode === 'edit' && selectedPolicy
                     ? policyToFormDefaults(selectedPolicy)
-                    : undefined
+                    : { ownerScope: defaultOwnerScope }
                 }
                 submitLabel={modalMode === 'create' ? 'Create Policy' : 'Update Policy'}
                 loading={submitting}
+                showOwnerScope={modalMode === 'create' && isPartnerScope}
               />
             </div>
           </div>

--- a/apps/web/src/components/software/PolicyForm.tsx
+++ b/apps/web/src/components/software/PolicyForm.tsx
@@ -15,6 +15,11 @@ const policyFormSchema = z.object({
   name: z.string().min(1, 'Policy name is required').max(200),
   description: z.string().max(4000).optional().or(z.literal('')),
   mode: z.enum(['allowlist', 'blocklist', 'audit']),
+  // Ownership axis (#2126, mirrors config policies #1724): 'partner' =
+  // partner-wide / all-orgs template. Only surfaced on create for
+  // partner-scope users (showOwnerScope); the server derives the partner
+  // from the caller's own token.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   software: z.array(softwareRuleSchema).min(1, 'At least one software rule is required'),
   allowUnknown: z.boolean().optional(),
   enforceMode: z.boolean(),
@@ -30,6 +35,8 @@ type PolicyFormProps = {
   defaultValues?: Partial<PolicyFormValues>;
   submitLabel?: string;
   loading?: boolean;
+  /** Show the ownership-scope selector (create-only, partner-scope users). */
+  showOwnerScope?: boolean;
 };
 
 export default function PolicyForm({
@@ -38,6 +45,7 @@ export default function PolicyForm({
   defaultValues,
   submitLabel = 'Save Policy',
   loading,
+  showOwnerScope = false,
 }: PolicyFormProps) {
   const {
     register,
@@ -77,6 +85,31 @@ export default function PolicyForm({
       })}
       className="space-y-4"
     >
+      {/* Ownership scope — partner-scope creators only (#2126) */}
+      {showOwnerScope && (
+        <fieldset className="space-y-2 rounded-md border p-4" data-testid="software-policy-owner">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="partner"
+              {...register('ownerScope')}
+              data-testid="software-policy-owner-partner"
+            />
+            All organizations <span className="text-muted-foreground">(partner-wide template)</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="organization"
+              {...register('ownerScope')}
+              data-testid="software-policy-owner-org"
+            />
+            This organization only
+          </label>
+        </fieldset>
+      )}
+
       {/* Basic Info */}
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">


### PR DESCRIPTION
## Summary

Breeze is an RMM: techs operate across many customer orgs at once, so partner-wide ("all organizations") configuration is the primary model. This PR removes the artificial org-first restrictions on patching, hardens the partner-wide surface, and lands the first two dual-ownership template migrations of the partner-wide-first epic (#2135).

**Partner-wide patch (d07eb355f):** removes `patch` from the partner-wide blocklist — update rings are partner-axis and the scheduler groups jobs by each device's own org, so a partner-wide patch policy resolves and schedules end-to-end. Ring linking allowed on partner-wide policies; the patch-job cross-org guard gets a partner-axis equivalent (each device's org must resolve to the policy's partner); the scheduler stops skipping partner-wide policies. Also hardens create/org-scoping: atomic create+auto-assign via the request transaction, system-scope 404 on missing orgs, clearer partner errors.

**Capability gate + list scoping (fd60f48bb):** the `orgAccess='all'` guard existed only on create — a `selected`-access partner user could still modify/delete partner-wide policies and their feature links. `AuthContext` now carries `partnerOrgAccess` (captured from the partner_users lookup authMiddleware already performs), `canManagePartnerWidePolicies()` is the single capability check, and `updateConfigPolicy`/`deleteConfigPolicy` enforce it in the service (typed error → 403) so AI tool callers are covered too. The org-filtered policy list now scopes its partner-wide branch to the filtered org's own partner (a system-scope caller previously got every partner's policies).

**Dual-ownership software policies, #2126 (80e25d436):** `software_policies` org XOR partner with dual-axis RLS; `software_policy_audit` dual-owned (device org + policy partner, both admins see device events). Partner-wide create/update/delete gated; `PARTNER_LINKABLE_FEATURE_TYPES` replaces the hardcoded patch exception; workers carry both owner axes; AI tools + web management UI updated. New leaf module `services/partnerWideAccess.ts` holds the capability check dependency-free.

**Dual-ownership security policies, #2127 (edd344acd):** same playbook, simpler surface (leaf table, no worker coupling). Dual-axis RLS replaces the four legacy per-command policies; `ownerScope` is create-only and kept out of the settings JSONB; editor gains the scope selector.

Closes #2126
Closes #2127
Refs #2135, #1724

## Verification

- New functional RLS integration suites for `software_policies` + `security_policies` + `configuration_policies` against real Postgres: cross-partner forge rejected with 42501, XOR CHECKs enforced (23514), dual-owned audit visibility, org-scope isolation
- All three tables registered in `DUAL_AXIS_TENANT_TABLES` — 50/50 RLS contract tests
- `db:check-drift` clean (357 migrations); API + web `tsc` clean; unit suites green across routes/services/workers/middleware
- Partner-wide patch behavior covered by scheduler/route/featureLinks units

🤖 Generated with [Claude Code](https://claude.com/claude-code)
