### PR TITLE
Partner-wide first phase 2: compliance, sensitive-data, peripheral, and maintenance dual-ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,19 @@ API connects to Postgres as unprivileged `breeze_app`. Every tenant-scoped table
 
 For production backfills of `org_id` on hot tables (>1M rows), batch via `UPDATE ... WHERE ctid IN (... LIMIT N)` loops before `SET NOT NULL`. Full narrative and rationale: `docs/superpowers/plans/2026-04-11-rls-coverage-gaps.md`.
 
+### Partner-Wide First (config/policy tables) — epic #2135
+
+Breeze is an MSP tool: techs define one policy and apply it to ALL their orgs. **Every new config-ish table (policies, templates, rules, windows, baselines) defaults to dual-ownership: `org_id` XOR `partner_id`, both nullable, exactly one set.** `org_id NOT NULL` on a new config table needs an explicit justification in the PR (e.g. `backup_configs` — org-owned storage credentials). Org-first designs have required painful retrofits every time (#1724, #2126–#2129).
+
+The playbook (copy a `2026-07-01-*-partner-ownership.sql` migration as the reference):
+1. **Migration**: `partner_id` FK + `org_id` nullable + `<table>_one_owner_chk` CHECK `((org_id IS NULL) <> (partner_id IS NULL))` + partner index + ONE dual-axis RLS policy (`system OR org-access OR partner-access`), replacing any per-command org-only policies.
+2. **Writes**: gate partner-wide create/update/delete on `canManagePartnerWidePolicies(auth)` (`services/partnerWideAccess.ts` — the single source of truth). Create routes take an `ownerScope: 'organization' | 'partner'` field; update schemas derived via `.partial()` must `.omit({ ownerScope: true })`.
+3. **Reads**: app-layer dual-axis conditions (`orgCondition OR (org_id IS NULL AND partner_id = auth.partnerId)`) must be gated on `auth.scope === 'partner'` — org tokens carry a partnerId but never pass `breeze_has_partner_access`; RLS is stricter than the app layer, never claim parity. Readers running inside an org-scoped RLS context (agent paths!) cannot see partner-wide rows at all — move them to a system context (see the heartbeat probe-config pattern, #1105).
+4. **Config-policy linkage**: add the feature type to `PARTNER_LINKABLE_FEATURE_TYPES` and the dual-axis branch of `validateFeaturePolicyExists` (`services/configurationPolicy.ts`); remove it from the org-only `FEATURE_TABLE_MAP`.
+5. **Evaluation/enforcement**: if a worker/scheduler evaluates the table against devices, partner-wide rows MUST fan out by the device org's partner (never `eq(table.orgId, device.orgId)` alone — that silently no-ops on `org_id NULL`). Worker-created child rows (results, alerts, findings) always take the DEVICE's org. One integration test must prove the fan-out fires against real Postgres.
+6. **Tests + UI**: register in `DUAL_AXIS_TENANT_TABLES` (`rls-coverage.integration.test.ts`), add a `<table>PartnerRls.integration.test.ts` suite (cross-partner forge 42501, XOR 23514, org isolation, fan-out), create-only ownerScope selector + "All orgs" badge in the web UI (pattern: `apps/web/src/components/software/PolicyForm.tsx`).
+7. **Sweep ALL `<table>.orgId` call sites repo-wide** before calling it done — hidden second routes/readers (agent config delivery, AI tools, alert bridges, stats endpoints) are how features get missed.
+
 ### Database Schema Location
 - `apps/api/src/db/schema/` - All Drizzle schema definitions
 - Key tables: devices, users, organizations, sites, alerts, scripts, automations

--- a/apps/api/migrations/2026-07-01-automation-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-automation-policies-partner-ownership.sql
@@ -1,0 +1,80 @@
+-- Partner-owned compliance rule sets / automation policies (epic #2135, issue #2129).
+--
+-- Until now an automation_policies row (the table behind the config-policy
+-- "compliance" feature) was always owned by exactly one org (org_id NOT NULL),
+-- so a compliance rule set could not be defined once and evaluated across every
+-- org under a partner. This migration makes an automation policy ownable by
+-- EITHER an org (org_id set, partner_id NULL — the existing shape) OR a
+-- partner (partner_id set, org_id NULL — the "partner-wide / all orgs" shape),
+-- enforced by an exactly-one-axis CHECK. Mirrors software_policies (#2126),
+-- security_policies (#2127), and alert_rules (#2128).
+--
+-- automation_policy_compliance (the per-device result child) is unchanged: it
+-- has no org_id/partner_id and reaches its tenant through the device join
+-- (2026-04-11-bucket-c-phase-5-admin-cold-rls.sql), which is correct for
+-- partner-wide policies too — each compliance row belongs to the device's own
+-- org, exactly like software_compliance_status.
+--
+-- RLS: automation_policies moves from the four pure org-axis baseline policies
+-- to a single dual-axis policy (org OR partner) with the system short-circuit,
+-- matching the software_policies precedent.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE automation_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE automation_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+-- Exactly one ownership axis must be set. (org_id IS NULL) <> (partner_id IS NULL)
+-- is true iff exactly one of the two is NULL — i.e. exactly one is set.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'automation_policies_one_owner_chk'
+      AND conrelid = 'automation_policies'::regclass
+  ) THEN
+    ALTER TABLE automation_policies
+      ADD CONSTRAINT automation_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS automation_policies_partner_id_idx
+  ON automation_policies(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+-- Replaces the four pure org-axis policies from 0001-baseline.sql with a
+-- single dual-axis policy, matching the software_policies shape. ENABLE/FORCE
+-- are re-asserted for idempotence (the baseline already set them).
+
+ALTER TABLE automation_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE automation_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON automation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON automation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON automation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON automation_policies;
+DROP POLICY IF EXISTS automation_policies_isolation ON automation_policies;
+CREATE POLICY automation_policies_isolation
+  ON automation_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/migrations/2026-07-01-maintenance-windows-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-maintenance-windows-partner-ownership.sql
@@ -1,0 +1,135 @@
+-- Partner-owned maintenance windows (epic #2135, issue #2131).
+--
+-- Until now a maintenance_windows row was always owned by exactly one org
+-- (org_id NOT NULL), so a maintenance window could not be defined once and
+-- suppress alerts/patching/automations/scripts across every org under a
+-- partner. This migration makes a window ownable by EITHER an org (org_id
+-- set, partner_id NULL — the existing shape) OR a partner (partner_id set,
+-- org_id NULL — "partner-wide / all orgs"), enforced by an exactly-one-axis
+-- CHECK. Mirrors software_policies (#2126) and automation_policies (#2129).
+--
+-- maintenance_occurrences has no ownership columns and reaches its tenant
+-- through the window join (2026-06-13-b-fk-child-rls-backstop.sql). Those
+-- EXISTS policies checked breeze_has_org_access(mw.org_id) only, which is
+-- FALSE for a partner-owned parent (org_id NULL) — so they are re-issued
+-- here with the dual-axis parent predicate (org OR partner), keeping the
+-- same per-command policy names the backstop introduced.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE maintenance_windows
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE maintenance_windows
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'maintenance_windows_one_owner_chk'
+      AND conrelid = 'maintenance_windows'::regclass
+  ) THEN
+    ALTER TABLE maintenance_windows
+      ADD CONSTRAINT maintenance_windows_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS maintenance_windows_partner_id_idx
+  ON maintenance_windows(partner_id);
+
+-- ============================================
+-- Step 2: RLS — maintenance_windows dual-axis (org OR partner)
+-- ============================================
+
+ALTER TABLE maintenance_windows ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_windows FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON maintenance_windows;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON maintenance_windows;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON maintenance_windows;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON maintenance_windows;
+DROP POLICY IF EXISTS maintenance_windows_isolation ON maintenance_windows;
+CREATE POLICY maintenance_windows_isolation
+  ON maintenance_windows
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: RLS — maintenance_occurrences window-join gains the partner branch
+-- ============================================
+-- Same EXISTS shape and policy names as the 2026-06-13-b backstop, with the
+-- parent predicate widened to the dual-axis form so occurrences of a
+-- partner-owned window stay visible to the owning partner.
+
+ALTER TABLE maintenance_occurrences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_occurrences FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON maintenance_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON maintenance_occurrences;
+CREATE POLICY breeze_org_isolation_select ON maintenance_occurrences FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM maintenance_windows mw
+    WHERE mw.id = maintenance_occurrences.window_id
+      AND (
+        (mw.org_id IS NOT NULL AND public.breeze_has_org_access(mw.org_id))
+        OR (mw.partner_id IS NOT NULL AND public.breeze_has_partner_access(mw.partner_id))
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_insert ON maintenance_occurrences FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM maintenance_windows mw
+    WHERE mw.id = maintenance_occurrences.window_id
+      AND (
+        (mw.org_id IS NOT NULL AND public.breeze_has_org_access(mw.org_id))
+        OR (mw.partner_id IS NOT NULL AND public.breeze_has_partner_access(mw.partner_id))
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_update ON maintenance_occurrences FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM maintenance_windows mw
+    WHERE mw.id = maintenance_occurrences.window_id
+      AND (
+        (mw.org_id IS NOT NULL AND public.breeze_has_org_access(mw.org_id))
+        OR (mw.partner_id IS NOT NULL AND public.breeze_has_partner_access(mw.partner_id))
+      )
+  )
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM maintenance_windows mw
+    WHERE mw.id = maintenance_occurrences.window_id
+      AND (
+        (mw.org_id IS NOT NULL AND public.breeze_has_org_access(mw.org_id))
+        OR (mw.partner_id IS NOT NULL AND public.breeze_has_partner_access(mw.partner_id))
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_delete ON maintenance_occurrences FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM maintenance_windows mw
+    WHERE mw.id = maintenance_occurrences.window_id
+      AND (
+        (mw.org_id IS NOT NULL AND public.breeze_has_org_access(mw.org_id))
+        OR (mw.partner_id IS NOT NULL AND public.breeze_has_partner_access(mw.partner_id))
+      )
+  )
+);

--- a/apps/api/migrations/2026-07-01-peripheral-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-peripheral-policies-partner-ownership.sql
@@ -1,0 +1,69 @@
+-- Partner-owned peripheral-control policies (epic #2135, issue #2131).
+--
+-- Until now a peripheral_policies row was always owned by exactly one org
+-- (org_id NOT NULL), so a USB/peripheral rule could not be defined once and
+-- enforced across every org under a partner. This migration makes the policy
+-- ownable by EITHER an org (org_id set, partner_id NULL — the existing shape)
+-- OR a partner (partner_id set, org_id NULL — "partner-wide / all orgs"),
+-- enforced by an exactly-one-axis CHECK. Mirrors software_policies (#2126)
+-- and automation_policies (#2129).
+--
+-- peripheral_events is unchanged: each event carries the reporting DEVICE's
+-- own org_id, which is correct for partner-wide policies too.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE peripheral_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE peripheral_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'peripheral_policies_one_owner_chk'
+      AND conrelid = 'peripheral_policies'::regclass
+  ) THEN
+    ALTER TABLE peripheral_policies
+      ADD CONSTRAINT peripheral_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS peripheral_policy_partner_idx
+  ON peripheral_policies(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+-- Replaces the four per-command org-axis policies from
+-- 0050-peripheral-control.sql with a single dual-axis policy.
+
+ALTER TABLE peripheral_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE peripheral_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON peripheral_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON peripheral_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON peripheral_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON peripheral_policies;
+DROP POLICY IF EXISTS peripheral_policies_isolation ON peripheral_policies;
+CREATE POLICY peripheral_policies_isolation
+  ON peripheral_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/migrations/2026-07-01-sensitive-data-policies-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-sensitive-data-policies-partner-ownership.sql
@@ -1,0 +1,74 @@
+-- Partner-owned sensitive-data policies (epic #2135, issue #2131).
+--
+-- Until now a sensitive_data_policies row was always owned by exactly one org
+-- (org_id NOT NULL), so a data-discovery policy could not be defined once and
+-- scanned across every org under a partner. This migration makes the policy
+-- ownable by EITHER an org (org_id set, partner_id NULL — the existing shape)
+-- OR a partner (partner_id set, org_id NULL — "partner-wide / all orgs"),
+-- enforced by an exactly-one-axis CHECK. Mirrors software_policies (#2126) and
+-- automation_policies (#2129).
+--
+-- sensitive_data_scans and sensitive_data_findings are unchanged: each row
+-- carries the scanned DEVICE's own org_id (the scheduler now sources scan
+-- org_id from the device, not the policy), so their org-axis RLS stays
+-- correct for partner-wide policies too.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE sensitive_data_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE sensitive_data_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sensitive_data_policies_one_owner_chk'
+      AND conrelid = 'sensitive_data_policies'::regclass
+  ) THEN
+    ALTER TABLE sensitive_data_policies
+      ADD CONSTRAINT sensitive_data_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sensitive_policy_partner_idx
+  ON sensitive_data_policies(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+-- Drops every legacy policy-name candidate: the four per-command
+-- breeze_org_isolation_* from the baseline AND the combined
+-- sensitive_data_policies_org_isolation from 0051 (which also had no
+-- WITH CHECK — the replacement adds it).
+
+ALTER TABLE sensitive_data_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sensitive_data_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON sensitive_data_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON sensitive_data_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON sensitive_data_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON sensitive_data_policies;
+DROP POLICY IF EXISTS sensitive_data_policies_org_isolation ON sensitive_data_policies;
+DROP POLICY IF EXISTS sensitive_data_policies_isolation ON sensitive_data_policies;
+CREATE POLICY sensitive_data_policies_isolation
+  ON sensitive_data_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/src/__tests__/integration/automationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationPoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * automation_policies RLS — dual-axis (org OR partner) enforcement (#2129, epic #2135).
+ *
+ * Migration under test: 2026-07-01-automation-policies-partner-ownership.sql.
+ *
+ * An automation policy (the config-policy "compliance" feature's rule-set
+ * table) is owned by EITHER an org (org_id set, partner_id NULL — the original
+ * shape) OR a partner (partner_id set, org_id NULL — partner-wide / "all
+ * orgs"). Per-device results (automation_policy_compliance) have no ownership
+ * columns and stay device-join — each result row belongs to the device's own
+ * org. Same dual-axis contract-test blindspot as the sibling suites: this
+ * functional test through the REAL postgres.js driver (breeze_app role) is the
+ * guard that a partner cannot forge a partner_id for another partner.
+ *
+ * The second describe block proves the evaluation fan-out (#1724 trap): a
+ * stored partner-wide policy must actually EVALUATE devices across every org
+ * under the owning partner — resolveTargetDevices is mocked away in every
+ * unit test, so this is the only place the real query shape is proven.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { automationPolicies, automationPolicyCompliance, devices, sites } from '../../db/schema';
+import { evaluatePolicy } from '../../services/policyEvaluationService';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdPolicies.length === 0 && createdDevices.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    if (createdPolicies.length > 0) {
+      await db
+        .delete(automationPolicyCompliance)
+        .where(inArray(automationPolicyCompliance.policyId, createdPolicies));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(automationPolicies).where(eq(automationPolicies.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_POLICY = {
+  name: 'Partner-wide compliance baseline',
+  targets: { targetType: 'all', targetIds: [] },
+  rules: [{ type: 'prohibited_software', softwareName: 'BitTorrent' }],
+  enforcement: 'monitor' as const,
+};
+
+async function seedPartnerPolicy(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(automationPolicies)
+      .values({ ...BASE_POLICY, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdPolicies.push(id);
+  return id;
+}
+
+describe('automation_policies RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(automationPolicies)
+        .values({ ...BASE_POLICY, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdPolicies.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge a policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: automationPolicies.id }).from(automationPolicies).where(eq(automationPolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge (Postgres 42501 on the cause).
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(automationPolicies)
+          .values({ ...BASE_POLICY, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide policy owned by its partner (evaluation still covers its devices via the worker)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: automationPolicies.id }).from(automationPolicies).where(eq(automationPolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('org scope can still INSERT and SELECT an org-scoped policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(automationPolicies)
+        .values({ ...BASE_POLICY, name: 'Org policy', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) createdPolicies.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: automationPolicies.id })
+        .from(automationPolicies)
+        .where(eq(automationPolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('the one-owner CHECK rejects a policy that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(automationPolicies)
+          .values({ ...BASE_POLICY, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(automationPolicies)
+          .values({ ...BASE_POLICY, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(automationPolicies)
+        .set({ name: 'Renamed baseline', enabled: false })
+        .where(eq(automationPolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.enabled).toBe(false);
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(automationPolicies).where(eq(automationPolicies.id, id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdPolicies.splice(createdPolicies.indexOf(id), 1);
+  });
+});
+
+// ============================================================
+// Evaluation fan-out (#2129): the load-bearing SQL that makes a stored
+// partner-wide policy actually EVALUATE. resolveTargetDevices previously
+// filtered every branch by eq(devices.orgId, policy.orgId), which silently
+// matched ZERO devices for org_id NULL — the #1724 trap. Unit tests mock the
+// resolution away, so this is the only proof against real Postgres.
+// ============================================================
+
+describe('evaluatePolicy — partner-wide evaluation fan-out (#2129)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  it('a partner-wide policy evaluates devices in EVERY member org; result rows land on the devices, not the policy owner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA1 = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
+    const orgB1 = await createOrganization({ partnerId: partnerB.id });
+
+    const deviceA1 = await seedDevice(orgA1.id, 'fanout-a1');
+    const deviceA2 = await seedDevice(orgA2.id, 'fanout-a2');
+    const deviceB1 = await seedDevice(orgB1.id, 'fanout-b1');
+
+    const policyId = await seedPartnerPolicy(partnerA.id);
+    const [policy] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.select().from(automationPolicies).where(eq(automationPolicies.id, policyId)),
+    );
+
+    // The worker evaluates under system context (RLS bypass) — mirror that.
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      evaluatePolicy(policy!, { source: 'integration-test', requestRemediation: false }),
+    );
+
+    const evaluatedIds = result.results.map((r) => r.deviceId);
+    expect(evaluatedIds).toContain(deviceA1); // fan-out reaches org A1
+    expect(evaluatedIds).toContain(deviceA2); // ...and org A2
+    expect(evaluatedIds).not.toContain(deviceB1); // another partner's device NEVER matches
+
+    // Result child rows exist for both member-org devices. The child table has
+    // no ownership columns — each row reaches its tenant via the DEVICE join,
+    // so the device's own org admin sees their compliance results.
+    const complianceRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ deviceId: automationPolicyCompliance.deviceId })
+        .from(automationPolicyCompliance)
+        .where(eq(automationPolicyCompliance.policyId, policyId)),
+    );
+    const complianceDeviceIds = complianceRows.map((r) => r.deviceId);
+    expect(complianceDeviceIds).toContain(deviceA1);
+    expect(complianceDeviceIds).toContain(deviceA2);
+    expect(complianceDeviceIds).not.toContain(deviceB1);
+
+    // The org-scope caller of a member org can read ITS device's result row
+    // (device-join RLS) even though the policy template itself is invisible.
+    const orgVisibleRows = await withDbAccessContext(orgContext(orgA1.id), () =>
+      db
+        .select({ deviceId: automationPolicyCompliance.deviceId })
+        .from(automationPolicyCompliance)
+        .where(eq(automationPolicyCompliance.policyId, policyId)),
+    );
+    expect(orgVisibleRows.map((r) => r.deviceId)).toEqual([deviceA1]);
+  });
+
+  it('an org-owned policy still evaluates only its own org (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org1 = await createOrganization({ partnerId: partner.id });
+    const org2 = await createOrganization({ partnerId: partner.id });
+
+    const device1 = await seedDevice(org1.id, 'org-scope-1');
+    const device2 = await seedDevice(org2.id, 'org-scope-2');
+
+    const inserted = await withDbAccessContext(orgContext(org1.id), () =>
+      db
+        .insert(automationPolicies)
+        .values({ ...BASE_POLICY, name: 'Org-owned baseline', orgId: org1.id, partnerId: null })
+        .returning(),
+    );
+    createdPolicies.push(inserted[0]!.id);
+
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      evaluatePolicy(inserted[0]!, { source: 'integration-test', requestRemediation: false }),
+    );
+
+    const evaluatedIds = result.results.map((r) => r.deviceId);
+    expect(evaluatedIds).toContain(device1);
+    expect(evaluatedIds).not.toContain(device2);
+  });
+});

--- a/apps/api/src/__tests__/integration/maintenanceWindowsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/maintenanceWindowsPartnerRls.integration.test.ts
@@ -1,0 +1,332 @@
+/**
+ * maintenance_windows RLS — dual-axis (org OR partner) enforcement
+ * (#2131, epic #2135).
+ *
+ * Migration under test: 2026-07-01-maintenance-windows-partner-ownership.sql.
+ *
+ * A maintenance window is owned by EITHER an org (org_id set, partner_id
+ * NULL) OR a partner (partner_id set, org_id NULL — partner-wide / "all
+ * orgs"). maintenance_occurrences stay window-join; their EXISTS policies
+ * gained the partner branch in the same migration. Same dual-axis
+ * contract-test blindspot as the sibling suites: this functional test through
+ * the REAL postgres.js driver (breeze_app role) is the guard that a partner
+ * cannot forge a partner_id for another partner.
+ *
+ * The second describe block proves the enforcement fan-out (#1724 trap): the
+ * standalone window checks previously filtered
+ * maintenance_windows.org_id = device.org_id, so a stored partner-wide window
+ * would silently never suppress anything.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, maintenanceOccurrences, maintenanceWindows, sites } from '../../db/schema';
+import { isDeviceInMaintenance } from '../../services/maintenanceService';
+import { isDeviceInMaintenanceWindow } from '../../services/deploymentEngine';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdWindows: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdWindows.length === 0 && createdDevices.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdWindows) {
+      await db.delete(maintenanceOccurrences).where(eq(maintenanceOccurrences.windowId, id));
+      await db.delete(maintenanceWindows).where(eq(maintenanceWindows.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdWindows.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function baseWindow(): {
+  name: string;
+  startTime: Date;
+  endTime: Date;
+  targetType: string;
+  suppressAlerts: boolean;
+  suppressPatching: boolean;
+  status: 'scheduled';
+} {
+  const now = Date.now();
+  return {
+    name: 'Partner-wide patch night',
+    startTime: new Date(now - HOUR_MS),
+    endTime: new Date(now + HOUR_MS),
+    targetType: 'all',
+    suppressAlerts: true,
+    suppressPatching: true,
+    status: 'scheduled',
+  };
+}
+
+async function seedPartnerWindow(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(maintenanceWindows)
+      .values({ ...baseWindow(), orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdWindows.push(id);
+  return id;
+}
+
+describe('maintenance_windows RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide window (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(maintenanceWindows)
+        .values({ ...baseWindow(), orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdWindows.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge a window attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerWindow(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: maintenanceWindows.id }).from(maintenanceWindows).where(eq(maintenanceWindows.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(maintenanceWindows)
+          .values({ ...baseWindow(), name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide window owned by its partner (suppression still applies via workers)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerWindow(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: maintenanceWindows.id }).from(maintenanceWindows).where(eq(maintenanceWindows.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('occurrences of a partner-owned window are visible to the owning partner (window-join partner branch)', async () => {
+    const partner = await createPartner();
+    const windowId = await seedPartnerWindow(partner.id);
+
+    // System (route/worker) writes the occurrence, as generateOccurrences does.
+    const [occurrence] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(maintenanceOccurrences)
+        .values({
+          windowId,
+          startTime: new Date(Date.now() - HOUR_MS),
+          endTime: new Date(Date.now() + HOUR_MS),
+          status: 'scheduled',
+        })
+        .returning(),
+    );
+    expect(occurrence).toBeTruthy();
+
+    const visibleToPartner = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: maintenanceOccurrences.id })
+        .from(maintenanceOccurrences)
+        .where(eq(maintenanceOccurrences.windowId, windowId)),
+    );
+    expect(visibleToPartner.map((r) => r.id)).toContain(occurrence!.id);
+  });
+
+  it('the one-owner CHECK rejects a window that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(maintenanceWindows)
+          .values({ ...baseWindow(), name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(maintenanceWindows)
+          .values({ ...baseWindow(), name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide window', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerWindow(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(maintenanceWindows)
+        .set({ name: 'Renamed window', status: 'cancelled' })
+        .where(eq(maintenanceWindows.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.status).toBe('cancelled');
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(maintenanceWindows).where(eq(maintenanceWindows.id, id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdWindows.splice(createdWindows.indexOf(id), 1);
+  });
+});
+
+// ============================================================
+// Enforcement fan-out (#2131): the load-bearing SQL that makes a stored
+// partner-wide window actually SUPPRESS. Both standalone checks previously
+// filtered maintenance_windows.org_id = device.org_id, silently missing
+// org_id NULL rows — the #1724 trap.
+// ============================================================
+
+describe('maintenance enforcement — partner-wide window fan-out (#2131)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  it("a partner-wide window suppresses devices in a member org; a FOREIGN partner's window does not", async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    const deviceA = await seedDevice(orgA.id, 'mw-fanout-a');
+    const deviceB = await seedDevice(orgB.id, 'mw-fanout-b');
+
+    // Active NOW; targetType 'all' satisfies maintenanceService's 'all'
+    // branch, and the explicit deviceIds (deliberately including the FOREIGN
+    // device) satisfy deploymentEngine's array-overlap match — so for both
+    // checks, only the ownership predicate decides, which is exactly what
+    // this test proves.
+    const windowRows = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      db
+        .insert(maintenanceWindows)
+        .values({
+          ...baseWindow(),
+          deviceIds: [deviceA, deviceB],
+          orgId: null,
+          partnerId: partnerA.id,
+        })
+        .returning(),
+    );
+    createdWindows.push(windowRows[0]!.id);
+
+    // Workers evaluate under system context (RLS bypass) — mirror that.
+    const statusA = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenance(deviceA));
+    expect(statusA.active).toBe(true); // partner-wide window covers the member-org device
+    expect(statusA.source).toBe('standalone');
+    expect(statusA.suppressPatching).toBe(true);
+
+    const statusB = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenance(deviceB));
+    expect(statusB.active).toBe(false); // another partner's window NEVER matches
+
+    // deploymentEngine's independent check agrees.
+    const inWindowA = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenanceWindow(deviceA));
+    expect(inWindowA).toBe(true);
+    const inWindowB = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenanceWindow(deviceB));
+    expect(inWindowB).toBe(false);
+  });
+
+  it('an org-owned window still suppresses only its own org (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org1 = await createOrganization({ partnerId: partner.id });
+    const org2 = await createOrganization({ partnerId: partner.id });
+
+    const device1 = await seedDevice(org1.id, 'mw-org-1');
+    const device2 = await seedDevice(org2.id, 'mw-org-2');
+
+    const rows = await withDbAccessContext(orgContext(org1.id), () =>
+      db
+        .insert(maintenanceWindows)
+        .values({ ...baseWindow(), name: 'Org-owned window', orgId: org1.id, partnerId: null })
+        .returning(),
+    );
+    createdWindows.push(rows[0]!.id);
+
+    const status1 = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenance(device1));
+    expect(status1.active).toBe(true);
+
+    const status2 = await withDbAccessContext(SYSTEM_CTX, () => isDeviceInMaintenance(device2));
+    expect(status2.active).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/integration/peripheralPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/peripheralPoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * peripheral_policies RLS — dual-axis (org OR partner) enforcement
+ * (#2131, epic #2135).
+ *
+ * Migration under test: 2026-07-01-peripheral-policies-partner-ownership.sql.
+ *
+ * A peripheral policy is owned by EITHER an org (org_id set, partner_id NULL)
+ * OR a partner (partner_id set, org_id NULL — partner-wide / "all orgs").
+ * peripheral_events stay owned by the reporting DEVICE's org. Same dual-axis
+ * contract-test blindspot as the sibling suites: this functional test through
+ * the REAL postgres.js driver (breeze_app role) is the guard that a partner
+ * cannot forge a partner_id for another partner.
+ *
+ * The second describe block proves the distribution fan-out (#1724 trap): the
+ * org-keyed distribution worker's policy set previously filtered
+ * eq(peripheralPolicies.orgId, data.orgId), so a stored partner-wide policy
+ * would silently never reach any agent.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { deviceCommands, devices, peripheralPolicies, sites } from '../../db/schema';
+import { processPolicyDistribution } from '../../jobs/peripheralJobs';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdPolicies.length === 0 && createdDevices.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    if (createdDevices.length > 0) {
+      await db.delete(deviceCommands).where(inArray(deviceCommands.deviceId, createdDevices));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(peripheralPolicies).where(eq(peripheralPolicies.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_POLICY = {
+  name: 'Partner-wide USB block',
+  deviceClass: 'storage' as const,
+  action: 'block' as const,
+  targetType: 'organization' as const,
+  targetIds: {},
+  exceptions: [],
+  isActive: true,
+};
+
+async function seedPartnerPolicy(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(peripheralPolicies)
+      .values({ ...BASE_POLICY, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdPolicies.push(id);
+  return id;
+}
+
+describe('peripheral_policies RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(peripheralPolicies)
+        .values({ ...BASE_POLICY, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdPolicies.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge a policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: peripheralPolicies.id }).from(peripheralPolicies).where(eq(peripheralPolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(peripheralPolicies)
+          .values({ ...BASE_POLICY, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide policy owned by its partner (agents still receive it via distribution)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: peripheralPolicies.id }).from(peripheralPolicies).where(eq(peripheralPolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('org scope can still INSERT and SELECT an org-scoped policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(peripheralPolicies)
+        .values({ ...BASE_POLICY, name: 'Org policy', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) createdPolicies.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: peripheralPolicies.id })
+        .from(peripheralPolicies)
+        .where(eq(peripheralPolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('the one-owner CHECK rejects a policy that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(peripheralPolicies)
+          .values({ ...BASE_POLICY, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(peripheralPolicies)
+          .values({ ...BASE_POLICY, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(peripheralPolicies)
+        .set({ name: 'Renamed USB block', isActive: false })
+        .where(eq(peripheralPolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.isActive).toBe(false);
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(peripheralPolicies).where(eq(peripheralPolicies.id, id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdPolicies.splice(createdPolicies.indexOf(id), 1);
+  });
+});
+
+// ============================================================
+// Distribution fan-out (#2131): the load-bearing SQL that makes a stored
+// partner-wide policy actually reach agents. The org-keyed distribution
+// worker previously selected eq(peripheralPolicies.orgId, data.orgId), which
+// silently excluded org_id NULL rows — the #1724 trap.
+// ============================================================
+
+describe('processPolicyDistribution — partner-wide policy fan-out (#2131)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  function payloadPolicyIds(payload: unknown): string[] {
+    if (!payload || typeof payload !== 'object') return [];
+    const policies = (payload as { policies?: Array<{ id?: string }> }).policies;
+    if (!Array.isArray(policies)) return [];
+    return policies.map((p) => p.id).filter((id): id is string => typeof id === 'string');
+  }
+
+  it("a member org's distribution payload includes its partner's partner-wide policy but NOT a foreign partner's", async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const deviceA = await seedDevice(orgA.id, 'usb-fanout-a');
+
+    const partnerWideA = await seedPartnerPolicy(partnerA.id);
+    const partnerWideB = await seedPartnerPolicy(partnerB.id);
+
+    // An org-owned policy coexists on the same org.
+    const [orgPolicy] = await withDbAccessContext(orgContext(orgA.id), () =>
+      db
+        .insert(peripheralPolicies)
+        .values({ ...BASE_POLICY, name: 'Org-owned USB block', orgId: orgA.id, partnerId: null })
+        .returning(),
+    );
+    createdPolicies.push(orgPolicy!.id);
+
+    // The distribution worker runs under system context — mirror that.
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      processPolicyDistribution({
+        type: 'policy-distribution',
+        orgId: orgA.id,
+        changedPolicyIds: [partnerWideA],
+        reason: 'integration-test',
+        queuedAt: new Date().toISOString(),
+      }),
+    );
+    expect(result.queued).toBe(1);
+
+    const commands = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ payload: deviceCommands.payload })
+        .from(deviceCommands)
+        .where(eq(deviceCommands.deviceId, deviceA)),
+    );
+    expect(commands.length).toBeGreaterThan(0);
+
+    const distributedIds = payloadPolicyIds(commands[commands.length - 1]!.payload);
+    expect(distributedIds).toContain(partnerWideA); // partner-wide policy reaches the member org's devices
+    expect(distributedIds).toContain(orgPolicy!.id); // org-owned policy still distributed
+    expect(distributedIds).not.toContain(partnerWideB); // another partner's policy NEVER leaks in
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -279,6 +279,13 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // Functional cross-partner forge + scheduler fan-out proof:
   // sensitiveDataPoliciesPartnerRls.integration.test.ts.
   'sensitive_data_policies',
+  // peripheral_policies (#2131, epic #2135): org-scoped OR partner-wide
+  // USB/peripheral policy. peripheral_events stay org-owned by the reporting
+  // DEVICE's org. Converted in 2026-07-01-peripheral-policies-partner-
+  // ownership. CHECK peripheral_policies_one_owner_chk enforces exactly one
+  // axis. Functional cross-partner forge + distribution fan-out proof:
+  // peripheralPoliciesPartnerRls.integration.test.ts.
+  'peripheral_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -262,6 +262,15 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // alert_rules_one_owner_chk enforces exactly one axis. Functional
   // cross-partner forge proof: alertRulesPartnerRls.integration.test.ts.
   'alert_rules',
+  // automation_policies (#2129, epic #2135): org-scoped OR partner-wide
+  // compliance rule set (the config-policy "compliance" feature). Per-device
+  // results (automation_policy_compliance) stay device-join — each result row
+  // belongs to the device's own org. Converted in
+  // 2026-07-01-automation-policies-partner-ownership. CHECK
+  // automation_policies_one_owner_chk enforces exactly one axis. Functional
+  // cross-partner forge + evaluation fan-out proof:
+  // automationPoliciesPartnerRls.integration.test.ts.
+  'automation_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -286,6 +286,14 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // axis. Functional cross-partner forge + distribution fan-out proof:
   // peripheralPoliciesPartnerRls.integration.test.ts.
   'peripheral_policies',
+  // maintenance_windows (#2131, epic #2135): org-scoped OR partner-wide
+  // maintenance window. maintenance_occurrences stay window-join (their
+  // EXISTS policies gained the partner branch in the same migration).
+  // Converted in 2026-07-01-maintenance-windows-partner-ownership. CHECK
+  // maintenance_windows_one_owner_chk enforces exactly one axis. Functional
+  // cross-partner forge + enforcement fan-out proof:
+  // maintenanceWindowsPartnerRls.integration.test.ts.
+  'maintenance_windows',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -271,6 +271,14 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // cross-partner forge + evaluation fan-out proof:
   // automationPoliciesPartnerRls.integration.test.ts.
   'automation_policies',
+  // sensitive_data_policies (#2131, epic #2135): org-scoped OR partner-wide
+  // data-discovery policy. Scans/findings stay org-owned by the scanned
+  // DEVICE's org (the scheduler sources scan org_id from the device).
+  // Converted in 2026-07-01-sensitive-data-policies-partner-ownership. CHECK
+  // sensitive_data_policies_one_owner_chk enforces exactly one axis.
+  // Functional cross-partner forge + scheduler fan-out proof:
+  // sensitiveDataPoliciesPartnerRls.integration.test.ts.
+  'sensitive_data_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/sensitiveDataPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/sensitiveDataPoliciesPartnerRls.integration.test.ts
@@ -1,0 +1,319 @@
+/**
+ * sensitive_data_policies RLS — dual-axis (org OR partner) enforcement
+ * (#2131, epic #2135).
+ *
+ * Migration under test: 2026-07-01-sensitive-data-policies-partner-ownership.sql.
+ *
+ * A sensitive-data policy is owned by EITHER an org (org_id set, partner_id
+ * NULL) OR a partner (partner_id set, org_id NULL — partner-wide / "all
+ * orgs"). Scans and findings stay owned by the scanned DEVICE's org. Same
+ * dual-axis contract-test blindspot as the sibling suites: this functional
+ * test through the REAL postgres.js driver (breeze_app role) is the guard
+ * that a partner cannot forge a partner_id for another partner.
+ *
+ * The second describe block proves the scheduler fan-out (#1724 trap): a
+ * stored partner-wide policy must actually queue scans for devices across
+ * every org under the owning partner, with each scan row carrying the
+ * DEVICE's org.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, sensitiveDataPolicies, sensitiveDataScans, sites } from '../../db/schema';
+import { schedulePolicyScans, shutdownSensitiveDataWorkers } from '../../jobs/sensitiveDataJobs';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  if (createdPolicies.length === 0 && createdDevices.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    if (createdPolicies.length > 0) {
+      await db
+        .delete(sensitiveDataScans)
+        .where(inArray(sensitiveDataScans.policyId, createdPolicies));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdPolicies.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+  // The scheduler touches the BullMQ queue; close any lazily-created
+  // connection so the vitest process can exit cleanly.
+  await shutdownSensitiveDataWorkers();
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_POLICY = {
+  name: 'Partner-wide PII sweep',
+  scope: {},
+  detectionClasses: ['pii', 'credential'],
+  isActive: true,
+};
+
+async function seedPartnerPolicy(partnerId: string, schedule: Record<string, unknown> | null = null): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(sensitiveDataPolicies)
+      .values({ ...BASE_POLICY, schedule, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdPolicies.push(id);
+  return id;
+}
+
+describe('sensitive_data_policies RLS — dual-axis (2026-07-01 migration)', () => {
+  it('partner scope can INSERT a partner-wide policy (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(sensitiveDataPolicies)
+        .values({ ...BASE_POLICY, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdPolicies.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge a policy attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerPolicy(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: sensitiveDataPolicies.id }).from(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(sensitiveDataPolicies)
+          .values({ ...BASE_POLICY, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide policy owned by its partner', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerPolicy(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: sensitiveDataPolicies.id }).from(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('org scope can still INSERT and SELECT an org-scoped policy (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(sensitiveDataPolicies)
+        .values({ ...BASE_POLICY, name: 'Org policy', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) createdPolicies.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: sensitiveDataPolicies.id })
+        .from(sensitiveDataPolicies)
+        .where(eq(sensitiveDataPolicies.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('the one-owner CHECK rejects a policy that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(sensitiveDataPolicies)
+          .values({ ...BASE_POLICY, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(sensitiveDataPolicies)
+          .values({ ...BASE_POLICY, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide policy', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerPolicy(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(sensitiveDataPolicies)
+        .set({ name: 'Renamed sweep', isActive: false })
+        .where(eq(sensitiveDataPolicies.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.isActive).toBe(false);
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdPolicies.splice(createdPolicies.indexOf(id), 1);
+  });
+});
+
+// ============================================================
+// Scheduler fan-out (#2131): the load-bearing SQL that makes a stored
+// partner-wide policy actually queue scans. The producer previously targeted
+// devices via eq(devices.orgId, policy.orgId), which silently matched ZERO
+// devices for org_id NULL — the #1724 trap.
+// ============================================================
+
+describe('schedulePolicyScans — partner-wide scan fan-out (#2131)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  it('a partner-wide policy queues scans for devices in EVERY member org, each scan carrying the DEVICE org', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA1 = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
+    const orgB1 = await createOrganization({ partnerId: partnerB.id });
+
+    const deviceA1 = await seedDevice(orgA1.id, 'sd-fanout-a1');
+    const deviceA2 = await seedDevice(orgA2.id, 'sd-fanout-a2');
+    const deviceB1 = await seedDevice(orgB1.id, 'sd-fanout-b1');
+
+    const policyId = await seedPartnerPolicy(partnerA.id, { enabled: true, type: 'interval', intervalMinutes: 60 });
+    const [policy] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.select().from(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, policyId)),
+    );
+
+    // The scheduler runs under system context (RLS bypass) — mirror that.
+    const queued = await withDbAccessContext(SYSTEM_CTX, () => schedulePolicyScans(policy!, new Date()));
+    expect(queued).toBe(2);
+
+    const scanRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ deviceId: sensitiveDataScans.deviceId, orgId: sensitiveDataScans.orgId })
+        .from(sensitiveDataScans)
+        .where(eq(sensitiveDataScans.policyId, policyId)),
+    );
+
+    const byDevice = new Map(scanRows.map((row) => [row.deviceId, row.orgId]));
+    expect(byDevice.get(deviceA1)).toBe(orgA1.id); // scan row takes the DEVICE's org
+    expect(byDevice.get(deviceA2)).toBe(orgA2.id);
+    expect(byDevice.has(deviceB1)).toBe(false); // another partner's device NEVER matches
+  });
+
+  it('an org-owned policy still queues scans only for its own org (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org1 = await createOrganization({ partnerId: partner.id });
+    const org2 = await createOrganization({ partnerId: partner.id });
+
+    const device1 = await seedDevice(org1.id, 'sd-org-1');
+    await seedDevice(org2.id, 'sd-org-2');
+
+    const inserted = await withDbAccessContext(orgContext(org1.id), () =>
+      db
+        .insert(sensitiveDataPolicies)
+        .values({
+          ...BASE_POLICY,
+          name: 'Org-owned sweep',
+          schedule: { enabled: true, type: 'interval', intervalMinutes: 60 },
+          orgId: org1.id,
+          partnerId: null,
+        })
+        .returning(),
+    );
+    createdPolicies.push(inserted[0]!.id);
+
+    const queued = await withDbAccessContext(SYSTEM_CTX, () => schedulePolicyScans(inserted[0]!, new Date()));
+    expect(queued).toBe(1);
+
+    const scanRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ deviceId: sensitiveDataScans.deviceId })
+        .from(sensitiveDataScans)
+        .where(eq(sensitiveDataScans.policyId, inserted[0]!.id)),
+    );
+    expect(scanRows.map((r) => r.deviceId)).toEqual([device1]);
+  });
+});

--- a/apps/api/src/db/schema/automations.ts
+++ b/apps/api/src/db/schema/automations.ts
@@ -1,5 +1,5 @@
 import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, index } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { devices } from './devices';
 import { scripts } from './scripts';
 import { users } from './users';
@@ -44,9 +44,16 @@ export const automationRuns = pgTable('automation_runs', {
   createdAt: timestamp('created_at').defaultNow().notNull()
 });
 
+// An automation policy (the config-policy "compliance" feature's rule-set
+// table) is owned by EITHER an org (orgId set, partnerId NULL — the original
+// shape) OR a partner (partnerId set, orgId NULL — "partner-wide / all orgs",
+// epic #2135 / #2129). Exactly one axis is set per row; the CHECK constraint
+// `automation_policies_one_owner_chk` (migration 2026-07-01) enforces it.
+// Mirrors software_policies (#2126).
 export const automationPolicies = pgTable('automation_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   enabled: boolean('enabled').notNull().default(true),
@@ -59,7 +66,9 @@ export const automationPolicies = pgTable('automation_policies', {
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  partnerIdIdx: index('automation_policies_partner_id_idx').on(table.partnerId),
+}));
 
 export const automationPolicyCompliance = pgTable('automation_policy_compliance', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/db/schema/maintenance.ts
+++ b/apps/api/src/db/schema/maintenance.ts
@@ -7,9 +7,10 @@ import {
   boolean,
   jsonb,
   pgEnum,
-  integer
+  integer,
+  index
 } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 import { alertSeverityEnum } from './alerts';
 
@@ -28,9 +29,15 @@ export const maintenanceRecurrenceEnum = pgEnum('maintenance_recurrence', [
   'custom'
 ]);
 
+// A maintenance window is owned by EITHER an org (orgId set, partnerId NULL —
+// the original shape) OR a partner (partnerId set, orgId NULL — "partner-wide
+// / all orgs", epic #2135 / #2131). Exactly one axis is set per row; CHECK
+// `maintenance_windows_one_owner_chk` (migration 2026-07-01) enforces it.
+// maintenance_occurrences reach tenancy through the window join.
 export const maintenanceWindows = pgTable('maintenance_windows', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   startTime: timestamp('start_time').notNull(),
@@ -56,7 +63,9 @@ export const maintenanceWindows = pgTable('maintenance_windows', {
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  partnerIdx: index('maintenance_windows_partner_id_idx').on(table.partnerId),
+}));
 
 export const maintenanceOccurrences = pgTable('maintenance_occurrences', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/db/schema/peripheralControl.ts
+++ b/apps/api/src/db/schema/peripheralControl.ts
@@ -23,7 +23,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { devices } from './devices';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 
 export const peripheralDeviceClassEnum = pgEnum('peripheral_device_class', [
@@ -76,9 +76,15 @@ export interface PeripheralExceptionRule {
   expiresAt?: string;
 }
 
+// A peripheral policy is owned by EITHER an org (orgId set, partnerId NULL —
+// the original shape) OR a partner (partnerId set, orgId NULL — "partner-wide
+// / all orgs", epic #2135 / #2131). Exactly one axis is set per row; CHECK
+// `peripheral_policies_one_owner_chk` (migration 2026-07-01) enforces it.
+// peripheral_events stay owned by the reporting DEVICE's org.
 export const peripheralPolicies = pgTable('peripheral_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 200 }).notNull(),
   deviceClass: peripheralDeviceClassEnum('device_class').notNull(),
   action: peripheralPolicyActionEnum('action').notNull(),
@@ -92,6 +98,7 @@ export const peripheralPolicies = pgTable('peripheral_policies', {
 }, (table) => ({
   orgActiveIdx: index('peripheral_policy_org_active_idx').on(table.orgId, table.isActive),
   orgClassIdx: index('peripheral_policy_org_class_idx').on(table.orgId, table.deviceClass),
+  partnerIdx: index('peripheral_policy_partner_idx').on(table.partnerId),
 }));
 
 export const peripheralEvents = pgTable('peripheral_events', {

--- a/apps/api/src/db/schema/sensitiveData.ts
+++ b/apps/api/src/db/schema/sensitiveData.ts
@@ -11,12 +11,18 @@ import {
   varchar
 } from 'drizzle-orm/pg-core';
 import { devices } from './devices';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 
+// A sensitive-data policy is owned by EITHER an org (orgId set, partnerId
+// NULL — the original shape) OR a partner (partnerId set, orgId NULL —
+// "partner-wide / all orgs", epic #2135 / #2131). Exactly one axis is set per
+// row; CHECK `sensitive_data_policies_one_owner_chk` (migration 2026-07-01)
+// enforces it. Scans/findings stay owned by the scanned DEVICE's org.
 export const sensitiveDataPolicies = pgTable('sensitive_data_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 200 }).notNull(),
   scope: jsonb('scope').notNull().default({}),
   detectionClasses: jsonb('detection_classes').notNull().default([]),
@@ -27,6 +33,7 @@ export const sensitiveDataPolicies = pgTable('sensitive_data_policies', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({
   orgIdx: index('sensitive_policy_org_idx').on(table.orgId),
+  partnerIdx: index('sensitive_policy_partner_idx').on(table.partnerId),
 }));
 
 export const sensitiveDataScans = pgTable('sensitive_data_scans', {

--- a/apps/api/src/jobs/peripheralJobs.distribution.test.ts
+++ b/apps/api/src/jobs/peripheralJobs.distribution.test.ts
@@ -18,6 +18,9 @@ function selectBuilder() {
     orderBy() {
       return builder;
     },
+    limit() {
+      return builder;
+    },
     then(resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) {
       return Promise.resolve(rows).then(resolve, reject);
     }
@@ -50,8 +53,9 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema', () => ({
   devices: { __table: 'devices' },
+  organizations: { __table: 'organizations', id: 'id', partnerId: 'partnerId' },
   peripheralEvents: { __table: 'peripheral_events' },
-  peripheralPolicies: { __table: 'peripheral_policies' }
+  peripheralPolicies: { __table: 'peripheral_policies', orgId: 'orgId', partnerId: 'partnerId' }
 }));
 
 vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));

--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -1,7 +1,7 @@
 import { Job, Queue, Worker } from 'bullmq';
-import { and, eq, gte, ne, sql } from 'drizzle-orm';
+import { and, eq, gte, isNull, ne, or, sql } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { devices, peripheralEvents, peripheralPolicies } from '../db/schema';
+import { devices, organizations, peripheralEvents, peripheralPolicies } from '../db/schema';
 import { publishEvent } from '../services/eventBus';
 import { CommandTypes, queueCommand, queueCommandForExecution } from '../services/commandQueue';
 import { getBullMQConnection } from '../services/redis';
@@ -171,11 +171,27 @@ export async function processPolicyDistribution(
   // policy id missing here means the producer txn hasn't committed yet — and
   // (b) build the payload from the *current* active subset (re-read each run so
   // coalesced bursts always send the latest state).
+  // The org's applicable policy set is dual-axis (#2131): its own org-owned
+  // rows PLUS partner-wide rows (org_id NULL) owned by the org's partner —
+  // the worker runs under system context, so both axes are visible.
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, data.orgId))
+    .limit(1);
+
+  const policyOwnershipCondition = orgRow?.partnerId
+    ? or(
+        eq(peripheralPolicies.orgId, data.orgId),
+        and(isNull(peripheralPolicies.orgId), eq(peripheralPolicies.partnerId, orgRow.partnerId))
+      )
+    : eq(peripheralPolicies.orgId, data.orgId);
+
   const [orgPolicies, orgDevices] = await Promise.all([
     db
       .select()
       .from(peripheralPolicies)
-      .where(eq(peripheralPolicies.orgId, data.orgId))
+      .where(policyOwnershipCondition)
       .orderBy(peripheralPolicies.updatedAt),
     db
       .select({

--- a/apps/api/src/jobs/sensitiveDataJobs.ts
+++ b/apps/api/src/jobs/sensitiveDataJobs.ts
@@ -2,7 +2,7 @@ import { Job, Queue, Worker, type JobsOptions } from 'bullmq';
 import { and, eq, inArray, ne, sql, type SQL } from 'drizzle-orm';
 
 import * as dbModule from '../db';
-import { deviceCommands, devices, sensitiveDataPolicies, sensitiveDataScans } from '../db/schema';
+import { deviceCommands, devices, organizations, sensitiveDataPolicies, sensitiveDataScans } from '../db/schema';
 import { CommandTypes, queueCommandForExecution } from '../services/commandQueue';
 import { isCronDue } from '../services/automationRuntime';
 import { attachWorkerObservability } from './workerObservability';
@@ -370,6 +370,119 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
   };
 }
 
+type SchedulablePolicy = {
+  id: string;
+  orgId: string | null;
+  partnerId: string | null;
+  scope: unknown;
+  detectionClasses: unknown;
+  schedule: unknown;
+};
+
+/**
+ * Queue scheduled scans for ONE due policy. Exported so the integration suite
+ * can prove the partner-wide device fan-out against real Postgres without
+ * sweeping every active policy in the shared test DB.
+ */
+export async function schedulePolicyScans(policy: SchedulablePolicy, now: Date): Promise<number> {
+  // Resolve the policy owner's device-org pool (#2131): an org-owned policy
+  // targets its own org; a partner-wide policy (orgId NULL) fans out to
+  // every org under the owning partner. The per-org queue backpressure
+  // check runs per member org so one saturated org doesn't starve the rest.
+  let ownerOrgIds: string[];
+  if (policy.orgId) {
+    ownerOrgIds = [policy.orgId];
+  } else if (policy.partnerId) {
+    const orgRows = await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.partnerId, policy.partnerId));
+    ownerOrgIds = orgRows.map((row) => row.id);
+  } else {
+    ownerOrgIds = [];
+  }
+
+  const admittedOrgIds: string[] = [];
+  for (const orgId of ownerOrgIds) {
+    const orgQueued = await getOrgQueuedScans(orgId);
+    if (orgQueued < SENSITIVE_DATA_ORG_QUEUE_BACKPRESSURE_LIMIT) {
+      admittedOrgIds.push(orgId);
+    }
+  }
+  if (admittedOrgIds.length === 0) return 0;
+
+  const schedule = parsePolicySchedule(policy.schedule);
+  const conditions: SQL[] = [
+    inArray(devices.orgId, admittedOrgIds),
+    ne(devices.status, 'decommissioned')
+  ];
+  if (schedule.deviceIds.length > 0) {
+    conditions.push(inArray(devices.id, schedule.deviceIds));
+  }
+
+  const targetDevices = await db
+    .select({ id: devices.id, orgId: devices.orgId })
+    .from(devices)
+    .where(and(...conditions));
+
+  if (targetDevices.length === 0) return 0;
+
+  const created = await db
+    .insert(sensitiveDataScans)
+    .values(
+      targetDevices.map((device) => ({
+        // Scan rows always take the DEVICE's org — identical to the
+        // policy's org for org-owned policies, and the only correct org
+        // for partner-wide ones.
+        orgId: device.orgId,
+        deviceId: device.id,
+        policyId: policy.id,
+        status: 'queued',
+        summary: {
+          source: 'policy_scheduler',
+          policySchedule: {
+            type: schedule.type,
+            cron: schedule.cron,
+            intervalMinutes: schedule.intervalMinutes
+          },
+          request: {
+            scope: isRecord(policy.scope) ? policy.scope : {},
+            detectionClasses: parseDetectionClasses(policy.detectionClasses)
+          }
+        }
+      }))
+    )
+    .returning({ id: sensitiveDataScans.id });
+
+  if (created.length > 0) {
+    const queue = getSensitiveDataQueue();
+    await queue.addBulk(
+      created.map((scan) => ({
+        name: 'dispatch-scan',
+        data: { type: 'dispatch-scan' as const, scanId: scan.id },
+        opts: {
+          jobId: `sensitive-scan-${scan.id}`,
+          removeOnComplete: { count: 200 },
+          removeOnFail: { count: 500 }
+        }
+      }))
+    );
+  }
+
+  await db
+    .update(sensitiveDataPolicies)
+    .set({
+      schedule: {
+        ...(isRecord(policy.schedule) ? policy.schedule : {}),
+        lastRunAt: now.toISOString()
+      },
+      updatedAt: new Date()
+    })
+    .where(eq(sensitiveDataPolicies.id, policy.id));
+
+  return created.length;
+}
+
 async function processSchedulePolicies(data: SchedulePoliciesJobData): Promise<{
   scheduledPolicies: number;
   scansQueued: number;
@@ -381,6 +494,7 @@ async function processSchedulePolicies(data: SchedulePoliciesJobData): Promise<{
     .select({
       id: sensitiveDataPolicies.id,
       orgId: sensitiveDataPolicies.orgId,
+      partnerId: sensitiveDataPolicies.partnerId,
       scope: sensitiveDataPolicies.scope,
       detectionClasses: sensitiveDataPolicies.detectionClasses,
       schedule: sensitiveDataPolicies.schedule
@@ -390,84 +504,17 @@ async function processSchedulePolicies(data: SchedulePoliciesJobData): Promise<{
 
   if (policies.length === 0) return { scheduledPolicies: 0, scansQueued: 0 };
 
-  const queue = getSensitiveDataQueue();
   let scheduledPolicies = 0;
   let scansQueued = 0;
 
   for (const policy of policies) {
     if (!shouldSchedulePolicy(policy.schedule, now)) continue;
 
-    const orgQueued = await getOrgQueuedScans(policy.orgId);
-    if (orgQueued >= SENSITIVE_DATA_ORG_QUEUE_BACKPRESSURE_LIMIT) {
-      continue;
-    }
-
-    const schedule = parsePolicySchedule(policy.schedule);
-    const conditions: SQL[] = [
-      eq(devices.orgId, policy.orgId),
-      ne(devices.status, 'decommissioned')
-    ];
-    if (schedule.deviceIds.length > 0) {
-      conditions.push(inArray(devices.id, schedule.deviceIds));
-    }
-
-    const targetDevices = await db
-      .select({ id: devices.id })
-      .from(devices)
-      .where(and(...conditions));
-
-    if (targetDevices.length === 0) continue;
-
-    const created = await db
-      .insert(sensitiveDataScans)
-      .values(
-        targetDevices.map((device) => ({
-          orgId: policy.orgId,
-          deviceId: device.id,
-          policyId: policy.id,
-          status: 'queued',
-          summary: {
-            source: 'policy_scheduler',
-            policySchedule: {
-              type: schedule.type,
-              cron: schedule.cron,
-              intervalMinutes: schedule.intervalMinutes
-            },
-            request: {
-              scope: isRecord(policy.scope) ? policy.scope : {},
-              detectionClasses: parseDetectionClasses(policy.detectionClasses)
-            }
-          }
-        }))
-      )
-      .returning({ id: sensitiveDataScans.id });
-
-    if (created.length > 0) {
-      await queue.addBulk(
-        created.map((scan) => ({
-          name: 'dispatch-scan',
-          data: { type: 'dispatch-scan' as const, scanId: scan.id },
-          opts: {
-            jobId: `sensitive-scan-${scan.id}`,
-            removeOnComplete: { count: 200 },
-            removeOnFail: { count: 500 }
-          }
-        }))
-      );
-      scansQueued += created.length;
+    const queued = await schedulePolicyScans(policy, now);
+    if (queued > 0) {
+      scansQueued += queued;
       scheduledPolicies++;
     }
-
-    await db
-      .update(sensitiveDataPolicies)
-      .set({
-        schedule: {
-          ...(isRecord(policy.schedule) ? policy.schedule : {}),
-          lastRunAt: now.toISOString()
-        },
-        updatedAt: new Date()
-      })
-      .where(eq(sensitiveDataPolicies.id, policy.id));
   }
 
   return { scheduledPolicies, scansQueued };

--- a/apps/api/src/jobs/sensitiveDataJobs.ts
+++ b/apps/api/src/jobs/sensitiveDataJobs.ts
@@ -403,11 +403,23 @@ export async function schedulePolicyScans(policy: SchedulablePolicy, now: Date):
   }
 
   const admittedOrgIds: string[] = [];
+  const backpressuredOrgIds: string[] = [];
   for (const orgId of ownerOrgIds) {
     const orgQueued = await getOrgQueuedScans(orgId);
     if (orgQueued < SENSITIVE_DATA_ORG_QUEUE_BACKPRESSURE_LIMIT) {
       admittedOrgIds.push(orgId);
+    } else {
+      backpressuredOrgIds.push(orgId);
     }
+  }
+  if (backpressuredOrgIds.length > 0) {
+    // A chronically backpressured member org under a partner-wide policy
+    // would otherwise be starved of scans with no trace in the logs — the
+    // policy still reports "scheduled" for the admitted orgs.
+    console.warn(
+      `[SensitiveDataJobs] policy ${policy.id}: skipped ${backpressuredOrgIds.length}/${ownerOrgIds.length} `
+      + `backpressured org(s) this cycle: ${backpressuredOrgIds.join(', ')}`
+    );
   }
   if (admittedOrgIds.length === 0) return 0;
 

--- a/apps/api/src/modules/mcpInvites/tools/configureDefaults.test.ts
+++ b/apps/api/src/modules/mcpInvites/tools/configureDefaults.test.ts
@@ -17,12 +17,17 @@ vi.mock('../../../db/schema', () => ({
   alertRules: {
     id: 'ar.id',
     orgId: 'ar.org_id',
+    partnerId: 'ar.partner_id',
     templateId: 'ar.template_id',
   },
   partners: {
     id: 'p.id',
     settings: 'p.settings',
     paymentMethodAttachedAt: 'p.payment_method_attached_at',
+  },
+  organizations: {
+    id: 'org.id',
+    partnerId: 'org.partner_id',
   },
 }));
 
@@ -44,6 +49,7 @@ vi.mock('drizzle-orm', async () => {
     eq: (a: unknown, b: unknown) => ({ _op: 'eq', a, b }),
     ilike: (a: unknown, b: unknown) => ({ _op: 'ilike', a, b }),
     inArray: (a: unknown, b: unknown) => ({ _op: 'inArray', a, b }),
+    isNull: (a: unknown) => ({ _op: 'isNull', a }),
     sql: Object.assign(
       (strings: TemplateStringsArray, ...vals: unknown[]) => ({
         _op: 'sql',
@@ -144,8 +150,16 @@ describe('ensureDefaultDeviceGroup', () => {
 });
 
 describe('applyStandardAlertPolicy', () => {
+  // SELECT order inside applyStandardAlertPolicy:
+  //   1. org -> partnerId lookup (NEW)
+  //   2. builtIns (alert templates)
+  //   3. existing rules (dedupe) — only reached when builtIns is non-empty
+
   it('skips gracefully when no built-in templates exist', async () => {
-    mockSelectQueue([[]]);
+    mockSelectQueue([
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
+      [], // builtIns
+    ]);
     const values = mockInsertOk();
     const res = await applyStandardAlertPolicy(ORG_ID, 'standard');
     expect(res.created).toBe(false);
@@ -155,6 +169,7 @@ describe('applyStandardAlertPolicy', () => {
 
   it('creates rules for all matching templates when none are present', async () => {
     mockSelectQueue([
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
       [
         { id: 'tpl-cpu', name: 'High CPU' },
         { id: 'tpl-disk', name: 'Low Disk' },
@@ -170,6 +185,7 @@ describe('applyStandardAlertPolicy', () => {
 
   it('is idempotent when all three rules already exist', async () => {
     mockSelectQueue([
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
       [
         { id: 'tpl-cpu', name: 'High CPU' },
         { id: 'tpl-disk', name: 'Low Disk' },
@@ -185,6 +201,115 @@ describe('applyStandardAlertPolicy', () => {
     const res = await applyStandardAlertPolicy(ORG_ID, 'standard');
     expect(res).toEqual({ created: false });
     expect(values).not.toHaveBeenCalled();
+  });
+
+  it('treats a partner-wide rule (org_id NULL) as existing coverage and skips it', async () => {
+    // 2 templates already covered by org-owned rules; the 3rd is covered by
+    // a partner-wide rule (org_id NULL, partner_id = PARTNER_ID) that the
+    // partner already created for every org under it. All three should be
+    // considered covered by the dedupe query.
+    mockSelectQueue([
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
+      [
+        { id: 'tpl-cpu', name: 'High CPU' },
+        { id: 'tpl-disk', name: 'Low Disk' },
+        { id: 'tpl-offline', name: 'Device Offline' },
+      ],
+      [
+        { templateId: 'tpl-cpu' }, // org-owned
+        { templateId: 'tpl-disk' }, // org-owned
+        { templateId: 'tpl-offline' }, // partner-wide (org_id NULL, partner_id PARTNER_ID)
+      ],
+    ]);
+    const values = mockInsertOk();
+    const res = await applyStandardAlertPolicy(ORG_ID, 'standard');
+    expect(res).toEqual({ created: false });
+    expect(values).not.toHaveBeenCalled();
+  });
+
+  it('creates only the still-missing template when a partner-wide rule covers one of three', async () => {
+    mockSelectQueue([
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
+      [
+        { id: 'tpl-cpu', name: 'High CPU' },
+        { id: 'tpl-disk', name: 'Low Disk' },
+        { id: 'tpl-offline', name: 'Device Offline' },
+      ],
+      [
+        { templateId: 'tpl-cpu' }, // org-owned
+        { templateId: 'tpl-disk' }, // partner-wide (org_id NULL, partner_id PARTNER_ID)
+      ],
+    ]);
+    const values = mockInsertOk();
+    const res = await applyStandardAlertPolicy(ORG_ID, 'standard');
+    expect(res).toEqual({ created: true });
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: 'tpl-offline' }),
+    );
+  });
+
+  it('falls back to org-only dedupe when the org has no resolvable partner', async () => {
+    // Regression guard: an empty org -> partnerId lookup must not crash and
+    // must not broaden the dedupe to match any partner-wide rule.
+    mockSelectQueue([
+      [], // org -> partnerId lookup: no row (orphaned/deleted partner)
+      [
+        { id: 'tpl-cpu', name: 'High CPU' },
+        { id: 'tpl-disk', name: 'Low Disk' },
+        { id: 'tpl-offline', name: 'Device Offline' },
+      ],
+      [], // no existing org-owned rules
+    ]);
+    const values = mockInsertOk();
+    const res = await applyStandardAlertPolicy(ORG_ID, 'standard');
+    expect(res.created).toBe(true);
+    expect(values).toHaveBeenCalledTimes(3);
+  });
+
+  it('scopes the partner-wide dedupe check to the resolved partnerId only', async () => {
+    // Structural check on the WHERE condition passed to the dedupe select:
+    // and(inArray(templateId, ids), or(eq(orgId, orgId), and(isNull(orgId), eq(partnerId, orgPartnerId))))
+    const whereArgs: unknown[] = [];
+    const queue: unknown[][] = [
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
+      [
+        { id: 'tpl-cpu', name: 'High CPU' },
+        { id: 'tpl-disk', name: 'Low Disk' },
+        { id: 'tpl-offline', name: 'Device Offline' },
+      ],
+      [],
+    ];
+    vi.mocked(db.select).mockImplementation(() => {
+      const result = queue.shift() ?? [];
+      const terminal: any = Promise.resolve(result);
+      terminal.limit = vi.fn().mockReturnValue(Promise.resolve(result));
+      const chain: any = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn((arg: unknown) => {
+          whereArgs.push(arg);
+          return terminal;
+        }),
+      };
+      return chain;
+    });
+    mockInsertOk();
+
+    await applyStandardAlertPolicy(ORG_ID, 'standard');
+
+    // 3rd select is the dedupe query.
+    const dedupeWhere = whereArgs[2] as any;
+    expect(dedupeWhere._op).toBe('and');
+    const orClause = dedupeWhere.args.find((a: any) => a?._op === 'or');
+    expect(orClause).toBeDefined();
+    const partnerWideClause = orClause.args.find((a: any) => a?._op === 'and');
+    expect(partnerWideClause).toBeDefined();
+    const isNullArg = partnerWideClause.args.find((a: any) => a?._op === 'isNull');
+    expect(isNullArg).toBeDefined();
+    const partnerEqArg = partnerWideClause.args.find(
+      (a: any) => a?._op === 'eq' && a?.b === PARTNER_ID,
+    );
+    expect(partnerEqArg).toBeDefined();
   });
 });
 
@@ -263,12 +388,14 @@ describe('configure_defaults tool', () => {
   it('happy path: all four steps apply cleanly on a blank tenant', async () => {
     // Order of SELECTs in handler:
     //   1. ensureDefaultDeviceGroup: existing check -> []
-    //   2. applyStandardAlertPolicy: builtIns -> 3 rows
-    //   3. applyStandardAlertPolicy: existing rules -> []
-    //   4. setRiskProfile: partners row -> empty settings
-    //   5. addNotificationChannel: existing check -> []
+    //   2. applyStandardAlertPolicy: org -> partnerId lookup -> PARTNER_ID
+    //   3. applyStandardAlertPolicy: builtIns -> 3 rows
+    //   4. applyStandardAlertPolicy: existing rules -> []
+    //   5. setRiskProfile: partners row -> empty settings
+    //   6. addNotificationChannel: existing check -> []
     mockSelectQueue([
       [], // device group exists?
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
       [
         { id: 'tpl-cpu', name: 'High CPU' },
         { id: 'tpl-disk', name: 'Low Disk' },
@@ -290,8 +417,10 @@ describe('configure_defaults tool', () => {
   });
 
   it('second call is fully idempotent (nothing created, no errors)', async () => {
+    // Order of SELECTs in handler (see happy-path test above for the list).
     mockSelectQueue([
       [{ id: 'dg-1' }], // group exists
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
       [
         { id: 'tpl-cpu', name: 'High CPU' },
         { id: 'tpl-disk', name: 'Low Disk' },
@@ -317,8 +446,12 @@ describe('configure_defaults tool', () => {
   });
 
   it('partial failure: one step throwing does not prevent the others', async () => {
-    // Make the FIRST select (device group existence check) throw.
+    // Make the FIRST select (device group existence check) throw. Calls
+    // after that: applyStandardAlertPolicy's org -> partnerId lookup, then
+    // builtIns -> none (alert_policy skips before reaching the dedupe
+    // select), then risk_profile lookup, then notification channel check.
     const queue = [
+      [{ partnerId: PARTNER_ID }], // org -> partnerId lookup
       [], // alert templates -> none (alert_policy will skip)
       [{ settings: {} }], // risk_profile lookup
       [], // notification channel existence check

--- a/apps/api/src/modules/mcpInvites/tools/configureDefaults.ts
+++ b/apps/api/src/modules/mcpInvites/tools/configureDefaults.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { and, eq, ilike, inArray, or } from 'drizzle-orm';
+import { and, eq, ilike, inArray, isNull, or } from 'drizzle-orm';
 import { db } from '../../../db';
 import {
   deviceGroups,
@@ -7,6 +7,7 @@ import {
   alertTemplates,
   alertRules,
   partners,
+  organizations,
 } from '../../../db/schema';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../../../services/auditEvents';
 import { encryptColumnValueForWrite } from '../../../services/encryptedColumnRegistry';
@@ -83,6 +84,17 @@ export async function applyStandardAlertPolicy(
   orgId: string,
   _framework: 'standard' | 'cis',
 ): Promise<StepResult> {
+  // Resolve the org's partner so the dedupe check below can recognize
+  // partner-wide rules (org_id NULL, partner_id set) as existing coverage —
+  // otherwise this step would create a redundant org-level duplicate of a
+  // rule the partner already applies to every org under it.
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  const orgPartnerId = orgRow?.partnerId ?? null;
+
   // Only look at built-in templates (org-agnostic) — deployments without
   // seeded templates will legitimately skip this step.
   const builtIns = await db
@@ -103,17 +115,24 @@ export async function applyStandardAlertPolicy(
     return { created: false, skipped_reason: 'no built-in alert templates found' };
   }
 
-  // Which of these already have a rule on this org?
+  // Which of these already have a rule covering this org — either an
+  // org-owned rule, or a partner-wide rule (org_id NULL) owned by the org's
+  // resolved partner? Without a resolvable partner (orphaned/deleted
+  // partner edge case), fall back to the org-only check.
   const templateIds = builtIns.map((t) => t.id);
+  const dedupeCondition = orgPartnerId
+    ? and(
+        inArray(alertRules.templateId, templateIds),
+        or(
+          eq(alertRules.orgId, orgId),
+          and(isNull(alertRules.orgId), eq(alertRules.partnerId, orgPartnerId)),
+        ),
+      )
+    : and(eq(alertRules.orgId, orgId), inArray(alertRules.templateId, templateIds));
   const existing = await db
     .select({ templateId: alertRules.templateId })
     .from(alertRules)
-    .where(
-      and(
-        eq(alertRules.orgId, orgId),
-        inArray(alertRules.templateId, templateIds),
-      ),
-    );
+    .where(dedupeCondition);
   const existingSet = new Set(existing.map((r) => r.templateId));
 
   let createdCount = 0;

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -203,6 +203,10 @@ vi.mock('../services/commandDispatch', () => ({
 }));
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import {
+  devices as devicesTable,
+  automationPolicies as automationPoliciesTable,
+} from '../db/schema';
 import { saveFilesystemSnapshot } from '../services/filesystemAnalysis';
 import { queueCommandForExecution } from '../services/commandQueue';
 import { processBackupVerificationResult } from './backup/verificationService';
@@ -796,37 +800,59 @@ describe('agent routes', () => {
     });
 
     it('returns deduplicated policy probe config updates', async () => {
-      vi.mocked(db.select)
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{
-                id: 'device-123',
-                agentId: 'agent-123',
-                orgId: 'org-123'
-              }])
-            })
-          })
-        } as any)
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue([
-              {
-                rules: [
-                  { type: 'registry_check', registryPath: 'HKLM\\SOFTWARE\\Policies\\Zeta', registryValueName: 'Enabled' },
-                  { type: 'config_check', configFilePath: '/etc/ssh/sshd_config', configKey: 'PermitRootLogin' },
-                  { type: 'config_check', configFilePath: '/etc/breeze/agent.yaml', configKey: 'auth_token' }
-                ]
-              },
-              {
-                rules: [
-                  { type: 'registry_check', registry_path: 'HKLM\\SOFTWARE\\Policies\\Alpha', registry_value_name: 'Flag' },
-                  { type: 'config_check', configFilePath: '/etc/ssh/sshd_config', configKey: 'PermitRootLogin' }
-                ]
-              }
-            ])
-          })
-        } as any);
+      // The probe config build (#2129/#2131) now runs AFTER the heartbeat's
+      // org-scoped block, so a positional once-mock queue is order-fragile.
+      // Dispatch by table identity instead: devices → the device row,
+      // organizations → the org-partner lookup, automation_policies → the
+      // probe rules; everything else keeps the tolerant default chain.
+      // Rows-per-table dispatch matching the default chain's shape exactly
+      // (where() is BOTH awaitable and .limit/.orderBy chainable — several
+      // resolvers await it directly).
+      const rowsChain = (rows: unknown[]) => ({
+        where: vi.fn(() => Object.assign(Promise.resolve(rows), {
+          limit: vi.fn(() => Promise.resolve(rows)),
+          orderBy: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve(rows))
+          }))
+        }))
+      });
+      const probePolicyRows = [
+        {
+          rules: [
+            { type: 'registry_check', registryPath: 'HKLM\\SOFTWARE\\Policies\\Zeta', registryValueName: 'Enabled' },
+            { type: 'config_check', configFilePath: '/etc/ssh/sshd_config', configKey: 'PermitRootLogin' },
+            { type: 'config_check', configFilePath: '/etc/breeze/agent.yaml', configKey: 'auth_token' }
+          ]
+        },
+        {
+          rules: [
+            { type: 'registry_check', registry_path: 'HKLM\\SOFTWARE\\Policies\\Alpha', registry_value_name: 'Flag' },
+            { type: 'config_check', configFilePath: '/etc/ssh/sshd_config', configKey: 'PermitRootLogin' }
+          ]
+        }
+      ];
+      // The probe config build (#2129/#2131) now runs AFTER the heartbeat's
+      // org-scoped block, so a positional once-mock queue is order-fragile.
+      // organizations intentionally falls through to the default chain ([]):
+      // the probe build's org-partner lookup then resolves no partner
+      // (org-only condition) and the org-settings resolvers keep emitting
+      // their defaults, as before.
+      // Only the handler's own device lookup (the FIRST devices select) gets
+      // the device row — later resolver-internal devices reads must keep
+      // seeing [] so they early-exit to their defaults, as they always did.
+      let deviceLookupServed = false;
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn((table: unknown) => {
+          if (table === devicesTable && !deviceLookupServed) {
+            deviceLookupServed = true;
+            return rowsChain([{ id: 'device-123', agentId: 'agent-123', orgId: 'org-123' }]);
+          }
+          if (table === automationPoliciesTable) {
+            return rowsChain(probePolicyRows);
+          }
+          return defaultSelectChain().from(table);
+        })
+      }) as any);
 
       vi.mocked(db.update).mockReturnValue({
         set: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -850,7 +850,8 @@ describe('agent routes', () => {
           if (table === automationPoliciesTable) {
             return rowsChain(probePolicyRows);
           }
-          return defaultSelectChain().from(table);
+          // default chain's from() ignores its argument (vi.fn with no params)
+          return defaultSelectChain().from();
         })
       }) as any);
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
 import { and, desc, eq } from 'drizzle-orm';
-import { db, withDbAccessContext } from '../../db';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import {
   devices,
   deviceMetrics,
@@ -115,7 +115,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
   const scoped = await withDbAccessContext(
     dbContext,
-    async (): Promise<Response | { mainResponse: Record<string, unknown> }> => {
+    async (): Promise<Response | { deviceOrgId: string; mainResponse: Record<string, unknown> }> => {
 
   const [device] = await db
     .select()
@@ -520,12 +520,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
   const commands = await claimPendingCommandsForDevice(device.id, 10);
 
-  let configUpdate: PolicyProbeConfigUpdate | null = null;
-  try {
-    configUpdate = await buildPolicyProbeConfigUpdate(device.orgId);
-  } catch (err) {
-    console.error(`[agents] failed to build policy probe config update for ${agentId}:`, err);
-  }
+  // Policy probe config (buildPolicyProbeConfigUpdate) is deliberately NOT
+  // built here: partner-wide compliance policies (org_id NULL, #2129) are
+  // invisible to this org-scoped RLS context, so it runs AFTER this block
+  // closes, under a system context — same #1105 pattern as the manifest
+  // trust keyset below.
 
   // Org > General > Agent update policy. Governs whether we may hand the agent
   // (or its helper/watchdog) an auto-upgrade target right now. `manual` blocks
@@ -727,8 +726,8 @@ if (latestHelper) {
   }
 
   let mergedConfigUpdate: Record<string, unknown> | null = null;
-  if (configUpdate || eventLogSettings || monitoringSettings || onedriveSettings || patchSourceSettings) {
-    mergedConfigUpdate = { ...(configUpdate ?? {}) };
+  if (eventLogSettings || monitoringSettings || onedriveSettings || patchSourceSettings) {
+    mergedConfigUpdate = {};
     if (eventLogSettings) {
       mergedConfigUpdate.event_log_settings = eventLogSettings;
     }
@@ -757,8 +756,10 @@ if (latestHelper) {
   }
 
   // Main-branch response payload — built inside the org context, but the
-  // manifest-trust-keyset is fetched AFTER this context closes (see below).
+  // manifest-trust-keyset and policy probe config are fetched AFTER this
+  // context closes (see below).
   return {
+    deviceOrgId: device.orgId,
     mainResponse: {
       commands: commands.map(cmd => ({
         id: cmd.id,
@@ -800,7 +801,26 @@ if (latestHelper) {
     captureException(err);
   }
 
-  return c.json({ ...scoped.mainResponse, manifestTrustKeys });
+  // Policy probe config also runs OUTSIDE the org context (#1105 pattern
+  // above) — and MUST: partner-wide compliance policies (org_id NULL, #2129)
+  // are invisible to the org-scoped RLS context, and the agent has to collect
+  // registry/config state for them too. The system context here is anchored to
+  // the authenticated device's own org, so it cannot pivot tenants.
+  let policyProbeConfig: PolicyProbeConfigUpdate | null = null;
+  try {
+    policyProbeConfig = await withSystemDbAccessContext(() =>
+      buildPolicyProbeConfigUpdate(scoped.deviceOrgId)
+    );
+  } catch (err) {
+    console.error(`[agents] failed to build policy probe config update for ${agentId}:`, err);
+  }
+
+  const scopedConfigUpdate = scoped.mainResponse.configUpdate as Record<string, unknown> | null;
+  const configUpdate = policyProbeConfig || scopedConfigUpdate
+    ? { ...(policyProbeConfig ?? {}), ...(scopedConfigUpdate ?? {}) }
+    : null;
+
+  return c.json({ ...scoped.mainResponse, configUpdate, manifestTrustKeys });
 });
 
 // Receive service/process monitoring check results from agent

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { and, desc, eq, gte, inArray, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, or, sql } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 import { db } from '../../db';
 import type { AgentAuthContext } from '../../middleware/agentAuth';
@@ -404,12 +404,29 @@ export async function buildPolicyProbeConfigUpdate(orgId: string | null | undefi
     return null;
   }
 
+  // Dual-ownership (#2129): the device's probe list must also cover
+  // partner-wide compliance policies (org_id NULL) owned by this org's
+  // partner — the evaluation worker fans those out to this device, so the
+  // agent has to collect their registry/config state too.
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  const ownershipCondition = org?.partnerId
+    ? or(
+        eq(automationPolicies.orgId, orgId),
+        and(isNull(automationPolicies.orgId), eq(automationPolicies.partnerId, org.partnerId))
+      )
+    : eq(automationPolicies.orgId, orgId);
+
   const policyRows = await db
     .select({ rules: automationPolicies.rules })
     .from(automationPolicies)
     .where(
       and(
-        eq(automationPolicies.orgId, orgId),
+        ownershipCondition,
         eq(automationPolicies.enabled, true)
       )
     );

--- a/apps/api/src/routes/agents/peripherals.test.ts
+++ b/apps/api/src/routes/agents/peripherals.test.ts
@@ -13,9 +13,10 @@ vi.mock('../../db', () => ({
 
 vi.mock('../../db/schema', () => ({
   devices: { id: 'id', orgId: 'orgId', hostname: 'hostname', agentId: 'agentId' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
   peripheralEventTypeEnum: { enumValues: ['connected', 'disconnected', 'blocked', 'mounted_read_only', 'policy_override'] },
   peripheralEvents: { id: 'id' },
-  peripheralPolicies: { id: 'id', orgId: 'orgId' }
+  peripheralPolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' }
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -51,7 +52,16 @@ function mockDeviceNotFound() {
   } as any);
 }
 
-function mockPolicyLookup(validPolicies: { id: string }[]) {
+// The policy-id validation (#2131) first resolves the device org's partner
+// (select ... limit 1), then runs the dual-axis policy lookup.
+function mockPolicyLookup(validPolicies: { id: string }[], partnerId: string | null = 'partner-1') {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{ partnerId }])
+      })
+    })
+  } as any);
   vi.mocked(db.select).mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue(validPolicies)
@@ -94,12 +104,7 @@ describe('agent peripheral ingest', () => {
 
   it('rejects policy IDs outside device org scope', async () => {
     mockDeviceLookup({ id: 'device-1', orgId: 'org-1', hostname: 'host-1' });
-
-    vi.mocked(db.select).mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([])
-      })
-    } as any);
+    mockPolicyLookup([]);
 
     const res = await app.request('/agents/agent-1/peripherals/events', {
       method: 'PUT',
@@ -125,12 +130,7 @@ describe('agent peripheral ingest', () => {
 
   it('reports deduplicated count when onConflictDoNothing skips duplicates', async () => {
     mockDeviceLookup({ id: 'device-1', orgId: 'org-1', hostname: 'host-1' });
-
-    vi.mocked(db.select).mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([{ id: '11111111-1111-1111-1111-111111111111' }])
-      })
-    } as any);
+    mockPolicyLookup([{ id: '11111111-1111-1111-1111-111111111111' }]);
 
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/agents/peripherals.ts
+++ b/apps/api/src/routes/agents/peripherals.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
-import { db } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import {
   devices,
+  organizations,
   peripheralEventTypeEnum,
   peripheralEvents,
   peripheralPolicies
@@ -76,21 +77,44 @@ peripheralRoutes.put('/:id/peripherals/events', zValidator('json', submitPeriphe
   ));
 
   if (policyIds.length > 0) {
-    const validPolicies = await db
-      .select({ id: peripheralPolicies.id })
-      .from(peripheralPolicies)
-      .where(
-        and(
-          eq(peripheralPolicies.orgId, device.orgId),
-          inArray(peripheralPolicies.id, policyIds)
-        )
-      );
+    // A reported policy id is valid if the policy is owned by the device's
+    // org OR is a partner-wide policy (org_id NULL, #2131) owned by that
+    // org's partner. Partner-wide rows are invisible to this request's
+    // org-scoped RLS context, so the check runs in a short system-context
+    // block (anchored to the authenticated device's own org — no tenant
+    // pivot), mirroring the commands.ts pattern.
+    const validPolicies = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () => {
+        const [orgRow] = await db
+          .select({ partnerId: organizations.partnerId })
+          .from(organizations)
+          .where(eq(organizations.id, device.orgId))
+          .limit(1);
+
+        const ownershipCondition = orgRow?.partnerId
+          ? or(
+              eq(peripheralPolicies.orgId, device.orgId),
+              and(isNull(peripheralPolicies.orgId), eq(peripheralPolicies.partnerId, orgRow.partnerId))
+            )
+          : eq(peripheralPolicies.orgId, device.orgId);
+
+        return db
+          .select({ id: peripheralPolicies.id })
+          .from(peripheralPolicies)
+          .where(
+            and(
+              ownershipCondition,
+              inArray(peripheralPolicies.id, policyIds)
+            )
+          );
+      })
+    );
 
     const validIds = new Set(validPolicies.map((row) => row.id));
     const invalidPolicyIds = policyIds.filter((id) => !validIds.has(id));
     if (invalidPolicyIds.length > 0) {
       return c.json({
-        error: 'One or more policy IDs do not belong to this device organization',
+        error: 'One or more policy IDs do not belong to this device organization or its partner',
         invalidPolicyIds
       }, 400);
     }

--- a/apps/api/src/routes/alerts/rules.list.test.ts
+++ b/apps/api/src/routes/alerts/rules.list.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression coverage for GET /alerts/rules dual-axis list branches (#2128,
+// PR #2143): partner-scope callers see their own partner-wide alert rules
+// (orgId NULL, partnerId set) unioned with their org-owned rules, both in the
+// "all my orgs" view and in an org-filtered view. Org-scope callers are
+// unaffected (no partner-wide branch). See ./rules.authz.test.ts for the
+// RBAC/permission-gate coverage on the mutating routes — this file only
+// covers the read path, which needs a working db.select() chain that
+// rules.authz.test.ts's bare `{}` db mock does not provide.
+
+const { authRef, dbQueueRef, capturedWhere } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      partnerId: null as string | null,
+      orgId: null as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  // Queue of result arrays consumed in call order across the (up to three)
+  // sequential db.select(...) calls a single request can make: an optional
+  // organizations.partnerId lookup (system+orgId branch only), the count
+  // select, then the rows select.
+  dbQueueRef: { current: [] as unknown[][] },
+  capturedWhere: { current: undefined as unknown },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db/schema', () => ({
+  alertRules: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', isActive: 'isActive', createdAt: 'createdAt', templateId: 'templateId' },
+  alertTemplates: {},
+  alerts: {},
+  devices: {},
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/partnerWideAccess', () => ({
+  canManagePartnerWidePolicies: vi.fn(),
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE: 'x',
+}));
+
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  getAlertRuleWithOrgCheck: vi.fn(),
+  isRecord: vi.fn(),
+  getOverrides: vi.fn(() => ({})),
+  normalizeTargetsForRule: vi.fn(),
+  getNotificationChannelIds: vi.fn(() => []),
+  containsNotificationBindingOverride: vi.fn(() => false),
+  validateAlertRuleNotificationBindings: vi.fn(),
+  formatAlertRuleResponse: vi.fn((rule: unknown) => rule),
+  resolveAlertTemplate: vi.fn(),
+}));
+
+// Chainable + thenable Drizzle stub. Every chain method (from/leftJoin/where/
+// orderBy/limit/offset) returns the SAME chain object so it works regardless
+// of exactly where the handler's `await` lands (count query: select().from().
+// where(); rows query: select().from().leftJoin().where().orderBy().limit().
+// offset(); org-partner lookup: select().from().where().limit()). The chain
+// implements `.then()` directly (a thenable, not a real Promise) so `await
+// chain` resolves to the next queued result array.
+vi.mock('../../db', () => {
+  function makeChain() {
+    const chain: any = {
+      from: () => chain,
+      leftJoin: () => chain,
+      where: (cond: unknown) => {
+        capturedWhere.current = cond;
+        return chain;
+      },
+      orderBy: () => chain,
+      limit: () => chain,
+      offset: () => chain,
+      then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+        Promise.resolve(dbQueueRef.current.shift() ?? []).then(resolve, reject),
+    };
+    return chain;
+  }
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+  };
+});
+
+import { rulesRoutes } from './rules';
+import * as helpers from './helpers';
+import { db } from '../../db';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', rulesRoutes);
+  return app;
+}
+
+function whereHasOrMarker() {
+  // Real drizzle-orm and()/or()/eq() all produce `SQL` class instances, so
+  // constructor.name can't distinguish them (verified empirically). But or()
+  // splices a literal " or " text chunk between its branches, which survives
+  // JSON.stringify — a single eq()/and(eq()) condition never contains it.
+  return JSON.stringify(capturedWhere.current).includes(' or ');
+}
+
+const ORG_1 = '11111111-1111-4111-8111-111111111111';
+const ORG_2 = '22222222-2222-4222-8222-222222222222';
+const PARTNER_1 = '33333333-3333-4333-8333-333333333333';
+
+describe('GET /alerts/rules (dual-axis list, #2128)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbQueueRef.current = [];
+    capturedWhere.current = undefined;
+    vi.mocked(helpers.ensureOrgAccess).mockReturnValue(true);
+    vi.mocked(helpers.getPagination).mockReturnValue({ page: 1, limit: 50, offset: 0 } as never);
+    vi.mocked(helpers.formatAlertRuleResponse).mockImplementation((rule: unknown) => rule as never);
+  });
+
+  it('org scope: returns only org-owned rules, no OR-branch in the where condition', async () => {
+    authRef.current = {
+      scope: 'organization',
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    dbQueueRef.current = [
+      [{ count: 1 }],
+      [{ rule: { id: 'r1', orgId: 'org-1', partnerId: null, templateId: 't1', isActive: true, createdAt: '2026-01-01' }, template: null }],
+    ];
+
+    const res = await makeApp().request('/alerts/rules');
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].orgId).toBe('org-1');
+    expect(whereHasOrMarker()).toBe(false);
+  });
+
+  it('org scope: 403 when auth.orgId is missing', async () => {
+    authRef.current = {
+      scope: 'organization',
+      partnerId: null,
+      orgId: null,
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/rules');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Organization context required' });
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+
+  it('partner scope, no ?orgId=: unions org-owned rules with partner-wide rules', async () => {
+    authRef.current = {
+      scope: 'partner',
+      partnerId: 'p-1',
+      orgId: null,
+      accessibleOrgIds: ['org-1', 'org-2'],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    dbQueueRef.current = [
+      [{ count: 2 }],
+      [
+        { rule: { id: 'r-org', orgId: 'org-1', partnerId: null, templateId: 't1', isActive: true, createdAt: '2026-01-01' }, template: null },
+        { rule: { id: 'r-pw', orgId: null, partnerId: 'p-1', templateId: 't2', isActive: true, createdAt: '2026-01-02' }, template: null },
+      ],
+    ];
+
+    const res = await makeApp().request('/alerts/rules');
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.data).toContainEqual(expect.objectContaining({ orgId: null, partnerId: 'p-1' }));
+    expect(body.data).toContainEqual(expect.objectContaining({ orgId: 'org-1' }));
+    expect(whereHasOrMarker()).toBe(true);
+  });
+
+  it('partner scope, no ?orgId=, no accessible orgs but has partnerId: returns partner-wide-only results (not the empty short-circuit)', async () => {
+    authRef.current = {
+      scope: 'partner',
+      partnerId: 'p-1',
+      orgId: null,
+      accessibleOrgIds: [],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    dbQueueRef.current = [
+      [{ count: 1 }],
+      [{ rule: { id: 'r-pw2', orgId: null, partnerId: 'p-1', templateId: 't3', isActive: true, createdAt: '2026-01-03' }, template: null }],
+    ];
+
+    const res = await makeApp().request('/alerts/rules');
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].orgId).toBeNull();
+  });
+
+  it('partner scope, no ?orgId=, no accessible orgs and no partnerId: 200 empty short-circuit, no db query', async () => {
+    authRef.current = {
+      scope: 'partner',
+      partnerId: null,
+      orgId: null,
+      accessibleOrgIds: [],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/rules');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [], pagination: { page: 1, limit: 50, total: 0 } });
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+
+  it('partner scope with ?orgId=: org-filtered view still unions in partner-wide rules', async () => {
+    authRef.current = {
+      scope: 'partner',
+      partnerId: PARTNER_1,
+      orgId: null,
+      accessibleOrgIds: [ORG_1],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+    vi.mocked(helpers.ensureOrgAccess).mockReturnValue(true);
+
+    dbQueueRef.current = [
+      [{ count: 2 }],
+      [
+        { rule: { id: 'r-c1', orgId: ORG_1, partnerId: null, templateId: 't1', isActive: true, createdAt: '2026-01-01' }, template: null },
+        { rule: { id: 'r-c2', orgId: null, partnerId: PARTNER_1, templateId: 't2', isActive: true, createdAt: '2026-01-02' }, template: null },
+      ],
+    ];
+
+    const res = await makeApp().request(`/alerts/rules?orgId=${ORG_1}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.data).toHaveLength(2);
+    expect(body.data).toContainEqual(expect.objectContaining({ orgId: ORG_1 }));
+    expect(body.data).toContainEqual(expect.objectContaining({ orgId: null, partnerId: PARTNER_1 }));
+    // Distinct code path from the no-orgId union (query.orgId branch), but
+    // still an or(...) between the queried org and the partner-wide clause.
+    expect(whereHasOrMarker()).toBe(true);
+  });
+
+  it('partner scope with ?orgId=: 403 when ensureOrgAccess denies, no rows query made', async () => {
+    authRef.current = {
+      scope: 'partner',
+      partnerId: PARTNER_1,
+      orgId: null,
+      accessibleOrgIds: [ORG_1],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+    vi.mocked(helpers.ensureOrgAccess).mockReturnValue(false);
+
+    const res = await makeApp().request(`/alerts/rules?orgId=${ORG_2}`);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Access to this organization denied' });
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -445,22 +445,23 @@ describe('featureLinks routes', () => {
       );
     });
 
-    it('still rejects linking an org-scoped feature policy (compliance) on a partner-owned policy → 400', async () => {
-      // TODO(#2129): compliance links automationPolicies, which is still
-      // org-only — when #2129 migrates it, switch this test to another
-      // org-only linked type. security graduated to PARTNER_LINKABLE in #2127.
+    it('still rejects linking an org-scoped feature policy (backup) on a partner-owned policy → 400', async () => {
+      // backup is the deliberate org-locked exception (org-owned storage
+      // credentials; #2132 tracks its template/binding design). compliance
+      // graduated to PARTNER_LINKABLE in #2129, sensitive_data / peripheral /
+      // maintenance in #2131 — backup is the last org-only linked type.
       const res = await app.request(`/${POLICY_ID}/features`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          featureType: 'compliance',
+          featureType: 'backup',
           featurePolicyId: '44444444-4444-4444-4444-444444444444',
         }),
       });
 
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(String(body.error)).toContain('partner-owned');
+      expect(String(body.error)).toContain('not supported on partner-wide policies');
       expect(addFeatureLinkMock).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/routes/maintenance.test.ts
+++ b/apps/api/src/routes/maintenance.test.ts
@@ -34,7 +34,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema/maintenance', () => ({
-  maintenanceWindows: {},
+  maintenanceWindows: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' },
   maintenanceOccurrences: {}
 }));
 
@@ -60,12 +60,27 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+
+const PARTNER_ID = 'partner-1';
 
 describe('maintenance routes', () => {
   let app: Hono;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+        scope: 'organization',
+        partnerId: null,
+        orgId: 'org-123',
+        token: { sub: 'user-123' },
+        canAccessOrg: (orgId: string) => orgId === 'org-123'
+      });
+      return next();
+    });
     app = new Hono();
     app.route('/maintenance', maintenanceRoutes);
   });
@@ -488,5 +503,157 @@ describe('maintenance routes', () => {
     const body = await res.json();
     expect(body.data).toHaveLength(1);
     expect(body.data[0].window.id).toBe('win-1');
+  });
+
+  // ----------------------------------------------------------------
+  // Partner-wide dual-ownership gate (#2131): a maintenance window with
+  // orgId null + partnerId set is only mutable by a caller with
+  // canManagePartnerWidePolicies(auth) === true (system scope, or partner
+  // scope with partnerOrgAccess === 'all'). PR review flagged these 403s as
+  // unit-untested — only real-DB integration suites (not run in the
+  // required CI job) covered them.
+  // ----------------------------------------------------------------
+  describe('partner-wide dual-ownership gate', () => {
+    it('should return 403 patching a partner-wide window when the partner caller lacks partnerOrgAccess=all', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess: 'selected',
+          token: { sub: 'user-partner' },
+          canAccessOrg: () => true
+        });
+        return next();
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'win-1',
+              orgId: null,
+              partnerId: PARTNER_ID,
+              name: 'Partner-wide Window'
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/maintenance/windows/win-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'New Name' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 creating a partner-wide window without the partner-wide capability', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess: 'selected',
+          token: { sub: 'user-partner' },
+          canAccessOrg: () => true
+        });
+        return next();
+      });
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner-wide Maintenance',
+          startTime: '2024-01-01T10:00:00.000Z',
+          endTime: '2024-01-01T12:00:00.000Z',
+          timezone: 'UTC',
+          recurrence: 'once',
+          targetType: 'all',
+          suppressAlerts: true,
+          suppressPatches: true,
+          suppressAutomations: false,
+          notifyOnStart: false,
+          notifyOnEnd: false
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('should create a partner-wide window with orgId null and partnerId set when the caller has partnerOrgAccess=all', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess: 'all',
+          token: { sub: 'user-partner' },
+          canAccessOrg: () => true
+        });
+        return next();
+      });
+
+      const createdWindow = {
+        id: 'win-1',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        name: 'Partner-wide Maintenance',
+        status: 'scheduled'
+      };
+      const occurrencesValues = vi.fn().mockResolvedValue(undefined);
+      const windowValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([createdWindow])
+      });
+
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({ values: windowValues } as any)
+        .mockReturnValueOnce({ values: occurrencesValues } as any);
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner-wide Maintenance',
+          startTime: '2024-01-01T10:00:00.000Z',
+          endTime: '2024-01-01T12:00:00.000Z',
+          timezone: 'UTC',
+          recurrence: 'once',
+          targetType: 'all',
+          suppressAlerts: true,
+          suppressPatches: true,
+          suppressAutomations: false,
+          notifyOnStart: false,
+          notifyOnEnd: false
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.id).toBe('win-1');
+
+      const insertCall = windowValues.mock.calls[0];
+      expect(insertCall).toBeDefined();
+      if (!insertCall) {
+        throw new Error('Expected window insert call');
+      }
+      expect(insertCall[0]).toMatchObject({
+        orgId: null,
+        partnerId: PARTNER_ID
+      });
+    });
   });
 });

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -1,11 +1,15 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, and, or, lte, gte, inArray, desc, asc, sql } from 'drizzle-orm';
+import { eq, and, or, isNull, lte, gte, inArray, desc, asc, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import { maintenanceWindows, maintenanceOccurrences } from '../db/schema/maintenance';
 import { devices } from '../db/schema';
-import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 import { writeRouteAudit } from '../services/auditEvents';
 import { isDeviceInMaintenance } from '../services/maintenanceService';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
@@ -62,6 +66,36 @@ function resolveOrgId(
   return { orgId: requestedOrgId ?? auth.orgId ?? null } as const;
 }
 
+// Dual-ownership helpers (#2131). A window is org-owned (orgId set) or
+// partner-wide (orgId NULL, partnerId set).
+
+// Access to a LOADED window row: org-owned keeps the org check; partner-wide
+// rows are visible to system scope and the owning partner's own tokens. Org
+// tokens never see partner-wide windows (RLS is stricter than the app layer).
+function canAccessWindow(
+  auth: AuthContext,
+  window: { orgId: string | null; partnerId: string | null }
+): boolean {
+  if (window.orgId !== null) {
+    return auth.canAccessOrg(window.orgId);
+  }
+  if (auth.scope === 'system') return true;
+  return auth.scope === 'partner' && !!auth.partnerId && window.partnerId === auth.partnerId;
+}
+
+// Window-set condition for an org view: the org's own windows PLUS — for
+// partner-scope callers — their partner-wide windows, which now apply to the
+// org's devices via the enforcement checks.
+function windowOwnershipCondition(auth: AuthContext, orgId: string): SQL {
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return or(
+      eq(maintenanceWindows.orgId, orgId),
+      and(isNull(maintenanceWindows.orgId), eq(maintenanceWindows.partnerId, auth.partnerId))
+    ) as SQL;
+  }
+  return eq(maintenanceWindows.orgId, orgId);
+}
+
 // Validation schemas
 const recurrenceRuleSchema = z.object({
   interval: z.number().int().positive().optional(),
@@ -73,6 +107,9 @@ const recurrenceRuleSchema = z.object({
 
 const createWindowSchema = z.object({
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") window: orgId NULL,
+  // partnerId = caller's partner (#2131). Create-only.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(100),
   description: z.string().optional(),
   startTime: z.string().datetime(),
@@ -300,7 +337,7 @@ maintenanceRoutes.get(
       return c.json({ data: [] });
     }
 
-    const conditions = [eq(maintenanceWindows.orgId, orgResult.orgId)];
+    const conditions = [windowOwnershipCondition(auth, orgResult.orgId)];
 
     if (query.status) {
       conditions.push(eq(maintenanceWindows.status, query.status));
@@ -332,10 +369,21 @@ maintenanceRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const body = c.req.valid('json');
-    const orgResult = resolveOrgId(auth, body.orgId, true);
 
-    if ('error' in orgResult) {
-      return c.json({ error: orgResult.error }, orgResult.status);
+    // Resolve the ownership axis (#2131): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (body.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgResult = resolveOrgId(auth, body.orgId, true);
+      if ('error' in orgResult) {
+        return c.json({ error: orgResult.error }, orgResult.status);
+      }
+      owner = { orgId: orgResult.orgId as string, partnerId: null };
     }
 
     const startTime = new Date(body.startTime);
@@ -345,7 +393,8 @@ maintenanceRoutes.post(
     const [createdWindow] = await db
       .insert(maintenanceWindows)
       .values({
-        orgId: orgResult.orgId as string,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: body.name,
         description: body.description,
         startTime,
@@ -417,7 +466,7 @@ maintenanceRoutes.get(
       .where(eq(maintenanceWindows.id, windowId))
       .limit(1);
 
-    if (!window || !(await canAccessOrg(auth, window.orgId))) {
+    if (!window || !canAccessWindow(auth, window)) {
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 
@@ -462,8 +511,14 @@ maintenanceRoutes.patch(
       .where(eq(maintenanceWindows.id, windowId))
       .limit(1);
 
-    if (!window || !(await canAccessOrg(auth, window.orgId))) {
+    if (!window || !canAccessWindow(auth, window)) {
       return c.json({ error: 'Maintenance window not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     // Build update object
@@ -531,8 +586,14 @@ maintenanceRoutes.delete(
       .where(eq(maintenanceWindows.id, windowId))
       .limit(1);
 
-    if (!window || !(await canAccessOrg(auth, window.orgId))) {
+    if (!window || !canAccessWindow(auth, window)) {
       return c.json({ error: 'Maintenance window not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     // Delete only future occurrences (preserve past ones for audit)
@@ -578,8 +639,14 @@ maintenanceRoutes.post(
       .where(eq(maintenanceWindows.id, windowId))
       .limit(1);
 
-    if (!window || !(await canAccessOrg(auth, window.orgId))) {
+    if (!window || !canAccessWindow(auth, window)) {
       return c.json({ error: 'Maintenance window not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     if (window.status === 'cancelled') {
@@ -638,7 +705,7 @@ maintenanceRoutes.get(
       .where(eq(maintenanceWindows.id, windowId))
       .limit(1);
 
-    if (!window || !(await canAccessOrg(auth, window.orgId))) {
+    if (!window || !canAccessWindow(auth, window)) {
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 
@@ -667,11 +734,11 @@ maintenanceRoutes.get(
       return c.json({ error: orgResult.error }, orgResult.status);
     }
 
-    // Get all windows for this org first
+    // Get all windows for this org first (dual-axis, #2131)
     const windows = await db
       .select({ id: maintenanceWindows.id })
       .from(maintenanceWindows)
-      .where(eq(maintenanceWindows.orgId, orgResult.orgId as string));
+      .where(windowOwnershipCondition(auth, orgResult.orgId as string));
 
     const windowIds = windows.map(w => w.id);
 
@@ -745,8 +812,14 @@ maintenanceRoutes.patch(
       .where(eq(maintenanceOccurrences.id, occurrenceId))
       .limit(1);
 
-    if (!occurrence || !(await canAccessOrg(auth, occurrence.window.orgId))) {
+    if (!occurrence || !canAccessWindow(auth, occurrence.window)) {
       return c.json({ error: 'Occurrence not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (occurrence.window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     // Build overrides and update data
@@ -815,8 +888,14 @@ maintenanceRoutes.post(
       .where(eq(maintenanceOccurrences.id, occurrenceId))
       .limit(1);
 
-    if (!occurrence || !(await canAccessOrg(auth, occurrence.window.orgId))) {
+    if (!occurrence || !canAccessWindow(auth, occurrence.window)) {
       return c.json({ error: 'Occurrence not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (occurrence.window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     if (occurrence.occurrence.status !== 'scheduled') {
@@ -873,8 +952,14 @@ maintenanceRoutes.post(
       .where(eq(maintenanceOccurrences.id, occurrenceId))
       .limit(1);
 
-    if (!occurrence || !(await canAccessOrg(auth, occurrence.window.orgId))) {
+    if (!occurrence || !canAccessWindow(auth, occurrence.window)) {
       return c.json({ error: 'Occurrence not found' }, 404);
+    }
+
+    // Partner-wide windows are administrable only with the partner-wide
+    // capability (#2131).
+    if (occurrence.window.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     if (occurrence.occurrence.status !== 'active') {
@@ -926,11 +1011,11 @@ maintenanceRoutes.get(
 
     const now = new Date();
 
-    // Get all windows for this org
+    // Get all windows for this org (dual-axis, #2131)
     const windows = await db
       .select()
       .from(maintenanceWindows)
-      .where(eq(maintenanceWindows.orgId, orgResult.orgId as string));
+      .where(windowOwnershipCondition(auth, orgResult.orgId as string));
 
     if (windows.length === 0) {
       return c.json({ data: [] });

--- a/apps/api/src/routes/peripheralControl.test.ts
+++ b/apps/api/src/routes/peripheralControl.test.ts
@@ -40,6 +40,7 @@ vi.mock('../db/schema', () => ({
   peripheralPolicies: {
     id: 'id',
     orgId: 'orgId',
+    partnerId: 'partnerId',
     name: 'name',
     deviceClass: 'deviceClass',
     action: 'action',
@@ -51,6 +52,10 @@ vi.mock('../db/schema', () => ({
     id: 'id',
     orgId: 'orgId',
     siteId: 'siteId'
+  },
+  organizations: {
+    id: 'id',
+    partnerId: 'partnerId'
   }
 }));
 
@@ -106,10 +111,13 @@ vi.mock('../services/permissions', () => ({
 import { db } from '../db';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
 import { publishEvent } from '../services/eventBus';
+import { authMiddleware } from '../middleware/auth';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { peripheralControlRoutes } from './peripheralControl';
 
 const orgId = '11111111-1111-1111-1111-111111111111';
 const policyId = '22222222-2222-2222-2222-222222222222';
+const partnerId = '66666666-6666-6666-6666-666666666666';
 
 const basePolicy = {
   id: policyId,
@@ -422,7 +430,7 @@ describe('peripheralControl routes', () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.warning).toContain('distribution scheduling failed');
-    expect(body.warning).toContain('Redis connection lost');
+    expect(body.warning).toContain(orgId);
   });
 
   it('includes both error messages when distribution and event publish fail', async () => {
@@ -454,8 +462,8 @@ describe('peripheralControl routes', () => {
 
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.warning).toContain('distribution scheduling failed: Redis down');
-    expect(body.warning).toContain('event publish failed: Event bus unavailable');
+    expect(body.warning).toContain(`distribution scheduling failed for 1/1 org(s): ${orgId}`);
+    expect(body.warning).toContain(`event publish failed for 1/1 org(s): ${orgId}`);
     expect(body.warning).toContain(';');
   });
 
@@ -747,6 +755,142 @@ describe('peripheralControl routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.id).toBe(policyId);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Partner-wide dual-ownership gate (#2131): a policy with orgId null +
+  // partnerId set is only mutable by a caller with
+  // canManagePartnerWidePolicies(auth) === true (system scope, or partner
+  // scope with partnerOrgAccess 'all'). PR review flagged the 403 gates in
+  // this route as unit-untested — only real-DB integration suites (which
+  // don't run in the required CI job) covered them.
+  // ----------------------------------------------------------------
+  describe('partner-wide ownership gate (#2131)', () => {
+    function setPartnerAuth(partnerOrgAccess: 'all' | 'selected') {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          orgId: null,
+          partnerId,
+          partnerOrgAccess,
+          accessibleOrgIds: [orgId],
+          canAccessOrg: (id: string) => id === orgId,
+          orgCondition: () => undefined,
+          user: { id: 'user-partner', email: 'partner@example.com' }
+        });
+        return next();
+      });
+    }
+
+    it('returns 403 updating a partner-wide policy when the partner caller lacks partnerOrgAccess=all', async () => {
+      setPartnerAuth('selected');
+
+      const existingPartnerWidePolicy = { ...basePolicy, orgId: null, partnerId };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([existingPartnerWidePolicy])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/peripherals/policies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: policyId,
+          name: 'Updated name',
+          deviceClass: 'storage',
+          action: 'block',
+          targetType: 'organization'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 creating a partner-wide policy when the partner caller lacks partnerOrgAccess=all', async () => {
+      setPartnerAuth('selected');
+
+      const res = await app.request('/peripherals/policies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner-wide block',
+          deviceClass: 'storage',
+          action: 'block',
+          targetType: 'organization'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('creates a partner-wide policy (orgId null, partnerId set) when the partner caller has partnerOrgAccess=all', async () => {
+      setPartnerAuth('all');
+
+      const createdPartnerWidePolicy = { ...basePolicy, orgId: null, partnerId };
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([createdPartnerWidePolicy])
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+      // resolvePolicyTargetOrgIds: db.select({id}).from(organizations).where(...)
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: orgId }])
+        })
+      } as any);
+
+      const res = await app.request('/peripherals/policies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner-wide block',
+          deviceClass: 'storage',
+          action: 'block',
+          targetType: 'organization'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.orgId).toBeNull();
+      expect(body.data.partnerId).toBe(partnerId);
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ orgId: null, partnerId })
+      );
+    });
+
+    it('returns 403 disabling a partner-wide policy when the partner caller lacks partnerOrgAccess=all', async () => {
+      setPartnerAuth('selected');
+
+      const existingPartnerWidePolicy = { ...basePolicy, orgId: null, partnerId };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([existingPartnerWidePolicy])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/peripherals/policies/${policyId}/disable`, {
+        method: 'POST'
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -4,6 +4,7 @@ import { and, desc, eq, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';
 import {
+  organizations,
   peripheralDeviceClassEnum,
   peripheralEventTypeEnum,
   peripheralEvents,
@@ -15,6 +16,10 @@ import {
   type PeripheralPolicyTargetIds
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
@@ -29,6 +34,11 @@ peripheralControlRoutes.use('*', requireScope('organization', 'partner', 'system
 const policySchema = z.object({
   id: z.string().guid().optional(),
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") policy: orgId NULL,
+  // partnerId = caller's partner (#2131). Honored on CREATE only — this
+  // schema doubles as the update body (id set), and updates never move a
+  // policy between ownership axes.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(200),
   deviceClass: z.enum(peripheralDeviceClassEnum.enumValues),
   action: z.enum(peripheralPolicyActionEnum.enumValues),
@@ -210,10 +220,23 @@ function sanitizeTargetIds(targetIds: z.infer<typeof policySchema>['targetIds'])
   };
 }
 
+// Dual-axis access condition (#2131): org-owned rows the caller can reach OR
+// partner-wide rows (org_id NULL) owned by the caller's own partner. Gated on
+// partner scope — org tokens carry a partnerId but never pass
+// breeze_has_partner_access, so RLS is stricter than this app condition.
+function peripheralPolicyAccessCondition(auth: AuthContext): SQL | undefined {
+  const orgCond = auth.orgCondition(peripheralPolicies.orgId);
+  if (!orgCond) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${orgCond} OR (${peripheralPolicies.orgId} IS NULL AND ${peripheralPolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return orgCond;
+}
+
 async function getPolicyWithAccess(policyId: string, auth: AuthContext) {
   const conditions: SQL[] = [eq(peripheralPolicies.id, policyId)];
-  const orgCondition = auth.orgCondition(peripheralPolicies.orgId);
-  if (orgCondition) conditions.push(orgCondition);
+  const accessCondition = peripheralPolicyAccessCondition(auth);
+  if (accessCondition) conditions.push(accessCondition);
 
   const [policy] = await db
     .select()
@@ -222,6 +245,21 @@ async function getPolicyWithAccess(policyId: string, auth: AuthContext) {
     .limit(1);
 
   return policy ?? null;
+}
+
+/**
+ * The org(s) whose devices a policy applies to (#2131): its own org, or —
+ * for a partner-wide policy — every org under the owning partner. Used to
+ * fan out the org-keyed distribution jobs and change events.
+ */
+async function resolvePolicyTargetOrgIds(policy: { orgId: string | null; partnerId: string | null }): Promise<string[]> {
+  if (policy.orgId) return [policy.orgId];
+  if (!policy.partnerId) return [];
+  const rows = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.partnerId, policy.partnerId));
+  return rows.map((row) => row.id);
 }
 
 async function emitPolicyChanged(
@@ -413,6 +451,12 @@ peripheralControlRoutes.post(
         return c.json({ error: 'Policy not found' }, 404);
       }
 
+      // Partner-wide templates are administrable only with the partner-wide
+      // capability (#2131).
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+
       const [updated] = await db
         .update(peripheralPolicies)
         .set({
@@ -432,9 +476,13 @@ peripheralControlRoutes.post(
         return c.json({ error: 'Failed to update policy' }, 500);
       }
 
+      const updateTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
+
       let distributionWarning: string | undefined;
       try {
-        await schedulePeripheralPolicyDistribution(updated.orgId, [updated.id], 'policy-updated');
+        for (const targetOrgId of updateTargetOrgIds) {
+          await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-updated');
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
@@ -442,11 +490,13 @@ peripheralControlRoutes.post(
       }
 
       try {
-        await emitPolicyChanged(updated.orgId, {
-          policyId: updated.id,
-          action: 'updated',
-          changedBy: auth.user.id
-        });
+        for (const targetOrgId of updateTargetOrgIds) {
+          await emitPolicyChanged(targetOrgId, {
+            policyId: updated.id,
+            action: 'updated',
+            changedBy: auth.user.id
+          });
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
@@ -474,15 +524,27 @@ peripheralControlRoutes.post(
       return c.json({ data: updated, warning: distributionWarning });
     }
 
-    const orgResolution = resolveOrgIdForWrite(auth, payload.orgId);
-    if (!orgResolution.orgId) {
-      return c.json({ error: orgResolution.error ?? 'Organization resolution failed' }, orgResolution.status ?? 400);
+    // Resolve the ownership axis (#2131): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (payload.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgResolution = resolveOrgIdForWrite(auth, payload.orgId);
+      if (!orgResolution.orgId) {
+        return c.json({ error: orgResolution.error ?? 'Organization resolution failed' }, orgResolution.status ?? 400);
+      }
+      owner = { orgId: orgResolution.orgId, partnerId: null };
     }
 
     const [created] = await db
       .insert(peripheralPolicies)
       .values({
-        orgId: orgResolution.orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: payload.name,
         deviceClass: payload.deviceClass,
         action: payload.action,
@@ -498,9 +560,13 @@ peripheralControlRoutes.post(
       return c.json({ error: 'Failed to create policy' }, 500);
     }
 
+    const createTargetOrgIds = await resolvePolicyTargetOrgIds(created);
+
     let distributionWarning: string | undefined;
     try {
-      await schedulePeripheralPolicyDistribution(created.orgId, [created.id], 'policy-created');
+      for (const targetOrgId of createTargetOrgIds) {
+        await schedulePeripheralPolicyDistribution(targetOrgId, [created.id], 'policy-created');
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
@@ -508,11 +574,13 @@ peripheralControlRoutes.post(
     }
 
     try {
-      await emitPolicyChanged(created.orgId, {
-        policyId: created.id,
-        action: 'created',
-        changedBy: auth.user.id
-      });
+      for (const targetOrgId of createTargetOrgIds) {
+        await emitPolicyChanged(targetOrgId, {
+          policyId: created.id,
+          action: 'created',
+          changedBy: auth.user.id
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
@@ -555,6 +623,12 @@ peripheralControlRoutes.post(
       return c.json({ error: 'Policy not found' }, 404);
     }
 
+    // Partner-wide templates are administrable only with the partner-wide
+    // capability (#2131).
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const [updated] = await db
       .update(peripheralPolicies)
       .set({
@@ -568,9 +642,13 @@ peripheralControlRoutes.post(
       return c.json({ error: 'Failed to disable policy' }, 500);
     }
 
+    const disableTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
+
     let distributionWarning: string | undefined;
     try {
-      await schedulePeripheralPolicyDistribution(updated.orgId, [updated.id], 'policy-disabled');
+      for (const targetOrgId of disableTargetOrgIds) {
+        await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-disabled');
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
@@ -578,11 +656,13 @@ peripheralControlRoutes.post(
     }
 
     try {
-      await emitPolicyChanged(updated.orgId, {
-        policyId: updated.id,
-        action: 'disabled',
-        changedBy: auth.user.id
-      });
+      for (const targetOrgId of disableTargetOrgIds) {
+        await emitPolicyChanged(targetOrgId, {
+          policyId: updated.id,
+          action: 'disabled',
+          changedBy: auth.user.id
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
@@ -620,6 +700,12 @@ peripheralControlRoutes.post(
     const policy = await getPolicyWithAccess(payload.policyId, auth);
     if (!policy) {
       return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    // Partner-wide templates are administrable only with the partner-wide
+    // capability (#2131).
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const currentExceptions = Array.isArray(policy.exceptions)
@@ -665,9 +751,13 @@ peripheralControlRoutes.post(
       return c.json({ error: 'Failed to update policy exceptions' }, 500);
     }
 
+    const exceptionsTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
+
     let distributionWarning: string | undefined;
     try {
-      await schedulePeripheralPolicyDistribution(updated.orgId, [updated.id], 'policy-exceptions-updated');
+      for (const targetOrgId of exceptionsTargetOrgIds) {
+        await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-exceptions-updated');
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
@@ -675,13 +765,15 @@ peripheralControlRoutes.post(
     }
 
     try {
-      await emitPolicyChanged(updated.orgId, {
-        policyId: updated.id,
-        action: 'exceptions_updated',
-        changedBy: auth.user.id,
-        operation: payload.operation,
-        changed
-      });
+      for (const targetOrgId of exceptionsTargetOrgIds) {
+        await emitPolicyChanged(targetOrgId, {
+          policyId: updated.id,
+          action: 'exceptions_updated',
+          changedBy: auth.user.id,
+          operation: payload.operation,
+          changed
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -274,6 +274,56 @@ async function emitPolicyChanged(
   );
 }
 
+/**
+ * Fan a policy change out to its target orgs (#2131): schedule the org-keyed
+ * distribution job and emit the change event PER ORG, each with its own
+ * try/catch — one org's Redis/queue failure must not silently skip the
+ * remaining orgs of a partner-wide fan-out. Returns a warning naming how many
+ * orgs failed (mirrors processPolicyDistribution's per-device accounting).
+ */
+async function fanOutPolicyChange(
+  targetOrgIds: string[],
+  policyId: string,
+  reason: string,
+  eventPayload: Record<string, unknown>
+): Promise<string | undefined> {
+  let warning: string | undefined;
+
+  const distributionFailures: string[] = [];
+  for (const targetOrgId of targetOrgIds) {
+    try {
+      await schedulePeripheralPolicyDistribution(targetOrgId, [policyId], reason);
+    } catch (error) {
+      distributionFailures.push(targetOrgId);
+      console.error(`[peripheralControl] Failed to schedule policy distribution for policy ${policyId} (org ${targetOrgId}):`, error);
+    }
+  }
+  if (distributionFailures.length > 0) {
+    warning = combineWarning(
+      warning,
+      `distribution scheduling failed for ${distributionFailures.length}/${targetOrgIds.length} org(s): ${distributionFailures.join(', ')}`
+    );
+  }
+
+  const eventFailures: string[] = [];
+  for (const targetOrgId of targetOrgIds) {
+    try {
+      await emitPolicyChanged(targetOrgId, eventPayload);
+    } catch (error) {
+      eventFailures.push(targetOrgId);
+      console.error(`[peripheralControl] Failed to emit policy change event for policy ${policyId} (org ${targetOrgId}):`, error);
+    }
+  }
+  if (eventFailures.length > 0) {
+    warning = combineWarning(
+      warning,
+      `event publish failed for ${eventFailures.length}/${targetOrgIds.length} org(s): ${eventFailures.join(', ')}`
+    );
+  }
+
+  return warning;
+}
+
 peripheralControlRoutes.get(
   '/activity',
   // Populates `permissions` in context (site-scope narrowing below depends on
@@ -383,8 +433,10 @@ peripheralControlRoutes.get(
     }
 
     const conditions: SQL[] = [];
-    const orgCondition = auth.orgCondition(peripheralPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    // Dual-axis (#2131): partner-scope callers also see their partner-wide
+    // policies in the list, not just via get-by-id.
+    const accessCondition = peripheralPolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     if (query.orgId) conditions.push(eq(peripheralPolicies.orgId, query.orgId));
     if (query.isActive !== undefined) conditions.push(eq(peripheralPolicies.isActive, query.isActive === 'true'));
@@ -477,31 +529,11 @@ peripheralControlRoutes.post(
       }
 
       const updateTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
-
-      let distributionWarning: string | undefined;
-      try {
-        for (const targetOrgId of updateTargetOrgIds) {
-          await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-updated');
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
-        console.error(`[peripheralControl] Failed to schedule policy distribution for policy ${updated.id}:`, error);
-      }
-
-      try {
-        for (const targetOrgId of updateTargetOrgIds) {
-          await emitPolicyChanged(targetOrgId, {
-            policyId: updated.id,
-            action: 'updated',
-            changedBy: auth.user.id
-          });
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
-        console.error(`[peripheralControl] Failed to emit policy change event for policy ${updated.id}:`, error);
-      }
+      const distributionWarning = await fanOutPolicyChange(updateTargetOrgIds, updated.id, 'policy-updated', {
+        policyId: updated.id,
+        action: 'updated',
+        changedBy: auth.user.id
+      });
 
       try {
         writeRouteAudit(c, {
@@ -561,31 +593,11 @@ peripheralControlRoutes.post(
     }
 
     const createTargetOrgIds = await resolvePolicyTargetOrgIds(created);
-
-    let distributionWarning: string | undefined;
-    try {
-      for (const targetOrgId of createTargetOrgIds) {
-        await schedulePeripheralPolicyDistribution(targetOrgId, [created.id], 'policy-created');
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
-      console.error(`[peripheralControl] Failed to schedule policy distribution for policy ${created.id}:`, error);
-    }
-
-    try {
-      for (const targetOrgId of createTargetOrgIds) {
-        await emitPolicyChanged(targetOrgId, {
-          policyId: created.id,
-          action: 'created',
-          changedBy: auth.user.id
-        });
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
-      console.error(`[peripheralControl] Failed to emit policy change event for policy ${created.id}:`, error);
-    }
+    const distributionWarning = await fanOutPolicyChange(createTargetOrgIds, created.id, 'policy-created', {
+      policyId: created.id,
+      action: 'created',
+      changedBy: auth.user.id
+    });
 
     try {
       writeRouteAudit(c, {
@@ -643,31 +655,11 @@ peripheralControlRoutes.post(
     }
 
     const disableTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
-
-    let distributionWarning: string | undefined;
-    try {
-      for (const targetOrgId of disableTargetOrgIds) {
-        await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-disabled');
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
-      console.error(`[peripheralControl] Failed to schedule policy distribution for policy ${updated.id}:`, error);
-    }
-
-    try {
-      for (const targetOrgId of disableTargetOrgIds) {
-        await emitPolicyChanged(targetOrgId, {
-          policyId: updated.id,
-          action: 'disabled',
-          changedBy: auth.user.id
-        });
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
-      console.error(`[peripheralControl] Failed to emit policy change event for policy ${updated.id}:`, error);
-    }
+    const distributionWarning = await fanOutPolicyChange(disableTargetOrgIds, updated.id, 'policy-disabled', {
+      policyId: updated.id,
+      action: 'disabled',
+      changedBy: auth.user.id
+    });
 
     try {
       writeRouteAudit(c, {
@@ -752,33 +744,13 @@ peripheralControlRoutes.post(
     }
 
     const exceptionsTargetOrgIds = await resolvePolicyTargetOrgIds(updated);
-
-    let distributionWarning: string | undefined;
-    try {
-      for (const targetOrgId of exceptionsTargetOrgIds) {
-        await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'policy-exceptions-updated');
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `distribution scheduling failed: ${message}`);
-      console.error(`[peripheralControl] Failed to schedule policy distribution for policy ${updated.id}:`, error);
-    }
-
-    try {
-      for (const targetOrgId of exceptionsTargetOrgIds) {
-        await emitPolicyChanged(targetOrgId, {
-          policyId: updated.id,
-          action: 'exceptions_updated',
-          changedBy: auth.user.id,
-          operation: payload.operation,
-          changed
-        });
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      distributionWarning = combineWarning(distributionWarning, `event publish failed: ${message}`);
-      console.error(`[peripheralControl] Failed to emit policy change event for policy ${updated.id}:`, error);
-    }
+    const distributionWarning = await fanOutPolicyChange(exceptionsTargetOrgIds, updated.id, 'policy-exceptions-updated', {
+      policyId: updated.id,
+      action: 'exceptions_updated',
+      changedBy: auth.user.id,
+      operation: payload.operation,
+      changed
+    });
 
     try {
       writeRouteAudit(c, {

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -1,15 +1,36 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../../db';
-import { automationPolicies, automationRuns, automations } from '../../db/schema';
+import { automationPolicies, automationRuns, automations, organizations } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../../services/partnerWideAccess';
 import { evaluatePolicy, resolvePolicyRemediationAutomationId } from '../../services/policyEvaluationService';
 import { AuthContext, policyIdSchema } from './schemas';
 import { getPolicyWithOrgCheck, normalizePolicyResponse } from './helpers';
 
 export const actionRoutes = new Hono();
+
+/**
+ * Partner-wide policies (org_id NULL, #2129) mutate enforcement across every
+ * org under the partner — administrable only with the partner-wide capability
+ * (partner_users.org_access = 'all', same gate as the config-policy routes).
+ */
+function partnerWideWriteDenied(policy: { orgId: string | null }, auth: AuthContext): boolean {
+  // The route-local AuthContext types scope as plain string; narrow for the
+  // shared capability check (unknown scopes fail closed inside it anyway).
+  return (
+    policy.orgId === null &&
+    !canManagePartnerWidePolicies({
+      scope: auth.scope as 'system' | 'partner' | 'organization',
+      partnerOrgAccess: auth.partnerOrgAccess ?? null,
+    })
+  );
+}
 
 // POST /policies/:id/activate
 actionRoutes.post(
@@ -26,6 +47,10 @@ actionRoutes.post(
     const policy = await getPolicyWithOrgCheck(id, auth);
     if (!policy) {
       return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    if (partnerWideWriteDenied(policy, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const [updated] = await db
@@ -61,6 +86,10 @@ actionRoutes.post(
     const policy = await getPolicyWithOrgCheck(id, auth);
     if (!policy) {
       return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    if (partnerWideWriteDenied(policy, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const [updated] = await db
@@ -138,6 +167,10 @@ actionRoutes.post(
       return c.json({ error: 'Policy not found' }, 404);
     }
 
+    if (partnerWideWriteDenied(policy, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const targetAutomationId = await resolvePolicyRemediationAutomationId(policy);
     if (!targetAutomationId) {
       return c.json({
@@ -146,13 +179,26 @@ actionRoutes.post(
       }, 400);
     }
 
+    // Automations are org-owned. An org-owned policy anchors the lookup to its
+    // own org; a partner-wide policy (org_id NULL, #2129) accepts an explicit
+    // automation from any org under the owning partner.
+    const automationOwnerCondition = policy.orgId
+      ? eq(automations.orgId, policy.orgId)
+      : inArray(
+          automations.orgId,
+          db
+            .select({ id: organizations.id })
+            .from(organizations)
+            .where(eq(organizations.partnerId, policy.partnerId ?? ''))
+        );
+
     const [automation] = await db
       .select()
       .from(automations)
       .where(
         and(
           eq(automations.id, targetAutomationId),
-          eq(automations.orgId, policy.orgId)
+          automationOwnerCondition
         )
       )
       .limit(1);

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -128,6 +128,13 @@ actionRoutes.post(
       return c.json({ error: 'Policy not found' }, 404);
     }
 
+    // Evaluate requests remediation, so for a partner-wide policy it fans
+    // enforcement out to EVERY org under the partner — gate it like the
+    // sibling mutators, not like a read (#2149 review).
+    if (partnerWideWriteDenied(policy, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     if (!policy.enabled) {
       return c.json({ error: 'Cannot evaluate disabled policy' }, 400);
     }

--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -20,6 +20,7 @@ import {
   getPagination,
   ensureOrgAccess,
   getPolicyWithOrgCheck,
+  automationPolicyOwnershipCondition,
   getPolicyComplianceMap,
   buildComplianceSummary,
   extractViolationsFromComplianceDetails,
@@ -60,9 +61,13 @@ complianceRoutes.get(
       orgIds = [orgId];
     }
 
-    const policyCondition = orgIds.length > 0
-      ? inArray(automationPolicies.orgId, orgIds)
-      : undefined;
+    // Partner "all orgs" view also counts this partner's partner-wide
+    // templates (org_id NULL, #2129); a specific-org view stays org-only.
+    const policyCondition = automationPolicyOwnershipCondition(
+      auth,
+      orgIds,
+      auth.scope === 'partner' && !orgId
+    );
 
     const configPolicyCondition = orgIds.length > 0
       ? inArray(configurationPolicies.orgId, orgIds)
@@ -178,9 +183,13 @@ complianceRoutes.get(
       orgIds = [orgId];
     }
 
-    const policyCondition = orgIds.length > 0
-      ? inArray(automationPolicies.orgId, orgIds)
-      : undefined;
+    // Partner "all orgs" view also counts this partner's partner-wide
+    // templates (org_id NULL, #2129); a specific-org view stays org-only.
+    const policyCondition = automationPolicyOwnershipCondition(
+      auth,
+      orgIds,
+      auth.scope === 'partner' && !orgId
+    );
 
     const configPolicyCondition = orgIds.length > 0
       ? inArray(configurationPolicies.orgId, orgIds)

--- a/apps/api/src/routes/policyManagement/crud.ts
+++ b/apps/api/src/routes/policyManagement/crud.ts
@@ -13,6 +13,7 @@ import {
   getPagination,
   ensureOrgAccess,
   getPolicyWithOrgCheck,
+  automationPolicyOwnershipCondition,
   normalizePolicyResponse,
   getPolicyComplianceMap,
   buildComplianceSummary,
@@ -45,11 +46,14 @@ crudRoutes.get(
         }
         conditions.push(eq(automationPolicies.orgId, query.orgId));
       } else {
+        // "All orgs" view: org-owned policies across accessible orgs PLUS this
+        // partner's own partner-wide templates (org_id NULL, #2129).
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        const ownership = automationPolicyOwnershipCondition(auth, orgIds, true);
+        if (!ownership) {
           return c.json({ data: [], pagination: { page, limit, total: 0 } });
         }
-        conditions.push(inArray(automationPolicies.orgId, orgIds));
+        conditions.push(ownership);
       }
     } else if (auth.scope === 'system' && query.orgId) {
       conditions.push(eq(automationPolicies.orgId, query.orgId));

--- a/apps/api/src/routes/policyManagement/helpers.ts
+++ b/apps/api/src/routes/policyManagement/helpers.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {
   automationPolicies,
@@ -44,12 +44,56 @@ export async function getPolicyWithOrgCheck(policyId: string, auth: AuthContext)
     return null;
   }
 
-  const hasAccess = ensureOrgAccess(policy.orgId, auth);
-  if (!hasAccess) {
-    return null;
+  // Dual-ownership (#2129): org-owned rows keep the org check; partner-wide
+  // rows (org_id NULL) are visible to system scope and to the owning partner's
+  // own tokens. Org-scope tokens never see partner-wide templates (RLS is
+  // stricter than this app-layer check, never looser).
+  if (policy.orgId !== null) {
+    if (!ensureOrgAccess(policy.orgId, auth)) {
+      return null;
+    }
+    return policy;
   }
 
-  return policy;
+  if (auth.scope === 'system') {
+    return policy;
+  }
+
+  if (auth.scope === 'partner' && auth.partnerId && policy.partnerId === auth.partnerId) {
+    return policy;
+  }
+
+  return null;
+}
+
+/**
+ * List-scoping condition for automation policies over a set of accessible
+ * orgs (#2129 dual-ownership). When `includePartnerWide` is set, partner
+ * tokens additionally see partner-wide templates (org_id NULL) owned by their
+ * OWN partner. The branch is gated on scope === 'partner' because org tokens
+ * also carry a partnerId yet never hold the partner RLS axis — RLS is
+ * stricter than this app-layer condition, never looser.
+ *
+ * Returns undefined when nothing constrains the query (system scope) — and
+ * ALSO when an org/partner caller has no visible axis at all, so callers must
+ * short-circuit to an empty result instead of querying with undefined.
+ */
+export function automationPolicyOwnershipCondition(
+  auth: AuthContext,
+  orgIds: string[],
+  includePartnerWide: boolean
+): SQL | undefined {
+  const orgCondition = orgIds.length > 0 ? inArray(automationPolicies.orgId, orgIds) : undefined;
+
+  if (includePartnerWide && auth.scope === 'partner' && auth.partnerId) {
+    const partnerCondition = and(
+      isNull(automationPolicies.orgId),
+      eq(automationPolicies.partnerId, auth.partnerId)
+    ) as SQL;
+    return orgCondition ? (or(orgCondition, partnerCondition) as SQL) : partnerCondition;
+  }
+
+  return orgCondition;
 }
 
 export function sanitizeStringArray(value: unknown): string[] {

--- a/apps/api/src/routes/policyManagement/schemas.ts
+++ b/apps/api/src/routes/policyManagement/schemas.ts
@@ -6,6 +6,9 @@ export type AuthContext = {
   orgId: string | null;
   accessibleOrgIds: string[] | null;
   canAccessOrg?: (orgId: string) => boolean;
+  // Partner-membership org access ('all' unlocks partner-wide administration
+  // via canManagePartnerWidePolicies); absent on org/system tokens.
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
   user: {
     id: string;
     email?: string;

--- a/apps/api/src/routes/policyManagement_actions.test.ts
+++ b/apps/api/src/routes/policyManagement_actions.test.ts
@@ -50,6 +50,7 @@ vi.mock('../db/schema', () => ({
   automationPolicies: {
     id: 'id',
     orgId: 'orgId',
+    partnerId: 'partnerId',
     name: 'name',
     description: 'description',
     enabled: 'enabled',
@@ -143,6 +144,7 @@ vi.mock('../middleware/auth', () => ({
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 
 function makePolicy(overrides: Record<string, unknown> = {}) {
   return {
@@ -265,6 +267,88 @@ describe('policyManagement routes', () => {
       });
 
       expect(res.status).toBe(404);
+    });
+
+    // ----------------------------------------------------------------
+    // Partner-wide dual-ownership gate (#2129): a policy with orgId null +
+    // partnerId set is only mutable by a partner-scope caller whose
+    // partnerOrgAccess is 'all' (or system scope). PR review flagged this
+    // app-layer 403 as unit-untested — only real-DB integration suites (not
+    // run in the required CI job) covered it.
+    // ----------------------------------------------------------------
+    it('should return 403 activating a partner-wide policy when the partner caller lacks partnerOrgAccess=all', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess: 'selected',
+          accessibleOrgIds: [ORG_ID],
+          canAccessOrg: (orgId: string) => orgId === ORG_ID
+        });
+        return next();
+      });
+
+      const policy = makePolicy({ orgId: null, partnerId: PARTNER_ID, enabled: false });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([policy])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/policies/${POLICY_ID}/activate`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('should allow activating a partner-wide policy when the partner caller has partnerOrgAccess=all and a matching partnerId', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess: 'all',
+          accessibleOrgIds: [ORG_ID],
+          canAccessOrg: (orgId: string) => orgId === ORG_ID
+        });
+        return next();
+      });
+
+      const policy = makePolicy({ orgId: null, partnerId: PARTNER_ID, enabled: false });
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([policy])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...policy, enabled: true }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/policies/${POLICY_ID}/activate`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.enabled).toBe(true);
+      expect(db.update).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/api/src/routes/policyManagement_crud.test.ts
+++ b/apps/api/src/routes/policyManagement_crud.test.ts
@@ -50,6 +50,7 @@ vi.mock('../db/schema', () => ({
   automationPolicies: {
     id: 'id',
     orgId: 'orgId',
+    partnerId: 'partnerId',
     name: 'name',
     description: 'description',
     enabled: 'enabled',
@@ -260,7 +261,10 @@ describe('policyManagement routes', () => {
       expect(res.status).toBe(403);
     });
 
-    it('should return empty for partner with no accessible orgs', async () => {
+    it('still queries partner-wide templates for a partner with no accessible orgs (#2129)', async () => {
+      // A partner member with zero accessible orgs still holds the partner
+      // axis, so the list no longer short-circuits — it queries for
+      // partner-wide templates (org_id NULL) owned by their partner.
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
         c.set('auth', {
           user: { id: 'user-123', email: 'partner@example.com', name: 'Partner' },
@@ -273,6 +277,26 @@ describe('policyManagement routes', () => {
         return next();
       });
 
+      vi.mocked(db.select)
+        // count query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }])
+          })
+        } as any)
+        // policies list
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([])
+                })
+              })
+            })
+          })
+        } as any);
+
       const res = await app.request('/policies', {
         method: 'GET',
         headers: { Authorization: 'Bearer token' }
@@ -281,6 +305,61 @@ describe('policyManagement routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data).toEqual([]);
+    });
+
+    it('lists a partner-wide policy (org_id NULL) in the partner "all orgs" view (#2129)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'partner@example.com', name: 'Partner' },
+          scope: 'partner',
+          orgId: null,
+          partnerId: PARTNER_ID,
+          accessibleOrgIds: [ORG_ID],
+          canAccessOrg: (orgId: string) => orgId === ORG_ID
+        });
+        return next();
+      });
+
+      const partnerWide = makePolicy({ id: POLICY_ID_2, name: 'Partner-wide baseline', orgId: null, partnerId: PARTNER_ID });
+      vi.mocked(db.select)
+        // count query
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 2 }])
+          })
+        } as any)
+        // policies list
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([makePolicy(), partnerWide])
+                })
+              })
+            })
+          })
+        } as any)
+        // getPolicyComplianceMap
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+
+      const res = await app.request('/policies', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(2);
+      const partnerRow = body.data.find((p: { id: string }) => p.id === POLICY_ID_2);
+      expect(partnerRow.orgId).toBeNull();
+      expect(partnerRow.partnerId).toBe(PARTNER_ID);
     });
   });
 

--- a/apps/api/src/routes/sensitiveData.test.ts
+++ b/apps/api/src/routes/sensitiveData.test.ts
@@ -18,30 +18,42 @@ vi.mock('../db/schema', () => ({
   devices: {},
   sensitiveDataScans: {},
   sensitiveDataFindings: {},
-  sensitiveDataPolicies: {}
+  sensitiveDataPolicies: {
+    id: 'id',
+    orgId: 'orgId',
+    partnerId: 'partnerId',
+    name: 'name',
+    scope: 'scope',
+    detectionClasses: 'detectionClasses',
+    schedule: 'schedule',
+    isActive: 'isActive',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt'
+  }
 }));
 
+// authMiddleware is a vi.fn() so individual tests can override the auth
+// context (scope/partnerId/partnerOrgAccess) via mockImplementation — needed
+// to exercise the partner-wide write gate (#2131). requireScope is a plain
+// passthrough: it must NOT re-set 'auth' (it used to, clobbering whatever
+// authMiddleware — or a per-test override — set for every route below it in
+// the chain, since every /policies route applies requireScope after
+// authMiddleware).
 vi.mock('../middleware/auth', () => ({
-  authMiddleware: async (c: any, next: any) => {
+  authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
       user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
       orgId: '11111111-1111-1111-1111-111111111111',
-      accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
-      orgCondition: () => undefined,
-      canAccessOrg: () => true
-    });
-    return next();
-  },
-  requireScope: vi.fn(() => async (c: any, next: any) => {
-    c.set('auth', {
-      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
-      orgId: '11111111-1111-1111-1111-111111111111',
+      partnerId: null,
+      partnerOrgAccess: null,
       accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
       orgCondition: () => undefined,
       canAccessOrg: () => true
     });
     return next();
   }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (c: any, next: any) => {
     // Mirror the real middleware: populate permissions.allowedSiteIds when the
     // caller is site-restricted (signalled here via the x-restrict-site header).
@@ -76,8 +88,10 @@ vi.mock('../services/auditEvents', () => ({
 }));
 
 import { db } from '../db';
+import { authMiddleware } from '../middleware/auth';
 import { queueCommand } from '../services/commandQueue';
 import { writeRouteAudit } from '../services/auditEvents';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { sensitiveDataRoutes } from './sensitiveData';
 
 function mockDeviceLookup(rows: any[]) {
@@ -150,6 +164,19 @@ describe('sensitive data routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+        scope: 'organization',
+        orgId: '11111111-1111-1111-1111-111111111111',
+        partnerId: null,
+        partnerOrgAccess: null,
+        accessibleOrgIds: ['11111111-1111-1111-1111-111111111111'],
+        orgCondition: () => undefined,
+        canAccessOrg: () => true
+      });
+      return next();
+    });
     app = new Hono();
     app.route('/sensitive-data', sensitiveDataRoutes);
   });
@@ -614,5 +641,141 @@ describe('sensitive data routes', () => {
         resourceId: policyId
       })
     );
+  });
+
+  // --- Partner-wide policy write gate (#2131) ---
+  //
+  // A policy row with orgId NULL + partnerId set is "partner-wide" and is
+  // only mutable by a caller for whom canManagePartnerWidePolicies(auth) is
+  // true (system scope, or partner scope with partnerOrgAccess === 'all').
+  // These 403 gates in sensitiveData.ts (PUT/DELETE/POST) previously had zero
+  // unit coverage — only real-DB integration suites (not run in the required
+  // CI job) exercised them.
+  describe('partner-wide policy write gate (#2131)', () => {
+    const partnerId = '77777777-7777-7777-7777-777777777777';
+
+    function partnerAuth(overrides: Record<string, unknown> = {}) {
+      return {
+        user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+        scope: 'partner',
+        orgId: null,
+        partnerId,
+        partnerOrgAccess: 'selected',
+        accessibleOrgIds: [],
+        orgCondition: () => undefined,
+        canAccessOrg: () => true,
+        ...overrides
+      };
+    }
+
+    it('denies PUT on a partner-wide policy when the caller lacks partnerOrgAccess=all (403, no update)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', partnerAuth());
+        return next();
+      });
+
+      mockSelectFromWhereLimit([
+        {
+          id: policyId,
+          orgId: null,
+          partnerId,
+          name: 'Partner Policy',
+          scope: {},
+          detectionClasses: ['credential'],
+          schedule: null,
+          isActive: true
+        }
+      ]);
+
+      const res = await app.request(`/sensitive-data/policies/${policyId}`, {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'New Name' })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('denies DELETE on a partner-wide policy when the caller lacks partnerOrgAccess=all (403, no delete)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', partnerAuth());
+        return next();
+      });
+
+      mockSelectFromWhereLimit([
+        { id: policyId, name: 'Partner Policy', orgId: null, partnerId }
+      ]);
+
+      const res = await app.request(`/sensitive-data/policies/${policyId}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('denies POST /policies with ownerScope=partner when the caller lacks the capability (403, no insert)', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', partnerAuth());
+        return next();
+      });
+
+      const res = await app.request('/sensitive-data/policies', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Partner Wide Policy',
+          detectionClasses: ['credential'],
+          ownerScope: 'partner'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('creates a partner-wide policy (orgId null, partnerId set) when the caller has partnerOrgAccess=all', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', partnerAuth({ partnerOrgAccess: 'all' }));
+        return next();
+      });
+
+      const valuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: policyId,
+            orgId: null,
+            partnerId,
+            name: 'Partner Wide Policy',
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ])
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/sensitive-data/policies', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Partner Wide Policy',
+          detectionClasses: ['credential'],
+          ownerScope: 'partner'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      expect(valuesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ orgId: null, partnerId })
+      );
+    });
   });
 });

--- a/apps/api/src/routes/sensitiveData.ts
+++ b/apps/api/src/routes/sensitiveData.ts
@@ -11,7 +11,11 @@ import {
   sensitiveDataPolicies,
   sensitiveDataScans
 } from '../db/schema';
-import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 import { getPagination } from '../utils/pagination';
 import { CommandTypes, queueCommand } from '../services/commandQueue';
 import { enqueueSensitiveDataScan } from '../jobs/sensitiveDataJobs';
@@ -67,6 +71,10 @@ const policyScheduleSchema = z.object({
 
 const createPolicySchema = z.object({
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") policy: orgId NULL,
+  // partnerId = caller's partner (#2131). Create-only — updates never move a
+  // policy between ownership axes.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(200),
   scope: policyScopeSchema.default({}),
   detectionClasses: z.array(z.enum(dataTypeValues)).min(1).max(5),
@@ -139,6 +147,19 @@ function readOrgIdFromAuth(auth: {
     return auth.accessibleOrgIds[0] ?? null;
   }
   return null;
+}
+
+// Dual-axis access condition (#2131): org-owned rows the caller can reach OR
+// partner-wide rows (org_id NULL) owned by the caller's own partner. Gated on
+// partner scope — org tokens carry a partnerId but never pass
+// breeze_has_partner_access, so RLS is stricter than this app condition.
+function sensitivePolicyAccessCondition(auth: AuthContext): SQL | undefined {
+  const orgCond = auth.orgCondition(sensitiveDataPolicies.orgId);
+  if (!orgCond) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${orgCond} OR (${sensitiveDataPolicies.orgId} IS NULL AND ${sensitiveDataPolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return orgCond;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -233,8 +254,8 @@ sensitiveDataRoutes.post(
     let policyRow: typeof sensitiveDataPolicies.$inferSelect | undefined;
     if (payload.policyId) {
       const policyConditions: SQL[] = [eq(sensitiveDataPolicies.id, payload.policyId)];
-      const orgCondition = auth.orgCondition(sensitiveDataPolicies.orgId);
-      if (orgCondition) policyConditions.push(orgCondition);
+      const accessCondition = sensitivePolicyAccessCondition(auth);
+      if (accessCondition) policyConditions.push(accessCondition);
 
       [policyRow] = await db
         .select()
@@ -918,8 +939,8 @@ sensitiveDataRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const conditions: SQL[] = [];
-    const orgCondition = auth.orgCondition(sensitiveDataPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const accessCondition = sensitivePolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     const rows = await db
       .select()
@@ -946,15 +967,28 @@ sensitiveDataRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const payload = c.req.valid('json');
-    const orgId = readOrgIdFromAuth(auth, payload.orgId);
-    if (!orgId) {
-      return c.json({ error: 'Unable to resolve target organization for policy creation' }, 400);
+
+    // Resolve the ownership axis (#2131): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (payload.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgId = readOrgIdFromAuth(auth, payload.orgId);
+      if (!orgId) {
+        return c.json({ error: 'Unable to resolve target organization for policy creation' }, 400);
+      }
+      owner = { orgId, partnerId: null };
     }
 
     const [policy] = await db
       .insert(sensitiveDataPolicies)
       .values({
-        orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: payload.name,
         scope: payload.scope,
         detectionClasses: payload.detectionClasses,
@@ -997,8 +1031,8 @@ sensitiveDataRoutes.put(
     const payload = c.req.valid('json');
 
     const conditions: SQL[] = [eq(sensitiveDataPolicies.id, id)];
-    const orgCondition = auth.orgCondition(sensitiveDataPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const accessCondition = sensitivePolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     const [existing] = await db
       .select()
@@ -1007,6 +1041,12 @@ sensitiveDataRoutes.put(
       .limit(1);
 
     if (!existing) return c.json({ error: 'Policy not found' }, 404);
+
+    // Partner-wide templates are administrable only with the partner-wide
+    // capability (#2131).
+    if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
 
     const [updated] = await db
       .update(sensitiveDataPolicies)
@@ -1053,8 +1093,8 @@ sensitiveDataRoutes.delete(
     const { id } = c.req.valid('param');
 
     const conditions: SQL[] = [eq(sensitiveDataPolicies.id, id)];
-    const orgCondition = auth.orgCondition(sensitiveDataPolicies.orgId);
-    if (orgCondition) conditions.push(orgCondition);
+    const accessCondition = sensitivePolicyAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
 
     const [existing] = await db
       .select({
@@ -1067,6 +1107,12 @@ sensitiveDataRoutes.delete(
       .limit(1);
 
     if (!existing) return c.json({ error: 'Policy not found' }, 404);
+
+    // Partner-wide templates are administrable only with the partner-wide
+    // capability (#2131).
+    if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
 
     await db.delete(sensitiveDataPolicies).where(eq(sensitiveDataPolicies.id, id));
 

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -521,8 +521,16 @@ registerTool({
     const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
 
     const conditions: SQL[] = [];
+    // Dual-axis (#2129): org-owned rows the caller can reach OR partner-wide
+    // rows (org_id NULL) owned by the caller's own partner.
     const orgCond = auth.orgCondition(automationPolicies.orgId);
-    if (orgCond) conditions.push(orgCond);
+    if (orgCond) {
+      conditions.push(
+        auth.scope === 'partner' && auth.partnerId
+          ? sql`(${orgCond} OR (${automationPolicies.orgId} IS NULL AND ${automationPolicies.partnerId} = ${auth.partnerId}))`
+          : orgCond
+      );
+    }
 
     if (input.enabled !== undefined) {
       conditions.push(eq(automationPolicies.enabled, input.enabled as boolean));

--- a/apps/api/src/services/aiToolsFleet.test.ts
+++ b/apps/api/src/services/aiToolsFleet.test.ts
@@ -112,7 +112,7 @@ vi.mock('../db/schema/maintenance', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>;
   return {
     ...actual,
-    maintenanceWindows: { orgId: 'orgId', id: 'id' },
+    maintenanceWindows: { orgId: 'orgId', partnerId: 'partnerId', id: 'id' },
     maintenanceOccurrences: { windowId: 'windowId' },
   };
 });
@@ -253,6 +253,48 @@ describe('registerFleetTools', () => {
 // ============================================
 // Handler-level tests for new actions
 // ============================================
+
+describe('manage_maintenance_windows handler', () => {
+  const toolMap = new Map<string, AiTool>();
+  registerFleetTools(toolMap);
+  const tool = toolMap.get('manage_maintenance_windows')!;
+
+  // Regression guard for the #2131 scripted-edit self-recursion bug:
+  // maintenanceWindowWhere once called ITSELF instead of orgWhere, so every
+  // invocation blew the stack and safeHandler masked it as a JSON error.
+  // These tests INVOKE the handler (registration-only checks can't catch it).
+  it('list succeeds for an org-scope caller (no error, returns windows)', async () => {
+    const orgAuth = {
+      user: { id: 'u1', email: 'test@test.com', name: 'Test' },
+      orgId: 'org-1',
+      scope: 'organization',
+      partnerId: null,
+      accessibleOrgIds: ['org-1'],
+      canAccessOrg: () => true,
+      orgCondition: () => ({ mockCondition: 'org' }),
+    } as any;
+
+    const result = JSON.parse(await tool.handler({ action: 'list' }, orgAuth));
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.windows)).toBe(true);
+  });
+
+  it('list succeeds for a partner-scope caller (dual-axis branch, #2131)', async () => {
+    const partnerAuth = {
+      user: { id: 'u1', email: 'test@test.com', name: 'Test' },
+      orgId: null,
+      scope: 'partner',
+      partnerId: 'partner-1',
+      accessibleOrgIds: ['org-1', 'org-2'],
+      canAccessOrg: () => true,
+      orgCondition: () => ({ mockCondition: 'orgs' }),
+    } as any;
+
+    const result = JSON.parse(await tool.handler({ action: 'list' }, partnerAuth));
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.windows)).toBe(true);
+  });
+});
 
 describe('manage_alert_rules handler', () => {
   const toolMap = new Map<string, AiTool>();

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -93,6 +93,18 @@ function alertRuleWhere(auth: AuthContext): SQL | undefined {
   return oc;
 }
 
+// Dual-axis access for automation_policies (#2129): same shape as
+// alertRuleWhere — org-owned compliance policies the caller can reach OR
+// partner-wide ones (org_id NULL) owned by the caller's own partner.
+function automationPolicyWhere(auth: AuthContext): SQL | undefined {
+  const oc = orgWhere(auth, automationPolicies.orgId);
+  if (!oc) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${oc} OR (${automationPolicies.orgId} IS NULL AND ${automationPolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
 /** Wrap handler in try-catch so DB/runtime errors return JSON instead of crashing */
 function safeHandler(toolName: string, fn: FleetHandler): FleetHandler {
   return async (input, auth) => {
@@ -1607,8 +1619,8 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         }
 
         if (reportType === 'compliance') {
-          // Get policy compliance summary
-          const oc = orgWhere(auth, automationPolicies.orgId);
+          // Get policy compliance summary (dual-axis, #2129)
+          const oc = automationPolicyWhere(auth);
           const conditions: SQL[] = [];
           if (oc) conditions.push(oc);
 

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -60,6 +60,7 @@ import { devices, sites } from '../db/schema';
 import { eq, and, desc, sql, inArray, gte, lte, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { deviceSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { upsertPatchApproval, resolvePartnerIdForOrg } from '../routes/patches/helpers';
 
@@ -89,6 +90,18 @@ function alertRuleWhere(auth: AuthContext): SQL | undefined {
   // carry a partnerId, so adding the branch for them would be dead code.
   if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${oc} OR (${alertRules.orgId} IS NULL AND ${alertRules.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
+// Dual-axis access for maintenance_windows (#2131): same shape as
+// alertRuleWhere — org-owned windows the caller can reach OR partner-wide
+// ones (org_id NULL) owned by the caller's own partner.
+function maintenanceWindowWhere(auth: AuthContext): SQL | undefined {
+  const oc = maintenanceWindowWhere(auth);
+  if (!oc) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${oc} OR (${maintenanceWindows.orgId} IS NULL AND ${maintenanceWindows.partnerId} = ${auth.partnerId}))`;
   }
   return oc;
 }
@@ -954,7 +967,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, maintenanceWindows.orgId);
+        const oc = maintenanceWindowWhere(auth);
         if (oc) conditions.push(oc);
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
@@ -979,7 +992,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'get') {
         if (!input.windowId) return JSON.stringify({ error: 'windowId is required' });
         const conditions: SQL[] = [eq(maintenanceWindows.id, input.windowId as string)];
-        const oc = orgWhere(auth, maintenanceWindows.orgId);
+        const oc = maintenanceWindowWhere(auth);
         if (oc) conditions.push(oc);
 
         const [win] = await db.select().from(maintenanceWindows).where(and(...conditions)).limit(1);
@@ -1001,7 +1014,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           gte(maintenanceWindows.endTime, now),
           eq(maintenanceWindows.status, 'active'),
         ];
-        const oc = orgWhere(auth, maintenanceWindows.orgId);
+        const oc = maintenanceWindowWhere(auth);
         if (oc) conditions.push(oc);
 
         const active = await db.select({
@@ -1021,7 +1034,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           gte(maintenanceWindows.endTime, now),
           eq(maintenanceWindows.status, 'scheduled'),
         ];
-        const oc2 = orgWhere(auth, maintenanceWindows.orgId);
+        const oc2 = maintenanceWindowWhere(auth);
         if (oc2) scheduledConditions.push(oc2);
 
         const scheduled = await db.select({
@@ -1067,11 +1080,17 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!input.windowId) return JSON.stringify({ error: 'windowId is required' });
         const windowId = input.windowId as string;
         const conditions: SQL[] = [eq(maintenanceWindows.id, windowId)];
-        const oc = orgWhere(auth, maintenanceWindows.orgId);
+        const oc = maintenanceWindowWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(maintenanceWindows).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
+
+        // Partner-wide windows are administrable only with the partner-wide
+        // capability (same gate as the HTTP route, #2131).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide maintenance window requires full partner org access (orgAccess must be "all")' });
+        }
 
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;
@@ -1092,11 +1111,17 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!input.windowId) return JSON.stringify({ error: 'windowId is required' });
         const windowId = input.windowId as string;
         const conditions: SQL[] = [eq(maintenanceWindows.id, windowId)];
-        const oc = orgWhere(auth, maintenanceWindows.orgId);
+        const oc = maintenanceWindowWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(maintenanceWindows).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
+
+        // Partner-wide windows are administrable only with the partner-wide
+        // capability (same gate as the HTTP route, #2131).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide maintenance window requires full partner org access (orgAccess must be "all")' });
+        }
 
         await db.transaction(async (tx) => {
           await tx.delete(maintenanceOccurrences).where(eq(maintenanceOccurrences.windowId, existing.id));

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -98,7 +98,7 @@ function alertRuleWhere(auth: AuthContext): SQL | undefined {
 // alertRuleWhere — org-owned windows the caller can reach OR partner-wide
 // ones (org_id NULL) owned by the caller's own partner.
 function maintenanceWindowWhere(auth: AuthContext): SQL | undefined {
-  const oc = maintenanceWindowWhere(auth);
+  const oc = orgWhere(auth, maintenanceWindows.orgId);
   if (!oc) return undefined; // system scope
   if (auth.scope === 'partner' && auth.partnerId) {
     return sql`(${oc} OR (${maintenanceWindows.orgId} IS NULL AND ${maintenanceWindows.partnerId} = ${auth.partnerId}))`;

--- a/apps/api/src/services/aiToolsPeripherals.ts
+++ b/apps/api/src/services/aiToolsPeripherals.ts
@@ -8,6 +8,7 @@
 
 import { db } from '../db';
 import {
+  organizations,
   peripheralEvents,
   peripheralPolicies,
   peripheralDeviceClassEnum,
@@ -20,6 +21,7 @@ import { eq, and, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
+import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { schedulePeripheralPolicyDistribution } from '../jobs/peripheralJobs';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
@@ -224,14 +226,40 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
       const fetchPolicy = async () => {
         if (!policyId) return null;
         const conditions: SQL[] = [eq(peripheralPolicies.id, policyId)];
+        // Dual-axis (#2131): org-owned rows the caller can reach OR
+        // partner-wide rows (org_id NULL) owned by the caller's own partner.
         const orgCondition = auth.orgCondition(peripheralPolicies.orgId);
-        if (orgCondition) conditions.push(orgCondition);
+        if (orgCondition) {
+          conditions.push(
+            auth.scope === 'partner' && auth.partnerId
+              ? sql`(${orgCondition} OR (${peripheralPolicies.orgId} IS NULL AND ${peripheralPolicies.partnerId} = ${auth.partnerId}))`
+              : orgCondition
+          );
+        }
         const [policy] = await db
           .select()
           .from(peripheralPolicies)
           .where(and(...conditions))
           .limit(1);
         return policy ?? null;
+      };
+
+      // Partner-wide templates are administrable only with the partner-wide
+      // capability (same gate as the HTTP route, #2131).
+      const partnerWideDenied = (policy: { orgId: string | null }): boolean =>
+        policy.orgId === null && !canManagePartnerWidePolicies(auth);
+
+      // Distribution jobs and change events are org-keyed: an org-owned
+      // policy targets its own org; a partner-wide policy fans out to every
+      // org under the owning partner.
+      const policyTargetOrgIds = async (policy: { orgId: string | null; partnerId: string | null }): Promise<string[]> => {
+        if (policy.orgId) return [policy.orgId];
+        if (!policy.partnerId) return [];
+        const rows = await db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, policy.partnerId));
+        return rows.map((row) => row.id);
       };
 
       if (action === 'create') {
@@ -279,7 +307,8 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
 
         let warning: string | undefined;
         try {
-          await schedulePeripheralPolicyDistribution(created.orgId, [created.id], 'ai-tool-create');
+          // AI-tool creates are always org-owned (resolveWritableToolOrgId).
+          await schedulePeripheralPolicyDistribution(orgResolved.orgId, [created.id], 'ai-tool-create');
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
@@ -289,7 +318,7 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         try {
           await publishEvent(
             'peripheral.policy_changed',
-            created.orgId,
+            orgResolved.orgId,
             { policyId: created.id, action: 'created', changedBy: auth.user.id },
             'ai-tools',
             { userId: auth.user.id }
@@ -307,6 +336,9 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         const policy = await fetchPolicy();
         if (!policy) {
           return JSON.stringify({ error: 'Policy not found or access denied' });
+        }
+        if (partnerWideDenied(policy)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide peripheral policy requires full partner org access (orgAccess must be "all")' });
         }
 
         const [updated] = await db
@@ -337,9 +369,13 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({ error: 'Failed to update policy' });
         }
 
+        const updateTargetOrgIds = await policyTargetOrgIds(updated);
+
         let warning: string | undefined;
         try {
-          await schedulePeripheralPolicyDistribution(updated.orgId, [updated.id], 'ai-tool-update');
+          for (const targetOrgId of updateTargetOrgIds) {
+            await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'ai-tool-update');
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
@@ -347,13 +383,15 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         try {
-          await publishEvent(
-            'peripheral.policy_changed',
-            updated.orgId,
-            { policyId: updated.id, action: 'updated', changedBy: auth.user.id },
-            'ai-tools',
-            { userId: auth.user.id }
-          );
+          for (const targetOrgId of updateTargetOrgIds) {
+            await publishEvent(
+              'peripheral.policy_changed',
+              targetOrgId,
+              { policyId: updated.id, action: 'updated', changedBy: auth.user.id },
+              'ai-tools',
+              { userId: auth.user.id }
+            );
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `event publish failed: ${message}`);
@@ -368,6 +406,9 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         if (!policy) {
           return JSON.stringify({ error: 'Policy not found or access denied' });
         }
+        if (partnerWideDenied(policy)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide peripheral policy requires full partner org access (orgAccess must be "all")' });
+        }
 
         const [disabled] = await db
           .update(peripheralPolicies)
@@ -379,9 +420,13 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({ error: 'Failed to disable policy' });
         }
 
+        const disableTargetOrgIds = await policyTargetOrgIds(disabled);
+
         let warning: string | undefined;
         try {
-          await schedulePeripheralPolicyDistribution(disabled.orgId, [disabled.id], 'ai-tool-disable');
+          for (const targetOrgId of disableTargetOrgIds) {
+            await schedulePeripheralPolicyDistribution(targetOrgId, [disabled.id], 'ai-tool-disable');
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
@@ -389,13 +434,15 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         try {
-          await publishEvent(
-            'peripheral.policy_changed',
-            policy.orgId,
-            { policyId: policy.id, action: 'disabled', changedBy: auth.user.id },
-            'ai-tools',
-            { userId: auth.user.id }
-          );
+          for (const targetOrgId of disableTargetOrgIds) {
+            await publishEvent(
+              'peripheral.policy_changed',
+              targetOrgId,
+              { policyId: policy.id, action: 'disabled', changedBy: auth.user.id },
+              'ai-tools',
+              { userId: auth.user.id }
+            );
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `event publish failed: ${message}`);
@@ -409,6 +456,9 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         const policy = await fetchPolicy();
         if (!policy) {
           return JSON.stringify({ error: 'Policy not found or access denied' });
+        }
+        if (partnerWideDenied(policy)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide peripheral policy requires full partner org access (orgAccess must be "all")' });
         }
 
         const existingExceptions = Array.isArray(policy.exceptions)
@@ -465,9 +515,13 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
           return JSON.stringify({ error: 'Failed to update policy exceptions' });
         }
 
+        const exceptionTargetOrgIds = await policyTargetOrgIds(policy);
+
         let warning: string | undefined;
         try {
-          await schedulePeripheralPolicyDistribution(policy.orgId, [policy.id], `ai-tool-${action}`);
+          for (const targetOrgId of exceptionTargetOrgIds) {
+            await schedulePeripheralPolicyDistribution(targetOrgId, [policy.id], `ai-tool-${action}`);
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
@@ -475,13 +529,15 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         try {
-          await publishEvent(
-            'peripheral.policy_changed',
-            policy.orgId,
-            { policyId: policy.id, action, changedBy: auth.user.id, changed },
-            'ai-tools',
-            { userId: auth.user.id }
-          );
+          for (const targetOrgId of exceptionTargetOrgIds) {
+            await publishEvent(
+              'peripheral.policy_changed',
+              targetOrgId,
+              { policyId: policy.id, action, changedBy: auth.user.id, changed },
+              'ai-tools',
+              { userId: auth.user.id }
+            );
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           warning = combineWarning(warning, `event publish failed: ${message}`);

--- a/apps/api/src/services/aiToolsPeripherals.ts
+++ b/apps/api/src/services/aiToolsPeripherals.ts
@@ -262,6 +262,58 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         return rows.map((row) => row.id);
       };
 
+      // Per-org fan-out with per-iteration try/catch (#2131): one org's
+      // Redis/queue failure must not silently skip the remaining orgs of a
+      // partner-wide fan-out. Returns a warning naming how many orgs failed.
+      const fanOutPolicyChange = async (
+        targetOrgIds: string[],
+        distributedPolicyId: string,
+        reason: string,
+        eventPayload: Record<string, unknown>
+      ): Promise<string | undefined> => {
+        let warning: string | undefined;
+
+        const distributionFailures: string[] = [];
+        for (const targetOrgId of targetOrgIds) {
+          try {
+            await schedulePeripheralPolicyDistribution(targetOrgId, [distributedPolicyId], reason);
+          } catch (error) {
+            distributionFailures.push(targetOrgId);
+            console.error(`[aiTools] Failed to schedule peripheral policy distribution for policy ${distributedPolicyId} (org ${targetOrgId}):`, error);
+          }
+        }
+        if (distributionFailures.length > 0) {
+          warning = combineWarning(
+            warning,
+            `policy distribution scheduling failed for ${distributionFailures.length}/${targetOrgIds.length} org(s): ${distributionFailures.join(', ')}`
+          );
+        }
+
+        const eventFailures: string[] = [];
+        for (const targetOrgId of targetOrgIds) {
+          try {
+            await publishEvent(
+              'peripheral.policy_changed',
+              targetOrgId,
+              eventPayload,
+              'ai-tools',
+              { userId: auth.user.id }
+            );
+          } catch (error) {
+            eventFailures.push(targetOrgId);
+            console.error(`[aiTools] Failed to publish peripheral policy change event for policy ${distributedPolicyId} (org ${targetOrgId}):`, error);
+          }
+        }
+        if (eventFailures.length > 0) {
+          warning = combineWarning(
+            warning,
+            `event publish failed for ${eventFailures.length}/${targetOrgIds.length} org(s): ${eventFailures.join(', ')}`
+          );
+        }
+
+        return warning;
+      };
+
       if (action === 'create') {
         const orgResolved = resolveWritableToolOrgId(
           auth,
@@ -370,33 +422,8 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         const updateTargetOrgIds = await policyTargetOrgIds(updated);
-
-        let warning: string | undefined;
-        try {
-          for (const targetOrgId of updateTargetOrgIds) {
-            await schedulePeripheralPolicyDistribution(targetOrgId, [updated.id], 'ai-tool-update');
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
-          console.error(`[aiTools] Failed to schedule peripheral policy distribution for policy ${updated.id}:`, error);
-        }
-
-        try {
-          for (const targetOrgId of updateTargetOrgIds) {
-            await publishEvent(
-              'peripheral.policy_changed',
-              targetOrgId,
-              { policyId: updated.id, action: 'updated', changedBy: auth.user.id },
-              'ai-tools',
-              { userId: auth.user.id }
-            );
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `event publish failed: ${message}`);
-          console.error(`[aiTools] Failed to publish peripheral policy change event for policy ${updated.id}:`, error);
-        }
+        const warning = await fanOutPolicyChange(updateTargetOrgIds, updated.id, 'ai-tool-update',
+          { policyId: updated.id, action: 'updated', changedBy: auth.user.id });
 
         return JSON.stringify({ success: true, policyId: updated.id, action, ...(warning ? { warning } : {}) });
       }
@@ -421,33 +448,8 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         const disableTargetOrgIds = await policyTargetOrgIds(disabled);
-
-        let warning: string | undefined;
-        try {
-          for (const targetOrgId of disableTargetOrgIds) {
-            await schedulePeripheralPolicyDistribution(targetOrgId, [disabled.id], 'ai-tool-disable');
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
-          console.error(`[aiTools] Failed to schedule peripheral policy distribution for policy ${policy.id}:`, error);
-        }
-
-        try {
-          for (const targetOrgId of disableTargetOrgIds) {
-            await publishEvent(
-              'peripheral.policy_changed',
-              targetOrgId,
-              { policyId: policy.id, action: 'disabled', changedBy: auth.user.id },
-              'ai-tools',
-              { userId: auth.user.id }
-            );
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `event publish failed: ${message}`);
-          console.error(`[aiTools] Failed to publish peripheral policy change event for policy ${policy.id}:`, error);
-        }
+        const warning = await fanOutPolicyChange(disableTargetOrgIds, disabled.id, 'ai-tool-disable',
+          { policyId: policy.id, action: 'disabled', changedBy: auth.user.id });
 
         return JSON.stringify({ success: true, policyId: policy.id, action, ...(warning ? { warning } : {}) });
       }
@@ -516,33 +518,8 @@ export function registerPeripheralTools(aiTools: Map<string, AiTool>): void {
         }
 
         const exceptionTargetOrgIds = await policyTargetOrgIds(policy);
-
-        let warning: string | undefined;
-        try {
-          for (const targetOrgId of exceptionTargetOrgIds) {
-            await schedulePeripheralPolicyDistribution(targetOrgId, [policy.id], `ai-tool-${action}`);
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `policy distribution scheduling failed: ${message}`);
-          console.error(`[aiTools] Failed to schedule peripheral policy distribution for policy ${policy.id}:`, error);
-        }
-
-        try {
-          for (const targetOrgId of exceptionTargetOrgIds) {
-            await publishEvent(
-              'peripheral.policy_changed',
-              targetOrgId,
-              { policyId: policy.id, action, changedBy: auth.user.id, changed },
-              'ai-tools',
-              { userId: auth.user.id }
-            );
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warning = combineWarning(warning, `event publish failed: ${message}`);
-          console.error(`[aiTools] Failed to publish peripheral policy change event for policy ${policy.id}:`, error);
-        }
+        const warning = await fanOutPolicyChange(exceptionTargetOrgIds, policy.id, `ai-tool-${action}`,
+          { policyId: policy.id, action, changedBy: auth.user.id, changed });
 
         return JSON.stringify({ success: true, policyId: policy.id, action, changed, ...(warning ? { warning } : {}) });
       }

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -63,6 +63,18 @@ function partnerWhere(auth: AuthContext, partnerIdCol: any): SQL | undefined {
   return sql`false`;
 }
 
+// Dual-axis access for peripheral_policies (#2131): same shape as
+// softwarePolicyWhere — org-owned rows the caller can reach OR partner-wide
+// rows (org_id NULL) owned by the caller's own partner.
+function peripheralPolicyWhere(auth: AuthContext): SQL | undefined {
+  const oc = orgWhere(auth, peripheralPolicies.orgId);
+  if (!oc) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${oc} OR (${peripheralPolicies.orgId} IS NULL AND ${peripheralPolicies.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
 // Dual-axis access for software_policies (#2126): org-owned rows the caller can
 // reach OR partner-wide rows (org_id NULL) owned by the caller's own partner.
 // Mirrors softwarePolicyAccessCondition in routes/softwarePolicies.ts.
@@ -432,7 +444,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, peripheralPolicies.orgId);
+        const oc = peripheralPolicyWhere(auth);
         if (oc) conditions.push(oc);
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
@@ -459,7 +471,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
       if (action === 'get') {
         if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
         const conditions: SQL[] = [eq(peripheralPolicies.id, input.policyId as string)];
-        const oc = orgWhere(auth, peripheralPolicies.orgId);
+        const oc = peripheralPolicyWhere(auth);
         if (oc) conditions.push(oc);
 
         const [policy] = await db.select().from(peripheralPolicies).where(and(...conditions)).limit(1);
@@ -498,11 +510,17 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
       if (action === 'update') {
         if (!input.policyId) return JSON.stringify({ error: 'policyId is required' });
         const conditions: SQL[] = [eq(peripheralPolicies.id, input.policyId as string)];
-        const oc = orgWhere(auth, peripheralPolicies.orgId);
+        const oc = peripheralPolicyWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(peripheralPolicies).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Peripheral policy not found or access denied' });
+
+        // Partner-wide templates are administrable only with the partner-wide
+        // capability (same gate as the HTTP route, #2131).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide peripheral policy requires full partner org access (orgAccess must be "all")' });
+        }
 
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1537,14 +1537,13 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch, software_policy, security, alert_rule, compliance, and
-  // sensitive_data are handled separately in validateFeaturePolicyExists:
-  // rings are pure partner-axis, and the rest are dual-ownership (org XOR
-  // partner, #2126/#2127/#2128/#2129/#2131) — none fits the org-only lookup
-  // below.
+  // patch, software_policy, security, alert_rule, compliance, sensitive_data,
+  // and peripheral_control are handled separately in
+  // validateFeaturePolicyExists: rings are pure partner-axis, and the rest
+  // are dual-ownership (org XOR partner, #2126/#2127/#2128/#2129/#2131) —
+  // none fits the org-only lookup below.
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
-  peripheral_control: { table: peripheralPolicies, orgIdCol: peripheralPolicies.orgId },
 };
 
 /**
@@ -1561,6 +1560,7 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
   'alert_rule',
   'compliance',
   'sensitive_data',
+  'peripheral_control',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1605,15 +1605,16 @@ export async function validateFeaturePolicyExists(
     featureType === 'security' ||
     featureType === 'alert_rule' ||
     featureType === 'compliance' ||
-    featureType === 'sensitive_data'
+    featureType === 'sensitive_data' ||
+    featureType === 'peripheral_control'
   ) {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
     // Software (#2126), security (#2127), alert-rule (#2128), compliance
-    // (#2129, automation_policies), and sensitive-data (#2131) policies are
-    // dual-ownership. A config policy may link:
+    // (#2129, automation_policies), sensitive-data, and peripheral-control
+    // (#2131) policies are dual-ownership. A config policy may link:
     //  - an org-owned policy belonging to the config policy's own org
     //  - a partner-owned ("all orgs") template belonging to the config
     //    policy's partner (derived from its org for org-owned config policies)
@@ -1627,7 +1628,9 @@ export async function validateFeaturePolicyExists(
           ? { table: alertRules, label: 'Alert rule' }
           : featureType === 'compliance'
             ? { table: automationPolicies, label: 'Compliance policy' }
-            : { table: sensitiveDataPolicies, label: 'Sensitive data policy' };
+            : featureType === 'sensitive_data'
+              ? { table: sensitiveDataPolicies, label: 'Sensitive data policy' }
+              : { table: peripheralPolicies, label: 'Peripheral policy' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1537,12 +1537,12 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch, software_policy, security, and alert_rule are handled separately in
-  // validateFeaturePolicyExists: rings are pure partner-axis, and software /
-  // security / alert-rule policies are dual-ownership (org XOR partner,
-  // #2126/#2127/#2128) — none fits the org-only lookup below.
+  // patch, software_policy, security, alert_rule, and compliance are handled
+  // separately in validateFeaturePolicyExists: rings are pure partner-axis,
+  // and software / security / alert-rule / compliance (automation) policies
+  // are dual-ownership (org XOR partner, #2126/#2127/#2128/#2129) — none fits
+  // the org-only lookup below.
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
-  compliance: { table: automationPolicies, orgIdCol: automationPolicies.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
   sensitive_data: { table: sensitiveDataPolicies, orgIdCol: sensitiveDataPolicies.orgId },
   peripheral_control: { table: peripheralPolicies, orgIdCol: peripheralPolicies.orgId },
@@ -1560,6 +1560,7 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
   'software_policy',
   'security',
   'alert_rule',
+  'compliance',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1599,13 +1600,19 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  if (featureType === 'software_policy' || featureType === 'security' || featureType === 'alert_rule') {
+  if (
+    featureType === 'software_policy' ||
+    featureType === 'security' ||
+    featureType === 'alert_rule' ||
+    featureType === 'compliance'
+  ) {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
-    // Software (#2126), security (#2127), and alert-rule (#2128) policies are
-    // dual-ownership. A config policy may link:
+    // Software (#2126), security (#2127), alert-rule (#2128), and compliance
+    // (#2129, automation_policies) policies are dual-ownership. A config
+    // policy may link:
     //  - an org-owned policy belonging to the config policy's own org
     //  - a partner-owned ("all orgs") template belonging to the config
     //    policy's partner (derived from its org for org-owned config policies)
@@ -1615,7 +1622,9 @@ export async function validateFeaturePolicyExists(
       ? { table: softwarePolicies, label: 'Software policy' }
       : featureType === 'security'
         ? { table: securityPolicies, label: 'Security policy' }
-        : { table: alertRules, label: 'Alert rule' };
+        : featureType === 'alert_rule'
+          ? { table: alertRules, label: 'Alert rule' }
+          : { table: automationPolicies, label: 'Compliance policy' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1537,14 +1537,13 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch, software_policy, security, alert_rule, and compliance are handled
-  // separately in validateFeaturePolicyExists: rings are pure partner-axis,
-  // and software / security / alert-rule / compliance (automation) policies
-  // are dual-ownership (org XOR partner, #2126/#2127/#2128/#2129) — none fits
-  // the org-only lookup below.
+  // patch, software_policy, security, alert_rule, compliance, and
+  // sensitive_data are handled separately in validateFeaturePolicyExists:
+  // rings are pure partner-axis, and the rest are dual-ownership (org XOR
+  // partner, #2126/#2127/#2128/#2129/#2131) — none fits the org-only lookup
+  // below.
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
   maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
-  sensitive_data: { table: sensitiveDataPolicies, orgIdCol: sensitiveDataPolicies.orgId },
   peripheral_control: { table: peripheralPolicies, orgIdCol: peripheralPolicies.orgId },
 };
 
@@ -1561,6 +1560,7 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
   'security',
   'alert_rule',
   'compliance',
+  'sensitive_data',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1604,15 +1604,16 @@ export async function validateFeaturePolicyExists(
     featureType === 'software_policy' ||
     featureType === 'security' ||
     featureType === 'alert_rule' ||
-    featureType === 'compliance'
+    featureType === 'compliance' ||
+    featureType === 'sensitive_data'
   ) {
     if (!featurePolicyId) {
       return { valid: true };
     }
 
-    // Software (#2126), security (#2127), alert-rule (#2128), and compliance
-    // (#2129, automation_policies) policies are dual-ownership. A config
-    // policy may link:
+    // Software (#2126), security (#2127), alert-rule (#2128), compliance
+    // (#2129, automation_policies), and sensitive-data (#2131) policies are
+    // dual-ownership. A config policy may link:
     //  - an org-owned policy belonging to the config policy's own org
     //  - a partner-owned ("all orgs") template belonging to the config
     //    policy's partner (derived from its org for org-owned config policies)
@@ -1624,7 +1625,9 @@ export async function validateFeaturePolicyExists(
         ? { table: securityPolicies, label: 'Security policy' }
         : featureType === 'alert_rule'
           ? { table: alertRules, label: 'Alert rule' }
-          : { table: automationPolicies, label: 'Compliance policy' };
+          : featureType === 'compliance'
+            ? { table: automationPolicies, label: 'Compliance policy' }
+            : { table: sensitiveDataPolicies, label: 'Sensitive data policy' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 
@@ -1648,6 +1651,31 @@ export async function validateFeaturePolicyExists(
       .limit(1);
 
     if (!row) {
+      // sensitive_data historically also accepts a featurePolicyId that
+      // references another Configuration Policy (whole-policy linking) — the
+      // generic fallback below used to allow it. Preserve that with the same
+      // dual-axis ownership conditions (config policies are dual-owned).
+      if (featureType === 'sensitive_data') {
+        const cpConditions: SQL[] = [];
+        if (owner.orgId) {
+          cpConditions.push(eq(configurationPolicies.orgId, owner.orgId));
+        }
+        if (partnerId) {
+          cpConditions.push(
+            sql`(${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${partnerId})`
+          );
+        }
+        if (cpConditions.length > 0) {
+          const [configPolicy] = await db
+            .select({ id: configurationPolicies.id })
+            .from(configurationPolicies)
+            .where(and(eq(configurationPolicies.id, featurePolicyId), or(...cpConditions)))
+            .limit(1);
+          if (configPolicy) {
+            return { valid: true };
+          }
+        }
+      }
       return { valid: false, error: `${dualAxis.label} "${featurePolicyId}" not found for this organization or partner` };
     }
 
@@ -1667,8 +1695,8 @@ export async function validateFeaturePolicyExists(
     return { valid: true };
   }
 
-  // sensitive_data supports both linked policy and inline settings
-  // If featurePolicyId is provided, it can reference a sensitiveDataPolicies record or a config policy
+  // (sensitive_data is handled in the dual-axis branch above, including its
+  // legacy config-policy-reference fallback.)
 
   if (!featurePolicyId) {
     return { valid: true }; // inline-only is allowed; schema ensures inlineSettings is present

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1537,13 +1537,14 @@ export async function previewEffectiveConfig(
 // ============================================
 
 const FEATURE_TABLE_MAP: Partial<Record<ConfigFeatureType, { table: any; orgIdCol: any }>> = {
-  // patch, software_policy, security, alert_rule, compliance, sensitive_data,
-  // and peripheral_control are handled separately in
-  // validateFeaturePolicyExists: rings are pure partner-axis, and the rest
-  // are dual-ownership (org XOR partner, #2126/#2127/#2128/#2129/#2131) —
-  // none fits the org-only lookup below.
+  // Every other linked feature type is handled separately in
+  // validateFeaturePolicyExists: rings are pure partner-axis, and software /
+  // security / alert-rule / compliance / sensitive-data / peripheral /
+  // maintenance are dual-ownership (org XOR partner,
+  // #2126/#2127/#2128/#2129/#2131). backup stays org-only deliberately —
+  // backup configs carry org-owned storage credentials (see the
+  // partner-wide-first rule in CLAUDE.md; #2132 tracks its template design).
   backup: { table: backupConfigs, orgIdCol: backupConfigs.orgId },
-  maintenance: { table: maintenanceWindows, orgIdCol: maintenanceWindows.orgId },
 };
 
 /**
@@ -1561,6 +1562,7 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
   'compliance',
   'sensitive_data',
   'peripheral_control',
+  'maintenance',
 ]);
 
 export async function validateFeaturePolicyExists(
@@ -1606,7 +1608,8 @@ export async function validateFeaturePolicyExists(
     featureType === 'alert_rule' ||
     featureType === 'compliance' ||
     featureType === 'sensitive_data' ||
-    featureType === 'peripheral_control'
+    featureType === 'peripheral_control' ||
+    featureType === 'maintenance'
   ) {
     if (!featurePolicyId) {
       return { valid: true };
@@ -1630,7 +1633,9 @@ export async function validateFeaturePolicyExists(
             ? { table: automationPolicies, label: 'Compliance policy' }
             : featureType === 'sensitive_data'
               ? { table: sensitiveDataPolicies, label: 'Sensitive data policy' }
-              : { table: peripheralPolicies, label: 'Peripheral policy' };
+              : featureType === 'peripheral_control'
+                ? { table: peripheralPolicies, label: 'Peripheral policy' }
+                : { table: maintenanceWindows, label: 'Maintenance window' };
     const partnerId =
       owner.partnerId ?? (owner.orgId ? await resolvePartnerIdForOrg(owner.orgId) : null);
 

--- a/apps/api/src/services/deploymentEngine.ts
+++ b/apps/api/src/services/deploymentEngine.ts
@@ -1,5 +1,5 @@
 import { db } from '../db';
-import { deployments, deploymentDevices, devices, deviceGroupMemberships, maintenanceWindows } from '../db/schema';
+import { deployments, deploymentDevices, devices, deviceGroupMemberships, maintenanceWindows, organizations } from '../db/schema';
 import { eq, and, sql, asc } from 'drizzle-orm';
 import { resolveDeploymentTargets } from './deploymentTargetResolver';
 import type { DeploymentTargetConfig } from './deploymentTargetResolver';
@@ -74,7 +74,9 @@ export async function isDeviceInMaintenanceWindow(
   deviceId: string,
   timezone: string = 'UTC'
 ): Promise<boolean> {
-  const now = new Date();
+  // ISO string: raw sql`` params skip Drizzle's column-type mapping, and
+  // postgres.js cannot serialize a bare Date instance there.
+  const now = new Date().toISOString();
 
   // Get device's org, site, and groups
   const [device] = await db
@@ -98,12 +100,25 @@ export async function isDeviceInMaintenanceWindow(
 
   const groupIds = deviceGroupIds.map(g => g.groupId);
 
+  // Ownership is dual-axis (#2131): the device's own org's windows OR
+  // partner-wide windows (org_id NULL) owned by the device org's partner.
+  // Partner id is bound as a plain value — a parameterized scalar subquery
+  // trips the postgres.js ParameterDescription bug.
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+  const ownershipPredicate = orgRow?.partnerId
+    ? sql`(${maintenanceWindows.orgId} = ${device.orgId} OR (${maintenanceWindows.orgId} IS NULL AND ${maintenanceWindows.partnerId} = ${orgRow.partnerId}))`
+    : sql`${maintenanceWindows.orgId} = ${device.orgId}`;
+
   // Check for active maintenance windows
   const activeWindows = await db
     .select({ id: maintenanceWindows.id })
     .from(maintenanceWindows)
     .where(
-      sql`${maintenanceWindows.orgId} = ${device.orgId}
+      sql`${ownershipPredicate}
         AND ${maintenanceWindows.status} = 'scheduled'
         AND ${maintenanceWindows.startTime} <= ${now}
         AND ${maintenanceWindows.endTime} >= ${now}
@@ -123,7 +138,8 @@ export async function isDeviceInMaintenanceWindow(
 export async function getNextMaintenanceWindow(
   deviceId: string
 ): Promise<{ start: Date; end: Date } | null> {
-  const now = new Date();
+  // ISO string - see isDeviceInMaintenanceWindow above.
+  const now = new Date().toISOString();
 
   const [device] = await db
     .select({
@@ -138,6 +154,16 @@ export async function getNextMaintenanceWindow(
     return null;
   }
 
+  // Dual-axis ownership (#2131) — see isDeviceInMaintenanceWindow above.
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+  const ownershipPredicate = orgRow?.partnerId
+    ? sql`(${maintenanceWindows.orgId} = ${device.orgId} OR (${maintenanceWindows.orgId} IS NULL AND ${maintenanceWindows.partnerId} = ${orgRow.partnerId}))`
+    : sql`${maintenanceWindows.orgId} = ${device.orgId}`;
+
   const [nextWindow] = await db
     .select({
       startTime: maintenanceWindows.startTime,
@@ -145,7 +171,7 @@ export async function getNextMaintenanceWindow(
     })
     .from(maintenanceWindows)
     .where(
-      sql`${maintenanceWindows.orgId} = ${device.orgId}
+      sql`${ownershipPredicate}
         AND ${maintenanceWindows.status} = 'scheduled'
         AND ${maintenanceWindows.startTime} > ${now}
         AND (

--- a/apps/api/src/services/maintenanceService.ts
+++ b/apps/api/src/services/maintenanceService.ts
@@ -1,5 +1,5 @@
 import { db } from '../db';
-import { devices, deviceGroupMemberships, maintenanceWindows } from '../db/schema';
+import { devices, deviceGroupMemberships, maintenanceWindows, organizations } from '../db/schema';
 import { eq, sql } from 'drizzle-orm';
 import {
   resolveMaintenanceConfigForDevice,
@@ -84,7 +84,9 @@ export async function isDeviceInMaintenance(
 async function checkStandaloneMaintenanceWindows(
   deviceId: string
 ): Promise<DeviceMaintenanceStatus | null> {
-  const now = new Date();
+  // Bound as an ISO string: raw sql`` params skip Drizzle's column-type
+  // mapping, and postgres.js cannot serialize a bare Date instance there.
+  const now = new Date().toISOString();
 
   // Load device org/site
   const [device] = await db
@@ -108,6 +110,20 @@ async function checkStandaloneMaintenanceWindows(
 
   const groupIds = deviceGroupIds.map((g) => g.groupId);
 
+  // Ownership is dual-axis (#2131): the device's own org's windows OR
+  // partner-wide windows (org_id NULL) owned by the device org's partner.
+  // The partner id is resolved in a separate query and bound as a plain
+  // value — a parameterized scalar subquery trips the postgres.js
+  // ParameterDescription bug (same class as the nested-EXISTS RLS issue).
+  const [orgRow] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, device.orgId))
+    .limit(1);
+  const ownershipPredicate = orgRow?.partnerId
+    ? sql`(${maintenanceWindows.orgId} = ${device.orgId} OR (${maintenanceWindows.orgId} IS NULL AND ${maintenanceWindows.partnerId} = ${orgRow.partnerId}))`
+    : sql`${maintenanceWindows.orgId} = ${device.orgId}`;
+
   // Query for active standalone windows matching this device
   const activeWindows = await db
     .select({
@@ -120,7 +136,7 @@ async function checkStandaloneMaintenanceWindows(
     })
     .from(maintenanceWindows)
     .where(
-      sql`${maintenanceWindows.orgId} = ${device.orgId}
+      sql`${ownershipPredicate}
         AND ${maintenanceWindows.status} IN ('scheduled', 'active')
         AND ${maintenanceWindows.startTime} <= ${now}
         AND ${maintenanceWindows.endTime} >= ${now}

--- a/apps/api/src/services/maintenanceService.ts
+++ b/apps/api/src/services/maintenanceService.ts
@@ -1,4 +1,4 @@
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, deviceGroupMemberships, maintenanceWindows, organizations } from '../db/schema';
 import { eq, sql } from 'drizzle-orm';
 import {
@@ -31,6 +31,13 @@ export interface DeviceMaintenanceStatus {
  *   2. Standalone maintenance windows (legacy `maintenance_windows` table)
  *
  * The first source that yields an active window wins.
+ *
+ * Runs its reads in a SHORT system-context block: callers include org-scoped
+ * request paths (GET /maintenance/device/:deviceId/status), whose RLS context
+ * cannot see partner-wide windows/config policies (org_id NULL, #2131) — the
+ * answer would silently be wrong for them. The lookup is anchored to a
+ * deviceId the ROUTE has already authorized, so there is no tenant pivot;
+ * same pattern as the agent heartbeat probe config and commands.ts.
  */
 export async function isDeviceInMaintenance(
   deviceId: string
@@ -44,31 +51,35 @@ export async function isDeviceInMaintenance(
     suppressScripts: false,
   };
 
-  // ---- 1. Try config policy path ----
-  const cpSettings = await resolveMaintenanceConfigForDevice(deviceId);
-  if (cpSettings) {
-    const status = isInMaintenanceWindow(cpSettings);
-    if (status.active) {
-      return {
-        active: true,
-        source: 'config_policy',
-        suppressAlerts: status.suppressAlerts,
-        suppressPatching: status.suppressPatching,
-        suppressAutomations: status.suppressAutomations,
-        suppressScripts: status.suppressScripts,
-      };
-    }
-    // Config policy exists but window is not currently active — still fall through
-    // to check standalone windows for backward compatibility.
-  }
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      // ---- 1. Try config policy path ----
+      const cpSettings = await resolveMaintenanceConfigForDevice(deviceId);
+      if (cpSettings) {
+        const status = isInMaintenanceWindow(cpSettings);
+        if (status.active) {
+          return {
+            active: true,
+            source: 'config_policy' as const,
+            suppressAlerts: status.suppressAlerts,
+            suppressPatching: status.suppressPatching,
+            suppressAutomations: status.suppressAutomations,
+            suppressScripts: status.suppressScripts,
+          };
+        }
+        // Config policy exists but window is not currently active — still fall
+        // through to check standalone windows for backward compatibility.
+      }
 
-  // ---- 2. Fall back to standalone maintenance windows ----
-  const standaloneStatus = await checkStandaloneMaintenanceWindows(deviceId);
-  if (standaloneStatus) {
-    return standaloneStatus;
-  }
+      // ---- 2. Fall back to standalone maintenance windows ----
+      const standaloneStatus = await checkStandaloneMaintenanceWindows(deviceId);
+      if (standaloneStatus) {
+        return standaloneStatus;
+      }
 
-  return inactive;
+      return inactive;
+    })
+  );
 }
 
 // ============================================

--- a/apps/api/src/services/policyAlertBridge.test.ts
+++ b/apps/api/src/services/policyAlertBridge.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #2149: automation_policies became dual-ownership (org_id XOR partner_id).
+// handlePolicyViolation resolves an org-owned policy against the event's
+// device org directly, but a partner-wide policy (org_id NULL) resolves
+// against the device org's *partner* instead. This app-layer axis check has
+// no other coverage in the unit suite (only real-DB integration tests, which
+// don't run in the required CI job) — see PR #2149 review.
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  automationPolicies: {
+    id: 'id',
+    orgId: 'org_id',
+    partnerId: 'partner_id',
+  },
+  organizations: {
+    id: 'id',
+    partnerId: 'partner_id',
+  },
+  alertRules: {
+    id: 'id',
+    orgId: 'org_id',
+    name: 'name',
+  },
+  alertTemplates: {
+    id: 'id',
+    orgId: 'org_id',
+    name: 'name',
+  },
+  alerts: {
+    id: 'id',
+    ruleId: 'rule_id',
+    deviceId: 'device_id',
+    status: 'status',
+  },
+}));
+
+vi.mock('./alertService', () => ({
+  createAlert: vi.fn().mockResolvedValue('alert-created-1'),
+  resolveAlert: vi.fn(),
+}));
+
+vi.mock('./eventBus', () => ({
+  getEventBus: vi.fn(),
+}));
+
+import { db } from '../db';
+import { createAlert } from './alertService';
+import { handlePolicyViolation } from './policyAlertBridge';
+
+function mockSelectOnce(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as any);
+}
+
+const POLICY_ID = 'policy-1';
+const DEVICE_ID = 'device-1';
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    policyId: POLICY_ID,
+    policyName: 'Test Policy',
+    deviceId: DEVICE_ID,
+    hostname: 'TST-01',
+    enforcement: 'enforce',
+    ...overrides,
+  };
+}
+
+describe('handlePolicyViolation (dual-axis policy check, #2149)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an alert when the policy is org-owned and matches the event org', async () => {
+    // 1) policy lookup, 2) ensureRule's alertRules lookup (existing rule, so
+    // ensureTemplate/insert paths are never reached).
+    mockSelectOnce([{ id: POLICY_ID, orgId: 'org-1', partnerId: null }]);
+    mockSelectOnce([{ id: 'rule-1' }]);
+
+    await handlePolicyViolation('org-1', payload());
+
+    expect(vi.mocked(createAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createAlert)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleId: 'rule-1',
+        deviceId: DEVICE_ID,
+        orgId: 'org-1',
+      })
+    );
+  });
+
+  it('does not create an alert when the policy is org-owned but belongs to a different org', async () => {
+    mockSelectOnce([{ id: POLICY_ID, orgId: 'org-1', partnerId: null }]);
+
+    await handlePolicyViolation('org-2', payload());
+
+    expect(vi.mocked(createAlert)).not.toHaveBeenCalled();
+    // Only the policy lookup ran — no org lookup, no rule lookup.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates an alert when the policy is partner-wide and the event org belongs to the same partner', async () => {
+    // 1) policy lookup (org_id null), 2) organizations lookup for the event
+    // org's partnerId, 3) ensureRule's alertRules lookup (existing rule).
+    mockSelectOnce([{ id: POLICY_ID, orgId: null, partnerId: 'partner-1' }]);
+    mockSelectOnce([{ partnerId: 'partner-1' }]);
+    mockSelectOnce([{ id: 'rule-1' }]);
+
+    await handlePolicyViolation('org-under-partner-1', payload());
+
+    expect(vi.mocked(createAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createAlert)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleId: 'rule-1',
+        deviceId: DEVICE_ID,
+        orgId: 'org-under-partner-1',
+      })
+    );
+  });
+
+  it('does not create an alert when the policy is partner-wide but the event org belongs to a different partner', async () => {
+    mockSelectOnce([{ id: POLICY_ID, orgId: null, partnerId: 'partner-1' }]);
+    mockSelectOnce([{ partnerId: 'partner-2' }]);
+
+    await handlePolicyViolation('org-under-partner-2', payload());
+
+    expect(vi.mocked(createAlert)).not.toHaveBeenCalled();
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not create an alert when the partner-wide policy has no organization match at all (org not found)', async () => {
+    mockSelectOnce([{ id: POLICY_ID, orgId: null, partnerId: 'partner-1' }]);
+    mockSelectOnce([]);
+
+    await handlePolicyViolation('org-unknown', payload());
+
+    expect(vi.mocked(createAlert)).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the payload is missing policyId or deviceId', async () => {
+    await handlePolicyViolation('org-1', payload({ policyId: undefined }));
+    await handlePolicyViolation('org-1', payload({ deviceId: undefined }));
+
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+    expect(vi.mocked(createAlert)).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the policy does not exist', async () => {
+    mockSelectOnce([]);
+
+    await handlePolicyViolation('org-1', payload());
+
+    expect(vi.mocked(createAlert)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/policyAlertBridge.ts
+++ b/apps/api/src/services/policyAlertBridge.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { alerts, alertRules, alertTemplates, automationPolicies } from '../db/schema';
+import { alerts, alertRules, alertTemplates, automationPolicies, organizations } from '../db/schema';
 import { createAlert, resolveAlert } from './alertService';
 import { getEventBus } from './eventBus';
 
@@ -149,19 +149,32 @@ async function handlePolicyViolation(orgId: string, payload: PolicyEventPayload)
   const policyName = payload.policyName ?? 'Policy';
   const hostname = payload.hostname ?? payload.deviceId;
 
+  // The event's orgId is the DEVICE's org. The policy is either owned by that
+  // org, or partner-wide (org_id NULL, #2129) and owned by that org's partner.
   const [policy] = await db
-    .select({ id: automationPolicies.id })
+    .select({ id: automationPolicies.id, orgId: automationPolicies.orgId, partnerId: automationPolicies.partnerId })
     .from(automationPolicies)
-    .where(
-      and(
-        eq(automationPolicies.id, payload.policyId),
-        eq(automationPolicies.orgId, orgId)
-      )
-    )
+    .where(eq(automationPolicies.id, payload.policyId))
     .limit(1);
 
   if (!policy) {
     return;
+  }
+
+  if (policy.orgId !== null) {
+    if (policy.orgId !== orgId) {
+      return;
+    }
+  } else {
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    if (!org || !policy.partnerId || org.partnerId !== policy.partnerId) {
+      return;
+    }
   }
 
   const ruleId = await ensureRule(orgId, payload.policyId, policyName, payload.enforcement);

--- a/apps/api/src/services/policyAlertBridge.ts
+++ b/apps/api/src/services/policyAlertBridge.ts
@@ -141,7 +141,10 @@ async function resolvePolicyAlertsForDevice(ruleId: string, deviceId: string): P
   }
 }
 
-async function handlePolicyViolation(orgId: string, payload: PolicyEventPayload): Promise<void> {
+// Exported for unit testing (dual-axis partner-wide policy check, #2149) — not
+// used outside this module otherwise; subscribeToPolicyEvents wires it to the
+// event bus.
+export async function handlePolicyViolation(orgId: string, payload: PolicyEventPayload): Promise<void> {
   if (!payload.policyId || !payload.deviceId) {
     return;
   }
@@ -163,6 +166,13 @@ async function handlePolicyViolation(orgId: string, payload: PolicyEventPayload)
 
   if (policy.orgId !== null) {
     if (policy.orgId !== orgId) {
+      // Should never happen — an org-owned policy only evaluates its own
+      // org's devices. Leave a trace: silently dropping means an alert that
+      // should have fired never does.
+      console.warn(
+        `[policyAlertBridge] dropping policy.violation for policy ${payload.policyId}: `
+        + `policy org ${policy.orgId} does not match event org ${orgId}`
+      );
       return;
     }
   } else {
@@ -173,6 +183,12 @@ async function handlePolicyViolation(orgId: string, payload: PolicyEventPayload)
       .limit(1);
 
     if (!org || !policy.partnerId || org.partnerId !== policy.partnerId) {
+      // Race (policy deleted / org re-parented mid-evaluation) — log rather
+      // than silently swallowing the violation.
+      console.warn(
+        `[policyAlertBridge] dropping policy.violation for partner-wide policy ${payload.policyId}: `
+        + `event org ${orgId} is not under owning partner ${policy.partnerId ?? 'NULL'}`
+      );
       return;
     }
   }

--- a/apps/api/src/services/policyEvaluationService.ts
+++ b/apps/api/src/services/policyEvaluationService.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   automationPolicies,
@@ -27,6 +27,10 @@ type PolicyRow = typeof automationPolicies.$inferSelect;
 
 type TargetDevice = {
   id: string;
+  // The device's own org — for an org-owned policy this equals policy.orgId;
+  // for a partner-wide policy (#2129) it varies per device and is what child
+  // rows, events, and remediation lookups must be scoped to.
+  orgId: string;
   hostname: string;
   osType: string;
   osVersion: string;
@@ -761,6 +765,7 @@ export function __evaluateRulesForDevice(
   const evaluation = evaluateDeviceRules(parsedRules, {
     device: {
       id: 'debug-device',
+      orgId: 'debug-org',
       hostname: 'debug-host',
       osType: input.device.osType,
       osVersion: input.device.osVersion,
@@ -924,12 +929,24 @@ function extractScriptIdFromAction(action: unknown): string | null {
 }
 
 export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): Promise<string | null> {
+  return resolvePolicyRemediationAutomationIdForOrg(policy, policy.orgId);
+}
+
+/**
+ * Automations are org-owned, so script-based remediation matching must be
+ * anchored to a specific org. For an org-owned policy that is policy.orgId;
+ * for a partner-wide policy (#2129) evaluatePolicy resolves per DEVICE org.
+ */
+export async function resolvePolicyRemediationAutomationIdForOrg(
+  policy: PolicyRow,
+  orgId: string | null
+): Promise<string | null> {
   const explicitAutomationId = extractRemediationAutomationId(policy.rules);
   if (explicitAutomationId) {
     return explicitAutomationId;
   }
 
-  if (!policy.remediationScriptId) {
+  if (!policy.remediationScriptId || !orgId) {
     return null;
   }
 
@@ -938,7 +955,7 @@ export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): P
     .from(automations)
     .where(
       and(
-        eq(automations.orgId, policy.orgId),
+        eq(automations.orgId, orgId),
         eq(automations.enabled, true)
       )
     );
@@ -959,21 +976,57 @@ export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): P
   return null;
 }
 
+/**
+ * Ownership → device-scope condition. An org-owned policy targets devices in
+ * its own org; a partner-wide policy (orgId NULL, #2129) fans out to every
+ * device in every org under the owning partner. Returns null when the owner
+ * resolves to no orgs — i.e. zero target devices.
+ */
+async function policyDeviceScopeCondition(policy: PolicyRow): Promise<SQL | null> {
+  if (policy.orgId) {
+    return eq(devices.orgId, policy.orgId);
+  }
+
+  if (!policy.partnerId) {
+    // The one-owner CHECK makes this unreachable; guard against bad legacy data.
+    return null;
+  }
+
+  const orgRows = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.partnerId, policy.partnerId));
+
+  if (orgRows.length === 0) {
+    return null;
+  }
+
+  return inArray(devices.orgId, orgRows.map((row) => row.id));
+}
+
+const TARGET_DEVICE_COLUMNS = {
+  id: devices.id,
+  orgId: devices.orgId,
+  hostname: devices.hostname,
+  osType: devices.osType,
+  osVersion: devices.osVersion,
+};
+
 async function resolveTargetDevices(policy: PolicyRow): Promise<TargetDevice[]> {
   const targets = normalizeTargetConfig(policy.targets);
+  const scopeCondition = await policyDeviceScopeCondition(policy);
+
+  if (!scopeCondition) {
+    return [];
+  }
 
   if (targets.deviceIds && targets.deviceIds.length > 0) {
     return db
-      .select({
-        id: devices.id,
-        hostname: devices.hostname,
-        osType: devices.osType,
-        osVersion: devices.osVersion,
-      })
+      .select(TARGET_DEVICE_COLUMNS)
       .from(devices)
       .where(
         and(
-          eq(devices.orgId, policy.orgId),
+          scopeCondition,
           inArray(devices.id, targets.deviceIds)
         )
       );
@@ -981,16 +1034,11 @@ async function resolveTargetDevices(policy: PolicyRow): Promise<TargetDevice[]> 
 
   if (targets.siteIds && targets.siteIds.length > 0) {
     return db
-      .select({
-        id: devices.id,
-        hostname: devices.hostname,
-        osType: devices.osType,
-        osVersion: devices.osVersion,
-      })
+      .select(TARGET_DEVICE_COLUMNS)
       .from(devices)
       .where(
         and(
-          eq(devices.orgId, policy.orgId),
+          scopeCondition,
           inArray(devices.siteId, targets.siteIds)
         )
       );
@@ -998,17 +1046,12 @@ async function resolveTargetDevices(policy: PolicyRow): Promise<TargetDevice[]> 
 
   if (targets.groupIds && targets.groupIds.length > 0) {
     return db
-      .select({
-        id: devices.id,
-        hostname: devices.hostname,
-        osType: devices.osType,
-        osVersion: devices.osVersion,
-      })
+      .select(TARGET_DEVICE_COLUMNS)
       .from(devices)
       .innerJoin(deviceGroupMemberships, eq(deviceGroupMemberships.deviceId, devices.id))
       .where(
         and(
-          eq(devices.orgId, policy.orgId),
+          scopeCondition,
           inArray(deviceGroupMemberships.groupId, targets.groupIds)
         )
       );
@@ -1016,30 +1059,20 @@ async function resolveTargetDevices(policy: PolicyRow): Promise<TargetDevice[]> 
 
   if (targets.tags && targets.tags.length > 0) {
     return db
-      .select({
-        id: devices.id,
-        hostname: devices.hostname,
-        osType: devices.osType,
-        osVersion: devices.osVersion,
-      })
+      .select(TARGET_DEVICE_COLUMNS)
       .from(devices)
       .where(
         and(
-          eq(devices.orgId, policy.orgId),
+          scopeCondition,
           sql<boolean>`${devices.tags} && ${targets.tags}`
         )
       );
   }
 
   return db
-    .select({
-      id: devices.id,
-      hostname: devices.hostname,
-      osType: devices.osType,
-      osVersion: devices.osVersion,
-    })
+    .select(TARGET_DEVICE_COLUMNS)
     .from(devices)
-    .where(eq(devices.orgId, policy.orgId));
+    .where(scopeCondition);
 }
 
 async function triggerRemediationAutomation(
@@ -1052,13 +1085,16 @@ async function triggerRemediationAutomation(
     return null;
   }
 
+  // Automations are org-owned: anchor the lookup to the DEVICE's org. For an
+  // org-owned policy that equals policy.orgId (resolveTargetDevices filters by
+  // it); for a partner-wide policy it is the only org that makes sense.
   const [automation] = await db
     .select()
     .from(automations)
     .where(
       and(
         eq(automations.id, remediationAutomationId),
-        eq(automations.orgId, policy.orgId)
+        eq(automations.orgId, device.orgId)
       )
     )
     .limit(1);
@@ -1152,7 +1188,11 @@ async function publishPolicyEvents(
 
   const publishSafely = async (eventType: 'policy.evaluated' | 'policy.violation' | 'policy.compliant' | 'policy.remediation.triggered') => {
     try {
-      await publishEvent(eventType, policy.orgId, basePayload, source);
+      // Events are per-device, so they carry the DEVICE's org — identical to
+      // policy.orgId for org-owned policies, and the only correct org for
+      // partner-wide ones (policy.orgId is NULL there, #2129). Downstream
+      // consumers (policyAlertBridge) create org-scoped rows from this.
+      await publishEvent(eventType, device.orgId, basePayload, source);
     } catch (error) {
       console.error(`[PolicyEvaluation] Failed to publish ${eventType}:`, error);
     }
@@ -1176,9 +1216,24 @@ export async function evaluatePolicy(
 ): Promise<PolicyEvaluationResponse> {
   const source = options.source ?? 'policy-evaluation-service';
   const requestRemediation = options.requestRemediation ?? true;
-  const remediationAutomationId = requestRemediation && policy.enforcement === 'enforce'
-    ? await resolvePolicyRemediationAutomationId(policy)
-    : null;
+  const wantsRemediation = requestRemediation && policy.enforcement === 'enforce';
+
+  // Remediation automations are org-owned, so a partner-wide policy resolves
+  // them per DEVICE org (memoized); an org-owned policy hits the cache with a
+  // single key — its own org — preserving the previous resolve-once behavior.
+  const remediationIdByOrg = new Map<string, string | null>();
+  const remediationAutomationIdForOrg = async (deviceOrgId: string): Promise<string | null> => {
+    if (!wantsRemediation) {
+      return null;
+    }
+    if (!remediationIdByOrg.has(deviceOrgId)) {
+      remediationIdByOrg.set(
+        deviceOrgId,
+        await resolvePolicyRemediationAutomationIdForOrg(policy, deviceOrgId)
+      );
+    }
+    return remediationIdByOrg.get(deviceOrgId) ?? null;
+  };
 
   const targetDevices = dedupeTargetDevices(await resolveTargetDevices(policy));
   const targetDeviceIds = targetDevices.map((device) => device.id);
@@ -1334,7 +1389,7 @@ export async function evaluatePolicy(
     }
 
     const remediationRunId = requestRemediation
-      ? await triggerRemediationAutomation(policy, device, status, remediationAutomationId)
+      ? await triggerRemediationAutomation(policy, device, status, await remediationAutomationIdForOrg(device.orgId))
       : null;
 
     evaluationResults.push({
@@ -1550,6 +1605,7 @@ export async function evaluateDeviceComplianceFromConfigPolicy(
 
   const targetDevice: TargetDevice = {
     id: device.id,
+    orgId: device.orgId,
     hostname: device.hostname,
     osType: device.osType,
     osVersion: device.osVersion,

--- a/apps/helper/src-tauri/.cargo/audit.toml
+++ b/apps/helper/src-tauri/.cargo/audit.toml
@@ -33,4 +33,13 @@ ignore = [
   # rand::rng(); transitive via phf_generator → markup5ever → html5ever.
   # Direct rand usage in this crate is on 0.9.4 (patched).
   "RUSTSEC-2026-0097",
+  # quick-xml DoS pair — quadratic-time duplicate-attribute check (0194) and
+  # unbounded namespace-declaration allocation in NsReader (0195). Both fixed
+  # in quick-xml >= 0.41.0, but our only consumer is `plist` (Apple
+  # property-list parsing of our OWN bundle metadata) — a trusted-input path
+  # that never parses attacker-controlled XML at runtime. The fix is gated
+  # behind a plist release pinned by the Tauri stack, so it is unfixable from
+  # this crate's perspective.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]

--- a/apps/viewer/src-tauri/.cargo/audit.toml
+++ b/apps/viewer/src-tauri/.cargo/audit.toml
@@ -32,4 +32,14 @@ ignore = [
   # rand 0.7.3 / 0.8.5 unsoundness — only triggered with custom logger using
   # rand::rng(); transitive via phf_generator → markup5ever → html5ever.
   "RUSTSEC-2026-0097",
+  # quick-xml DoS pair — quadratic-time duplicate-attribute check (0194) and
+  # unbounded namespace-declaration allocation in NsReader (0195). Both fixed
+  # in quick-xml >= 0.41.0, but our only consumers are `plist` (Apple
+  # property-list parsing of our OWN bundle metadata) and `wayland-scanner`
+  # (build-time codegen from system Wayland protocol XML) — both trusted-input
+  # paths, neither parses attacker-controlled XML at runtime. The fix is gated
+  # behind plist/wayland-scanner releases pinned by the Tauri/Linux stack, so
+  # it is unfixable from this crate's perspective.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]

--- a/apps/web/src/components/alerts/AlertRuleEditPage.ownerScope.test.tsx
+++ b/apps/web/src/components/alerts/AlertRuleEditPage.ownerScope.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// Partner scope is detected from the JWT claims (same pattern as
+// ConfigPolicyCreatePage — #1724 / #2128). The owner picker also reads
+// currentOrgId/allOrgs from the org store, so the mock applies the selector
+// to a mutable state object each test can override. AlertRuleEditPage reads
+// the store both via destructuring (no selector) and via a selector, so the
+// mock must support both call shapes.
+const { getJwtClaimsMock, orgState } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null })
+  ),
+  orgState: {
+    current: {
+      currentOrgId: null as string | null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    },
+  },
+}));
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
+}));
+
+import AlertRuleEditPage from './AlertRuleEditPage';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const navMock = vi.mocked(navigateTo);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 400, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const EXISTING_RULE = {
+  id: 'existing',
+  name: 'Existing Rule',
+  description: '',
+  severity: 'medium',
+  targets: { type: 'all', ids: [] },
+  conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }],
+  notificationChannelIds: [],
+  cooldownMinutes: 15,
+  autoResolve: false,
+};
+
+function mockBackgroundEndpoints() {
+  fetchMock.mockImplementation((url: string) => {
+    if (url === '/alerts/rules/existing') return Promise.resolve(json({ rule: EXISTING_RULE }));
+    if (url === '/orgs/sites') return Promise.resolve(json({ sites: [] }));
+    if (url === '/groups') return Promise.resolve(json({ groups: [] }));
+    if (url === '/devices') return Promise.resolve(json({ devices: [] }));
+    if (url === '/alerts/channels') return Promise.resolve(json({ channels: [] }));
+    // POST /alerts/rules (create) and PUT /alerts/rules/:id (edit) both fall
+    // through to this default success response.
+    return Promise.resolve(json({ id: 'new-rule' }));
+  });
+}
+
+function postBody(): Record<string, unknown> {
+  const post = fetchMock.mock.calls.find(
+    (c) => c[0] === '/alerts/rules' && (c[1] as RequestInit)?.method === 'POST'
+  );
+  expect(post).toBeTruthy();
+  return JSON.parse((post![1] as RequestInit).body as string);
+}
+
+describe('AlertRuleEditPage — owner scope (#2128)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    orgState.current = {
+      currentOrgId: null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    };
+    mockBackgroundEndpoints();
+  });
+
+  it('shows the owner picker on create for a partner-scope user, defaulting to partner-wide in All-orgs scope', async () => {
+    render(<AlertRuleEditPage isNew />);
+    await waitFor(() => expect(screen.getByTestId('alert-rule-owner')).toBeInTheDocument());
+    expect(screen.getByTestId('alert-rule-owner-partner')).toBeChecked();
+  });
+
+  it('does not show the owner picker when editing an existing rule, even for partner scope', async () => {
+    render(<AlertRuleEditPage ruleId="existing" />);
+    await waitFor(() => expect(screen.getByDisplayValue('Existing Rule')).toBeInTheDocument());
+    expect(screen.queryByTestId('alert-rule-owner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the owner picker on create for an org-scope user', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
+    orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };
+    render(<AlertRuleEditPage isNew />);
+    await waitFor(() => expect(screen.getByPlaceholderText('High CPU Alert')).toBeInTheDocument());
+    expect(screen.queryByTestId('alert-rule-owner')).not.toBeInTheDocument();
+  });
+
+  it('POSTs ownerScope:partner, targetType:all and drops notificationChannelIds for the default partner-wide selection', async () => {
+    render(<AlertRuleEditPage isNew />);
+    await waitFor(() => expect(screen.getByTestId('alert-rule-owner')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText('High CPU Alert'), { target: { value: 'Fleet-wide CPU' } });
+    fireEvent.click(screen.getByText('Create Rule'));
+
+    await waitFor(() => {
+      const body = postBody();
+      expect(body.ownerScope).toBe('partner');
+      expect(body.targetType).toBe('all');
+      expect('notificationChannelIds' in body).toBe(false);
+      expect(body.name).toBe('Fleet-wide CPU');
+    });
+    expect(navMock).toHaveBeenCalledWith('/alerts/rules');
+  });
+
+  it('POSTs orgId (no ownerScope) for an org-scope create with a focused org', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
+    orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };
+    render(<AlertRuleEditPage isNew />);
+    await waitFor(() => expect(screen.getByPlaceholderText('High CPU Alert')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText('High CPU Alert'), { target: { value: 'Org CPU Rule' } });
+    fireEvent.click(screen.getByText('Create Rule'));
+
+    await waitFor(() => {
+      const body = postBody();
+      expect(body.orgId).toBe('org-9');
+      expect('ownerScope' in body).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/components/automations/PolicyList.tsx
+++ b/apps/web/src/components/automations/PolicyList.tsx
@@ -11,7 +11,8 @@ import {
   ShieldAlert,
   Calendar,
   CheckCircle,
-  XCircle
+  XCircle,
+  Globe
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -19,6 +20,9 @@ export type EnforcementLevel = 'monitor' | 'warn' | 'enforce';
 
 export type Policy = {
   id: string;
+  // null = partner-wide ("All organizations") compliance rule set (#2129).
+  // Optional because older callers/fixtures omit it.
+  orgId?: string | null;
   name: string;
   description?: string;
   enforcementLevel: EnforcementLevel;
@@ -264,7 +268,19 @@ export default function PolicyList({
                   <tr key={policy.id} className="transition hover:bg-muted/40">
                     <td className="px-4 py-3">
                       <div>
-                        <p className="text-sm font-medium">{policy.name}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium">{policy.name}</p>
+                          {policy.orgId === null && (
+                            <span
+                              className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                              title="Partner-wide policy — evaluates devices in every organization"
+                              data-testid="automation-policy-partner-wide-badge"
+                            >
+                              <Globe className="h-3 w-3" />
+                              All orgs
+                            </span>
+                          )}
+                        </div>
                         {policy.description && (
                           <p className="text-xs text-muted-foreground truncate max-w-xs">
                             {policy.description}

--- a/apps/web/src/components/peripherals/PeripheralPoliciesList.tsx
+++ b/apps/web/src/components/peripherals/PeripheralPoliciesList.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, RefreshCw } from 'lucide-react';
+import { Plus, RefreshCw, Globe } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import PeripheralPolicyForm from './PeripheralPolicyForm';
 
 type PeripheralPolicy = {
   id: string;
+  // null = partner-wide ("All organizations") policy (#2131)
+  orgId?: string | null;
   name: string;
   deviceClass: string;
   action: string;
@@ -163,7 +165,21 @@ export default function PeripheralPoliciesList() {
                     className="cursor-pointer text-sm hover:bg-muted/30 transition"
                     onClick={() => handleRowClick(policy)}
                   >
-                    <td className="px-4 py-3 font-medium">{policy.name}</td>
+                    <td className="px-4 py-3 font-medium">
+                      <div className="flex items-center gap-2">
+                        <span>{policy.name}</span>
+                        {policy.orgId === null && (
+                          <span
+                            className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                            title="Partner-wide policy — enforced on devices in every organization"
+                            data-testid="peripheral-policy-partner-wide-badge"
+                          >
+                            <Globe className="h-3 w-3" />
+                            All orgs
+                          </span>
+                        )}
+                      </div>
+                    </td>
                     <td className="px-4 py-3">
                       <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${deviceClassBadge[policy.deviceClass] ?? 'bg-muted text-muted-foreground'}`}>
                         {policy.deviceClass.replace('_', ' ')}

--- a/apps/web/src/components/peripherals/PeripheralPolicyForm.tsx
+++ b/apps/web/src/components/peripherals/PeripheralPolicyForm.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { extractApiError } from '@/lib/apiError';
 
 type ExceptionRule = {
@@ -39,6 +41,17 @@ export default function PeripheralPolicyForm({ policy, onClose }: PeripheralPoli
   const isEdit = !!policy?.id;
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
+
+  // Ownership axis (#2131, mirrors software PolicyForm #2126): partner-scope
+  // creators may own the policy partner-wide ("all orgs"). Gate on the JWT
+  // scope; default to partner-wide when viewing All orgs. Create-only.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const [ownerScope, setOwnerScope] = useState<'organization' | 'partner'>(
+    isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization'
+  );
 
   const [name, setName] = useState(policy?.name ?? '');
   const [deviceClass, setDeviceClass] = useState(policy?.deviceClass ?? 'storage');
@@ -80,7 +93,12 @@ export default function PeripheralPolicyForm({ policy, onClose }: PeripheralPoli
         })),
     };
 
-    if (isEdit) body.id = policy!.id;
+    if (isEdit) {
+      body.id = policy!.id;
+    } else if (isPartnerScope) {
+      // Create-only: updates never move a policy between ownership axes.
+      body.ownerScope = ownerScope;
+    }
 
     try {
       const response = await fetchWithAuth('/peripherals/policies', {
@@ -128,6 +146,31 @@ export default function PeripheralPolicyForm({ policy, onClose }: PeripheralPoli
             <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               {error}
             </div>
+          )}
+
+          {/* Ownership scope — partner-scope creators only, create-only (#2131) */}
+          {!isEdit && isPartnerScope && (
+            <fieldset className="space-y-2 rounded-md border p-4" data-testid="peripheral-policy-owner">
+              <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  checked={ownerScope === 'partner'}
+                  onChange={() => setOwnerScope('partner')}
+                  data-testid="peripheral-policy-owner-partner"
+                />
+                All organizations <span className="text-muted-foreground">(partner-wide policy)</span>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  checked={ownerScope === 'organization'}
+                  onChange={() => setOwnerScope('organization')}
+                  data-testid="peripheral-policy-owner-org"
+                />
+                This organization only
+              </label>
+            </fieldset>
           )}
 
           <div>

--- a/apps/web/src/components/security/SecurityPolicyEditor.ownerScope.test.tsx
+++ b/apps/web/src/components/security/SecurityPolicyEditor.ownerScope.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+// Partner scope is detected from the JWT claims (same pattern as
+// ConfigPolicyCreatePage — #1724 / #2127). The owner picker also reads
+// currentOrgId/allOrgs from the org store, so the mock applies the selector
+// to a mutable state object each test can override.
+const { getJwtClaimsMock, orgState } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null })
+  ),
+  orgState: {
+    current: {
+      currentOrgId: null as string | null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    },
+  },
+}));
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
+}));
+
+import SecurityPolicyEditor from './SecurityPolicyEditor';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 400, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const EXISTING_POLICY = {
+  id: 'existing-id',
+  name: 'Baseline AV',
+  description: 'Standard baseline',
+  realTimeProtection: true,
+  autoQuarantine: true,
+  exclusions: [] as string[],
+  scanSchedule: 'daily' as const,
+};
+
+function postOrPutBody(method: 'POST' | 'PUT', url: string): Record<string, unknown> {
+  const call = fetchMock.mock.calls.find(
+    (c) => c[0] === url && (c[1] as RequestInit)?.method === method
+  );
+  expect(call).toBeTruthy();
+  return JSON.parse((call![1] as RequestInit).body as string);
+}
+
+describe('SecurityPolicyEditor — owner scope (#2127)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    orgState.current = {
+      currentOrgId: null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    };
+    fetchMock.mockResolvedValue(json({ data: EXISTING_POLICY }, true));
+  });
+
+  it('shows the owner picker on create for a partner-scope user, defaulting to partner-wide in All-orgs scope', () => {
+    render(<SecurityPolicyEditor />);
+    expect(screen.getByTestId('security-policy-owner')).toBeInTheDocument();
+    expect(screen.getByTestId('security-policy-owner-partner')).toBeChecked();
+  });
+
+  it('does not show the owner picker when editing an existing policy, even for partner scope', async () => {
+    render(<SecurityPolicyEditor policyId="existing-id" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/security/policies'));
+    expect(screen.queryByTestId('security-policy-owner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the owner picker on create for an org-scope user', () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
+    orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };
+    render(<SecurityPolicyEditor />);
+    expect(screen.queryByTestId('security-policy-owner')).not.toBeInTheDocument();
+  });
+
+  it('POSTs ownerScope:partner when saving with the default partner-wide selection', async () => {
+    render(<SecurityPolicyEditor />);
+    fireEvent.click(screen.getByText('Save policy'));
+
+    await waitFor(() => {
+      const body = postOrPutBody('POST', '/security/policies');
+      expect(body.ownerScope).toBe('partner');
+    });
+  });
+
+  it('omits ownerScope entirely for an org-scope create', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
+    orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };
+    render(<SecurityPolicyEditor />);
+    fireEvent.click(screen.getByText('Save policy'));
+
+    await waitFor(() => {
+      const body = postOrPutBody('POST', '/security/policies');
+      expect('ownerScope' in body).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/components/sensitiveData/PoliciesTab.tsx
+++ b/apps/web/src/components/sensitiveData/PoliciesTab.tsx
@@ -1,13 +1,17 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, Pencil, Trash2 } from 'lucide-react';
+import { Plus, Pencil, Trash2, Globe } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { DETECTION_CLASSES, DATA_TYPE_COLORS } from './constants';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
 
 type Policy = {
   id: string;
-  orgId: string;
+  // null = partner-wide ("All organizations") policy (#2131)
+  orgId: string | null;
+  partnerId?: string | null;
   name: string;
   scope: Record<string, unknown>;
   detectionClasses: unknown;
@@ -48,6 +52,15 @@ export default function PoliciesTab() {
   const [deleteTarget, setDeleteTarget] = useState<Policy | null>(null);
   const [deleting, setDeleting] = useState(false);
 
+  // Ownership axis (#2131, mirrors software PolicyForm #2126): partner-scope
+  // creators may own the policy partner-wide ("all orgs"). Gate on the JWT
+  // scope; default to partner-wide when viewing All orgs. Create-only.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const [ownerScope, setOwnerScope] = useState<'organization' | 'partner'>('organization');
+
   const fetchPolicies = useCallback(async () => {
     try {
       setLoading(true);
@@ -70,6 +83,7 @@ export default function PoliciesTab() {
   const openCreate = () => {
     setEditingId(null);
     setForm(defaultForm);
+    setOwnerScope(isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization');
     setShowForm(true);
   };
 
@@ -112,6 +126,8 @@ export default function PoliciesTab() {
         detectionClasses: form.detectionClasses,
         isActive: form.isActive,
         schedule,
+        // Create-only: updates never move a policy between ownership axes.
+        ...(editingId ? {} : isPartnerScope ? { ownerScope } : {}),
       };
 
       const url = editingId ? `/sensitive-data/policies/${editingId}` : '/sensitive-data/policies';
@@ -196,6 +212,30 @@ export default function PoliciesTab() {
         <div className="rounded-lg border bg-card p-5 shadow-xs">
           <h3 className="text-sm font-semibold">{editingId ? 'Edit Policy' : 'Create Policy'}</h3>
           <div className="mt-4 grid gap-4">
+            {/* Ownership scope — partner-scope creators only, create-only (#2131) */}
+            {!editingId && isPartnerScope && (
+              <fieldset className="space-y-2 rounded-md border p-4" data-testid="sensitive-policy-owner">
+                <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={ownerScope === 'partner'}
+                    onChange={() => setOwnerScope('partner')}
+                    data-testid="sensitive-policy-owner-partner"
+                  />
+                  All organizations <span className="text-muted-foreground">(partner-wide policy)</span>
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={ownerScope === 'organization'}
+                    onChange={() => setOwnerScope('organization')}
+                    data-testid="sensitive-policy-owner-org"
+                  />
+                  This organization only
+                </label>
+              </fieldset>
+            )}
             <div>
               <label className="text-sm font-medium">Name</label>
               <input
@@ -317,7 +357,21 @@ export default function PoliciesTab() {
 
               return (
                 <tr key={policy.id} className="text-sm hover:bg-muted/20">
-                  <td className="px-4 py-3 font-medium">{policy.name}</td>
+                  <td className="px-4 py-3 font-medium">
+                    <div className="flex items-center gap-2">
+                      <span>{policy.name}</span>
+                      {policy.orgId === null && (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                          title="Partner-wide policy — scans devices in every organization"
+                          data-testid="sensitive-policy-partner-wide-badge"
+                        >
+                          <Globe className="h-3 w-3" />
+                          All orgs
+                        </span>
+                      )}
+                    </div>
+                  </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap gap-1">
                       {classes.map((cls) => (

--- a/apps/web/src/components/software/ComplianceDashboard.ownerScope.test.tsx
+++ b/apps/web/src/components/software/ComplianceDashboard.ownerScope.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+// Partner scope is detected from the JWT claims (same pattern as
+// ConfigPolicyCreatePage — #1724 / #2126). The owner picker also reads
+// currentOrgId/allOrgs from the org store, so the mock applies the selector
+// to a mutable state object each test can override.
+const { getJwtClaimsMock, orgState } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null })
+  ),
+  orgState: {
+    current: {
+      currentOrgId: null as string | null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    },
+  },
+}));
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
+}));
+
+import ComplianceDashboard from './ComplianceDashboard';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 400, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const OVERVIEW = { total: 0, compliant: 0, violations: 0, unknown: 0 };
+
+type SeedPolicy = {
+  id: string;
+  name: string;
+  mode: 'allowlist' | 'blocklist' | 'audit';
+  isActive: boolean;
+  enforceMode: boolean;
+  orgId?: string | null;
+};
+
+function mockRefreshEndpoints(policies: SeedPolicy[] = []) {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+    if (url.startsWith('/software-policies/violations')) return Promise.resolve(json({ data: [] }));
+    if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: policies }));
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+function postBody(): Record<string, unknown> {
+  const post = fetchMock.mock.calls.find(
+    (c) => c[0] === '/software-policies' && (c[1] as RequestInit)?.method === 'POST'
+  );
+  expect(post).toBeTruthy();
+  return JSON.parse((post![1] as RequestInit).body as string);
+}
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByPlaceholderText('e.g. Block Unauthorized Software'), {
+    target: { value: 'Fleet-wide Policy' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Name *'), { target: { value: 'Chrome' } });
+}
+
+describe('ComplianceDashboard — owner scope (#2126)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    orgState.current = {
+      currentOrgId: null,
+      allOrgs: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }, { id: 'org-2', name: 'Beta' }],
+    };
+    mockRefreshEndpoints();
+  });
+
+  it('shows the owner picker for a partner-scope creator on create, defaulting to partner-wide in All-orgs scope', async () => {
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Create Policy'));
+
+    expect(screen.getByTestId('software-policy-owner')).toBeInTheDocument();
+    expect(screen.getByTestId('software-policy-owner-partner')).toBeChecked();
+  });
+
+  it('does not show the owner picker when editing an existing policy, even for partner scope', async () => {
+    const existing: SeedPolicy = {
+      id: 'pol-1',
+      name: 'Existing Policy',
+      mode: 'blocklist',
+      isActive: true,
+      enforceMode: false,
+      orgId: 'org-1',
+    };
+    mockRefreshEndpoints([existing]);
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.getByText('Existing Policy')).toBeInTheDocument());
+
+    // handleEdit GETs /software-policies/:id — resolve with the same row.
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/software-policies/pol-1') return Promise.resolve(json({ data: existing }));
+      if (url.startsWith('/software-policies/compliance/overview')) return Promise.resolve(json(OVERVIEW));
+      if (url.startsWith('/software-policies/violations')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/software-policies?')) return Promise.resolve(json({ data: [existing] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+
+    fireEvent.click(screen.getByTitle('Edit'));
+
+    await waitFor(() => expect(screen.getByText('Edit Software Policy')).toBeInTheDocument());
+    expect(screen.queryByTestId('software-policy-owner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the owner picker on create for an org-scope user', async () => {
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'org-9' });
+    orgState.current = { currentOrgId: 'org-9', allOrgs: false, organizations: [] };
+    render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Create Policy'));
+
+    expect(screen.queryByTestId('software-policy-owner')).not.toBeInTheDocument();
+  });
+
+  it('POSTs ownerScope:partner when submitting with the default partner-wide selection', async () => {
+    const { container } = render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Create Policy'));
+    fillRequiredFields();
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      const body = postBody();
+      expect(body.ownerScope).toBe('partner');
+      expect(body.name).toBe('Fleet-wide Policy');
+    });
+  });
+
+  it('POSTs ownerScope:organization when "This organization only" is selected', async () => {
+    const { container } = render(<ComplianceDashboard />);
+    await waitFor(() => expect(screen.queryByText('Loading software policy compliance...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Create Policy'));
+    fireEvent.click(screen.getByTestId('software-policy-owner-org'));
+    fillRequiredFields();
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      const body = postBody();
+      expect(body.ownerScope).toBe('organization');
+    });
+  });
+});


### PR DESCRIPTION
Phase 2 of the partner-wide-first epic #2135, stacked on #2143. One commit per table, each following the software-policies reference implementation (migration with XOR CHECK + single dual-axis RLS policy, `canManagePartnerWidePolicies` write gates, dual-axis app conditions gated on partner scope, `PARTNER_LINKABLE_FEATURE_TYPES` + `validateFeaturePolicyExists` dual-axis branch, `DUAL_AXIS_TENANT_TABLES` registration, and a functional `*PartnerRls` integration suite with an enforcement fan-out proof).

Closes #2129
Closes #2131
Closes #2134

## Tables converted (org XOR partner)

- **automation_policies** (#2129, the config-policy `compliance` feature) — evaluation fan-out in `resolveTargetDevices` (previously silently evaluated zero devices for partner-wide rows), per-device-org events/remediation, alert bridge accepts partner-wide policies, agent heartbeat probe config moved to a system context (partner rows invisible to the org-scoped agent RLS context) and now includes partner-wide policies' registry/config probes.
- **sensitive_data_policies** (#2131) — scheduled-scan producer fans out across member orgs; scan rows take the DEVICE's org; ownerScope create + write gates on the standalone routes.
- **peripheral_policies** (#2131) — org-keyed distribution worker's policy set is dual-axis; mutations fan distribution jobs/events across member orgs; agent event-ingest validates partner-wide policy ids in a system-context block; both AI tool surfaces updated.
- **maintenance_windows** (#2131) — all three standalone enforcement checks (`maintenanceService`, `deploymentEngine` ×2) now match the device org's partner's windows; `maintenance_occurrences` window-join RLS gained the partner branch. Also fixes a pre-existing driver bug: those raw-sql checks bound bare `Date` instances that postgres.js can't serialize.

## Also

- CLAUDE.md partner-wide-first rule (#2134): new config tables default to dual-axis; `org_id NOT NULL` needs explicit justification (backup is the documented exception, #2132).
- #2143 review fast-follows: component tests for the three web ownerScope selectors, GET /alerts/rules dual-axis list-branch unit tests, and `configureDefaults` alert-rule dedupe now recognizes partner-wide rules as existing coverage.
- Hidden-reader sweep per the #2143 lesson found and fixed: agent heartbeat probe builder, aiToolsFleet compliance report, aiToolsCompliance list, aiToolsPolicyPrereqs peripheral tool.

## Verification

Per table: new integration suites (8/8, 8/8, 7/7, 8/8 across the four), rls-coverage 50/50 with all four tables registered dual-axis, `pnpm db:check-drift` clean, API + web tsc clean, all touched unit suites green (~600 tests run locally). Web: create-only scope selectors + "All orgs" badges for sensitive-data and peripheral; compliance and maintenance have no standalone create UI (managed via config policies, which already carry ownerScope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)