### PR TITLE
Quotes/Invoices/Contracts polishing round 2: shared billing kit + editor parity

### DIFF
--- a/apps/api/src/routes/invoices/invoices.test.ts
+++ b/apps/api/src/routes/invoices/invoices.test.ts
@@ -28,6 +28,12 @@ vi.mock('../../services/invoicePdf', () => ({
   getInvoicePdf: vi.fn()
 }));
 
+// GET /:id resolves document branding (partner/portal) for the in-app preview,
+// mirroring the quotes route. Stub it so route tests don't hit the real DB.
+vi.mock('../../services/quoteBranding', () => ({
+  resolveQuoteBranding: vi.fn()
+}));
+
 // Payment routes write to the durable audit chain; stub it so route tests don't
 // hit the real audit persistence path.
 vi.mock('../../services/auditEvents', () => ({
@@ -55,6 +61,7 @@ import { invoiceRoutes } from './index';
 import { invoiceAssemblyRoutes } from './assembly';
 import * as svc from '../../services/invoiceService';
 import * as pdfSvc from '../../services/invoicePdf';
+import * as brandingSvc from '../../services/quoteBranding';
 import { InvoiceServiceError } from '../../services/invoiceTypes';
 
 function app() {
@@ -101,13 +108,16 @@ describe('invoice crud + lines routes', () => {
     expect(svc.listInvoices).toHaveBeenCalledOnce();
   });
 
-  it('GET /:id fetches one invoice', async () => {
-    (svc.getInvoice as any).mockResolvedValue({ id: INV_ID });
+  it('GET /:id fetches one invoice and attaches resolved branding', async () => {
+    (svc.getInvoice as any).mockResolvedValue({ invoice: { id: INV_ID }, lines: [], stripeConnected: false });
+    (brandingSvc.resolveQuoteBranding as any).mockResolvedValue({ partnerName: 'Lantern IT', logoUrl: null, primaryColor: null, footer: null, currencyCode: 'USD', seller: null });
     const res = await app().request(`/${INV_ID}`, { method: 'GET' });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data.id).toBe(INV_ID);
+    expect(body.data.invoice.id).toBe(INV_ID);
+    expect(body.data.branding.partnerName).toBe('Lantern IT');
     expect(svc.getInvoice).toHaveBeenCalledWith(INV_ID, expect.anything());
+    expect(brandingSvc.resolveQuoteBranding).toHaveBeenCalledWith({ id: INV_ID });
   });
 
   it('POST /:id/lines adds a manual line', async () => {

--- a/apps/api/src/routes/invoices/invoices.ts
+++ b/apps/api/src/routes/invoices/invoices.ts
@@ -12,6 +12,7 @@ import {
   updateLine, removeLine, deleteDraftInvoice, updateInvoice
 } from '../../services/invoiceService';
 import { InvoiceServiceError, type InvoiceActor } from '../../services/invoiceTypes';
+import { resolveQuoteBranding } from '../../services/quoteBranding';
 
 export const invoiceCrudRoutes = new Hono();
 const scopes = requireScope('partner', 'system');
@@ -38,8 +39,14 @@ invoiceCrudRoutes.post('/', scopes, writePerm, zValidator('json', createManualIn
   catch (err) { return handleServiceError(c, err); }
 });
 invoiceCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {
-  try { return c.json({ data: await getInvoice(c.req.valid('param').id, invoiceActorFrom(c)) }); }
-  catch (err) { return handleServiceError(c, err); }
+  try {
+    const detail = await getInvoice(c.req.valid('param').id, invoiceActorFrom(c));
+    // Branding (partner name/logo, accent, seller, footer) lets the in-app Preview
+    // render the customer-facing document without a second round-trip — the same
+    // partner/portal source the invoice PDF resolves, so the two brand identically.
+    const branding = await resolveQuoteBranding(detail.invoice);
+    return c.json({ data: { ...detail, branding } });
+  } catch (err) { return handleServiceError(c, err); }
 });
 invoiceCrudRoutes.patch('/:id', scopes, writePerm, zValidator('param', idParam), zValidator('json', updateInvoiceSchema), async (c) => {
   try { return c.json({ data: await updateInvoice(c.req.valid('param').id, c.req.valid('json'), invoiceActorFrom(c)) }); }

--- a/apps/web/src/components/billing/InvoiceActions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceActions from './InvoiceActions';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+type Perm = { resource: string; action: string };
+
+// Mutable grant set the mocked auth store reads from. This file owns BOTH the
+// behavior tests (issue / issue & send / delete flows, moved here from
+// InvoiceEditor.test / InvoiceDetail.delete.test when the actions were extracted
+// into InvoiceActions) and the permission gating for the extracted buttons.
+const state = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const visibleLine: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  name: null, description: 'Consulting', quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+function detail(lines: InvoiceDetail['lines'], extra: Partial<InvoiceDetail['invoice']> = {}): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+      taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+      ...extra,
+    },
+    lines,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: '*', action: '*' }];
+  fetchMock.mockImplementation(async () => json({ data: {} }));
+});
+
+describe('InvoiceActions — issue flows', () => {
+  it('disables Issue / Issue & Send when there are no customer-visible lines, with a visible hint', () => {
+    render(<InvoiceActions detail={detail([])} variant="header" />);
+    expect(screen.getByTestId('invoice-issue')).toBeDisabled();
+    expect(screen.getByTestId('invoice-issue-send')).toBeDisabled();
+    expect(screen.getByTestId('invoice-no-visible-hint')).toBeInTheDocument();
+    // The hint is wired to the disabled buttons for AT.
+    expect(screen.getByTestId('invoice-issue')).toHaveAttribute('aria-describedby', 'invoice-no-visible-hint-header');
+  });
+
+  it('enables Issue when a customer-visible line exists (no hint)', () => {
+    render(<InvoiceActions detail={detail([visibleLine])} variant="header" />);
+    expect(screen.getByTestId('invoice-issue')).not.toBeDisabled();
+    expect(screen.queryByTestId('invoice-no-visible-hint')).not.toBeInTheDocument();
+  });
+
+  it('plain Issue POSTs /issue directly (no confirm) and triggers onChanged', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail([visibleLine])} onChanged={onChanged} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1/issue', { method: 'POST' });
+    // Plain Issue never hits /send.
+    expect(fetchMock.mock.calls.find((c) => c[0] === '/invoices/inv-1/send')).toBeUndefined();
+  });
+
+  it('Issue & Send shows a success toast when the email was dispatched (emailed:true)', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
+      if (input === '/invoices/inv-1/send' && opts?.method === 'POST') return json({ data: { invoice: { id: 'inv-1', status: 'sent' }, emailed: true } });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail([visibleLine])} onChanged={onChanged} variant="header" />);
+
+    fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Invoice issued and sent' }));
+  });
+
+  it('Issue & Send shows a WARNING toast (not error) when nothing was emailed (emailed:false)', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
+      if (input === '/invoices/inv-1/send' && opts?.method === 'POST') return json({ data: { invoice: { id: 'inv-1', status: 'sent' }, emailed: false, reason: 'no_billing_contact' } });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail([visibleLine])} onChanged={onChanged} variant="header" />);
+
+    fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+    // never a success "sent" claim when nothing went out
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Invoice issued and sent' }));
+  });
+
+  it('shows an "Issuing…" label on the Issue button while the mutation is in flight (#1418)', async () => {
+    let resolveIssue: (r: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') {
+        return new Promise<Response>((res) => { resolveIssue = res; });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail([visibleLine])} onChanged={vi.fn()} variant="header" />);
+
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+
+    // In flight: button is disabled AND relabelled so it never reads as a stuck "Issue".
+    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issuing…'));
+    expect(screen.getByTestId('invoice-issue')).toBeDisabled();
+
+    resolveIssue(json({ data: { id: 'inv-1', status: 'sent' } }));
+    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issue'));
+  });
+
+  it('hides Issue / Issue & Send on a non-draft invoice', () => {
+    render(<InvoiceActions detail={detail([visibleLine], { status: 'sent', invoiceNumber: 'INV-1', sentAt: '2026-06-02T00:00:00Z' })} variant="header" />);
+    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
+    // PDF stays reachable on an issued invoice.
+    expect(screen.getByTestId('invoice-download-pdf')).toBeInTheDocument();
+  });
+});
+
+describe('InvoiceActions — delete flow', () => {
+  it('deletes a draft invoice through the confirm dialog and navigates to the invoices list', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    const navigateMock = vi.mocked(navigateTo);
+
+    render(<InvoiceActions detail={detail([])} variant="rail" />);
+
+    fireEvent.click(screen.getByTestId('invoice-delete-open'));
+    await waitFor(() => expect(screen.getByTestId('invoice-delete-confirm')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-delete-confirm'));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1', { method: 'DELETE' });
+      expect(navigateMock).toHaveBeenCalledWith('/billing/invoices');
+    });
+  });
+
+  it('hides Delete draft on a non-draft invoice', () => {
+    render(<InvoiceActions detail={detail([visibleLine], { status: 'sent', sentAt: '2026-06-02T00:00:00Z' })} variant="rail" />);
+    expect(screen.queryByTestId('invoice-delete-open')).not.toBeInTheDocument();
+  });
+});
+
+describe('InvoiceActions — permission gating', () => {
+  it('invoices:write only — Delete renders, Issue / Issue & Send / PDF stay hidden', () => {
+    // write builds and can discard the draft; issuing/sending is a separate grant
+    // (invoices:send), export another (invoices:export).
+    state.permissions = [{ resource: 'invoices', action: 'write' }];
+    render(<InvoiceActions detail={detail([visibleLine])} variant="header" />);
+    expect(screen.getByTestId('invoice-delete-open')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+  });
+
+  it('invoices:send only — Issue / Issue & Send render, Delete / PDF stay hidden', () => {
+    state.permissions = [{ resource: 'invoices', action: 'send' }];
+    render(<InvoiceActions detail={detail([visibleLine])} variant="header" />);
+    expect(screen.getByTestId('invoice-issue')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-issue-send')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-delete-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-download-pdf')).not.toBeInTheDocument();
+  });
+
+  it('invoices:export only — Download PDF renders, Issue / Delete stay hidden', () => {
+    state.permissions = [{ resource: 'invoices', action: 'export' }];
+    render(<InvoiceActions detail={detail([visibleLine])} variant="header" />);
+    expect(screen.getByTestId('invoice-download-pdf')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-delete-open')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing at all (no empty container) for a read-only viewer', () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceActions detail={detail([visibleLine])} variant="header" />);
+    expect(screen.queryByTestId('invoice-actions-header')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/InvoiceActions.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, handleActionError } from '../../lib/runAction';
+import { usePermissions } from '../../lib/permissions';
+import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { usePdfDownload } from './shared/usePdfDownload';
+import { type InvoiceDetail as InvoiceDetailData, formatMoney } from './invoiceTypes';
+
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+
+interface Props {
+  detail: InvoiceDetailData;
+  onChanged?: () => void;
+  /**
+   * 'rail' — the stacked, full-width treatment inside the Detail summary column.
+   * 'header' — the compact, inline treatment in the workspace header so the
+   * primary money-actions (Issue / Issue & Send) are reachable from any tab, not
+   * buried inside the Editor tab. The two never render at once: the workspace
+   * passes `actionsInHeader` to InvoiceDetail, which suppresses its rail copy
+   * when the header owns the actions (mirrors QuoteActions).
+   */
+  variant: 'rail' | 'header';
+}
+
+/**
+ * The invoice's primary actions — Issue, Issue & Send (the irreversible
+ * money-moment), Download PDF, Delete draft — with their confirm dialogs.
+ * Single source (the QuoteActions pattern) so the Detail rail and the workspace
+ * header can't drift in behavior or copy; the data-testids are stable across
+ * both variants. Void stays in InvoiceDetail: its written-reason dialog shares
+ * the detail view's busy state with the payment mutations and belongs with the
+ * issued-lifecycle rail, not the header.
+ */
+export default function InvoiceActions({ detail, onChanged, variant }: Props) {
+  const { can } = usePermissions();
+  const { invoice, lines } = detail;
+  const currency = invoice.currencyCode;
+
+  const { download: downloadPdf, downloading } = usePdfDownload({
+    path: `/invoices/${invoice.id}/pdf`,
+    filename: `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`,
+    errorMessage: 'Could not download the invoice PDF.',
+  });
+
+  // Distinct in-flight flag so the Issue buttons can show an unambiguous
+  // "Issuing…" label. Without it the disabled-but-still-"Issue" button + a
+  // still-"Draft" header during the POST reads as "done but stuck" (#1418).
+  const [issuing, setIssuing] = useState(false);
+  // Issue-and-send emails the customer and can't be undone, so it goes through a
+  // confirm step (plain Issue stays direct — it's reversible via Void).
+  const [issueSendOpen, setIssueSendOpen] = useState(false);
+  const [delOpen, setDelOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const refresh = useCallback(() => onChanged?.(), [onChanged]);
+
+  const isDraft = invoice.status === 'draft';
+  // An invoice with no customer-visible line can't be issued.
+  const hasVisibleLines = lines.some((l) => l.customerVisible);
+
+  const issue = useCallback(async (alsoSend: boolean) => {
+    if (issuing) return;
+    setIssuing(true);
+    try {
+      // Issue first; on success optionally send.
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/issue`, { method: 'POST' }),
+        errorFallback: 'Could not issue invoice.',
+        successMessage: alsoSend ? undefined : 'Invoice issued',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      if (alsoSend) {
+        // /send is honest about whether an email actually went out. The invoice
+        // is issued either way; only claim "sent" when an email was dispatched,
+        // otherwise warn so the operator knows nothing was emailed. We suppress
+        // runAction's own success toast and post-process the result ourselves.
+        const result = await runAction<{ data: { emailed: boolean } }>({
+          request: () => fetchWithAuth(`/invoices/${invoice.id}/send`, { method: 'POST' }),
+          errorFallback: 'Invoice issued, but sending failed.',
+          onUnauthorized: UNAUTHORIZED,
+        });
+        if (result?.data?.emailed) {
+          showToast({ type: 'success', message: 'Invoice issued and sent' });
+        } else {
+          showToast({ type: 'warning', message: 'Invoice issued — but no email was sent (no billing contact / email not configured)' });
+        }
+      }
+    } catch (err) {
+      handleActionError(err, 'Could not issue invoice.');
+    } finally {
+      // Always refresh: if issue succeeded but send threw, we still need to leave
+      // the draft editor so a second click doesn't re-issue and hit 409 NOT_A_DRAFT.
+      refresh();
+      setIssuing(false);
+      setIssueSendOpen(false);
+    }
+  }, [issuing, invoice.id, refresh]);
+
+  const remove = useCallback(async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}`, { method: 'DELETE' }),
+        errorFallback: 'Could not delete the draft.',
+        successMessage: 'Draft deleted',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDelOpen(false);
+      void navigateTo('/billing/invoices');
+    } catch (err) {
+      handleActionError(err, 'Could not delete the draft.');
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleting, invoice.id]);
+
+  const header = variant === 'header';
+  // Rail buttons stretch full-width and stack; header buttons size to content and
+  // sit in a row. The class fragments below are the only thing the variant changes.
+  const layout = header ? 'flex flex-wrap items-center justify-end gap-2' : 'space-y-2';
+  const btnBase = header
+    ? 'inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium'
+    : 'inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium';
+
+  const canIssue = can('invoices', 'send') && isDraft;
+  const canDownload = can('invoices', 'export');
+  const canDelete = can('invoices', 'write') && isDraft;
+
+  // Nothing to show (e.g. a viewer on an issued invoice) — render no empty container.
+  if (!canIssue && !canDownload && !canDelete) return null;
+
+  const issueDisabled = issuing || !hasVisibleLines;
+
+  return (
+    <>
+      <div className={layout} data-testid={`invoice-actions-${variant}`}>
+        {/* Issuing assigns a number and flips draft→sent; Issue & Send also emails
+            the customer's billing contact. Gated on invoices:send; drafts only;
+            an invoice with no customer-visible line can't be issued. */}
+        {canIssue && (
+          <>
+            <button
+              type="button"
+              onClick={() => void issue(false)}
+              disabled={issueDisabled}
+              aria-describedby={!hasVisibleLines ? `invoice-no-visible-hint-${variant}` : undefined}
+              title={!hasVisibleLines ? 'Add at least one customer-visible line to issue.' : undefined}
+              data-testid="invoice-issue"
+              className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+            >
+              {issuing ? 'Issuing…' : 'Issue'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setIssueSendOpen(true)}
+              disabled={issueDisabled}
+              aria-describedby={!hasVisibleLines ? `invoice-no-visible-hint-${variant}` : undefined}
+              title={!hasVisibleLines ? 'Add at least one customer-visible line to issue.' : undefined}
+              data-testid="invoice-issue-send"
+              className={`${btnBase} bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
+            >
+              {issuing ? 'Issuing…' : 'Issue & Send'}
+            </button>
+          </>
+        )}
+        {/* PDF download is gated on the dedicated invoices:export permission. */}
+        {canDownload && (
+          <button
+            type="button"
+            onClick={() => void downloadPdf()}
+            disabled={downloading}
+            data-testid="invoice-download-pdf"
+            className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+          >
+            {downloading ? 'Preparing…' : 'Download PDF'}
+          </button>
+        )}
+        {canDelete && (
+          <button
+            type="button"
+            onClick={() => setDelOpen(true)}
+            data-testid="invoice-delete-open"
+            className={`${btnBase} border border-destructive/40 text-destructive hover:bg-destructive/10`}
+          >
+            Delete draft
+          </button>
+        )}
+        {canIssue && !hasVisibleLines && (
+          // Visible in BOTH variants — a sighted keyboard user needs to see WHY the
+          // highest-stakes buttons are disabled. Rendered LAST so in the header row
+          // it wraps onto its own line BELOW the whole action cluster (never inline
+          // between buttons), right-aligned under the right-aligned buttons.
+          <p
+            id={`invoice-no-visible-hint-${variant}`}
+            data-testid="invoice-no-visible-hint"
+            className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
+          >
+            Add at least one customer-visible line to issue.
+          </p>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={issueSendOpen}
+        onClose={() => setIssueSendOpen(false)}
+        onConfirm={() => void issue(true)}
+        isLoading={issuing}
+        variant="warning"
+        title="Issue and send this invoice?"
+        message={`This issues the invoice and emails it to ${invoice.billToName ?? 'the customer'} for ${formatMoney(invoice.total, currency)}. This can't be undone.`}
+        confirmLabel="Issue & Send"
+        confirmTestId="invoice-issue-send-confirm"
+      />
+      <ConfirmDialog
+        open={delOpen}
+        onClose={() => setDelOpen(false)}
+        onConfirm={() => void remove()}
+        isLoading={deleting}
+        title="Delete draft invoice"
+        message="This permanently deletes the draft invoice. This cannot be undone."
+        confirmLabel="Delete draft"
+        confirmTestId="invoice-delete-confirm"
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -24,7 +24,7 @@ import {
   computeInvoiceProfit,
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
-import { usePdfDownload } from './shared/usePdfDownload';
+import InvoiceActions from './InvoiceActions';
 import { MarginPanel } from './billingUi';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -32,8 +32,9 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 interface Props {
   detail: InvoiceDetailData;
   onChanged: () => void;
-  /** The workspace header owns the primary actions (Download PDF) — suppress the
-   *  rail copy so the two don't render at once (mirrors QuoteDetail.actionsInHeader). */
+  /** The workspace header owns the primary actions (Issue / Issue & Send /
+   *  Download PDF / Delete draft) — suppress the rail copy so the two don't
+   *  render at once (mirrors QuoteDetail.actionsInHeader). */
   actionsInHeader?: boolean;
 }
 
@@ -61,8 +62,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const [reversePayment, setReversePayment] = useState<InvoicePayment | null>(null);
   // Void dialog
   const [voidOpen, setVoidOpen] = useState(false);
-  // Delete dialog
-  const [delOpen, setDelOpen] = useState(false);
   const [voidReason, setVoidReason] = useState('');
   const [voidReissue, setVoidReissue] = useState(false);
 
@@ -116,12 +115,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const canRecordPayment =
     invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
-
-  const { download: downloadPdf, downloading } = usePdfDownload({
-    path: `/invoices/${invoice.id}/pdf`,
-    filename: `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`,
-    errorMessage: 'Could not download the invoice PDF.',
-  });
 
   const recordPayment = useCallback(async () => {
     if (busy || !payAmount) return;
@@ -226,25 +219,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
       setBusy(false);
     }
   }, [busy, voidReason, voidReissue, invoice.id, refresh]);
-
-  const remove = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      await runAction({
-        request: () => fetchWithAuth(`/invoices/${invoice.id}`, { method: 'DELETE' }),
-        errorFallback: 'Could not delete the draft.',
-        successMessage: 'Draft deleted',
-        onUnauthorized: UNAUTHORIZED,
-      });
-      setDelOpen(false);
-      void navigateTo('/billing/invoices');
-    } catch (err) {
-      handleActionError(err, 'Could not delete the draft.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id]);
 
   return (
     <div className="space-y-6" data-testid="invoice-detail">
@@ -372,17 +346,12 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
             </div>
           )}
 
-          {/* PDF + void */}
+          {/* Primary actions (Issue / PDF / Delete) + void. The rail copy of
+              InvoiceActions is suppressed when the workspace header owns the
+              actions; Void stays here — its written-reason dialog belongs with
+              the issued-lifecycle rail, not the header. */}
           <div className="space-y-2">
-            {!actionsInHeader && can('invoices', 'export') && (
-              <button
-                type="button" onClick={() => void downloadPdf()} disabled={busy || downloading}
-                data-testid="invoice-download-pdf"
-                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                Download PDF
-              </button>
-            )}
+            {!actionsInHeader && <InvoiceActions detail={detail} onChanged={onChanged} variant="rail" />}
             {canVoid && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => { setVoidReason(''); setVoidReissue(false); setVoidOpen(true); }}
@@ -390,16 +359,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
                 className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
               >
                 Void invoice
-              </button>
-            )}
-            {invoice.status === 'draft' && can('invoices', 'write') && (
-              <button
-                type="button"
-                onClick={() => setDelOpen(true)}
-                data-testid="invoice-delete-open"
-                className="inline-flex w-full items-center justify-center rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
-              >
-                Delete draft
               </button>
             )}
           </div>
@@ -545,18 +504,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
         message={`Record a ${formatMoney(Number(payAmount), currency)} payment (${PAYMENT_METHOD_LABELS[payMethod]}) dated ${formatDate(payDate)}?`}
         confirmLabel="Record payment"
         confirmTestId="invoice-payment-confirm"
-      />
-
-      {/* Delete draft dialog */}
-      <ConfirmDialog
-        open={delOpen}
-        onClose={() => setDelOpen(false)}
-        onConfirm={() => void remove()}
-        isLoading={busy}
-        title="Delete draft invoice"
-        message="This permanently deletes the draft invoice. This cannot be undone."
-        confirmLabel="Delete draft"
-        confirmTestId="invoice-delete-confirm"
       />
 
       {/* Void dialog */}

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -12,7 +12,7 @@ import {
   type InvoicePayment,
   type PaymentMethod,
   PAYMENT_METHOD_LABELS,
-  STATUS_COLORS,
+  STATUS_ROLES,
   statusLabel,
   formatDate,
   formatMoney,
@@ -23,6 +23,7 @@ import {
   sellerLines,
   computeInvoiceProfit,
 } from './invoiceTypes';
+import { StatusPill } from './shared/StatusPill';
 import { MarginPanel } from './billingUi';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -320,9 +321,12 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-detail-summary">
             <div className="mb-3 flex items-center justify-between">
-              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`} data-testid="invoice-detail-status" aria-label={`Status: ${statusLabel(invoice)}`}>
-                {statusLabel(invoice)}
-              </span>
+              <StatusPill
+                role={STATUS_ROLES[invoice.status].role}
+                label={statusLabel(invoice)}
+                className={STATUS_ROLES[invoice.status].className}
+                testId="invoice-detail-status"
+              />
               <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
             </div>
             <dl className="space-y-1 text-sm tabular-nums">

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -24,6 +24,7 @@ import {
   computeInvoiceProfit,
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
+import { usePdfDownload } from './shared/usePdfDownload';
 import { MarginPanel } from './billingUi';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -31,9 +32,12 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 interface Props {
   detail: InvoiceDetailData;
   onChanged: () => void;
+  /** The workspace header owns the primary actions (Download PDF) — suppress the
+   *  rail copy so the two don't render at once (mirrors QuoteDetail.actionsInHeader). */
+  actionsInHeader?: boolean;
 }
 
-export default function InvoiceDetail({ detail, onChanged }: Props) {
+export default function InvoiceDetail({ detail, onChanged, actionsInHeader = false }: Props) {
   const { can } = usePermissions();
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
@@ -113,28 +117,11 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
     invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
 
-  const downloadPdf = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const res = await fetchWithAuth(`/invoices/${invoice.id}/pdf`);
-      if (res.status === 401) return UNAUTHORIZED();
-      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the invoice PDF.'); return; }
-      const blob = await res.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
-    } catch (err) {
-      handleActionError(err, 'Could not download the invoice PDF.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, invoice.invoiceNumber]);
+  const { download: downloadPdf, downloading } = usePdfDownload({
+    path: `/invoices/${invoice.id}/pdf`,
+    filename: `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`,
+    errorMessage: 'Could not download the invoice PDF.',
+  });
 
   const recordPayment = useCallback(async () => {
     if (busy || !payAmount) return;
@@ -387,9 +374,9 @@ export default function InvoiceDetail({ detail, onChanged }: Props) {
 
           {/* PDF + void */}
           <div className="space-y-2">
-            {can('invoices', 'export') && (
+            {!actionsInHeader && can('invoices', 'export') && (
               <button
-                type="button" onClick={() => void downloadPdf()} disabled={busy}
+                type="button" onClick={() => void downloadPdf()} disabled={busy || downloading}
                 data-testid="invoice-download-pdf"
                 className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
               >

--- a/apps/web/src/components/billing/InvoiceDocument.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { InvoiceDocument } from './InvoiceDocument';
+import InvoiceDocumentPreview from './InvoiceDocument';
 import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
 
 // InvoiceDocument is presentational, but its module imports the auth/org stores
@@ -55,5 +56,23 @@ describe('InvoiceDocument — customer-facing, no internal cost', () => {
     expect(screen.queryByText(/^Cost$/)).not.toBeInTheDocument();
     expect(screen.queryByText('Secret component')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
+  });
+});
+
+describe('InvoiceDocumentPreview — customer-name fallback', () => {
+  it('falls back to an em-dash (never a raw org UUID fragment) when neither billToName nor the org store resolves', () => {
+    const d: InvoiceDetailData = {
+      ...detail,
+      invoice: {
+        ...detail.invoice,
+        billToName: null, // no explicit bill-to
+        orgId: '9f8e7d6c-1234-4abc-9def-0123456789ab', // not in the mocked org store
+      },
+    };
+    render(<InvoiceDocumentPreview detail={d} />);
+    const customer = screen.getByTestId('invoice-document-customer');
+    expect(customer).toHaveTextContent('—');
+    // The UUID (or its first 8 chars) must never leak onto the customer document.
+    expect(customer).not.toHaveTextContent('9f8e7d6c');
   });
 });

--- a/apps/web/src/components/billing/InvoiceDocument.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.test.tsx
@@ -59,6 +59,33 @@ describe('InvoiceDocument — customer-facing, no internal cost', () => {
   });
 });
 
+describe('InvoiceDocument — partner branding letterhead', () => {
+  const branded: InvoiceDetailData = {
+    ...detail,
+    branding: {
+      partnerName: 'Lantern IT', logoUrl: null, primaryColor: '#1c8a9e',
+      footer: 'Thank you for your business.', currencyCode: 'USD', seller: null,
+    },
+  };
+
+  it('renders the partner wordmark from branding when no logo is present', () => {
+    render(<InvoiceDocument detail={branded} customerName="Acme Industries" />);
+    expect(screen.getByTestId('invoice-document-wordmark')).toHaveTextContent('Lantern IT');
+  });
+
+  it('renders the partner logo (alt = partner name) when a logoUrl is present', () => {
+    const withLogo: InvoiceDetailData = {
+      ...branded,
+      branding: { ...branded.branding!, logoUrl: 'https://cdn.example.com/logo.png' },
+    };
+    render(<InvoiceDocument detail={withLogo} customerName="Acme Industries" />);
+    const logo = screen.getByAltText('Lantern IT');
+    expect(logo).toHaveAttribute('src', 'https://cdn.example.com/logo.png');
+    // The wordmark fallback must not also render when a logo is shown.
+    expect(screen.queryByTestId('invoice-document-wordmark')).not.toBeInTheDocument();
+  });
+});
+
 describe('InvoiceDocumentPreview — customer-name fallback', () => {
   it('falls back to an em-dash (never a raw org UUID fragment) when neither billToName nor the org store resolves', () => {
     const d: InvoiceDetailData = {

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -1,8 +1,6 @@
-import { useCallback, useMemo, useState, type CSSProperties } from 'react';
-import { fetchWithAuth } from '../../stores/auth';
-import { navigateTo } from '@/lib/navigation';
-import { handleActionError } from '../../lib/runAction';
+import { useMemo, type CSSProperties } from 'react';
 import { useOrgStore } from '../../stores/orgStore';
+import { usePdfDownload } from './shared/usePdfDownload';
 import {
   type InvoiceDetail as InvoiceDetailData,
   type InvoiceLine,
@@ -17,8 +15,6 @@ import {
   sellerLines,
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
-
-const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 function LineRow({ line, currency, taxRate, showTax }: { line: InvoiceLine; currency: string; taxRate: string | null; showTax: boolean }) {
   const child = !!line.parentLineId;
@@ -223,7 +219,6 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
 export default function InvoiceDocumentPreview({ detail }: { detail: InvoiceDetailData }) {
   const { invoice } = detail;
   const organizations = useOrgStore((s) => s.organizations);
-  const [busy, setBusy] = useState(false);
 
   const customerName = useMemo(() => {
     const billTo = invoice.billToName?.trim();
@@ -232,28 +227,11 @@ export default function InvoiceDocumentPreview({ detail }: { detail: InvoiceDeta
     return resolved || invoice.orgId.slice(0, 8);
   }, [invoice.billToName, invoice.orgId, organizations]);
 
-  const downloadPdf = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const res = await fetchWithAuth(`/invoices/${invoice.id}/pdf`);
-      if (res.status === 401) return UNAUTHORIZED();
-      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the invoice PDF.'); return; }
-      const blob = await res.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
-    } catch (err) {
-      handleActionError(err, 'Could not download the invoice PDF.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, invoice.invoiceNumber]);
+  const { download: downloadPdf, downloading: busy } = usePdfDownload({
+    path: `/invoices/${invoice.id}/pdf`,
+    filename: `${invoice.invoiceNumber ?? `invoice-${invoice.id}`}.pdf`,
+    errorMessage: 'Could not download the invoice PDF.',
+  });
 
   return (
     <div className="space-y-4" data-testid="invoice-preview">

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -6,7 +6,7 @@ import { useOrgStore } from '../../stores/orgStore';
 import {
   type InvoiceDetail as InvoiceDetailData,
   type InvoiceLine,
-  STATUS_COLORS,
+  STATUS_ROLES,
   statusLabel,
   formatDate,
   formatMoney,
@@ -16,6 +16,7 @@ import {
   pctFromFraction,
   sellerLines,
 } from './invoiceTypes';
+import { StatusPill } from './shared/StatusPill';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -107,12 +108,11 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
             {/* The "Invoice" type label is redundant on an unnumbered draft, where the
                 heading above already reads "Invoice" and the status pill reads "Draft". */}
             {invoice.invoiceNumber && <p className="text-sm font-medium text-muted-foreground">Invoice</p>}
-            <span
-              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[invoice.status]}`}
-              aria-label={`Status: ${statusLabel(invoice)}`}
-            >
-              {statusLabel(invoice)}
-            </span>
+            <StatusPill
+              role={STATUS_ROLES[invoice.status].role}
+              label={statusLabel(invoice)}
+              className={STATUS_ROLES[invoice.status].className}
+            />
             <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
               {invoice.issueDate && (
                 <div className="flex gap-2"><dt>Issued</dt><dd className="font-medium text-foreground/80">{formatDate(invoice.issueDate)}</dd></div>

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -224,7 +224,9 @@ export default function InvoiceDocumentPreview({ detail }: { detail: InvoiceDeta
     const billTo = invoice.billToName?.trim();
     if (billTo) return billTo;
     const resolved = organizations.find((o) => o.id === invoice.orgId)?.name?.trim();
-    return resolved || invoice.orgId.slice(0, 8);
+    // Never leak a raw org UUID fragment onto a customer-facing document — if the
+    // org store hasn't resolved a name yet, show a neutral em-dash instead.
+    return resolved || '—';
   }, [invoice.billToName, invoice.orgId, organizations]);
 
   const { download: downloadPdf, downloading: busy } = usePdfDownload({

--- a/apps/web/src/components/billing/InvoiceDocument.tsx
+++ b/apps/web/src/components/billing/InvoiceDocument.tsx
@@ -46,12 +46,16 @@ interface DocumentProps {
  *  using the seller snapshot and the app accent. The sibling of QuoteDocument;
  *  works for drafts without a portal round-trip. */
 export function InvoiceDocument({ detail, customerName }: DocumentProps) {
-  const { invoice, lines } = detail;
-  const currency = invoice.currencyCode;
-  const seller = invoice.sellerSnapshot;
-  // Invoices carry no per-partner branding payload (unlike quotes), so the
-  // document is anchored on the app's primary accent.
-  const accentStyle = { ['--doc-accent']: 'hsl(var(--primary))' } as CSSProperties;
+  const { invoice, lines, branding } = detail;
+  const currency = branding?.currencyCode ?? invoice.currencyCode;
+  const seller = branding?.seller ?? invoice.sellerSnapshot;
+  // Partner brand accent when resolved; otherwise the app's primary accent.
+  const accent = branding?.primaryColor || 'hsl(var(--primary))';
+  const accentStyle = { ['--doc-accent']: accent } as CSSProperties;
+  // Wordmark/logo identity: partner logo → partner name → seller name. The
+  // letterhead rule renders whenever any identity is shown. Same source and
+  // precedence as QuoteDocument so invoices and quotes brand identically.
+  const wordmark = branding?.partnerName || seller?.name || null;
 
   // Customers only ever see customer-visible lines — cost/margin and hidden
   // bundle components never reach the document.
@@ -75,17 +79,19 @@ export function InvoiceDocument({ detail, customerName }: DocumentProps) {
         {/* ── Header ─────────────────────────────────────────────── */}
         <header className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-3">
-            {/* Seller wordmark + letterhead rule only when the seller is named. An
-                unbranded invoice lets the right-hand "Invoice" meta carry identity
-                rather than repeating the word "Invoice" on both sides of the header. */}
-            {seller?.name && (
-              <>
-                <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
-                  {seller.name}
-                </p>
-                {/* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */}
-                <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
-              </>
+            {/* Partner logo (or wordmark) + letterhead rule, mirroring the quote
+                document. An unbranded invoice with no seller name lets the
+                right-hand "Invoice" meta carry identity instead. */}
+            {branding?.logoUrl ? (
+              <img src={branding.logoUrl} alt={branding.partnerName} className="h-11 w-auto max-w-[220px] object-contain" />
+            ) : wordmark ? (
+              <p className="text-xl font-semibold tracking-tight text-foreground" data-testid="invoice-document-wordmark">
+                {wordmark}
+              </p>
+            ) : null}
+            {(branding?.logoUrl || wordmark) && (
+              /* Brand letterhead rule — a short, deliberate accent mark, not a full-bleed stripe. */
+              <div className="h-0.5 w-10 rounded-full" style={{ backgroundColor: 'var(--doc-accent)' }} aria-hidden />
             )}
             {seller && (
               <address className="space-y-0.5 text-xs not-italic leading-relaxed text-muted-foreground">

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -9,9 +9,9 @@ type Perm = { resource: string; action: string };
 
 // Mutable grant set the mocked auth store reads from. Covers the NEGATIVE gating
 // branches the wildcard-positive sibling (InvoiceEditor.test.tsx) never touches:
-// the editor draws a hard line between invoices:write (edit lines/notes) and
-// invoices:send (issue / issue & send). A write-only operator must be able to
-// build the draft but NOT issue or send it.
+// invoices:write gates the editing controls (add-line, per-line remove, notes).
+// Issue / Issue & Send moved to the workspace header with the InvoiceActions
+// extraction — their invoices:send gating is covered in InvoiceActions.test.tsx.
 const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
 
 vi.mock('../../stores/auth', () => ({
@@ -57,24 +57,20 @@ beforeEach(() => {
 });
 
 describe('InvoiceEditor — permission gating', () => {
-  it('read-only (invoices:read) hides the add-line form, per-line remove, and issue/send', async () => {
+  it('read-only (invoices:read) hides the add-line form and per-line remove', async () => {
     state.permissions = [{ resource: 'invoices', action: 'read' }];
     render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
     expect(screen.queryByTestId('invoice-add-line')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-line-remove-line-1')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
     // Notes entry is disabled (gated on write) rather than removed.
     expect(screen.getByTestId('invoice-notes')).toBeDisabled();
     // Cost/margin is a read affordance — invoices:read sees the margin panel.
     expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
   });
 
-  it('invoices:write reveals editing controls but still hides Issue / Issue & Send', async () => {
-    // The security-relevant line: write builds the draft; issuing/sending is a
-    // separate grant (invoices:send).
+  it('invoices:write reveals the editing controls', async () => {
     state.permissions = [{ resource: 'invoices', action: 'write' }];
     render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
@@ -82,22 +78,18 @@ describe('InvoiceEditor — permission gating', () => {
     expect(screen.getByTestId('invoice-add-line')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-line-remove-line-1')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-notes')).not.toBeDisabled();
-    // send-gated:
-    expect(screen.queryByTestId('invoice-issue')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('invoice-issue-send')).not.toBeInTheDocument();
     // Margin gates on invoices:read specifically — write without read does not see it.
     expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
   });
 
-  it('invoices:send reveals Issue / Issue & Send but NOT the editing controls', async () => {
-    // Mirror image: send is not a license to edit lines. add-line and per-line
-    // remove gate on invoices:write and must stay hidden.
+  it('invoices:send alone reveals NO editing controls', async () => {
+    // send is not a license to edit lines: add-line and per-line remove gate on
+    // invoices:write and must stay hidden. (send's positive branch — the Issue /
+    // Issue & Send buttons — lives in the workspace header, InvoiceActions.test.tsx.)
     state.permissions = [{ resource: 'invoices', action: 'send' }];
     render(<InvoiceEditor detail={draft} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
-    expect(screen.getByTestId('invoice-issue')).toBeInTheDocument();
-    expect(screen.getByTestId('invoice-issue-send')).toBeInTheDocument();
     expect(screen.queryByTestId('invoice-add-line')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-line-remove-line-1')).not.toBeInTheDocument();
     expect(screen.getByTestId('invoice-notes')).toBeDisabled();

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -52,18 +52,13 @@ describe('InvoiceEditor', () => {
     });
   });
 
-  it('disables Issue when there are no customer-visible lines', async () => {
-    render(<InvoiceEditor detail={draft([])} onChanged={vi.fn()} />);
-    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
-    expect(screen.getByTestId('invoice-issue')).toBeDisabled();
-    expect(screen.getByTestId('invoice-issue-send')).toBeDisabled();
-    expect(screen.getByTestId('invoice-no-visible-hint')).toBeInTheDocument();
-  });
+  // Issue / Issue & Send behavior (disabled-without-visible-lines, toasts,
+  // in-flight label) moved to InvoiceActions.test.tsx with the buttons — the
+  // actions now live in the workspace header (InvoiceActions), not the editor.
 
-  it('enables Issue when a visible line exists and shows the total', async () => {
+  it('renders an editable line (full-width description row)', async () => {
     render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
-    expect(screen.getByTestId('invoice-issue')).not.toBeDisabled();
     // Name/description are now editable inputs (full-width description row) rather
     // than static text; the legacy name-less line shows its description in the box.
     expect(screen.getByTestId('invoice-line-desc-line-1')).toHaveValue('Consulting');
@@ -156,64 +151,6 @@ describe('InvoiceEditor', () => {
     const unapproved = { ...manualLine, id: 'line-u', isUnapprovedTime: true };
     render(<InvoiceEditor detail={draft([unapproved])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-unapproved-warning')).toBeInTheDocument());
-  });
-
-  it('Issue & Send shows a success toast when the email was dispatched (emailed:true)', async () => {
-    const onChanged = vi.fn();
-    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
-      if (input.startsWith('/catalog')) return json({ data: [] });
-      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
-      if (input === '/invoices/inv-1/send' && opts?.method === 'POST') return json({ data: { invoice: { id: 'inv-1', status: 'sent' }, emailed: true } });
-      return json({ data: {} });
-    });
-    render(<InvoiceEditor detail={draft([manualLine])} onChanged={onChanged} />);
-    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
-
-    fireEvent.click(screen.getByTestId('invoice-issue-send'));
-    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
-    await waitFor(() => expect(onChanged).toHaveBeenCalled());
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Invoice issued and sent' }));
-  });
-
-  it('shows an "Issuing…" label on the Issue button while the mutation is in flight (#1418)', async () => {
-    let resolveIssue: (r: Response) => void = () => {};
-    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
-      if (input.startsWith('/catalog')) return json({ data: [] });
-      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') {
-        return new Promise<Response>((res) => { resolveIssue = res; });
-      }
-      return json({ data: {} });
-    });
-    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
-    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
-
-    fireEvent.click(screen.getByTestId('invoice-issue'));
-
-    // In flight: button is disabled AND relabelled so it never reads as a stuck "Issue".
-    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issuing…'));
-    expect(screen.getByTestId('invoice-issue')).toBeDisabled();
-
-    resolveIssue(json({ data: { id: 'inv-1', status: 'sent' } }));
-    await waitFor(() => expect(screen.getByTestId('invoice-issue')).toHaveTextContent('Issue'));
-  });
-
-  it('Issue & Send shows a WARNING toast (not error) when nothing was emailed (emailed:false)', async () => {
-    const onChanged = vi.fn();
-    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
-      if (input.startsWith('/catalog')) return json({ data: [] });
-      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
-      if (input === '/invoices/inv-1/send' && opts?.method === 'POST') return json({ data: { invoice: { id: 'inv-1', status: 'sent' }, emailed: false, reason: 'no_billing_contact' } });
-      return json({ data: {} });
-    });
-    render(<InvoiceEditor detail={draft([manualLine])} onChanged={onChanged} />);
-    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
-
-    fireEvent.click(screen.getByTestId('invoice-issue-send'));
-    fireEvent.click(await screen.findByTestId('invoice-issue-send-confirm'));
-    await waitFor(() => expect(onChanged).toHaveBeenCalled());
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
-    // never a success "sent" claim when nothing went out
-    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Invoice issued and sent' }));
   });
 
   it('editing the T&C textarea and blurring issues PATCH /invoices/:id with { termsAndConditions }', async () => {

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -153,6 +153,100 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-unapproved-warning')).toBeInTheDocument());
   });
 
+  // ── Save-grammar parity backport (Task 6): scoped pending, commit guards,
+  //    dirty/saved cues, resync guard — ported from QuoteEditor. ─────────────
+
+  const patchCalls = (lineId: string) =>
+    fetchMock.mock.calls.filter(
+      (c) => c[0] === `/invoices/inv-1/lines/${lineId}` && (c[1] as RequestInit)?.method === 'PATCH',
+    );
+
+  it('qty blur with a non-numeric value does not PATCH and surfaces an error', async () => {
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const qty = screen.getByTestId('invoice-line-qty-line-1');
+    fireEvent.change(qty, { target: { value: 'abc' } });
+    fireEvent.blur(qty);
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })),
+    );
+    expect(patchCalls('line-1')).toHaveLength(0);
+  });
+
+  it('qty blur with a non-positive value is rejected without a PATCH', async () => {
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const qty = screen.getByTestId('invoice-line-qty-line-1');
+    fireEvent.change(qty, { target: { value: '-1' } });
+    fireEvent.blur(qty);
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', message: expect.stringContaining('greater than 0') }),
+      ),
+    );
+    expect(patchCalls('line-1')).toHaveLength(0);
+  });
+
+  it('re-typing the same price in a different format ("3.00" over "3") fires no PATCH', async () => {
+    const priced = { ...manualLine, unitPrice: '3.00', lineTotal: '6.00' };
+    render(<InvoiceEditor detail={draft([priced])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const price = screen.getByTestId('invoice-line-price-line-1');
+    fireEvent.change(price, { target: { value: '3' } }); // numerically identical to 3.00
+    fireEvent.blur(price);
+
+    // Give any (erroneous) async PATCH a chance to fire before asserting none did.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(patchCalls('line-1')).toHaveLength(0);
+  });
+
+  it('an in-flight PATCH on one line does not disable another line', async () => {
+    const l1 = { ...manualLine, id: 'line-1' };
+    const l2 = { ...manualLine, id: 'line-2', description: 'Other' };
+    // Hold the PATCH open so line-1's save stays in flight while we inspect line-2.
+    let releasePatch: (v: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1/lines/line-1' && opts?.method === 'PATCH') {
+        return new Promise<Response>((resolve) => { releasePatch = resolve; });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([l1, l2])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const qty1 = screen.getByTestId('invoice-line-qty-line-1');
+    fireEvent.change(qty1, { target: { value: '9' } });
+    fireEvent.blur(qty1);
+
+    // line-1's save is in flight; line-2's inputs must remain usable.
+    await waitFor(() => expect(patchCalls('line-1')).toHaveLength(1));
+    expect(screen.getByTestId('invoice-line-qty-line-2')).not.toBeDisabled();
+    expect(screen.getByTestId('invoice-line-price-line-2')).not.toBeDisabled();
+
+    releasePatch(json({ data: {} }));
+  });
+
+  it('a background refresh does not clobber a qty field being edited', async () => {
+    const { rerender } = render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const qty = screen.getByTestId('invoice-line-qty-line-1');
+    fireEvent.change(qty, { target: { value: '9' } }); // mid-edit, not yet blurred
+
+    // A background poll re-supplies the invoice prop with a different server qty.
+    const serverEcho = { ...manualLine, quantity: '5.00', lineTotal: '250.00' };
+    rerender(<InvoiceEditor detail={draft([serverEcho])} onChanged={vi.fn()} />);
+
+    // The user's in-progress "9" survives the resync.
+    expect(screen.getByTestId('invoice-line-qty-line-1')).toHaveValue(9);
+  });
+
   it('editing the T&C textarea and blurring issues PATCH /invoices/:id with { termsAndConditions }', async () => {
     const onChanged = vi.fn();
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -3,8 +3,6 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
-import { showToast } from '../shared/Toast';
-import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { UnsavedBadge, MarginPanel } from './billingUi';
 import {
   type InvoiceDetail,
@@ -37,13 +35,6 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
   const [busy, setBusy] = useState(false);
-  // Distinct from `busy` (which any line edit sets) so the Issue buttons can show
-  // an unambiguous in-flight label. Without it the disabled-but-still-"Issue"
-  // button + still-"Draft" header during the POST reads as "done but stuck" (#1418).
-  const [issuing, setIssuing] = useState(false);
-  // Issue-and-send emails the customer and can't be undone, so it goes through a
-  // confirm step (plain Issue stays direct — it's reversible via Void).
-  const [issueSendOpen, setIssueSendOpen] = useState(false);
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
   const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
@@ -214,47 +205,6 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
     }
   }, [busy, termsDirty, terms, invoice.id, refresh]);
 
-  const issue = useCallback(async (alsoSend: boolean) => {
-    if (busy) return;
-    setBusy(true);
-    setIssuing(true);
-    try {
-      // Issue first; on success optionally send.
-      await runAction({
-        request: () => fetchWithAuth(`/invoices/${invoice.id}/issue`, { method: 'POST' }),
-        errorFallback: 'Could not issue invoice.',
-        successMessage: alsoSend ? undefined : 'Invoice issued',
-        onUnauthorized: UNAUTHORIZED,
-      });
-      if (alsoSend) {
-        // /send is honest about whether an email actually went out. The invoice
-        // is issued either way; only claim "sent" when an email was dispatched,
-        // otherwise warn so the operator knows nothing was emailed. We suppress
-        // runAction's own success toast and post-process the result ourselves.
-        const result = await runAction<{ data: { emailed: boolean } }>({
-          request: () => fetchWithAuth(`/invoices/${invoice.id}/send`, { method: 'POST' }),
-          errorFallback: 'Invoice issued, but sending failed.',
-          onUnauthorized: UNAUTHORIZED,
-        });
-        if (result?.data?.emailed) {
-          showToast({ type: 'success', message: 'Invoice issued and sent' });
-        } else {
-          showToast({ type: 'warning', message: 'Invoice issued — but no email was sent (no billing contact / email not configured)' });
-        }
-      }
-    } catch (err) {
-      handleActionError(err, 'Could not issue invoice.');
-    } finally {
-      // Always refresh: if issue succeeded but send threw, we still need to leave
-      // the draft editor so a second click doesn't re-issue and hit 409 NOT_A_DRAFT.
-      refresh();
-      setIssuing(false);
-      setBusy(false);
-      setIssueSendOpen(false);
-    }
-  }, [busy, invoice.id, refresh]);
-
-  const hasVisibleLines = lines.some((l) => l.customerVisible);
   // Tax rate is inherited from partner Billing settings, not set per invoice. When
   // a line is marked taxable but no rate is configured, the Tax row reads $0.00
   // with no obvious cause — point the operator at where the rate actually lives.
@@ -493,49 +443,11 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
             />
           </div>
 
-          <div className="space-y-2">
-            {can('invoices', 'send') && (
-              <button
-                type="button"
-                onClick={() => void issue(false)}
-                disabled={busy || !hasVisibleLines}
-                data-testid="invoice-issue"
-                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                {issuing ? 'Issuing…' : 'Issue'}
-              </button>
-            )}
-            {can('invoices', 'send') && (
-              <button
-                type="button"
-                onClick={() => setIssueSendOpen(true)}
-                disabled={busy || !hasVisibleLines}
-                data-testid="invoice-issue-send"
-                className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-              >
-                {issuing ? 'Issuing…' : 'Issue & Send'}
-              </button>
-            )}
-            {!hasVisibleLines && (
-              <p className="text-center text-xs text-muted-foreground" data-testid="invoice-no-visible-hint">
-                Add at least one customer-visible line to issue.
-              </p>
-            )}
-          </div>
+          {/* Issue / Issue & Send / Download PDF / Delete draft live in the
+              workspace header (InvoiceActions) so they're reachable from any tab
+              — mirrors the quote editor, which carries no Send button of its own. */}
         </div>
       </div>
-
-      <ConfirmDialog
-        open={issueSendOpen}
-        onClose={() => setIssueSendOpen(false)}
-        onConfirm={() => void issue(true)}
-        isLoading={issuing}
-        variant="warning"
-        title="Issue and send this invoice?"
-        message={`This issues the invoice and emails it to ${invoice.billToName ?? 'the customer'} for ${formatMoney(invoice.total, currency)}. This can't be undone.`}
-        confirmLabel="Issue & Send"
-        confirmTestId="invoice-issue-send-confirm"
-      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -24,6 +24,39 @@ interface Props {
 
 type AddMode = 'catalog' | 'manual';
 
+// ── Save-grammar helpers (byte-similar local copies of QuoteEditor's — kept
+//    inline per CLAUDE.md; a later pass may extract them to shared/). ─────────
+
+// A transient "Saved" cue for a blur-to-save field. Returns the on-flag (drives
+// the SR live region + green ring) and a trigger; clears its timer on unmount so
+// a late fire can't setState a gone node.
+function useSavedFlash(): [boolean, () => void] {
+  const [on, setOn] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const flash = useCallback(() => {
+    setOn(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setOn(false), 1500);
+  }, []);
+  return [on, flash];
+}
+
+// Visually-hidden polite live region — announces a transient "Saved" to screen
+// readers, pairing with the dirty-ring clearing that sighted users see. The
+// single per-field announcer (no toast) so SR users hear "Saved" once.
+function SrSaved({ show, label = 'Saved', testId }: { show: boolean; label?: string; testId?: string }) {
+  // role="status" already implies aria-live="polite" — don't double it.
+  return <span role="status" className="sr-only" data-testid={testId}>{show ? label : ''}</span>;
+}
+
+// A field's save-state outline: amber while unsaved, a brief green pulse when it
+// lands, nothing at rest. It's a box-shadow (ring), so it never reflows
+// neighbours. Pair with a constant `transition-shadow` on the field.
+function fieldRing(dirty: boolean, saved: boolean): string {
+  return dirty ? 'ring-1 ring-warning' : saved ? 'ring-1 ring-success' : '';
+}
+
 export default function InvoiceEditor({ detail, onChanged }: Props) {
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
@@ -34,11 +67,43 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const currency = invoice.currencyCode;
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
-  const [busy, setBusy] = useState(false);
+  // Per-item "saving" state, keyed so one in-flight mutation never freezes the
+  // rest of the editor. Keys: 'notes', 'terms', 'addLine', `qty-<lineId>`,
+  // `price-<lineId>`, `name-<lineId>`, `desc-<lineId>`, `taxable-<lineId>`,
+  // `visible-<lineId>`, `remove-<lineId>`. `pending` drives disabled styling;
+  // `inFlight` is the synchronous double-submit guard (state updates are async).
+  const inFlight = useRef<Set<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
+  const isPending = useCallback((key: string) => pending.has(key), [pending]);
+
+  // Run a scoped mutation: mark the key pending, run, surface failures via the
+  // standard handleActionError path, and always clear the key. Returns whether
+  // the mutation succeeded so callers can flash a quiet "Saved" cue.
+  const runScoped = useCallback(
+    async (key: string, fn: () => Promise<void>, errMsg: string): Promise<boolean> => {
+      if (inFlight.current.has(key)) return false;
+      inFlight.current.add(key);
+      setPending((s) => { const n = new Set(s); n.add(key); return n; });
+      try {
+        await fn();
+        return true;
+      } catch (err) {
+        handleActionError(err, errMsg);
+        return false;
+      } finally {
+        inFlight.current.delete(key);
+        setPending((s) => { const n = new Set(s); n.delete(key); return n; });
+      }
+    },
+    [],
+  );
+
   const [notes, setNotes] = useState(invoice.notes ?? '');
   const [notesDirty, setNotesDirty] = useState(false);
+  const [notesSaved, flashNotesSaved] = useSavedFlash();
   const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
   const [termsDirty, setTermsDirty] = useState(false);
+  const [termsSaved, flashTermsSaved] = useSavedFlash();
 
   // Add-line form
   const [addMode, setAddMode] = useState<AddMode>('catalog');
@@ -79,21 +144,31 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
 
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
-  const addLine = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const addLine = useCallback(() =>
+    runScoped('addLine', async () => {
       if (addMode === 'manual') {
         // A line needs at least a title (name) or a description (mirrors the API refine).
         if (!manualName.trim() && !manualDesc.trim()) return;
+        // Guard qty/price with the same rules as the inline commit path so a bad
+        // manual entry is explained, not silently coerced (Number('abc') → NaN).
+        const q = Number(manualQty);
+        const p = Number(manualPrice);
+        if (!Number.isFinite(q) || q <= 0) {
+          handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+          return;
+        }
+        if (!Number.isFinite(p) || p < 0) {
+          handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+          return;
+        }
         await runAction({
           request: () => fetchWithAuth(`/invoices/${invoice.id}/lines`, {
             method: 'POST',
             body: JSON.stringify({
               name: manualName.trim() || null,
               description: manualDesc.trim() || null,
-              quantity: Number(manualQty),
-              unitPrice: Number(manualPrice),
+              quantity: q,
+              unitPrice: p,
               taxable: manualTaxable,
             }),
           }),
@@ -104,12 +179,17 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         setManualName(''); setManualDesc(''); setManualQty('1'); setManualPrice('0.00'); setManualTaxable(false);
       } else {
         if (!picked) return;
+        const pq = Number(pickQty);
+        if (!Number.isFinite(pq) || pq <= 0) {
+          handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+          return;
+        }
         const path = picked.isBundle
           ? `/invoices/${invoice.id}/lines/bundle`
           : `/invoices/${invoice.id}/lines/catalog`;
         const body = picked.isBundle
-          ? { bundleId: picked.id, quantity: Number(pickQty) }
-          : { catalogItemId: picked.id, quantity: Number(pickQty) };
+          ? { bundleId: picked.id, quantity: pq }
+          : { catalogItemId: picked.id, quantity: pq };
         await runAction({
           request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify(body) }),
           errorFallback: 'Could not add line.',
@@ -119,17 +199,14 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         setPicked(null); setPickQty('1');
       }
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not add line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, addMode, manualName, manualDesc, manualQty, manualPrice, manualTaxable, picked, pickQty, invoice.id, refresh]);
+    }, 'Could not add line.'),
+  [runScoped, addMode, manualName, manualDesc, manualQty, manualPrice, manualTaxable, picked, pickQty, invoice.id, refresh]);
 
-  const patchLine = useCallback(async (lineId: string, patch: Record<string, unknown>) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  // Inline edit of an existing line. `scopeKey` is per-field so one in-flight
+  // save (e.g. qty) never disables the sibling controls. Returns whether it
+  // succeeded so the row can flash a quiet "Saved" cue.
+  const patchLine = useCallback((lineId: string, patch: Record<string, unknown>, scopeKey: string) =>
+    runScoped(scopeKey, async () => {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}/lines/${lineId}`, {
           method: 'PATCH', body: JSON.stringify(patch),
@@ -138,17 +215,11 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not update line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, refresh]);
+    }, 'Could not update line.'),
+  [runScoped, invoice.id, refresh]);
 
-  const removeLine = useCallback(async (lineId: string) => {
-    if (busy) return;
-    setBusy(true);
-    try {
+  const removeLine = useCallback((lineId: string) =>
+    runScoped(`remove-${lineId}`, async () => {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}/lines/${lineId}`, { method: 'DELETE' }),
         errorFallback: 'Could not remove line.',
@@ -156,17 +227,12 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, refresh]);
+    }, 'Could not remove line.'),
+  [runScoped, invoice.id, refresh]);
 
   const saveNotes = useCallback(async () => {
-    if (busy || !notesDirty) return;
-    setBusy(true);
-    try {
+    if (!notesDirty) return;
+    const ok = await runScoped('notes', async () => {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}`, {
           method: 'PATCH', body: JSON.stringify({ notes }),
@@ -177,17 +243,13 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       });
       setNotesDirty(false);
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save notes.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, notesDirty, notes, invoice.id, refresh]);
+    }, 'Could not save notes.');
+    if (ok) flashNotesSaved();
+  }, [notesDirty, notes, invoice.id, refresh, runScoped, flashNotesSaved]);
 
   const saveTerms = useCallback(async () => {
-    if (busy || !termsDirty) return;
-    setBusy(true);
-    try {
+    if (!termsDirty) return;
+    const ok = await runScoped('terms', async () => {
       await runAction({
         request: () => fetchWithAuth(`/invoices/${invoice.id}`, {
           method: 'PATCH', body: JSON.stringify({ termsAndConditions: terms }),
@@ -198,12 +260,9 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       });
       setTermsDirty(false);
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save terms.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, termsDirty, terms, invoice.id, refresh]);
+    }, 'Could not save terms.');
+    if (ok) flashTermsSaved();
+  }, [termsDirty, terms, invoice.id, refresh, runScoped, flashTermsSaved]);
 
   // Tax rate is inherited from partner Billing settings, not set per invoice. When
   // a line is marked taxable but no rate is configured, the Tax row reads $0.00
@@ -252,7 +311,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                       line={l}
                       children={childrenOf(l.id)}
                       currency={currency}
-                      disabled={busy}
+                      isPending={isPending}
                       onPatch={patchLine}
                       onRemove={removeLine}
                     />
@@ -325,7 +384,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                   Taxable
                 </label>
                 <button
-                  type="button" onClick={() => void addLine()} disabled={busy || (!manualName.trim() && !manualDesc.trim())}
+                  type="button" onClick={() => void addLine()} disabled={isPending('addLine') || (!manualName.trim() && !manualDesc.trim())}
                   data-testid="invoice-add-line-submit"
                   className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
@@ -349,7 +408,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                   className="h-9 w-20 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
                 <button
-                  type="button" onClick={() => void addLine()} disabled={busy}
+                  type="button" onClick={() => void addLine()} disabled={isPending('addLine')}
                   data-testid="invoice-catalog-add"
                   className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                 >
@@ -421,7 +480,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-notes"
               rows={3}
-              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${notesDirty ? 'ring-1 ring-warning' : ''}`}
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(notesDirty, notesSaved)}`}
               placeholder="Internal or customer notes…"
             />
           </div>
@@ -438,7 +497,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite}
               data-testid="invoice-terms"
               rows={3}
-              className={`w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${termsDirty ? 'ring-1 ring-warning' : ''}`}
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}
               placeholder="Payment terms, warranty clauses, etc."
             />
           </div>
@@ -453,26 +512,39 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
 }
 
 function LineRow({
-  line, children, currency, disabled, onPatch, onRemove,
+  line, children, currency, isPending, onPatch, onRemove,
 }: {
   line: InvoiceLine;
   children: InvoiceLine[];
   currency: string;
-  disabled: boolean;
-  onPatch: (lineId: string, patch: Record<string, unknown>) => void;
+  isPending: (key: string) => boolean;
+  onPatch: (lineId: string, patch: Record<string, unknown>, scopeKey: string) => Promise<boolean>;
   onRemove: (lineId: string) => void;
 }) {
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
-  const editDisabled = disabled || !canWrite;
+  // Per-field pending: only the in-flight control disables, so a slow qty save
+  // never freezes price/name/desc or a sibling line (scoped-pending backport).
+  const nameKey = `name-${line.id}`;
+  const descKey = `desc-${line.id}`;
+  const qtyKey = `qty-${line.id}`;
+  const priceKey = `price-${line.id}`;
+  const taxableKey = `taxable-${line.id}`;
+  const visibleKey = `visible-${line.id}`;
+  const removeKey = `remove-${line.id}`;
   const [name, setName] = useState(line.name ?? '');
   const [desc, setDesc] = useState(line.description ?? '');
   const [qty, setQty] = useState(line.quantity);
   const [price, setPrice] = useState(line.unitPrice);
-  // Guard an in-progress name/description edit from being clobbered by a server
-  // resync mid-type (mirrors the quote editor's EditableLineRow pattern).
+  // Guard an in-progress edit from being clobbered by a server resync mid-type:
+  // the flag is set on keystroke and cleared when a commit is initiated (on
+  // blur), so a background refresh landing mid-edit keeps the user's keystrokes
+  // while a settled field re-adopts the server's canonical value (mirrors the
+  // quote editor's EditableLineRow pattern).
   const nameEdited = useRef(false);
   const descEdited = useRef(false);
+  const qtyEdited = useRef(false);
+  const priceEdited = useRef(false);
   // Auto-grow the (full-width) description textarea to fit its content, while
   // still letting the user drag the resize handle for a bigger/smaller box.
   const descRef = useRef<HTMLTextAreaElement>(null);
@@ -485,7 +557,31 @@ function LineRow({
   useEffect(() => { if (!nameEdited.current) setName(line.name ?? ''); }, [line.name]);
   useEffect(() => { if (!descEdited.current) setDesc(line.description ?? ''); }, [line.description]);
   useEffect(() => { autoGrowDesc(); }, [desc]);
-  useEffect(() => { setQty(line.quantity); setPrice(line.unitPrice); }, [line.quantity, line.unitPrice]);
+  useEffect(() => { if (!qtyEdited.current) setQty(line.quantity); }, [line.quantity]);
+  useEffect(() => { if (!priceEdited.current) setPrice(line.unitPrice); }, [line.unitPrice]);
+
+  // Quiet row-level "Saved" flash in place of a per-field success toast:
+  // committing any one field briefly pulses the green ring across the row.
+  const [saved, setSaved] = useState(false);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedTimer.current) clearTimeout(savedTimer.current); }, []);
+  const flashSaved = useCallback(() => {
+    setSaved(true);
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+    savedTimer.current = setTimeout(() => setSaved(false), 1500);
+  }, []);
+  const edit = useCallback(async (patch: Record<string, unknown>, key: string): Promise<boolean> => {
+    const ok = await onPatch(line.id, patch, key);
+    if (ok) flashSaved();
+    return ok;
+  }, [onPatch, line.id, flashSaved]);
+
+  // Per-field dirty cue (numeric compare for qty/price so re-typing "3.00" over
+  // "3" reads as clean, not dirty).
+  const nameDirty = name.trim() !== (line.name ?? '');
+  const descDirty = desc.trim() !== (line.description ?? '');
+  const qtyDirty = Number(qty) !== Number(line.quantity);
+  const priceDirty = Number(price) !== Number(line.unitPrice);
 
   const commitName = () => {
     if (!canWrite) return;
@@ -498,7 +594,7 @@ function LineRow({
       setName(line.name ?? '');
       return;
     }
-    onPatch(line.id, { name: next || null });
+    void edit({ name: next || null }, nameKey);
   };
   const commitDesc = () => {
     if (!canWrite) return;
@@ -510,7 +606,32 @@ function LineRow({
       setDesc(line.description ?? '');
       return;
     }
-    onPatch(line.id, { description: next || null });
+    void edit({ description: next || null }, descKey);
+  };
+  const commitQty = () => {
+    if (!canWrite) return;
+    const n = Number(qty);
+    qtyEdited.current = false;
+    if (n === Number(line.quantity)) { setQty(line.quantity); return; } // unchanged — silent (numeric compare)
+    // A rejected entry no longer snaps back silently: tell the user why before reverting.
+    if (!Number.isFinite(n) || n <= 0) {
+      handleActionError(new Error('invalid quantity'), 'Enter a quantity greater than 0.');
+      setQty(line.quantity);
+      return;
+    }
+    void edit({ quantity: n }, qtyKey);
+  };
+  const commitPrice = () => {
+    if (!canWrite) return;
+    const n = Number(price);
+    priceEdited.current = false;
+    if (n === Number(line.unitPrice)) { setPrice(line.unitPrice); return; } // unchanged — silent (numeric compare)
+    if (!Number.isFinite(n) || n < 0) {
+      handleActionError(new Error('invalid price'), 'Enter a unit price of 0 or more.');
+      setPrice(line.unitPrice);
+      return;
+    }
+    void edit({ unitPrice: n }, priceKey);
   };
 
   return (
@@ -518,51 +639,56 @@ function LineRow({
       <tr className="border-t" data-testid={`invoice-line-${line.id}`}>
         <td className="px-3 py-2">
           <input
-            type="text" value={name} disabled={editDisabled}
+            type="text" value={name} disabled={!canWrite || isPending(nameKey)}
             aria-label="Line name" placeholder="Name"
             onChange={(e) => { setName(e.target.value); nameEdited.current = true; }}
             onBlur={commitName}
             data-testid={`invoice-line-name-${line.id}`}
-            className="h-8 w-full rounded-md border bg-background px-2 text-sm font-medium focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            className={`h-8 w-full rounded-md border bg-background px-2 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
           />
         </td>
         <td className="px-3 py-2 text-right">
           <input
-            type="number" min="0" step="0.01" value={qty} disabled={editDisabled}
-            onChange={(e) => setQty(e.target.value)}
-            onBlur={() => { if (canWrite && qty !== line.quantity) onPatch(line.id, { quantity: Number(qty) }); }}
+            type="number" min="0" step="0.01" value={qty} disabled={!canWrite || isPending(qtyKey)}
+            aria-label="Quantity"
+            onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; }}
+            onBlur={commitQty}
             data-testid={`invoice-line-qty-${line.id}`}
-            className="h-8 w-20 rounded-md border bg-background px-2 text-right text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+            className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(qtyDirty, saved)}`}
           />
         </td>
         <td className="px-3 py-2 text-right">
           <input
-            type="number" min="0" step="0.01" value={price} disabled={editDisabled}
-            onChange={(e) => setPrice(e.target.value)}
-            onBlur={() => { if (canWrite && price !== line.unitPrice) onPatch(line.id, { unitPrice: Number(price) }); }}
+            type="number" min="0" step="0.01" value={price} disabled={!canWrite || isPending(priceKey)}
+            aria-label="Unit price"
+            onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; }}
+            onBlur={commitPrice}
             data-testid={`invoice-line-price-${line.id}`}
-            className="h-8 w-24 rounded-md border bg-background px-2 text-right text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+            className={`h-8 w-24 rounded-md border bg-background px-2 text-right text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(priceDirty, saved)}`}
           />
         </td>
         <td className="px-3 py-2 text-center">
           <input
-            type="checkbox" checked={line.taxable} disabled={editDisabled}
-            onChange={(e) => onPatch(line.id, { taxable: e.target.checked })}
+            type="checkbox" checked={line.taxable} disabled={!canWrite || isPending(taxableKey)}
+            onChange={(e) => void edit({ taxable: e.target.checked }, taxableKey)}
             data-testid={`invoice-line-taxable-${line.id}`}
           />
         </td>
         <td className="px-3 py-2 text-center">
           <input
-            type="checkbox" checked={line.customerVisible} disabled={editDisabled}
-            onChange={(e) => onPatch(line.id, { customerVisible: e.target.checked })}
+            type="checkbox" checked={line.customerVisible} disabled={!canWrite || isPending(visibleKey)}
+            onChange={(e) => void edit({ customerVisible: e.target.checked }, visibleKey)}
             data-testid={`invoice-line-visible-${line.id}`}
           />
         </td>
-        <td className="px-3 py-2 text-right">{formatMoney(line.lineTotal, currency)}</td>
+        <td className="px-3 py-2 text-right">
+          {formatMoney(line.lineTotal, currency)}
+          <SrSaved show={saved} testId={`invoice-line-saved-${line.id}`} />
+        </td>
         <td className="px-3 py-2 text-right">
           {canWrite && (
             <button
-              type="button" onClick={() => onRemove(line.id)} disabled={disabled}
+              type="button" onClick={() => onRemove(line.id)} disabled={isPending(removeKey)}
               data-testid={`invoice-line-remove-${line.id}`}
               className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
             >
@@ -578,14 +704,14 @@ function LineRow({
           <textarea
             ref={descRef}
             value={desc}
-            disabled={editDisabled}
+            disabled={!canWrite || isPending(descKey)}
             aria-label="Line description"
             placeholder="Description (optional)"
             onChange={(e) => { setDesc(e.target.value); descEdited.current = true; autoGrowDesc(); }}
             onBlur={commitDesc}
             rows={2}
             data-testid={`invoice-line-desc-${line.id}`}
-            className="min-h-8 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+            className={`min-h-8 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(descDirty, saved)}`}
           />
         </td>
       </tr>

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -1,16 +1,20 @@
-import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { usePermissions } from '../../lib/permissions';
+import { DocumentWorkspace, type DocumentTab } from './shared/DocumentWorkspace';
+import { StatusPill } from './shared/StatusPill';
+import { usePdfDownload } from './shared/usePdfDownload';
 import InvoiceEditor from './InvoiceEditor';
 import InvoiceDetail from './InvoiceDetail';
 import InvoiceDocumentPreview from './InvoiceDocument';
-import { type InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+import { type InvoiceDetail as InvoiceDetailData, STATUS_ROLES, statusLabel } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 type Tab = 'editor' | 'preview' | 'detail';
 
-const TABS: { value: Tab; label: string }[] = [
+const TAB_LABELS: { value: Tab; label: string }[] = [
   { value: 'editor', label: 'Editor' },
   { value: 'preview', label: 'Preview' },
   { value: 'detail', label: 'Detail' },
@@ -23,15 +27,28 @@ interface Props {
 function readTab(isDraft: boolean): Tab {
   if (typeof window === 'undefined') return isDraft ? 'editor' : 'detail';
   const raw = window.location.hash.replace(/^#/, '');
-  if (TABS.some((t) => t.value === raw)) return raw as Tab;
+  if (TAB_LABELS.some((t) => t.value === raw)) return raw as Tab;
   return isDraft ? 'editor' : 'detail';
 }
 
 export default function InvoiceWorkspace({ invoiceId }: Props) {
+  const { can } = usePermissions();
   const [detail, setDetail] = useState<InvoiceDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
+
+  const invoice = detail?.invoice;
+  // Download PDF is the one primary action liftable to the header for free: it's a
+  // stateless authed-fetch hook, so both the draft editor tab and the read-only
+  // detail tab can reach it without duplicating a stateful confirm flow. (Issue /
+  // Issue & Send / Delete carry runAction + ConfirmDialog state that lives in
+  // InvoiceEditor / InvoiceDetail and stays there.)
+  const { download: downloadPdf, downloading } = usePdfDownload({
+    path: `/invoices/${invoiceId}/pdf`,
+    filename: `${invoice?.invoiceNumber ?? `invoice-${invoiceId}`}.pdf`,
+    errorMessage: 'Could not download the invoice PDF.',
+  });
 
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
   // so the editor stays mounted — a full-page spinner would remount the form and
@@ -76,28 +93,10 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     return () => window.removeEventListener('hashchange', onHash);
   }, [detail]);
 
-  const selectTab = useCallback((next: Tab) => {
-    setTab(next);
+  const selectTab = useCallback((next: string) => {
+    setTab(next as Tab);
     if (typeof window !== 'undefined') window.location.hash = `#${next}`;
   }, []);
-
-  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
-  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
-  // tab is both activated and focused.
-  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
-    const idx = tabs.findIndex((t) => t.value === current);
-    if (idx < 0) return;
-    let nextIdx: number | null = null;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
-    else if (e.key === 'Home') nextIdx = 0;
-    else if (e.key === 'End') nextIdx = tabs.length - 1;
-    if (nextIdx === null) return;
-    e.preventDefault();
-    const next = tabs[nextIdx].value;
-    selectTab(next);
-    if (typeof document !== 'undefined') document.getElementById(`invoice-tab-${next}`)?.focus();
-  }, [selectTab]);
 
   if (loading) {
     return (
@@ -123,66 +122,58 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
   // The Editor only applies to drafts, so it's hidden once an invoice is issued —
   // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
   // on a non-draft falls back to Detail.
-  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
-  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
+  const tabs: DocumentTab[] = TAB_LABELS.map((t) => ({
+    id: t.value,
+    label: t.label,
+    hidden: t.value === 'editor' && !isDraft,
+  }));
+  const activeTab: Tab = tabs.some((t) => t.id === tab && !t.hidden) ? tab : 'detail';
+
+  const roles = STATUS_ROLES[detail.invoice.status];
+  const statusPill = (
+    <StatusPill
+      role={roles.role}
+      label={statusLabel(detail.invoice)}
+      className={roles.className ? `${roles.className} shrink-0` : 'shrink-0'}
+      testId="invoice-workspace-status"
+    />
+  );
+
+  // Download PDF is surfaced from any tab; the Detail tab suppresses its own copy
+  // (actionsInHeader) so the two don't render at once.
+  const actions = can('invoices', 'export') ? (
+    <button
+      type="button"
+      onClick={() => void downloadPdf()}
+      disabled={downloading}
+      data-testid="invoice-download-pdf"
+      className="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+    >
+      {downloading ? 'Preparing…' : 'Download PDF'}
+    </button>
+  ) : undefined;
 
   return (
-    <div className="space-y-4" data-testid="invoice-workspace">
-      <div className="flex items-center justify-between">
-        <div>
-          <a href="/billing/invoices" className="text-xs text-muted-foreground hover:underline">← Invoices</a>
-          <h1 className="text-xl font-semibold" data-testid="invoice-workspace-title">
-            {detail.invoice.invoiceNumber ?? 'Draft invoice'}
-          </h1>
-        </div>
-      </div>
-
-      {/* Tabs */}
-      <div
-        className="flex gap-1 border-b"
-        role="tablist"
-        data-testid="invoice-workspace-tabs"
-        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
-      >
-        {visibleTabs.map((t) => (
-          <button
-            key={t.value}
-            type="button"
-            role="tab"
-            id={`invoice-tab-${t.value}`}
-            aria-selected={activeTab === t.value}
-            aria-controls={`invoice-tabpanel-${t.value}`}
-            tabIndex={activeTab === t.value ? 0 : -1}
-            onClick={() => selectTab(t.value)}
-            data-testid={`invoice-tab-${t.value}`}
-            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
-              activeTab === t.value
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
+    <DocumentWorkspace
+      idPrefix="invoice"
+      backHref="/billing/invoices"
+      backLabel="Invoices"
+      title={detail.invoice.invoiceNumber ?? 'Draft invoice'}
+      statusPill={statusPill}
+      actions={actions}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={selectTab}
+    >
       {activeTab === 'editor' && isDraft && (
-        <div role="tabpanel" id="invoice-tabpanel-editor" aria-labelledby="invoice-tab-editor" tabIndex={0}>
-          <InvoiceEditor detail={detail} onChanged={() => void reload()} />
-        </div>
+        <InvoiceEditor detail={detail} onChanged={() => void reload()} />
       )}
-
       {activeTab === 'preview' && (
-        <div role="tabpanel" id="invoice-tabpanel-preview" aria-labelledby="invoice-tab-preview" tabIndex={0}>
-          <InvoiceDocumentPreview detail={detail} />
-        </div>
+        <InvoiceDocumentPreview detail={detail} />
       )}
-
       {activeTab === 'detail' && (
-        <div role="tabpanel" id="invoice-tabpanel-detail" aria-labelledby="invoice-tab-detail" tabIndex={0}>
-          <InvoiceDetail detail={detail} onChanged={() => void reload()} />
-        </div>
+        <InvoiceDetail detail={detail} onChanged={() => void reload()} actionsInHeader />
       )}
-    </div>
+    </DocumentWorkspace>
   );
 }

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { usePermissions } from '../../lib/permissions';
 import { DocumentWorkspace, type DocumentTab } from './shared/DocumentWorkspace';
 import { StatusPill } from './shared/StatusPill';
-import { usePdfDownload } from './shared/usePdfDownload';
 import InvoiceEditor from './InvoiceEditor';
 import InvoiceDetail from './InvoiceDetail';
 import InvoiceDocumentPreview from './InvoiceDocument';
+import InvoiceActions from './InvoiceActions';
 import { type InvoiceDetail as InvoiceDetailData, STATUS_ROLES, statusLabel } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -32,23 +31,10 @@ function readTab(isDraft: boolean): Tab {
 }
 
 export default function InvoiceWorkspace({ invoiceId }: Props) {
-  const { can } = usePermissions();
   const [detail, setDetail] = useState<InvoiceDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
-
-  const invoice = detail?.invoice;
-  // Download PDF is the one primary action liftable to the header for free: it's a
-  // stateless authed-fetch hook, so both the draft editor tab and the read-only
-  // detail tab can reach it without duplicating a stateful confirm flow. (Issue /
-  // Issue & Send / Delete carry runAction + ConfirmDialog state that lives in
-  // InvoiceEditor / InvoiceDetail and stays there.)
-  const { download: downloadPdf, downloading } = usePdfDownload({
-    path: `/invoices/${invoiceId}/pdf`,
-    filename: `${invoice?.invoiceNumber ?? `invoice-${invoiceId}`}.pdf`,
-    errorMessage: 'Could not download the invoice PDF.',
-  });
 
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
   // so the editor stays mounted — a full-page spinner would remount the form and
@@ -139,20 +125,6 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     />
   );
 
-  // Download PDF is surfaced from any tab; the Detail tab suppresses its own copy
-  // (actionsInHeader) so the two don't render at once.
-  const actions = can('invoices', 'export') ? (
-    <button
-      type="button"
-      onClick={() => void downloadPdf()}
-      disabled={downloading}
-      data-testid="invoice-download-pdf"
-      className="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-    >
-      {downloading ? 'Preparing…' : 'Download PDF'}
-    </button>
-  ) : undefined;
-
   return (
     <DocumentWorkspace
       idPrefix="invoice"
@@ -160,7 +132,11 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
       backLabel="Invoices"
       title={detail.invoice.invoiceNumber ?? 'Draft invoice'}
       statusPill={statusPill}
-      actions={actions}
+      // Primary actions live in the header so Issue / Issue & Send (the
+      // money-moment) and Download are reachable from any tab, not buried inside
+      // the Editor tab. The Detail tab suppresses its rail copy (actionsInHeader)
+      // so the two never render at once.
+      actions={<InvoiceActions detail={detail} onChanged={reload} variant="header" />}
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={selectTab}

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -89,9 +89,15 @@ describe('InvoicesPage', () => {
 
     // Clicking the link must not double-navigate via the row's onClick handler.
     const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    // Cancel the anchor's default action up front so jsdom doesn't attempt a real
+    // document navigation (unimplemented → console noise). Propagation behavior
+    // — the thing under test — is unaffected.
+    clickEvent.preventDefault();
     const stop = vi.spyOn(clickEvent, 'stopPropagation');
     link.dispatchEvent(clickEvent);
     expect(stop).toHaveBeenCalled();
+    // The row's onClick (SPA navigateTo) must not fire — the anchor navigates natively.
+    expect(navigateTo).not.toHaveBeenCalled();
   });
 
   it('writes filter selections to the URL hash', async () => {

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -106,6 +106,22 @@ describe('InvoicesPage', () => {
     expect(screen.queryByTestId('invoices-filters')).not.toBeInTheDocument();
   });
 
+  it('shows the filtered-empty state (not the teaching empty) when a filter returns nothing', async () => {
+    window.location.hash = '#status=void';
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/invoices')) return json({ data: [] });
+      return json({}, false, 404);
+    });
+    render(<InvoicesPage />);
+
+    await screen.findByTestId('invoices-filtered-empty');
+    // The first-run teaching empty must NOT be shown — that reads as data loss.
+    expect(screen.queryByTestId('invoices-empty')).not.toBeInTheDocument();
+    // The toolbar (and its existing Clear control) stays available while filtered.
+    expect(screen.getByTestId('invoices-filters-clear')).toBeInTheDocument();
+  });
+
   it('shows a Clear control once a filter is active and resets all filters', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -100,6 +100,22 @@ describe('InvoicesPage', () => {
     expect(navigateTo).not.toHaveBeenCalled();
   });
 
+  it('unnumbered draft rows show an em-dash link (no redundant DRAFT chip) with an accessible name', async () => {
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+
+    // inv-2 has invoiceNumber === null. The Status column already carries the Draft
+    // pill, so the Number column shows a plain em-dash rather than a second chip…
+    const link = screen.getByTestId('invoices-row-link-inv-2');
+    expect(link).toHaveTextContent('—');
+    expect(within(link).queryByText('Draft')).not.toBeInTheDocument();
+    // …but the link keeps an accessible name so it doesn't read as just a dash.
+    expect(link).toHaveAttribute('aria-label', 'Draft invoice');
+    // The Status column still communicates draft state.
+    expect(screen.getByTestId('invoices-status-inv-2')).toHaveTextContent('Draft');
+  });
+
   it('writes filter selections to the URL hash', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -138,6 +138,30 @@ describe('InvoicesPage', () => {
     expect(window.location.hash).toContain('status=draft');
   });
 
+  it('labels a single-currency Outstanding total from the OPEN subset, not rows[0]', async () => {
+    // rows[0] is a void EUR invoice (excluded from the open subset); every open
+    // invoice is USD. The strip must read $…, never €… — labeling the USD sum
+    // with rows[0]'s currency was the original mislabeling bug.
+    const mixed = [
+      {
+        ...INVOICES[0], id: 'inv-void', invoiceNumber: 'INV-VOID', status: 'void',
+        currencyCode: 'EUR', balance: '999.00', createdAt: '2026-06-02T00:00:00Z',
+      },
+      { ...INVOICES[0], id: 'inv-open', invoiceNumber: 'INV-OPEN', status: 'sent', currencyCode: 'USD', balance: '100.00' },
+    ];
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/invoices')) return json({ data: mixed });
+      return json({}, false, 404);
+    });
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-outstanding-strip')).toBeInTheDocument());
+
+    const strip = screen.getByTestId('invoices-outstanding-strip');
+    expect(strip).toHaveTextContent('$100.00');
+    expect(strip.textContent).not.toContain('€');
+  });
+
   it('hides the filter toolbar on a genuinely empty list', async () => {
     fetchMock.mockImplementation(async (input: string) => {
       if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -72,6 +72,28 @@ describe('InvoicesPage', () => {
     expect(row.querySelector('.bg-destructive')).not.toBeNull();
   });
 
+  it('exposes a focusable link to the invoice detail (desktop table + mobile card)', async () => {
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+
+    const link = screen.getByTestId('invoices-row-link-inv-1');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/billing/invoices/inv-1');
+    expect(link).toHaveTextContent('INV-0001');
+    expect(link.getAttribute('tabindex')).not.toBe('-1');
+
+    const cardLink = screen.getByTestId('invoices-card-link-inv-1');
+    expect(cardLink.tagName).toBe('A');
+    expect(cardLink).toHaveAttribute('href', '/billing/invoices/inv-1');
+
+    // Clicking the link must not double-navigate via the row's onClick handler.
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const stop = vi.spyOn(clickEvent, 'stopPropagation');
+    link.dispatchEvent(clickEvent);
+    expect(stop).toHaveBeenCalled();
+  });
+
   it('writes filter selections to the URL hash', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../lib/runAction';
@@ -9,6 +8,7 @@ import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from './bulk/useBulkSelection';
 import { BulkActionBar } from './bulk/BulkActionBar';
+import { SortableTh } from './shared/SortableTh';
 import { DataCard, CardField } from '../shared/ResponsiveTable';
 import AccessDenied from '../shared/AccessDenied';
 import {
@@ -309,35 +309,6 @@ export function InvoicesPage() {
   // affordance and whether the toolbar shows on an otherwise-empty list.
   const filtersActive = !!(filters.orgId || filters.status || filters.from || filters.to || search.trim());
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
-    const active = sort?.key === sortKey;
-    const ariaLabel = active
-      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
-      : `Sort by ${label}`;
-    return (
-      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-        <button
-          type="button"
-          onClick={() => toggleSort(sortKey)}
-          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-          data-testid={`invoices-sort-${sortKey}`}
-          aria-label={ariaLabel}
-        >
-          {label}
-          {active ? (
-            sort!.dir === 'asc' ? (
-              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-            )
-          ) : (
-            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-          )}
-        </button>
-      </th>
-    );
-  };
-
   if (forbidden) {
     return (
       <div className="space-y-5" data-testid="invoices-page">
@@ -534,10 +505,10 @@ export function InvoicesPage() {
                     </th>
                     <th className="px-3 py-3 font-medium">Number</th>
                     <th className="px-3 py-3 font-medium">Organization</th>
-                    <SortHeaderLeft label="Issued" sortKey="issued" sort={sort} onSort={toggleSort} />
-                    <SortHeaderLeft label="Due" sortKey="due" sort={sort} onSort={toggleSort} />
-                    <SortHeader label="Total" sortKey="total" />
-                    <SortHeader label="Balance" sortKey="balance" />
+                    <SortableTh label="Issued" sortKey="issued" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} testId="invoices-sort-issued" />
+                    <SortableTh label="Due" sortKey="due" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} testId="invoices-sort-due" />
+                    <SortableTh label="Total" sortKey="total" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} align="right" testId="invoices-sort-total" />
+                    <SortableTh label="Balance" sortKey="balance" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} align="right" testId="invoices-sort-balance" />
                     <th className="px-3 py-3 font-medium">Status</th>
                   </tr>
                 </thead>
@@ -824,38 +795,6 @@ export function InvoicesPage() {
   );
 }
 
-// Left-aligned sortable header (Issued/Due). Right-aligned headers use the inline
-// SortHeader defined in the component.
-function SortHeaderLeft({
-  label, sortKey, sort, onSort,
-}: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
-  const active = sort?.key === sortKey;
-  const ariaLabel = active
-    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
-    : `Sort by ${label}`;
-  return (
-    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-      <button
-        type="button"
-        onClick={() => onSort(sortKey)}
-        className="inline-flex items-center gap-1 hover:text-foreground"
-        data-testid={`invoices-sort-${sortKey}`}
-        aria-label={ariaLabel}
-      >
-        {label}
-        {active ? (
-          sort!.dir === 'asc' ? (
-            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-          ) : (
-            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-          )
-        ) : (
-          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-        )}
-      </button>
-    </th>
-  );
-}
 
 // re-exported for tests that need the error type
 export { ActionError };

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -69,7 +69,13 @@ function writeFilters(f: Filters): void {
   if (f.from) params.set('from', f.from);
   if (f.to) params.set('to', f.to);
   const next = params.toString();
-  window.location.hash = next ? `#${next}` : '';
+  if (next) {
+    window.location.hash = `#${next}`;
+  } else if (window.location.hash) {
+    // Clearing: plain `location.hash = ''` can leave a bare '#' dangling in the
+    // URL. replaceState strips the fragment cleanly without a history entry.
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -464,27 +470,32 @@ export function InvoicesPage() {
               </button>
             </div>
           </div>
-        ) : invoices.length === 0 ? (
-          <div className="px-4 py-14 text-center" data-testid="invoices-empty">
-            <h3 className="text-sm font-semibold">No invoices yet</h3>
-            <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
-              Assemble unbilled time and parts into a draft, or start a blank invoice.
-            </p>
-            {can('invoices', 'write') && (
-              <button
-                type="button"
-                onClick={openAssemble}
-                className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-                data-testid="invoices-empty-new"
-              >
-                New invoice
-              </button>
-            )}
-          </div>
         ) : rows.length === 0 ? (
-          <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="invoices-no-match">
-            No invoices match these filters.
-          </div>
+          filtersActive ? (
+            // Filtered to nothing. The toolbar above stays mounted (it renders
+            // whenever a filter is active) so its existing Clear control is the
+            // recovery affordance — no redundant button here.
+            <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="invoices-filtered-empty">
+              No invoices match these filters.
+            </div>
+          ) : (
+            <div className="px-4 py-14 text-center" data-testid="invoices-empty">
+              <h3 className="text-sm font-semibold">No invoices yet</h3>
+              <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+                Assemble unbilled time and parts into a draft, or start a blank invoice.
+              </p>
+              {can('invoices', 'write') && (
+                <button
+                  type="button"
+                  onClick={openAssemble}
+                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                  data-testid="invoices-empty-new"
+                >
+                  New invoice
+                </button>
+              )}
+            </div>
+          )
         ) : (
           <div className="relative">
             {/* Desktop: scrollable table from `sm` up. Below `sm` a 8-column table

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -546,11 +546,18 @@ export function InvoicesPage() {
                         <td className="px-3 py-3 font-medium">
                           <span className="flex items-center gap-2">
                             <span className={`h-1.5 w-1.5 rounded-full ${overdue ? 'bg-destructive' : 'bg-transparent'}`} aria-hidden="true" />
-                            {inv.invoiceNumber ?? (
-                              <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                                Draft
-                              </span>
-                            )}
+                            <a
+                              href={`/billing/invoices/${inv.id}`}
+                              onClick={(e) => e.stopPropagation()}
+                              data-testid={`invoices-row-link-${inv.id}`}
+                              className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                            >
+                              {inv.invoiceNumber ?? (
+                                <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                                  Draft
+                                </span>
+                              )}
+                            </a>
                           </span>
                         </td>
                         <td className="px-3 py-3">{orgName(inv.orgId)}</td>
@@ -589,20 +596,29 @@ export function InvoicesPage() {
                     className={overdue ? 'border-destructive/30' : undefined}
                   >
                     <div className="flex items-start justify-between gap-3">
-                      <label className="flex items-center gap-2 font-medium" onClick={(e) => e.stopPropagation()}>
-                        <input
-                          type="checkbox"
-                          aria-label={`Select invoice ${inv.invoiceNumber ?? inv.id}`}
-                          data-testid={`invoices-card-select-${inv.id}`}
-                          checked={bulk.has(inv.id)}
-                          onChange={() => bulk.toggle(inv.id)}
-                        />
-                        {inv.invoiceNumber ?? (
-                          <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                            Draft
-                          </span>
-                        )}
-                      </label>
+                      <div className="flex items-center gap-2 font-medium">
+                        <label onClick={(e) => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            aria-label={`Select invoice ${inv.invoiceNumber ?? inv.id}`}
+                            data-testid={`invoices-card-select-${inv.id}`}
+                            checked={bulk.has(inv.id)}
+                            onChange={() => bulk.toggle(inv.id)}
+                          />
+                        </label>
+                        <a
+                          href={`/billing/invoices/${inv.id}`}
+                          onClick={(e) => e.stopPropagation()}
+                          data-testid={`invoices-card-link-${inv.id}`}
+                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        >
+                          {inv.invoiceNumber ?? (
+                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              Draft
+                            </span>
+                          )}
+                        </a>
+                      </div>
                       <StatusPill
                         role={STATUS_ROLES[inv.status].role}
                         label={statusLabel(inv)}

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -19,8 +19,10 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  sumByCurrency,
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
+import { StatCard } from './shared/StatCard';
 import { INVOICE_STATUSES, BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
@@ -305,11 +307,19 @@ export function InvoicesPage() {
     const outstanding = open.reduce((sum, i) => sum + num(i.balance), 0);
     const overdue = invoices.filter((i) => i.status === 'overdue').length;
     const draftCount = invoices.filter((i) => i.status === 'draft').length;
-    // Single-currency partners are the norm; label the strip with the first
-    // invoice's currency. Multi-currency outstanding totals are not split in v1.
+    // Per-currency outstanding so a mixed-currency book isn't summed under one
+    // (wrong) currency label. Single-currency partners (the norm) get one entry
+    // that renders exactly as a plain total did.
+    const byCurrency = sumByCurrency(open.map((i) => ({ amount: num(i.balance), currencyCode: i.currencyCode })));
     const ccy = (invoices[0]?.currencyCode) || 'USD';
-    return { outstanding, overdue, draftCount, openCount: open.length, ccy };
+    return { outstanding, overdue, draftCount, openCount: open.length, byCurrency, ccy };
   }, [invoices]);
+
+  // '$12,300 + €4,100' when the outstanding book spans currencies; a single
+  // formatted total otherwise (identical to the pre-split single-currency path).
+  const outstandingDisplay = summary.byCurrency.length > 1
+    ? summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
+    : formatMoney(summary.outstanding, summary.ccy);
 
   // Any server- or client-side filter narrowing the list. Drives both the Clear
   // affordance and whether the toolbar shows on an otherwise-empty list.
@@ -347,34 +357,27 @@ export function InvoicesPage() {
       {/* Outstanding summary */}
       {!loading && !error && invoices.length > 0 && (
         <div className="flex flex-wrap gap-3" data-testid="invoices-outstanding-strip">
-          <div className="rounded-lg border bg-card px-4 py-3">
-            <div className="text-xs text-muted-foreground">Outstanding</div>
-            <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outstanding, summary.ccy)}</div>
-            <div className="text-xs text-muted-foreground">{summary.openCount} open</div>
-          </div>
+          <StatCard label="Outstanding" value={outstandingDisplay} hint={`${summary.openCount} open`} />
           {summary.draftCount > 0 && (
-            <button
-              type="button"
+            <StatCard
+              label="Drafts"
+              value={summary.draftCount}
+              hint="not yet issued"
               onClick={() => applyFilter({ status: 'draft' })}
-              className="rounded-lg border bg-card px-4 py-3 text-left transition hover:bg-muted/40"
-              data-testid="invoices-drafts-card"
-            >
-              <div className="text-xs text-muted-foreground">Drafts</div>
-              <div className="mt-0.5 text-lg font-semibold tabular-nums">{summary.draftCount}</div>
-              <div className="text-xs text-muted-foreground">not yet issued</div>
-            </button>
+              active={filters.status === 'draft'}
+              testId="invoices-drafts-card"
+            />
           )}
           {summary.overdue > 0 && (
-            <button
-              type="button"
+            <StatCard
+              label="Overdue"
+              value={summary.overdue}
+              hint="needs follow-up"
+              tone="destructive"
               onClick={() => applyFilter({ status: 'overdue' })}
-              className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-left transition hover:bg-destructive/10"
-              data-testid="invoices-overdue-card"
-            >
-              <div className="text-xs text-destructive">Overdue</div>
-              <div className="mt-0.5 text-lg font-semibold tabular-nums text-destructive">{summary.overdue}</div>
-              <div className="text-xs text-muted-foreground">needs follow-up</div>
-            </button>
+              active={filters.status === 'overdue'}
+              testId="invoices-overdue-card"
+            />
           )}
         </div>
       )}

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -14,12 +14,13 @@ import AccessDenied from '../shared/AccessDenied';
 import {
   type InvoiceStatus,
   type InvoiceSummary,
-  STATUS_COLORS,
+  STATUS_ROLES,
   STATUS_LABELS,
   statusLabel,
   formatDate,
   formatMoney,
 } from './invoiceTypes';
+import { StatusPill } from './shared/StatusPill';
 import { INVOICE_STATUSES, BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
@@ -580,13 +581,12 @@ export function InvoicesPage() {
                           {formatMoney(inv.balance, inv.currencyCode)}
                         </td>
                         <td className="px-3 py-3">
-                          <span
-                            className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
-                            data-testid={`invoices-status-${inv.id}`}
-                            aria-label={`Status: ${statusLabel(inv)}`}
-                          >
-                            {statusLabel(inv)}
-                          </span>
+                          <StatusPill
+                            role={STATUS_ROLES[inv.status].role}
+                            label={statusLabel(inv)}
+                            className={STATUS_ROLES[inv.status].className}
+                            testId={`invoices-status-${inv.id}`}
+                          />
                         </td>
                       </tr>
                     );
@@ -621,13 +621,12 @@ export function InvoicesPage() {
                           </span>
                         )}
                       </label>
-                      <span
-                        className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[inv.status]}`}
-                        data-testid={`invoices-card-status-${inv.id}`}
-                        aria-label={`Status: ${statusLabel(inv)}`}
-                      >
-                        {statusLabel(inv)}
-                      </span>
+                      <StatusPill
+                        role={STATUS_ROLES[inv.status].role}
+                        label={statusLabel(inv)}
+                        className={['shrink-0', STATUS_ROLES[inv.status].className].filter(Boolean).join(' ')}
+                        testId={`invoices-card-status-${inv.id}`}
+                      />
                     </div>
                     <div className="mt-3 space-y-1.5">
                       <CardField label="Organization">{orgName(inv.orgId)}</CardField>

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -550,13 +550,14 @@ export function InvoicesPage() {
                               href={`/billing/invoices/${inv.id}`}
                               onClick={(e) => e.stopPropagation()}
                               data-testid={`invoices-row-link-${inv.id}`}
+                              // Unnumbered drafts show an em-dash (the Status column
+                              // already carries the "Draft" pill, so a DRAFT chip here
+                              // was redundant). The dash is decorative — give the link
+                              // an accessible name so it doesn't read as just "—".
+                              aria-label={inv.invoiceNumber ? undefined : 'Draft invoice'}
                               className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                             >
-                              {inv.invoiceNumber ?? (
-                                <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                                  Draft
-                                </span>
-                              )}
+                              {inv.invoiceNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                             </a>
                           </span>
                         </td>
@@ -610,13 +611,10 @@ export function InvoicesPage() {
                           href={`/billing/invoices/${inv.id}`}
                           onClick={(e) => e.stopPropagation()}
                           data-testid={`invoices-card-link-${inv.id}`}
+                          aria-label={inv.invoiceNumber ? undefined : 'Draft invoice'}
                           className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                         >
-                          {inv.invoiceNumber ?? (
-                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                              Draft
-                            </span>
-                          )}
+                          {inv.invoiceNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                         </a>
                       </div>
                       <StatusPill

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -315,11 +315,13 @@ export function InvoicesPage() {
     return { outstanding, overdue, draftCount, openCount: open.length, byCurrency, ccy };
   }, [invoices]);
 
-  // '$12,300 + €4,100' when the outstanding book spans currencies; a single
-  // formatted total otherwise (identical to the pre-split single-currency path).
-  const outstandingDisplay = summary.byCurrency.length > 1
-    ? summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
-    : formatMoney(summary.outstanding, summary.ccy);
+  // '$12,300 + €4,100' when the outstanding book spans currencies. With one
+  // currency, label with the SUMMED SUBSET's code (byCurrency[0]) — not rows[0]'s
+  // (`summary.ccy`), which may come from a void/settled invoice in a different
+  // currency. The rows[0] fallback only applies when nothing is open ($0.00).
+  const outstandingDisplay = summary.byCurrency.length === 0
+    ? formatMoney(summary.outstanding, summary.ccy)
+    : summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ');
 
   // Any server- or client-side filter narrowing the list. Drives both the Clear
   // affordance and whether the toolbar shows on an otherwise-empty list.

--- a/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
@@ -26,7 +26,7 @@ describe('BulkActionBar', () => {
     expect(onClear).toHaveBeenCalledTimes(1);
   });
 
-  it('reserves its own space with an in-flow spacer so the last row is never occluded', () => {
+  it('renders the bar in-flow (sticky, not absolute) so the last row is never occluded', () => {
     render(
       <BulkActionBar
         count={2}
@@ -35,13 +35,17 @@ describe('BulkActionBar', () => {
         testIdPrefix="quotes"
       />
     );
-    // The floating bar is absolutely positioned; a sibling spacer in normal flow
-    // pushes the container taller by the bar's height so callers need no padding hack.
-    expect(screen.getByTestId('bulk-bar-spacer')).toBeInTheDocument();
+    // A `sticky` in-flow bar occupies its own layout box, so the last table row
+    // can never be occluded regardless of the bar's height — no spacer needed.
+    const bar = screen.getByTestId('quotes-bulk-bar');
+    expect(bar).toHaveClass('sticky');
+    expect(bar).not.toHaveClass('absolute');
+    // The old in-flow spacer sibling is gone.
+    expect(screen.queryByTestId('bulk-bar-spacer')).not.toBeInTheDocument();
   });
 
-  it('renders no spacer when count is 0', () => {
+  it('renders nothing (no bar) when count is 0', () => {
     render(<BulkActionBar count={0} actions={[]} onClear={() => {}} testIdPrefix="quotes" />);
-    expect(screen.queryByTestId('bulk-bar-spacer')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quotes-bulk-bar')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.test.tsx
@@ -25,4 +25,23 @@ describe('BulkActionBar', () => {
     fireEvent.click(screen.getByTestId('quotes-bulk-clear'));
     expect(onClear).toHaveBeenCalledTimes(1);
   });
+
+  it('reserves its own space with an in-flow spacer so the last row is never occluded', () => {
+    render(
+      <BulkActionBar
+        count={2}
+        actions={[{ key: 'delete', label: 'Delete', onClick: () => {} }]}
+        onClear={() => {}}
+        testIdPrefix="quotes"
+      />
+    );
+    // The floating bar is absolutely positioned; a sibling spacer in normal flow
+    // pushes the container taller by the bar's height so callers need no padding hack.
+    expect(screen.getByTestId('bulk-bar-spacer')).toBeInTheDocument();
+  });
+
+  it('renders no spacer when count is 0', () => {
+    render(<BulkActionBar count={0} actions={[]} onClear={() => {}} testIdPrefix="quotes" />);
+    expect(screen.queryByTestId('bulk-bar-spacer')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/billing/bulk/BulkActionBar.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.tsx
@@ -16,10 +16,16 @@ export interface BulkActionBarProps {
 export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkActionBarProps) {
   if (count === 0) return null;
   return (
-    <div
-      className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
-      data-testid={`${testIdPrefix}-bulk-bar`}
-    >
+    <>
+      {/* In-flow spacer: the bar itself is absolutely positioned and would float
+          over the last table row(s). This sibling reserves an equal slice of
+          height in normal flow so the bar overlays blank space, never data — the
+          caller needs no `pb-*` padding hack of its own. */}
+      <div aria-hidden="true" data-testid="bulk-bar-spacer" className="h-14" />
+      <div
+        className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
+        data-testid={`${testIdPrefix}-bulk-bar`}
+      >
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-sm font-medium tabular-nums">{count} selected</span>
         <div className="ml-auto flex flex-wrap items-center gap-2">
@@ -49,6 +55,7 @@ export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkAct
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/billing/bulk/BulkActionBar.tsx
+++ b/apps/web/src/components/billing/bulk/BulkActionBar.tsx
@@ -16,16 +16,15 @@ export interface BulkActionBarProps {
 export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkActionBarProps) {
   if (count === 0) return null;
   return (
-    <>
-      {/* In-flow spacer: the bar itself is absolutely positioned and would float
-          over the last table row(s). This sibling reserves an equal slice of
-          height in normal flow so the bar overlays blank space, never data — the
-          caller needs no `pb-*` padding hack of its own. */}
-      <div aria-hidden="true" data-testid="bulk-bar-spacer" className="h-14" />
-      <div
-        className="absolute inset-x-0 bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
-        data-testid={`${testIdPrefix}-bulk-bar`}
-      >
+    // In-flow `sticky` bar: a sticky element occupies its own layout box, so the
+    // last table row can never be occluded no matter how tall the bar grows (e.g.
+    // when its actions wrap to two lines on a narrow viewport). It still floats
+    // above the viewport bottom while the table scrolls. No spacer / `pb-*` hack
+    // needed — the height guarantee is structural, not a magic number.
+    <div
+      className="sticky bottom-0 z-10 border-t bg-background px-3 py-2 shadow-[0_-4px_12px_-6px_rgba(0,0,0,0.15)] animate-[fade-up_0.18s_ease-out_both]"
+      data-testid={`${testIdPrefix}-bulk-bar`}
+    >
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-sm font-medium tabular-nums">{count} selected</span>
         <div className="ml-auto flex flex-wrap items-center gap-2">
@@ -55,7 +54,6 @@ export function BulkActionBar({ count, actions, onClear, testIdPrefix }: BulkAct
           </button>
         </div>
       </div>
-      </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -145,14 +145,28 @@ export const STATUS_PILL = {
   danger: 'border-destructive/40 bg-destructive/10 text-[hsl(4_74%_42%)] dark:text-destructive',
 } as const;
 
-export const STATUS_COLORS: Record<InvoiceStatus, string> = {
-  draft: STATUS_PILL.neutral,
-  sent: STATUS_PILL.info,
-  partially_paid: STATUS_PILL.warning,
-  overdue: STATUS_PILL.danger,
-  paid: STATUS_PILL.success,
-  void: `${STATUS_PILL.neutral} line-through`,
+/** The five semantic pill roles (keys of STATUS_PILL). Consumed by the shared
+ *  `<StatusPill role>` and by the per-domain status→role maps below and in
+ *  quoteTypes / contracts. */
+export type StatusPillRole = keyof typeof STATUS_PILL;
+
+/** Source-of-truth status → { role, extra className } map. `STATUS_COLORS` (the
+ *  class-string form) is derived from it so the two can't drift, and the status
+ *  pills pass `role`/`className` straight to `<StatusPill>`. */
+export const STATUS_ROLES: Record<InvoiceStatus, { role: StatusPillRole; className?: string }> = {
+  draft: { role: 'neutral' },
+  sent: { role: 'info' },
+  partially_paid: { role: 'warning' },
+  overdue: { role: 'danger' },
+  paid: { role: 'success' },
+  void: { role: 'neutral', className: 'line-through' },
 };
+
+export const STATUS_COLORS = Object.fromEntries(
+  (Object.entries(STATUS_ROLES) as [InvoiceStatus, { role: StatusPillRole; className?: string }][]).map(
+    ([status, { role, className }]) => [status, className ? `${STATUS_PILL[role]} ${className}` : STATUS_PILL[role]],
+  ),
+) as Record<InvoiceStatus, string>;
 
 /** Display label for an invoice's status. The 'sent' lifecycle status means
  *  "issued"; it only reads as "Sent" once an email actually went out (sentAt).
@@ -170,18 +184,10 @@ export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
   other: 'Other',
 };
 
-/** Currency-aware money formatter (invoices carry their own currencyCode,
- *  unlike the USD-only lib/timeFormat.formatMoney). */
-export function formatMoney(value: string | number | null | undefined, currencyCode = 'USD'): string {
-  const n = typeof value === 'number' ? value : Number(value);
-  const safe = Number.isFinite(n) ? n : 0;
-  try {
-    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
-  } catch {
-    // Unknown/invalid currency code → fall back to plain 2-decimal + code suffix.
-    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
-  }
-}
+// Money/date formatters live in ./shared/format (the canonical copies, shared
+// with quotes + contracts); re-exported here so existing './invoiceTypes'
+// import sites are unaffected.
+export { formatMoney, formatDate } from './shared/format';
 
 /** Convert a stored tax-rate FRACTION (e.g. '0.07') to a percent string for an
  *  input ('7'), rounding the percent to 3 decimals — equivalently the numeric(8,5)
@@ -249,12 +255,4 @@ export function computeInvoiceProfit(lines: InvoiceLine[]): QuoteProfit {
         recurrence: 'one_time' as const,
       })),
   );
-}
-
-/** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
-export function formatDate(value: string | null | undefined): string {
-  if (!value) return '—';
-  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleDateString();
 }

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -90,9 +90,24 @@ export function lineBlurb(l: { name: string | null; description: string | null }
   return b || null;
 }
 
+/** Document branding resolved server-side (same partner/portal source the invoice
+ *  PDF uses) so the in-app Preview matches what the customer receives. Optional
+ *  because test fixtures and the list endpoint don't carry it. Mirrors
+ *  QuoteBranding — invoices and quotes share the one letterhead. */
+export interface InvoiceBranding {
+  partnerName: string;
+  logoUrl: string | null;
+  /** Partner brand accent (hex); null → fall back to the app's primary accent. */
+  primaryColor: string | null;
+  footer: string | null;
+  currencyCode: string;
+  seller: SellerSnapshot | null;
+}
+
 export interface InvoiceDetail {
   invoice: InvoiceSummary;
   lines: InvoiceLine[];
+  branding?: InvoiceBranding;
   /** Whether the partner has an active Stripe Connect account (gates "Send
    *  payment link"). Absent on older API responses → treated as not connected. */
   stripeConnected?: boolean;
@@ -187,7 +202,7 @@ export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
 // Money/date formatters live in ./shared/format (the canonical copies, shared
 // with quotes + contracts); re-exported here so existing './invoiceTypes'
 // import sites are unaffected.
-export { formatMoney, formatDate } from './shared/format';
+export { formatMoney, formatDate, sumByCurrency } from './shared/format';
 
 /** Convert a stored tax-rate FRACTION (e.g. '0.07') to a percent string for an
  *  input ('7'), rounding the percent to 3 decimals — equivalently the numeric(8,5)

--- a/apps/web/src/components/billing/quotes/QuoteActions.sendcopy.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.sendcopy.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteActions from './QuoteActions';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// The post-send success toast should tell the seller "what happens next" — that
+// the proposal will move to Viewed and Accepted on its own as the customer opens
+// and signs — instead of a bare "Proposal sent". This asserts the copy (and the
+// customer name interpolation) via the successMessage passed to runAction.
+const runAction = vi.hoisted(() => vi.fn(async (opts: { request: () => Promise<unknown> }) => { await opts.request(); }));
+vi.mock('../../../lib/runAction', () => ({ runAction, handleActionError: vi.fn() }));
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+vi.mock('../../../stores/orgStore', () => ({ useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../../lib/api/quotes', () => ({ sendQuote: vi.fn().mockResolvedValue({}), deleteQuote: vi.fn(), quotePdfUrl: vi.fn().mockReturnValue('/quotes/q-1/pdf') }));
+// A clickable ConfirmDialog stand-in so we can drive the confirm path.
+vi.mock('../../shared/ConfirmDialog', () => ({
+  ConfirmDialog: ({ open, onConfirm, confirmTestId }: { open: boolean; onConfirm: () => void; confirmTestId?: string }) =>
+    open ? <button type="button" data-testid={confirmTestId} onClick={onConfirm}>confirm</button> : null,
+}));
+
+function draft(extra: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', billToName: 'Acme Inc.', introNotes: null,
+      terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+      convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+      createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z', ...extra,
+    },
+    blocks: [{ id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' }],
+    lines: [],
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('QuoteActions — post-send success copy', () => {
+  it('the success toast advertises the auto Viewed/Accepted lifecycle with the customer name', async () => {
+    render(<QuoteActions detail={draft()} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    fireEvent.click(await screen.findByTestId('quote-send-confirm'));
+
+    await waitFor(() => expect(runAction).toHaveBeenCalled());
+    const opts = runAction.mock.calls[0]![0] as { successMessage?: string };
+    expect(opts.successMessage).toBe(
+      "Proposal sent — we'll mark it Viewed and Accepted as Acme Inc. opens and signs.",
+    );
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -112,36 +112,19 @@ export default function QuoteActions({ detail, onChanged, variant }: Props) {
             contact with the PDF + a public accept link, and flips draft→sent.
             Gated on quotes:send; only a draft can be sent. An empty quote can't. */}
         {canSend && (
-          <>
-            <button
-              type="button"
-              onClick={() => setSendOpen(true)}
-              disabled={sending || isEmpty}
-              // Tie the disabled button to the visible hint below (rendered in both
-              // variants) so AT announces the reason when the button takes focus.
-              aria-describedby={isEmpty ? `quote-send-empty-hint-${variant}` : undefined}
-              title={isEmpty ? 'Add at least one item before sending.' : undefined}
-              data-testid="quote-send"
-              className={`${btnBase} bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
-            >
-              {sending ? 'Sending…' : 'Send proposal'}
-            </button>
-            {isEmpty && (
-              // Visible in BOTH variants — a sighted keyboard user (or anyone not
-              // hovering for the title tooltip) needs to see WHY the highest-stakes
-              // button is disabled. In the header row it takes a full-width basis so
-              // it wraps onto its own line BELOW the action buttons (never inline
-              // between them, which would drag the cluster into the page centre),
-              // right-aligned to sit under the right-aligned buttons.
-              <p
-                id={`quote-send-empty-hint-${variant}`}
-                data-testid="quote-send-empty-hint"
-                className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
-              >
-                Add at least one item before sending.
-              </p>
-            )}
-          </>
+          <button
+            type="button"
+            onClick={() => setSendOpen(true)}
+            disabled={sending || isEmpty}
+            // Tie the disabled button to the visible hint below (rendered in both
+            // variants) so AT announces the reason when the button takes focus.
+            aria-describedby={isEmpty ? `quote-send-empty-hint-${variant}` : undefined}
+            title={isEmpty ? 'Add at least one item before sending.' : undefined}
+            data-testid="quote-send"
+            className={`${btnBase} bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
+          >
+            {sending ? 'Sending…' : 'Send proposal'}
+          </button>
         )}
         {/* PDF download is a read affordance (quotes has no dedicated export
             permission), so it's gated on quotes:read. */}
@@ -165,6 +148,21 @@ export default function QuoteActions({ detail, onChanged, variant }: Props) {
           >
             Delete draft
           </button>
+        )}
+        {canSend && isEmpty && (
+          // Visible in BOTH variants — a sighted keyboard user (or anyone not
+          // hovering for the title tooltip) needs to see WHY the highest-stakes
+          // button is disabled. Rendered LAST so in the header row it takes a
+          // full-width basis and wraps onto its own line BELOW the whole action
+          // cluster (never inline between buttons, which would drag the cluster
+          // into the page centre), right-aligned under the right-aligned buttons.
+          <p
+            id={`quote-send-empty-hint-${variant}`}
+            data-testid="quote-send-empty-hint"
+            className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
+          >
+            Add at least one item before sending.
+          </p>
         )}
       </div>
 

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -60,7 +60,9 @@ export default function QuoteActions({ detail, onChanged, variant }: Props) {
       await runAction({
         request: () => sendQuote(quote.id),
         errorFallback: 'Could not send the proposal.',
-        successMessage: 'Proposal sent',
+        // Tell the seller what happens next: the quote advances to Viewed and
+        // Accepted on its own as the customer engages — no further action here.
+        successMessage: `Proposal sent — we'll mark it Viewed and Accepted as ${orgName} opens and signs.`,
         onUnauthorized: UNAUTHORIZED,
       });
       setSendOpen(false);
@@ -70,7 +72,7 @@ export default function QuoteActions({ detail, onChanged, variant }: Props) {
     } finally {
       setSending(false);
     }
-  }, [sending, quote.id, refresh]);
+  }, [sending, quote.id, orgName, refresh]);
 
   const remove = useCallback(async () => {
     if (deleting) return;

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -130,11 +130,13 @@ export default function QuoteActions({ detail, onChanged, variant }: Props) {
               // Visible in BOTH variants — a sighted keyboard user (or anyone not
               // hovering for the title tooltip) needs to see WHY the highest-stakes
               // button is disabled. In the header row it takes a full-width basis so
-              // it wraps onto its own line under the action buttons.
+              // it wraps onto its own line BELOW the action buttons (never inline
+              // between them, which would drag the cluster into the page centre),
+              // right-aligned to sit under the right-aligned buttons.
               <p
                 id={`quote-send-empty-hint-${variant}`}
                 data-testid="quote-send-empty-hint"
-                className={header ? 'basis-full text-xs text-muted-foreground' : 'text-center text-xs text-muted-foreground'}
+                className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
               >
                 Add at least one item before sending.
               </p>

--- a/apps/web/src/components/billing/quotes/QuoteDetail.lifecycle.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.lifecycle.test.tsx
@@ -70,6 +70,10 @@ describe('QuoteDetail — lifecycle strip', () => {
     expect(strip).toHaveTextContent(formatDate('2026-06-04T00:00:00Z'));
     // A quote that was accepted was never declined — no danger stage.
     expect(strip).not.toHaveTextContent('Declined');
+    // The `·` separator renders BETWEEN stages only — never before the first one
+    // (a stray leading `· Sent …` shipped once; keep this pinned).
+    expect(strip.textContent?.trim().startsWith('·')).toBe(false);
+    expect(strip.textContent?.trim()).toMatch(/^Sent/);
   });
 
   it('renders only the non-null stages (sent, no view/accept yet)', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteDetail.lifecycle.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.lifecycle.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import { type QuoteDetail as QuoteDetailData, formatDate } from './quoteTypes';
+import { useOrgStore } from '../../../stores/orgStore';
+
+// A quote's most valuable moment — the customer accepted, or the proposal was
+// converted to an invoice — used to render as nothing but a status pill. This
+// covers the compact lifecycle strip (Sent · Viewed · Accepted / Declined) and
+// the converted-invoice link in the Detail summary card.
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [{ resource: 'quotes', action: 'read' }] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const ORG_ID = 'aa0e43c8-1111-2222-3333-444455556666';
+
+function detailWith(overrides: Partial<QuoteDetailData['quote']>): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: ORG_ID, siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00',
+      billToName: 'Acme Inc.', introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
+      viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+      ...overrides,
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+const initialOrgState = useOrgStore.getState();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'read' }];
+  useOrgStore.setState({ organizations: [] });
+});
+
+afterEach(() => {
+  useOrgStore.setState(initialOrgState, true);
+});
+
+describe('QuoteDetail — lifecycle strip', () => {
+  it('renders Accepted with the formatted date on an accepted quote', async () => {
+    render(<QuoteDetail detail={detailWith({
+      status: 'accepted', sentAt: '2026-06-02T00:00:00Z', viewedAt: '2026-06-03T00:00:00Z',
+      acceptedAt: '2026-06-04T00:00:00Z',
+    })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const strip = screen.getByTestId('quote-detail-lifecycle');
+    expect(strip).toHaveTextContent('Sent');
+    expect(strip).toHaveTextContent('Viewed');
+    expect(strip).toHaveTextContent('Accepted');
+    expect(strip).toHaveTextContent(formatDate('2026-06-04T00:00:00Z'));
+    // A quote that was accepted was never declined — no danger stage.
+    expect(strip).not.toHaveTextContent('Declined');
+  });
+
+  it('renders only the non-null stages (sent, no view/accept yet)', async () => {
+    render(<QuoteDetail detail={detailWith({ status: 'sent', sentAt: '2026-06-02T00:00:00Z' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const strip = screen.getByTestId('quote-detail-lifecycle');
+    expect(strip).toHaveTextContent('Sent');
+    expect(strip).not.toHaveTextContent('Viewed');
+    expect(strip).not.toHaveTextContent('Accepted');
+  });
+
+  it('shows Declined in the destructive token when declined', async () => {
+    render(<QuoteDetail detail={detailWith({
+      status: 'declined', sentAt: '2026-06-02T00:00:00Z', declinedAt: '2026-06-05T00:00:00Z',
+    })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const declined = screen.getByTestId('quote-detail-lifecycle-declined');
+    expect(declined).toHaveTextContent('Declined');
+    expect(declined.className).toContain('text-destructive');
+  });
+
+  it('renders no lifecycle strip on a plain draft (nothing to show)', async () => {
+    render(<QuoteDetail detail={detailWith({ status: 'draft' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-detail-lifecycle')).not.toBeInTheDocument();
+  });
+});
+
+describe('QuoteDetail — converted-invoice link', () => {
+  it('links to the converted invoice with the correct href', async () => {
+    render(<QuoteDetail detail={detailWith({
+      status: 'converted', sentAt: '2026-06-02T00:00:00Z', acceptedAt: '2026-06-04T00:00:00Z',
+      convertedAt: '2026-06-06T00:00:00Z', convertedInvoiceId: 'inv-99',
+    })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    const link = screen.getByTestId('quote-view-invoice');
+    expect(link).toHaveAttribute('href', '/billing/invoices/inv-99');
+    expect(link).toHaveTextContent('View invoice');
+  });
+
+  it('renders no invoice link when the quote has not been converted', async () => {
+    render(<QuoteDetail detail={detailWith({ status: 'accepted', acceptedAt: '2026-06-04T00:00:00Z' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-view-invoice')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -161,6 +161,29 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
                 <div className="flex justify-between"><dt className="text-muted-foreground">Created</dt><dd>{formatDate(quote.createdAt)}</dd></div>
               )}
             </dl>
+            {/* Lifecycle strip — the customer-journey milestones (Sent → Viewed →
+                Accepted, or Declined) that used to be visible only as a status pill.
+                Only stamped stages render; a plain draft has none, so nothing shows.
+                Declined is the one destructive outcome and gets the danger token. */}
+            {(quote.sentAt || quote.viewedAt || quote.acceptedAt || quote.declinedAt) && (
+              <dl className="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t pt-3 text-xs" data-testid="quote-detail-lifecycle">
+                {quote.sentAt && <LifecycleStage label="Sent" date={quote.sentAt} />}
+                {quote.viewedAt && <LifecycleStage label="Viewed" date={quote.viewedAt} first={!quote.sentAt} />}
+                {quote.acceptedAt && <LifecycleStage label="Accepted" date={quote.acceptedAt} first={!quote.sentAt && !quote.viewedAt} />}
+                {quote.declinedAt && <LifecycleStage label="Declined" date={quote.declinedAt} first={!quote.sentAt && !quote.viewedAt && !quote.acceptedAt} danger testId="quote-detail-lifecycle-declined" />}
+              </dl>
+            )}
+            {/* Once accepted → converted, the resulting invoice is the next stop; a
+                direct link beats hunting for it in the invoices list. */}
+            {quote.convertedInvoiceId && (
+              <a
+                href={`/billing/invoices/${quote.convertedInvoiceId}`}
+                data-testid="quote-view-invoice"
+                className="mt-3 inline-flex items-center gap-1 rounded-xs text-sm font-medium text-primary hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                View invoice <span aria-hidden>→</span>
+              </a>
+            )}
           </div>
 
           {/* Recurring + totals summary — the rail's anchor (shadow + large figure). */}
@@ -230,6 +253,20 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
           {!actionsInHeader && <QuoteActions detail={detail} onChanged={onChanged} variant="rail" />}
         </div>
       </div>
+    </div>
+  );
+}
+
+// One `Label date` pair in the lifecycle strip, with a `·` separator before every
+// stage except the first-rendered one. Declined is the sole destructive outcome
+// and paints its label + date in the danger token.
+function LifecycleStage({ label, date, first, danger, testId }: { label: string; date: string; first?: boolean; danger?: boolean; testId?: string }) {
+  const tone = danger ? 'text-destructive' : '';
+  return (
+    <div className={`flex items-center gap-1 ${tone}`} data-testid={testId}>
+      {!first && <span aria-hidden className="text-muted-foreground">·</span>}
+      <dt className={danger ? undefined : 'text-muted-foreground'}>{label}</dt>
+      <dd className={danger ? undefined : 'text-foreground'}>{formatDate(date)}</dd>
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -10,7 +10,7 @@ import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
   type QuoteLine,
-  STATUS_COLORS,
+  STATUS_ROLES,
   statusLabel,
   stripHtml,
   formatDate,
@@ -22,6 +22,7 @@ import {
   pctFromFraction,
   sellerLines,
 } from './quoteTypes';
+import { StatusPill } from '../shared/StatusPill';
 
 interface Props {
   detail: QuoteDetailData;
@@ -143,14 +144,12 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4" data-testid="quote-detail-summary">
             <div className="mb-3 flex items-center justify-between">
-              <span
-                className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
-                data-testid="quote-detail-status"
-              >
-                {/* Real visually-hidden text rather than aria-label on a non-
-                    interactive span, which screen readers don't reliably announce. */}
-                <span className="sr-only">Status: </span>{statusLabel(quote)}
-              </span>
+              <StatusPill
+                role={STATUS_ROLES[quote.status].role}
+                label={statusLabel(quote)}
+                className={STATUS_ROLES[quote.status].className}
+                testId="quote-detail-status"
+              />
               {quote.expiryDate && (
                 <span className="text-xs text-muted-foreground">Expires {formatDate(quote.expiryDate)}</span>
               )}

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -167,7 +167,7 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
                 Declined is the one destructive outcome and gets the danger token. */}
             {(quote.sentAt || quote.viewedAt || quote.acceptedAt || quote.declinedAt) && (
               <dl className="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t pt-3 text-xs" data-testid="quote-detail-lifecycle">
-                {quote.sentAt && <LifecycleStage label="Sent" date={quote.sentAt} />}
+                {quote.sentAt && <LifecycleStage label="Sent" date={quote.sentAt} first />}
                 {quote.viewedAt && <LifecycleStage label="Viewed" date={quote.viewedAt} first={!quote.sentAt} />}
                 {quote.acceptedAt && <LifecycleStage label="Accepted" date={quote.acceptedAt} first={!quote.sentAt && !quote.viewedAt} />}
                 {quote.declinedAt && <LifecycleStage label="Declined" date={quote.declinedAt} first={!quote.sentAt && !quote.viewedAt && !quote.acceptedAt} danger testId="quote-detail-lifecycle-declined" />}

--- a/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
@@ -120,4 +120,15 @@ describe('QuoteDocumentPreview', () => {
     expect(screen.getByTestId('quote-document-customer')).toHaveTextContent('Acme Industries');
     expect(document.querySelector('iframe')).toBeNull();
   });
+
+  it('falls back to an em-dash (never a raw org UUID fragment) when neither billToName nor the org store resolves', () => {
+    const d = makeDetail();
+    d.quote.billToName = null; // no explicit bill-to
+    d.quote.orgId = '9f8e7d6c-1234-4abc-9def-0123456789ab'; // not in the mocked org store
+    render(<QuoteDocumentPreview detail={d} />);
+    const customer = screen.getByTestId('quote-document-customer');
+    expect(customer).toHaveTextContent('—');
+    // The UUID (or its first 8 chars) must never leak onto the customer document.
+    expect(customer).not.toHaveTextContent('9f8e7d6c');
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -325,7 +325,9 @@ export default function QuoteDocumentPreview({ detail }: { detail: QuoteDetailDa
     const billTo = quote.billToName?.trim();
     if (billTo) return billTo;
     const resolved = organizations.find((o) => o.id === quote.orgId)?.name?.trim();
-    return resolved || quote.orgId.slice(0, 8);
+    // Never leak a raw org UUID fragment onto a customer-facing document — if the
+    // org store hasn't resolved a name yet, show a neutral em-dash instead.
+    return resolved || '—';
   }, [quote.billToName, quote.orgId, organizations]);
 
   return (

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -6,7 +6,7 @@ import {
   type QuoteDetail as QuoteDetailData,
   type QuoteBlock,
   type QuoteLine,
-  STATUS_COLORS,
+  STATUS_ROLES,
   statusLabel,
   stripHtml,
   formatDate,
@@ -17,6 +17,7 @@ import {
   pctFromFraction,
   sellerLines,
 } from './quoteTypes';
+import { StatusPill } from '../shared/StatusPill';
 
 const RECURRENCE_LABEL: Record<QuoteLine['recurrence'], string> = {
   one_time: '',
@@ -200,12 +201,11 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
               {quote.quoteNumber ?? 'Draft'}
             </p>
             <p className="text-sm font-medium text-muted-foreground">Proposal</p>
-            <span
-              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[quote.status]}`}
-              aria-label={`Status: ${statusLabel(quote)}`}
-            >
-              {statusLabel(quote)}
-            </span>
+            <StatusPill
+              role={STATUS_ROLES[quote.status].role}
+              label={statusLabel(quote)}
+              className={STATUS_ROLES[quote.status].className}
+            />
             <dl className="space-y-0.5 pt-1 text-xs text-muted-foreground sm:flex sm:flex-col sm:items-end">
               <div className="flex gap-2"><dt>Issued</dt><dd className="font-medium text-foreground/80">{formatDate(quote.issueDate)}</dd></div>
               {quote.expiryDate && (

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
@@ -91,6 +91,56 @@ describe('QuoteEditor', () => {
     await waitFor(() => expect(screen.getByTestId('quote-terms-saved')).toHaveTextContent('Saved'));
     expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Saved' }));
     expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'Terms saved' }));
+  });
+
+  it('debounces the screen-reader totals announcement to settle-time while visible figures stay live', async () => {
+    vi.useFakeTimers();
+    try {
+      const detail = draftDetail();
+      detail.blocks = [
+        { id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' },
+      ];
+      detail.lines = [
+        {
+          id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual', catalogItemId: null,
+          parentLineId: null, name: 'Widget', description: null, quantity: '1', unitPrice: '100.00', unitCost: null,
+          sku: null, partNumber: null, taxable: true, customerVisible: true, lineTotal: '100.00', recurrence: 'one_time',
+          termMonths: null, billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+        },
+      ];
+      render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+      // Flush the mount-time catalog/distributor status fetches so their state
+      // updates don't dangle into the assertions below.
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      const sr = screen.getByTestId('quote-totals-sr');
+      // Right after mount the announcement is still empty (debounced), so a screen
+      // reader isn't handed the sentence before the totals settle.
+      expect(sr.textContent).toBe('');
+
+      // After the settle window the initial sentence lands (server totals are $0).
+      act(() => { vi.advanceTimersByTime(800); });
+      expect(sr).toHaveTextContent('due on acceptance $0.00');
+      expect(sr).not.toHaveTextContent('tax');
+
+      // Editing the tax rate recomputes the VISIBLE figures immediately…
+      fireEvent.change(screen.getByTestId('quote-tax-rate'), { target: { value: '10' } });
+      expect(screen.getByTestId('quote-total-due-on-acceptance')).toHaveTextContent('$110.00');
+      // …but the SR announcement still shows the previous settled sentence.
+      expect(sr).toHaveTextContent('due on acceptance $0.00');
+      expect(sr).not.toHaveTextContent('tax');
+
+      // Before the settle window closes, still the old sentence.
+      act(() => { vi.advanceTimersByTime(700); });
+      expect(sr).toHaveTextContent('due on acceptance $0.00');
+
+      // Once the window closes, the announcement catches up to the settled totals.
+      act(() => { vi.advanceTimersByTime(100); });
+      expect(sr).toHaveTextContent('tax $10.00');
+      expect(sr).toHaveTextContent('due on acceptance $110.00');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('renders the T&C textarea pre-filled with existing termsAndConditions', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -1929,9 +1929,11 @@ function EditableLineRow({
     <>
     <tr className="border-t align-top" data-testid={`quote-line-${line.id}`}>
       <td className="px-2 py-2">
-        <div className="flex items-start gap-2">
+        {/* min-w-0 lets the name input honour its own min-w-[12rem] floor rather
+            than the flex row's min-content, so a catalog thumbnail can't crush it. */}
+        <div className="flex min-w-0 items-start gap-2">
           {line.catalogItemId && <CatalogLineThumb catalogItemId={line.catalogItemId} />}
-          <div className="w-full space-y-1">
+          <div className="w-full min-w-0 space-y-1">
             <input
               type="text"
               value={name}
@@ -1941,7 +1943,7 @@ function EditableLineRow({
               onBlur={commitName}
               disabled={busy}
               data-testid={`quote-line-name-${line.id}`}
-              className={`h-9 w-full rounded-md border bg-background px-2 py-1 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
+              className={`h-9 w-full min-w-[12rem] rounded-md border bg-background px-2 py-1 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
             />
           </div>
         </div>
@@ -1981,7 +1983,7 @@ function EditableLineRow({
           }}
           disabled={busy}
           data-testid={`quote-line-recurrence-${line.id}`}
-          className="h-9 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          className="h-9 w-full min-w-0 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
         >
           <option value="one_time">One-time</option>
           <option value="monthly">Monthly</option>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -448,6 +448,35 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
   const railTotal = optimisticTotals?.total ?? quote.total;
   const railDue = optimisticTotals?.dueOnAcceptanceTotal ?? quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
 
+  // The full "Live totals" sentence a screen reader would announce. The visible
+  // figures above update live (per keystroke), but re-announcing this whole
+  // sentence on every keypress is SR chatter, so the announcement is DEBOUNCED to
+  // settle-time (below) — only the debounced copy feeds the role="status" node.
+  const srSentence = useMemo(
+    () =>
+      `Totals updated. One-time ${formatMoney(railOneTime, currency)}, `
+      + `monthly recurring ${formatMoney(railMonthly, currency)}, `
+      + `annual recurring ${formatMoney(railAnnual, currency)}`
+      + (Number(railTax) > 0 ? `, tax ${formatMoney(railTax, currency)}` : '')
+      + `, due on acceptance ${formatMoney(railDue, currency)}.`,
+    [railOneTime, railMonthly, railAnnual, railTax, railDue, currency],
+  );
+
+  // Debounced announcement: the status node's text only updates ~800ms after the
+  // last change, so a screen reader announces the settled totals once per edit
+  // burst instead of re-reading the sentence on every keystroke. The VISIBLE
+  // numbers are unaffected — they still track `rail*` live. Starts empty so the
+  // very first settle is the first announcement (a status node ignores its
+  // initial content anyway).
+  const SR_SETTLE_MS = 800;
+  const [srAnnouncement, setSrAnnouncement] = useState('');
+  const srTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (srTimer.current) clearTimeout(srTimer.current);
+    srTimer.current = setTimeout(() => setSrAnnouncement(srSentence), SR_SETTLE_MS);
+    return () => { if (srTimer.current) clearTimeout(srTimer.current); };
+  }, [srSentence]);
+
   // Internal net-profit summary for the rail's "Margin (internal)" block. Built
   // over the SAME merged line set as the totals: draft-or-persisted values plus
   // each line's cost (draft cost from a cost-only edit, else the persisted cost).
@@ -1031,13 +1060,11 @@ export default function QuoteEditor({ detail, onChanged }: Props) {
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live totals</h3>
             {/* One concise SR announcement covering every figure, so editing a
                 recurring line (which doesn't move "due on acceptance") still tells
-                a screen-reader user the totals recomputed. */}
+                a screen-reader user the totals recomputed. Debounced to settle-time
+                (srAnnouncement) so rapid edits don't machine-gun the same sentence
+                at the screen reader — the visible figures below stay live. */}
             <p className="sr-only" role="status" data-testid="quote-totals-sr">
-              {`Totals updated. One-time ${formatMoney(railOneTime, currency)}, `
-                + `monthly recurring ${formatMoney(railMonthly, currency)}, `
-                + `annual recurring ${formatMoney(railAnnual, currency)}`
-                + (Number(railTax) > 0 ? `, tax ${formatMoney(railTax, currency)}` : '')
-                + `, due on acceptance ${formatMoney(railDue, currency)}.`}
+              {srAnnouncement}
             </p>
             <dl className="space-y-2 text-sm tabular-nums">
               <div className="flex items-baseline justify-between">

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { DocumentWorkspace, type DocumentTab } from '../shared/DocumentWorkspace';
 import QuoteEditor from './QuoteEditor';
 import QuoteDetail from './QuoteDetail';
 import QuoteDocumentPreview from './QuoteDocument';
@@ -11,7 +12,7 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 type Tab = 'editor' | 'preview' | 'detail';
 
-const TABS: { value: Tab; label: string }[] = [
+const TAB_LABELS: { value: Tab; label: string }[] = [
   { value: 'editor', label: 'Editor' },
   { value: 'preview', label: 'Preview' },
   { value: 'detail', label: 'Detail' },
@@ -24,7 +25,7 @@ interface Props {
 function readTab(isDraft: boolean): Tab {
   if (typeof window === 'undefined') return isDraft ? 'editor' : 'detail';
   const raw = window.location.hash.replace(/^#/, '');
-  if (TABS.some((t) => t.value === raw)) return raw as Tab;
+  if (TAB_LABELS.some((t) => t.value === raw)) return raw as Tab;
   return isDraft ? 'editor' : 'detail';
 }
 
@@ -77,28 +78,10 @@ export default function QuoteWorkspace({ id }: Props) {
     return () => window.removeEventListener('hashchange', onHash);
   }, [detail]);
 
-  const selectTab = useCallback((next: Tab) => {
-    setTab(next);
+  const selectTab = useCallback((next: string) => {
+    setTab(next as Tab);
     if (typeof window !== 'undefined') window.location.hash = `#${next}`;
   }, []);
-
-  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
-  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
-  // tab is both activated and focused.
-  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>, tabs: { value: Tab }[], current: Tab) => {
-    const idx = tabs.findIndex((t) => t.value === current);
-    if (idx < 0) return;
-    let nextIdx: number | null = null;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % tabs.length;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + tabs.length) % tabs.length;
-    else if (e.key === 'Home') nextIdx = 0;
-    else if (e.key === 'End') nextIdx = tabs.length - 1;
-    if (nextIdx === null) return;
-    e.preventDefault();
-    const next = tabs[nextIdx].value;
-    selectTab(next);
-    if (typeof document !== 'undefined') document.getElementById(`quote-tab-${next}`)?.focus();
-  }, [selectTab]);
 
   if (loading) {
     return (
@@ -124,69 +107,35 @@ export default function QuoteWorkspace({ id }: Props) {
   // The Editor only applies to drafts, so it's hidden once a quote is issued —
   // no dead-end tab that just shows a "can't edit" message. A stale #editor hash
   // on a non-draft falls back to Detail.
-  const visibleTabs = isDraft ? TABS : TABS.filter((t) => t.value !== 'editor');
-  const activeTab: Tab = visibleTabs.some((t) => t.value === tab) ? tab : 'detail';
+  const tabs: DocumentTab[] = TAB_LABELS.map((t) => ({
+    id: t.value,
+    label: t.label,
+    hidden: t.value === 'editor' && !isDraft,
+  }));
+  const activeTab: Tab = tabs.some((t) => t.id === tab && !t.hidden) ? tab : 'detail';
 
   return (
-    <div className="space-y-4" data-testid="quote-workspace">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <a href="/billing/quotes" aria-label="Back to quotes" className="text-xs text-muted-foreground hover:underline"><span aria-hidden="true">←</span> Quotes</a>
-          <h1 className="text-xl font-semibold" data-testid="quote-workspace-title">
-            {detail.quote.quoteNumber ?? 'Draft quote'}
-          </h1>
-        </div>
-        {/* Primary actions live here so Send (the money-moment) and Download are
-            reachable from any tab, not buried inside the Detail tab. */}
-        <QuoteActions detail={detail} onChanged={reload} variant="header" />
-      </div>
-
-      {/* Tabs */}
-      <div
-        className="flex gap-1 border-b"
-        role="tablist"
-        data-testid="quote-workspace-tabs"
-        onKeyDown={(e) => onTabKeyDown(e, visibleTabs, activeTab)}
-      >
-        {visibleTabs.map((t) => (
-          <button
-            key={t.value}
-            type="button"
-            role="tab"
-            id={`quote-tab-${t.value}`}
-            aria-selected={activeTab === t.value}
-            aria-controls={`quote-tabpanel-${t.value}`}
-            tabIndex={activeTab === t.value ? 0 : -1}
-            onClick={() => selectTab(t.value)}
-            data-testid={`quote-tab-${t.value}`}
-            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
-              activeTab === t.value
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
+    <DocumentWorkspace
+      idPrefix="quote"
+      backHref="/billing/quotes"
+      backLabel="Quotes"
+      title={detail.quote.quoteNumber ?? 'Draft quote'}
+      // Primary actions live in the header so Send (the money-moment) and Download
+      // are reachable from any tab, not buried inside the Detail tab.
+      actions={<QuoteActions detail={detail} onChanged={reload} variant="header" />}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={selectTab}
+    >
       {activeTab === 'editor' && isDraft && (
-        <div role="tabpanel" id="quote-tabpanel-editor" aria-labelledby="quote-tab-editor" tabIndex={0}>
-          <QuoteEditor detail={detail} onChanged={() => void reload()} />
-        </div>
+        <QuoteEditor detail={detail} onChanged={() => void reload()} />
       )}
-
       {activeTab === 'preview' && (
-        <div role="tabpanel" id="quote-tabpanel-preview" aria-labelledby="quote-tab-preview" tabIndex={0}>
-          <QuoteDocumentPreview detail={detail} />
-        </div>
+        <QuoteDocumentPreview detail={detail} />
       )}
-
       {activeTab === 'detail' && (
-        <div role="tabpanel" id="quote-tabpanel-detail" aria-labelledby="quote-tab-detail" tabIndex={0}>
-          <QuoteDetail detail={detail} onChanged={() => void reload()} actionsInHeader />
-        </div>
+        <QuoteDetail detail={detail} onChanged={() => void reload()} actionsInHeader />
       )}
-    </div>
+    </DocumentWorkspace>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -126,4 +126,41 @@ describe('QuotesPage', () => {
     // The row's onClick (SPA navigateTo) must not fire — the anchor navigates natively.
     expect(navigateTo).not.toHaveBeenCalled();
   });
+
+  it('unnumbered draft rows show an em-dash link (no redundant DRAFT chip) with an accessible name', async () => {
+    const draft = { ...QUOTES[0], id: 'q-draft', quoteNumber: null };
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ data: [draft] });
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-table')).toBeInTheDocument());
+
+    const link = screen.getByTestId('quotes-row-link-q-draft');
+    // The Status column already carries the Draft pill, so the Number column shows
+    // a plain em-dash rather than a second "DRAFT" chip…
+    expect(link).toHaveTextContent('—');
+    expect(within(link).queryByText('Draft')).not.toBeInTheDocument();
+    // …but the link keeps an accessible name so it doesn't read as just a dash.
+    expect(link).toHaveAttribute('aria-label', 'Draft quote');
+    // The Status column still communicates draft state.
+    expect(screen.getByTestId('quotes-status-q-draft')).toHaveTextContent('Draft');
+  });
+
+  it('renders the access-denied state (not the retryable error) on a 403', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ error: 'forbidden' }, false, 403);
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+
+    await waitFor(() => expect(screen.getByTestId('access-denied')).toBeInTheDocument());
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view quotes.")).toBeInTheDocument();
+    // The generic data-load-failure UI must NOT appear for a 403.
+    expect(screen.queryByTestId('quotes-error')).not.toBeInTheDocument();
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuotesPage from './QuotesPage';
@@ -49,6 +49,37 @@ describe('QuotesPage', () => {
     render(<QuotesPage />);
     await waitFor(() => expect(screen.getByTestId('quotes-empty')).toBeInTheDocument());
     expect(screen.getByText('No quotes yet')).toBeInTheDocument();
+  });
+
+  it('shows the filtered-empty state (not the teaching empty) when an active filter returns nothing', async () => {
+    // The page seeds its filter from the URL hash on mount.
+    window.location.hash = '#status=declined';
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ data: [] });
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+
+    await screen.findByTestId('quotes-filtered-empty');
+    expect(screen.getByTestId('quotes-clear-filters')).toBeInTheDocument();
+    // The first-run teaching empty must NOT be shown — that reads as data loss.
+    expect(screen.queryByTestId('quotes-empty')).not.toBeInTheDocument();
+  });
+
+  it('Clear filters resets the hash with no bare-# residue', async () => {
+    window.location.hash = '#status=declined';
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ data: [] });
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+
+    fireEvent.click(await screen.findByTestId('quotes-clear-filters'));
+    expect(window.location.hash).toBe('');
+    // With no active filter left, the teaching empty returns.
+    await waitFor(() => expect(screen.getByTestId('quotes-empty')).toBeInTheDocument());
   });
 
   it('renders quote rows with status badge and currency total', async () => {

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -116,8 +116,14 @@ describe('QuotesPage', () => {
 
     // Clicking the link must not double-navigate via the row's onClick handler.
     const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    // Cancel the anchor's default action up front so jsdom doesn't attempt a real
+    // document navigation (unimplemented → console noise). Propagation behavior
+    // — the thing under test — is unaffected.
+    clickEvent.preventDefault();
     const stop = vi.spyOn(clickEvent, 'stopPropagation');
     link.dispatchEvent(clickEvent);
     expect(stop).toHaveBeenCalled();
+    // The row's onClick (SPA navigateTo) must not fire — the anchor navigates natively.
+    expect(navigateTo).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -97,4 +97,27 @@ describe('QuotesPage', () => {
     expect(within(row).getByText('$150.00')).toBeInTheDocument();
     expect(screen.getByTestId('quotes-status-q-1')).toHaveTextContent('Draft');
   });
+
+  it('exposes a focusable link to the quote detail so keyboard users can open it', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ data: QUOTES });
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-table')).toBeInTheDocument());
+
+    const link = screen.getByTestId('quotes-row-link-q-1');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/billing/quotes/q-1');
+    expect(link).toHaveTextContent('Q-0001');
+    // A native anchor is focusable; it must never be removed from the tab order.
+    expect(link.getAttribute('tabindex')).not.toBe('-1');
+
+    // Clicking the link must not double-navigate via the row's onClick handler.
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const stop = vi.spyOn(clickEvent, 'stopPropagation');
+    link.dispatchEvent(clickEvent);
+    expect(stop).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -82,6 +82,27 @@ describe('QuotesPage', () => {
     await waitFor(() => expect(screen.getByTestId('quotes-empty')).toBeInTheDocument());
   });
 
+  it('labels a single-currency Out-for-signature total from the AWAITING subset, not quotes[0]', async () => {
+    // quotes[0] is a draft EUR quote (excluded from the sent/viewed subset); the
+    // only awaiting quote is USD. The strip must read $…, never €… — labeling
+    // the USD sum with quotes[0]'s currency was the original mislabeling bug.
+    const mixed = [
+      { ...QUOTES[0], id: 'q-eur-draft', quoteNumber: 'Q-EUR', status: 'draft', currencyCode: 'EUR', total: '999.00' },
+      { ...QUOTES[0], id: 'q-usd-sent', quoteNumber: 'Q-USD', status: 'sent', currencyCode: 'USD', total: '150.00' },
+    ];
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+      if (input.startsWith('/quotes')) return json({ data: mixed });
+      return json({}, false, 404);
+    });
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-outstanding-strip')).toBeInTheDocument());
+
+    const strip = screen.getByTestId('quotes-outstanding-strip');
+    expect(strip).toHaveTextContent('$150.00');
+    expect(strip.textContent).not.toContain('€');
+  });
+
   it('renders quote rows with status badge and currency total', async () => {
     fetchMock.mockImplementation(async (input: string) => {
       if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
 import { fetchWithAuth } from '../../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
@@ -10,6 +9,7 @@ import { listQuotes, createQuote } from '../../../lib/api/quotes';
 import { showToast } from '../../shared/Toast';
 import { useBulkSelection } from '../bulk/useBulkSelection';
 import { BulkActionBar } from '../bulk/BulkActionBar';
+import { SortableTh } from '../shared/SortableTh';
 import {
   type Quote,
   type QuoteStatus,
@@ -258,35 +258,6 @@ export function QuotesPage() {
     [bulk, loadQuotes, filters],
   );
 
-  const SortHeader = ({ label, sortKey }: { label: string; sortKey: SortKey }) => {
-    const active = sort?.key === sortKey;
-    const ariaLabel = active
-      ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
-      : `Sort by ${label}`;
-    return (
-      <th className="px-3 py-3 text-right font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-        <button
-          type="button"
-          onClick={() => toggleSort(sortKey)}
-          className="inline-flex flex-row-reverse items-center gap-1 hover:text-foreground"
-          data-testid={`quotes-sort-${sortKey}`}
-          aria-label={ariaLabel}
-        >
-          {label}
-          {active ? (
-            sort!.dir === 'asc' ? (
-              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-            )
-          ) : (
-            <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-          )}
-        </button>
-      </th>
-    );
-  };
-
   return (
     <div className="space-y-5" data-testid="quotes-page">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -419,8 +390,8 @@ export function QuotesPage() {
                     <th className="px-3 py-3 font-medium">Number</th>
                     <th className="px-3 py-3 font-medium">Organization</th>
                     <th className="px-3 py-3 font-medium">Status</th>
-                    <SortHeader label="Total" sortKey="total" />
-                    <SortHeaderLeft label="Created" sortKey="created" sort={sort} onSort={toggleSort} />
+                    <SortableTh label="Total" sortKey="total" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} align="right" testId="quotes-sort-total" />
+                    <SortableTh label="Created" sortKey="created" activeSort={sort?.key} direction={sort?.dir ?? 'desc'} onSort={toggleSort} testId="quotes-sort-created" />
                   </tr>
                 </thead>
                 <tbody>
@@ -564,39 +535,6 @@ export function QuotesPage() {
         </div>
       </Dialog>
     </div>
-  );
-}
-
-// Left-aligned sortable header (Created). Right-aligned headers use the inline
-// SortHeader defined in the component.
-function SortHeaderLeft({
-  label, sortKey, sort, onSort,
-}: { label: string; sortKey: SortKey; sort: Sort | null; onSort: (k: SortKey) => void }) {
-  const active = sort?.key === sortKey;
-  const ariaLabel = active
-    ? `Sort by ${label}, ${sort!.dir === 'asc' ? 'ascending' : 'descending'}`
-    : `Sort by ${label}`;
-  return (
-    <th className="px-3 py-3 font-medium" aria-sort={active ? (sort!.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-      <button
-        type="button"
-        onClick={() => onSort(sortKey)}
-        className="inline-flex items-center gap-1 hover:text-foreground"
-        data-testid={`quotes-sort-${sortKey}`}
-        aria-label={ariaLabel}
-      >
-        {label}
-        {active ? (
-          sort!.dir === 'asc' ? (
-            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-          ) : (
-            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-          )
-        ) : (
-          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-        )}
-      </button>
-    </th>
   );
 }
 

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -17,8 +17,10 @@ import {
   statusLabel,
   formatDate,
   formatMoney,
+  sumByCurrency,
 } from './quoteTypes';
 import { StatusPill } from '../shared/StatusPill';
+import { StatCard } from '../shared/StatCard';
 import AccessDenied from '../../shared/AccessDenied';
 import { BULK_ID_LIMIT } from '@breeze/shared';
 
@@ -222,9 +224,17 @@ export function QuotesPage() {
   const summary = useMemo(() => {
     const awaiting = quotes.filter((qt) => qt.status === 'sent' || qt.status === 'viewed');
     const outForSignature = awaiting.reduce((sum, qt) => sum + num(qt.total), 0);
+    const draftCount = quotes.filter((qt) => qt.status === 'draft').length;
+    // Per-currency so a mixed-currency pipeline isn't summed under one wrong code.
+    const byCurrency = sumByCurrency(awaiting.map((qt) => ({ amount: num(qt.total), currencyCode: qt.currencyCode })));
     const ccy = quotes[0]?.currencyCode || 'USD';
-    return { outForSignature, awaitingCount: awaiting.length, ccy };
+    return { outForSignature, awaitingCount: awaiting.length, draftCount, byCurrency, ccy };
   }, [quotes]);
+
+  // '$12,300 + €4,100' across currencies; a single total otherwise (unchanged).
+  const outForSignatureDisplay = summary.byCurrency.length > 1
+    ? summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
+    : formatMoney(summary.outForSignature, summary.ccy);
 
   // ---- derived rows: search filter (client) then optional sort ------------
   const rows = useMemo(() => {
@@ -309,14 +319,26 @@ export function QuotesPage() {
         )}
       </div>
 
-      {/* Out-for-signature summary */}
-      {!loading && !error && summary.awaitingCount > 0 && (
+      {/* Out-for-signature + drafts summary */}
+      {!loading && !error && (summary.awaitingCount > 0 || summary.draftCount > 0) && (
         <div className="flex flex-wrap gap-3" data-testid="quotes-outstanding-strip">
-          <div className="rounded-lg border bg-card px-4 py-3">
-            <div className="text-xs text-muted-foreground">Out for signature</div>
-            <div className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(summary.outForSignature, summary.ccy)}</div>
-            <div className="text-xs text-muted-foreground">{summary.awaitingCount} awaiting</div>
-          </div>
+          {summary.awaitingCount > 0 && (
+            <StatCard
+              label="Out for signature"
+              value={outForSignatureDisplay}
+              hint={`${summary.awaitingCount} awaiting`}
+            />
+          )}
+          {summary.draftCount > 0 && (
+            <StatCard
+              label="Drafts"
+              value={summary.draftCount}
+              hint="not yet sent"
+              onClick={() => applyFilter({ status: 'draft' })}
+              active={filters.status === 'draft'}
+              testId="quotes-drafts-card"
+            />
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -67,7 +67,13 @@ function writeFilters(f: Filters): void {
   if (f.orgId) params.set('orgId', f.orgId);
   if (f.status) params.set('status', f.status);
   const next = params.toString();
-  window.location.hash = next ? `#${next}` : '';
+  if (next) {
+    window.location.hash = `#${next}`;
+  } else if (window.location.hash) {
+    // Clearing: plain `location.hash = ''` can leave a bare '#' dangling in the
+    // URL. replaceState strips the fragment cleanly without a history entry.
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -149,6 +155,16 @@ export function QuotesPage() {
       return next;
     });
   }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(EMPTY_FILTERS);
+    writeFilters(EMPTY_FILTERS);
+    setSearch('');
+  }, []);
+
+  // Distinguishes a filtered-empty result (offer "clear filters") from a genuine
+  // first-run empty state (offer "create your first quote").
+  const hasActiveFilters = !!(filters.orgId || filters.status || search.trim());
 
   // Load sites for the org picker in the dialog.
   const loadNewSites = useCallback(async (orgId: string) => {
@@ -351,27 +367,37 @@ export function QuotesPage() {
               </button>
             </div>
           </div>
-        ) : quotes.length === 0 ? (
-          <div className="px-4 py-14 text-center" data-testid="quotes-empty">
-            <h3 className="text-sm font-semibold">No quotes yet</h3>
-            <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
-              Draft a proposal with headings, rich text, and a pricing table, then send it for acceptance.
-            </p>
-            {canWrite && (
+        ) : rows.length === 0 ? (
+          hasActiveFilters ? (
+            <div className="px-4 py-12 text-center" data-testid="quotes-filtered-empty">
+              <p className="text-sm text-muted-foreground">No quotes match these filters.</p>
               <button
                 type="button"
-                onClick={openCreate}
-                className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-                data-testid="quotes-empty-new"
+                onClick={clearFilters}
+                data-testid="quotes-clear-filters"
+                className="mt-3 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
               >
-                New quote
+                Clear filters
               </button>
-            )}
-          </div>
-        ) : rows.length === 0 ? (
-          <div className="px-4 py-12 text-center text-sm text-muted-foreground" data-testid="quotes-no-match">
-            No quotes match these filters.
-          </div>
+            </div>
+          ) : (
+            <div className="px-4 py-14 text-center" data-testid="quotes-empty">
+              <h3 className="text-sm font-semibold">No quotes yet</h3>
+              <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+                Draft a proposal with headings, rich text, and a pricing table, then send it for acceptance.
+              </p>
+              {canWrite && (
+                <button
+                  type="button"
+                  onClick={openCreate}
+                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                  data-testid="quotes-empty-new"
+                >
+                  New quote
+                </button>
+              )}
+            </div>
+          )
         ) : (
           <div className="relative">
             <div className="overflow-x-auto">

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -13,11 +13,12 @@ import { BulkActionBar } from '../bulk/BulkActionBar';
 import {
   type Quote,
   type QuoteStatus,
-  STATUS_COLORS,
+  STATUS_ROLES,
   statusLabel,
   formatDate,
   formatMoney,
 } from './quoteTypes';
+import { StatusPill } from '../shared/StatusPill';
 import { BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
@@ -448,14 +449,12 @@ export function QuotesPage() {
                       </td>
                       <td className="px-3 py-3">{orgName(qt.orgId)}</td>
                       <td className="px-3 py-3">
-                        <span
-                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${STATUS_COLORS[qt.status]}`}
-                          data-testid={`quotes-status-${qt.id}`}
-                        >
-                          {/* Real visually-hidden text, not aria-label on a non-interactive
-                              span (unreliable for screen readers) — mirrors QuoteDetail. */}
-                          <span className="sr-only">Status: </span>{statusLabel(qt)}
-                        </span>
+                        <StatusPill
+                          role={STATUS_ROLES[qt.status].role}
+                          label={statusLabel(qt)}
+                          className={STATUS_ROLES[qt.status].className}
+                          testId={`quotes-status-${qt.id}`}
+                        />
                       </td>
                       <td className="px-3 py-3 text-right tabular-nums">{formatMoney(qt.total, qt.currencyCode)}</td>
                       <td className="px-3 py-3 text-muted-foreground">{formatDate(qt.createdAt)}</td>

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -231,10 +231,14 @@ export function QuotesPage() {
     return { outForSignature, awaitingCount: awaiting.length, draftCount, byCurrency, ccy };
   }, [quotes]);
 
-  // '$12,300 + €4,100' across currencies; a single total otherwise (unchanged).
-  const outForSignatureDisplay = summary.byCurrency.length > 1
-    ? summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
-    : formatMoney(summary.outForSignature, summary.ccy);
+  // '$12,300 + €4,100' across currencies. With one currency, label with the
+  // SUMMED SUBSET's code (byCurrency[0]) — not quotes[0]'s (`summary.ccy`),
+  // which may come from a draft/expired quote in a different currency. The
+  // quotes[0] fallback only applies when nothing is awaiting ($0.00; the card
+  // is hidden then anyway).
+  const outForSignatureDisplay = summary.byCurrency.length === 0
+    ? formatMoney(summary.outForSignature, summary.ccy)
+    : summary.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ');
 
   // ---- derived rows: search filter (client) then optional sort ------------
   const rows = useMemo(() => {

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -438,11 +438,18 @@ export function QuotesPage() {
                         />
                       </td>
                       <td className="px-3 py-3 font-medium">
-                        {qt.quoteNumber ?? (
-                          <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                            Draft
-                          </span>
-                        )}
+                        <a
+                          href={`/billing/quotes/${qt.id}`}
+                          onClick={(e) => e.stopPropagation()}
+                          data-testid={`quotes-row-link-${qt.id}`}
+                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        >
+                          {qt.quoteNumber ?? (
+                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              Draft
+                            </span>
+                          )}
+                        </a>
                       </td>
                       <td className="px-3 py-3">{orgName(qt.orgId)}</td>
                       <td className="px-3 py-3">

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -19,6 +19,7 @@ import {
   formatMoney,
 } from './quoteTypes';
 import { StatusPill } from '../shared/StatusPill';
+import AccessDenied from '../../shared/AccessDenied';
 import { BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
@@ -88,6 +89,9 @@ export function QuotesPage() {
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // A 403 from the quotes route is a permission denial, not a load failure, so it
+  // renders the access-denied state rather than the retryable error.
+  const [forbidden, setForbidden] = useState(false);
   const [filters, setFilters] = useState<Filters>(() => readFilters());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<Sort | null>(null);
@@ -120,8 +124,10 @@ export function QuotesPage() {
     try {
       setLoading(true);
       setError(undefined);
+      setForbidden(false);
       const res = await listQuotes({ orgId: f.orgId || undefined, status: f.status || undefined });
       if (res.status === 401) return UNAUTHORIZED();
+      if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error('Failed to load quotes');
       const body = (await res.json()) as { data: Quote[] };
       setQuotes(body.data ?? []);
@@ -273,6 +279,14 @@ export function QuotesPage() {
     },
     [bulk, loadQuotes, filters],
   );
+
+  if (forbidden) {
+    return (
+      <div className="space-y-5" data-testid="quotes-page">
+        <AccessDenied message="You don't have permission to view quotes." />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5" data-testid="quotes-page">
@@ -442,13 +456,14 @@ export function QuotesPage() {
                           href={`/billing/quotes/${qt.id}`}
                           onClick={(e) => e.stopPropagation()}
                           data-testid={`quotes-row-link-${qt.id}`}
+                          // Unnumbered drafts show an em-dash (the Status column
+                          // already carries the "Draft" pill, so a DRAFT chip here
+                          // was redundant). The dash is decorative — give the link
+                          // an accessible name so it doesn't read as just "—".
+                          aria-label={qt.quoteNumber ? undefined : 'Draft quote'}
                           className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                         >
-                          {qt.quoteNumber ?? (
-                            <span className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                              Draft
-                            </span>
-                          )}
+                          {qt.quoteNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                         </a>
                       </td>
                       <td className="px-3 py-3">{orgName(qt.orgId)}</td>

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -163,7 +163,7 @@ export function statusLabel(quote: { status: QuoteStatus; sentAt: string | null 
 // Money/date formatters live in ../shared/format (the canonical copies, shared
 // with invoices + contracts); re-exported here so existing './quoteTypes' import
 // sites are unaffected.
-export { formatMoney, formatDate } from '../shared/format';
+export { formatMoney, formatDate, sumByCurrency } from '../shared/format';
 
 /** Convert a stored tax-rate FRACTION (e.g. '0.07') to a percent string for an
  *  input ('7'), rounding to 3 decimals to match the numeric(6,3)-on-fraction

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -5,7 +5,7 @@
 import type { SellerSnapshot } from '../invoiceTypes';
 export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
-import { STATUS_PILL } from '../invoiceTypes';
+import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
 
 export type QuoteStatus =
   | 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'expired' | 'converted';
@@ -133,22 +133,25 @@ export const STATUS_LABELS: Record<QuoteStatus, string> = {
   converted: 'Converted',
 };
 
-// Tailwind badge classes per status (mirrors the invoice/contract status-pill style).
-// Five semantic roles shared with the invoice pills (see STATUS_PILL): the
-// colour reads the lifecycle (neutral → info while it's with the customer →
-// success when won → warning when lapsing → danger when lost), and the label
-// carries the finer distinction. sent/viewed share info; accepted/converted
-// share success — collapsing the old blue/indigo/violet/emerald rainbow that
-// was hard to tell apart at pill scale.
-export const STATUS_COLORS: Record<QuoteStatus, string> = {
-  draft: STATUS_PILL.neutral,
-  sent: STATUS_PILL.info,
-  viewed: STATUS_PILL.info,
-  accepted: STATUS_PILL.success,
-  declined: STATUS_PILL.danger,
-  expired: STATUS_PILL.warning,
-  converted: STATUS_PILL.success,
+// Source-of-truth status → role map; STATUS_COLORS (class-string form) is
+// derived from it. sent/viewed share info; accepted/converted share success —
+// collapsing the old blue/indigo/violet/emerald rainbow that was hard to tell
+// apart at pill scale. The status pills pass `role` straight to <StatusPill>.
+export const STATUS_ROLES: Record<QuoteStatus, { role: StatusPillRole; className?: string }> = {
+  draft: { role: 'neutral' },
+  sent: { role: 'info' },
+  viewed: { role: 'info' },
+  accepted: { role: 'success' },
+  declined: { role: 'danger' },
+  expired: { role: 'warning' },
+  converted: { role: 'success' },
 };
+
+export const STATUS_COLORS = Object.fromEntries(
+  (Object.entries(STATUS_ROLES) as [QuoteStatus, { role: StatusPillRole; className?: string }][]).map(
+    ([status, { role, className }]) => [status, className ? `${STATUS_PILL[role]} ${className}` : STATUS_PILL[role]],
+  ),
+) as Record<QuoteStatus, string>;
 
 /** Display label for a quote's status. The 'sent' lifecycle status only reads as
  *  "Sent" once an email actually went out (sentAt); otherwise it's "Issued". */
@@ -157,18 +160,10 @@ export function statusLabel(quote: { status: QuoteStatus; sentAt: string | null 
   return STATUS_LABELS[quote.status];
 }
 
-/** Currency-aware money formatter (quotes carry their own currencyCode, unlike
- *  the USD-only lib/timeFormat.formatMoney). Identical to invoiceTypes.formatMoney. */
-export function formatMoney(value: string | number | null | undefined, currencyCode = 'USD'): string {
-  const n = typeof value === 'number' ? value : Number(value);
-  const safe = Number.isFinite(n) ? n : 0;
-  try {
-    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
-  } catch {
-    // Unknown/invalid currency code → fall back to plain 2-decimal + code suffix.
-    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
-  }
-}
+// Money/date formatters live in ../shared/format (the canonical copies, shared
+// with invoices + contracts); re-exported here so existing './quoteTypes' import
+// sites are unaffected.
+export { formatMoney, formatDate } from '../shared/format';
 
 /** Convert a stored tax-rate FRACTION (e.g. '0.07') to a percent string for an
  *  input ('7'), rounding to 3 decimals to match the numeric(6,3)-on-fraction
@@ -193,14 +188,6 @@ export function lineTaxAmount(
   const cents = Math.round(Number(lineTotal) * 100);
   if (!Number.isFinite(rate) || rate <= 0 || !Number.isFinite(cents)) return null;
   return Math.round(cents * rate) / 100;
-}
-
-/** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
-export function formatDate(value: string | null | undefined): string {
-  if (!value) return '—';
-  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleDateString();
 }
 
 /**

--- a/apps/web/src/components/billing/quotes/useQuoteImage.ts
+++ b/apps/web/src/components/billing/quotes/useQuoteImage.ts
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { fetchWithAuth } from '../../../stores/auth';
-import { navigateTo } from '@/lib/navigation';
-import { handleActionError } from '../../../lib/runAction';
 import { quotePdfUrl } from '../../../lib/api/quotes';
+import { usePdfDownload } from '../shared/usePdfDownload';
 
 /**
  * Fetch an access-controlled image (a quote image, a catalog thumbnail) that
@@ -48,34 +47,16 @@ export function useAuthedImage(path: string | null): { url?: string; failed: boo
 }
 
 /**
- * Download a quote's PDF (authed bytes → blob → anchor click). One implementation
- * for both the workspace header action and the customer-preview button, so the
- * two can't drift in URL, filename, or error handling. Returns `{ busy, downloadPdf }`;
- * `busy` guards against double-submit and drives the button's disabled/label state.
+ * Download a quote's PDF — a thin specialization of the shared `usePdfDownload`
+ * (authed bytes → blob → anchor click), so the quote surfaces can't drift from
+ * the invoice ones in URL, 401 handling, or error copy. Preserves the historical
+ * `{ busy, downloadPdf }` shape the quote header/preview buttons consume.
  */
 export function useQuotePdfDownload(quote: { id: string; quoteNumber: string | null }) {
-  const [busy, setBusy] = useState(false);
-  const downloadPdf = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const res = await fetchWithAuth(quotePdfUrl(quote.id));
-      if (res.status === 401) { void navigateTo('/login', { replace: true }); return; }
-      if (!res.ok) { handleActionError(new Error('pdf'), 'Could not download the quote PDF.'); return; }
-      const blob = await res.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${quote.quoteNumber ?? `quote-${quote.id}`}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
-    } catch (err) {
-      handleActionError(err, 'Could not download the quote PDF.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, quote.id, quote.quoteNumber]);
-  return { busy, downloadPdf };
+  const { download, downloading } = usePdfDownload({
+    path: quotePdfUrl(quote.id),
+    filename: `${quote.quoteNumber ?? `quote-${quote.id}`}.pdf`,
+    errorMessage: 'Could not download the quote PDF.',
+  });
+  return { busy: downloading, downloadPdf: download };
 }

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocumentWorkspace } from './DocumentWorkspace';
+
+const TABS = [
+  { id: 'editor', label: 'Editor' },
+  { id: 'preview', label: 'Preview' },
+  { id: 'detail', label: 'Detail' },
+];
+
+function renderWs(over: Partial<React.ComponentProps<typeof DocumentWorkspace>> = {}) {
+  const onTabChange = vi.fn();
+  render(
+    <DocumentWorkspace
+      idPrefix="doc"
+      backHref="/billing/things"
+      backLabel="Things"
+      title="THING-1"
+      tabs={TABS}
+      activeTab="editor"
+      onTabChange={onTabChange}
+      {...over}
+    >
+      <div data-testid="panel-body">body for {over.activeTab ?? 'editor'}</div>
+    </DocumentWorkspace>,
+  );
+  return { onTabChange };
+}
+
+describe('DocumentWorkspace', () => {
+  it('renders the title, back link, and a WAI-ARIA tablist with the active tab selected', () => {
+    renderWs();
+    expect(screen.getByTestId('doc-workspace-title')).toHaveTextContent('THING-1');
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-tab-editor')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('doc-tab-preview')).toHaveAttribute('aria-selected', 'false');
+    // Roving tabindex: only the active tab is in the tab order.
+    expect(screen.getByTestId('doc-tab-editor')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('doc-tab-preview')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders the status pill and actions slots when provided', () => {
+    renderWs({
+      statusPill: <span data-testid="doc-status">Draft</span>,
+      actions: <button data-testid="doc-action">Do it</button>,
+    });
+    expect(screen.getByTestId('doc-status')).toBeInTheDocument();
+    expect(screen.getByTestId('doc-action')).toBeInTheDocument();
+  });
+
+  it('omits hidden tabs from the tablist', () => {
+    renderWs({ tabs: [{ id: 'editor', label: 'Editor', hidden: true }, ...TABS.slice(1)], activeTab: 'detail' });
+    expect(screen.queryByTestId('doc-tab-editor')).not.toBeInTheDocument();
+    expect(screen.getByTestId('doc-tab-preview')).toBeInTheDocument();
+  });
+
+  it('moves selection with ArrowRight (roving tabindex) and calls onTabChange', () => {
+    const { onTabChange } = renderWs();
+    fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowRight' });
+    expect(onTabChange).toHaveBeenCalledWith('preview');
+  });
+
+  it('jumps to the last tab on End and the first on Home', () => {
+    const { onTabChange } = renderWs();
+    fireEvent.keyDown(screen.getByRole('tablist'), { key: 'End' });
+    expect(onTabChange).toHaveBeenCalledWith('detail');
+    fireEvent.keyDown(screen.getByRole('tablist'), { key: 'Home' });
+    expect(onTabChange).toHaveBeenCalledWith('editor');
+  });
+
+  it('activates a tab on click', () => {
+    const { onTabChange } = renderWs();
+    fireEvent.click(screen.getByTestId('doc-tab-detail'));
+    expect(onTabChange).toHaveBeenCalledWith('detail');
+  });
+
+  it('renders the active panel with tabpanel semantics', () => {
+    renderWs();
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('id', 'doc-tabpanel-editor');
+    expect(panel).toHaveAttribute('aria-labelledby', 'doc-tab-editor');
+    expect(screen.getByTestId('panel-body')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
@@ -1,0 +1,137 @@
+import { useCallback, type KeyboardEvent, type ReactNode } from 'react';
+
+export interface DocumentTab {
+  id: string;
+  label: string;
+  /** Hidden tabs are dropped from the tablist (e.g. Editor once a doc is issued). */
+  hidden?: boolean;
+}
+
+export interface DocumentWorkspaceProps {
+  /** Prefix for every id / data-testid (`quote`, `invoice`) so the two surfaces
+   *  keep their existing, stable testids while sharing one implementation. */
+  idPrefix: string;
+  backHref: string;
+  backLabel: string;
+  title: string;
+  statusPill?: ReactNode;
+  actions?: ReactNode;
+  tabs: DocumentTab[];
+  activeTab: string;
+  onTabChange: (id: string) => void;
+  children: ReactNode;
+}
+
+/**
+ * The shared quote/invoice workspace chrome: a back link + truncating title (+
+ * optional status pill and right-aligned actions cluster) over a WAI-ARIA
+ * tablist. Extracted from the near-verbatim QuoteWorkspace/InvoiceWorkspace so
+ * the tablist keyboard model (roving tabindex, Arrow/Home/End, aria-selected)
+ * lives in exactly one place. Tab STATE (which tab, hash persistence, hide rules)
+ * stays with the caller — this component is presentational and reports intent via
+ * `onTabChange`.
+ *
+ * The actions slot is a right-aligned flex cluster; a disabled-primary-action's
+ * reason hint must be rendered by the caller BELOW the buttons (a full-basis,
+ * right-aligned `<p>`), never inline between them — an inline hint drags the whole
+ * cluster into the page centre.
+ */
+export function DocumentWorkspace({
+  idPrefix,
+  backHref,
+  backLabel,
+  title,
+  statusPill,
+  actions,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+}: DocumentWorkspaceProps) {
+  const visibleTabs = tabs.filter((t) => !t.hidden);
+
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right (and Up/Down) move between tabs, Home/End jump to the ends, and the
+  // moved-to tab is both activated and focused.
+  const onTabKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    const idx = visibleTabs.findIndex((t) => t.id === activeTab);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % visibleTabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + visibleTabs.length) % visibleTabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = visibleTabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = visibleTabs[nextIdx].id;
+    onTabChange(next);
+    if (typeof document !== 'undefined') document.getElementById(`${idPrefix}-tab-${next}`)?.focus();
+  }, [visibleTabs, activeTab, onTabChange, idPrefix]);
+
+  return (
+    <div className="space-y-4" data-testid={`${idPrefix}-workspace`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <a
+            href={backHref}
+            aria-label={`Back to ${backLabel.toLowerCase()}`}
+            className="text-xs text-muted-foreground hover:underline"
+          >
+            <span aria-hidden="true">←</span> {backLabel}
+          </a>
+          <div className="flex items-center gap-2 min-w-0">
+            <h1 className="truncate text-xl font-semibold" data-testid={`${idPrefix}-workspace-title`}>
+              {title}
+            </h1>
+            {statusPill}
+          </div>
+        </div>
+        {actions && (
+          // Right-aligned cluster; the caller renders any disabled-reason hint on
+          // its own full-basis line below the buttons (never inline between them).
+          <div className="flex items-center gap-2 flex-wrap justify-end">{actions}</div>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        data-testid={`${idPrefix}-workspace-tabs`}
+        onKeyDown={onTabKeyDown}
+      >
+        {visibleTabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            id={`${idPrefix}-tab-${t.id}`}
+            aria-selected={activeTab === t.id}
+            aria-controls={`${idPrefix}-tabpanel-${t.id}`}
+            tabIndex={activeTab === t.id ? 0 : -1}
+            onClick={() => onTabChange(t.id)}
+            data-testid={`${idPrefix}-tab-${t.id}`}
+            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
+              activeTab === t.id
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`${idPrefix}-tabpanel-${activeTab}`}
+        aria-labelledby={`${idPrefix}-tab-${activeTab}`}
+        tabIndex={0}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default DocumentWorkspace;

--- a/apps/web/src/components/billing/shared/SortableTh.test.tsx
+++ b/apps/web/src/components/billing/shared/SortableTh.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SortableTh } from './SortableTh';
+
+function renderTh(props: Partial<Parameters<typeof SortableTh>[0]> = {}) {
+  const onSort = vi.fn();
+  render(
+    <table>
+      <thead>
+        <tr>
+          <SortableTh
+            label="Total"
+            sortKey="total"
+            activeSort={undefined}
+            direction="desc"
+            onSort={onSort}
+            testId="sort-total"
+            {...props}
+          />
+        </tr>
+      </thead>
+    </table>,
+  );
+  return { onSort };
+}
+
+describe('SortableTh', () => {
+  it('renders aria-sort="ascending" when active and ascending', () => {
+    renderTh({ activeSort: 'total', direction: 'asc' });
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('renders aria-sort="descending" when active and descending', () => {
+    renderTh({ activeSort: 'total', direction: 'desc' });
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('renders aria-sort="none" when inactive', () => {
+    renderTh({ activeSort: 'created' });
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('calls onSort with the sortKey when the header button is clicked', () => {
+    const { onSort } = renderTh({ activeSort: 'created' });
+    fireEvent.click(screen.getByTestId('sort-total'));
+    expect(onSort).toHaveBeenCalledTimes(1);
+    expect(onSort).toHaveBeenCalledWith('total');
+  });
+
+  it('right-aligns the header and button when align="right"', () => {
+    renderTh({ align: 'right' });
+    expect(screen.getByRole('columnheader').className).toContain('text-right');
+    expect(screen.getByTestId('sort-total').className).toContain('flex-row-reverse');
+  });
+
+  it('left-aligns (no text-right / flex-row-reverse) by default', () => {
+    renderTh();
+    expect(screen.getByRole('columnheader').className).not.toContain('text-right');
+    expect(screen.getByTestId('sort-total').className).not.toContain('flex-row-reverse');
+  });
+});

--- a/apps/web/src/components/billing/shared/SortableTh.tsx
+++ b/apps/web/src/components/billing/shared/SortableTh.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+
+/**
+ * Shared sortable table header for the billing surfaces (quotes / invoices /
+ * contracts). Lifted verbatim from the identical `SortHeader` / `SortHeaderLeft`
+ * copies that lived in QuotesPage and InvoicesPage — parameterized on alignment
+ * and test id, with markup/classes kept byte-compatible so the rendered output
+ * is unchanged.
+ *
+ * `align="right"` reverses the icon/label order and right-aligns the cell (used
+ * for numeric money columns); `align="left"` (default) is used for text/date
+ * columns.
+ */
+export interface SortableThProps<K extends string> {
+  label: string;
+  sortKey: K;
+  /** The currently active sort key, if any. */
+  activeSort: K | null | undefined;
+  /** Direction of the active sort — only consulted when this column is active. */
+  direction: 'asc' | 'desc';
+  onSort: (key: K) => void;
+  align?: 'left' | 'right';
+  testId?: string;
+}
+
+export function SortableTh<K extends string>({
+  label,
+  sortKey,
+  activeSort,
+  direction,
+  onSort,
+  align = 'left',
+  testId,
+}: SortableThProps<K>) {
+  const active = activeSort === sortKey;
+  const ariaLabel = active
+    ? `Sort by ${label}, ${direction === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
+  const thClass = align === 'right' ? 'px-3 py-3 text-right font-medium' : 'px-3 py-3 font-medium';
+  const buttonClass =
+    align === 'right'
+      ? 'inline-flex flex-row-reverse items-center gap-1 hover:text-foreground'
+      : 'inline-flex items-center gap-1 hover:text-foreground';
+  return (
+    <th className={thClass} aria-sort={active ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={buttonClass}
+        data-testid={testId}
+        aria-label={ariaLabel}
+      >
+        {label}
+        {active ? (
+          direction === 'asc' ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </button>
+    </th>
+  );
+}
+
+export default SortableTh;

--- a/apps/web/src/components/billing/shared/StatCard.test.tsx
+++ b/apps/web/src/components/billing/shared/StatCard.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { StatCard } from './StatCard';
+
+describe('StatCard', () => {
+  it('renders a static card as a non-interactive div', () => {
+    render(<StatCard label="Est. monthly recurring" value="$1,200.00" hint="4 active" testId="mrr" />);
+    const card = screen.getByTestId('mrr');
+    expect(card.tagName).toBe('DIV');
+    expect(card).toHaveTextContent('Est. monthly recurring');
+    expect(card).toHaveTextContent('$1,200.00');
+    expect(card).toHaveTextContent('4 active');
+  });
+
+  it('renders a clickable card as a button and fires onClick', () => {
+    const onClick = vi.fn();
+    render(<StatCard label="Drafts" value={3} onClick={onClick} testId="drafts" />);
+    const card = screen.getByTestId('drafts');
+    expect(card.tagName).toBe('BUTTON');
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the active filter via aria-pressed', () => {
+    const { rerender } = render(<StatCard label="Drafts" value={3} onClick={() => {}} active={false} testId="drafts" />);
+    expect(screen.getByTestId('drafts')).toHaveAttribute('aria-pressed', 'false');
+    rerender(<StatCard label="Drafts" value={3} onClick={() => {}} active testId="drafts" />);
+    expect(screen.getByTestId('drafts')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not fire on a static card (no onClick, no button)', () => {
+    render(<StatCard label="Outstanding" value="$0.00" testId="out" />);
+    const card = screen.getByTestId('out');
+    // A static card must not be a button — it carries no filter affordance.
+    expect(card.tagName).not.toBe('BUTTON');
+  });
+});

--- a/apps/web/src/components/billing/shared/StatCard.tsx
+++ b/apps/web/src/components/billing/shared/StatCard.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+
+interface StatCardProps {
+  /** Small muted caption above the figure (e.g. 'Outstanding', 'Drafts'). */
+  label: string;
+  /** The figure itself — a formatted money string, a count, or per-currency JSX. */
+  value: ReactNode;
+  /** Optional sub-caption below the figure (e.g. '3 open', 'needs follow-up'). */
+  hint?: string;
+  /** When provided the card is an interactive filter button; omit for a static
+   *  read-only stat (e.g. contracts MRR). */
+  onClick?: () => void;
+  /** Whether the filter this card sets is currently applied — draws a ring so the
+   *  active filter is visible. Only meaningful for a clickable card. */
+  active?: boolean;
+  /** 'destructive' tints the card red for attention-worthy stats (overdue). */
+  tone?: 'default' | 'destructive';
+  /** Extra classes on the outer element (e.g. `inline-flex` to size to content). */
+  className?: string;
+  testId?: string;
+}
+
+const BASE = 'rounded-lg border px-4 py-3 text-left';
+
+/**
+ * The one summary-strip stat card for every billing surface (invoices, quotes,
+ * contracts). Clickable cards render as a real <button> with a focus ring so
+ * keyboard users can operate the stat-as-filter affordance; static cards render
+ * as a <div>. Extracted from the Invoices strip so quotes/contracts can't drift
+ * in padding, tone, or focus behaviour.
+ */
+export function StatCard({ label, value, hint, onClick, active, tone = 'default', className, testId }: StatCardProps) {
+  const destructive = tone === 'destructive';
+  const toneCls = destructive ? 'border-destructive/30 bg-destructive/5' : 'bg-card';
+  const labelCls = destructive ? 'text-destructive' : 'text-muted-foreground';
+  const valueCls = destructive ? 'text-destructive' : 'text-foreground';
+  const classes = [BASE, toneCls, className].filter(Boolean).join(' ');
+
+  const content = (
+    <>
+      <div className={`text-xs ${labelCls}`}>{label}</div>
+      <div className={`mt-0.5 text-lg font-semibold tabular-nums ${valueCls}`}>{value}</div>
+      {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className={classes} data-testid={testId}>
+        {content}
+      </div>
+    );
+  }
+
+  const hover = destructive ? 'hover:bg-destructive/10' : 'hover:bg-muted/40';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      data-testid={testId}
+      className={`${classes} transition ${hover} focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${active ? 'ring-2 ring-ring' : ''}`}
+    >
+      {content}
+    </button>
+  );
+}
+
+export default StatCard;

--- a/apps/web/src/components/billing/shared/StatusPill.test.tsx
+++ b/apps/web/src/components/billing/shared/StatusPill.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusPill } from './StatusPill';
+import { STATUS_PILL } from '../invoiceTypes';
+
+describe('StatusPill', () => {
+  it('renders the visible label', () => {
+    render(<StatusPill role="success" label="Paid" />);
+    expect(screen.getByText('Paid')).toBeInTheDocument();
+  });
+
+  it('renders a visually-hidden "Status:" prefix for screen readers', () => {
+    render(<StatusPill role="success" label="Paid" />);
+    const prefix = screen.getByText('Status:');
+    expect(prefix).toHaveClass('sr-only');
+  });
+
+  it('does NOT put aria-label on the (non-interactive) span — uses sr-only text instead', () => {
+    const { container } = render(<StatusPill role="info" label="Sent" />);
+    const pill = container.firstElementChild as HTMLElement;
+    expect(pill.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('applies the STATUS_PILL classes for the given role', () => {
+    render(<StatusPill role="warning" label="Overdue" testId="pill" />);
+    const pill = screen.getByTestId('pill');
+    for (const cls of STATUS_PILL.warning.split(' ')) {
+      expect(pill.className).toContain(cls);
+    }
+  });
+
+  it('passes through testId and an extra className (e.g. line-through)', () => {
+    render(<StatusPill role="neutral" label="Void" className="line-through" testId="void-pill" />);
+    const pill = screen.getByTestId('void-pill');
+    expect(pill).toHaveClass('line-through');
+    expect(pill).toHaveTextContent('Void');
+  });
+});

--- a/apps/web/src/components/billing/shared/StatusPill.tsx
+++ b/apps/web/src/components/billing/shared/StatusPill.tsx
@@ -1,0 +1,35 @@
+import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
+
+const BASE = 'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium';
+
+interface StatusPillProps {
+  /** Semantic colour role (see STATUS_PILL) — meaning drives the hue, the label
+   *  carries the finer distinction. Shared across invoices/quotes/contracts. */
+  role: StatusPillRole;
+  /** Visible status text (e.g. 'Paid', 'Active', 'Issued'). */
+  label: string;
+  /** Extra classes (e.g. `line-through` for a void/cancelled pill, `shrink-0`
+   *  where the pill sits in a flex row). */
+  className?: string;
+  testId?: string;
+}
+
+/**
+ * The one status pill for every billing surface. Renders a real visually-hidden
+ * "Status:" prefix (the accessible pattern from QuotesPage) rather than an
+ * `aria-label` on a non-interactive span — screen readers don't reliably
+ * announce aria-label on a plain <span>, so the sr-only text is the SSOT for the
+ * spoken value. The visible `label` sits alongside it.
+ */
+export function StatusPill({ role, label, className, testId }: StatusPillProps) {
+  return (
+    <span
+      className={className ? `${BASE} ${STATUS_PILL[role]} ${className}` : `${BASE} ${STATUS_PILL[role]}`}
+      data-testid={testId}
+    >
+      <span className="sr-only">Status: </span>{label}
+    </span>
+  );
+}
+
+export default StatusPill;

--- a/apps/web/src/components/billing/shared/TableSkeleton.tsx
+++ b/apps/web/src/components/billing/shared/TableSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * Shared loading skeleton for the billing list tables. Generalizes the 6-row
+ * pulsing-bar block that QuotesPage rendered inline while a list loads, so the
+ * contracts / invoices / quotes surfaces show a table-shaped placeholder instead
+ * of a bare spinner.
+ *
+ * The first cell of each row is a fixed-width bar, the last stretches to the
+ * right (the money column), and the middle cells fill the remaining width —
+ * matching the visual rhythm of the original quotes skeleton.
+ */
+export interface TableSkeletonProps {
+  /** Number of placeholder cells per row. */
+  cols: number;
+  /** Number of skeleton rows (defaults to 6, the original count). */
+  rows?: number;
+}
+
+export function TableSkeleton({ cols, rows = 6 }: TableSkeletonProps) {
+  const cellClass = (col: number) => {
+    if (col === 0) return 'h-4 w-20 animate-pulse rounded bg-muted';
+    if (col === cols - 1) return 'ml-auto h-4 w-24 animate-pulse rounded bg-muted';
+    return 'h-4 w-1/4 animate-pulse rounded bg-muted';
+  };
+  return (
+    <div className="divide-y" data-testid="table-skeleton">
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex items-center gap-4 px-4 py-3.5">
+          {Array.from({ length: Math.max(cols, 1) }).map((_, c) => (
+            <div key={c} className={cellClass(c)} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default TableSkeleton;

--- a/apps/web/src/components/billing/shared/format.test.ts
+++ b/apps/web/src/components/billing/shared/format.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatMoney, formatDate } from './format';
+
+describe('formatMoney', () => {
+  // NOTE: formatMoney takes a *dollar* amount (numeric(12,2)), not cents — every
+  // call site passes API money strings like '500.00'. So 1125 → $1,125.00, and
+  // 112500 → $112,500.00 (the task brief's "112500 → $1,125.00" example conflated
+  // dollars with cents; dividing by 100 would break every billing surface).
+  it('formats a whole USD amount with grouping and 2 decimals', () => {
+    expect(formatMoney(1125)).toBe('$1,125.00');
+  });
+
+  it('treats the argument as dollars, not cents', () => {
+    expect(formatMoney(112500)).toBe('$112,500.00');
+  });
+
+  it('formats a dollar string (the API shape) unchanged', () => {
+    expect(formatMoney('123.40')).toBe('$123.40');
+  });
+
+  it('renders a non-USD currency with its symbol or code', () => {
+    expect(formatMoney(0, 'EUR')).toMatch(/€|EUR/);
+  });
+
+  it('falls back to a plain amount + code for a malformed currency code', () => {
+    // Intl.NumberFormat throws RangeError on a non-3-letter code → catch branch.
+    expect(formatMoney(5, 'US')).toBe('5.00 US');
+  });
+
+  it('coerces a non-finite value to 0', () => {
+    expect(formatMoney(null)).toBe('$0.00');
+  });
+});
+
+describe('formatDate', () => {
+  it('returns the em-dash fallback for null/undefined/empty', () => {
+    expect(formatDate(null)).toBe('—');
+    expect(formatDate(undefined)).toBe('—');
+    expect(formatDate('')).toBe('—');
+  });
+
+  it('renders a YYYY-MM-DD date as a short locale date', () => {
+    expect(formatDate('2026-06-16')).toBe(new Date('2026-06-16T00:00:00').toLocaleDateString());
+  });
+
+  it('returns the raw input when it is not a parseable date', () => {
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/apps/web/src/components/billing/shared/format.test.ts
+++ b/apps/web/src/components/billing/shared/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMoney, formatDate } from './format';
+import { formatMoney, formatDate, sumByCurrency } from './format';
 
 describe('formatMoney', () => {
   // NOTE: formatMoney takes a *dollar* amount (numeric(12,2)), not cents — every
@@ -29,6 +29,47 @@ describe('formatMoney', () => {
 
   it('coerces a non-finite value to 0', () => {
     expect(formatMoney(null)).toBe('$0.00');
+  });
+});
+
+describe('sumByCurrency', () => {
+  it('returns [] for no entries', () => {
+    expect(sumByCurrency([])).toEqual([]);
+  });
+
+  it('collapses a single currency to one entry (the pre-existing single-currency path)', () => {
+    expect(
+      sumByCurrency([
+        { amount: 10, currencyCode: 'USD' },
+        { amount: 5, currencyCode: 'USD' },
+      ]),
+    ).toEqual([{ code: 'USD', amount: 15 }]);
+  });
+
+  it('splits a mixed-currency set into one entry per currency, summed within each', () => {
+    expect(
+      sumByCurrency([
+        { amount: 100, currencyCode: 'USD' },
+        { amount: 50, currencyCode: 'EUR' },
+        { amount: 25, currencyCode: 'USD' },
+      ]),
+    ).toEqual([
+      { code: 'USD', amount: 125 },
+      { code: 'EUR', amount: 50 },
+    ]);
+  });
+
+  it('preserves first-seen order (stable), not alphabetical', () => {
+    expect(
+      sumByCurrency([
+        { amount: 1, currencyCode: 'EUR' },
+        { amount: 2, currencyCode: 'USD' },
+      ]).map((e) => e.code),
+    ).toEqual(['EUR', 'USD']);
+  });
+
+  it('coalesces a falsy currency code to USD (matching the strips’ || "USD" default)', () => {
+    expect(sumByCurrency([{ amount: 3, currencyCode: '' }])).toEqual([{ code: 'USD', amount: 3 }]);
   });
 });
 

--- a/apps/web/src/components/billing/shared/format.ts
+++ b/apps/web/src/components/billing/shared/format.ts
@@ -1,0 +1,29 @@
+// Shared money/date formatters for the billing surfaces (invoices, quotes,
+// contracts). These are the canonical copies — `invoiceTypes.ts` and
+// `quoteTypes.ts` re-export them so existing `./invoiceTypes` / `./quoteTypes`
+// import sites keep working, and the contracts components import them directly
+// (replacing two hand-rolled `formatDate` copies that had drifted).
+//
+// Money fields arrive from the API as numeric(12,2) *dollar* strings
+// (e.g. '123.40') — these format dollars, NOT cents.
+
+/** Currency-aware money formatter (invoices/quotes/contracts carry their own
+ *  currencyCode, unlike the USD-only lib/timeFormat.formatMoney). */
+export function formatMoney(value: string | number | null | undefined, currencyCode = 'USD'): string {
+  const n = typeof value === 'number' ? value : Number(value);
+  const safe = Number.isFinite(n) ? n : 0;
+  try {
+    return safe.toLocaleString('en-US', { style: 'currency', currency: currencyCode || 'USD' });
+  } catch {
+    // Unknown/invalid currency code → fall back to plain 2-decimal + code suffix.
+    return `${safe.toFixed(2)} ${currencyCode || ''}`.trim();
+  }
+}
+
+/** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
+export function formatDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString();
+}

--- a/apps/web/src/components/billing/shared/format.ts
+++ b/apps/web/src/components/billing/shared/format.ts
@@ -20,6 +20,25 @@ export function formatMoney(value: string | number | null | undefined, currencyC
   }
 }
 
+/** Sum money amounts grouped by currency, preserving first-seen order.
+ *  Amounts are *dollars* (the same units `formatMoney` and the list-row money
+ *  fields use), NOT cents. The list summary strips use this to render honest
+ *  per-currency totals when rows span more than one currency, instead of
+ *  labeling a mixed-currency sum with a single (wrong) currency code. Empty
+ *  input → []; a single currency → one entry (renders exactly as before). */
+export function sumByCurrency(
+  entries: { amount: number; currencyCode: string }[],
+): { code: string; amount: number }[] {
+  const order: string[] = [];
+  const totals = new Map<string, number>();
+  for (const { amount, currencyCode } of entries) {
+    const code = currencyCode || 'USD';
+    if (!totals.has(code)) order.push(code);
+    totals.set(code, (totals.get(code) ?? 0) + amount);
+  }
+  return order.map((code) => ({ code, amount: totals.get(code) ?? 0 }));
+}
+
 /** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
 export function formatDate(value: string | null | undefined): string {
   if (!value) return '—';

--- a/apps/web/src/components/billing/shared/usePdfDownload.test.ts
+++ b/apps/web/src/components/billing/shared/usePdfDownload.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePdfDownload } from './usePdfDownload';
+import { fetchWithAuth } from '../../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { handleActionError } from '../../../lib/runAction';
+
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../../lib/runAction', () => ({ handleActionError: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const navMock = vi.mocked(navigateTo);
+const errMock = vi.mocked(handleActionError);
+
+const blobResponse = (): Response =>
+  ({ ok: true, status: 200, blob: vi.fn().mockResolvedValue(new Blob(['%PDF'])) }) as unknown as Response;
+
+describe('usePdfDownload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom lacks these blob-URL primitives.
+    Object.assign(window.URL, {
+      createObjectURL: vi.fn().mockReturnValue('blob:mock'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  it('fetches the path, downloads via a blob-URL anchor, and revokes it', async () => {
+    fetchMock.mockResolvedValue(blobResponse());
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const { result } = renderHook(() => usePdfDownload({ path: '/invoices/inv-1/pdf', filename: 'INV-1.pdf' }));
+    await act(async () => { await result.current.download(); });
+
+    expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1/pdf');
+    expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+    clickSpy.mockRestore();
+  });
+
+  it('exposes a downloading flag that clears after completion', async () => {
+    fetchMock.mockResolvedValue(blobResponse());
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    const { result } = renderHook(() => usePdfDownload({ path: '/p', filename: 'f.pdf' }));
+    expect(result.current.downloading).toBe(false);
+    await act(async () => { await result.current.download(); });
+    await waitFor(() => expect(result.current.downloading).toBe(false));
+  });
+
+  it('redirects to login on 401 without attempting a download', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 } as unknown as Response);
+    const { result } = renderHook(() => usePdfDownload({ path: '/p', filename: 'f.pdf' }));
+    await act(async () => { await result.current.download(); });
+    expect(navMock).toHaveBeenCalledWith('/login', { replace: true });
+    expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a non-OK response through handleActionError', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 } as unknown as Response);
+    const { result } = renderHook(() => usePdfDownload({ path: '/p', filename: 'f.pdf', errorMessage: 'nope' }));
+    await act(async () => { await result.current.download(); });
+    expect(errMock).toHaveBeenCalledWith(expect.any(Error), 'nope');
+  });
+});

--- a/apps/web/src/components/billing/shared/usePdfDownload.ts
+++ b/apps/web/src/components/billing/shared/usePdfDownload.ts
@@ -1,0 +1,57 @@
+import { useCallback, useState } from 'react';
+import { fetchWithAuth } from '../../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { handleActionError } from '../../../lib/runAction';
+
+export interface UsePdfDownloadOptions {
+  /** API path passed straight to `fetchWithAuth` (it attaches the auth header and
+   *  prepends `/api/v1`). Accepts both bare (`/invoices/:id/pdf`) and already
+   *  `/api/v1`-prefixed paths. */
+  path: string;
+  /** The saved filename, e.g. `INV-2026-0001.pdf`. */
+  filename: string;
+  /** Toast copy on failure — domain-specific so quotes/invoices read naturally. */
+  errorMessage?: string;
+}
+
+export interface UsePdfDownload {
+  download: () => Promise<void>;
+  downloading: boolean;
+}
+
+/**
+ * Download an access-controlled PDF: authed fetch → blob → object URL → anchor
+ * click → revoke. A bare `<a href>`/`<a download>` would 401 (no Bearer header),
+ * so we fetch the bytes ourselves. One implementation for every billing surface
+ * (quote header + preview, invoice detail + preview) so they can't drift in URL,
+ * filename, 401 handling, or error copy. `downloading` guards double-submit and
+ * drives the button's disabled/label state.
+ */
+export function usePdfDownload({ path, filename, errorMessage = 'Could not download the PDF.' }: UsePdfDownloadOptions): UsePdfDownload {
+  const [downloading, setDownloading] = useState(false);
+
+  const download = useCallback(async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const res = await fetchWithAuth(path);
+      if (res.status === 401) { void navigateTo('/login', { replace: true }); return; }
+      if (!res.ok) { handleActionError(new Error('pdf'), errorMessage); return; }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      handleActionError(err, errorMessage);
+    } finally {
+      setDownloading(false);
+    }
+  }, [downloading, path, filename, errorMessage]);
+
+  return { download, downloading };
+}

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -15,7 +15,7 @@ import {
   type ContractStatus,
   type ContractTransition,
 } from '../../lib/api/contracts';
-import { formatMoney } from '../billing/invoiceTypes';
+import { formatMoney, formatDate } from '../billing/invoiceTypes';
 import { usePermissions } from '../../lib/permissions';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -48,13 +48,6 @@ const TRANSITION_LABELS: Record<ContractTransition, string> = {
   resume: 'Resume',
   cancel: 'Cancel',
 };
-
-function formatDate(value: string | null | undefined): string {
-  if (!value) return '—';
-  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleDateString();
-}
 
 export default function ContractDetail({ detail, onChanged }: Props) {
   const { can } = usePermissions();

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -146,6 +146,41 @@ describe('ContractEditor — blur autosave (existing contract)', () => {
     expect((api.updateContract as any).mock.calls[0][1]).toEqual({ endDate: null, autoRenew: false });
   });
 
+  it('defers the auto-renew PATCH until a renewal term is entered', async () => {
+    // autoRenew:true without a term 400s server-side, so checking the box only
+    // reveals the fields; the term's blur commit carries autoRenew:true.
+    const withEnd: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01' },
+    };
+    render(<ContractEditor detail={withEnd} onChanged={vi.fn()} />);
+    const toggle = await screen.findByTestId('contract-auto-renew-toggle');
+    fireEvent.click(toggle.querySelector('input')!);
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.updateContract).not.toHaveBeenCalled();
+
+    const term = await screen.findByTestId('contract-renewal-term');
+    fireEvent.change(term, { target: { value: '12' } });
+    fireEvent.blur(term);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ autoRenew: true, renewalTermMonths: 12 });
+  });
+
+  it('unchecking auto-renew PATCHes autoRenew:false immediately', async () => {
+    const renewing: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01', autoRenew: true, renewalTermMonths: 12 },
+    };
+    render(<ContractEditor detail={renewing} onChanged={vi.fn()} />);
+    const toggle = await screen.findByTestId('contract-auto-renew-toggle');
+    fireEvent.click(toggle.querySelector('input')!);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ autoRenew: false });
+  });
+
   it('locks schedule fields (timing, cadence, start) on a non-draft contract', async () => {
     const active: ContractDetail = { ...draftDetail, contract: { ...draftDetail.contract, status: 'active' } };
     render(<ContractEditor detail={active} onChanged={vi.fn()} />);

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -305,6 +305,62 @@ describe('ContractEditor — failed PATCH rolls optimistic controls back', () =>
   });
 });
 
+describe('ContractEditor — immediate-commit controls lock while their PATCH is in flight', () => {
+  // Without the lock, a rapid second toggle would capture the OPTIMISTIC value
+  // as `prev`, get guard-blocked by runScoped's inFlight set (which resolves
+  // false, same as a failure), and revert to the unconfirmed value — silently
+  // dropping the second action. Disabling during the window makes that
+  // physically impossible.
+  it('disables the auto-issue checkbox until the PATCH settles', async () => {
+    let resolvePatch!: (v: Response) => void;
+    (api.updateContract as any).mockReturnValue(new Promise<Response>((r) => { resolvePatch = r; }));
+
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const box = await screen.findByTestId('contract-form-auto-issue');
+    fireEvent.click(box);
+
+    await waitFor(() => expect(box).toBeDisabled());
+    resolvePatch(resp({ data: {} }));
+    await waitFor(() => expect(box).not.toBeDisabled());
+    expect(box).toBeChecked(); // success — the optimistic value stands
+  });
+
+  it('disables the billing-timing select until the PATCH settles', async () => {
+    let resolvePatch!: (v: Response) => void;
+    (api.updateContract as any).mockReturnValue(new Promise<Response>((r) => { resolvePatch = r; }));
+
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const sel = await screen.findByTestId('contract-form-timing');
+    fireEvent.change(sel, { target: { value: 'arrears' } });
+
+    await waitFor(() => expect(sel).toBeDisabled());
+    resolvePatch(resp({ data: {} }));
+    await waitFor(() => expect(sel).not.toBeDisabled());
+    expect(sel).toHaveValue('arrears');
+  });
+
+  it("shared 'interval' key: a custom-interval blur locks the preset select too", async () => {
+    let resolvePatch!: (v: Response) => void;
+    (api.updateContract as any).mockReturnValue(new Promise<Response>((r) => { resolvePatch = r; }));
+
+    // intervalMonths 5 → custom mode on mount.
+    const custom5: ContractDetail = { ...draftDetail, contract: { ...draftDetail.contract, intervalMonths: 5 } };
+    render(<ContractEditor detail={custom5} onChanged={vi.fn()} />);
+    const customInput = await screen.findByTestId('contract-form-interval-custom');
+    const presetSel = screen.getByTestId('contract-form-interval');
+    fireEvent.change(customInput, { target: { value: '6' } });
+    fireEvent.blur(customInput);
+
+    // Both controls share the 'interval' pending key: a preset click right
+    // after a custom blur must not race the in-flight custom commit.
+    await waitFor(() => expect(customInput).toBeDisabled());
+    expect(presetSel).toBeDisabled();
+    resolvePatch(resp({ data: {} }));
+    await waitFor(() => expect(customInput).not.toBeDisabled());
+    expect(presetSel).not.toBeDisabled();
+  });
+});
+
 describe('ContractEditor — remove line confirm', () => {
   it('opens a confirm naming the line; Cancel keeps the line', async () => {
     render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractEditor from './ContractEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import * as api from '../../lib/api/contracts';
+import type { ContractDetail } from '../../lib/api/contracts';
+
+// Wildcard-admin grants so every gated control renders (mirrors ContractEditor.test.tsx).
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../catalog/CatalogItemPicker', () => ({ default: () => null }));
+vi.mock('../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+}));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    createContract: vi.fn(),
+    updateContract: vi.fn(),
+    addContractLine: vi.fn(),
+    removeContractLine: vi.fn(),
+    contractTransition: vi.fn(),
+    getContractEstimate: vi.fn(),
+  };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const draftDetail: ContractDetail = {
+  contract: {
+    id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'draft',
+    billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
+    nextBillingAt: null, autoIssue: false, autoRenew: false, renewalTermMonths: null, renewalNoticeDays: null,
+    currencyCode: 'USD', notes: null, terms: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [
+    {
+      id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
+      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, taxable: false,
+      sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    },
+  ],
+  periods: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/orgs/organizations')) return resp({ data: [{ id: 'org-1', name: 'Acme' }] });
+    if (url.startsWith('/orgs/sites')) return resp({ data: [] });
+    return resp({ data: {} });
+  });
+  (api.getContractEstimate as any).mockResolvedValue(resp({ data: { currencyCode: 'USD', periodTotal: '500.00', lines: [] } }));
+  (api.updateContract as any).mockResolvedValue(resp({ data: {} }));
+  (api.removeContractLine as any).mockResolvedValue(resp({ data: { ok: true } }));
+});
+
+describe('ContractEditor — blur autosave (existing contract)', () => {
+  it('PATCHes the contract with the new name on blur', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const nameInput = await screen.findByTestId('contract-form-name');
+
+    fireEvent.change(nameInput, { target: { value: 'Acme MSA v2' } });
+    fireEvent.blur(nameInput);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toMatchObject({ name: 'Acme MSA v2' });
+  });
+
+  it('does NOT show a whole-form Save button for an existing contract', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    await screen.findByTestId('contract-form-name');
+    expect(screen.queryByTestId('save-contract-btn')).not.toBeInTheDocument();
+  });
+
+  it('announces "Saved" via the SR live region after a successful save', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const nameInput = await screen.findByTestId('contract-form-name');
+    fireEvent.change(nameInput, { target: { value: 'Renamed' } });
+    fireEvent.blur(nameInput);
+
+    await waitFor(() => expect(screen.getByTestId('contract-field-saved')).toHaveTextContent('Saved'));
+  });
+
+  it('saves billing timing on change (select commits without blur)', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    fireEvent.change(await screen.findByTestId('contract-form-timing'), { target: { value: 'arrears' } });
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ billingTiming: 'arrears' });
+  });
+
+  it('saves auto-issue on change (checkbox commits without blur)', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    fireEvent.click(await screen.findByTestId('contract-form-auto-issue'));
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ autoIssue: true });
+  });
+
+  it('saves notes on blur, trimming and nulling an emptied value', async () => {
+    render(<ContractEditor detail={{ ...draftDetail, contract: { ...draftDetail.contract, notes: 'old note' } }} onChanged={vi.fn()} />);
+    const notesInput = await screen.findByTestId('contract-form-notes');
+    fireEvent.change(notesInput, { target: { value: '   ' } });
+    fireEvent.blur(notesInput);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ notes: null });
+  });
+
+  it('does not PATCH when a field blurs unchanged', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const nameInput = await screen.findByTestId('contract-form-name');
+    fireEvent.blur(nameInput);
+    const notesInput = screen.getByTestId('contract-form-notes');
+    fireEvent.blur(notesInput);
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.updateContract).not.toHaveBeenCalled();
+  });
+
+  it('clearing the end date PATCHes endDate:null and turns auto-renew off', async () => {
+    const withEnd: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01', autoRenew: true, renewalTermMonths: 12 },
+    };
+    render(<ContractEditor detail={withEnd} onChanged={vi.fn()} />);
+    const endInput = await screen.findByTestId('contract-form-end');
+    fireEvent.change(endInput, { target: { value: '' } });
+    fireEvent.blur(endInput);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    expect((api.updateContract as any).mock.calls[0][1]).toEqual({ endDate: null, autoRenew: false });
+  });
+
+  it('locks schedule fields (timing, cadence, start) on a non-draft contract', async () => {
+    const active: ContractDetail = { ...draftDetail, contract: { ...draftDetail.contract, status: 'active' } };
+    render(<ContractEditor detail={active} onChanged={vi.fn()} />);
+    await screen.findByTestId('contract-form-name');
+
+    // Schedule fields drive next_billing_at — the API 409s these on a non-draft,
+    // so the editor renders them disabled instead of offering a doomed save.
+    expect(screen.getByTestId('contract-form-timing')).toBeDisabled();
+    expect(screen.getByTestId('contract-form-interval')).toBeDisabled();
+    expect(screen.getByTestId('contract-form-start')).toBeDisabled();
+    // Non-schedule fields stay editable.
+    expect(screen.getByTestId('contract-form-name')).not.toBeDisabled();
+    expect(screen.getByTestId('contract-form-notes')).not.toBeDisabled();
+  });
+
+  it('shows the org as read-only text (no org select) on an existing contract', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    await screen.findByTestId('contract-form-name');
+    expect(screen.queryByTestId('contract-form-org')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('contract-form-org-readonly')).toHaveTextContent('Acme');
+  });
+
+  it('shows an inline error when the custom interval is emptied, and does not PATCH', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const cadence = await screen.findByTestId('contract-form-interval');
+    fireEvent.change(cadence, { target: { value: 'custom' } });
+
+    const custom = await screen.findByTestId('contract-form-interval-custom');
+    fireEvent.change(custom, { target: { value: '' } });
+    fireEvent.blur(custom);
+
+    expect(await screen.findByTestId('contract-interval-error')).toHaveTextContent('Enter the number of months');
+    expect(api.updateContract).not.toHaveBeenCalled();
+  });
+});
+
+describe('ContractEditor — remove line confirm', () => {
+  it('opens a confirm naming the line; Cancel keeps the line', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const removeBtn = await screen.findByTestId('line-remove-0');
+    fireEvent.click(removeBtn);
+
+    // Confirm dialog names the line ("Managed services" alone also matches the
+    // table cell, so assert on the dialog's full sentence).
+    expect(await screen.findByText(/This removes "Managed services" from the contract/)).toBeInTheDocument();
+    // Cancel: no delete call, line still present.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByTestId('contract-line-remove-confirm')).not.toBeInTheDocument());
+    expect(api.removeContractLine).not.toHaveBeenCalled();
+    expect(screen.getByTestId('line-remove-0')).toBeInTheDocument();
+  });
+
+  it('confirming removes the line', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    fireEvent.click(await screen.findByTestId('line-remove-0'));
+    fireEvent.click(await screen.findByTestId('contract-line-remove-confirm'));
+
+    await waitFor(() => expect(api.removeContractLine).toHaveBeenCalledWith('ct-1', 'cl-1'));
+  });
+});

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ContractEditor from './ContractEditor';
 import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
 import * as api from '../../lib/api/contracts';
 import type { ContractDetail } from '../../lib/api/contracts';
 
@@ -214,6 +215,93 @@ describe('ContractEditor — blur autosave (existing contract)', () => {
 
     expect(await screen.findByTestId('contract-interval-error')).toHaveTextContent('Enter the number of months');
     expect(api.updateContract).not.toHaveBeenCalled();
+  });
+});
+
+describe('ContractEditor — failed PATCH rolls optimistic controls back', () => {
+  // Immediate-commit controls (selects/checkboxes) have no amber dirty ring, so
+  // a rejected save must revert the optimistic local flip AND toast the error —
+  // never keep displaying unpersisted state.
+  beforeEach(() => {
+    (api.updateContract as any).mockResolvedValue(resp({ error: 'nope' }, false));
+  });
+
+  it('reverts the auto-issue checkbox and toasts on failure', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const box = await screen.findByTestId('contract-form-auto-issue');
+    fireEvent.click(box);
+    expect(box).toBeChecked(); // optimistic
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    await waitFor(() => expect(box).not.toBeChecked());
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('reverts the billing-timing select on failure', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const sel = await screen.findByTestId('contract-form-timing');
+    fireEvent.change(sel, { target: { value: 'arrears' } });
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    await waitFor(() => expect(sel).toHaveValue('advance'));
+  });
+
+  it('reverts the cadence preset select on failure', async () => {
+    render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
+    const sel = await screen.findByTestId('contract-form-interval');
+    fireEvent.change(sel, { target: { value: '3' } });
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    await waitFor(() => expect(sel).toHaveValue('1'));
+  });
+
+  it('reverts the auto-renew checkbox when unchecking fails', async () => {
+    const renewing: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01', autoRenew: true, renewalTermMonths: 12 },
+    };
+    render(<ContractEditor detail={renewing} onChanged={vi.fn()} />);
+    const box = (await screen.findByTestId('contract-auto-renew-toggle')).querySelector('input')!;
+    fireEvent.click(box);
+    expect(box).not.toBeChecked(); // optimistic
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    await waitFor(() => expect(box).toBeChecked());
+  });
+
+  it('reverts the deferred auto-renew flip when the term commit fails', async () => {
+    const withEnd: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01' },
+    };
+    render(<ContractEditor detail={withEnd} onChanged={vi.fn()} />);
+    const box = (await screen.findByTestId('contract-auto-renew-toggle')).querySelector('input')!;
+    fireEvent.click(box); // reveals fields, no PATCH yet
+    const term = await screen.findByTestId('contract-renewal-term');
+    fireEvent.change(term, { target: { value: '12' } });
+    fireEvent.blur(term);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    // The combined { autoRenew: true, renewalTermMonths } PATCH failed — the
+    // toggle must not keep showing "on" for a contract the server left "off".
+    await waitFor(() => expect(box).not.toBeChecked());
+  });
+
+  it('resyncs the cascaded auto-renew flip when clearing the end date fails', async () => {
+    const renewing: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01', autoRenew: true, renewalTermMonths: 12 },
+    };
+    render(<ContractEditor detail={renewing} onChanged={vi.fn()} />);
+    const endInput = await screen.findByTestId('contract-form-end');
+    const box = screen.getByTestId('contract-auto-renew-toggle').querySelector('input')!;
+    fireEvent.change(endInput, { target: { value: '' } });
+    expect(box).not.toBeChecked(); // cascaded optimistic flip
+    fireEvent.blur(endInput);
+
+    await waitFor(() => expect(api.updateContract).toHaveBeenCalled());
+    // endDate keeps its amber ring for retry; the ringless checkbox resyncs.
+    await waitFor(() => expect(box).toBeChecked());
   });
 });
 

--- a/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
@@ -76,12 +76,15 @@ beforeEach(() => {
 });
 
 describe('ContractEditor — permission gating', () => {
-  it('read-only (contracts:read) hides create/save, add-line and per-line remove', async () => {
+  it('read-only (contracts:read) disables header fields, hides add-line and per-line remove', async () => {
+    // Existing contracts blur-autosave, so there is no whole-form Save button; the
+    // read gate instead disables the header fields and hides the write affordances.
     state.permissions = [{ resource: 'contracts', action: 'read' }];
     render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
 
     expect(screen.queryByTestId('save-contract-btn')).not.toBeInTheDocument();
+    expect(screen.getByTestId('contract-form-name')).toBeDisabled();
     expect(screen.queryByTestId('add-line-btn')).not.toBeInTheDocument();
     expect(screen.queryByTestId('line-remove-0')).not.toBeInTheDocument();
     expect(screen.queryByTestId('activate-contract-btn')).not.toBeInTheDocument();
@@ -94,7 +97,8 @@ describe('ContractEditor — permission gating', () => {
     render(<ContractEditor detail={draftDetail} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('contract-editor')).toBeInTheDocument());
 
-    expect(screen.getByTestId('save-contract-btn')).toBeInTheDocument();
+    // Existing contracts autosave per field — the header fields are editable.
+    expect(screen.getByTestId('contract-form-name')).not.toBeDisabled();
     expect(screen.getByTestId('add-line-btn')).toBeInTheDocument();
     expect(screen.getByTestId('line-remove-0')).toBeInTheDocument();
     // manage-gated:

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
+import { ConfirmDialog } from '../shared/ConfirmDialog';
 import {
   createContract,
   updateContract,
@@ -47,6 +48,23 @@ const INTERVAL_PRESETS = [
   { value: 12, label: 'Annual' },
 ];
 
+// ── Save-grammar helpers (byte-similar local copies of the invoice/quote
+//    editors' — kept inline per CLAUDE.md; a later pass may extract them). ──────
+
+// Visually-hidden polite live region — announces a transient "Saved" to screen
+// readers, pairing with the amber→green dirty-ring cue sighted users see.
+function SrSaved({ show, label = 'Saved', testId }: { show: boolean; label?: string; testId?: string }) {
+  // role="status" already implies aria-live="polite" — don't double it.
+  return <span role="status" className="sr-only" data-testid={testId}>{show ? label : ''}</span>;
+}
+
+// A field's save-state outline: amber while unsaved, a brief green pulse when it
+// lands, nothing at rest. It's a box-shadow (ring), so it never reflows
+// neighbours. Pair with a constant `transition-shadow` on the field.
+function fieldRing(dirty: boolean, saved: boolean): string {
+  return dirty ? 'ring-1 ring-warning' : saved ? 'ring-1 ring-success' : '';
+}
+
 interface Props {
   /** Present in edit mode (existing draft/active contract); absent when creating. */
   detail?: ContractDetail;
@@ -58,8 +76,13 @@ interface Props {
 
 export default function ContractEditor({ detail, presetOrgId, onChanged }: Props) {
   const { can } = usePermissions();
+  const canWrite = can('contracts', 'write');
   const isCreate = !detail;
   const contract = detail?.contract;
+  // Schedule fields (billingTiming, intervalMonths, startDate) drive next_billing_at
+  // and are draft-only server-side (PATCH 409s on a non-draft). Only offer them as
+  // editable while creating or on a draft; otherwise render read-only.
+  const scheduleEditable = isCreate || contract?.status === 'draft';
 
   const [busy, setBusy] = useState(false);
 
@@ -69,8 +92,11 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [billingTiming, setBillingTiming] = useState<ContractBillingTiming>(contract?.billingTiming ?? 'advance');
   const [intervalMonths, setIntervalMonths] = useState<number>(contract?.intervalMonths ?? 1);
   const [intervalCustom, setIntervalCustom] = useState(
-    contract && ![1, 3, 12].includes(contract.intervalMonths),
+    contract ? ![1, 3, 12].includes(contract.intervalMonths) : false,
   );
+  // Raw string for the custom-interval input so it can be emptied (an empty field
+  // reads as invalid → inline error, not a silent snap-back to 0).
+  const [customMonths, setCustomMonths] = useState<string>(String(contract?.intervalMonths ?? 1));
   const [startDate, setStartDate] = useState(
     contract?.startDate ?? new Date().toISOString().slice(0, 10),
   );
@@ -83,6 +109,41 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [terms, setTerms] = useState(contract?.terms ?? '');
   const [liveEstimate, setLiveEstimate] = useState<ContractEstimate | null>(null);
   const [estimateFailed, setEstimateFailed] = useState(false);
+
+  // Guard an in-progress edit from being clobbered by a server resync mid-type:
+  // the flag is set on keystroke and cleared when a commit is initiated (on
+  // blur), so a background refresh landing mid-edit keeps the user's keystrokes
+  // while a settled field re-adopts the server's canonical (e.g. trimmed) value
+  // — mirrors the invoice/quote editors' edited-flag pattern. Selects/checkboxes
+  // commit on the same event that changes them, so they resync unconditionally.
+  const nameEdited = useRef(false);
+  const startEdited = useRef(false);
+  const endEdited = useRef(false);
+  const notesEdited = useRef(false);
+  const termsEdited = useRef(false);
+  const renewalTermEdited = useRef(false);
+  const renewalNoticeEdited = useRef(false);
+  useEffect(() => { if (contract && !nameEdited.current) setName(contract.name); }, [contract?.name]);
+  useEffect(() => { if (contract && !startEdited.current) setStartDate(contract.startDate); }, [contract?.startDate]);
+  useEffect(() => { if (contract && !endEdited.current) setEndDate(contract.endDate ?? ''); }, [contract?.endDate]);
+  useEffect(() => { if (contract && !notesEdited.current) setNotes(contract.notes ?? ''); }, [contract?.notes]);
+  useEffect(() => { if (contract && !termsEdited.current) setTerms(contract.terms ?? ''); }, [contract?.terms]);
+  useEffect(() => {
+    if (contract && !renewalTermEdited.current) setRenewalTermMonths(contract.renewalTermMonths != null ? String(contract.renewalTermMonths) : '');
+  }, [contract?.renewalTermMonths]);
+  useEffect(() => {
+    if (contract && !renewalNoticeEdited.current) setRenewalNoticeDays(contract.renewalNoticeDays != null ? String(contract.renewalNoticeDays) : '');
+  }, [contract?.renewalNoticeDays]);
+  useEffect(() => { if (contract) setAutoIssue(contract.autoIssue); }, [contract?.autoIssue]);
+  useEffect(() => { if (contract) setAutoRenew(contract.autoRenew); }, [contract?.autoRenew]);
+  useEffect(() => { if (contract) setBillingTiming(contract.billingTiming); }, [contract?.billingTiming]);
+  useEffect(() => {
+    if (!contract) return;
+    setIntervalMonths(contract.intervalMonths);
+    const custom = ![1, 3, 12].includes(contract.intervalMonths);
+    setIntervalCustom(custom);
+    if (custom) setCustomMonths(String(contract.intervalMonths));
+  }, [contract?.intervalMonths]);
 
   // ---- reference data ------------------------------------------------------
   const [orgs, setOrgs] = useState<Organization[]>([]);
@@ -109,6 +170,56 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [pax8Active, setPax8Active] = useState(false);
 
   const lines: ContractLine[] = detail?.lines ?? [];
+
+  // Line removal is irreversible, so it goes through a confirm step (mirrors the
+  // quote/invoice editors) instead of deleting outright.
+  const [pendingRemove, setPendingRemove] = useState<ContractLine | null>(null);
+
+  // Per-field scoped pending + a keyed "Saved" flash, so one in-flight field save
+  // never freezes its siblings and each field can pulse green on its own. Keys:
+  // 'name', 'timing', 'interval', 'startDate', 'endDate', 'autoIssue',
+  // 'autoRenew', 'renewalTerm', 'renewalNotice', 'notes', 'terms',
+  // `remove-<lineId>`. `pending` drives disabled styling; `inFlight` is the
+  // synchronous double-submit guard (state updates are async).
+  const inFlight = useRef<Set<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
+  const isPending = useCallback((key: string) => pending.has(key), [pending]);
+
+  const [savedKeys, setSavedKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const savedTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  useEffect(() => () => { savedTimers.current.forEach((t) => clearTimeout(t)); }, []);
+  const flashSaved = useCallback((key: string) => {
+    setSavedKeys((s) => { const n = new Set(s); n.add(key); return n; });
+    const existing = savedTimers.current.get(key);
+    if (existing) clearTimeout(existing);
+    savedTimers.current.set(key, setTimeout(() => {
+      setSavedKeys((s) => { const n = new Set(s); n.delete(key); return n; });
+      savedTimers.current.delete(key);
+    }, 1500));
+  }, []);
+  const isSaved = useCallback((key: string) => savedKeys.has(key), [savedKeys]);
+
+  // Run a scoped mutation: mark the key pending, run, surface failures via the
+  // standard handleActionError path, and always clear the key. Returns whether
+  // the mutation succeeded so callers can flash a quiet "Saved" cue.
+  const runScoped = useCallback(
+    async (key: string, fn: () => Promise<void>, errMsg: string): Promise<boolean> => {
+      if (inFlight.current.has(key)) return false;
+      inFlight.current.add(key);
+      setPending((s) => { const n = new Set(s); n.add(key); return n; });
+      try {
+        await fn();
+        return true;
+      } catch (err) {
+        handleActionError(err, errMsg);
+        return false;
+      } finally {
+        inFlight.current.delete(key);
+        setPending((s) => { const n = new Set(s); n.delete(key); return n; });
+      }
+    },
+    [],
+  );
 
   const loadOrgs = useCallback(async () => {
     const res = await fetchWithAuth('/orgs/organizations');
@@ -152,7 +263,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     setLiveEstimate(body?.data ?? null);
   }, [contract]);
 
-  useEffect(() => { if (isCreate) void loadOrgs(); }, [isCreate, loadOrgs]);
+  // Load orgs in both modes: the create form needs the picker; the edit form
+  // resolves the (immutable) org's display name for the read-only Schedule field.
+  useEffect(() => { void loadOrgs(); }, [loadOrgs]);
   useEffect(() => { void loadCatalog(); }, [loadCatalog]);
 
   // Gate the distributor-import entry on a connected EC Express integration.
@@ -209,8 +322,16 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   useEffect(() => { void loadSites(orgId); }, [orgId, loadSites]);
   useEffect(() => { if (!isCreate) void loadEstimate(); }, [isCreate, loadEstimate]);
 
-  const intervalIsValid = intervalMonths >= 1 && intervalMonths <= 60;
-  const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalIsValid;
+  // Effective cadence in months: the custom text input when "Custom…" is chosen,
+  // otherwise the selected preset. Validation covers the empty/non-integer/out-of-
+  // range cases so the operator sees why, instead of a silently-disabled control.
+  const effectiveMonths = intervalCustom ? Number(customMonths) : intervalMonths;
+  const intervalValid = intervalCustom
+    ? customMonths.trim() !== '' && Number.isInteger(effectiveMonths) && effectiveMonths >= 1 && effectiveMonths <= 60
+    : intervalMonths >= 1 && intervalMonths <= 60;
+  const intervalError = intervalCustom && !intervalValid ? 'Enter the number of months' : null;
+  const canSaveHeader = !!orgId && name.trim().length > 0 && !!startDate && intervalValid;
+  const orgName = orgs.find((o) => o.id === orgId)?.name ?? orgId;
 
   // ---- live "Estimated this period" ----------------------------------------
   // flat/manual contribute qty×price; per_device/per_seat are resolved by the
@@ -255,7 +376,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           orgId,
           name: name.trim(),
           billingTiming,
-          intervalMonths,
+          intervalMonths: effectiveMonths,
           startDate,
           endDate: endDate || null,
           autoIssue,
@@ -276,42 +397,113 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, canSaveHeader, orgId, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms]);
+  }, [busy, canSaveHeader, orgId, name, billingTiming, effectiveMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms]);
 
-  // ---- edit flow -----------------------------------------------------------
-  const saveHeader = useCallback(async () => {
-    if (busy || !contract || !canSaveHeader) return;
-    setBusy(true);
-    try {
-      if (autoRenew && !renewalTermMonths) {
-        showToast({ type: 'error', message: 'Enter a renewal term (months) before saving.' });
-        return;
-      }
+  // ---- edit flow: per-field blur/change autosave ---------------------------
+  // Each header field PATCHes independently (updateContractSchema is fully
+  // partial). No per-field success toast — the amber→green ring + a single SR
+  // "Saved" announcement are the feedback; failures fall through to
+  // handleActionError. Selects/checkboxes commit on change; text/date/number
+  // fields on blur (with the same guards the create/commit paths use).
+  const savePatch = useCallback(async (patch: Record<string, unknown>, key: string) => {
+    if (!contract) return;
+    const ok = await runScoped(key, async () => {
       await runAction({
-        request: () => updateContract(contract.id, {
-          name: name.trim(),
-          billingTiming,
-          intervalMonths,
-          startDate,
-          endDate: endDate || null,
-          autoIssue,
-          autoRenew,
-          renewalTermMonths: autoRenew ? Number(renewalTermMonths) : null,
-          renewalNoticeDays: autoRenew ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
-          notes: notes.trim() || null,
-          terms: terms.trim() || null,
-        }),
+        request: () => updateContract(contract.id, patch),
         errorFallback: 'Could not save the contract.',
-        successMessage: 'Contract saved',
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not save the contract.');
-    } finally {
-      setBusy(false);
+    }, 'Could not save the contract.');
+    if (ok) flashSaved(key);
+  }, [contract, runScoped, refresh, flashSaved]);
+
+  // Per-field dirty cues compare the live value against the persisted contract so
+  // a successful save (which reloads `detail`) auto-clears the amber ring.
+  const nameDirty = !isCreate && name !== (contract?.name ?? '');
+  const startDirty = !isCreate && startDate !== (contract?.startDate ?? '');
+  const endDirty = !isCreate && (endDate || '') !== (contract?.endDate ?? '');
+  const intervalDirty = !isCreate && intervalCustom && intervalValid && effectiveMonths !== (contract?.intervalMonths ?? 0);
+  const notesDirty = !isCreate && notes !== (contract?.notes ?? '');
+  const termsDirty = !isCreate && terms !== (contract?.terms ?? '');
+  const persistedTerm = contract?.renewalTermMonths != null ? String(contract.renewalTermMonths) : '';
+  const persistedNotice = contract?.renewalNoticeDays != null ? String(contract.renewalNoticeDays) : '';
+  const renewalTermDirty = !isCreate && renewalTermMonths !== persistedTerm;
+  const renewalNoticeDirty = !isCreate && renewalNoticeDays !== persistedNotice;
+
+  const commitName = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    nameEdited.current = false; // committing — let the server value re-adopt next
+    const next = name.trim();
+    if (next === (contract?.name ?? '')) return;
+    if (!next) { handleActionError(new Error('empty name'), 'Enter a contract name.'); return; }
+    void savePatch({ name: next }, 'name');
+  }, [canWrite, isCreate, name, contract, savePatch]);
+
+  const commitStart = useCallback(() => {
+    if (!canWrite || isCreate || !scheduleEditable) return;
+    startEdited.current = false;
+    if (startDate === (contract?.startDate ?? '')) return;
+    if (!startDate) { handleActionError(new Error('empty start'), 'Enter a start date.'); return; }
+    void savePatch({ startDate }, 'startDate');
+  }, [canWrite, isCreate, scheduleEditable, startDate, contract, savePatch]);
+
+  const commitEnd = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    endEdited.current = false;
+    const norm = endDate || null;
+    if (norm === (contract?.endDate ?? null)) return;
+    // Clearing the end date also disables auto-renew (which requires an end date).
+    void savePatch(norm === null ? { endDate: null, autoRenew: false } : { endDate: norm }, 'endDate');
+  }, [canWrite, isCreate, endDate, contract, savePatch]);
+
+  const commitInterval = useCallback(() => {
+    if (!canWrite || isCreate || !scheduleEditable) return;
+    if (!intervalValid) return; // inline error already tells the operator why
+    if (effectiveMonths === (contract?.intervalMonths ?? 0)) return;
+    setIntervalMonths(effectiveMonths);
+    void savePatch({ intervalMonths: effectiveMonths }, 'interval');
+  }, [canWrite, isCreate, scheduleEditable, intervalValid, effectiveMonths, contract, savePatch]);
+
+  const commitRenewalTerm = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    renewalTermEdited.current = false;
+    if (renewalTermMonths === persistedTerm) return;
+    const n = renewalTermMonths === '' ? null : Number(renewalTermMonths);
+    if (n !== null && (!Number.isInteger(n) || n < 1 || n > 120)) {
+      handleActionError(new Error('invalid term'), 'Enter a renewal term between 1 and 120 months.');
+      return;
     }
-  }, [busy, contract, canSaveHeader, name, billingTiming, intervalMonths, startDate, endDate, autoIssue, autoRenew, renewalTermMonths, renewalNoticeDays, notes, terms, refresh]);
+    void savePatch({ renewalTermMonths: n }, 'renewalTerm');
+  }, [canWrite, isCreate, renewalTermMonths, persistedTerm, savePatch]);
+
+  const commitRenewalNotice = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    renewalNoticeEdited.current = false;
+    if (renewalNoticeDays === persistedNotice) return;
+    const n = renewalNoticeDays === '' ? null : Number(renewalNoticeDays);
+    if (n !== null && (!Number.isInteger(n) || n < 0 || n > 365)) {
+      handleActionError(new Error('invalid notice'), 'Enter advance notice between 0 and 365 days.');
+      return;
+    }
+    void savePatch({ renewalNoticeDays: n }, 'renewalNotice');
+  }, [canWrite, isCreate, renewalNoticeDays, persistedNotice, savePatch]);
+
+  const commitNotes = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    notesEdited.current = false;
+    const next = notes.trim();
+    if (next === (contract?.notes ?? '')) return;
+    void savePatch({ notes: next || null }, 'notes');
+  }, [canWrite, isCreate, notes, contract, savePatch]);
+
+  const commitTerms = useCallback(() => {
+    if (!canWrite || isCreate) return;
+    termsEdited.current = false;
+    const next = terms.trim();
+    if (next === (contract?.terms ?? '')) return;
+    void savePatch({ terms: next || null }, 'terms');
+  }, [canWrite, isCreate, terms, contract, savePatch]);
 
   const addLine = useCallback(async () => {
     if (busy || !contract || !lineDesc.trim()) return;
@@ -344,10 +536,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     }
   }, [busy, contract, lineType, lineDesc, linePrice, lineQty, lineSiteId, lineCatalogId, lineTaxable, refresh]);
 
-  const removeLine = useCallback(async (lineId: string) => {
-    if (busy || !contract) return;
-    setBusy(true);
-    try {
+  const removeLine = useCallback((lineId: string) =>
+    runScoped(`remove-${lineId}`, async () => {
+      if (!contract) return;
       await runAction({
         request: () => removeContractLine(contract.id, lineId),
         errorFallback: 'Could not remove the line.',
@@ -355,12 +546,8 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
-    } catch (err) {
-      handleActionError(err, 'Could not remove the line.');
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, contract, refresh]);
+    }, 'Could not remove the line.'),
+  [runScoped, contract, refresh]);
 
   const activate = useCallback(async () => {
     if (busy || !contract) return;
@@ -385,147 +572,222 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     [sites],
   );
 
+  // Shared field chrome. `transition-shadow` pairs with fieldRing's box-shadow so
+  // the amber→green cue animates without reflowing neighbours; `disabled:opacity-60`
+  // renders the read-only (no contracts:write) and non-draft schedule states.
+  const baseInput = 'h-10 rounded-md border bg-background px-3 text-sm text-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
+  const dateInput = `${baseInput} dark:[color-scheme:dark] [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100`;
+  const areaInput = 'rounded-md border bg-background px-3 py-2 text-sm text-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
+  const legendCls = 'mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground';
+
   return (
     <div className="space-y-6" data-testid="contract-editor">
       <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
         {/* ── header form + lines ─────────────────────────────────────── */}
         <div className="space-y-6">
-          <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="contract-header-form">
-            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Contract</h3>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {isCreate && (
-                <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                  Organization
-                  <select
-                    value={orgId}
-                    onChange={(e) => setOrgId(e.target.value)}
-                    data-testid="contract-form-org"
-                    className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="">Select an organization…</option>
-                    {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
-                  </select>
-                </label>
-              )}
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Name
-                <input
-                  type="text" value={name} onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. Managed Services — Acme Co"
-                  data-testid="contract-form-name"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Billing timing
-                <select
-                  value={billingTiming} onChange={(e) => setBillingTiming(e.target.value as ContractBillingTiming)}
-                  data-testid="contract-form-timing"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                >
-                  <option value="advance">In advance</option>
-                  <option value="arrears">In arrears</option>
-                </select>
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Billing cadence
-                <select
-                  value={intervalCustom ? 'custom' : String(intervalMonths)}
-                  onChange={(e) => {
-                    if (e.target.value === 'custom') { setIntervalCustom(true); return; }
-                    setIntervalCustom(false);
-                    setIntervalMonths(Number(e.target.value));
-                  }}
-                  data-testid="contract-form-interval"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                >
-                  {INTERVAL_PRESETS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
-                  <option value="custom">Custom…</option>
-                </select>
-              </label>
-              {intervalCustom && (
-                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                  Interval (months)
-                  <input
-                    type="number" min="1" max="60" value={intervalMonths}
-                    onChange={(e) => setIntervalMonths(Number(e.target.value))}
-                    data-testid="contract-form-interval-custom"
-                    className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                  />
-                </label>
-              )}
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                Start date
-                <input
-                  type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)}
-                  data-testid="contract-form-start"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring dark:[color-scheme:dark] [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                End date (optional)
-                <input
-                  type="date" value={endDate} onChange={(e) => { setEndDate(e.target.value); if (!e.target.value) setAutoRenew(false); }}
-                  data-testid="contract-form-end"
-                  className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring dark:[color-scheme:dark] [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100"
-                />
-              </label>
-              <label className="flex items-center gap-2 text-sm sm:col-span-2">
-                <input
-                  type="checkbox" checked={autoIssue} onChange={(e) => setAutoIssue(e.target.checked)}
-                  data-testid="contract-form-auto-issue"
-                />
-                Auto-issue generated invoices (otherwise they land as drafts)
-              </label>
-              <div className="sm:col-span-2">
-                <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
-                  <input
-                    type="checkbox" checked={autoRenew} disabled={!endDate}
-                    onChange={(e) => setAutoRenew(e.target.checked)}
-                  />
-                  <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
-                </label>
-                {autoRenew && (
-                  <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                      Renewal term (months)
-                      <input
-                        type="number" min={1} max={120} value={renewalTermMonths}
-                        onChange={(e) => setRenewalTermMonths(e.target.value)}
-                        data-testid="contract-renewal-term"
-                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                      />
-                    </label>
-                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                      Advance notice (days)
-                      <input
-                        type="number" min={0} max={365} value={renewalNoticeDays}
-                        onChange={(e) => setRenewalNoticeDays(e.target.value)}
-                        data-testid="contract-renewal-notice-days"
-                        className="h-10 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                      />
-                    </label>
+          <div className="space-y-6 rounded-lg border bg-card p-4 shadow-xs" data-testid="contract-header-form">
+            {/* Existing contracts blur-autosave per field; a single polite live
+                region announces the "Saved" that the amber→green ring shows. */}
+            <SrSaved show={!isCreate && savedKeys.size > 0} testId="contract-field-saved" />
+
+            {/* ── Schedule ─────────────────────────────────────────────── */}
+            <fieldset className="min-w-0" data-testid="contract-schedule-group">
+              <legend className={legendCls}>Schedule</legend>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {isCreate ? (
+                  <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
+                    Organization
+                    <select
+                      value={orgId}
+                      onChange={(e) => setOrgId(e.target.value)}
+                      data-testid="contract-form-org"
+                      className={baseInput}
+                    >
+                      <option value="">Select an organization…</option>
+                      {orgs.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+                    </select>
+                  </label>
+                ) : (
+                  // Org is fixed at creation — the API never re-parents a contract,
+                  // so it's a read-only display here.
+                  <div className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
+                    Organization
+                    <span
+                      data-testid="contract-form-org-readonly"
+                      className="inline-flex h-10 items-center rounded-md border bg-muted/40 px-3 text-sm text-foreground"
+                    >
+                      {orgName}
+                    </span>
                   </div>
                 )}
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
+                  Name
+                  <input
+                    type="text" value={name} onChange={(e) => { setName(e.target.value); nameEdited.current = true; }} onBlur={commitName}
+                    disabled={!canWrite}
+                    placeholder="e.g. Managed Services — Acme Co"
+                    data-testid="contract-form-name"
+                    className={`${baseInput} ${fieldRing(nameDirty, isSaved('name'))}`}
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  Billing timing
+                  <select
+                    value={billingTiming}
+                    disabled={!canWrite || !scheduleEditable}
+                    onChange={(e) => {
+                      const v = e.target.value as ContractBillingTiming;
+                      setBillingTiming(v);
+                      if (!isCreate) void savePatch({ billingTiming: v }, 'timing');
+                    }}
+                    data-testid="contract-form-timing"
+                    className={`${baseInput} ${fieldRing(false, isSaved('timing'))}`}
+                  >
+                    <option value="advance">In advance</option>
+                    <option value="arrears">In arrears</option>
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  Billing cadence
+                  <select
+                    value={intervalCustom ? 'custom' : String(intervalMonths)}
+                    disabled={!canWrite || !scheduleEditable}
+                    onChange={(e) => {
+                      if (e.target.value === 'custom') { setIntervalCustom(true); setCustomMonths(String(intervalMonths)); return; }
+                      setIntervalCustom(false);
+                      const n = Number(e.target.value);
+                      setIntervalMonths(n);
+                      if (!isCreate) void savePatch({ intervalMonths: n }, 'interval');
+                    }}
+                    data-testid="contract-form-interval"
+                    className={`${baseInput} ${fieldRing(false, isSaved('interval'))}`}
+                  >
+                    {INTERVAL_PRESETS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                    <option value="custom">Custom…</option>
+                  </select>
+                </label>
+                {intervalCustom && (
+                  <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                    Interval (months)
+                    <input
+                      type="number" min="1" max="60" value={customMonths}
+                      onChange={(e) => setCustomMonths(e.target.value)}
+                      onBlur={commitInterval}
+                      disabled={!canWrite || !scheduleEditable}
+                      data-testid="contract-form-interval-custom"
+                      className={`${baseInput} ${fieldRing(intervalDirty, isSaved('interval'))}`}
+                    />
+                    {intervalError && (
+                      <span className="text-destructive" data-testid="contract-interval-error">{intervalError}</span>
+                    )}
+                  </label>
+                )}
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  Start date
+                  <input
+                    type="date" value={startDate} onChange={(e) => { setStartDate(e.target.value); startEdited.current = true; }} onBlur={commitStart}
+                    disabled={!canWrite || !scheduleEditable}
+                    data-testid="contract-form-start"
+                    className={`${dateInput} ${fieldRing(startDirty, isSaved('startDate'))}`}
+                  />
+                </label>
               </div>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Notes (optional)
-                <textarea
-                  value={notes} onChange={(e) => setNotes(e.target.value)} rows={2}
-                  data-testid="contract-form-notes"
-                  className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:col-span-2">
-                Terms (optional, shown on the invoice)
-                <textarea
-                  value={terms} onChange={(e) => setTerms(e.target.value)} rows={2}
-                  data-testid="contract-form-terms"
-                  placeholder="e.g. Net 30. Auto-renews unless cancelled 30 days prior."
-                  className="rounded-md border bg-background px-3 py-2 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </label>
-            </div>
+            </fieldset>
+
+            {/* ── Renewal ──────────────────────────────────────────────── */}
+            <fieldset className="min-w-0" data-testid="contract-renewal-group">
+              <legend className={legendCls}>Renewal</legend>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  End date (optional)
+                  <input
+                    type="date" value={endDate}
+                    onChange={(e) => { setEndDate(e.target.value); endEdited.current = true; if (!e.target.value) setAutoRenew(false); }}
+                    onBlur={commitEnd}
+                    disabled={!canWrite}
+                    data-testid="contract-form-end"
+                    className={`${dateInput} ${fieldRing(endDirty, isSaved('endDate'))}`}
+                  />
+                </label>
+                <label className="flex items-center gap-2 text-sm sm:col-span-2">
+                  <input
+                    type="checkbox" checked={autoIssue} disabled={!canWrite}
+                    onChange={(e) => { setAutoIssue(e.target.checked); if (!isCreate) void savePatch({ autoIssue: e.target.checked }, 'autoIssue'); }}
+                    data-testid="contract-form-auto-issue"
+                  />
+                  Auto-issue generated invoices (otherwise they land as drafts)
+                </label>
+                <div className="sm:col-span-2">
+                  <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
+                    <input
+                      type="checkbox" checked={autoRenew} disabled={!canWrite || !endDate}
+                      onChange={(e) => {
+                        const checked = e.target.checked;
+                        setAutoRenew(checked);
+                        if (!isCreate) void savePatch({
+                          autoRenew: checked,
+                          renewalTermMonths: checked ? (renewalTermMonths === '' ? null : Number(renewalTermMonths)) : null,
+                          renewalNoticeDays: checked ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
+                        }, 'autoRenew');
+                      }}
+                    />
+                    <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>
+                  </label>
+                  {autoRenew && (
+                    <div className="mt-2 grid grid-cols-2 gap-3" data-testid="contract-renewal-fields">
+                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        Renewal term (months)
+                        <input
+                          type="number" min={1} max={120} value={renewalTermMonths}
+                          onChange={(e) => { setRenewalTermMonths(e.target.value); renewalTermEdited.current = true; }}
+                          onBlur={commitRenewalTerm}
+                          disabled={!canWrite}
+                          data-testid="contract-renewal-term"
+                          className={`${baseInput} ${fieldRing(renewalTermDirty, isSaved('renewalTerm'))}`}
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        Advance notice (days)
+                        <input
+                          type="number" min={0} max={365} value={renewalNoticeDays}
+                          onChange={(e) => { setRenewalNoticeDays(e.target.value); renewalNoticeEdited.current = true; }}
+                          onBlur={commitRenewalNotice}
+                          disabled={!canWrite}
+                          data-testid="contract-renewal-notice-days"
+                          className={`${baseInput} ${fieldRing(renewalNoticeDirty, isSaved('renewalNotice'))}`}
+                        />
+                      </label>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </fieldset>
+
+            {/* ── Content ──────────────────────────────────────────────── */}
+            <fieldset className="min-w-0" data-testid="contract-content-group">
+              <legend className={legendCls}>Content</legend>
+              <div className="grid grid-cols-1 gap-3">
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  Notes (optional)
+                  <textarea
+                    value={notes} onChange={(e) => { setNotes(e.target.value); notesEdited.current = true; }} onBlur={commitNotes}
+                    disabled={!canWrite} rows={2}
+                    data-testid="contract-form-notes"
+                    className={`${areaInput} ${fieldRing(notesDirty, isSaved('notes'))}`}
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  Terms (optional, shown on the invoice)
+                  <textarea
+                    value={terms} onChange={(e) => { setTerms(e.target.value); termsEdited.current = true; }} onBlur={commitTerms}
+                    disabled={!canWrite} rows={2}
+                    data-testid="contract-form-terms"
+                    placeholder="e.g. Net 30. Auto-renews unless cancelled 30 days prior."
+                    className={`${areaInput} ${fieldRing(termsDirty, isSaved('terms'))}`}
+                  />
+                </label>
+              </div>
+            </fieldset>
           </div>
 
           {/* Lines (edit mode only — a contract needs an id before lines attach) */}
@@ -570,9 +832,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                           </td>
                           <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
                           <td className="px-3 py-2 text-right">
-                            {can('contracts', 'write') && (
+                            {canWrite && (
                               <button
-                                type="button" onClick={() => void removeLine(l.id)} disabled={busy}
+                                type="button" onClick={() => setPendingRemove(l)} disabled={isPending(`remove-${l.id}`)}
                                 data-testid={`line-remove-${idx}`}
                                 className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
                               >
@@ -778,15 +1040,8 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
               )
             ) : (
               <>
-                {can('contracts', 'write') && (
-                  <button
-                    type="button" onClick={() => void saveHeader()} disabled={busy || !canSaveHeader}
-                    data-testid="save-contract-btn"
-                    className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-                  >
-                    Save changes
-                  </button>
-                )}
+                {/* No whole-form Save button: existing contracts blur-autosave each
+                    field. Status transitions (Activate) stay explicit. */}
                 {can('contracts', 'manage') && contract?.status === 'draft' && (
                   <button
                     type="button" onClick={() => void activate()} disabled={busy || lines.length === 0}
@@ -828,6 +1083,30 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
           onLinked={refresh}
         />
       )}
+
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        onClose={() => setPendingRemove(null)}
+        onConfirm={() => {
+          const line = pendingRemove;
+          if (!line) return;
+          // Leave the dialog open on failure (already toasted) so the user can
+          // retry; only close once the line is actually gone.
+          void (async () => {
+            if (!(await removeLine(line.id))) return;
+            setPendingRemove(null);
+          })();
+        }}
+        isLoading={pendingRemove ? isPending(`remove-${pendingRemove.id}`) : false}
+        title="Remove line"
+        message={
+          pendingRemove
+            ? `This removes "${pendingRemove.description || 'this line'}" from the contract. This can't be undone.`
+            : ''
+        }
+        confirmLabel="Remove line"
+        confirmTestId="contract-line-remove-confirm"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -654,7 +654,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                   Billing timing
                   <select
                     value={billingTiming}
-                    disabled={!canWrite || !scheduleEditable}
+                    disabled={!canWrite || !scheduleEditable || isPending('timing')}
                     onChange={(e) => {
                       const v = e.target.value as ContractBillingTiming;
                       const prev = billingTiming;
@@ -673,7 +673,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                   Billing cadence
                   <select
                     value={intervalCustom ? 'custom' : String(intervalMonths)}
-                    disabled={!canWrite || !scheduleEditable}
+                    disabled={!canWrite || !scheduleEditable || isPending('interval')}
                     onChange={(e) => {
                       if (e.target.value === 'custom') { setIntervalCustom(true); setCustomMonths(String(intervalMonths)); return; }
                       const prevMonths = intervalMonths;
@@ -698,7 +698,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       type="number" min="1" max="60" value={customMonths}
                       onChange={(e) => setCustomMonths(e.target.value)}
                       onBlur={commitInterval}
-                      disabled={!canWrite || !scheduleEditable}
+                      disabled={!canWrite || !scheduleEditable || isPending('interval')}
                       data-testid="contract-form-interval-custom"
                       className={`${baseInput} ${fieldRing(intervalDirty, isSaved('interval'))}`}
                     />
@@ -736,7 +736,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 </label>
                 <label className="flex items-center gap-2 text-sm sm:col-span-2">
                   <input
-                    type="checkbox" checked={autoIssue} disabled={!canWrite}
+                    type="checkbox" checked={autoIssue} disabled={!canWrite || isPending('autoIssue')}
                     onChange={(e) => {
                       const next = e.target.checked;
                       setAutoIssue(next);
@@ -750,7 +750,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 <div className="sm:col-span-2">
                   <label className="flex items-center gap-2 text-sm" data-testid="contract-auto-renew-toggle">
                     <input
-                      type="checkbox" checked={autoRenew} disabled={!canWrite || !endDate}
+                      type="checkbox" checked={autoRenew} disabled={!canWrite || !endDate || isPending('autoRenew')}
                       onChange={(e) => {
                         const checked = e.target.checked;
                         setAutoRenew(checked);

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -405,8 +405,12 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   // "Saved" announcement are the feedback; failures fall through to
   // handleActionError. Selects/checkboxes commit on change; text/date/number
   // fields on blur (with the same guards the create/commit paths use).
-  const savePatch = useCallback(async (patch: Record<string, unknown>, key: string) => {
-    if (!contract) return;
+  // Returns whether the PATCH landed so immediate-commit controls (selects /
+  // checkboxes, which have no dirty ring) can roll their optimistic local state
+  // back on failure — a rejected save must never leave a control displaying
+  // unpersisted state.
+  const savePatch = useCallback(async (patch: Record<string, unknown>, key: string): Promise<boolean> => {
+    if (!contract) return false;
     const ok = await runScoped(key, async () => {
       await runAction({
         request: () => updateContract(contract.id, patch),
@@ -416,6 +420,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
       refresh();
     }, 'Could not save the contract.');
     if (ok) flashSaved(key);
+    return ok;
   }, [contract, runScoped, refresh, flashSaved]);
 
   // Per-field dirty cues compare the live value against the persisted contract so
@@ -454,16 +459,21 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     const norm = endDate || null;
     if (norm === (contract?.endDate ?? null)) return;
     // Clearing the end date also disables auto-renew (which requires an end date).
-    void savePatch(norm === null ? { endDate: null, autoRenew: false } : { endDate: norm }, 'endDate');
+    // On failure the date field keeps its amber ring (retry by re-blurring), but
+    // the cascaded auto-renew flip has no ring — resync it to server truth.
+    void savePatch(norm === null ? { endDate: null, autoRenew: false } : { endDate: norm }, 'endDate')
+      .then((ok) => { if (!ok) setAutoRenew(contract?.autoRenew ?? false); });
   }, [canWrite, isCreate, endDate, contract, savePatch]);
 
   const commitInterval = useCallback(() => {
     if (!canWrite || isCreate || !scheduleEditable) return;
     if (!intervalValid) return; // inline error already tells the operator why
     if (effectiveMonths === (contract?.intervalMonths ?? 0)) return;
+    const prevMonths = intervalMonths;
     setIntervalMonths(effectiveMonths);
-    void savePatch({ intervalMonths: effectiveMonths }, 'interval');
-  }, [canWrite, isCreate, scheduleEditable, intervalValid, effectiveMonths, contract, savePatch]);
+    void savePatch({ intervalMonths: effectiveMonths }, 'interval')
+      .then((ok) => { if (!ok) setIntervalMonths(prevMonths); }); // custom input keeps its amber ring
+  }, [canWrite, isCreate, scheduleEditable, intervalValid, effectiveMonths, intervalMonths, contract, savePatch]);
 
   const commitRenewalTerm = useCallback(() => {
     if (!canWrite || isCreate) return;
@@ -478,7 +488,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
       return;
     }
     if (autoRenewPending && n === null) return; // still waiting for a term
-    void savePatch(autoRenewPending ? { autoRenew: true, renewalTermMonths: n } : { renewalTermMonths: n }, 'renewalTerm');
+    void savePatch(autoRenewPending ? { autoRenew: true, renewalTermMonths: n } : { renewalTermMonths: n }, 'renewalTerm')
+      .then((ok) => {
+        // The ridden-along auto-renew toggle has no dirty ring — on failure it
+        // must not keep showing "on" for a contract the server left "off". (The
+        // typed term survives in state; re-checking the box restores the fields.)
+        if (!ok && autoRenewPending) setAutoRenew(false);
+      });
   }, [canWrite, isCreate, autoRenew, contract, renewalTermMonths, persistedTerm, savePatch]);
 
   const commitRenewalNotice = useCallback(() => {
@@ -641,8 +657,10 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     disabled={!canWrite || !scheduleEditable}
                     onChange={(e) => {
                       const v = e.target.value as ContractBillingTiming;
+                      const prev = billingTiming;
                       setBillingTiming(v);
-                      if (!isCreate) void savePatch({ billingTiming: v }, 'timing');
+                      if (!isCreate) void savePatch({ billingTiming: v }, 'timing')
+                        .then((ok) => { if (!ok) setBillingTiming(prev); });
                     }}
                     data-testid="contract-form-timing"
                     className={`${baseInput} ${fieldRing(false, isSaved('timing'))}`}
@@ -658,10 +676,13 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                     disabled={!canWrite || !scheduleEditable}
                     onChange={(e) => {
                       if (e.target.value === 'custom') { setIntervalCustom(true); setCustomMonths(String(intervalMonths)); return; }
+                      const prevMonths = intervalMonths;
+                      const prevCustom = intervalCustom;
                       setIntervalCustom(false);
                       const n = Number(e.target.value);
                       setIntervalMonths(n);
-                      if (!isCreate) void savePatch({ intervalMonths: n }, 'interval');
+                      if (!isCreate) void savePatch({ intervalMonths: n }, 'interval')
+                        .then((ok) => { if (!ok) { setIntervalMonths(prevMonths); setIntervalCustom(prevCustom); } });
                     }}
                     data-testid="contract-form-interval"
                     className={`${baseInput} ${fieldRing(false, isSaved('interval'))}`}
@@ -716,7 +737,12 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                 <label className="flex items-center gap-2 text-sm sm:col-span-2">
                   <input
                     type="checkbox" checked={autoIssue} disabled={!canWrite}
-                    onChange={(e) => { setAutoIssue(e.target.checked); if (!isCreate) void savePatch({ autoIssue: e.target.checked }, 'autoIssue'); }}
+                    onChange={(e) => {
+                      const next = e.target.checked;
+                      setAutoIssue(next);
+                      if (!isCreate) void savePatch({ autoIssue: next }, 'autoIssue')
+                        .then((ok) => { if (!ok) setAutoIssue(!next); });
+                    }}
                     data-testid="contract-form-auto-issue"
                   />
                   Auto-issue generated invoices (otherwise they land as drafts)
@@ -729,7 +755,10 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                         const checked = e.target.checked;
                         setAutoRenew(checked);
                         if (isCreate) return;
-                        if (!checked) { void savePatch({ autoRenew: false }, 'autoRenew'); return; }
+                        // A checkbox has no dirty ring, so a failed PATCH rolls the
+                        // optimistic flip back rather than showing unpersisted state.
+                        const revert = (ok: boolean) => { if (!ok) setAutoRenew(!checked); };
+                        if (!checked) { void savePatch({ autoRenew: false }, 'autoRenew').then(revert); return; }
                         // The server requires a renewal term alongside autoRenew:true.
                         // With a term already entered, save both now; otherwise just
                         // reveal the fields — commitRenewalTerm carries autoRenew:true
@@ -740,7 +769,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                             autoRenew: true,
                             renewalTermMonths: term,
                             renewalNoticeDays: renewalNoticeDays === '' ? null : Number(renewalNoticeDays),
-                          }, 'autoRenew');
+                          }, 'autoRenew').then(revert);
                         }
                       }}
                     />

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -468,14 +468,18 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const commitRenewalTerm = useCallback(() => {
     if (!canWrite || isCreate) return;
     renewalTermEdited.current = false;
-    if (renewalTermMonths === persistedTerm) return;
+    // A locally-on but not-yet-persisted auto-renew rides along with the term
+    // (the toggle defers its PATCH until a term exists — see its onChange).
+    const autoRenewPending = autoRenew && !contract?.autoRenew;
+    if (renewalTermMonths === persistedTerm && !autoRenewPending) return;
     const n = renewalTermMonths === '' ? null : Number(renewalTermMonths);
     if (n !== null && (!Number.isInteger(n) || n < 1 || n > 120)) {
       handleActionError(new Error('invalid term'), 'Enter a renewal term between 1 and 120 months.');
       return;
     }
-    void savePatch({ renewalTermMonths: n }, 'renewalTerm');
-  }, [canWrite, isCreate, renewalTermMonths, persistedTerm, savePatch]);
+    if (autoRenewPending && n === null) return; // still waiting for a term
+    void savePatch(autoRenewPending ? { autoRenew: true, renewalTermMonths: n } : { renewalTermMonths: n }, 'renewalTerm');
+  }, [canWrite, isCreate, autoRenew, contract, renewalTermMonths, persistedTerm, savePatch]);
 
   const commitRenewalNotice = useCallback(() => {
     if (!canWrite || isCreate) return;
@@ -724,11 +728,20 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                       onChange={(e) => {
                         const checked = e.target.checked;
                         setAutoRenew(checked);
-                        if (!isCreate) void savePatch({
-                          autoRenew: checked,
-                          renewalTermMonths: checked ? (renewalTermMonths === '' ? null : Number(renewalTermMonths)) : null,
-                          renewalNoticeDays: checked ? (renewalNoticeDays === '' ? null : Number(renewalNoticeDays)) : null,
-                        }, 'autoRenew');
+                        if (isCreate) return;
+                        if (!checked) { void savePatch({ autoRenew: false }, 'autoRenew'); return; }
+                        // The server requires a renewal term alongside autoRenew:true.
+                        // With a term already entered, save both now; otherwise just
+                        // reveal the fields — commitRenewalTerm carries autoRenew:true
+                        // once a term is typed (an immediate PATCH would 400).
+                        const term = renewalTermMonths === '' ? null : Number(renewalTermMonths);
+                        if (term !== null && Number.isInteger(term) && term >= 1 && term <= 120) {
+                          void savePatch({
+                            autoRenew: true,
+                            renewalTermMonths: term,
+                            renewalNoticeDays: renewalNoticeDays === '' ? null : Number(renewalNoticeDays),
+                          }, 'autoRenew');
+                        }
                       }}
                     />
                     <span>Auto-renew at end of term{!endDate ? ' (set an end date first)' : ''}</span>

--- a/apps/web/src/components/contracts/ContractPax8Drawer.test.tsx
+++ b/apps/web/src/components/contracts/ContractPax8Drawer.test.tsx
@@ -65,6 +65,17 @@ describe('ContractPax8Drawer pick list', () => {
   });
 });
 
+describe('ContractPax8Drawer dialog semantics', () => {
+  it('renders a modal dialog and moves focus inside on open', async () => {
+    fetchWithAuth.mockResolvedValue(ok([baseSub]));
+    renderOpen();
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    // Focus lands on the first focusable control inside the dialog (the close button).
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+  });
+});
+
 describe('ContractPax8Drawer load failures', () => {
   it('surfaces an error when the subscriptions request is not ok', async () => {
     fetchWithAuth.mockResolvedValue(new Response('{"error":"nope"}', { status: 500 }));

--- a/apps/web/src/components/contracts/ContractPax8Drawer.tsx
+++ b/apps/web/src/components/contracts/ContractPax8Drawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { fetchWithAuth, AuthSessionExpiredError } from '../../stores/auth';
+import { Dialog } from '../shared/Dialog';
 import LinkSubscriptionPicker from '../integrations/LinkSubscriptionPicker';
 
 interface Pax8Subscription {
@@ -47,14 +47,6 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
   const [picked, setPicked] = useState<Pax8Subscription | null>(null);
 
   useEffect(() => {
-    if (!open) return;
-    document.body.style.overflow = 'hidden';
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    document.addEventListener('keydown', onKey);
-    return () => { document.body.style.overflow = ''; document.removeEventListener('keydown', onKey); };
-  }, [open, onClose]);
-
-  useEffect(() => {
     if (!open) { setSubs(null); setError(null); setPicked(null); return; }
     void (async () => {
       try {
@@ -74,18 +66,23 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
 
   const onDone = useCallback(() => { onLinked(); onClose(); }, [onLinked, onClose]);
 
-  if (!open || typeof document === 'undefined') return null;
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4 sm:p-8"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-      data-testid="contract-pax8-modal"
+  // Shared Dialog supplies role="dialog" + aria-modal, the focus trap, focus-in
+  // on open, Escape, overlay-click, and scroll lock. `alignTop` keeps the tall,
+  // scrollable drawer feel this modal had before.
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Link a Pax8 subscription"
+      labelledBy="contract-pax8-title"
+      maxWidth="xl"
+      alignTop
+      className="overflow-hidden"
     >
-      <div className="mt-8 w-full max-w-xl rounded-lg border bg-card shadow-xl">
+      <div data-testid="contract-pax8-modal">
         <div className="flex items-center justify-between border-b px-5 py-4">
           <div>
-            <h2 className="text-base font-semibold">Link a Pax8 subscription</h2>
+            <h2 id="contract-pax8-title" className="text-base font-semibold">Link a Pax8 subscription</h2>
             <p className="mt-0.5 text-xs text-muted-foreground">
               {picked ? 'Pick a line on this contract (or create one) to link.' : 'Choose a synced subscription to add to this contract.'}
             </p>
@@ -147,7 +144,6 @@ export default function ContractPax8Drawer({ open, orgId, integrationId, onClose
           )}
         </div>
       </div>
-    </div>,
-    document.body,
+    </Dialog>
   );
 }

--- a/apps/web/src/components/contracts/ContractWorkspace.tsx
+++ b/apps/web/src/components/contracts/ContractWorkspace.tsx
@@ -99,10 +99,10 @@ export default function ContractWorkspace({ contractId }: Props) {
   return (
     <div className="space-y-4" data-testid="contract-workspace">
       <div className="flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <a href="/contracts" className="text-xs text-muted-foreground hover:underline">← Contracts</a>
-          <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold" data-testid="contract-workspace-title">{contract.name}</h1>
+          <div className="flex items-center gap-2 min-w-0">
+            <h1 className="truncate text-xl font-semibold" data-testid="contract-workspace-title">{contract.name}</h1>
             <StatusPill
               role={CONTRACT_STATUS_ROLES[contract.status].role}
               label={CONTRACT_STATUS_ROLES[contract.status].label}

--- a/apps/web/src/components/contracts/ContractWorkspace.tsx
+++ b/apps/web/src/components/contracts/ContractWorkspace.tsx
@@ -5,10 +5,10 @@ import ContractDetail from './ContractDetail';
 import { usePermissions } from '../../lib/permissions';
 import {
   getContract,
-  CONTRACT_STATUS_COLORS,
-  CONTRACT_STATUS_LABELS,
+  CONTRACT_STATUS_ROLES,
   type ContractDetail as ContractDetailData,
 } from '../../lib/api/contracts';
+import { StatusPill } from '../billing/shared/StatusPill';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -103,9 +103,11 @@ export default function ContractWorkspace({ contractId }: Props) {
           <a href="/contracts" className="text-xs text-muted-foreground hover:underline">← Contracts</a>
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-semibold" data-testid="contract-workspace-title">{contract.name}</h1>
-            <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${CONTRACT_STATUS_COLORS[contract.status]}`}>
-              {CONTRACT_STATUS_LABELS[contract.status]}
-            </span>
+            <StatusPill
+              role={CONTRACT_STATUS_ROLES[contract.status].role}
+              label={CONTRACT_STATUS_ROLES[contract.status].label}
+              className={CONTRACT_STATUS_ROLES[contract.status].className}
+            />
           </div>
         </div>
         {contract.status === 'active' && canWrite && (

--- a/apps/web/src/components/contracts/ContractsList.empty.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.empty.test.tsx
@@ -69,6 +69,17 @@ describe('ContractsList — empty states & locked org', () => {
     expect(screen.queryByTestId('contracts-empty-cta')).not.toBeInTheDocument();
   });
 
+  it('renders the access-denied state (not the retryable error) on a 403', async () => {
+    listContracts.mockResolvedValue(json({ error: 'forbidden' }, 403));
+    render(<ContractsList />);
+
+    await screen.findByTestId('access-denied');
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText("You don't have permission to view contracts.")).toBeInTheDocument();
+    // The generic data-load-failure UI must NOT appear for a 403.
+    expect(screen.queryByTestId('contracts-error')).not.toBeInTheDocument();
+  });
+
   it('hides the Organization column when locked to an org (embedded view)', async () => {
     listContracts.mockResolvedValue(json({ data: [ACTIVE_CONTRACT] }));
     render(<ContractsList lockedOrgId="o1" />);

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../lib/api/contracts', async (importOriginal) => {
 });
 
 import { ContractsList } from './ContractsList';
+import { navigateTo } from '@/lib/navigation';
 
 const json = (payload: unknown, status = 200) =>
   ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
@@ -108,9 +109,15 @@ describe('ContractsList — search, sort & skeleton', () => {
     expect(link.getAttribute('tabindex')).not.toBe('-1');
 
     const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    // Cancel the anchor's default action up front so jsdom doesn't attempt a real
+    // document navigation (unimplemented → console noise). Propagation behavior
+    // — the thing under test — is unaffected.
+    clickEvent.preventDefault();
     const stop = vi.spyOn(clickEvent, 'stopPropagation');
     link.dispatchEvent(clickEvent);
     expect(stop).toHaveBeenCalled();
+    // The row's onClick (SPA navigateTo) must not fire — the anchor navigates natively.
+    expect(vi.mocked(navigateTo)).not.toHaveBeenCalled();
   });
 
   it('filters rows by organization name via the search box', async () => {

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+
+// Mock fetchWithAuth — called directly for loadOrgs.
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../lib/permissions', () => ({ usePermissions: () => ({ can: () => true }) }));
+
+const listContracts = vi.fn();
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return { ...orig, listContracts: (...a: unknown[]) => listContracts(...a) };
+});
+
+import { ContractsList } from './ContractsList';
+
+const json = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const base = {
+  partnerId: 'p1',
+  billingTiming: 'advance' as const,
+  currencyCode: 'USD',
+  endDate: null,
+  autoIssue: false,
+  autoRenew: false,
+  renewalTermMonths: null,
+  renewalNoticeDays: null,
+  createdBy: null,
+  notes: null,
+  terms: null,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+const ALPHA = {
+  ...base,
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  orgId: 'o1',
+  name: 'Alpha Retainer',
+  status: 'active' as const,
+  intervalMonths: 1,
+  nextBillingAt: '2026-02-01',
+  startDate: '2026-01-01',
+  estimatedPeriodValue: '100.00',
+};
+
+const ZETA = {
+  ...base,
+  id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  orgId: 'o2',
+  name: 'Zeta Support',
+  status: 'active' as const,
+  intervalMonths: 3,
+  nextBillingAt: '2026-03-01',
+  startDate: '2026-02-01',
+  estimatedPeriodValue: '900.00',
+};
+
+const ORGS = [
+  { id: 'o1', name: 'Acme Corp' },
+  { id: 'o2', name: 'Globex' },
+];
+
+describe('ContractsList — search, sort & skeleton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    fetchWithAuth.mockResolvedValue(json({ data: ORGS }));
+  });
+
+  it('renders a skeleton (not a spinner) while loading', async () => {
+    // Never-resolving load keeps the component in the loading state.
+    listContracts.mockReturnValue(new Promise(() => {}));
+    render(<ContractsList />);
+
+    expect(await screen.findByTestId('table-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('contracts-loading')).not.toBeInTheDocument();
+  });
+
+  it('filters rows by contract name via the search box', async () => {
+    listContracts.mockResolvedValue(json({ data: [ALPHA, ZETA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    expect(screen.getByTestId(`contract-row-${ALPHA.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`contract-row-${ZETA.id}`)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('contracts-search'), { target: { value: 'zeta' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(`contract-row-${ALPHA.id}`)).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId(`contract-row-${ZETA.id}`)).toBeInTheDocument();
+  });
+
+  it('filters rows by organization name via the search box', async () => {
+    listContracts.mockResolvedValue(json({ data: [ALPHA, ZETA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.change(screen.getByTestId('contracts-search'), { target: { value: 'globex' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(`contract-row-${ALPHA.id}`)).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId(`contract-row-${ZETA.id}`)).toBeInTheDocument();
+  });
+
+  it('sorts by name when the Name header is clicked', async () => {
+    listContracts.mockResolvedValue(json({ data: [ZETA, ALPHA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.click(screen.getByTestId('contracts-sort-name'));
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^contract-row-/);
+      // asc → Alpha before Zeta
+      expect(rows[0]).toHaveAttribute('data-testid', `contract-row-${ALPHA.id}`);
+      expect(rows[1]).toHaveAttribute('data-testid', `contract-row-${ZETA.id}`);
+    });
+
+    // Toggle to descending → Zeta first.
+    fireEvent.click(screen.getByTestId('contracts-sort-name'));
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^contract-row-/);
+      expect(rows[0]).toHaveAttribute('data-testid', `contract-row-${ZETA.id}`);
+    });
+  });
+
+  it('marks the active sort header with aria-sort', async () => {
+    listContracts.mockResolvedValue(json({ data: [ALPHA, ZETA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    const nameHeader = screen.getByTestId('contracts-sort-name').closest('th')!;
+    expect(nameHeader).toHaveAttribute('aria-sort', 'none');
+
+    fireEvent.click(screen.getByTestId('contracts-sort-name'));
+    await waitFor(() => {
+      expect(screen.getByTestId('contracts-sort-name').closest('th')).toHaveAttribute('aria-sort', 'ascending');
+    });
+  });
+});

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -97,6 +97,27 @@ describe('ContractsList — search, sort & skeleton', () => {
     expect(screen.getByTestId(`contract-row-${ZETA.id}`)).toBeInTheDocument();
   });
 
+  it('labels a single-currency MRR total from the ACTIVE subset, not contracts[0]', async () => {
+    // contracts[0] is a draft EUR contract (excluded from the active subset); the
+    // only active contract is USD. The strip must read $…, never €… — labeling
+    // the USD sum with contracts[0]'s currency was the original mislabeling bug.
+    const eurDraft = {
+      ...ALPHA,
+      id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      name: 'Euro Draft',
+      status: 'draft' as const,
+      currencyCode: 'EUR',
+      estimatedPeriodValue: '999.00',
+    };
+    listContracts.mockResolvedValue(json({ data: [eurDraft, ALPHA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    const strip = screen.getByTestId('contracts-mrr-strip');
+    expect(strip).toHaveTextContent('$100.00'); // ALPHA: 100.00 / 1 month
+    expect(strip.textContent).not.toContain('€');
+  });
+
   it('exposes a focusable link to the contract detail so keyboard users can open it', async () => {
     listContracts.mockResolvedValue(json({ data: [ALPHA] }));
     render(<ContractsList />);

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -96,6 +96,23 @@ describe('ContractsList — search, sort & skeleton', () => {
     expect(screen.getByTestId(`contract-row-${ZETA.id}`)).toBeInTheDocument();
   });
 
+  it('exposes a focusable link to the contract detail so keyboard users can open it', async () => {
+    listContracts.mockResolvedValue(json({ data: [ALPHA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    const link = screen.getByTestId(`contract-row-link-${ALPHA.id}`);
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', `/contracts/${ALPHA.id}`);
+    expect(link).toHaveTextContent('Alpha Retainer');
+    expect(link.getAttribute('tabindex')).not.toBe('-1');
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const stop = vi.spyOn(clickEvent, 'stopPropagation');
+    link.dispatchEvent(clickEvent);
+    expect(stop).toHaveBeenCalled();
+  });
+
   it('filters rows by organization name via the search box', async () => {
     listContracts.mockResolvedValue(json({ data: [ALPHA, ZETA] }));
     render(<ContractsList />);
@@ -117,7 +134,7 @@ describe('ContractsList — search, sort & skeleton', () => {
     fireEvent.click(screen.getByTestId('contracts-sort-name'));
 
     await waitFor(() => {
-      const rows = screen.getAllByTestId(/^contract-row-/);
+      const rows = screen.getAllByTestId(/^contract-row-(?!link)/);
       // asc → Alpha before Zeta
       expect(rows[0]).toHaveAttribute('data-testid', `contract-row-${ALPHA.id}`);
       expect(rows[1]).toHaveAttribute('data-testid', `contract-row-${ZETA.id}`);
@@ -126,7 +143,7 @@ describe('ContractsList — search, sort & skeleton', () => {
     // Toggle to descending → Zeta first.
     fireEvent.click(screen.getByTestId('contracts-sort-name'));
     await waitFor(() => {
-      const rows = screen.getAllByTestId(/^contract-row-/);
+      const rows = screen.getAllByTestId(/^contract-row-(?!link)/);
       expect(rows[0]).toHaveAttribute('data-testid', `contract-row-${ZETA.id}`);
     });
   });

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -7,12 +7,12 @@ import {
   listContracts,
   formatCadence,
   monthlyValue,
-  CONTRACT_STATUS_COLORS,
-  CONTRACT_STATUS_LABELS,
+  CONTRACT_STATUS_ROLES,
   type ContractStatus,
   type ContractSummary,
 } from '../../lib/api/contracts';
-import { formatMoney } from '../billing/invoiceTypes';
+import { formatMoney, formatDate } from '../billing/invoiceTypes';
+import { StatusPill } from '../billing/shared/StatusPill';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from '../billing/bulk/useBulkSelection';
@@ -57,14 +57,6 @@ function writeFilters(f: Filters): void {
   if (f.status) params.set('status', f.status);
   const next = params.toString();
   window.location.hash = next ? `#${next}` : '';
-}
-
-/** Render an ISO date (YYYY-MM-DD or timestamp) as a short locale date, '—' if absent. */
-function formatDate(value: string | null | undefined): string {
-  if (!value) return '—';
-  const d = new Date(value.length === 10 ? `${value}T00:00:00` : value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleDateString();
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -361,12 +353,12 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
                       <td className="px-3 py-3 font-medium">{ctr.name}</td>
                       {!lockedOrgId && <td className="px-3 py-3">{orgName(ctr.orgId)}</td>}
                       <td className="px-3 py-3">
-                        <span
-                          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${CONTRACT_STATUS_COLORS[ctr.status]}`}
-                          data-testid={`contract-status-${ctr.id}`}
-                        >
-                          {CONTRACT_STATUS_LABELS[ctr.status]}
-                        </span>
+                        <StatusPill
+                          role={CONTRACT_STATUS_ROLES[ctr.status].role}
+                          label={CONTRACT_STATUS_ROLES[ctr.status].label}
+                          className={CONTRACT_STATUS_ROLES[ctr.status].className}
+                          testId={`contract-status-${ctr.id}`}
+                        />
                       </td>
                       <td className="px-3 py-3">{formatCadence(ctr.intervalMonths)}</td>
                       <td className="px-3 py-3">{formatDate(ctr.nextBillingAt)}</td>

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -20,6 +20,7 @@ import { showToast } from '../shared/Toast';
 import { useBulkSelection } from '../billing/bulk/useBulkSelection';
 import { BulkActionBar } from '../billing/bulk/BulkActionBar';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+import AccessDenied from '../shared/AccessDenied';
 
 interface Organization {
   id: string;
@@ -84,6 +85,9 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  // A 403 from the contracts route is a permission denial, not a load failure, so
+  // it renders the access-denied state rather than the retryable error.
+  const [forbidden, setForbidden] = useState(false);
   const [filters, setFilters] = useState<Filters>(() =>
     lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : readFilters(),
   );
@@ -111,8 +115,10 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     try {
       setLoading(true);
       setError(undefined);
+      setForbidden(false);
       const res = await listContracts({ orgId: f.orgId || undefined, status: f.status || undefined });
       if (res.status === 401) return UNAUTHORIZED();
+      if (res.status === 403) { setForbidden(true); return; }
       if (!res.ok) throw new Error('Failed to load contracts');
       const body = (await res.json().catch(() => null)) as { data: ContractSummary[] } | null;
       if (!body) throw new Error('Failed to load contracts');
@@ -240,6 +246,14 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     },
     [bulk, loadContracts, filters],
   );
+
+  if (forbidden) {
+    return (
+      <div className="space-y-6" data-testid="contracts-page">
+        <AccessDenied message="You don't have permission to view contracts." />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6" data-testid="contracts-page">

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -364,8 +364,9 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
           )
         ) : (
           <div className="relative">
-            {/* BulkActionBar reserves its own space via an in-flow spacer, so no
-                bottom-padding hack is needed here. */}
+            {/* BulkActionBar is an in-flow `sticky bottom-0` element (last child),
+                so it reserves its own layout space and never occludes the last
+                row — no bottom-padding hack is needed here. */}
             <div className="overflow-x-auto">
               <table className="w-full text-sm" data-testid="contracts-list">
                 <thead>

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -364,9 +364,9 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
           )
         ) : (
           <div className="relative">
-            {/* Reserve space below the rows while selected so the absolute
-                bulk bar floats in blank space instead of covering the rows. */}
-            <div className={`overflow-x-auto ${bulk.size > 0 ? 'pb-14' : ''}`}>
+            {/* BulkActionBar reserves its own space via an in-flow spacer, so no
+                bottom-padding hack is needed here. */}
+            <div className="overflow-x-auto">
               <table className="w-full text-sm" data-testid="contracts-list">
                 <thead>
                   <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../lib/api/contracts';
 import { formatMoney, formatDate } from '../billing/invoiceTypes';
 import { StatusPill } from '../billing/shared/StatusPill';
+import { SortableTh } from '../billing/shared/SortableTh';
+import { TableSkeleton } from '../billing/shared/TableSkeleton';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from '../billing/bulk/useBulkSelection';
@@ -59,6 +61,13 @@ function writeFilters(f: Filters): void {
   window.location.hash = next ? `#${next}` : '';
 }
 
+// ---- client-side sort ----------------------------------------------------
+type SortKey = 'name' | 'org' | 'status' | 'estimate' | 'start';
+interface Sort { key: SortKey; dir: 'asc' | 'desc' }
+
+const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
+const ts = (d: string | null | undefined) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
+
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 interface Props {
@@ -78,6 +87,8 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   const [filters, setFilters] = useState<Filters>(() =>
     lockedOrgId ? { ...EMPTY_FILTERS, orgId: lockedOrgId } : readFilters(),
   );
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<Sort | null>(null);
   const [cancelOpen, setCancelOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
@@ -125,11 +136,11 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     return () => window.removeEventListener('hashchange', onHash);
   }, [lockedOrgId]);
 
-  // Clear bulk selection whenever the server-side filters change so stale
-  // invisible rows are never acted on. No client-side search in this component.
+  // Clear bulk selection whenever the server-side filters or client-side search
+  // change so stale, now-invisible rows are never acted on.
   useEffect(() => {
     bulk.clear();
-  }, [filters.orgId, filters.status, bulk.clear]);
+  }, [filters.orgId, filters.status, search, bulk.clear]);
 
   const applyFilter = useCallback((patch: Partial<Filters>) => {
     setFilters((prev) => {
@@ -141,7 +152,43 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
   const newContractHref = lockedOrgId ? `/contracts/new#orgId=${lockedOrgId}` : '/contracts/new';
 
-  const rows = useMemo(() => contracts, [contracts]);
+  const toggleSort = (key: SortKey) =>
+    setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }));
+
+  // ---- derived rows: client-side search (name/org) then optional sort ------
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let out = contracts.filter((c) => {
+      if (!q) return true;
+      return c.name.toLowerCase().includes(q) || orgName(c.orgId).toLowerCase().includes(q);
+    });
+    if (sort) {
+      const dir = sort.dir === 'asc' ? 1 : -1;
+      out = [...out].sort((a, b) => {
+        switch (sort.key) {
+          case 'name':
+            return a.name.localeCompare(b.name) * dir;
+          case 'org':
+            return orgName(a.orgId).localeCompare(orgName(b.orgId)) * dir;
+          case 'status':
+            return a.status.localeCompare(b.status) * dir;
+          case 'estimate':
+            return (num(a.estimatedPeriodValue) - num(b.estimatedPeriodValue)) * dir;
+          case 'start': {
+            const av = ts(a.startDate);
+            const bv = ts(b.startDate);
+            if (av == null && bv == null) return 0;
+            if (av == null) return 1;
+            if (bv == null) return -1;
+            return (av - bv) * dir;
+          }
+          default:
+            return 0;
+        }
+      });
+    }
+    return out;
+  }, [contracts, search, sort, orgName]);
 
   // Only DRAFT contracts can be bulk-deleted, so the action is offered only when
   // the selection actually contains one — otherwise it's a confusing no-op.
@@ -152,7 +199,8 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
   // Distinguishes a filtered-empty result (offer "clear filters") from a genuine
   // first-run empty state (offer "create your first contract").
-  const hasActiveFilters = Boolean(filters.status) || (!lockedOrgId && Boolean(filters.orgId));
+  const hasActiveFilters =
+    Boolean(search.trim()) || Boolean(filters.status) || (!lockedOrgId && Boolean(filters.orgId));
 
   // Estimated monthly recurring across active contracts (normalized by cadence).
   const mrr = useMemo(() => {
@@ -219,6 +267,14 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
       {/* Filters */}
       <div className="flex flex-wrap items-end gap-3" data-testid="contracts-filters">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search name or org"
+          aria-label="Search contracts"
+          data-testid="contracts-search"
+          className="h-10 min-w-[12rem] flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+        />
         {!lockedOrgId && (
           <label className="flex flex-col gap-1 text-xs text-muted-foreground">
             Organization
@@ -262,9 +318,7 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
       {/* Table */}
       <div className="rounded-lg border bg-card shadow-xs">
         {loading ? (
-          <div className="flex items-center justify-center py-12" data-testid="contracts-loading">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          </div>
+          <TableSkeleton cols={lockedOrgId ? 6 : 7} />
         ) : error ? (
           <div className="p-6 text-center text-sm text-destructive" data-testid="contracts-error">
             {error}
@@ -284,7 +338,7 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
               <p className="text-sm text-muted-foreground">No contracts match these filters.</p>
               <button
                 type="button"
-                onClick={() => applyFilter(lockedOrgId ? { status: '' } : { status: '', orgId: '' })}
+                onClick={() => { setSearch(''); applyFilter(lockedOrgId ? { status: '' } : { status: '', orgId: '' }); }}
                 data-testid="contracts-clear-filters"
                 className="mt-3 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
               >
@@ -325,12 +379,15 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
                         onChange={(e) => (e.target.checked ? bulk.selectAll(rows.map((r) => r.id)) : bulk.clear())}
                       />
                     </th>
-                    <th className="px-3 py-3 font-medium">Name</th>
-                    {!lockedOrgId && <th className="px-3 py-3 font-medium">Organization</th>}
-                    <th className="px-3 py-3 font-medium">Status</th>
+                    <SortableTh label="Name" sortKey="name" activeSort={sort?.key} direction={sort?.dir ?? 'asc'} onSort={toggleSort} testId="contracts-sort-name" />
+                    {!lockedOrgId && (
+                      <SortableTh label="Organization" sortKey="org" activeSort={sort?.key} direction={sort?.dir ?? 'asc'} onSort={toggleSort} testId="contracts-sort-org" />
+                    )}
+                    <SortableTh label="Status" sortKey="status" activeSort={sort?.key} direction={sort?.dir ?? 'asc'} onSort={toggleSort} testId="contracts-sort-status" />
+                    <SortableTh label="Start date" sortKey="start" activeSort={sort?.key} direction={sort?.dir ?? 'asc'} onSort={toggleSort} testId="contracts-sort-start" />
                     <th className="px-3 py-3 font-medium">Cadence</th>
                     <th className="px-3 py-3 font-medium">Next bill</th>
-                    <th className="px-3 py-3 text-right font-medium">Est. / period</th>
+                    <SortableTh label="Est. / period" sortKey="estimate" activeSort={sort?.key} direction={sort?.dir ?? 'asc'} onSort={toggleSort} align="right" testId="contracts-sort-estimate" />
                   </tr>
                 </thead>
                 <tbody>
@@ -360,6 +417,7 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
                           testId={`contract-status-${ctr.id}`}
                         />
                       </td>
+                      <td className="px-3 py-3">{formatDate(ctr.startDate)}</td>
                       <td className="px-3 py-3">{formatCadence(ctr.intervalMonths)}</td>
                       <td className="px-3 py-3">{formatDate(ctr.nextBillingAt)}</td>
                       <td className="px-3 py-3 text-right tabular-nums" data-testid={`contract-estimate-${ctr.id}`}>

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -11,8 +11,9 @@ import {
   type ContractStatus,
   type ContractSummary,
 } from '../../lib/api/contracts';
-import { formatMoney, formatDate } from '../billing/invoiceTypes';
+import { formatMoney, formatDate, sumByCurrency } from '../billing/invoiceTypes';
 import { StatusPill } from '../billing/shared/StatusPill';
+import { StatCard } from '../billing/shared/StatCard';
 import { SortableTh } from '../billing/shared/SortableTh';
 import { TableSkeleton } from '../billing/shared/TableSkeleton';
 import { usePermissions } from '../../lib/permissions';
@@ -212,8 +213,17 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
   const mrr = useMemo(() => {
     const active = contracts.filter((c) => c.status === 'active');
     const total = active.reduce((sum, c) => sum + monthlyValue(c.estimatedPeriodValue, c.intervalMonths), 0);
-    return { total, count: active.length, ccy: contracts[0]?.currencyCode || 'USD' };
+    // Per-currency so a mixed-currency book isn't summed under one wrong code.
+    const byCurrency = sumByCurrency(
+      active.map((c) => ({ amount: monthlyValue(c.estimatedPeriodValue, c.intervalMonths), currencyCode: c.currencyCode })),
+    );
+    return { total, count: active.length, byCurrency, ccy: contracts[0]?.currencyCode || 'USD' };
   }, [contracts]);
+
+  // '$12,300 + €4,100' across currencies; a single total otherwise (unchanged).
+  const mrrDisplay = mrr.byCurrency.length > 1
+    ? mrr.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
+    : formatMoney(mrr.total, mrr.ccy);
 
   const runBulkContracts = useCallback(
     async (path: string, verb: string) => {
@@ -322,11 +332,13 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
       {/* Estimated monthly recurring */}
       {!loading && !error && rows.length > 0 && (
-        <div className="inline-flex flex-col rounded-lg border bg-card px-4 py-3" data-testid="contracts-mrr-strip">
-          <span className="text-xs text-muted-foreground">Est. monthly recurring</span>
-          <span className="mt-0.5 text-lg font-semibold tabular-nums">{formatMoney(mrr.total, mrr.ccy)}</span>
-          <span className="text-xs text-muted-foreground">{mrr.count} active contract{mrr.count === 1 ? '' : 's'}</span>
-        </div>
+        <StatCard
+          label="Est. monthly recurring"
+          value={mrrDisplay}
+          hint={`${mrr.count} active contract${mrr.count === 1 ? '' : 's'}`}
+          className="inline-flex flex-col"
+          testId="contracts-mrr-strip"
+        />
       )}
 
       {/* Table */}

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -220,10 +220,13 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
     return { total, count: active.length, byCurrency, ccy: contracts[0]?.currencyCode || 'USD' };
   }, [contracts]);
 
-  // '$12,300 + €4,100' across currencies; a single total otherwise (unchanged).
-  const mrrDisplay = mrr.byCurrency.length > 1
-    ? mrr.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ')
-    : formatMoney(mrr.total, mrr.ccy);
+  // '$12,300 + €4,100' across currencies. With one currency, label with the
+  // SUMMED SUBSET's code (byCurrency[0]) — not contracts[0]'s (`mrr.ccy`), which
+  // may come from a draft/cancelled contract in a different currency. The
+  // contracts[0] fallback only applies when nothing is active ($0.00).
+  const mrrDisplay = mrr.byCurrency.length === 0
+    ? formatMoney(mrr.total, mrr.ccy)
+    : mrr.byCurrency.map((e) => formatMoney(e.amount, e.code)).join(' + ');
 
   const runBulkContracts = useCallback(
     async (path: string, verb: string) => {

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -408,7 +408,16 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
                           onChange={() => bulk.toggle(ctr.id)}
                         />
                       </td>
-                      <td className="px-3 py-3 font-medium">{ctr.name}</td>
+                      <td className="px-3 py-3 font-medium">
+                        <a
+                          href={`/contracts/${ctr.id}`}
+                          onClick={(e) => e.stopPropagation()}
+                          data-testid={`contract-row-link-${ctr.id}`}
+                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        >
+                          {ctr.name}
+                        </a>
+                      </td>
                       {!lockedOrgId && <td className="px-3 py-3">{orgName(ctr.orgId)}</td>}
                       <td className="px-3 py-3">
                         <StatusPill

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -61,7 +61,13 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2" data-testid="toast-container">
+    // Bottom-right, but lifted on lg+ so the toast clears the quote editor's
+    // sticky right-rail (Live totals + Terms panel) whose lower controls the
+    // stock bottom-6 anchor visually overlapped on shorter viewports. z-index was
+    // never the issue — the toast sat on top of the rail's interactive controls;
+    // raising the anchor keeps bottom-right while leaving the rail usable. The
+    // extra lift on wide screens is harmless on pages without a right rail.
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 lg:bottom-24" data-testid="toast-container">
       {toasts.map(toast => {
         const isError = toast.type === 'error';
         const isWarning = toast.type === 'warning';

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -12,6 +12,7 @@
 // (e.g. '150.00'), matching the invoice client's string-money convention.
 
 import { fetchWithAuth } from '../../stores/auth';
+import type { StatusPillRole } from '../../components/billing/invoiceTypes';
 
 export type ContractStatus = 'draft' | 'active' | 'paused' | 'cancelled' | 'expired';
 export type ContractBillingTiming = 'advance' | 'arrears';
@@ -170,13 +171,17 @@ export const CONTRACT_STATUS_LABELS: Record<ContractStatus, string> = {
   expired: 'Expired',
 };
 
-// Tailwind badge classes per status (mirrors the invoice STATUS_COLORS style).
-export const CONTRACT_STATUS_COLORS: Record<ContractStatus, string> = {
-  draft: 'border-border bg-muted text-muted-foreground',
-  active: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  paused: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
-  cancelled: 'border-border bg-muted text-muted-foreground line-through',
-  expired: 'border-border bg-muted text-muted-foreground',
+// Contracts share the invoice/quote semantic pill vocabulary (STATUS_PILL roles)
+// instead of raw emerald/amber palette hues, so a contract's "Active" green
+// matches an invoice's "Paid" green. Rendered via the shared <StatusPill role>.
+// active→success, draft→neutral, paused/expired→warning (lapsing),
+// cancelled→neutral with the historical line-through preserved as className.
+export const CONTRACT_STATUS_ROLES: Record<ContractStatus, { role: StatusPillRole; label: string; className?: string }> = {
+  draft: { role: 'neutral', label: CONTRACT_STATUS_LABELS.draft },
+  active: { role: 'success', label: CONTRACT_STATUS_LABELS.active },
+  paused: { role: 'warning', label: CONTRACT_STATUS_LABELS.paused },
+  cancelled: { role: 'neutral', label: CONTRACT_STATUS_LABELS.cancelled, className: 'line-through' },
+  expired: { role: 'warning', label: CONTRACT_STATUS_LABELS.expired },
 };
 
 /** Human cadence from intervalMonths: 1→Monthly, 3→Quarterly, 12→Annual, else "Every N months". */

--- a/docs/superpowers/plans/2026-07-01-quotes-invoices-contracts-polish-round-2.md
+++ b/docs/superpowers/plans/2026-07-01-quotes-invoices-contracts-polish-round-2.md
@@ -1,0 +1,212 @@
+# Quotes / Invoices / Contracts Polish Round 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the Quotes, Invoices, and Contracts surfaces onto a shared component kit and bring the invoice/contract editors up to the quote editor's interaction quality, per the 2026-07-01 design critique (`.impeccable/critique/2026-07-01T22-01-07Z__apps-web-src-components-billing.md`).
+
+**Architecture:** Extract best-of-breed patterns (identified per-pattern in the critique) into `apps/web/src/components/billing/shared/`, then adopt them in all three surfaces; then backport the quote editor's save/validation grammar to the invoice and contract editors; then a final polish sweep. Each task is one reviewable PR-sized unit and leaves all tests green.
+
+**Tech Stack:** React 19 islands in Astro, Tailwind 4 (token classes, `dark:` variants), Vitest + jsdom + Testing Library, `runAction` for mutations, `data-testid` selectors (E2E convention).
+
+## Global Constraints
+
+- Decisions locked by the user: keep the 3-tab workspace for invoices; contract editor moves to **blur-autosave** (quote-editor grammar); all three phases in scope.
+- Every mutation handler goes through `runAction` (`apps/web/src/lib/runAction.ts`) — see CLAUDE.md catch pattern; do not add entries to `runActionAllowlist.ts` (adopted surfaces already comply).
+- Tests live alongside sources (`Foo.tsx` → `Foo.test.tsx`). Run web tests with `cd apps/web && pnpm vitest run <file>`; full suite `pnpm test --filter=@breeze/web`.
+- All interactive elements query-able by `data-testid`; keep every existing `data-testid` working (E2E depends on them). New interactive elements get new testids.
+- Tailwind semantic tokens only (`text-muted-foreground`, `bg-card`, `border-border`, status tokens via `STATUS_PILL` roles); no raw palette hues (`emerald-500`) in new code; every new visual has a `dark:` story via tokens.
+- Client-side UI state in `window.location.hash`, never query params.
+- Preserve behaviors called out as strengths: block-remove message counting child lines, Issued/Sent distinction, sticky actions column, distributor pre-check, reorder burst-coalescing, hash-persisted filters.
+- Never edit shipped migrations; no schema changes are needed in this plan (all data already exists — e.g. `convertedInvoiceId`, `acceptedAt`).
+- Files touched here are large; do not split files beyond what a task specifies (CLAUDE.md: no proactive splitting).
+- Commit per task step with conventional-commit messages; branch is `ToddHebebrand/quotes-invoices-contracts-polishing-round-2`.
+
+**Verification stack:** worktree stack is running at `http://localhost:32801` (`.breeze-stack.json`, admin `admin@breeze.local` / `BreezeAdmin123!`). Use it to eyeball each task's result on `/billing/quotes`, `/billing/invoices`, `/contracts`.
+
+---
+
+## Phase 1 — Shared billing kit
+
+### Task 1: `StatusPill` + shared `format.ts`
+
+**Files:**
+- Create: `apps/web/src/components/billing/shared/StatusPill.tsx`
+- Create: `apps/web/src/components/billing/shared/StatusPill.test.tsx`
+- Create: `apps/web/src/components/billing/shared/format.ts`
+- Create: `apps/web/src/components/billing/shared/format.test.ts`
+- Modify: `apps/web/src/components/billing/invoiceTypes.ts` (re-export formatters from shared; keep `STATUS_PILL` as source of truth or move it — see below)
+- Modify: `apps/web/src/components/billing/quotes/quoteTypes.ts` (delete duplicate `formatMoney`/`formatDate`, re-export from shared)
+- Modify: `apps/web/src/lib/api/contracts.ts:174-180` (delete `CONTRACT_STATUS_COLORS` raw-palette map; replace with STATUS_PILL role mapping)
+- Modify: `apps/web/src/components/contracts/ContractsList.tsx`, `ContractDetail.tsx`, `ContractWorkspace.tsx` (render `<StatusPill>`; delete the two local `formatDate` copies at `ContractsList.tsx:63`, `ContractDetail.tsx:52`)
+- Modify: `apps/web/src/components/billing/quotes/QuotesPage.tsx`, `QuoteDetail.tsx`, `InvoicesPage.tsx`, `InvoiceDetail.tsx`, `InvoiceDocument.tsx`, `QuoteDocument.tsx` (replace inline status spans with `<StatusPill>`)
+
+**Interfaces:**
+- Produces: `StatusPill({ role, label, className?, testId? })` where `role: 'success' | 'warning' | 'danger' | 'info' | 'neutral'` (exactly the existing `STATUS_PILL` roles in `invoiceTypes.ts:124-146`); renders `<span>` with the STATUS_PILL classes for `role`, an `sr-only` prefix `Status:` (the quotes pattern from `QuotesPage.tsx:455-456` — NOT `aria-label` on a span), and visible `label`.
+- Produces: `formatMoney(cents: number, currencyCode?: string): string` and `formatDate(iso: string | null | undefined): string` in `shared/format.ts` — move the implementations from `invoiceTypes.ts` verbatim (they are the canonical copies per critique). `invoiceTypes.ts` and `quoteTypes.ts` re-export them so no import site breaks.
+- Produces: `CONTRACT_STATUS_ROLES: Record<ContractStatus, {role: StatusPillRole, label: string}>` — active→success, draft→neutral, paused→warning, cancelled→neutral (keep any existing line-through styling as `className`), expired→warning.
+
+- [ ] **Step 1: Write failing tests** — `StatusPill.test.tsx`: renders visible label; renders `sr-only` text `Status:` (assert `screen.getByText('Status:')` has class `sr-only`); applies STATUS_PILL classes per role; no `aria-label` attribute. `format.test.ts`: `formatMoney(112500)` → `$1,125.00`; `formatMoney(0, 'EUR')` includes `€` or `EUR`; `formatDate(null)` → the same fallback string invoiceTypes' current impl returns (read it first, assert exact).
+- [ ] **Step 2: Run tests, verify they fail** — `cd apps/web && pnpm vitest run src/components/billing/shared/`
+- [ ] **Step 3: Implement `StatusPill.tsx` and `format.ts`** (move code from invoiceTypes, don't rewrite the math). Update `invoiceTypes.ts`/`quoteTypes.ts` to re-export.
+- [ ] **Step 4: Run tests, verify pass; run existing suites** — `pnpm vitest run src/components/billing` must stay green (they cover formatters via existing tests).
+- [ ] **Step 5: Adopt in all six render sites + contracts role map; delete dead local copies.** Grep for `CONTRACT_STATUS_COLORS` and both local `formatDate` definitions to confirm zero remaining references.
+- [ ] **Step 6: Full web test run + visual check** on the stack (contracts pill green must now match invoices "Paid" green; VoiceOver-style check: pill text includes hidden "Status:").
+- [ ] **Step 7: Commit** — `feat(web): shared StatusPill + billing format helpers; contracts on semantic status roles`
+
+### Task 2: `SortableTh` + shared skeletons; Contracts gains search/sort/skeletons
+
+**Files:**
+- Create: `apps/web/src/components/billing/shared/SortableTh.tsx` (+ `SortableTh.test.tsx`)
+- Create: `apps/web/src/components/billing/shared/TableSkeleton.tsx`
+- Modify: `QuotesPage.tsx:260-287,573-602` and `InvoicesPage.tsx:311-338,830-859` (delete verbatim-duplicate `SortHeader`/`SortHeaderLeft`, use `SortableTh`)
+- Modify: `ContractsList.tsx` (add search box over name/org — same client-side filter pipeline as quotes; add sort on Name/Org/Status/Est-per-period/Start; replace spinner at `:273-275` with `TableSkeleton`; delete the vestigial `useMemo` at `:152`)
+
+**Interfaces:**
+- Produces: `SortableTh({ label, sortKey, activeSort, direction, onSort, align?: 'left' | 'right', testId? })` — renders `<th aria-sort=...>` with button; extracted from the existing quotes/invoices implementation (they are identical — lift, parameterize alignment, keep markup/classes byte-compatible so visual output is unchanged).
+- Produces: `TableSkeleton({ rows?: number, cols: number })` — the 6-row skeleton block pattern from `QuotesPage.tsx:359-368`, generalized to column count.
+
+- [ ] **Step 1: Failing tests** — `SortableTh.test.tsx`: renders `aria-sort="ascending"` when active+asc, `none` when inactive; clicking calls `onSort(sortKey)`. Contracts: extend `ContractsList` tests — typing in new search box (`data-testid="contracts-search"`) filters rows by name; loading state renders skeleton rows not a spinner (assert by testid `table-skeleton`).
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement; adopt in quotes+invoices (pure refactor, snapshots of table headers unchanged) and contracts (new capability).**
+- [ ] **Step 4: Run `pnpm vitest run src/components/billing src/components/contracts` — green.**
+- [ ] **Step 5: Commit** — `feat(web): shared SortableTh/TableSkeleton; contracts list gains search, sort, skeletons`
+
+### Task 3: `ListFilterBar` semantics + `BulkActionBar` fixes
+
+**Files:**
+- Modify: `apps/web/src/components/billing/bulk/BulkActionBar.tsx` (bar reserves its own space; accept optional `draftCount` label awareness from contracts)
+- Modify: `QuotesPage.tsx` (add `hasActiveFilters` + filtered-empty branch + Clear-filters button; fix `writeFilters` bare-`#` residue at `:69`)
+- Modify: `InvoicesPage.tsx` (same filtered-empty branch; keep its existing Clear button; fix `:71` hash residue)
+- Modify: `ContractsList.tsx:321-323` (drop the manual `pb-14` once the bar reserves space)
+
+**Interfaces:**
+- Consumes: contracts' `hasActiveFilters` branching pattern (`ContractsList.tsx:163,289-318`) — port the logic, don't re-invent: filtered-empty state says "No quotes match these filters" + `Clear filters` button (testid `quotes-clear-filters` / reuse `invoices-clear-filters`); first-run keeps the existing teaching empty state.
+- Produces: `BulkActionBar` renders an in-flow spacer (or `position: sticky` bottom) such that the last table row is never occluded; callers need no padding hacks.
+
+- [ ] **Step 1: Failing tests** — QuotesPage: with `status=declined` in hash and zero rows, renders `quotes-filtered-empty` (not the teaching empty), Clear button resets hash to no residue (`window.location.hash === ''` and no trailing `#` — use `history.replaceState` pattern if the bare-`#` can't be avoided via assignment). BulkActionBar: selecting rows does not change table container's scroll height overlap — assert the bar container includes the spacer element (testid `bulk-bar-spacer`).
+- [ ] **Step 2: Verify fail.** — note existing bulk tests: `QuotesPage.bulk.test.tsx`, `InvoicesPage.bulk.test.tsx`, `ContractsList.bulk.test.tsx` must stay green.
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Suite green; visual check: select a row near viewport bottom on quotes — last row visible above bar.**
+- [ ] **Step 5: Commit** — `fix(web): filtered-empty states + clear filters on quotes/invoices; BulkActionBar reserves its own space`
+
+### Task 4: `DocumentWorkspace` + `usePdfDownload`
+
+**Files:**
+- Create: `apps/web/src/components/billing/shared/DocumentWorkspace.tsx` (+ test)
+- Create: `apps/web/src/components/billing/shared/usePdfDownload.ts`
+- Modify: `QuoteWorkspace.tsx`, `InvoiceWorkspace.tsx` → thin wrappers over `DocumentWorkspace` (~190 duplicated lines deleted)
+- Modify: `InvoiceDetail.tsx:115-136`, `InvoiceDocument.tsx:235-256` (delete both inline `downloadPdf` copies; use `usePdfDownload`)
+- Modify: `apps/web/src/components/billing/quotes/useQuotePdfDownload.ts` → re-export of `usePdfDownload(path, filename)` specialization
+- Modify: `InvoiceWorkspace.tsx` header: gains action slot (Issue / Issue & Send / Download PDF / Delete draft surfaced from `InvoiceDetail`/`InvoiceEditor` as appropriate for status), and the status pill in the header (contracts pattern). `ContractWorkspace.tsx:104-109`: align header composition (back + truncating title + StatusPill + actions) — add `truncate` + `min-w-0` so long names can't wreck the row.
+
+**Interfaces:**
+- Produces: `DocumentWorkspace({ backHref, backLabel, title, statusPill?: ReactNode, actions?: ReactNode, tabs: {id, label, hidden?}[], activeTab, onTabChange, children })` — lifts the existing WAI-ARIA tablist implementation with roving tabindex + Home/End verbatim from `QuoteWorkspace.tsx:88-101`; tab state stays in `window.location.hash`.
+- Produces: `usePdfDownload({ path, filename }): { download: () => Promise<void>, downloading: boolean }` — generalized from `useQuotePdfDownload` (authed fetch → blob → object URL → anchor click → revoke), error surfaced via `runAction`/toast like the current hook.
+- Header layout must handle the disabled-primary-action case without wrapping into page center (critique browser finding): actions cluster is `flex items-center gap-2 flex-wrap justify-end`, disabled-reason hint rendered below the cluster (`text-xs text-muted-foreground text-right`), not inline between buttons.
+
+- [ ] **Step 1: Failing tests** — DocumentWorkspace: renders tablist with `aria-selected`, ArrowRight moves focus (fireEvent.keyDown), hidden tab absent; header renders title + actions slot. usePdfDownload: mocks fetch, asserts blob URL anchor download + revoke (mirror the existing `useQuotePdfDownload` test if present; else write one).
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement; port both workspaces; wire invoice header actions (Issue button visible from any tab for drafts — behavior handlers already exist in `InvoiceDetail`/`InvoiceEditor`, lift them up via props, don't duplicate logic).**
+- [ ] **Step 4: All existing workspace/permission tests green** (`QuoteWorkspace`, `InvoiceWorkspace.test.tsx`, `ContractWorkspace.permissions.test.tsx`); visual check on the stack: invoice draft header shows actions; long contract name truncates.
+- [ ] **Step 5: Commit** — `refactor(web): shared DocumentWorkspace + usePdfDownload; invoice header actions; contract title truncation`
+
+---
+
+## Phase 2 — Behavior parity
+
+### Task 5: Keyboard-accessible list rows (P0)
+
+**Files:**
+- Modify: `QuotesPage.tsx:427-431`, `InvoicesPage.tsx:548-553` (+ mobile `DataCard` at `:604`), `ContractsList.tsx:345-351`
+
+**Interfaces:**
+- The Number/Name cell content becomes a real `<a href={detailUrl}>` styled as the current text (`text-foreground` + `hover:underline`, `focus-visible` ring token), `data-testid` preserved on the row plus new `*-row-link` testids. Row `onClick` stays for pointer convenience; the anchor's click must `stopPropagation` to avoid double navigation. Mobile invoice `DataCard`: wrap title in the same anchor.
+
+- [ ] **Step 1: Failing tests** — each list: the row contains a link with `href` `/billing/quotes/<id>` (resp. invoices/contracts); link is focusable (`tabIndex` not `-1`).
+- [ ] **Step 2: Verify fail. Step 3: Implement. Step 4: Suites green; manual: Tab from search box reaches first row link, Enter opens detail.**
+- [ ] **Step 5: Commit** — `fix(web): billing/contract list rows keyboard-accessible via real links`
+
+### Task 6: Invoice editor parity backport (P1)
+
+**Files:**
+- Modify: `apps/web/src/components/billing/InvoiceEditor.tsx` (the whole editing grammar), tests in `InvoiceEditor.test.tsx`
+
+**Interfaces (all consumed from `QuoteEditor.tsx` — read these before coding):**
+- Scoped pending: replace the single `busy` boolean (`InvoiceEditor.tsx:39,138-155`) with the `runScoped(key, fn)` pattern from `QuoteEditor.tsx:189-215` — key per line-field (`qty-<lineId>`, `price-<lineId>`, `notes`, `addLine`), only the in-flight control disables.
+- Commit guards: port `commitQty`/`commitPrice` semantics from `QuoteEditor.tsx:297-326` — clamp/reject NaN, qty>0, price≥0, numeric compare (not string compare — fixes the `3.00` vs `3` redundant PATCH at `:621`), keep-input + inline explanation on invalid.
+- Dirty/saved cues: port `fieldRing` (amber dirty ring → green saved pulse) + `SrSaved` polite announcement from `QuoteEditor.tsx:97-125`.
+- Resync guard: port the edited-flag resync (`QuoteEditor.tsx:1704-1743`) for qty/price so a background refresh cannot clobber mid-keystroke edits (`InvoiceEditor.tsx:576`).
+- `addLine` validates `manualQty`/`manualPrice` with the same guards before POST (`InvoiceEditor.tsx:104`).
+
+- [ ] **Step 1: Failing tests** — qty blur with `abc` does not PATCH and shows inline error; qty blur with `-1` rejected; price `3.00` over `3` does not PATCH; while one line's PATCH is in flight, another line's input is not disabled; background `invoice` prop refresh while a field is edited does not overwrite the field's draft value.
+- [ ] **Step 2: Verify fail (existing `InvoiceEditor.test.tsx` stays green throughout).**
+- [ ] **Step 3: Implement (largest task in the plan — port, don't reinvent; same helper names as QuoteEditor for grep-ability).**
+- [ ] **Step 4: Suite green + manual stack check: edit two lines rapidly, no global freeze; amber/green rings behave as on quotes.**
+- [ ] **Step 5: Commit** — `fix(web): invoice editor gets quote-editor save grammar (scoped pending, validation, dirty rings, resync guard)`
+
+### Task 7: Contract editor — blur-autosave, grouping, confirms, Pax8 dialog
+
+**Files:**
+- Modify: `apps/web/src/components/contracts/ContractEditor.tsx` (+ its tests)
+- Modify: `apps/web/src/components/contracts/ContractPax8Drawer.tsx:79-152` (rebuild on `shared/Dialog`)
+
+**Interfaces:**
+- Save model (user decision): **blur-autosave** for existing contracts — each header field PATCHes on blur via `runAction` with the quote editor's `fieldRing`/`SrSaved` grammar (port as in Task 6). The **create** flow (`/contracts/new`) keeps its explicit `Create contract` button (nothing exists to PATCH yet).
+- Form grouping: split the flat ~12-field card (`ContractEditor.tsx:393-528`) into three fieldsets with `<legend>`-style section labels: **Schedule** (org, name, billing timing, cadence, custom interval, start), **Renewal** (end date, auto-issue, auto-renew + conditionals), **Content** (notes, terms). Pure layout regrouping — no field behavior changes beyond autosave.
+- `intervalCustom` empty → inline error message ("Enter the number of {units}") instead of silently disabled save (`ContractEditor.tsx:451`).
+- Line Remove gets `ConfirmDialog` (same copy pattern as `QuoteEditor.tsx:561-565`: name the line).
+- Pax8 drawer: `shared/Dialog` provides role/aria-modal/focus trap; keep drawer styling via Dialog's className hooks; Escape and overlay-click behavior preserved.
+
+- [ ] **Step 1: Failing tests** — blur on name field PATCHes contract with new name; invalid custom interval shows inline error text; Remove line opens confirm naming the line, cancel keeps it; Pax8 drawer root has `role="dialog"` and `aria-modal="true"`, focus lands inside on open.
+- [ ] **Step 2: Verify fail. Step 3: Implement. Step 4: All contract tests green (`ContractEditor`, `ContractDetail.*`, `ContractWorkspace.permissions`, `ContractPax8Drawer`); manual: edit an active contract's name, amber→green ring; Tab stays inside Pax8 drawer.**
+- [ ] **Step 5: Commit** — `feat(web): contract editor blur-autosave + grouped form + remove confirm; Pax8 drawer on shared Dialog`
+
+### Task 8: Quote lifecycle strip + converted-invoice link (P1)
+
+**Files:**
+- Modify: `apps/web/src/components/billing/quotes/QuoteDetail.tsx:144-165` (+ test)
+- Modify: `QuoteActions.tsx` (post-send success copy gains "what happens next")
+
+**Interfaces:**
+- Consumes: `quote.sentAt`, `viewedAt`, `acceptedAt`, `declinedAt`, `convertedInvoiceId` (`quoteTypes.ts:47-52`) — all already returned by the API (verify with a quick curl on the stack before coding; if absent from the list-serializer, they ARE on the detail response the component already holds).
+- Produces: a compact lifecycle `<dl>` in the summary card: `Sent {formatDate} · Viewed {…} · Accepted {…}` (render only non-null stages; declined shows `Declined {…}` in danger text). When `convertedInvoiceId` is set: a link `View invoice →` to `/billing/invoices/{convertedInvoiceId}` (testid `quote-view-invoice`).
+- Post-send toast/confirm copy: after successful send, the success toast reads `Proposal sent — we'll mark it Viewed and Accepted as {customer} opens and signs.`
+
+- [ ] **Step 1: Failing tests** — accepted quote renders `Accepted` with formatted date; converted quote renders link with correct href; draft renders no lifecycle strip.
+- [ ] **Step 2: Verify fail. Step 3: Implement. Step 4: Green + manual check.**
+- [ ] **Step 5: Commit** — `feat(web): quote lifecycle timestamps + converted-invoice link`
+
+---
+
+## Phase 3 — Polish sweep
+
+### Task 9: A11y + feedback polish
+
+**Files/changes (one PR, each item independently verifiable):**
+- `QuoteEditor.tsx:1035-1041` — debounce the Live-totals `role="status"` sentence to commit-time (blur / 800ms trailing), not per keystroke.
+- `QuotesPage.tsx:443-447`, `InvoicesPage.tsx:566-570` — drop the redundant `DRAFT` chip in the Number column (Status column already says Draft); show em-dash for missing number.
+- Toast container placement — quote editor toasts overlap the Terms panel (browser finding): audit shared toast anchor; bottom-right is fine but must clear the right rail (`z` + offset), smallest fix wins.
+- 403 → `AccessDenied` on quotes list and contracts list (port from `InvoicesPage.tsx:85-87,340-346`).
+- `QuoteDocument.tsx:324-329`, `InvoiceDocument.tsx:228-233` — customer-facing fallback: replace `orgId.slice(0,8)` with `"—"` (never leak UUID fragments into "Prepared for").
+
+- [ ] **Step 1-4: per item — failing test where testable (redundant chip absence, AccessDenied rendering, document fallback string), implement, green.**
+- [ ] **Step 5: Commit** — `fix(web): billing a11y/feedback polish (SR debounce, 403 views, chip dedupe, safe doc fallbacks)`
+
+### Task 10: Money honesty + branding + stat cards
+
+**Files/changes (one PR):**
+- Multi-currency summary strips (`QuotesPage.tsx:199-204`, `InvoicesPage.tsx:296-305`, `ContractsList.tsx:166-170`): when rows span >1 `currencyCode`, render per-currency totals (`$12,300 + €4,100`) instead of one mislabeled sum — small helper `sumByCurrency(rows): {code, cents}[]` in `shared/format.ts` with tests.
+- `InvoiceDocument.tsx:55-57` — add the partner branding header the quote document already renders (`QuoteDocument.tsx` letterhead block + `useAuthedImage` loader); customers get consistent branded documents.
+- Extract `StatCard` from Invoices' clickable stat-filter cards (`InvoicesPage.tsx` summary strip) into `shared/StatCard.tsx`; quotes + contracts adopt (quotes: Draft count → status filter; contracts: MRR stays static display).
+- Quote editor line-grid width (browser finding): give the description/name input a sane `min-w` and let Recurrence shrink (`min-w-0` on the flex row) so the grid is usable at 1280px; Total column must be visible without horizontal scroll at ≥1280px viewport with the rail open.
+
+- [ ] **Step 1-4: per item — `sumByCurrency` unit tests (mixed currencies → two entries, single → one), StatCard click test (fires filter callback), InvoiceDocument branding render test, implement, green; manual stack check at 1280px viewport.**
+- [ ] **Step 5: Commit** — `feat(web): per-currency totals, branded invoice document, shared StatCard, editor grid width fixes`
+
+---
+
+## Self-review notes
+
+- Spec coverage: every P0/P1/P2 from the critique maps to a task (P0→5; P1s→3,6,7,8; P2s→1,2,3,4,7,10); below-cut minors→9,10. Divergence-table rows all land in Phase 1 tasks except 403 (Task 9) and StatCard (Task 10).
+- Type consistency: `StatusPillRole` union defined in Task 1 and consumed in Tasks 4 (header pill) and 1's contracts map; `usePdfDownload` signature consistent between Task 4 create and adoption sites; `runScoped`/`fieldRing`/`SrSaved` names reused verbatim from QuoteEditor in Tasks 6-7 for grep-ability.
+- Deliberately out of scope (would need product decisions not yet made): undo system, keyboard shortcuts, pagination/virtualization, single-page invoice redesign (user chose tabs), quote acceptance-portal changes, PDF permission vocabulary unification (`quotes:read` vs `invoices:export` — flag for RBAC review, don't change).


### PR DESCRIPTION
## Summary

Round 2 polish of the Quotes, Invoices, and Contracts surfaces, executed from a full design critique (29.5/40 Nielsen baseline; snapshot in `.impeccable/critique/`). The three surfaces had drifted — three save paradigms, two status-pill systems, three loading treatments. This PR reconciles them onto a shared kit and closes the critique's P0/P1 findings.

**Phase 1 — shared billing kit** (`apps/web/src/components/billing/shared/`)
- `StatusPill` (semantic roles + sr-only "Status:" text) — contracts rebuilt onto it, killing the raw emerald/amber palette map and the two-greens drift
- `SortableTh` + `TableSkeleton` — deduped verbatim copies; contracts list gains search, sort (incl. new Start date column), and skeletons
- Filtered-empty vs first-run empty states + Clear filters on quotes/invoices; `BulkActionBar` now sticky in-flow (can never occlude the last row)
- `DocumentWorkspace` (shared ARIA tabbed workspace w/ composite header) + `usePdfDownload`; new `InvoiceActions` surfaces Issue / Issue & Send / Download PDF / Delete in the invoice header (was buried in tabs); contract titles truncate

**Phase 2 — behavior parity**
- P0: list rows keyboard-accessible via real links on all three lists
- Invoice editor gets the quote editor's save grammar: scoped pending (no more global input freeze), qty/price validation (no more NaN PATCHes), amber/green dirty rings + SR announcements, mid-edit resync guard
- Contract editor: blur-autosave (was explicit-save with silent data loss), Schedule/Renewal/Content fieldsets, remove-line confirm, failed-PATCH rollback + in-flight disable, Pax8 drawer on shared `Dialog` (focus trap)
- Quote lifecycle strip (Sent/Viewed/Accepted/Declined timestamps) + "View invoice →" link on converted quotes

**Phase 3 — polish**
- SR-announcement debounce on live totals; DRAFT chip dedupe; toast clears the editor rail; 403 → AccessDenied everywhere; customer documents never show UUID fragments; per-currency summary totals (`sumByCurrency`); branded invoice document (mirrors the quotes branding path — one additive API change on `GET /invoices/:id`); shared `StatCard`; editor grid width fixes

## Notes for reviewers
- Renamed testids (no e2e references existed): `contracts-loading` → `table-skeleton`, `quotes-no-match`/`invoices-no-match` → `*-filtered-empty`, `save-contract-btn` removed in edit mode (autosave), `line-remove-<idx>` now opens `contract-line-remove-confirm`.
- The one API change (`GET /invoices/:id` + `branding`) is additive and mirrors `GET /quotes/:id` line-for-line; tenancy path verified (`requireOrgAccess` before branding resolution).

## Testing
- Web: 350 tests green across billing + contracts + `no-silent-mutations` guard (51+ files), `tsc --noEmit` clean
- API: `invoices.test.ts` 28 green, `tsc` clean
- Every task went through implementer → independent spec+quality review → fix rounds where needed (5 fix rounds total), plus a final whole-branch review and live Playwright verification on a seeded worktree stack

Follow-up issue with triaged minor findings to be filed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)