### PR TITLE
feat(tickets): soft-delete + admin restore for tickets (#2140)

### DIFF
--- a/apps/api/migrations/2026-07-07-ticket-soft-delete.sql
+++ b/apps/api/migrations/2026-07-07-ticket-soft-delete.sql
@@ -1,0 +1,26 @@
+-- Native ticketing Phase 6: soft-delete for tickets (issue #2140).
+-- A non-null deleted_at hides a ticket from every staff/portal list, stats
+-- count, and by-id mutation, but preserves the row for audit + admin restore.
+-- Mirrors ticket_comments.deleted_at. No RLS change: tickets is already
+-- org-scoped (breeze_has_org_access(org_id)); these are plain data columns.
+-- Gated in the API on the existing tickets:manage permission (Partner Admin /
+-- Org Admin) — no new permission grant required.
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS deleted_at timestamp;
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS deleted_by uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'tickets_deleted_by_users_id_fk' AND table_name = 'tickets'
+  ) THEN
+    ALTER TABLE tickets
+      ADD CONSTRAINT tickets_deleted_by_users_id_fk
+      FOREIGN KEY (deleted_by) REFERENCES users(id);
+  END IF;
+END $$;
+
+-- Partial index for the admin "Archived" view (the rare deleted-only scan). The
+-- hot path (deleted_at IS NULL, every normal list) is already carried by the
+-- existing org_id/status indexes ANDed into the same WHERE.
+CREATE INDEX IF NOT EXISTS tickets_deleted_at_idx ON tickets (deleted_at) WHERE deleted_at IS NOT NULL;

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -92,6 +92,12 @@ export const tickets = pgTable('tickets', {
   closedBy: uuid('closed_by').references(() => users.id),
   resolutionNote: text('resolution_note'),
   statusId: uuid('status_id'),  // FK + ON DELETE SET NULL added in SQL (ticketStatuses lives in ticketConfig.ts — avoid a circular import; same pattern as categoryId above)
+  // Soft-delete (Phase 6). A non-null deletedAt hides the ticket from every
+  // staff/portal list, stats count, and by-id mutation (getScopedTicketOr404),
+  // but preserves the row for audit and admin restore. Mirrors ticket_comments'
+  // deletedAt above. Hard purge (if ever added) is a separate retention job.
+  deletedAt: timestamp('deleted_at'),
+  deletedBy: uuid('deleted_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -95,7 +95,7 @@ export const tickets = pgTable('tickets', {
   // Soft-delete (Phase 6). A non-null deletedAt hides the ticket from every
   // staff/portal list, stats count, and by-id mutation (getScopedTicketOr404),
   // but preserves the row for audit and admin restore. Mirrors ticket_comments'
-  // deletedAt above. Hard purge (if ever added) is a separate retention job.
+  // deletedAt (defined below). Hard purge (if ever added) is a separate retention job.
   deletedAt: timestamp('deleted_at'),
   deletedBy: uuid('deleted_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/apps/api/src/routes/alerts/alertTickets.test.ts
+++ b/apps/api/src/routes/alerts/alertTickets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
-const { authRef, dbJoinResult, getAlertWithOrgCheckMock } = vi.hoisted(() => ({
+const { authRef, dbJoinResult, getAlertWithOrgCheckMock, capturedWhere } = vi.hoisted(() => ({
   authRef: {
     current: {
       scope: 'partner' as string,
@@ -13,7 +13,10 @@ const { authRef, dbJoinResult, getAlertWithOrgCheckMock } = vi.hoisted(() => ({
     }
   },
   dbJoinResult: vi.fn(),
-  getAlertWithOrgCheckMock: vi.fn()
+  getAlertWithOrgCheckMock: vi.fn(),
+  // Captures the arg the linked-tickets join hands to .where() so the soft-delete
+  // exclusion can be asserted on the serialized SQL.
+  capturedWhere: { args: [] as unknown[] }
 }));
 
 // requireScope injects auth here because alertsRoutes gets authMiddleware from
@@ -35,9 +38,12 @@ vi.mock('../../db', () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         innerJoin: vi.fn(() => ({
-          where: vi.fn(() => ({
-            orderBy: vi.fn(() => dbJoinResult())
-          }))
+          where: vi.fn((...args: unknown[]) => {
+            capturedWhere.args = args;
+            return {
+              orderBy: vi.fn(() => dbJoinResult())
+            };
+          })
         })),
         // GET /:id and friends use other chains; tolerate them.
         where: vi.fn(() => ({
@@ -54,7 +60,7 @@ vi.mock('../../db/schema', () => ({
   alertNotifications: {}, devices: {},
   tickets: {
     id: 'id', internalNumber: 'internalNumber', subject: 'subject',
-    status: 'status', priority: 'priority'
+    status: 'status', priority: 'priority', deletedAt: 'deletedAt'
   },
   ticketAlertLinks: {
     ticketId: 'ticketId', alertId: 'alertId', linkType: 'linkType', createdAt: 'createdAt'
@@ -112,6 +118,19 @@ describe('GET /alerts/:id/tickets', () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0].internalNumber).toBe('T-2026-0042');
     expect(body.data[0].linkType).toBe('created_from');
+  });
+
+  it('excludes soft-deleted tickets from the linked-tickets panel (deleted_at IS NULL)', async () => {
+    // Phase 6: the join filters on and(eq(alertId), isNull(tickets.deletedAt)) so a
+    // soft-deleted ticket never surfaces as a dead link / false open-duplicate.
+    getAlertWithOrgCheckMock.mockResolvedValue({ id: ALERT_ID, orgId: 'org-1' });
+    dbJoinResult.mockResolvedValue([]);
+    const res = await makeApp().request(`/alerts/${ALERT_ID}/tickets`);
+    expect(res.status).toBe(200);
+
+    const whereStr = JSON.stringify(capturedWhere.args);
+    expect(whereStr).toContain('deletedAt');
+    expect(whereStr).toContain('is null');
   });
 
   it('returns an empty list when nothing is linked', async () => {

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -954,7 +954,9 @@ alertsRoutes.get(
       })
       .from(ticketAlertLinks)
       .innerJoin(tickets, eq(ticketAlertLinks.ticketId, tickets.id))
-      .where(eq(ticketAlertLinks.alertId, id))
+      // Exclude soft-deleted tickets: a deleted ticket must not surface in the
+      // alert's linked-tickets panel (dead link + false open-duplicate detection).
+      .where(and(eq(ticketAlertLinks.alertId, id), isNull(tickets.deletedAt)))
       .orderBy(desc(ticketAlertLinks.createdAt));
 
     return c.json({ data });

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -64,7 +64,7 @@ vi.mock('../../db/schema', () => ({
     id: 'id', orgId: 'orgId', ticketNumber: 'ticketNumber',
     subject: 'subject', description: 'description', status: 'status',
     priority: 'priority', submittedBy: 'submittedBy', createdAt: 'createdAt',
-    updatedAt: 'updatedAt', statusId: 'statusId'
+    updatedAt: 'updatedAt', statusId: 'statusId', deletedAt: 'deletedAt'
   },
   ticketComments: {
     id: 'id', ticketId: 'ticketId', authorName: 'authorName',
@@ -256,6 +256,92 @@ describe('GET /tickets/:id — portal internal-note isolation', () => {
     });
 
     expect(res.status).toBe(404);
+  });
+});
+
+// ── Soft-delete exclusion: customer list + detail (Phase 6) ──────────────────
+
+describe('portal ticket soft-delete exclusion', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it('GET /tickets: customer list WHERE includes isNull(tickets.deletedAt)', async () => {
+    // The list query builds `conditions` (org + submittedBy + isNull(deletedAt))
+    // once and reuses it for both the count and the data select. Capturing either
+    // proves a soft-deleted ticket can never appear in the customer's own list.
+    let capturedListWhere: unknown[] = [];
+    dbSelectMock.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        // count query: `.from(tickets).where(conditions)` awaited directly
+        where: vi.fn((...args: unknown[]) => {
+          capturedListWhere = args;
+          return Promise.resolve([{ count: 0 }]);
+        }),
+        // data query: `.from(tickets).leftJoin().where(conditions).orderBy().limit().offset()`
+        leftJoin: vi.fn(() => ({
+          where: vi.fn((...args: unknown[]) => {
+            capturedListWhere = args;
+            return {
+              orderBy: vi.fn(() => ({
+                limit: vi.fn(() => ({ offset: vi.fn(() => Promise.resolve([])) }))
+              }))
+            };
+          })
+        }))
+      }))
+    }));
+
+    const res = await app.request('/tickets', {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(200);
+
+    const whereStr = JSON.stringify(capturedListWhere);
+    expect(whereStr).toContain('deletedAt');
+    expect(whereStr).toContain('is null');
+  });
+
+  it('GET /tickets/:id: detail lookup WHERE includes isNull(tickets.deletedAt)', async () => {
+    // A customer must never resolve their OWN soft-deleted ticket by id — the
+    // by-id lookup gates on isNull(tickets.deletedAt) alongside the org/submitter
+    // predicates.
+    let capturedDetailWhere: unknown[] = [];
+    let callCount = 0;
+    dbSelectMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // ticket lookup — .from().leftJoin().where().limit()
+        return {
+          from: vi.fn(() => ({
+            leftJoin: vi.fn(() => ({
+              where: vi.fn((...args: unknown[]) => {
+                capturedDetailWhere = args;
+                return { limit: vi.fn(() => Promise.resolve([TICKET_ROW])) };
+              })
+            }))
+          }))
+        };
+      }
+      // comments lookup — .from().where().orderBy()
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ orderBy: vi.fn(() => Promise.resolve([])) }))
+        }))
+      };
+    });
+
+    const res = await app.request(`/tickets/${TICKET_ID}`, {
+      headers: { Authorization: 'Bearer portal-token' }
+    });
+    expect(res.status).toBe(200);
+
+    const whereStr = JSON.stringify(capturedDetailWhere);
+    expect(whereStr).toContain('deletedAt');
+    expect(whereStr).toContain('is null');
   });
 });
 

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -30,7 +30,8 @@ ticketRoutes.get('/tickets', zValidator('query', listSchema), async (c) => {
 
   const conditions = and(
     eq(tickets.orgId, auth.user.orgId),
-    eq(tickets.submittedBy, auth.user.id)
+    eq(tickets.submittedBy, auth.user.id),
+    isNull(tickets.deletedAt) // soft-deleted tickets are invisible to portal customers
   );
 
   const ticketCountResult = await db
@@ -166,7 +167,8 @@ ticketRoutes.get('/tickets/:id', zValidator('param', ticketParamSchema), async (
       and(
         eq(tickets.id, id),
         eq(tickets.orgId, auth.user.orgId),
-        eq(tickets.submittedBy, auth.user.id)
+        eq(tickets.submittedBy, auth.user.id),
+        isNull(tickets.deletedAt)
       )
     )
     .limit(1);
@@ -229,7 +231,8 @@ ticketRoutes.post(
         and(
           eq(tickets.id, id),
           eq(tickets.orgId, auth.user.orgId),
-          eq(tickets.submittedBy, auth.user.id)
+          eq(tickets.submittedBy, auth.user.id),
+          isNull(tickets.deletedAt)
         )
       )
       .limit(1);

--- a/apps/api/src/routes/tickets/bulk.ts
+++ b/apps/api/src/routes/tickets/bulk.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { requireScope, requirePermission } from '../../middleware/auth';
-import { PERMISSIONS } from '../../services/permissions';
+import { PERMISSIONS, hasPermission, type UserPermissions } from '../../services/permissions';
 import { bulkTicketActionSchema } from '@breeze/shared';
-import { assignTicket, changeTicketStatus, getAssigneeForValidation, TicketServiceError } from '../../services/ticketService';
+import { assignTicket, changeTicketStatus, softDeleteTicket, getAssigneeForValidation, TicketServiceError } from '../../services/ticketService';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { actorFrom, getScopedTicketOr404 } from './tickets';
 
@@ -38,6 +38,17 @@ ticketsBulkRoutes.post(
 
     if (auth.scope === 'organization' && !auth.orgId) {
       return c.json({ error: 'Organization context required' }, 403);
+    }
+
+    // 'delete' is a soft-delete and needs the elevated tickets:manage grant
+    // (the route-level requirePermission only asserts tickets:write, which
+    // assign/status share). Partner Admin (*:*) and Org Admin hold manage.
+    if (body.action === 'delete') {
+      const perms = c.get('permissions') as UserPermissions | undefined;
+      const canManage = perms
+        ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action)
+        : false;
+      if (!canManage) return c.json({ error: 'Deleting tickets requires ticket management permission' }, 403);
     }
 
     // Request-level assignee pre-validation: an unknown assignee (or, for
@@ -76,6 +87,10 @@ ticketsBulkRoutes.post(
         if (body.action === 'assign') {
           // Schema refine guarantees assigneeId is present (null = unassign).
           await assignTicket(ticketId, body.assigneeId ?? null, actor);
+        } else if (body.action === 'delete') {
+          // Soft-delete. Already-deleted ids can't reach here (getScopedTicketOr404
+          // excludes deleted rows → counted as OUT_OF_SCOPE skip above).
+          await softDeleteTicket(ticketId, actor);
         } else {
           // Schema refine guarantees status is present and not 'resolved'.
           await changeTicketStatus(ticketId, { status: body.status! }, {}, actor);

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -308,6 +308,20 @@ describe('GET /tickets', () => {
     expect(serialized).toContain('resolution_sla_minutes');
   });
 
+  it('default (non-archived) list excludes soft-deleted tickets (deleted_at IS NULL)', async () => {
+    // Phase 6: the default GET /tickets branch appends isNull(tickets.deletedAt)
+    // so soft-deleted tickets never appear in the staff queue. The `deleted=only`
+    // archived view is gated + tested separately; this guards the DEFAULT branch.
+    dbSelectMock.mockResolvedValue([]);
+    const res = await makeApp().request('/tickets');
+    expect(res.status).toBe(200);
+
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastWhereArgs[0]!.conditions);
+    expect(serialized).toContain('deletedAt');
+    expect(serialized).toContain('is null');
+  });
+
   it('triage sort orders breached first, then at-risk, then priority', async () => {
     dbSelectMock.mockResolvedValue([]);
     const res = await makeApp().request('/tickets?sort=triage');
@@ -517,6 +531,20 @@ describe('GET /tickets/stats', () => {
 
     // Ensure groupBy was used (not orderBy) — the mock resolves via dbGroupByMock
     expect(dbGroupByMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes soft-deleted tickets from queue counts (deleted_at IS NULL)', async () => {
+    // Phase 6: /stats appends isNull(tickets.deletedAt) so soft-deleted tickets
+    // never inflate the queue tab / dashboard-widget counts.
+    dbGroupByMock.mockResolvedValue([]);
+    dbSelectMock.mockResolvedValue([{ atRisk: 0 }]);
+    const res = await makeApp().request('/tickets/stats');
+    expect(res.status).toBe(200);
+
+    expect(lastWhereArgs.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(lastWhereArgs[0]!.conditions);
+    expect(serialized).toContain('deletedAt');
+    expect(serialized).toContain('is null');
   });
 
   it('403 when partner scope has null partnerId (broken context)', async () => {

--- a/apps/api/src/routes/tickets/tickets.test.ts
+++ b/apps/api/src/routes/tickets/tickets.test.ts
@@ -16,6 +16,8 @@ const { serviceMocks, ticketTriageMocks, dbSelectMock, dbGroupByMock, authRef, l
       getAssigneeForValidation: vi.fn(),
       editTicketComment: vi.fn(),
       deleteTicketComment: vi.fn(),
+      softDeleteTicket: vi.fn(),
+      restoreTicket: vi.fn(),
       listRequestersForOrg: vi.fn(),
     },
     ticketTriageMocks: {
@@ -67,6 +69,10 @@ vi.mock('../../middleware/auth', async () => ({
       return c.json({ error: 'Not authenticated' }, 401);
     }
     c.set('auth', authRef.current);
+    // Mirror the real permission middleware for the handful of handlers that
+    // read c.get('permissions') directly (archived-view + bulk-delete gates).
+    const perms = (authRef.current as any).permissions;
+    if (perms) c.set('permissions', perms);
     await next();
   }),
   requireScope: () => async (c: any, next: any) => {
@@ -162,7 +168,8 @@ vi.mock('../../db/schema', () => ({
     source: 'source', slaBreachedAt: 'sla_breached_at', firstResponseAt: 'first_response_at',
     responseSlaMinutes: 'response_sla_minutes', resolutionSlaMinutes: 'resolution_sla_minutes',
     slaPausedAt: 'sla_paused_at', slaPausedMinutes: 'sla_paused_minutes',
-    slaBreachReason: 'sla_breach_reason', statusId: 'statusId'
+    slaBreachReason: 'sla_breach_reason', statusId: 'statusId',
+    deletedAt: 'deletedAt', deletedBy: 'deletedBy'
   },
   ticketStatuses: { id: 'id', name: 'name', color: 'color' },
   ticketComments: { ticketId: 'ticketId', deletedAt: 'deletedAt', createdAt: 'createdAt' },
@@ -903,6 +910,109 @@ describe('POST /tickets/:id/assign', () => {
     });
     expect(res.status).toBe(404);
     expect(serviceMocks.assignTicket).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /tickets/:id — soft-delete', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('calls softDeleteTicket and returns 200', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]); // getScopedTicketOr404
+    serviceMocks.softDeleteTicket.mockResolvedValue({ id: TICKET_ID });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.softDeleteTicket).toHaveBeenCalledWith(
+      TICKET_ID,
+      expect.objectContaining({ userId: 'u-1' })
+    );
+  });
+
+  it('returns 404 when the ticket is out of scope / already deleted (scoped pre-check empty)', async () => {
+    dbSelectMock.mockResolvedValueOnce([]); // getScopedTicketOr404 excludes deleted rows
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    expect(serviceMocks.softDeleteTicket).not.toHaveBeenCalled();
+  });
+
+  it('maps a 409 TicketServiceError (already deleted) through from the service', async () => {
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]);
+    serviceMocks.softDeleteTicket.mockRejectedValue(new TicketServiceError('Ticket already deleted', 409));
+    const res = await makeApp().request(`/tickets/${TICKET_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('POST /tickets/:id/restore', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('calls restoreTicket (finding the deleted row) and returns 200', async () => {
+    dbSelectMock.mockResolvedValueOnce([{ ...STUB_TICKET, deletedAt: new Date().toISOString() }]); // getScopedTicketOr404 includeDeleted
+    serviceMocks.restoreTicket.mockResolvedValue({ ...STUB_TICKET, deletedAt: null });
+
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/restore`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(serviceMocks.restoreTicket).toHaveBeenCalledWith(
+      TICKET_ID,
+      expect.objectContaining({ userId: 'u-1' })
+    );
+  });
+
+  it('returns 404 when the id is out of scope', async () => {
+    dbSelectMock.mockResolvedValueOnce([]);
+    const res = await makeApp().request(`/tickets/${TICKET_ID}/restore`, { method: 'POST' });
+    expect(res.status).toBe(404);
+    expect(serviceMocks.restoreTicket).not.toHaveBeenCalled();
+  });
+});
+
+const MANAGE_PERMS = { permissions: [{ resource: 'tickets', action: 'manage' }] };
+
+describe('GET /tickets?deleted=only — archived queue gate', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('403s without ticket-management permission (no permissions on context)', async () => {
+    const res = await makeApp().request('/tickets?deleted=only');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the archived queue for a ticket-manager', async () => {
+    (authRef.current as any).permissions = MANAGE_PERMS;
+    dbSelectMock.mockResolvedValue([{ id: 't-1', subject: 'Spam', deletedAt: new Date().toISOString() }]);
+    const res = await makeApp().request('/tickets?deleted=only');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({ deletedAt: expect.any(String) });
+  });
+});
+
+describe('POST /tickets/bulk — delete action', () => {
+  beforeEach(() => { vi.clearAllMocks(); resetAuth(); });
+
+  it('403s when the caller lacks tickets:manage', async () => {
+    const res = await makeApp().request('/tickets/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticketIds: [TICKET_ID], action: 'delete' })
+    });
+    expect(res.status).toBe(403);
+    expect(serviceMocks.softDeleteTicket).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes each in-scope ticket for a manager', async () => {
+    (authRef.current as any).permissions = MANAGE_PERMS;
+    dbSelectMock.mockResolvedValueOnce([STUB_TICKET]); // getScopedTicketOr404 for the one id
+    serviceMocks.softDeleteTicket.mockResolvedValue({ id: TICKET_ID });
+
+    const res = await makeApp().request('/tickets/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticketIds: [TICKET_ID], action: 'delete' })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toMatchObject({ updated: 1, total: 1 });
+    expect(serviceMocks.softDeleteTicket).toHaveBeenCalledWith(TICKET_ID, expect.objectContaining({ userId: 'u-1' }));
   });
 });
 

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -741,8 +741,8 @@ ticketsRoutes.post(
 
 // DELETE /tickets/:id — soft-delete a ticket (Phase 6, issue #2140).
 // tickets:manage (Partner Admin / Org Admin) — the same elevated grant that
-// already gates "delete any comment" and "reassign ticket org". Hides the
-// ticket from every list/stats/by-id path; reversible via POST /:id/restore.
+// already gates deleting/editing another user's comment. Hides the ticket from
+// every list/stats/by-id path; reversible via POST /:id/restore.
 ticketsRoutes.delete(
   '/:id',
   requireScope('organization', 'partner', 'system'),

--- a/apps/api/src/routes/tickets/tickets.ts
+++ b/apps/api/src/routes/tickets/tickets.ts
@@ -17,6 +17,7 @@ import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, updateTicketFields,
   editTicketComment, deleteTicketComment, listRequestersForOrg,
+  softDeleteTicket, restoreTicket,
   TicketServiceError
 } from '../../services/ticketService';
 import {
@@ -107,12 +108,18 @@ export function handleServiceError(c: { json: (b: unknown, s: number) => Respons
  * - system scope: no extra condition (unrestricted)
  * - site axis: device-bound tickets are additionally gated by the caller's
  *   `allowedSiteIds` allowlist (see deviceInSiteScope).
+ * - soft-delete: deleted tickets are treated as not-found (404) by default so
+ *   every by-id mutation (status/assign/comment/patch/alerts/delete) rejects
+ *   them. Pass `{ includeDeleted: true }` on the restore path, which needs to
+ *   load the deleted row.
  */
 export async function getScopedTicketOr404(
   auth: AuthContext,
-  id: string
+  id: string,
+  opts: { includeDeleted?: boolean } = {}
 ): Promise<(typeof tickets.$inferSelect) | null> {
   const conditions: SQL[] = [eq(tickets.id, id)];
+  if (!opts.includeDeleted) conditions.push(isNull(tickets.deletedAt));
 
   if (auth.scope === 'organization') {
     if (!auth.orgId) return null; // 403 callers: treat as not-found for consistency
@@ -192,6 +199,7 @@ ticketsRoutes.get(
     // device-bound tickets (deviceless tickets remain counted).
     const siteCondition = ticketSiteScopeCondition(auth);
     if (siteCondition) conditions.push(siteCondition);
+    conditions.push(isNull(tickets.deletedAt)); // soft-deleted tickets never count toward queue tabs
     const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
     const rows = await db
@@ -298,6 +306,19 @@ ticketsRoutes.get(
     }
     const siteCondition = ticketSiteScopeCondition(auth);
     if (siteCondition) conditions.push(siteCondition);
+    // Soft-delete: default list excludes deleted tickets. `deleted=only` returns
+    // the admin "Archived" queue and requires tickets:manage (the same grant that
+    // gates delete/restore) so viewers/technicians can't enumerate deleted rows.
+    if (q.deleted === 'only') {
+      const perms = c.get('permissions') as UserPermissions | undefined;
+      const canManage = perms
+        ? hasPermission(perms, PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action)
+        : false;
+      if (!canManage) return c.json({ error: 'Viewing deleted tickets requires ticket management permission' }, 403);
+      conditions.push(sql`${tickets.deletedAt} IS NOT NULL`);
+    } else {
+      conditions.push(isNull(tickets.deletedAt));
+    }
     if (q.status) conditions.push(eq(tickets.status, q.status));
     else if (q.statusGroup === 'open') conditions.push(inArray(tickets.status, [...OPEN_STATUSES]));
     else if (q.statusGroup === 'closed') conditions.push(inArray(tickets.status, [...CLOSED_STATUSES]));
@@ -351,6 +372,7 @@ ticketsRoutes.get(
         slaBreachReason: tickets.slaBreachReason,
         createdAt: tickets.createdAt,
         updatedAt: tickets.updatedAt,
+        deletedAt: tickets.deletedAt,
         statusName: ticketStatuses.name,
         statusColor: ticketStatuses.color
       })
@@ -710,6 +732,56 @@ ticketsRoutes.post(
 
     try {
       const ticket = await assignTicket(id, assigneeId, actorFrom(c));
+      return c.json({ data: ticket });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+
+// DELETE /tickets/:id — soft-delete a ticket (Phase 6, issue #2140).
+// tickets:manage (Partner Admin / Org Admin) — the same elevated grant that
+// already gates "delete any comment" and "reassign ticket org". Hides the
+// ticket from every list/stats/by-id path; reversible via POST /:id/restore.
+ticketsRoutes.delete(
+  '/:id',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action),
+  zValidator('param', idParam),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id);
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    try {
+      const result = await softDeleteTicket(id, actorFrom(c));
+      return c.json({ data: result });
+    } catch (err) {
+      return handleServiceError(c, err);
+    }
+  }
+);
+
+// POST /tickets/:id/restore — undo a soft-delete (Phase 6). includeDeleted so
+// the scope lookup can find the already-deleted row; same tickets:manage gate.
+ticketsRoutes.post(
+  '/:id/restore',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.TICKETS_MANAGE.resource, PERMISSIONS.TICKETS_MANAGE.action),
+  zValidator('param', idParam),
+  async (c) => {
+    const auth = c.get('auth');
+    const { id } = c.req.valid('param');
+    if (auth.scope === 'organization' && !auth.orgId) {
+      return c.json({ error: 'Organization context required' }, 403);
+    }
+    const found = await getScopedTicketOr404(auth, id, { includeDeleted: true });
+    if (!found) return c.json({ error: 'Ticket not found' }, 404);
+    try {
+      const ticket = await restoreTicket(id, actorFrom(c));
       return c.json({ data: ticket });
     } catch (err) {
       return handleServiceError(c, err);

--- a/apps/api/src/services/aiToolsTicketing.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.test.ts
@@ -443,11 +443,16 @@ describe('manage_tickets list — site-axis scoping', () => {
     expect(JSON.stringify(whereArg)).toContain('is null');
   });
 
-  it("leaves an unrestricted caller's list unchanged (no site condition)", async () => {
+  it("adds no site condition for an unrestricted caller (only the soft-delete filter)", async () => {
     const out = await getTool().handler({ action: 'list' }, auth);
     expect(JSON.parse(out)).toHaveProperty('tickets');
+    // One select (no devices subquery) → no site-axis condition was applied.
     expect(mockSelect).toHaveBeenCalledTimes(1);
-    expect(mockWhere.mock.calls.at(-1)?.[0]).toBeUndefined();
+    // The list still always excludes soft-deleted tickets (Phase 6), so where()
+    // now carries the deleted_at IS NULL filter instead of being undefined.
+    const whereArg = mockWhere.mock.calls.at(-1)?.[0];
+    expect(whereArg).toBeDefined();
+    expect(JSON.stringify(whereArg)).toContain('is null');
   });
 });
 

--- a/apps/api/src/services/aiToolsTicketing.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.test.ts
@@ -199,6 +199,18 @@ describe('manage_tickets tool', () => {
     expect(parsed.error).toMatch(/not found/i);
   });
 
+  it('get always applies the soft-delete filter (excludes deleted tickets)', async () => {
+    // Phase 6: findTicketWithAccess must gate on isNull(tickets.deletedAt) so a
+    // soft-deleted ticket resolves as not-found even when its id is guessed.
+    // Regression guard: dropping that predicate would remove the "is null" clause
+    // from the WHERE the scoped by-id select hands to .where().
+    mockLimit.mockResolvedValue(TICKET_ROW);
+    await getTool().handler({ action: 'get', ticketId: 't-1' }, auth);
+    const whereArg = mockWhere.mock.calls.at(-1)?.[0];
+    expect(whereArg).toBeDefined();
+    expect(JSON.stringify(whereArg)).toContain('is null');
+  });
+
   // ── comment ───────────────────────────────────────────────────────────────
 
   it('comment delegates to addTicketComment when ticket is in scope', async () => {

--- a/apps/api/src/services/aiToolsTicketing.ts
+++ b/apps/api/src/services/aiToolsTicketing.ts
@@ -6,7 +6,7 @@
  * All mutations delegate to ticketService — this file is a thin adapter.
  */
 
-import { and, desc, eq, type SQL } from 'drizzle-orm';
+import { and, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { tickets } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
@@ -58,7 +58,7 @@ function timeEntryActorFrom(auth: AuthContext) {
  * Returns the ticket row, or null when not found / out of the caller's scope.
  */
 async function findTicketWithAccess(ticketId: string, auth: AuthContext) {
-  const conditions: SQL[] = [eq(tickets.id, ticketId)];
+  const conditions: SQL[] = [eq(tickets.id, ticketId), isNull(tickets.deletedAt)];
   const orgCond = auth.orgCondition(tickets.orgId);
   if (orgCond) conditions.push(orgCond);
   const [ticket] = await db.select().from(tickets).where(and(...conditions)).limit(1);
@@ -166,7 +166,7 @@ export function registerTicketingTools(aiTools: Map<string, AiTool>): void {
 
       // ── list ──────────────────────────────────────────────────────────────
       if (action === 'list') {
-        const conditions: SQL[] = [];
+        const conditions: SQL[] = [isNull(tickets.deletedAt)]; // never surface soft-deleted tickets to the AI
         const orgCond = auth.orgCondition(tickets.orgId);
         if (orgCond) conditions.push(orgCond);
         // Site axis: mirror the HTTP list route (routes/tickets/tickets.ts) —

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -48,11 +48,32 @@ function extractStatusConstraint(cond: unknown): { op: string; value: string } |
   return null;
 }
 
+// Walk a drizzle SQL condition's queryChunks to detect an `isNull(tickets.deletedAt)`
+// predicate. The schema mock makes `tickets.deletedAt` the plain string 'deletedAt',
+// so isNull serializes as the chunk sequence ["deletedAt", { value: [" is null"] }].
+// When present, the tickets-select mock filters out any soft-deleted candidate row
+// (deletedAt != null) — so if production ever drops the isNull filter, the mock will
+// (correctly) surface the deleted row and the exclusion tests below fail.
+function whereExcludesDeleted(cond: unknown): boolean {
+  const chunks = (cond as { queryChunks?: unknown[] })?.queryChunks;
+  if (!Array.isArray(chunks)) return false;
+  for (let i = 0; i < chunks.length; i++) {
+    if (chunks[i] === 'deletedAt') {
+      const opChunk = chunks[i + 1] as { value?: string[] } | undefined;
+      const op = opChunk?.value?.[0];
+      if (typeof op === 'string' && op.includes('is null')) return true;
+    }
+    if (whereExcludesDeleted(chunks[i])) return true;
+  }
+  return false;
+}
+
 vi.mock('../../db', () => {
   // select(cols).from(table).where().limit() and .innerJoin().where().limit()
   function makeSelect() {
     let resolvedTable = 'unknown';
     let statusConstraint: { op: string; value: string } | null = null;
+    let excludesDeleted = false;
     const chain: Record<string, unknown> = {
       from(tbl: unknown) {
         resolvedTable = tableName(tbl);
@@ -63,6 +84,7 @@ vi.mock('../../db', () => {
       },
       where(w: unknown) {
         statusConstraint = extractStatusConstraint(w);
+        excludesDeleted = whereExcludesDeleted(w);
         return chain;
       },
       limit(_n: number) {
@@ -75,6 +97,11 @@ vi.mock('../../db', () => {
             const s = (r as { status?: string }).status;
             return op.includes('<>') ? s !== value : s === value;
           });
+        }
+        // Honor isNull(tickets.deletedAt): a soft-deleted candidate must never match,
+        // so the reply forks a new ticket instead of re-threading onto the deleted one.
+        if (resolvedTable === 'tickets' && excludesDeleted) {
+          rows = rows.filter((r) => (r as { deletedAt?: unknown }).deletedAt == null);
         }
         return Promise.resolve(rows);
       }
@@ -131,7 +158,8 @@ vi.mock('../../db/schema', () => ({
     __t: 'tickets',
     id: 'id', partnerId: 'partnerId', orgId: 'orgId', status: 'status', subject: 'subject',
     emailThreadKey: 'emailThreadKey', emailMessageId: 'emailMessageId',
-    internalNumber: 'internalNumber', resolvedAt: 'resolvedAt', updatedAt: 'updatedAt'
+    internalNumber: 'internalNumber', resolvedAt: 'resolvedAt', updatedAt: 'updatedAt',
+    deletedAt: 'deletedAt'
   },
   ticketComments: { __t: 'ticket_comments', ticketId: 'ticketId' },
   portalUsers: { __t: 'portal_users', id: 'id', orgId: 'orgId', email: 'email' },
@@ -559,6 +587,63 @@ describe('processInboundEmail', () => {
     expect(log).toHaveLength(1);
     expect(log[0]!.parseStatus).toBe('created');
     expect(log[0]!.ticketId).toBe('t-linked');
+  });
+
+  // SOFT-DELETE EXCLUSION (Phase 6): findTicketInPartner gates the live thread-key /
+  // subject-token match on isNull(tickets.deletedAt). A reply whose thread key matches
+  // a SOFT-DELETED ticket must NOT re-thread onto it — the deleted row is invisible to
+  // the matcher, so the reply forks a brand-new ticket instead.
+  it('does NOT thread onto a soft-deleted ticket — forks a new ticket instead (live match)', async () => {
+    resolveMock.mockResolvedValue('p-1');
+    state.selectRows['ticket_email_inbound'] = []; // no dup
+    // A resolved ticket matches the thread key BUT has been soft-deleted.
+    state.selectRows['tickets'] = [{
+      id: 't-deleted', partnerId: 'p-1', orgId: 'o-1', status: 'resolved',
+      emailThreadKey: '<msg-1@tickets.example.com>', internalNumber: 'T-2026-0001',
+      deletedAt: new Date()
+    }];
+    // Known portal user + org so the fall-through create path succeeds.
+    state.selectRows['portal_users'] = [{ id: 'pu-1', orgId: 'o-1' }];
+    state.selectRows['organizations'] = [{ id: 'o-1' }];
+    createTicketMock.mockResolvedValue({ id: 't-fresh', internalNumber: 'T-2026-0050' });
+
+    await processInboundEmail(email({ inReplyTo: '<msg-1@tickets.example.com>' }));
+
+    // The soft-deleted ticket must NOT be appended to or reopened.
+    expect(state.inserts.filter((i) => i.table === 'ticket_comments')).toHaveLength(0);
+    expect(state.updates.filter((u) => u.table === 'tickets' && u.set.status === 'open')).toHaveLength(0);
+    // Instead, a brand-new ticket is created for the reply.
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+
+    const log = inboundOf();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.parseStatus).toBe('created');
+    expect(log[0]!.ticketId).toBe('t-fresh');
+  });
+
+  // findClosedTicketInPartner is likewise gated on isNull(tickets.deletedAt): a reply to
+  // a soft-deleted CLOSED original must not spawn a continuation from the deleted row.
+  it('does NOT spawn a continuation from a soft-deleted CLOSED original — quarantines instead', async () => {
+    resolveMock.mockResolvedValue('p-1');
+    state.selectRows['ticket_email_inbound'] = []; // no dup
+    // A CLOSED ticket matches the subject token / thread key BUT is soft-deleted.
+    state.selectRows['tickets'] = [{
+      id: 't-closed-deleted', partnerId: 'p-1', orgId: 'o-1', status: 'closed',
+      emailThreadKey: '<thread-key-old>', internalNumber: 'T-2026-0001',
+      deletedAt: new Date()
+    }];
+    // Unknown sender (no portal user, no domain mapping) so the ONLY path that could
+    // create a ticket is the closed-continuation — which must NOT fire for a deleted original.
+    state.selectRows['portal_users'] = [];
+
+    await processInboundEmail(email({ subject: 'Re: [T-2026-0001] printer down', inReplyTo: '<thread-key-old>' }));
+
+    // The soft-deleted closed original is excluded → no continuation ticket created.
+    expect(createTicketMock).not.toHaveBeenCalled();
+    const log = inboundOf();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.parseStatus).toBe('quarantined');
+    expect(log[0]!.ticketId).toBeNull();
   });
 
   // TEST 2 — durable failed-log path: when a WORK write throws, logInboundFailedDurable

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, ne, or } from 'drizzle-orm';
+import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { ticketEmailInbound, tickets, ticketComments, portalUsers, organizations, partners } from '../../db/schema';
 import { createTicket } from '../ticketService';
@@ -346,6 +346,7 @@ async function findTicketInPartner(n: NormalizedInboundEmail, partnerId: string)
       .where(and(
         eq(tickets.partnerId, partnerId),
         ne(tickets.status, 'closed'),
+        isNull(tickets.deletedAt), // never thread a reply onto a soft-deleted ticket
         or(
           inArray(tickets.emailThreadKey, candidateKeys),
           inArray(tickets.emailMessageId, candidateKeys)
@@ -364,6 +365,7 @@ async function findTicketInPartner(n: NormalizedInboundEmail, partnerId: string)
       .where(and(
         eq(tickets.partnerId, partnerId),
         ne(tickets.status, 'closed'),
+        isNull(tickets.deletedAt),
         eq(tickets.internalNumber, m[0])
       ))
       .limit(1);
@@ -387,6 +389,7 @@ async function findClosedTicketInPartner(n: NormalizedInboundEmail, partnerId: s
       .where(and(
         eq(tickets.partnerId, partnerId),
         eq(tickets.status, 'closed'),
+        isNull(tickets.deletedAt), // a deleted closed original must not spawn a continuation
         inArray(tickets.emailThreadKey, candidateKeys)
       ))
       .limit(1);
@@ -401,6 +404,7 @@ async function findClosedTicketInPartner(n: NormalizedInboundEmail, partnerId: s
       .where(and(
         eq(tickets.partnerId, partnerId),
         eq(tickets.status, 'closed'),
+        isNull(tickets.deletedAt),
         eq(tickets.internalNumber, m[0])
       ))
       .limit(1);

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -121,7 +121,7 @@ import {
   createTicket, changeTicketStatus, assignTicket, addTicketComment,
   linkAlertToTicket, unlinkAlertFromTicket, createTicketFromAlert,
   updateTicketFields, editTicketComment, deleteTicketComment, portalCommentMutable,
-  moveTicketOrg,
+  moveTicketOrg, softDeleteTicket, restoreTicket,
   TicketServiceError, TICKET_STATUS_TRANSITIONS, SYSTEM_COMMENT_TYPES
 } from './ticketService';
 
@@ -2088,6 +2088,99 @@ describe('deleteTicketComment', () => {
     // Audit and event must NOT have fired.
     expect(auditMock).not.toHaveBeenCalled();
     expect(emitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('softDeleteTicket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('stamps deletedAt/deletedBy, audits ticket.delete, and emits NO event', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([{ ...BASE_TICKET, ticketNumber: 'ABC123', subject: 'Spam', deletedAt: null }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't1' }]); // CAS returns the row
+
+    const res = await softDeleteTicket('t1', actor);
+    expect(res).toEqual({ id: 't1' });
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.deletedAt).toBeInstanceOf(Date);
+    expect(updatePayload.deletedBy).toBe('u-1');
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ticket.delete',
+      resourceType: 'ticket',
+      resourceId: 't1',
+      details: expect.objectContaining({ ticketNumber: 'ABC123', subject: 'Spam' }),
+      result: 'success'
+    }));
+    // Deleting must not emit a lifecycle event (would notify the portal requester).
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an already-deleted ticket (409) without updating or auditing', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([{ ...BASE_TICKET, deletedAt: new Date() }]);
+
+    const err = await softDeleteTicket('t1', actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(409);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('throws 409 when the CAS update loses a race (no row returned)', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([{ ...BASE_TICKET, deletedAt: null }]);
+    dbMocks.updateReturning.mockResolvedValue([]); // concurrent delete won
+
+    const err = await softDeleteTicket('t1', actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(409);
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it('throws 404 when the ticket does not exist', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([]);
+    const err = await softDeleteTicket('nope', actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(404);
+  });
+});
+
+describe('restoreTicket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuesMock.mockClear();
+    setMock.mockClear();
+  });
+
+  it('clears deletedAt/deletedBy and audits ticket.restore', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([{ ...BASE_TICKET, ticketNumber: 'ABC123', subject: 'Spam', deletedAt: new Date() }]);
+    dbMocks.updateReturning.mockResolvedValue([{ id: 't1', deletedAt: null }]);
+
+    const res = await restoreTicket('t1', actor);
+    expect(res).toMatchObject({ id: 't1', deletedAt: null });
+
+    const updatePayload = setMock.mock.calls[0]![0];
+    expect(updatePayload.deletedAt).toBeNull();
+    expect(updatePayload.deletedBy).toBeNull();
+
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ticket.restore',
+      resourceId: 't1',
+      result: 'success'
+    }));
+  });
+
+  it('rejects restoring a ticket that is not deleted (409)', async () => {
+    dbMocks.selectResult.mockResolvedValueOnce([{ ...BASE_TICKET, deletedAt: null }]);
+
+    const err = await restoreTicket('t1', actor).catch(e => e);
+    expect(err).toBeInstanceOf(TicketServiceError);
+    expect(err.status).toBe(409);
+    expect(setMock).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1143,6 +1143,71 @@ export async function deleteTicketComment(
   return { id: commentId };
 }
 
+// ─── Soft-delete / restore (Phase 6, issue #2140) ─────────────────────────────
+
+/**
+ * Soft-delete a ticket. Stamps deleted_at/deleted_by so the ticket drops out of
+ * every staff/portal list, stats count, and by-id mutation (getScopedTicketOr404
+ * excludes deleted rows by default), while the row is preserved for audit and
+ * admin restore. Deliberately emits NO ticket lifecycle event — deletion must
+ * not send a portal notification (mirrors deleteTicketComment). Re-deleting an
+ * already-deleted ticket is a 409 so a double-click can't overwrite deleted_by.
+ * Gated at the route on tickets:manage.
+ */
+export async function softDeleteTicket(ticketId: string, actor: TicketActor): Promise<{ id: string }> {
+  const ticket = await getTicketOrThrow(ticketId);
+  if (ticket.deletedAt) throw new TicketServiceError('Ticket already deleted', 409);
+
+  const now = new Date();
+  const deleted = await db
+    .update(tickets)
+    .set({ deletedAt: now, deletedBy: actor.userId, updatedAt: now })
+    .where(and(eq(tickets.id, ticketId), isNull(tickets.deletedAt)))
+    .returning({ id: tickets.id });
+  // CAS on deleted_at IS NULL: an empty result means we lost a race to a
+  // concurrent delete — report it rather than emit a second audit entry.
+  if (deleted.length === 0) throw new TicketServiceError('Ticket already deleted', 409);
+
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.delete',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { ticketNumber: ticket.ticketNumber, subject: ticket.subject, status: ticket.status },
+    result: 'success'
+  });
+  return { id: ticketId };
+}
+
+/**
+ * Restore a soft-deleted ticket. Clears deleted_at/deleted_by. Restoring a
+ * ticket that isn't deleted is a 409 (nothing to restore). Audited as
+ * ticket.restore. Gated at the route on tickets:manage.
+ */
+export async function restoreTicket(ticketId: string, actor: TicketActor): Promise<typeof tickets.$inferSelect> {
+  const ticket = await getTicketOrThrow(ticketId);
+  if (!ticket.deletedAt) throw new TicketServiceError('Ticket is not deleted', 409);
+
+  const [updated] = await db
+    .update(tickets)
+    .set({ deletedAt: null, deletedBy: null, updatedAt: new Date() })
+    .where(and(eq(tickets.id, ticketId), sql`${tickets.deletedAt} IS NOT NULL`))
+    .returning();
+  if (!updated) throw new TicketServiceError('Ticket is not deleted', 409);
+
+  await createAuditLogAsync({
+    orgId: ticket.orgId,
+    actorId: actor.userId,
+    action: 'ticket.restore',
+    resourceType: 'ticket',
+    resourceId: ticketId,
+    details: { ticketNumber: ticket.ticketNumber, subject: ticket.subject },
+    result: 'success'
+  });
+  return updated;
+}
+
 // ─── Org re-assignment (Phase 6a) ─────────────────────────────────────────────
 
 // Child tables that denormalize org_id and reference a ticket. Mirrors the

--- a/apps/web/src/components/tickets/TicketArchivedList.tsx
+++ b/apps/web/src/components/tickets/TicketArchivedList.tsx
@@ -1,0 +1,92 @@
+import { memo } from 'react';
+import { cn } from '@/lib/utils';
+import { statusConfig, priorityConfig, type TicketSummary } from './ticketConfig';
+import { priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
+import { formatDateTime } from '@/lib/dateTimeFormat';
+
+interface Props {
+  tickets: TicketSummary[];
+  loading: boolean;
+  /** Ticket config for custom-status names/colors and priority labels; null falls back to core config. */
+  config?: TicketConfig | null;
+  /** Restore a soft-deleted ticket (POST /tickets/:id/restore, wrapped in runAction by the host). */
+  onRestore: (t: TicketSummary) => void;
+  /** Ids with an in-flight restore — disables their button so a double-click can't double-POST. */
+  restoringIds?: Set<string>;
+}
+
+// Local twin of TicketQueueList.timeAgo — "deleted 3d ago" reads relative to the
+// soft-delete stamp. Duplicated (per CLAUDE.md) to keep this surface self-contained.
+function timeAgo(iso: string): string {
+  const mins = (Date.now() - new Date(iso).getTime()) / 60_000;
+  if (mins < 60) return `${Math.max(1, Math.floor(mins))}m ago`;
+  if (mins < 60 * 24) return `${Math.floor(mins / 60)}h ago`;
+  return `${Math.floor(mins / (60 * 24))}d ago`;
+}
+
+function TicketArchivedList({ tickets, loading, config = null, onRestore, restoringIds }: Props) {
+  if (loading && tickets.length === 0) {
+    return (
+      <div className="divide-y" data-testid="tickets-archived-loading">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="px-3 py-3 animate-pulse">
+            <div className="h-3.5 w-3/4 rounded bg-muted" />
+            <div className="mt-2 h-3 w-1/2 rounded bg-muted/60" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (tickets.length === 0) {
+    return (
+      <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="tickets-archived-empty">
+        <p>No archived tickets.</p>
+        <p className="mt-1">Deleted tickets land here. Restore one to return it to the live queues.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y" aria-label="Archived tickets" data-testid="tickets-archived-list">
+      {tickets.map((t) => (
+        <li key={t.id} className="flex items-start gap-3 px-3 py-2.5" data-testid={`ticket-archived-row-${t.id}`}>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs text-muted-foreground shrink-0">{t.internalNumber ?? '·'}</span>
+              <span className="truncate text-sm font-medium">{t.subject}</span>
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium', priorityConfig[t.priority].color)}>
+                {priorityLabel(config, t.priority)}
+              </span>
+              <span className={cn('inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 font-medium', statusConfig[t.status].color)}>
+                {t.statusColor && (
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: t.statusColor }} aria-hidden="true" />
+                )}
+                {statusLabel(config, t.status, t.statusName)}
+              </span>
+              <span className="truncate">{t.orgName ?? ''}</span>
+              {t.deletedAt && (
+                <span title={formatDateTime(t.deletedAt)}>deleted {timeAgo(t.deletedAt)}</span>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onRestore(t)}
+            disabled={restoringIds?.has(t.id)}
+            data-testid={`ticket-restore-${t.id}`}
+            className="shrink-0 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {restoringIds?.has(t.id) ? 'Restoring…' : 'Restore'}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// Memoized for parity with TicketQueueList: the host re-renders on unrelated
+// state (search box, reconcile timers) and the archived list can carry 100 rows.
+export default memo(TicketArchivedList);

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -6,12 +6,16 @@ import { fetchWithAuth } from '../../stores/auth';
 import { fetchTicketConfig, type TicketConfig } from '../../lib/ticketConfigApi';
 import type { TicketDetail } from './ticketConfig';
 
+// Mutable grant set read by usePermissions() (via the selector form). Delete is
+// tickets:manage-gated; most tests run without it, delete tests opt in.
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
   // Selector hook stub — the composer reads the signed-in agent's name for the
-  // {{agent_name}} canned-response variable.
-  useAuthStore: (selector: (s: { user: { name: string } | null }) => unknown) =>
-    selector({ user: { name: 'Test Agent' } })
+  // {{agent_name}} canned-response variable; usePermissions reads user.permissions.
+  useAuthStore: (selector: (s: { user: { name: string; permissions: Perm[] } | null }) => unknown) =>
+    selector({ user: { name: 'Test Agent', permissions: authState.permissions } })
 }));
 
 // Stub only fetchTicketConfig; the real display/grouping helpers run unchanged.
@@ -85,6 +89,9 @@ function mockTicketApi(detailById: Record<string, TicketDetail>) {
 
 const mutationCalls = () =>
   fetchMock.mock.calls.filter(([, init]) => init?.method && init.method !== 'GET');
+
+// Reset the grant set before every test (some opt into tickets:manage).
+beforeEach(() => { authState.permissions = []; });
 
 describe('TicketWorkbench resolve-flow gating', () => {
   beforeEach(() => {
@@ -1735,5 +1742,60 @@ describe('TicketWorkbench move-org action', () => {
     expect(
       fetchMock.mock.calls.filter(([url, init]) => init?.method === 'POST' && String(url).includes('/move-org'))
     ).toHaveLength(0);
+  });
+});
+
+describe('TicketWorkbench soft-delete (tickets:manage)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the Delete button without tickets:manage', async () => {
+    mockTicketApi({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" />);
+
+    await screen.findByTestId('ticket-workbench');
+    expect(screen.queryByTestId('ticket-delete-button')).toBeNull();
+  });
+
+  it('confirms first, then DELETEs the ticket and signals the host via onChanged', async () => {
+    authState.permissions = [{ resource: 'tickets', action: 'manage' }];
+    mockTicketApi({ 'tk-1': makeTicket() });
+    const onChanged = vi.fn();
+    render(<TicketWorkbench ticketId="tk-1" onChanged={onChanged} />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-delete-button'));
+
+    // Dialog is up; no DELETE fired yet.
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => init?.method === 'DELETE' && String(url) === '/tickets/tk-1')
+    ).toBe(false);
+
+    fireEvent.click(await screen.findByTestId('ticket-delete-confirm'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1', expect.objectContaining({ method: 'DELETE' }));
+    });
+    await waitFor(() => {
+      expect(onChanged).toHaveBeenCalled();
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Ticket deleted' }));
+    // Split-pane mode: the host handles re-selection, so no navigation here.
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('in full-page (expanded) mode, navigates back to the queue after delete', async () => {
+    authState.permissions = [{ resource: 'tickets', action: 'manage' }];
+    mockTicketApi({ 'tk-1': makeTicket() });
+    render(<TicketWorkbench ticketId="tk-1" expanded />);
+
+    await screen.findByTestId('ticket-workbench');
+    fireEvent.click(screen.getByTestId('ticket-delete-button'));
+    fireEvent.click(await screen.findByTestId('ticket-delete-confirm'));
+
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith('/tickets');
+    });
   });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -7,6 +7,8 @@ import { listCannedResponses, type CannedResponse } from '../../lib/ticketRespon
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { loginPathWithNext } from '../../lib/authScope';
+import { usePermissions } from '../../lib/permissions';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import TicketFeed from './TicketFeed';
 import TicketComposer from './TicketComposer';
 import SlaChip from './SlaChip';
@@ -124,6 +126,11 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const [creatingInvoice, setCreatingInvoice] = useState(false);
   const [moveOrgOpen, setMoveOrgOpen] = useState(false);
   const [moveOrgTargetId, setMoveOrgTargetId] = useState('');
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  // Soft-delete is tickets:manage-gated (server re-enforces). UX-only gate.
+  const { can } = usePermissions();
+  const canManage = can('tickets', 'manage');
   const [orgs, setOrgs] = useState<Array<{ id: string; name: string }>>([]);
   // Ticket configuration (custom statuses + priority labels). null = not loaded
   // or fetch failed; every render falls back to the static core config.
@@ -264,6 +271,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     setPendingOpen(null);
     setPendingReason('');
     setPendingStatusId(null);
+    setDeleteOpen(false);
   }, [ticketId]);
 
   // Page-level `e` shortcut: open the inline resolve form (UI brief: `e` opens the resolution-note form)
@@ -397,6 +405,31 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
     }).then(() => void load({ background: true })).catch((err) => { if (!(err instanceof ActionError)) throw err; });
   }, [ticketId, load]);
+
+  // Soft-delete this ticket (tickets:manage). Confirm-gated by the ConfirmDialog
+  // below. On success the ticket leaves every queue: in full-page mode we
+  // navigate back to the queue; in the split pane we lean on onChanged (the same
+  // reconcile hook status changes use) — the list refetch drops the deleted row,
+  // and the host re-selects a live ticket.
+  const handleDelete = useCallback(async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}`, { method: 'DELETE' }),
+        errorFallback: 'Delete failed. Retry.',
+        successMessage: 'Ticket deleted',
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      setDeleteOpen(false);
+      onChanged?.();
+      if (expanded) void navigateTo('/tickets');
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleting, ticketId, onChanged, expanded]);
 
   const applyTriageSuggestion = useCallback(async () => {
     if (!triageSuggestion || applyingTriage) return;
@@ -767,6 +800,16 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
           >
             Move to another org…
           </button>
+          {canManage && (
+            <button
+              type="button"
+              data-testid="ticket-delete-button"
+              className="text-xs text-destructive hover:underline"
+              onClick={() => setDeleteOpen(true)}
+            >
+              Delete
+            </button>
+          )}
         </div>
         {moveOrgOpen && (
           <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-move-org-form">
@@ -1142,6 +1185,17 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
           </aside>
         )}
       </div>
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => void handleDelete()}
+        isLoading={deleting}
+        title="Delete this ticket?"
+        message="This hides the ticket from all queues. An admin can restore it from the Archived queue."
+        confirmLabel="Delete ticket"
+        confirmTestId="ticket-delete-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/tickets/TicketsPage.test.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.test.tsx
@@ -6,11 +6,20 @@ import { fetchWithAuth } from '../../stores/auth';
 import { fetchTicketConfig, type TicketConfig } from '../../lib/ticketConfigApi';
 import type { TicketSummary } from './ticketConfig';
 
+// Mutable grant set the mocked auth store reads from. usePermissions() reads
+// `user.permissions` via the selector form; assignMe reads `getState().user.id`.
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+const userState = () => ({ id: 'user-1', permissions: authState.permissions });
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
-  useAuthStore: Object.assign(vi.fn(), {
-    getState: () => ({ user: { id: 'user-1' } })
-  })
+  useAuthStore: Object.assign(
+    (selector?: (s: { user: ReturnType<typeof userState> }) => unknown) => {
+      const s = { user: userState() };
+      return selector ? selector(s) : s;
+    },
+    { getState: () => ({ user: userState() }) }
+  )
 }));
 
 // Stub fetchTicketConfig; real display helpers (statusLabel/priorityLabel) run unchanged.
@@ -119,6 +128,7 @@ function mockListApi(
     const url = String(input);
     if (url === '/tickets/stats') return makeJsonResponse(opts.stats ?? STATS);
     if (url === '/tickets/bulk') return makeJsonResponse(opts.bulkResult ?? BULK_RESULT);
+    if (url.startsWith('/tickets/') && url.endsWith('/restore')) return makeJsonResponse({ data: { id: url.split('/')[2] } });
     if (url.startsWith('/tickets?')) return makeJsonResponse({ data: typeof tickets === 'function' ? tickets(url) : tickets });
     if (url.startsWith('/orgs/organizations')) return makeJsonResponse(ORGS);
     if (url === '/ticket-categories') return makeJsonResponse(CATEGORIES);
@@ -148,6 +158,8 @@ describe('TicketsPage', () => {
     vi.clearAllMocks();
     clearHash();
     capturedWorkbenchProps.length = 0;
+    // Default: no manage grant → delete/archived controls hidden. Manage tests opt in.
+    authState.permissions = [];
     // Default to partner scope so existing tests behave as before.
     mockGetJwtClaims.mockReturnValue({ scope: 'partner', orgId: null, partnerId: 'p-1' });
     fetchConfigMock.mockResolvedValue(null);
@@ -844,6 +856,95 @@ describe('TicketsPage', () => {
       // The ticket filter bar and queue list are not rendered on the review tab.
       expect(screen.queryByTestId('tickets-filter-bar')).toBeNull();
       expect(screen.queryByTestId('ticket-row-tk-healthy')).toBeNull();
+    });
+  });
+
+  describe('soft-delete + archived (tickets:manage)', () => {
+    const grantManage = () => { authState.permissions = [{ resource: 'tickets', action: 'manage' }]; };
+
+    it('hides the Archived tab and the bulk Delete button without tickets:manage', async () => {
+      mockListApi([healthy, atRisk]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      expect(screen.queryByTestId('tickets-tab-archived')).toBeNull();
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      // Bulk bar is present, but the Delete affordance is manage-gated.
+      expect(screen.getByTestId('tickets-bulk-bar')).toBeInTheDocument();
+      expect(screen.queryByTestId('tickets-bulk-delete')).toBeNull();
+    });
+
+    it('shows the Archived tab and bulk Delete for a manager', async () => {
+      grantManage();
+      mockListApi([healthy, atRisk]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      expect(screen.getByTestId('tickets-tab-archived')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      expect(screen.getByTestId('tickets-bulk-delete')).toBeInTheDocument();
+    });
+
+    it('bulk delete confirms first, then POSTs action=delete and clears the bar', async () => {
+      grantManage();
+      mockListApi([healthy, atRisk, breached]);
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('ticket-select-tk-healthy'));
+      fireEvent.click(screen.getByTestId('ticket-select-tk-risk'));
+
+      // Clicking Delete opens the confirm dialog — no request yet.
+      fireEvent.click(screen.getByTestId('tickets-bulk-delete'));
+      expect(fetchMock.mock.calls.some((c) => String(c[0]) === '/tickets/bulk')).toBe(false);
+
+      fireEvent.click(await screen.findByTestId('tickets-bulk-delete-confirm'));
+
+      await waitFor(() => {
+        const bulkCall = fetchMock.mock.calls.find((call) => String(call[0]) === '/tickets/bulk');
+        expect(bulkCall).toBeTruthy();
+        const body = JSON.parse(String((bulkCall![1] as RequestInit).body));
+        expect(body).toEqual({ ticketIds: expect.arrayContaining(['tk-healthy', 'tk-risk']), action: 'delete' });
+        expect(body.ticketIds).toHaveLength(2);
+      });
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: '2 deleted' });
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('tickets-bulk-bar')).toBeNull();
+      });
+    });
+
+    it('Archived tab fetches ?deleted=only and restores a row', async () => {
+      grantManage();
+      const archived = makeTicket({ id: 'tk-arch', internalNumber: 'T-2026-0100', subject: 'Deleted ticket', deletedAt: minutesAgo(60 * 24 * 3) });
+      mockListApi((url) => (url.includes('deleted=only') ? [archived] : [healthy]));
+      render(<TicketsPage />);
+
+      await screen.findByTestId('ticket-row-tk-healthy');
+      fireEvent.click(screen.getByTestId('tickets-tab-archived'));
+
+      await waitFor(() => {
+        expect(ticketFetchUrls().at(-1)).toContain('deleted=only');
+      });
+      const row = await screen.findByTestId('ticket-archived-row-tk-arch');
+      expect(row).toHaveTextContent('deleted 3d ago');
+      // No workbench on the archived tab.
+      expect(screen.queryByTestId('ticket-workbench-mock')).toBeNull();
+
+      fireEvent.click(screen.getByTestId('ticket-restore-tk-arch'));
+
+      await waitFor(() => {
+        const restoreCall = fetchMock.mock.calls.find((call) => String(call[0]) === '/tickets/tk-arch/restore');
+        expect(restoreCall).toBeTruthy();
+        expect((restoreCall![1] as RequestInit).method).toBe('POST');
+      });
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ type: 'success', message: 'Ticket restored' });
+      });
     });
   });
 });

--- a/apps/web/src/components/tickets/TicketsPage.tsx
+++ b/apps/web/src/components/tickets/TicketsPage.tsx
@@ -7,11 +7,17 @@ import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 import { getJwtClaims, loginPathWithNext } from '../../lib/authScope';
 import TicketQueueList from './TicketQueueList';
+import TicketArchivedList from './TicketArchivedList';
 import TicketWorkbench from './TicketWorkbench';
 import InboundReviewQueue from './InboundReviewQueue';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { usePermissions } from '../../lib/permissions';
 import { useQueueKeyboard } from './useQueueKeyboard';
 import { type TicketPriority, type TicketStatus, type TicketSummary } from './ticketConfig';
 import { fetchTicketConfig, priorityLabel, statusLabel, type TicketConfig } from '../../lib/ticketConfigApi';
+
+// Aggregate outcome of a POST /tickets/bulk call.
+interface BulkResult { updated: number; skipped: number; failed: number; total: number; skippedReasons?: Record<string, number> }
 
 // Human-readable labels for bulk-skip reason codes returned by POST /tickets/bulk.
 const SKIP_REASON_LABELS: Record<string, string> = {
@@ -24,10 +30,28 @@ const SKIP_REASON_LABELS: Record<string, string> = {
   OTHER: 'other errors'
 };
 
+// Shared toast for a POST /tickets/bulk aggregate result. `verb` is the past-
+// tense action word ('updated' for status/assign, 'deleted' for delete) so the
+// message reads naturally. Failures are reported distinctly from skips: "skipped"
+// implies pre-validation, "failed" means the write itself errored.
+function showBulkOutcomeToast(result: BulkResult, verb: string): void {
+  const { updated, skipped, failed, skippedReasons } = result;
+  if (skipped + failed > 0) {
+    const reasons = Object.entries(skippedReasons ?? {})
+      .map(([code, n]) => `${n} ${SKIP_REASON_LABELS[code] ?? code.toLowerCase().replace(/_/g, ' ')}`)
+      .join(', ');
+    showToast({ type: 'warning', message: `${updated} ${verb}, ${skipped} skipped${failed ? `, ${failed} failed` : ''}${reasons ? ` — ${reasons}` : ''}` });
+  } else {
+    showToast({ type: 'success', message: `${updated} ${verb}` });
+  }
+}
+
 // 'review' is the inbound email review queue — a sibling surface, not a ticket
 // query. It renders InboundReviewQueue instead of the queue/workbench split, and
 // is only present for admins (visibility gated by a 200 from the queue endpoint).
-type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed' | 'review';
+// 'archived' is the soft-deleted queue (GET /tickets?deleted=only) — a ticket
+// query, but rendered as a restore-only list (no workbench). tickets:manage-gated.
+type Tab = 'mine' | 'unassigned' | 'open' | 'breaching' | 'closed' | 'review' | 'archived';
 type TicketSort = 'triage' | 'newest' | 'oldest' | 'due';
 
 const SORT_OPTIONS: Array<{ value: TicketSort; label: string }> = [
@@ -54,7 +78,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'closed', label: 'Closed' }
 ];
 
-function tabQuery(tab: Exclude<Tab, 'review'>): string {
+function tabQuery(tab: Exclude<Tab, 'review' | 'archived'>): string {
   switch (tab) {
     case 'mine': return 'statusGroup=open&assignee=me';
     case 'unassigned': return 'statusGroup=open&assignee=unassigned';
@@ -101,6 +125,11 @@ export default function TicketsPage() {
   // keeps the filter hidden either way (belt and braces).
   const orgScoped = getJwtClaims().scope === 'organization';
 
+  // Soft-delete / restore / archived queue are all tickets:manage-gated (server
+  // re-enforces). UX-only: hides controls the caller can't use. Partner/Org Admin.
+  const { can } = usePermissions();
+  const canManage = can('tickets', 'manage');
+
   const [tab, setTab] = useState<Tab>('open');
   const [resolveToken, setResolveToken] = useState(0);
   const [paneRefresh, setPaneRefresh] = useState(0);
@@ -126,6 +155,10 @@ export default function TicketsPage() {
   const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(new Set());
   const [bulkAssignee, setBulkAssignee] = useState(''); // '' = none; 'unassign' sentinel = null assignee
   const [bulkStatus, setBulkStatus] = useState('');
+  // Bulk delete is confirm-gated (soft-delete hides from all queues).
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  // Ids with an in-flight restore (archived queue) — disables their row button.
+  const [restoringIds, setRestoringIds] = useState<Set<string>>(new Set());
   // Ticket config (custom statuses + priority labels). null = not loaded / fetch
   // failed; chips and bulk-status options fall back to the static core config.
   const [config, setConfig] = useState<TicketConfig | null>(null);
@@ -191,7 +224,11 @@ export default function TicketsPage() {
     setLoading(true);
     setError(undefined);
     try {
-      const params = new URLSearchParams(tabQuery(tab));
+      // The archived tab is a normal ticket query with deleted=only (the server
+      // gates it on tickets:manage and stamps each row with deletedAt).
+      const params = tab === 'archived'
+        ? new URLSearchParams({ deleted: 'only' })
+        : new URLSearchParams(tabQuery(tab));
       if (debouncedSearch) params.set('search', debouncedSearch);
       if (orgFilter) params.set('orgId', orgFilter);
       if (priorityFilter) params.set('priority', priorityFilter);
@@ -315,7 +352,8 @@ export default function TicketsPage() {
 
   // Auto-select first row when nothing valid is selected (UI brief: no-selection state auto-selects)
   useEffect(() => {
-    if (tab === 'review') return; // the review tab has no ticket selection
+    // The review + archived tabs have no ticket selection / workbench pane.
+    if (tab === 'review' || tab === 'archived') return;
     if (!loading && tickets.length > 0 && !selected) {
       const first = tickets[0];
       const key = first.internalNumber ?? first.id;
@@ -388,22 +426,12 @@ export default function TicketsPage() {
       ? { ticketIds, action: 'status', status: bulkStatus }
       : { ticketIds, action: 'assign', assigneeId: bulkAssignee === 'unassign' ? null : bulkAssignee };
     try {
-      const result = await runAction<{ data: { updated: number; skipped: number; failed: number; total: number; skippedReasons?: Record<string, number> } }>({
+      const result = await runAction<{ data: BulkResult }>({
         request: () => fetchWithAuth('/tickets/bulk', { method: 'POST', body: JSON.stringify(body) }),
         errorFallback: 'Bulk update failed. Retry.',
         onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
       });
-      const { updated, skipped, failed, skippedReasons } = result.data;
-      if (skipped + failed > 0) {
-        const reasons = Object.entries(skippedReasons ?? {})
-          .map(([code, n]) => `${n} ${SKIP_REASON_LABELS[code] ?? code.toLowerCase().replace(/_/g, ' ')}`)
-          .join(', ');
-        // Failures are reported distinctly from skips — "skipped" implies a
-        // pre-validation outcome, "failed" means the write itself errored.
-        showToast({ type: 'warning', message: `${updated} updated, ${skipped} skipped${failed ? `, ${failed} failed` : ''}${reasons ? ` — ${reasons}` : ''}` });
-      } else {
-        showToast({ type: 'success', message: `${updated} updated` });
-      }
+      showBulkOutcomeToast(result.data, 'updated');
       clearBulkSelection();
       setPaneRefresh((t) => t + 1);
       void fetchTickets();
@@ -413,6 +441,47 @@ export default function TicketsPage() {
       if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Bulk update failed. Retry.' });
     }
   }, [bulkSelectedIds, bulkAssignee, bulkStatus, clearBulkSelection, fetchTickets, fetchStats]);
+
+  // Bulk soft-delete (tickets:manage). Confirm-gated by the ConfirmDialog below;
+  // this runs on confirm. Same aggregate-result toast + refresh as applyBulk.
+  const applyBulkDelete = useCallback(async () => {
+    const ticketIds = Array.from(bulkSelectedIds);
+    if (ticketIds.length === 0) return;
+    setBulkDeleteOpen(false);
+    try {
+      const result = await runAction<{ data: BulkResult }>({
+        request: () => fetchWithAuth('/tickets/bulk', { method: 'POST', body: JSON.stringify({ ticketIds, action: 'delete' }) }),
+        errorFallback: 'Bulk delete failed. Retry.',
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      showBulkOutcomeToast(result.data, 'deleted');
+      clearBulkSelection();
+      setPaneRefresh((t) => t + 1);
+      void fetchTickets();
+      void fetchStats();
+    } catch (err) {
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Bulk delete failed. Retry.' });
+    }
+  }, [bulkSelectedIds, clearBulkSelection, fetchTickets, fetchStats]);
+
+  // Restore a soft-deleted ticket from the archived queue (tickets:manage).
+  const restoreTicket = useCallback(async (id: string) => {
+    setRestoringIds((prev) => new Set(prev).add(id));
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${id}/restore`, { method: 'POST' }),
+        errorFallback: 'Restore failed. Retry.',
+        successMessage: 'Ticket restored',
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      void fetchTickets();
+      void fetchStats();
+    } catch (err) {
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: 'Restore failed. Retry.' });
+    } finally {
+      setRestoringIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }
+  }, [fetchTickets, fetchStats]);
 
   const focusComposer = useCallback((internal: boolean) => {
     const tabBtn = document.querySelector<HTMLButtonElement>(
@@ -503,6 +572,21 @@ export default function TicketsPage() {
             )}
           </button>
         )}
+        {canManage && (
+          // Soft-deleted queue. tickets:manage only (server re-enforces via
+          // deleted=only → 403 for non-managers), so the tab stays hidden otherwise.
+          <button
+            type="button"
+            onClick={() => setTab('archived')}
+            data-testid="tickets-tab-archived"
+            className={cn(
+              'border-b-2 px-3 py-2 text-sm font-medium -mb-px',
+              tab === 'archived' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Archived
+          </button>
+        )}
         <input
           type="search"
           value={search}
@@ -591,6 +675,25 @@ export default function TicketsPage() {
       {tab === 'review' ? (
         <div className="min-h-0 flex-1 overflow-y-auto" data-testid="tickets-review-pane">
           <InboundReviewQueue onTotalChange={setReviewTotal} />
+        </div>
+      ) : tab === 'archived' ? (
+        <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border" data-testid="tickets-archived-pane">
+          {error ? (
+            <div className="flex h-full items-center justify-center" data-testid="tickets-archived-error">
+              <div className="text-center">
+                <p className="text-sm text-muted-foreground">{error}</p>
+                <button type="button" onClick={() => void fetchTickets()} className="mt-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Retry</button>
+              </div>
+            </div>
+          ) : (
+            <TicketArchivedList
+              tickets={tickets}
+              loading={loading}
+              config={config}
+              onRestore={(t) => void restoreTicket(t.id)}
+              restoringIds={restoringIds}
+            />
+          )}
         </div>
       ) : trueEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center text-center" data-testid="tickets-empty">
@@ -687,6 +790,16 @@ export default function TicketsPage() {
                   >
                     Apply
                   </button>
+                  {canManage && (
+                    <button
+                      type="button"
+                      onClick={() => setBulkDeleteOpen(true)}
+                      data-testid="tickets-bulk-delete"
+                      className="rounded-md border border-destructive/40 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={clearBulkSelection}
@@ -710,6 +823,16 @@ export default function TicketsPage() {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={bulkDeleteOpen}
+        onClose={() => setBulkDeleteOpen(false)}
+        onConfirm={() => void applyBulkDelete()}
+        title={`Delete ${bulkSelectedIds.size} ticket${bulkSelectedIds.size === 1 ? '' : 's'}?`}
+        message="This hides them from all queues; an admin can restore them from Archived."
+        confirmLabel="Delete tickets"
+        confirmTestId="tickets-bulk-delete-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/tickets/ticketConfig.ts
+++ b/apps/web/src/components/tickets/ticketConfig.ts
@@ -31,6 +31,9 @@ export interface TicketSummary {
   firstResponseAt: string | null;
   createdAt: string;
   updatedAt: string;
+  // Only present on the soft-deleted "Archived" queue (GET /tickets?deleted=only).
+  // ISO timestamp of when the ticket was soft-deleted; null/absent on live rows.
+  deletedAt?: string | null;
 }
 
 export interface TicketComment {

--- a/packages/shared/src/validators/tickets.test.ts
+++ b/packages/shared/src/validators/tickets.test.ts
@@ -186,6 +186,14 @@ describe('ticket validators', () => {
       const tooMany = Array.from({ length: 101 }, () => ID);
       expect(bulkTicketActionSchema.safeParse({ ticketIds: tooMany, action: 'status', status: 'closed' }).success).toBe(false);
     });
+
+    it('accepts action:delete with no extra fields (soft-delete)', () => {
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'delete' }).success).toBe(true);
+    });
+
+    it('rejects an unknown action', () => {
+      expect(bulkTicketActionSchema.safeParse({ ticketIds: [ID], action: 'purge' }).success).toBe(false);
+    });
   });
 
   describe('editCommentSchema', () => {

--- a/packages/shared/src/validators/tickets.ts
+++ b/packages/shared/src/validators/tickets.ts
@@ -65,11 +65,13 @@ export const assignTicketSchema = z.object({
   assigneeId: z.string().guid().nullable()
 });
 
-// Bulk queue actions (assign / status). Resolving is intentionally excluded:
-// it requires a per-ticket resolution note, so it stays a per-ticket action.
+// Bulk queue actions (assign / status / delete). Resolving is intentionally
+// excluded: it requires a per-ticket resolution note, so it stays a per-ticket
+// action. 'delete' is a soft-delete and carries no extra fields; the route gates
+// it on tickets:manage (assign/status only need tickets:write).
 export const bulkTicketActionSchema = z.object({
   ticketIds: z.array(z.string().guid()).min(1).max(100),
-  action: z.enum(['assign', 'status']),
+  action: z.enum(['assign', 'status', 'delete']),
   assigneeId: z.string().guid().nullable().optional(),
   status: ticketStatusSchema.optional()
 }).refine(
@@ -108,7 +110,10 @@ export const listTicketsQuerySchema = z.object({
   priority: ticketPrioritySchema.optional(),
   slaState: z.enum(['ok', 'at_risk', 'breached', 'breaching']).optional(),
   search: z.string().max(200).optional(),
-  sort: z.enum(['triage', 'newest', 'oldest', 'due']).default('triage')
+  sort: z.enum(['triage', 'newest', 'oldest', 'due']).default('triage'),
+  // deleted=only returns the soft-deleted "Archived" queue (tickets:manage only).
+  // Omitted/any other value returns live tickets (deleted rows excluded).
+  deleted: z.enum(['only']).optional()
 });
 
 export const ticketCategoryInputSchema = z.object({


### PR DESCRIPTION
Closes #2140.

## What & why

Adds a **reversible ticket delete** so partner/org admins can clear out test / spam / duplicate tickets (the ones that pile up during inbound-email validation) instead of only being able to *close* them — closed tickets stay in **Closed** forever. Requested by **SemoTech** against v0.88.0.

## Design decision: soft-delete, not hard delete

Grounded in existing repo patterns rather than a new convention:
- the inbound **Review queue** "Dismiss" already flips a flag (`parse_status='ignored'`) and preserves the row;
- `ticket_comments` already carries a `deleted_at` column.

Soft-delete keeps the row for **audit + admin restore**, avoids orphaning SLA / alert-link / billing data, and makes "accidental delete" reversible. Deleting deliberately emits **no** lifecycle event, so the portal requester isn't sent a ghost notification (same rule as comment-delete).

## Permission

Gated on the **existing `tickets:manage`** grant — held only by **Partner Admin** (`*:*`) and **Org Admin**; technicians/viewers have `tickets:read`. This is exactly the "partner admin" gate the request asked for, so **no new permission / seed / migration** was needed. `tickets:manage` already covers analogous destructive ticket-admin actions (delete any comment, reassign org).

## Changes

**Schema / migration**
- `tickets.deleted_at` + `deleted_by` (`2026-07-07-ticket-soft-delete.sql`, idempotent; FK + partial index for the archived view). No RLS change — `tickets` is already org-scoped.

**API**
- `softDeleteTicket` / `restoreTicket` in `ticketService` with `ticket.delete` / `ticket.restore` audit entries; CAS on `deleted_at` rejects a double-delete (409).
- `getScopedTicketOr404` excludes deleted rows by default (opt-in `includeDeleted` for restore) → every by-id mutation (status/assign/comment/patch/alerts) now 404s a deleted ticket.
- Deleted tickets are filtered out of: staff list + stats, the customer **portal** list/detail/comment, **AI tools** list/get, and **inbound-email** thread matching (a reply can't resurrect a deleted ticket).
- `GET /tickets?deleted=only` archived queue + `POST /tickets/:id/restore` + bulk `action:'delete'` — all `tickets:manage`-gated (403 otherwise).

**Web**
- Bulk **Delete** in the bulk bar and a single-ticket **Delete** in the workbench, both behind a `ConfirmDialog` and wrapped in `runAction`.
- An **Archived** tab (fetches `?deleted=only`) with per-row **Restore**.
- Everything hidden unless the user has `tickets:manage`.

## Tests

- **API** (all green): `ticketService` soft-delete/restore (stamp, audit, no-event, 409 double-delete, 404); route DELETE/restore (200 / 404 / 409) and the archived-view + bulk-delete **manage gates** (403 without, 200 with); shared validator accepts `action:'delete'` / rejects unknown; consolidated run of touched files **457 passed**.
- **Web** (subagent): tickets suite **215 passed**, `no-silent-mutations` **69 passed**, `astro check` clean, eslint clean.
- `apps/api` `tsc --noEmit` clean; `autoMigrate.test.ts` (migration ordering/idempotency) green.
- Drift / RLS / integration suites run in CI (no local Postgres in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)