### PR TITLE
Reports: PDF email attachments, exec-summary cover, trend deltas, next-run visibility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,6 +61,8 @@
     "hono": "^4.12.27",
     "ioredis": "^5.10.1",
     "jose": "^6.2.3",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "nanoid": "^5.1.15",
     "node-stream-zip": "^1.15.0",
     "nodemailer": "^9.0.1",

--- a/apps/api/src/jobs/reportScheduleWorker.test.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.test.ts
@@ -58,6 +58,22 @@ vi.mock('../services/reportBranding', () => ({
   loadReportBrandingForOrg: (...args: unknown[]) => loadReportBrandingForOrgMock(...(args as [])),
 }));
 
+// Passthrough mock of the shared PDF renderer with a failure switch: by default
+// it delegates to the REAL buildReportPdf (so the %PDF magic-byte test stays a
+// genuine end-to-end Node render proof); flipping `shouldThrow` simulates a
+// render bug to verify delivery degrades to a link-only email instead of failing.
+const pdfRender = vi.hoisted(() => ({ shouldThrow: false }));
+vi.mock('@breeze/shared/reportPdf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@breeze/shared/reportPdf')>();
+  return {
+    ...actual,
+    buildReportPdf: (...args: Parameters<typeof actual.buildReportPdf>) => {
+      if (pdfRender.shouldThrow) throw new Error('render exploded');
+      return actual.buildReportPdf(...args);
+    },
+  };
+});
+
 vi.mock('../services/redis', () => ({
   isRedisAvailable: vi.fn(() => false),
   getBullMQConnection: vi.fn(() => ({})),
@@ -107,6 +123,7 @@ function updateChain() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  pdfRender.shouldThrow = false;
 });
 
 // ─── Occurrence math (pure) ──────────────────────────────────────────────────
@@ -336,6 +353,42 @@ describe('processRunScheduledReport', () => {
     expect(attachment.contentType).toBe('application/pdf');
     expect(Buffer.isBuffer(attachment.content)).toBe(true);
     expect(attachment.content.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('falls back to a link-only email (run still completed) when the PDF render throws', async () => {
+    pdfRender.shouldThrow = true;
+    selectMock.mockReturnValueOnce(
+      selectChain([{ ...report, format: 'pdf', config: { emailRecipients: ['a@b.co'] } }]),
+    );
+    selectMock.mockReturnValueOnce(
+      selectChain([{ orgSettings: {}, partnerTimezone: 'UTC', partnerSettings: {} }]), // org/partner timezone lookup
+    );
+    insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
+    const updates = [updateChain(), updateChain()];
+    updateMock.mockReturnValueOnce(updates[0]).mockReturnValueOnce(updates[1]);
+    generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: 'PC-1' }], rowCount: 1 });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
+      // Prove the render actually failed (vs. silently succeeding): the catch
+      // block logs the fallback before sending the link-only email.
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('PDF render failed; sending link-only email'),
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    // A render failure must not block delivery: the email still goes out,
+    // link-only, and the run row is still marked completed.
+    expect(updates[1]!.set).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const mail = sendEmailMock.mock.calls[0]![0] as { attachments: unknown[]; html: string; text: string };
+    expect(mail.attachments).toHaveLength(0);
+    expect(mail.html).toContain('Open Breeze to view and download the formatted report.');
+    expect(mail.text).toContain('Open Breeze to view and download the formatted report.');
   });
 
   it('does not query branding when there are no valid recipients', async () => {

--- a/apps/api/src/jobs/reportScheduleWorker.test.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.test.ts
@@ -310,7 +310,8 @@ describe('processRunScheduledReport', () => {
 
   it('marks the run failed (and still stamps lastGeneratedAt) when generation throws', async () => {
     selectMock.mockReturnValueOnce(selectChain([report]));
-    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
+    // No org/partner timezone select here: generateReport throws before the
+    // recipients branch (where the tz lookup now lives) is ever reached.
     insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
     const updates = [updateChain(), updateChain()];
     updateMock.mockReturnValueOnce(updates[0]).mockReturnValueOnce(updates[1]);
@@ -438,7 +439,9 @@ describe('processRunScheduledReport', () => {
     selectMock.mockReturnValueOnce(
       selectChain([{ ...report, format: 'pdf', config: { emailRecipients: ['not-an-email'] } }]),
     );
-    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
+    // No org/partner timezone select here either: with zero valid recipients
+    // the recipients branch (where both the tz lookup and branding load now
+    // live) never runs.
     insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
     updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
     generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: 'pc-1' }], rowCount: 1 });
@@ -447,5 +450,64 @@ describe('processRunScheduledReport', () => {
 
     expect(loadReportBrandingForOrgMock).not.toHaveBeenCalled();
     expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('still emails (unbranded) when the branding load throws', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([{ ...report, format: 'csv', config: { emailRecipients: ['a@b.co'] } }]),
+    );
+    selectMock.mockReturnValueOnce(
+      selectChain([{ orgSettings: {}, partnerTimezone: 'UTC', partnerSettings: {} }]), // org/partner timezone lookup
+    );
+    insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
+    updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
+    generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: 'PC-1' }], rowCount: 1 });
+    loadReportBrandingForOrgMock.mockRejectedValueOnce(new Error('branding query failed'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Branding load failed; sending unbranded'),
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    // A branding lookup failure must not drop the whole email — it still
+    // goes out (unbranded), same as a PDF render failure degrading to link-only.
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const mail = sendEmailMock.mock.calls[0]![0] as { attachments: Array<{ filename: string }> };
+    expect(mail.attachments).toHaveLength(1);
+    expect(mail.attachments[0]!.filename).toMatch(/device_inventory-report-.*\.csv/);
+  });
+
+  it('warns when an attachment exceeds 5MB and sends link-only', async () => {
+    const bigHostname = 'x'.repeat(6 * 1024 * 1024);
+    selectMock.mockReturnValueOnce(
+      selectChain([{ ...report, format: 'csv', config: { emailRecipients: ['a@b.co'] } }]),
+    );
+    selectMock.mockReturnValueOnce(
+      selectChain([{ orgSettings: {}, partnerTimezone: 'UTC', partnerSettings: {} }]), // org/partner timezone lookup
+    );
+    insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
+    updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
+    generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: bigHostname }], rowCount: 1 });
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('Attachment exceeds 5MB; sending link-only'),
+        expect.objectContaining({ reportName: report.name, bytes: expect.any(Number) }),
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const mail = sendEmailMock.mock.calls[0]![0] as { attachments: unknown[] };
+    expect(mail.attachments).toHaveLength(0);
   });
 });

--- a/apps/api/src/jobs/reportScheduleWorker.test.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.test.ts
@@ -39,9 +39,13 @@ vi.mock('../db/schema', () => ({
   },
 }));
 
+type PreviousBaseline = { generatedAt: string | null; summary?: Record<string, unknown> } | undefined;
+
 const generateReportMock = vi.fn();
+const previousBaselineForMock = vi.fn<() => Promise<PreviousBaseline>>(async () => undefined);
 vi.mock('../services/reportGenerationService', () => ({
   generateReport: (...args: unknown[]) => generateReportMock(...(args as [])),
+  previousBaselineFor: (...args: unknown[]) => previousBaselineForMock(...(args as [])),
 }));
 
 const sendEmailMock = vi.fn();
@@ -124,6 +128,7 @@ function updateChain() {
 beforeEach(() => {
   vi.clearAllMocks();
   pdfRender.shouldThrow = false;
+  previousBaselineForMock.mockResolvedValue(undefined);
 });
 
 // ─── Occurrence math (pure) ──────────────────────────────────────────────────
@@ -328,6 +333,44 @@ describe('processRunScheduledReport', () => {
 
     expect(insertMock).not.toHaveBeenCalled();
     expect(generateReportMock).not.toHaveBeenCalled();
+  });
+
+  it('includes a trend line in the email when a previous baseline exists', async () => {
+    const postureReport = {
+      ...report,
+      type: 'security_compliance_posture',
+      config: { emailRecipients: ['ops@example.com'] },
+    };
+    selectMock.mockReturnValueOnce(selectChain([postureReport]));
+    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
+    insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
+    const updates = [updateChain(), updateChain()];
+    updateMock.mockReturnValueOnce(updates[0]).mockReturnValueOnce(updates[1]);
+    generateReportMock.mockResolvedValueOnce({
+      rows: [{ hostname: 'PC-1' }],
+      rowCount: 1,
+      summary: { postureScore: 79 },
+    });
+    previousBaselineForMock.mockResolvedValueOnce({
+      generatedAt: '2026-06-01T09:00:00Z',
+      summary: { postureScore: 74 },
+    });
+
+    await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
+
+    expect(previousBaselineForMock).toHaveBeenCalledWith(REPORT_ID);
+    // The stored snapshot carries the baseline forward so the download path
+    // (and any future re-render) reflects the same trend as this email.
+    expect(updates[1]!.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({
+          previous: { generatedAt: '2026-06-01T09:00:00Z', summary: { postureScore: 74 } },
+        }),
+      }),
+    );
+    const mail = sendEmailMock.mock.calls[0]![0] as { html: string; text: string };
+    expect(mail.html).toContain('up from 74');
+    expect(mail.text).toContain('up from 74');
   });
 
   it('attaches a real branded PDF for pdf-format reports (end-to-end Node render, not mocked)', async () => {

--- a/apps/api/src/jobs/reportScheduleWorker.test.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.test.ts
@@ -49,6 +49,15 @@ vi.mock('../services/email', () => ({
   getEmailService: vi.fn(() => ({ sendEmail: sendEmailMock })),
 }));
 
+const loadReportBrandingForOrgMock = vi.fn(async () => ({
+  name: 'Olive MSP',
+  logoDataUrl: null,
+  logoAspect: null,
+}));
+vi.mock('../services/reportBranding', () => ({
+  loadReportBrandingForOrg: (...args: unknown[]) => loadReportBrandingForOrgMock(...(args as [])),
+}));
+
 vi.mock('../services/redis', () => ({
   isRedisAvailable: vi.fn(() => false),
   getBullMQConnection: vi.fn(() => ({})),
@@ -250,6 +259,7 @@ describe('processRunScheduledReport', () => {
 
   it('stores a completed run, stamps lastGeneratedAt, and emails valid recipients with a CSV', async () => {
     selectMock.mockReturnValueOnce(selectChain([report]));
+    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
     const runInsert = insertChain([{ id: RUN_ID }]);
     insertMock.mockReturnValueOnce(runInsert);
     const updates = [updateChain(), updateChain()];
@@ -278,6 +288,7 @@ describe('processRunScheduledReport', () => {
 
   it('marks the run failed (and still stamps lastGeneratedAt) when generation throws', async () => {
     selectMock.mockReturnValueOnce(selectChain([report]));
+    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
     insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
     const updates = [updateChain(), updateChain()];
     updateMock.mockReturnValueOnce(updates[0]).mockReturnValueOnce(updates[1]);
@@ -302,15 +313,43 @@ describe('processRunScheduledReport', () => {
     expect(generateReportMock).not.toHaveBeenCalled();
   });
 
-  it('does not attach a CSV for pdf-format reports (link-only email)', async () => {
-    selectMock.mockReturnValueOnce(selectChain([{ ...report, format: 'pdf' }]));
+  it('attaches a real branded PDF for pdf-format reports (end-to-end Node render, not mocked)', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([{ ...report, format: 'pdf', config: { emailRecipients: ['a@b.co'] } }]),
+    );
+    selectMock.mockReturnValueOnce(
+      selectChain([{ orgSettings: {}, partnerTimezone: 'UTC', partnerSettings: {} }]), // org/partner timezone lookup
+    );
+    insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
+    updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
+    generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: 'PC-1' }], rowCount: 1 });
+
+    await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
+
+    expect(loadReportBrandingForOrgMock).toHaveBeenCalledWith(ORG_ID);
+    const mail = sendEmailMock.mock.calls[0]![0] as {
+      attachments: Array<{ filename: string; content: Buffer; contentType?: string }>;
+    };
+    expect(mail.attachments).toHaveLength(1);
+    const attachment = mail.attachments[0]!;
+    expect(attachment.filename).toMatch(/device_inventory-report-.*\.pdf$/);
+    expect(attachment.contentType).toBe('application/pdf');
+    expect(Buffer.isBuffer(attachment.content)).toBe(true);
+    expect(attachment.content.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('does not query branding when there are no valid recipients', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([{ ...report, format: 'pdf', config: { emailRecipients: ['not-an-email'] } }]),
+    );
+    selectMock.mockReturnValueOnce(selectChain([])); // org/partner timezone lookup
     insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));
     updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
     generateReportMock.mockResolvedValueOnce({ rows: [{ hostname: 'pc-1' }], rowCount: 1 });
 
     await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
 
-    const mail = sendEmailMock.mock.calls[0]![0] as { attachments: unknown[] };
-    expect(mail.attachments).toHaveLength(0);
+    expect(loadReportBrandingForOrgMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -28,10 +28,24 @@ import { generateReport, previousBaselineFor, type ReportResult } from '../servi
 import { getEmailService } from '../services/email';
 import { renderLayout, renderButton, renderParagraph, escapeHtml } from '../services/emailLayout';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
-import { resolveEffectiveTimezone, canonicalizeTimezone, rowsToCsv } from '@breeze/shared';
+import {
+  resolveEffectiveTimezone,
+  canonicalizeTimezone,
+  rowsToCsv,
+  lastOccurrenceKey,
+  isDue,
+  type ScheduleCadence,
+  type ScheduleConfig,
+} from '@breeze/shared';
 import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';
 import { loadReportBrandingForOrg } from '../services/reportBranding';
 import { attachWorkerObservability } from './workerObservability';
+
+// Re-exported so the occurrence-math tests colocated with this worker keep
+// importing from here; the implementation lives in @breeze/shared so the web
+// can compute "next run" from the same math.
+export { lastOccurrenceKey, isDue, wallClockIn } from '@breeze/shared';
+export type { ScheduleCadence, ScheduleConfig } from '@breeze/shared';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -59,130 +73,6 @@ type ReportScheduleJobData = CheckSchedulesJobData | RunScheduledReportJobData;
 
 let reportScheduleQueue: Queue<ReportScheduleJobData> | null = null;
 let reportScheduleWorker: Worker<ReportScheduleJobData> | null = null;
-
-// ─── Occurrence math ─────────────────────────────────────────────────────────
-// All comparisons happen in wall-clock space for the report's timezone, encoded
-// as a sortable number (YYYYMMDDHHmm). This avoids DST/offset conversions: a
-// "daily at 09:00" report is due once the org's local clock passes 09:00,
-// whatever UTC instant that is.
-
-export type ScheduleCadence = 'daily' | 'weekly' | 'monthly';
-
-export type ScheduleConfig = {
-  /** 24h "HH:MM"; defaults to 09:00 (the builder's default). */
-  time?: string;
-  /** Weekly: lowercase weekday name; defaults to monday. */
-  day?: string;
-  /** Monthly: day-of-month "1".."31" (clamped to month length); defaults to 1. */
-  date?: string;
-};
-
-const DAY_INDEX: Record<string, number> = {
-  sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6,
-};
-
-const WEEKDAY_SHORT_INDEX: Record<string, number> = {
-  Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
-};
-
-type WallClock = { y: number; m: number; d: number; hh: number; mm: number; weekday: number };
-
-/** Decompose a UTC instant into wall-clock parts for a timezone. */
-export function wallClockIn(instant: Date, timeZone: string): WallClock {
-  let parts: Intl.DateTimeFormatPart[];
-  try {
-    parts = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
-      weekday: 'short',
-    }).formatToParts(instant);
-  } catch {
-    // Bad/unknown zone string in stored settings — fall back to UTC.
-    return wallClockIn(instant, 'UTC');
-  }
-  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
-  return {
-    y: Number(get('year')),
-    m: Number(get('month')),
-    d: Number(get('day')),
-    hh: Number(get('hour')),
-    mm: Number(get('minute')),
-    weekday: WEEKDAY_SHORT_INDEX[get('weekday')] ?? 0,
-  };
-}
-
-const keyOf = (y: number, m: number, d: number, hh: number, mm: number): number =>
-  ((y * 100 + m) * 100 + d) * 10000 + hh * 100 + mm;
-
-/** Pure calendar arithmetic (timezone-free): shift a Y/M/D by whole days. */
-function shiftDays(y: number, m: number, d: number, days: number): { y: number; m: number; d: number } {
-  const t = new Date(Date.UTC(y, m - 1, d + days));
-  return { y: t.getUTCFullYear(), m: t.getUTCMonth() + 1, d: t.getUTCDate() };
-}
-
-const daysInMonth = (y: number, m: number): number => new Date(Date.UTC(y, m, 0)).getUTCDate();
-
-function parseTime(time: string | undefined): { hh: number; mm: number } {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(time ?? '');
-  const hh = match ? Number(match[1]) : 9;
-  const mm = match ? Number(match[2]) : 0;
-  if (!match || hh > 23 || mm > 59) return { hh: 9, mm: 0 };
-  return { hh, mm };
-}
-
-/**
- * The most recent scheduled occurrence at or before `now`, as a wall-clock key
- * in `timeZone`. A report is due when its lastGeneratedAt (in the same
- * wall-clock space) predates this key.
- */
-export function lastOccurrenceKey(
-  now: Date,
-  cadence: ScheduleCadence,
-  cfg: ScheduleConfig,
-  timeZone: string,
-): number {
-  const nowWc = wallClockIn(now, timeZone);
-  const nowKey = keyOf(nowWc.y, nowWc.m, nowWc.d, nowWc.hh, nowWc.mm);
-  const { hh, mm } = parseTime(cfg.time);
-
-  if (cadence === 'daily') {
-    let day = { y: nowWc.y, m: nowWc.m, d: nowWc.d };
-    if (keyOf(day.y, day.m, day.d, hh, mm) > nowKey) day = shiftDays(day.y, day.m, day.d, -1);
-    return keyOf(day.y, day.m, day.d, hh, mm);
-  }
-
-  if (cadence === 'weekly') {
-    const target = DAY_INDEX[(cfg.day ?? 'monday').toLowerCase()] ?? 1;
-    const delta = (nowWc.weekday - target + 7) % 7;
-    let day = shiftDays(nowWc.y, nowWc.m, nowWc.d, -delta);
-    if (keyOf(day.y, day.m, day.d, hh, mm) > nowKey) day = shiftDays(day.y, day.m, day.d, -7);
-    return keyOf(day.y, day.m, day.d, hh, mm);
-  }
-
-  // monthly
-  const wanted = Math.max(1, Math.min(31, Number(cfg.date) || 1));
-  let y = nowWc.y;
-  let m = nowWc.m;
-  let d = Math.min(wanted, daysInMonth(y, m));
-  if (keyOf(y, m, d, hh, mm) > nowKey) {
-    m -= 1;
-    if (m === 0) { m = 12; y -= 1; }
-    d = Math.min(wanted, daysInMonth(y, m));
-  }
-  return keyOf(y, m, d, hh, mm);
-}
-
-/** Due when the report has never run, or last ran before the latest occurrence. */
-export function isDue(
-  lastGeneratedAt: Date | null,
-  occurrenceKey: number,
-  timeZone: string,
-): boolean {
-  if (!lastGeneratedAt) return true;
-  const wc = wallClockIn(lastGeneratedAt, timeZone);
-  return keyOf(wc.y, wc.m, wc.d, wc.hh, wc.mm) < occurrenceKey;
-}
 
 // ─── Due-report discovery ────────────────────────────────────────────────────
 

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -38,6 +38,7 @@ import {
   type ScheduleConfig,
 } from '@breeze/shared';
 import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';
+import type { PostureSummary, ExecutiveSummary } from '@breeze/shared';
 import { loadReportBrandingForOrg } from '../services/reportBranding';
 import { attachWorkerObservability } from './workerObservability';
 
@@ -220,13 +221,18 @@ async function emailReportRun(opts: {
         reportType: opts.reportType,
         generatedAt,
         timezone: opts.timezone,
-        summary: opts.summary as never,
+        summary: opts.summary as PostureSummary | ExecutiveSummary | undefined,
         previous: opts.previous,
         branding: opts.branding,
       });
       const content = Buffer.from(doc.output('arraybuffer'));
       if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
         attachments.push({ filename: `${opts.reportType}-report-${dateStr}.pdf`, content, contentType: 'application/pdf' });
+      } else {
+        console.warn('[ReportScheduleWorker] Attachment exceeds 5MB; sending link-only', {
+          reportName: opts.reportName,
+          bytes: content.byteLength,
+        });
       }
     } catch (err) {
       // A render failure must not block delivery — fall back to the link-only email.
@@ -237,6 +243,11 @@ async function emailReportRun(opts: {
     const content = Buffer.from(csv, 'utf8');
     if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
       attachments.push({ filename: `${opts.reportType}-report-${dateStr}.csv`, content, contentType: 'text/csv' });
+    } else {
+      console.warn('[ReportScheduleWorker] Attachment exceeds 5MB; sending link-only', {
+        reportName: opts.reportName,
+        bytes: content.byteLength,
+      });
     }
   }
 
@@ -282,14 +293,6 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
 
   const config = (report.config ?? {}) as Record<string, unknown>;
 
-  const [tzRow] = await db
-    .select({ orgSettings: organizations.settings, partnerTimezone: partners.timezone, partnerSettings: partners.settings })
-    .from(organizations)
-    .leftJoin(partners, eq(organizations.partnerId, partners.id))
-    .where(eq(organizations.id, report.orgId))
-    .limit(1);
-  const timeZone = timezoneFor(tzRow?.orgSettings ?? null, tzRow?.partnerTimezone ?? null, tzRow?.partnerSettings ?? null);
-
   const [run] = await db
     .insert(reportRuns)
     .values({ reportId: report.id, status: 'running', startedAt: new Date() })
@@ -325,6 +328,23 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
     const recipients = recipientsOf(config);
     if (recipients.length > 0) {
       try {
+        // Timezone + branding are only needed to build the email — deferred
+        // here (rather than fetched unconditionally for every run) so a
+        // transient failure in either lookup can't sink a no-recipient run's
+        // occurrence-keyed job (a failed job blocks re-enqueue of that
+        // occurrence, and by this point the run row is already stored).
+        const [tzRow] = await db
+          .select({ orgSettings: organizations.settings, partnerTimezone: partners.timezone, partnerSettings: partners.settings })
+          .from(organizations)
+          .leftJoin(partners, eq(organizations.partnerId, partners.id))
+          .where(eq(organizations.id, report.orgId))
+          .limit(1);
+        const timeZone = timezoneFor(tzRow?.orgSettings ?? null, tzRow?.partnerTimezone ?? null, tzRow?.partnerSettings ?? null);
+        const branding = await loadReportBrandingForOrg(report.orgId).catch((err) => {
+          console.error('[ReportScheduleWorker] Branding load failed; sending unbranded:', err);
+          return { name: null, logoDataUrl: null, logoAspect: null };
+        });
+
         await emailReportRun({
           reportName: report.name,
           reportType: report.type,
@@ -335,7 +355,7 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
           previous: result.previous,
           trendLine: trendLineOf(result),
           timezone: timeZone,
-          branding: await loadReportBrandingForOrg(report.orgId),
+          branding,
         });
       } catch (err) {
         // Delivery failure must not fail the (already stored) run.

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -12,9 +12,10 @@
  *   when `lastGeneratedAt` predates that occurrence.
  * - `run-scheduled-report` mirrors the on-demand POST /reports/:id/generate
  *   path: insert a report_runs row, generateReport, store the snapshot. When
- *   `config.emailRecipients` is set, recipients get an email with a CSV
- *   attachment (tabular formats) or a link into the app (PDF renders
- *   client-side).
+ *   `config.emailRecipients` is set, recipients get an email with the branded
+ *   PDF attached for PDF-format reports (rendered server-side via
+ *   @breeze/shared/reportPdf) or a CSV attachment for tabular formats — either
+ *   way, plus an in-app link.
  * - Without Redis the check falls back to inline processing, matching the
  *   other queue workers.
  */

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -29,6 +29,8 @@ import { getEmailService } from '../services/email';
 import { renderLayout, renderButton, renderParagraph, escapeHtml } from '../services/emailLayout';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
 import { resolveEffectiveTimezone, canonicalizeTimezone, rowsToCsv } from '@breeze/shared';
+import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';
+import { loadReportBrandingForOrg } from '../services/reportBranding';
 import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
@@ -276,6 +278,9 @@ async function emailReportRun(opts: {
   format: string;
   recipients: string[];
   rows: unknown[];
+  summary?: Record<string, unknown>;
+  timezone: string;
+  branding: ReportBranding;
 }): Promise<void> {
   const email = getEmailService();
   if (!email) {
@@ -284,18 +289,36 @@ async function emailReportRun(opts: {
   }
   const base = (process.env.DASHBOARD_URL || process.env.PUBLIC_APP_URL || 'http://localhost:4321').replace(/\/$/, '');
   const link = `${base}/reports`;
+  const dateStr = new Date().toISOString().split('T')[0];
 
   const attachments = [] as Array<{ filename: string; content: Buffer; contentType?: string }>;
-  if (opts.rows.length > 0 && opts.format !== 'pdf') {
+  if (opts.format === 'pdf') {
+    // The branded PDF is the deliverable an MSP wants landing in the client's
+    // inbox — render it here exactly as the web does (same shared renderer).
+    try {
+      const generatedAt = new Intl.DateTimeFormat('en-US', {
+        timeZone: opts.timezone, dateStyle: 'medium', timeStyle: 'short',
+      }).format(new Date());
+      const doc = buildReportPdf(opts.rows, {
+        reportType: opts.reportType,
+        generatedAt,
+        timezone: opts.timezone,
+        summary: opts.summary as never,
+        branding: opts.branding,
+      });
+      const content = Buffer.from(doc.output('arraybuffer'));
+      if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
+        attachments.push({ filename: `${opts.reportType}-report-${dateStr}.pdf`, content, contentType: 'application/pdf' });
+      }
+    } catch (err) {
+      // A render failure must not block delivery — fall back to the link-only email.
+      console.error('[ReportScheduleWorker] PDF render failed; sending link-only email:', err);
+    }
+  } else if (opts.rows.length > 0) {
     const csv = rowsToCsv(opts.rows);
     const content = Buffer.from(csv, 'utf8');
     if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
-      const dateStr = new Date().toISOString().split('T')[0];
-      attachments.push({
-        filename: `${opts.reportType}-report-${dateStr}.csv`,
-        content,
-        contentType: 'text/csv',
-      });
+      attachments.push({ filename: `${opts.reportType}-report-${dateStr}.csv`, content, contentType: 'text/csv' });
     }
   }
 
@@ -304,9 +327,11 @@ async function emailReportRun(opts: {
       ? `Your scheduled report "${opts.reportName}" has been generated with ${opts.rows.length} record${opts.rows.length === 1 ? '' : 's'}.`
       : `Your scheduled report "${opts.reportName}" has been generated.`;
   const attachmentNote =
-    attachments.length > 0
-      ? 'The data is attached as CSV; open Breeze for the fully formatted report.'
-      : 'Open Breeze to view and download the formatted report.';
+    attachments.length === 0
+      ? 'Open Breeze to view and download the formatted report.'
+      : attachments[0]!.contentType === 'application/pdf'
+        ? 'The formatted report is attached as a PDF.'
+        : 'The data is attached as CSV; open Breeze for the fully formatted report.';
 
   await email.sendEmail({
     to: opts.recipients,
@@ -335,6 +360,14 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
   if (!report) return; // deleted or switched to one_time since enqueue
 
   const config = (report.config ?? {}) as Record<string, unknown>;
+
+  const [tzRow] = await db
+    .select({ orgSettings: organizations.settings, partnerTimezone: partners.timezone, partnerSettings: partners.settings })
+    .from(organizations)
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
+    .where(eq(organizations.id, report.orgId))
+    .limit(1);
+  const timeZone = timezoneFor(tzRow?.orgSettings ?? null, tzRow?.partnerTimezone ?? null, tzRow?.partnerSettings ?? null);
 
   const [run] = await db
     .insert(reportRuns)
@@ -375,6 +408,9 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
           format: report.format,
           recipients,
           rows,
+          summary: result.summary,
+          timezone: timeZone,
+          branding: await loadReportBrandingForOrg(report.orgId),
         });
       } catch (err) {
         // Delivery failure must not fail the (already stored) run.

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -24,7 +24,7 @@ import { Job, Queue, Worker } from 'bullmq';
 
 import * as dbModule from '../db';
 import { reports, reportRuns, organizations, partners } from '../db/schema';
-import { generateReport } from '../services/reportGenerationService';
+import { generateReport, previousBaselineFor, type ReportResult } from '../services/reportGenerationService';
 import { getEmailService } from '../services/email';
 import { renderLayout, renderButton, renderParagraph, escapeHtml } from '../services/emailLayout';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
@@ -272,6 +272,31 @@ function recipientsOf(config: Record<string, unknown>): string[] {
     .filter((r) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(r));
 }
 
+/** One-line trend summary for the email body — "Posture score 79 — up from
+ * 74 last run." — built from the same `result.summary`/`result.previous`
+ * snapshot the PDF scorecard reads, so the two never disagree. */
+function trendLineOf(result: ReportResult): string | null {
+  const s = result.summary as Record<string, unknown> | undefined;
+  const prev = result.previous?.summary as Record<string, unknown> | undefined;
+  const score = typeof s?.postureScore === 'number' ? (s.postureScore as number) : null;
+  if (score != null) {
+    const prevScore = typeof prev?.postureScore === 'number' ? (prev.postureScore as number) : null;
+    if (prevScore != null && prevScore !== score) {
+      return `Posture score ${score} — ${score > prevScore ? 'up' : 'down'} from ${prevScore} last run.`;
+    }
+    return `Posture score ${score}.`;
+  }
+  const health = (s?.devices as { healthPercentage?: unknown } | undefined)?.healthPercentage;
+  if (typeof health === 'number') {
+    const prevHealth = (prev?.devices as { healthPercentage?: unknown } | undefined)?.healthPercentage;
+    if (typeof prevHealth === 'number' && prevHealth !== health) {
+      return `Fleet health ${health}% — ${health > prevHealth ? 'up' : 'down'} from ${prevHealth}% last run.`;
+    }
+    return `Fleet health ${health}%.`;
+  }
+  return null;
+}
+
 async function emailReportRun(opts: {
   reportName: string;
   reportType: string;
@@ -279,6 +304,8 @@ async function emailReportRun(opts: {
   recipients: string[];
   rows: unknown[];
   summary?: Record<string, unknown>;
+  previous?: ReportResult['previous'];
+  trendLine?: string | null;
   timezone: string;
   branding: ReportBranding;
 }): Promise<void> {
@@ -304,6 +331,7 @@ async function emailReportRun(opts: {
         generatedAt,
         timezone: opts.timezone,
         summary: opts.summary as never,
+        previous: opts.previous,
         branding: opts.branding,
       });
       const content = Buffer.from(doc.output('arraybuffer'));
@@ -333,20 +361,23 @@ async function emailReportRun(opts: {
         ? 'The formatted report is attached as a PDF.'
         : 'The data is attached as CSV; open Breeze for the fully formatted report.';
 
+  const trendLine = opts.trendLine;
+
   await email.sendEmail({
     to: opts.recipients,
     subject: `Scheduled report ready: ${opts.reportName}`,
     html: renderLayout({
       title: 'Scheduled report',
-      preheader: bodyText,
+      preheader: trendLine ?? bodyText,
       heading: 'Scheduled report ready',
       body: [
         renderParagraph(escapeHtml(bodyText)),
+        ...(trendLine ? [renderParagraph(escapeHtml(trendLine))] : []),
         renderParagraph(escapeHtml(attachmentNote), { muted: true }),
         renderButton('View in Breeze', link),
       ].join(''),
     }),
-    text: `${bodyText}\n${attachmentNote}\n${link}`,
+    text: `${bodyText}${trendLine ? `\n${trendLine}` : ''}\n${attachmentNote}\n${link}`,
     attachments,
   });
 }
@@ -386,6 +417,8 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
     // System context: scheduled runs execute with full org scope (no user
     // site-permission filter — parity with a report owner generating it).
     const result = await generateReport(report.type, report.orgId, config, undefined);
+    const previous = await previousBaselineFor(report.id);
+    if (previous) result.previous = previous;
     const rows = Array.isArray(result.rows) ? result.rows : [];
     const rowCount = result.rowCount ?? rows.length;
     await db
@@ -409,6 +442,8 @@ export async function processRunScheduledReport(data: RunScheduledReportJobData)
           recipients,
           rows,
           summary: result.summary,
+          previous: result.previous,
+          trendLine: trendLineOf(result),
           timezone: timeZone,
           branding: await loadReportBrandingForOrg(report.orgId),
         });

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -700,6 +700,57 @@ describe('reports routes', () => {
     expect(body.status).toBe('completed');
   });
 
+  it('stores the previous baseline on the run when previousBaselineFor finds a prior completed run', async () => {
+    const setArgs: any[] = [];
+    vi.mocked(db.update).mockReturnValue({
+      set: (v: any) => { setArgs.push(v); return { where: () => Promise.resolve() }; }
+    } as any);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{
+        id: 'report-1',
+        orgId: ORG_ID,
+        name: 'Device Inventory',
+        type: 'device_inventory',
+        config: {},
+        schedule: 'daily',
+        format: 'csv'
+      }]))
+      .mockReturnValueOnce(selectChain([])) // generator query (device_inventory rows)
+      .mockReturnValueOnce(selectChain([{
+        summary: { postureScore: 74 },
+        generatedAt: '2026-06-01T09:00:00.000Z',
+        completedAt: new Date('2026-06-01T09:00:00Z')
+      }])); // previousBaselineFor: prior completed run
+
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'run-1',
+          reportId: 'report-1',
+          status: 'pending'
+        }])
+      })
+    } as any);
+
+    const res = await app.request('/reports/report-1/generate', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.runId).toBe('run-1');
+    expect(body.status).toBe('completed');
+
+    const completedSet = setArgs.find((a) => a.status === 'completed');
+    expect(completedSet).toBeDefined();
+    expect(completedSet.result.previous).toEqual({
+      generatedAt: '2026-06-01T09:00:00.000Z',
+      summary: { postureScore: 74 }
+    });
+  });
+
   it('should update a report schedule', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -676,7 +676,8 @@ describe('reports routes', () => {
         schedule: 'daily',
         format: 'csv'
       }]))
-      .mockReturnValueOnce(selectChain([]));
+      .mockReturnValueOnce(selectChain([])) // generator query (device_inventory rows)
+      .mockReturnValueOnce(selectChain([])); // previousBaselineFor: no prior completed run
 
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/reports/runs.ts
+++ b/apps/api/src/routes/reports/runs.ts
@@ -6,7 +6,7 @@ import { reports, reportRuns } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
-import { generateReport, siteScopeRequestAllowed, type ReportResult } from '../../services/reportGenerationService';
+import { generateReport, previousBaselineFor, siteScopeRequestAllowed, type ReportResult } from '../../services/reportGenerationService';
 import { rowsToCsv, rowsToTsv } from '@breeze/shared';
 import { getPagination, ensureOrgAccess, getReportWithOrgCheck, getReportRunWithOrgCheck } from './helpers';
 import { downloadQuerySchema, listRunsSchema } from './schemas';
@@ -71,6 +71,8 @@ runsRoutes.post(
 
     try {
       const result = await generateReport(report.type, report.orgId, config, perms);
+      const previous = await previousBaselineFor(report.id);
+      if (previous) result.previous = previous;
       const rowCount = result.rowCount ?? (Array.isArray(result.rows) ? result.rows.length : 0);
       await db
         .update(reportRuns)

--- a/apps/api/src/routes/reports/schemas.config.test.ts
+++ b/apps/api/src/routes/reports/schemas.config.test.ts
@@ -37,9 +37,25 @@ describe('report config schema', () => {
     expect(() =>
       createReportSchema.parse({
         name: 'x', type: 'compliance',
+        config: { emailRecipients: ['a@b'] },
+      })
+    ).toThrow();
+    expect(() =>
+      createReportSchema.parse({
+        name: 'x', type: 'compliance',
         config: { schedule: { time: '25:99' } },
       })
     ).toThrow();
+  });
+
+  // Same loose chip regex as ReportBuilder/recipientsOf — persistence must
+  // never reject what the builder already accepted as a chip.
+  it('accepts a unicode-local-part address, matching the builder chip validator', () => {
+    const parsed = createReportSchema.parse({
+      name: 'x', type: 'compliance',
+      config: { emailRecipients: ['jörg@example.com'] },
+    });
+    expect(parsed.config.emailRecipients).toEqual(['jörg@example.com']);
   });
 
   it('validates config on update too (was z.any())', () => {
@@ -48,5 +64,16 @@ describe('report config schema', () => {
     ).toThrow();
     const ok = updateReportSchema.parse({ config: builderConfig });
     expect(ok.config?.emailRecipients).toHaveLength(2);
+  });
+
+  it('coerces a legacy numeric schedule.date to string on both create and update', () => {
+    const created = createReportSchema.parse({
+      name: 'x', type: 'compliance',
+      config: { schedule: { date: 1 } },
+    });
+    expect(created.config.schedule).toEqual({ date: '1' });
+
+    const updated = updateReportSchema.parse({ config: { schedule: { date: 1 } } });
+    expect(updated.config?.schedule).toEqual({ date: '1' });
   });
 });

--- a/apps/api/src/routes/reports/schemas.config.test.ts
+++ b/apps/api/src/routes/reports/schemas.config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createReportSchema, updateReportSchema } from './schemas';
+
+const builderConfig = {
+  builderType: 'device_inventory',
+  dataSource: 'devices',
+  columns: ['hostname'],
+  filterConditions: [{ field: 'status', operator: 'eq', value: 'online' }],
+  schedule: { time: '09:00', day: 'monday', date: '1' },
+  exportFormats: ['pdf'],
+  emailRecipients: ['client@example.com', 'msp@example.com'],
+};
+
+describe('report config schema', () => {
+  it('preserves schedule detail and emailRecipients on create', () => {
+    const parsed = createReportSchema.parse({
+      name: 'Monthly posture',
+      type: 'security_compliance_posture',
+      schedule: 'monthly',
+      format: 'pdf',
+      config: builderConfig,
+    });
+    expect(parsed.config.schedule).toEqual({ time: '09:00', day: 'monday', date: '1' });
+    expect(parsed.config.emailRecipients).toEqual(['client@example.com', 'msp@example.com']);
+    // Builder metadata must round-trip for the edit page.
+    expect((parsed.config as Record<string, unknown>).builderType).toBe('device_inventory');
+    expect((parsed.config as Record<string, unknown>).exportFormats).toEqual(['pdf']);
+  });
+
+  it('rejects malformed recipients and times', () => {
+    expect(() =>
+      createReportSchema.parse({
+        name: 'x', type: 'compliance',
+        config: { emailRecipients: ['not-an-email'] },
+      })
+    ).toThrow();
+    expect(() =>
+      createReportSchema.parse({
+        name: 'x', type: 'compliance',
+        config: { schedule: { time: '25:99' } },
+      })
+    ).toThrow();
+  });
+
+  it('validates config on update too (was z.any())', () => {
+    expect(() =>
+      updateReportSchema.parse({ config: { emailRecipients: ['nope'] } })
+    ).toThrow();
+    const ok = updateReportSchema.parse({ config: builderConfig });
+    expect(ok.config?.emailRecipients).toHaveLength(2);
+  });
+});

--- a/apps/api/src/routes/reports/schemas.ts
+++ b/apps/api/src/routes/reports/schemas.ts
@@ -36,6 +36,49 @@ const securityCompliancePostureConfigFields = {
   includeCis: z.boolean().optional()
 };
 
+/**
+ * Cadence detail + delivery config persisted inside `config`. The builder
+ * writes these and reportScheduleWorker reads them; they must be declared here
+ * because zod strips unknown object keys — before this schema existed, creates
+ * silently dropped schedule times and email recipients (edits survived only
+ * because update used z.any()).
+ */
+const reportScheduleDetailSchema = z.object({
+  // 24h "HH:MM"
+  time: z.string().regex(/^([01]?\d|2[0-3]):[0-5]\d$/).optional(),
+  // weekday name; the worker lowercases, so accept any case
+  day: z.string().max(16).optional(),
+  // day-of-month "1".."31" as string (builder sends strings)
+  date: z.string().regex(/^([1-9]|[12]\d|3[01])$/).optional()
+});
+
+const reportConfigFields = {
+  dateRange: z.object({
+    start: z.string().optional(),
+    end: z.string().optional(),
+    preset: z.enum(['last_7_days', 'last_30_days', 'last_90_days', 'custom']).optional()
+  }).optional(),
+  filters: z.object({
+    siteIds: z.array(z.string().guid()).optional(),
+    deviceIds: z.array(z.string().guid()).optional(),
+    osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
+    status: z.array(z.string()).optional(),
+    severity: z.array(z.string()).optional()
+  }).optional(),
+  columns: z.array(z.string()).optional(),
+  groupBy: z.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+  schedule: reportScheduleDetailSchema.optional(),
+  emailRecipients: z.array(z.string().email().max(254)).max(50).optional(),
+  ...securityCompliancePostureConfigFields
+};
+
+// Loose: the builder round-trips presentation metadata (builderType, dataSource,
+// filterConditions, aggregation, chartType, exportFormats, templateName…)
+// through config; declared keys above are validated, unknown keys pass through.
+export const reportConfigSchema = z.looseObject(reportConfigFields);
+
 export const listReportsSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
@@ -48,32 +91,14 @@ export const createReportSchema = z.object({
   orgId: z.string().guid().optional(),
   name: z.string().min(1).max(255),
   type: reportTypeSchema,
-  config: z.object({
-    dateRange: z.object({
-      start: z.string().optional(),
-      end: z.string().optional(),
-      preset: z.enum(['last_7_days', 'last_30_days', 'last_90_days', 'custom']).optional()
-    }).optional(),
-    filters: z.object({
-      siteIds: z.array(z.string().guid()).optional(),
-      deviceIds: z.array(z.string().guid()).optional(),
-      osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
-      status: z.array(z.string()).optional(),
-      severity: z.array(z.string()).optional()
-    }).optional(),
-    columns: z.array(z.string()).optional(),
-    groupBy: z.string().optional(),
-    sortBy: z.string().optional(),
-    sortOrder: z.enum(['asc', 'desc']).optional(),
-    ...securityCompliancePostureConfigFields
-  }).optional().default({}),
+  config: reportConfigSchema.optional().default({}),
   schedule: z.enum(['one_time', 'daily', 'weekly', 'monthly']).default('one_time'),
   format: z.enum(['csv', 'pdf', 'excel']).default('csv')
 });
 
 export const updateReportSchema = z.object({
   name: z.string().min(1).max(255).optional(),
-  config: z.any().optional(),
+  config: reportConfigSchema.optional(),
   schedule: z.enum(['one_time', 'daily', 'weekly', 'monthly']).optional(),
   format: z.enum(['csv', 'pdf', 'excel']).optional()
 });

--- a/apps/api/src/routes/reports/schemas.ts
+++ b/apps/api/src/routes/reports/schemas.ts
@@ -48,8 +48,10 @@ const reportScheduleDetailSchema = z.object({
   time: z.string().regex(/^([01]?\d|2[0-3]):[0-5]\d$/).optional(),
   // weekday name; the worker lowercases, so accept any case
   day: z.string().max(16).optional(),
-  // day-of-month "1".."31" as string (builder sends strings)
-  date: z.string().regex(/^([1-9]|[12]\d|3[01])$/).optional()
+  // day-of-month "1".."31" as string (builder sends strings). z.coerce
+  // tolerates legacy rows written while update used z.any() — some were
+  // persisted with a numeric `date` — so editing them doesn't 400.
+  date: z.coerce.string().regex(/^([1-9]|[12]\d|3[01])$/).optional()
 });
 
 const reportConfigFields = {
@@ -70,7 +72,12 @@ const reportConfigFields = {
   sortBy: z.string().optional(),
   sortOrder: z.enum(['asc', 'desc']).optional(),
   schedule: reportScheduleDetailSchema.optional(),
-  emailRecipients: z.array(z.string().email().max(254)).max(50).optional(),
+  // Deliberately the SAME loose regex as ReportBuilder's chip-validation
+  // (apps/web/src/components/reports/ReportBuilder.tsx) and the worker's
+  // recipientsOf (apps/api/src/jobs/reportScheduleWorker.ts) — z.string().email()
+  // is stricter than both, so persistence must never reject what the builder
+  // already accepted as a chip.
+  emailRecipients: z.array(z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/).max(254)).max(50).optional(),
   ...securityCompliancePostureConfigFields
 };
 

--- a/apps/api/src/services/reportBranding.test.ts
+++ b/apps/api/src/services/reportBranding.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const selectMock = vi.fn();
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...(args as [])),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partner_id',
+  },
+  partners: {
+    id: 'partners.id',
+    name: 'partners.name',
+    settings: 'partners.settings',
+  },
+}));
+
+import { loadReportBrandingForOrg, pngAspectFromDataUrl } from './reportBranding';
+
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+
+function selectChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(async () => rows);
+  return chain;
+}
+
+/** Build a minimal-but-valid PNG data URL with the given intrinsic dimensions
+ * (8-byte PNG signature + a 13-byte IHDR chunk carrying width/height). */
+function png(w: number, h: number): string {
+  const b = Buffer.alloc(24);
+  b.write('\x89PNG\r\n\x1a\n', 0, 'binary');
+  b.writeUInt32BE(13, 8);
+  b.write('IHDR', 12);
+  b.writeUInt32BE(w, 16);
+  b.writeUInt32BE(h, 20);
+  return 'data:image/png;base64,' + b.toString('base64');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('pngAspectFromDataUrl', () => {
+  it('returns width/height for a valid PNG data URL', () => {
+    expect(pngAspectFromDataUrl(png(1, 2))).toBe(0.5);
+  });
+
+  it('returns null for non-PNG data URLs', () => {
+    expect(pngAspectFromDataUrl('data:image/jpeg;base64,abcd')).toBeNull();
+    expect(pngAspectFromDataUrl('https://example.com/logo.png')).toBeNull();
+  });
+
+  it('returns null for malformed/truncated PNG data', () => {
+    expect(pngAspectFromDataUrl('data:image/png;base64,abcd')).toBeNull();
+  });
+});
+
+describe('loadReportBrandingForOrg', () => {
+  it('uploaded PNG logo: name + logoDataUrl + logoAspect all resolve', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([
+        { partnerName: 'Olive MSP', partnerSettings: { branding: { logoUrl: png(1, 2) } } },
+      ]),
+    );
+    const branding = await loadReportBrandingForOrg(ORG_ID);
+    expect(branding).toEqual({ name: 'Olive MSP', logoDataUrl: png(1, 2), logoAspect: 0.5 });
+  });
+
+  it('external https logo URL: name resolves, logo degrades to null (server cannot format-verify it)', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([
+        { partnerName: 'Olive MSP', partnerSettings: { branding: { logoUrl: 'https://cdn.example.com/logo.png' } } },
+      ]),
+    );
+    const branding = await loadReportBrandingForOrg(ORG_ID);
+    expect(branding).toEqual({ name: 'Olive MSP', logoDataUrl: null, logoAspect: null });
+  });
+
+  it('org has no partner: all-null branding', async () => {
+    selectMock.mockReturnValueOnce(selectChain([{ partnerName: null, partnerSettings: null }]));
+    expect(await loadReportBrandingForOrg(ORG_ID)).toEqual({ name: null, logoDataUrl: null, logoAspect: null });
+  });
+
+  it('org row missing entirely: all-null branding', async () => {
+    selectMock.mockReturnValueOnce(selectChain([]));
+    expect(await loadReportBrandingForOrg(ORG_ID)).toEqual({ name: null, logoDataUrl: null, logoAspect: null });
+  });
+});

--- a/apps/api/src/services/reportBranding.ts
+++ b/apps/api/src/services/reportBranding.ts
@@ -36,6 +36,9 @@ export async function loadReportBrandingForOrg(orgId: string): Promise<ReportBra
   const settings = (row.partnerSettings ?? {}) as { branding?: { logoUrl?: string } };
   const logoUrl = settings.branding?.logoUrl ?? null;
   const aspect = logoUrl ? pngAspectFromDataUrl(logoUrl) : null;
+  if (logoUrl && aspect == null) {
+    console.warn('[reportBranding] Partner logo is not an embeddable PNG data URL; sending name-only branding', { orgId });
+  }
   return {
     name: row.partnerName,
     logoDataUrl: aspect != null ? logoUrl : null,

--- a/apps/api/src/services/reportBranding.ts
+++ b/apps/api/src/services/reportBranding.ts
@@ -1,0 +1,44 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { organizations, partners } from '../db/schema';
+import type { ReportBranding } from '@breeze/shared/reportPdf';
+
+/** Parse intrinsic width/height from a PNG data URL (IHDR is always the first
+ * chunk: width at byte 16, height at byte 20). Returns null for non-PNG data. */
+export function pngAspectFromDataUrl(dataUrl: string): number | null {
+  if (!dataUrl.startsWith('data:image/png;base64,')) return null;
+  try {
+    const buf = Buffer.from(dataUrl.slice(dataUrl.indexOf(',') + 1), 'base64');
+    if (buf.length < 24 || buf.toString('latin1', 12, 16) !== 'IHDR') return null;
+    const w = buf.readUInt32BE(16);
+    const h = buf.readUInt32BE(20);
+    return w > 0 && h > 0 ? w / h : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Partner branding for server-rendered report PDFs. Mirrors the web's
+ * loadPartnerBranding (reportExport.ts) but headless: only uploaded PNG data
+ * URLs are embeddable (no canvas to re-encode external images); anything else
+ * degrades to name-only branding, matching the renderer's fallback chain.
+ */
+export async function loadReportBrandingForOrg(orgId: string): Promise<ReportBranding> {
+  const empty: ReportBranding = { name: null, logoDataUrl: null, logoAspect: null };
+  const [row] = await db
+    .select({ partnerName: partners.name, partnerSettings: partners.settings })
+    .from(organizations)
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!row?.partnerName) return empty;
+  const settings = (row.partnerSettings ?? {}) as { branding?: { logoUrl?: string } };
+  const logoUrl = settings.branding?.logoUrl ?? null;
+  const aspect = logoUrl ? pngAspectFromDataUrl(logoUrl) : null;
+  return {
+    name: row.partnerName,
+    logoDataUrl: aspect != null ? logoUrl : null,
+    logoAspect: aspect,
+  };
+}

--- a/apps/api/src/services/reportGenerationService.execSummary.test.ts
+++ b/apps/api/src/services/reportGenerationService.execSummary.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({ db: { select: vi.fn() } }));
+
+import { db } from '../db';
+import { generateExecutiveSummaryReport } from './reportGenerationService';
+
+/** Thenable that resolves to `rows` and supports any drizzle chain method. */
+function selectChain(rows: unknown[]) {
+  const p: any = Promise.resolve(rows);
+  for (const m of ['from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'groupBy', 'limit']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+const ORG = '00000000-0000-0000-0000-000000000001';
+
+/**
+ * The generator issues selects in this fixed order (with perms undefined, so
+ * resolveSiteAllowedDeviceIds short-circuits without a query):
+ *  1 organizations (org name)   2 devices (device stats)
+ *  3 alerts (alert stats)       4 devices (os distribution)
+ *  5 devices+sites (site breakdown)
+ */
+function mockGeneratorQueries() {
+  const seq: unknown[][] = [
+    /* 1 organizations */   [{ id: ORG, name: 'Acme Corp' }],
+    /* 2 device stats */    [{ total: 5, online: 3, offline: 2 }],
+    /* 3 alert stats */     [{ total: 10, critical: 2, high: 3, resolved: 5 }],
+    /* 4 os distribution */ [{ osType: 'windows', count: 5 }],
+    /* 5 site breakdown */  [{ siteName: 'HQ', deviceCount: 5 }]
+  ];
+  const m = vi.mocked(db.select);
+  m.mockReset();
+  for (const rows of seq) m.mockReturnValueOnce(selectChain(rows));
+  m.mockReturnValue(selectChain([]));
+}
+
+describe('generateExecutiveSummaryReport', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('populates org identity alongside the existing numeric summary', async () => {
+    mockGeneratorQueries();
+
+    const result = await generateExecutiveSummaryReport(ORG, {});
+
+    expect(result.summary.org).toEqual({ id: ORG, name: 'Acme Corp' });
+    expect(result.summary.devices).toEqual({
+      total: 5,
+      online: 3,
+      offline: 2,
+      healthPercentage: 60
+    });
+    expect(result.summary.alerts).toEqual({
+      total: 10,
+      critical: 2,
+      high: 3,
+      resolved: 5,
+      resolutionRate: 50
+    });
+    expect(result.summary.osDistribution).toEqual({ windows: 5 });
+    expect(result.summary.siteBreakdown).toEqual([{ site: 'HQ', count: 5 }]);
+    expect(typeof result.generatedAt).toBe('string');
+  });
+
+  it('falls back to an empty org name when the org row is missing', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReset();
+    m.mockReturnValueOnce(selectChain([])); // organizations: no row found
+    m.mockReturnValue(selectChain([]));
+
+    const result = await generateExecutiveSummaryReport(ORG, {});
+
+    expect(result.summary.org).toEqual({ id: ORG, name: '' });
+  });
+});

--- a/apps/api/src/services/reportGenerationService.previous.test.ts
+++ b/apps/api/src/services/reportGenerationService.previous.test.ts
@@ -96,7 +96,11 @@ describe('previousBaselineFor', () => {
     const previous = await previousBaselineFor(REPORT_ID);
 
     expect(previous).toBeUndefined();
-    expect(consoleError).toHaveBeenCalledWith('[reports] previous-baseline lookup failed', expect.any(Error));
+    expect(consoleError).toHaveBeenCalledWith(
+      '[reports] previous-baseline lookup failed',
+      { reportId: REPORT_ID },
+      expect.any(Error),
+    );
     consoleError.mockRestore();
   });
 });

--- a/apps/api/src/services/reportGenerationService.previous.test.ts
+++ b/apps/api/src/services/reportGenerationService.previous.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({ db: { select: vi.fn() } }));
+
+import { db } from '../db';
+import { previousBaselineFor } from './reportGenerationService';
+
+const REPORT_ID = '00000000-0000-0000-0000-000000000001';
+
+/** Thenable that resolves to `rows` and supports any drizzle chain method. */
+function selectChain(rows: unknown[]) {
+  const p: any = Promise.resolve(rows);
+  for (const m of ['from', 'where', 'orderBy', 'limit']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+describe('previousBaselineFor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the prior completed run\'s generatedAt + summary', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(
+      selectChain([
+        {
+          result: { summary: { postureScore: 74 }, generatedAt: '2026-06-01T09:00:00Z' },
+          completedAt: new Date('2026-06-01T09:05:00Z'),
+        },
+      ]),
+    );
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toEqual({ generatedAt: '2026-06-01T09:00:00Z', summary: { postureScore: 74 } });
+  });
+
+  it('falls back to completedAt when the stored result has no generatedAt', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(
+      selectChain([
+        {
+          result: { summary: { postureScore: 74 } },
+          completedAt: new Date('2026-06-01T09:05:00Z'),
+        },
+      ]),
+    );
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toEqual({ generatedAt: '2026-06-01T09:05:00.000Z', summary: { postureScore: 74 } });
+  });
+
+  it('returns undefined when no prior run exists', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(selectChain([]));
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toBeUndefined();
+  });
+
+  it('returns undefined when the prior run has no summary', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(
+      selectChain([
+        { result: { rows: [{ hostname: 'PC-1' }] }, completedAt: new Date('2026-06-01T09:05:00Z') },
+      ]),
+    );
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toBeUndefined();
+  });
+
+  it('returns undefined when the prior run has no result at all', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(selectChain([{ result: null, completedAt: new Date('2026-06-01T09:05:00Z') }]));
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/reportGenerationService.previous.test.ts
+++ b/apps/api/src/services/reportGenerationService.previous.test.ts
@@ -24,7 +24,8 @@ describe('previousBaselineFor', () => {
     m.mockReturnValueOnce(
       selectChain([
         {
-          result: { summary: { postureScore: 74 }, generatedAt: '2026-06-01T09:00:00Z' },
+          summary: { postureScore: 74 },
+          generatedAt: '2026-06-01T09:00:00Z',
           completedAt: new Date('2026-06-01T09:05:00Z'),
         },
       ]),
@@ -40,7 +41,8 @@ describe('previousBaselineFor', () => {
     m.mockReturnValueOnce(
       selectChain([
         {
-          result: { summary: { postureScore: 74 } },
+          summary: { postureScore: 74 },
+          generatedAt: null,
           completedAt: new Date('2026-06-01T09:05:00Z'),
         },
       ]),
@@ -64,7 +66,7 @@ describe('previousBaselineFor', () => {
     const m = vi.mocked(db.select);
     m.mockReturnValueOnce(
       selectChain([
-        { result: { rows: [{ hostname: 'PC-1' }] }, completedAt: new Date('2026-06-01T09:05:00Z') },
+        { summary: null, generatedAt: null, completedAt: new Date('2026-06-01T09:05:00Z') },
       ]),
     );
 
@@ -75,10 +77,26 @@ describe('previousBaselineFor', () => {
 
   it('returns undefined when the prior run has no result at all', async () => {
     const m = vi.mocked(db.select);
-    m.mockReturnValueOnce(selectChain([{ result: null, completedAt: new Date('2026-06-01T09:05:00Z') }]));
+    m.mockReturnValueOnce(
+      selectChain([{ summary: null, generatedAt: null, completedAt: new Date('2026-06-01T09:05:00Z') }]),
+    );
 
     const previous = await previousBaselineFor(REPORT_ID);
 
     expect(previous).toBeUndefined();
+  });
+
+  it('returns undefined (not a throw) when the select fails', async () => {
+    const m = vi.mocked(db.select);
+    m.mockImplementationOnce(() => {
+      throw new Error('connection reset');
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const previous = await previousBaselineFor(REPORT_ID);
+
+    expect(previous).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith('[reports] previous-baseline lookup failed', expect.any(Error));
+    consoleError.mockRestore();
   });
 });

--- a/apps/api/src/services/reportGenerationService.ts
+++ b/apps/api/src/services/reportGenerationService.ts
@@ -8,7 +8,8 @@ import {
   alerts,
   alertRules,
   sites,
-  organizations
+  organizations,
+  reportRuns
 } from '../db/schema';
 import { canAccessSite, type UserPermissions } from './permissions';
 import type { ExecutiveSummary } from '@breeze/shared';
@@ -27,7 +28,29 @@ export type ReportResult = {
   rowCount?: number;
   summary?: Record<string, unknown>;
   generatedAt?: string;
+  /** Slim baseline from the previous completed run of the same report, copied
+   * into the snapshot at generation time so trend deltas ("79, up from 74")
+   * render from the stored result alone. Only `summary` is copied — never
+   * `previous` — so baselines don't chain. */
+  previous?: { generatedAt: string | null; summary?: Record<string, unknown> };
 };
+
+/** Baseline from the most recent completed run of this report, if it captured
+ * a summary. Call BEFORE marking the new run completed. */
+export async function previousBaselineFor(reportId: string): Promise<ReportResult['previous']> {
+  const [prior] = await db
+    .select({ result: reportRuns.result, completedAt: reportRuns.completedAt })
+    .from(reportRuns)
+    .where(and(eq(reportRuns.reportId, reportId), eq(reportRuns.status, 'completed')))
+    .orderBy(desc(reportRuns.completedAt))
+    .limit(1);
+  const priorResult = prior?.result as ReportResult | null | undefined;
+  if (!priorResult?.summary || typeof priorResult.summary !== 'object') return undefined;
+  return {
+    generatedAt: priorResult.generatedAt ?? prior?.completedAt?.toISOString() ?? null,
+    summary: priorResult.summary,
+  };
+}
 
 export async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions | undefined): Promise<string[] | null> {
   if (!perms?.allowedSiteIds) return null;

--- a/apps/api/src/services/reportGenerationService.ts
+++ b/apps/api/src/services/reportGenerationService.ts
@@ -7,9 +7,11 @@ import {
   deviceHardware,
   alerts,
   alertRules,
-  sites
+  sites,
+  organizations
 } from '../db/schema';
 import { canAccessSite, type UserPermissions } from './permissions';
+import type { ExecutiveSummary } from '@breeze/shared';
 
 export type ReportType =
   | 'device_inventory'
@@ -344,6 +346,12 @@ export async function generatePerformanceReport(orgId: string, config: Record<st
 }
 
 export async function generateExecutiveSummaryReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+  const [orgRow] = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
   const dateRange = config.dateRange as Record<string, string> | undefined;
   const deviceConditions: SQL[] = [eq(devices.orgId, orgId)];
   const emptyDeviceScope = addAllowedSiteCondition(deviceConditions, perms);
@@ -415,6 +423,7 @@ export async function generateExecutiveSummaryReport(orgId: string, config: Reco
 
   return {
     summary: {
+      org: { id: orgId, name: orgRow?.name ?? '' },
       devices: {
         total: Number(deviceStats[0]?.total ?? 0),
         online: Number(deviceStats[0]?.online ?? 0),
@@ -434,7 +443,7 @@ export async function generateExecutiveSummaryReport(orgId: string, config: Reco
       },
       osDistribution: Object.fromEntries(osDistribution.map(o => [o.osType, Number(o.count)])),
       siteBreakdown: siteBreakdown.map(s => ({ site: s.siteName, count: Number(s.deviceCount) }))
-    },
+    } satisfies ExecutiveSummary,
     generatedAt: new Date().toISOString()
   };
 }

--- a/apps/api/src/services/reportGenerationService.ts
+++ b/apps/api/src/services/reportGenerationService.ts
@@ -36,20 +36,34 @@ export type ReportResult = {
 };
 
 /** Baseline from the most recent completed run of this report, if it captured
- * a summary. Call BEFORE marking the new run completed. */
+ * a summary. Call BEFORE marking the new run completed.
+ *
+ * Projects only `result->summary` / `result->>generatedAt` instead of the full
+ * `result` JSONB (which can be many MB — it includes every row) and never
+ * throws: this sits in the success path of both generation call sites, so a
+ * lookup failure must degrade to "no baseline" rather than fail an otherwise
+ * good run. */
 export async function previousBaselineFor(reportId: string): Promise<ReportResult['previous']> {
-  const [prior] = await db
-    .select({ result: reportRuns.result, completedAt: reportRuns.completedAt })
-    .from(reportRuns)
-    .where(and(eq(reportRuns.reportId, reportId), eq(reportRuns.status, 'completed')))
-    .orderBy(desc(reportRuns.completedAt))
-    .limit(1);
-  const priorResult = prior?.result as ReportResult | null | undefined;
-  if (!priorResult?.summary || typeof priorResult.summary !== 'object') return undefined;
-  return {
-    generatedAt: priorResult.generatedAt ?? prior?.completedAt?.toISOString() ?? null,
-    summary: priorResult.summary,
-  };
+  try {
+    const [prior] = await db
+      .select({
+        summary: sql<Record<string, unknown> | null>`${reportRuns.result}->'summary'`,
+        generatedAt: sql<string | null>`${reportRuns.result}->>'generatedAt'`,
+        completedAt: reportRuns.completedAt,
+      })
+      .from(reportRuns)
+      .where(and(eq(reportRuns.reportId, reportId), eq(reportRuns.status, 'completed')))
+      .orderBy(desc(reportRuns.completedAt))
+      .limit(1);
+    if (!prior?.summary || typeof prior.summary !== 'object') return undefined;
+    return {
+      generatedAt: prior.generatedAt ?? prior.completedAt?.toISOString() ?? null,
+      summary: prior.summary,
+    };
+  } catch (err) {
+    console.error('[reports] previous-baseline lookup failed', err);
+    return undefined;
+  }
 }
 
 export async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions | undefined): Promise<string[] | null> {

--- a/apps/api/src/services/reportGenerationService.ts
+++ b/apps/api/src/services/reportGenerationService.ts
@@ -61,7 +61,7 @@ export async function previousBaselineFor(reportId: string): Promise<ReportResul
       summary: prior.summary,
     };
   } catch (err) {
-    console.error('[reports] previous-baseline lookup failed', err);
+    console.error('[reports] previous-baseline lookup failed', { reportId }, err);
     return undefined;
   }
 }

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -19,5 +19,5 @@ export default defineConfig({
   // feed's UNION ALL query builder — failing the build for ~150 bytes of unused
   // .d.cts. Disable it; the Dockerfile and runbook only ever run dist/*.cjs.
   dts: false,
-  noExternal: ['@breeze/shared', 'dotenv'],
+  noExternal: [/^@breeze\/shared/, 'dotenv'],
 });

--- a/apps/web/src/components/reports/ReportsList.schedule.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.schedule.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+vi.mock('./reportExport', () => ({
+  exportReport: vi.fn(),
+  downloadBlob: vi.fn(),
+  getBrowserTimezone: () => 'UTC',
+}));
+
+import ReportsList from './ReportsList';
+
+const monthlyReport = {
+  id: 'rep-1',
+  name: 'Monthly Inventory',
+  type: 'device_inventory',
+  schedule: 'monthly',
+  format: 'csv',
+  config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'c@d.co'] },
+  lastGeneratedAt: null,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const oneTimeReport = {
+  id: 'rep-2',
+  name: 'One-off Alert Summary',
+  type: 'alert_summary',
+  schedule: 'one_time',
+  format: 'pdf',
+  config: {},
+  lastGeneratedAt: null,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+function mountWith(reports: unknown[]) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url === '/reports') return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: reports }) });
+    if (url.startsWith('/reports/runs?')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+describe('ReportsList schedule cell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows next-run time and recipient count for a recurring report', async () => {
+    mountWith([monthlyReport]);
+    render(<ReportsList onEdit={() => {}} onGenerate={() => {}} onDelete={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText('Monthly Inventory')).toBeInTheDocument());
+    expect(screen.getByText(/^Next: .+/)).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders no next-run line for a one-time report', async () => {
+    mountWith([oneTimeReport]);
+    render(<ReportsList onEdit={() => {}} onGenerate={() => {}} onDelete={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText('One-off Alert Summary')).toBeInTheDocument());
+    expect(screen.queryByText(/^Next: .+/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/reports/ReportsList.schedule.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.schedule.test.tsx
@@ -18,7 +18,7 @@ const monthlyReport = {
   type: 'device_inventory',
   schedule: 'monthly',
   format: 'csv',
-  config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'c@d.co'] },
+  config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'second@example.com'] },
   lastGeneratedAt: null,
   createdAt: '2026-06-01T00:00:00Z',
   updatedAt: '2026-06-01T00:00:00Z',

--- a/apps/web/src/components/reports/ReportsList.schedule.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.schedule.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
@@ -57,7 +57,7 @@ describe('ReportsList schedule cell', () => {
 
     await waitFor(() => expect(screen.getByText('Monthly Inventory')).toBeInTheDocument());
     expect(screen.getByText(/^Next: .+/)).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(within(screen.getByTitle('Email recipients')).getByText('2')).toBeInTheDocument();
   });
 
   it('renders no next-run line for a one-time report', async () => {

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -221,7 +221,11 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
       if (contentType.includes('application/json')) {
         // PDF path: server returned the stored snapshot; render client-side.
         const payload = await res.json();
-        const data = payload.data as { rows?: unknown[]; summary?: unknown } | undefined;
+        const data = payload.data as {
+          rows?: unknown[];
+          summary?: unknown;
+          previous?: { generatedAt?: string | null; summary?: unknown };
+        } | undefined;
         const rows = data?.rows ?? [];
         await exportReport(rows, {
           format: 'pdf',
@@ -230,6 +234,9 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
           // The posture and executive-summary covers consume this snapshot to
           // render their designed cover pages; ignored by other report types.
           summary: data?.summary as PostureSummary | undefined,
+          // Drives the scorecard trend chip ("79, up from 74 last month")
+          // when the stored run snapshot captured a prior baseline.
+          previous: data?.previous,
         });
         return;
       }

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -18,7 +18,13 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { exportReport, downloadBlob, getBrowserTimezone, type PostureSummary } from './reportExport';
 import { formatDateTime } from '@/lib/dateTimeFormat';
-import { nextOccurrence, formatNextOccurrence, type ScheduleCadence, type ScheduleConfig } from '@breeze/shared';
+import {
+  nextOccurrence,
+  formatNextOccurrence,
+  type ScheduleCadence,
+  type ScheduleConfig,
+  type ExecutiveSummary
+} from '@breeze/shared';
 
 export type ReportType =
   | 'device_inventory'
@@ -245,7 +251,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
           timezone: effectiveTimezone,
           // The posture and executive-summary covers consume this snapshot to
           // render their designed cover pages; ignored by other report types.
-          summary: data?.summary as PostureSummary | undefined,
+          summary: data?.summary as PostureSummary | ExecutiveSummary | undefined,
           // Drives the scorecard trend chip ("79, up from 74 last month")
           // when the stored run snapshot captured a prior baseline.
           previous: data?.previous,

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -227,7 +227,8 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
           format: 'pdf',
           reportType: payload.type ?? run.reportType ?? 'report',
           timezone: effectiveTimezone,
-          // posture report carries a summary scorecard; harmless for other types
+          // The posture and executive-summary covers consume this snapshot to
+          // render their designed cover pages; ignored by other report types.
           summary: data?.summary as PostureSummary | undefined,
         });
         return;

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -11,12 +11,14 @@ import {
   CheckCircle,
   XCircle,
   Loader2,
-  LayoutTemplate
+  LayoutTemplate,
+  Mail
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { exportReport, downloadBlob, getBrowserTimezone, type PostureSummary } from './reportExport';
 import { formatDateTime } from '@/lib/dateTimeFormat';
+import { nextOccurrence, formatNextOccurrence, type ScheduleCadence, type ScheduleConfig } from '@breeze/shared';
 
 export type ReportType =
   | 'device_inventory'
@@ -91,6 +93,16 @@ function parseContentDispositionFilename(header: string | null): string | null {
   if (!header) return null;
   const match = /filename="?([^";]+)"?/.exec(header);
   return match?.[1] ?? null;
+}
+
+function scheduleConfigOf(config: Record<string, unknown> | undefined): ScheduleConfig {
+  const raw = config?.schedule;
+  return raw && typeof raw === 'object' ? (raw as ScheduleConfig) : {};
+}
+
+function recipientCountOf(config: Record<string, unknown> | undefined): number {
+  const raw = config?.emailRecipients;
+  return Array.isArray(raw) ? raw.filter((r) => typeof r === 'string' && r.trim() !== '').length : 0;
 }
 
 export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: ReportsListProps) {
@@ -419,6 +431,30 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                           <Calendar className="h-3 w-3" />
                           {scheduleLabels[report.schedule]}
                         </span>
+                        {report.schedule !== 'one_time' && (
+                          /* Computed in the viewer's timezone; the worker fires in the
+                             org's timezone, so this is a close approximation shown to
+                             the user, not a contract for when the run actually fires. */
+                          <p className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                            <span>
+                              Next: {formatNextOccurrence(
+                                nextOccurrence(
+                                  new Date(),
+                                  report.schedule as ScheduleCadence,
+                                  scheduleConfigOf(report.config),
+                                  effectiveTimezone
+                                ),
+                                { weekday: report.schedule === 'weekly' }
+                              )}
+                            </span>
+                            {recipientCountOf(report.config) > 0 && (
+                              <span className="inline-flex items-center gap-1" title="Email recipients">
+                                <Mail className="h-3 w-3" />
+                                {recipientCountOf(report.config)}
+                              </span>
+                            )}
+                          </p>
+                        )}
                       </td>
                       <td className="px-4 py-3 text-sm">
                         {formatLabels[report.format]}

--- a/apps/web/src/components/reports/reportExport.posture.test.tsx
+++ b/apps/web/src/components/reports/reportExport.posture.test.tsx
@@ -45,7 +45,7 @@ vi.mock('jspdf', () => {
 vi.mock('jspdf-autotable', () => ({ default: vi.fn() }));
 
 import { exportReport, type PostureSummary } from './reportExport';
-import type { ReportBranding } from './reportPdf';
+import type { ReportBranding } from '@breeze/shared/reportPdf';
 
 // Pass branding explicitly so the PDF path never hits the network branding fetch.
 const noBranding: ReportBranding = { name: 'Breeze', logoDataUrl: null, logoAspect: null };

--- a/apps/web/src/components/reports/reportExport.ts
+++ b/apps/web/src/components/reports/reportExport.ts
@@ -3,7 +3,7 @@ import { formatDateTime } from '@/lib/dateTimeFormat';
 import { escapeCsvCell, escapeTsvCell, neutralizeSpreadsheetFormula } from '@/lib/csvExport';
 import { sanitizeImageSrc } from '@/lib/safeImageSrc';
 import { fetchWithAuth } from '../../stores/auth';
-import { buildReportPdf, type ReportBranding } from './reportPdf';
+import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';
 
 // Re-export the shared CSV helpers so existing importers of these names from
 // './reportExport' keep working; the canonical definitions now live in

--- a/apps/web/src/components/reports/reportExport.ts
+++ b/apps/web/src/components/reports/reportExport.ts
@@ -1,4 +1,4 @@
-import type { PostureSummary } from '@breeze/shared';
+import type { PostureSummary, ExecutiveSummary } from '@breeze/shared';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { escapeCsvCell, escapeTsvCell, neutralizeSpreadsheetFormula } from '@/lib/csvExport';
 import { sanitizeImageSrc } from '@/lib/safeImageSrc';
@@ -60,7 +60,7 @@ export async function exportReport(
     format: 'csv' | 'pdf' | 'excel';
     reportType: string;
     timezone: string;
-    summary?: PostureSummary;
+    summary?: PostureSummary | ExecutiveSummary;
     /** Slim baseline from the previous completed run (report_runs.result.previous),
      * used to draw the scorecard trend chip; ignored by non-cover report types. */
     previous?: { generatedAt?: string | null; summary?: unknown };

--- a/apps/web/src/components/reports/reportExport.ts
+++ b/apps/web/src/components/reports/reportExport.ts
@@ -61,11 +61,14 @@ export async function exportReport(
     reportType: string;
     timezone: string;
     summary?: PostureSummary;
+    /** Slim baseline from the previous completed run (report_runs.result.previous),
+     * used to draw the scorecard trend chip; ignored by non-cover report types. */
+    previous?: { generatedAt?: string | null; summary?: unknown };
     /** Pre-resolved partner branding; loaded automatically for PDFs when omitted. */
     branding?: ReportBranding;
   }
 ): Promise<void> {
-  const { format, reportType, timezone, summary } = opts;
+  const { format, reportType, timezone, summary, previous } = opts;
   const dateStr = new Date().toISOString().split('T')[0];
   const baseFilename = `${reportType}-report-${dateStr}`;
 
@@ -106,7 +109,7 @@ export async function exportReport(
     timeStyle: 'short',
   });
   const branding = opts.branding ?? (await loadPartnerBranding());
-  const doc = buildReportPdf(rows, { reportType, generatedAt, timezone, summary, branding });
+  const doc = buildReportPdf(rows, { reportType, generatedAt, timezone, summary, previous, branding });
   downloadBlob(doc.output('blob'), `${baseFilename}.pdf`);
 }
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@breeze/shared": ["../../packages/shared/src"]
+      "@breeze/shared": ["../../packages/shared/src"],
+      "@breeze/shared/reportPdf": ["../../packages/shared/src/reportPdf"]
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react"

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
       // Mirrors the `@breeze/shared` path in apps/web/tsconfig.json so vitest
       // can resolve workspace imports without a build step. Required for
       // testing any component that imports from `@breeze/shared`.
+      // Subpath exports (e.g. `/reportPdf`) need their own alias entry —
+      // Vite's object-form `resolve.alias` only does exact-string matching,
+      // it does not prefix-match `@breeze/shared` onto `@breeze/shared/*`.
+      '@breeze/shared/reportPdf': fileURLToPath(
+        new URL('../../packages/shared/src/reportPdf/index.ts', import.meta.url)
+      ),
       '@breeze/shared': fileURLToPath(
         new URL('../../packages/shared/src/index.ts', import.meta.url)
       ),

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,9 +8,13 @@ export default defineConfig({
       // Mirrors the `@breeze/shared` path in apps/web/tsconfig.json so vitest
       // can resolve workspace imports without a build step. Required for
       // testing any component that imports from `@breeze/shared`.
-      // Subpath exports (e.g. `/reportPdf`) need their own alias entry —
-      // Vite's object-form `resolve.alias` only does exact-string matching,
-      // it does not prefix-match `@breeze/shared` onto `@breeze/shared/*`.
+      // Subpath exports (e.g. `/reportPdf`) need their own alias entry, listed
+      // BEFORE the bare `@breeze/shared` entry below. Vite's object-form
+      // `resolve.alias` does prefix-match (it checks whether the import path
+      // starts with `key + '/'`), so alias order matters: if the bare
+      // `@breeze/shared` entry came first, it would win the prefix match on
+      // `@breeze/shared/reportPdf` and resolve it to the package root instead
+      // of the reportPdf subpath — the more specific alias must be listed first.
       '@breeze/shared/reportPdf': fileURLToPath(
         new URL('../../packages/shared/src/reportPdf/index.ts', import.meta.url)
       ),

--- a/docs/superpowers/plans/2026-07-01-partner-level-reports-design.md
+++ b/docs/superpowers/plans/2026-07-01-partner-level-reports-design.md
@@ -46,9 +46,13 @@ the current schema.
 Follow the **dual-owner precedent** already shipped for
 `configuration_policies` (`apps/api/src/db/schema/configurationPolicies.ts:64-82`,
 migration `2026-06-27-config-policies-partner-ownership.sql`), and identically for
-`custom_field_definitions`, `software_catalog`, `software_policies`,
-`security_policies` (commit `e42b34ac0`, #2143). The pattern is settled; we are
-the next table onto it.
+`custom_field_definitions`, `software_catalog`, and `client_ai_prompt_templates`
+— the dual-owner (org XOR partner) tables present on this branch. On main, `software_policies`
+and `security_policies` gained the same axis in commit `e42b34ac0` (#2143),
+which is **not** an ancestor of this branch yet (we're stacked one commit
+behind); it will be once this branch rebases after #2148 merges, giving the
+implementer two more copies of the template. The pattern is settled; we are the
+next table onto it.
 
 ### 2.1 Schema change
 

--- a/docs/superpowers/plans/2026-07-01-partner-level-reports-design.md
+++ b/docs/superpowers/plans/2026-07-01-partner-level-reports-design.md
@@ -1,0 +1,480 @@
+# Partner-Level Cross-Org Reports — Design
+
+> **Status:** Design pass for a future PR. No implementation lands with this doc.
+> It exists so a follow-up implementer can write the migration, routes, and
+> renderer changes without re-deriving the tenancy contract.
+
+**Goal:** Let a partner (MSP) own a report whose scope is *all of its client
+orgs*, not a single org — a fleet-wide roll-up that compares posture (and later
+patch) across every organization the partner manages. This is the report that
+sells an MSP's value upward: one artifact, one row per client org, one
+partner-level summary.
+
+**Non-goal:** rewriting the per-org reports. Everything that exists today
+(org-scoped `security_compliance_posture`, the six tabular reports, the schedule
+worker, the client-side PDF) keeps working unchanged. This adds a *second
+ownership axis*, following the partner-wide-first principle already applied to
+configuration/software/security policies.
+
+---
+
+## 1. Problem
+
+`reports.orgId` is `NOT NULL` (`apps/api/src/db/schema/reports.ts:33`). Every
+report belongs to exactly one org. A partner-scope user gets per-org reports
+only:
+
+- **List** (`routes/reports/core.ts:36-52`): partner scope filters
+  `inArray(reports.orgId, auth.accessibleOrgIds)` — a flat union of per-org
+  rows, never a cross-org aggregate.
+- **Generator** (`services/securityComplianceReport.ts:158`):
+  `generateSecurityCompliancePostureReport(orgId, …)` is single-org by
+  construction — every query is `eq(..., orgId)`.
+- **Renderer** (`packages/shared/src/reportPdf/reportPdf.ts`): the posture cover
+  + per-*device* table assume one org's device fleet.
+
+The MSP-shaped gap is a **fleet roll-up**: one posture table with one row per
+client org (devices, posture score, unprotected count, critical findings, patch
+currency), plus a partner-level headline (weighted-average score, best/worst
+org). There is no way to express "owned by the partner, spanning all orgs" in
+the current schema.
+
+---
+
+## 2. Ownership axis — dual-owner `reports`
+
+Follow the **dual-owner precedent** already shipped for
+`configuration_policies` (`apps/api/src/db/schema/configurationPolicies.ts:64-82`,
+migration `2026-06-27-config-policies-partner-ownership.sql`), and identically for
+`custom_field_definitions`, `software_catalog`, `software_policies`,
+`security_policies` (commit `e42b34ac0`, #2143). The pattern is settled; we are
+the next table onto it.
+
+### 2.1 Schema change
+
+In `reports.ts`:
+
+- Make `orgId` **nullable** (drop `.notNull()`).
+- Add nullable `partnerId: uuid('partner_id').references(() => partners.id)`.
+- A report is owned by **either** an org (`org_id` set, `partner_id` NULL — the
+  existing shape) **or** a partner (`partner_id` set, `org_id` NULL — the new
+  "all orgs" shape). Exactly one axis per row.
+
+### 2.2 Migration `2026-07-XX-b-partner-owned-reports.sql`
+
+Idempotent, no inner `BEGIN;`/`COMMIT;` (autoMigrate wraps each file). Mirror
+`2026-06-27-config-policies-partner-ownership.sql` step-for-step:
+
+```sql
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+ALTER TABLE reports ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                 WHERE conname = 'reports_one_owner_chk'
+                   AND conrelid = 'reports'::regclass) THEN
+    ALTER TABLE reports ADD CONSTRAINT reports_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS reports_partner_id_idx ON reports(partner_id);
+```
+
+`(org_id IS NULL) <> (partner_id IS NULL)` is true iff exactly one is set. No
+backfill needed: every existing row already has `org_id` set and `partner_id`
+NULL, which satisfies the CHECK — so this is a pure `ADD`/`DROP NOT NULL` with
+no `UPDATE` sweep and no row-count logging requirement.
+
+### 2.3 RLS — reports moves from Shape 1 to Shape 4 (dual-axis)
+
+**Today** `reports` rides **Shape 1 auto-discovery** on its `org_id` column:
+the RLS coverage test picks it up automatically because it has an `org_id`
+column and org-isolation policies. Nothing lists it explicitly.
+
+Once `org_id` is nullable and `partner_id` exists, the org-only policy is
+wrong: `breeze_has_org_access(NULL)` is `FALSE`, so a partner-owned row
+(`org_id` NULL) would be **structurally invisible and uncreatable** —
+`new row violates row-level security policy` on every partner-owned insert.
+This is the exact failure `custom_field_definitions` hit before
+`2026-06-11-i-custom-fields-dual-axis-rls.sql`.
+
+Replace the org-isolation policy with a **dual-axis** policy in the same
+migration (copy the `configuration_policies_org_isolation` shape verbatim,
+`2026-06-27-...:62-74`):
+
+```sql
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reports FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON reports;  -- and insert/update/delete
+-- (drop whatever the baseline named them; check pg_policies on a live DB first)
+
+CREATE POLICY reports_owner_isolation ON reports
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK ( … same predicate … );
+```
+
+`breeze_has_partner_access` is **flat** (never tree traversal) — a partner sees
+its own `partner_id`, full stop (per CLAUDE.md and `partner_scope_flat`).
+
+### 2.4 `report_runs` — the FK-child blindspot (MUST fix in the same migration)
+
+`report_runs` has **no `org_id` column**. It reaches its tenant by joining
+through `reports`, and is allowlisted as an FK-child in
+`rls-coverage.integration.test.ts:289` → `['report_runs', ['reports']]`. Its
+current policy (`2026-06-13-b-fk-child-rls-backstop.sql:181-194`) is:
+
+```sql
+EXISTS (SELECT 1 FROM reports r
+        WHERE r.id = report_runs.report_id AND public.breeze_has_org_access(r.org_id))
+```
+
+When a partner-owned report has `r.org_id = NULL`, `breeze_has_org_access(NULL)`
+is FALSE — so **runs of partner-owned reports become invisible and unwritable**.
+The schedule worker's `INSERT INTO report_runs` would 0-row / RLS-reject. This
+is precisely the config-policy child-table problem
+(`2026-06-27-...:77-98`): the parent gained a partner axis and every child
+policy that gated on `cp.org_id` had to OR in `cp.partner_id`.
+
+**Fix:** extend all four `report_runs` policies to:
+
+```sql
+EXISTS (SELECT 1 FROM reports r
+        WHERE r.id = report_runs.report_id
+          AND (public.breeze_has_org_access(r.org_id)
+               OR public.breeze_has_partner_access(r.partner_id)))
+```
+
+`breeze_has_org_access(NULL)` / `breeze_has_partner_access(NULL)` are both
+FALSE, so the org-owned case is unchanged.
+
+**Why this is a blindspot the contract test will NOT catch on its own:** the
+FK-child assertion (`PARENT_FK_JOIN_POLICY_TABLES`) only checks that the policy
+*text* contains `FROM reports` and `breeze_has_org_access` — it does not exercise
+a partner-owned parent functionally. A migration that dual-owns `reports` but
+forgets `report_runs` passes the static allowlist check and still silently
+breaks partner-owned run reads/writes. Guard it with a **functional** breeze_app
+insert test (§6), not just the allowlist.
+
+### 2.5 Contract-test allowlist changes
+
+In `rls-coverage.integration.test.ts`:
+
+1. **Add `'reports'` to `DUAL_AXIS_TENANT_TABLES`** (`:204-239`) with a comment
+   in the same style as the `configuration_policies` entry (`:220-230`).
+   Rationale to spell out: the `org_id` column means org-tenant auto-discovery
+   *already* asserts the `breeze_has_org_access` branch — this allowlist entry
+   is the **only** thing that asserts the `breeze_has_partner_access`
+   (partner-wide) branch. **This is the dual-axis contract blindspot**: without
+   the entry, a regression that drops the partner branch from the policy still
+   passes because the org branch alone satisfies auto-discovery.
+2. `report_runs` **stays** in `PARENT_FK_JOIN_POLICY_TABLES` (`:289`) — its
+   shape is unchanged (still FK-child through `reports`); only its predicate
+   gains the OR.
+3. Because the dual-axis static check is a blindspot, add a **functional**
+   `reportsPartnerRls.integration.test.ts` (model on
+   `configurationPoliciesPartnerRls.integration.test.ts`): as `breeze_app`,
+   forge a cross-partner report insert → expect `42501`; violate the XOR CHECK
+   (both axes set / neither set) → expect `23514`; insert a partner-owned report
+   + run under partner context → expect visible; under a *different* partner /
+   an org-scope caller → expect 0 rows.
+
+---
+
+## 3. Report types & generator
+
+### 3.1 New enum value(s)
+
+Add to `reportTypeEnum` (`reports.ts:5-13`) and the mirrored `reportTypeSchema`
+(`routes/reports/schemas.ts:3-11`):
+
+- `fleet_posture_rollup` — ship this first.
+- `fleet_patch_rollup` — reserved for a later PR (same shape, patch metrics).
+
+Enum additions require an `ALTER TYPE report_type ADD VALUE IF NOT EXISTS
+'fleet_posture_rollup'` **as the only statement in its own migration file** —
+under autoMigrate's per-file transaction the new label is uncommitted until the
+file commits, so no later statement in the same file may reference it (see
+`2026-06-29-a-report-type-security-compliance.sql`, which is exactly one line
+for this reason). Use a same-day `-a-`/`-b-` split: `2026-07-XX-a-report-type-
+fleet-rollup.sql` (the enum value, one line) sorts before `2026-07-XX-b-partner-
+owned-reports.sql` (schema + RLS below). The schema/RLS migration does not
+reference the new label in SQL, so it needs no dependency on the enum file at
+apply time, but the ordering keeps them coherent.
+
+### 3.2 Generator
+
+New `generateFleetPostureRollup(partnerId, rawConfig, perms?)`, dispatched from
+`reportGenerationService` alongside the existing types.
+
+- **Discover orgs:** `SELECT id, name FROM organizations WHERE partner_id = $1`
+  (flat — a partner's direct orgs).
+- **Per-org loop:** call the existing
+  `generateSecurityCompliancePostureReport(org.id, cfg, perms)` per org **under
+  system context**. Reuse — do not fork — the per-org generator; its output
+  `summary` (`PostureSummary`) already carries everything a roll-up row needs:
+  `deviceCount`, `postureScore`, `controls.unprotectedCount`,
+  `controls.patchCurrentPct`, and per-severity findings.
+- **Emit one row per org**, e.g.
+  `{ org: name, orgId, devices, postureScore, unprotected, criticalFindings, patchCurrentPct, edrCoveragePct }`.
+  The per-device detail is intentionally dropped at this level (see cost note).
+- **Partner-level summary:** weighted-average posture score (weight by
+  `deviceCount`, not org count — a 500-device client should move the needle more
+  than a 3-device one), best/worst org by score, fleet-wide device total,
+  fleet-wide unprotected total.
+
+Return the same `ReportResult` shape (`rows`, `rowCount`, `generatedAt`,
+`summary`) so the run-snapshot storage, download endpoint, and email path all
+work unchanged. The partner-level headline goes in `summary`; the per-org rows
+go in `rows`.
+
+**Trend baselines (Task 6) apply unchanged:** `previousBaselineFor(reportId)`
+keys on the report row, not its owner axis — a partner-owned report's previous
+run is found identically, and the scorecard trend chip reads
+`summary.postureScore` exactly as today.
+
+---
+
+## 4. Renderer
+
+`buildReportPdf` (`reportPdf.ts:1194`) already branches on
+`opts.reportType === 'security_compliance_posture'`. Add a
+`fleet_posture_rollup` branch that **reuses the scorecard primitives**:
+
+- **Cover:** `drawScorecard(doc, partnerWeightedScore, caption, stats, top, trend)`
+  (`reportPdf.ts:250`) — same big-numeral + band chip + trend chip used for the
+  per-org cover. `stats` (the right-rail risk stats) become fleet totals: total
+  orgs, total devices, total unprotected, orgs below threshold.
+- **Body:** a **per-ORG** table (new) rather than the per-*device*
+  `renderPostureTable` (`:1000`). Same `autoTable` styling, two-tier header,
+  colored at-risk cells, and a totals footer row — copy the structure of
+  `renderPostureTable` but with org-level columns (`Org`, `Devices`, `Score`,
+  `Unprotected`, `Critical`, `Patch %`). The color thresholds
+  (`postureCellColor`) carry over conceptually per metric.
+
+No server PDF engine is introduced — the PDF is still built client-side from the
+stored snapshot (download endpoint returns the snapshot for `format === 'pdf'`,
+`routes/reports/runs.ts:219-221`) and rendered server-side only for scheduled
+email attachments (`reportScheduleWorker.ts:212-234`). The renderer lives in
+`@breeze/shared` so both paths share it.
+
+---
+
+## 5. Routes
+
+Mirror `configurationPolicies/crud.ts:57-118` for ownership handling. **The
+partner id is ALWAYS derived from `auth.partnerId`, never client-supplied.**
+
+### 5.1 Create — `POST /reports`
+
+Add `ownerScope: 'organization' | 'partner'` to `createReportSchema`
+(`schemas.ts:90-97`), org default. When `ownerScope === 'partner'`:
+
+- Require `auth.partnerId` (else 403 "Partner-wide reports require partner
+  scope").
+- Require `orgAccess === 'all'` — read `c.get('permissions').orgAccess`, exactly
+  as `crud.ts:75-78`. A `selected`/`none`-access partner user must NOT create a
+  partner rollup: the report would aggregate orgs they cannot individually see.
+  System scope short-circuits the gate.
+- Insert `{ partnerId: auth.partnerId, orgId: null, … }`. Never read a
+  client-supplied partner id.
+
+The current create (`core.ts:180-238`) always sets `orgId`; the partner branch
+sits ahead of the org logic, like the config-policy handler.
+
+### 5.2 List / get / runs — branch on the owner axis
+
+- **List** (`core.ts:36-55`): the partner branch currently does
+  `inArray(reports.orgId, accessibleOrgIds)`. Extend it to **also** include
+  `eq(reports.partnerId, auth.partnerId)` (OR the two conditions) so a partner
+  sees both its per-org reports and its partner-owned rollups. **Org-scope
+  callers keep the pure `eq(reports.orgId, auth.orgId)` branch — they never see
+  a `partner_id` filter, so partner rollups are invisible to them at the query
+  layer** (RLS is the second gate; see §7).
+- **`ensureOrgAccess` / `getReportWithOrgCheck`** (`helpers.ts:8-44`) are
+  app-layer gates keyed on `report.orgId`. For a partner-owned report `orgId` is
+  NULL, so `canAccessOrg(null)` returns false and the helper 404s. Add a partner
+  branch: if `report.partnerId` is set, authorize iff
+  `auth.scope === 'system'` OR `auth.partnerId === report.partnerId`. Without
+  this, get/update/delete/generate of a partner-owned report all 404 even for
+  its owning partner.
+- **`getReportRunWithOrgCheck`** (`helpers.ts:46-78`) selects `reports.orgId`
+  for its access check — also select `reports.partnerId` and apply the same
+  partner branch.
+- **Runs list** (`runs.ts:122-131`): partner branch mirrors the report list —
+  OR in the partner-owned reports.
+
+### 5.3 Schedule worker — partner-timezone branch
+
+`findDueReports` (`reportScheduleWorker.ts:121-152`) `innerJoin`s
+`organizations` on `reports.orgId` to resolve the timezone
+(org → partner → UTC chain, `timezoneFor` at `:94-119`). For a partner-owned
+report `orgId` is NULL, so the **`innerJoin` drops the row entirely** — a
+partner-owned scheduled report would never fire.
+
+Fix:
+
+- Change the join to a `leftJoin` on `organizations`, and **also** `leftJoin`
+  `partners` directly on `reports.partnerId` (in addition to the existing
+  `organizations.partnerId` join). Resolve the timezone from the org chain when
+  `org_id` is set, or **from `reports.partnerId`'s partner row** (partner
+  timezone → UTC) when it's a partner-owned report. `timezoneFor` already
+  accepts `(orgSettings, partnerTzColumn, partnerSettings)` with `orgTz` null —
+  pass the directly-joined partner's `timezone`/`settings` for the org-less case.
+- `processRunScheduledReport` (`:275-343`) resolves timezone the same way
+  (`:285-291`) and calls `generateReport(report.type, report.orgId, …)`. For the
+  rollup, dispatch on `report.partnerId` instead of `report.orgId` — the
+  dispatcher must route `fleet_posture_rollup` to `generateFleetPostureRollup`
+  with the partner id. `loadReportBrandingForOrg(report.orgId)` (`:338`) needs a
+  partner-branding fallback (`loadReportBrandingForPartner`) for org-less
+  reports — otherwise a NULL orgId hits the branding loader.
+
+---
+
+## 6. Web
+
+Follow the config-policy web precedent
+(`ConfigPolicyCreatePage.tsx:41-47`):
+
+- **Scope gate:** `const { scope, partnerId } = getJwtClaims(); const isPartnerScope = scope === 'partner' && !!partnerId;`
+  Gate on the **JWT scope**, not `useOrgStore().partners.length` (per
+  `web_ispartnerscope_partners_length_gate_bug` — a partners-length gate is
+  broken).
+- **Builder** (`ReportBuilder.tsx`): show an owner-scope selector
+  (Organization / All organizations) **only** to partner-scope users. Default to
+  partner-wide when the user is on the All-orgs view (no concrete org selected),
+  else the focused org — same defaulting logic as
+  `ConfigPolicyCreatePage.tsx:44-47`. When partner-wide, restrict the report-type
+  list to the rollup types.
+- **`ReportsList.tsx`:** badge partner-wide rows ("All organizations") so they
+  read distinctly from per-org reports, mirroring the config-policy list badge.
+
+---
+
+## 7. Security invariants (non-negotiable)
+
+1. **Org-level users must NEVER see partner rollups.** Enforced twice:
+   (a) the list/get query never applies a `partner_id` filter for
+   `scope === 'organization'`; (b) RLS —
+   `breeze_has_partner_access(partner_id)` is false for an org-scope token, so
+   even a forged `?orgId`/id probe returns 0 rows. Double-gate, never rely on the
+   query alone.
+2. **Partner id always derived server-side** from `auth.partnerId`. `ownerScope`
+   is the only client input; a client-supplied partner id is never read
+   (`crud.ts:60-63` precedent). `ownerScope` should be **create-only** — do not
+   let an update flip an org report into a partner rollup (mirrors the
+   security-policy "ownerScope is create-only, kept out of settings JSONB"
+   decision in #2143).
+3. **`orgAccess === 'all'` gate** on partner-owned create (§5.1). A `selected`
+   partner user aggregating orgs they can't individually see is a data-exposure
+   escalation.
+4. **RLS dual-owner policy + FK-child fix + allowlist entry** ship in the same
+   migration/PR (§2.3–2.5). The `report_runs` predicate MUST gain the partner
+   OR, or partner-owned runs silently break under RLS.
+5. **Contract-test blindspots to call out explicitly in the PR:**
+   - *Dual-axis blindspot:* the static allowlist check is satisfied by the
+     org-access branch alone; only the `DUAL_AXIS_TENANT_TABLES` entry + a
+     functional cross-partner forge test prove the partner branch.
+   - *FK-child blindspot:* the `report_runs` static check only greps policy text
+     for `FROM reports` + `breeze_has_org_access`; it does not exercise a
+     partner-owned parent. A functional breeze_app insert against a
+     partner-owned report is the only thing that catches a forgotten partner OR.
+
+---
+
+## 8. Cost / fan-out note
+
+A `fleet_posture_rollup` fans out **one full posture generation per org**. The
+per-org generator issues ~15 queries (EDR, AV, patches, vulns, DNS, backup,
+c2c, m365, google, PAM, elevations, CIS, posture snapshot, devices,
+security_status). A 100-org partner = ~1,500 queries per rollup.
+
+Mitigations:
+
+- **Enqueue as a normal scheduled run** — no new queue. The
+  `reportScheduleWorker` already throttles at **concurrency 2**
+  (`reportScheduleWorker.ts:427`), so at most two rollups generate at once. Do
+  not parallelize the per-org loop inside a single rollup unboundedly; a simple
+  sequential loop (or a small bounded map, e.g. 4-wide) keeps DB pressure
+  predictable and respects the US DB connection ceiling.
+- **Cap orgs per rollup initially (e.g. 100).** Beyond the cap, truncate and
+  **log the truncation** (`console.warn` with partner id + total vs included
+  count) so it lands in logs — never silently drop orgs from an attestation.
+  Surface the truncation in the report `summary` too (e.g.
+  `orgsIncluded`/`orgsTotal`) so the PDF can print "showing 100 of 137 orgs".
+- Consider (later, not v1) reusing the most recent stored per-org posture
+  snapshot instead of regenerating, if freshness allows — out of scope here.
+
+---
+
+## 9. Open questions
+
+- **Per-org site filters in rollups** — skip in v1. The per-org generator
+  accepts `cfg.sites`, but a partner-level rollup has no coherent cross-org site
+  semantics. Rollup config ignores `sites`.
+- **Org-level users seeing partner rollups** — answered: never (§7.1),
+  RLS + route double-gate.
+- **Does the rollup email attach one PDF?** — **Yes.** A single branded artifact
+  is the entire point of the feature. The existing email path
+  (`reportScheduleWorker.ts:212-234`) renders one PDF from the snapshot; it needs
+  only the partner-branding fallback (§5.3) and the new renderer branch (§4). One
+  attachment, one rollup.
+- **Partner branding** — `loadReportBrandingForOrg` is org-keyed; a
+  `loadReportBrandingForPartner` (or a partner fallback inside the existing
+  loader) is required before org-less reports can render branded. Confirm the
+  branding source table has a partner axis before implementation.
+
+---
+
+## 10. Implementation checklist (for the follow-up PR)
+
+- [ ] `reports.ts`: nullable `orgId`, add `partnerId`.
+- [ ] Migration `2026-07-XX-a-report-type-fleet-rollup.sql`: `ALTER TYPE
+      report_type ADD VALUE IF NOT EXISTS 'fleet_posture_rollup'` (one line, its
+      own file).
+- [ ] Migration `2026-07-XX-b-partner-owned-reports.sql`: `ADD COLUMN` /
+      `DROP NOT NULL` / one-owner CHECK / partner index / dual-axis RLS on
+      `reports` / **partner-OR fix on `report_runs`'s four policies**.
+- [ ] `rls-coverage.integration.test.ts`: add `reports` to
+      `DUAL_AXIS_TENANT_TABLES` (with rationale comment); keep `report_runs` in
+      the FK-child map.
+- [ ] `reportsPartnerRls.integration.test.ts`: functional cross-partner forge
+      (42501), XOR CHECK (23514), partner-owned run visibility.
+- [ ] `schemas.ts`: `reportTypeSchema` + `fleet_posture_rollup`; `ownerScope` on
+      `createReportSchema` (create-only).
+- [ ] `securityCompliance`/new `generateFleetPostureRollup` + dispatcher wiring.
+- [ ] `reportPdf.ts`: `fleet_posture_rollup` branch — scorecard cover + per-org
+      table + truncation line.
+- [ ] `routes/reports/core.ts` + `helpers.ts` + `runs.ts`: partner-axis branches
+      (create gate, list OR, access-check partner branch).
+- [ ] `reportScheduleWorker.ts`: partner-timezone leftJoin branch + partner
+      dispatch + partner-branding fallback.
+- [ ] Web: `ReportBuilder` owner-scope selector (partner-scope only),
+      `ReportsList` partner-wide badge.
+- [ ] Cap + truncation logging (default 100).
+
+---
+
+## Self-review notes
+
+- **Grounded against current code**, not the brief's line numbers: `report_runs`
+  is an FK-child through `reports` (`rls-coverage...:289`), *not* a table with
+  its own `org_id` — the single most important correctness item here, and the
+  brief's dual-owner discussion would silently break it without §2.4.
+- The `orgAccess === 'all'` gate lives on `c.get('permissions').orgAccess`
+  (`crud.ts:75-78`); #2143 later added `partnerOrgAccess` to `AuthContext` and a
+  `canManagePartnerWidePolicies()` helper — the implementer should prefer that
+  single capability check if it's available on this branch, and enforce it on
+  update/delete too (not just create), per the #2143 lesson.
+- The schedule worker's `innerJoin organizations` (`:133`) is a real footgun for
+  org-less reports — flagged as `leftJoin` + direct partner join.
+- Enum-value addition is specified as its own single-statement migration
+  (`-a-` before the `-b-` schema/RLS file), matching
+  `2026-06-29-a-report-type-security-compliance.sql` and the uncommitted-label
+  transaction rule — not folded into the schema migration.

--- a/docs/superpowers/plans/2026-07-01-reports-pdf-enhancements.md
+++ b/docs/superpowers/plans/2026-07-01-reports-pdf-enhancements.md
@@ -943,7 +943,7 @@ In the Schedule `<td>` (currently just the pill), render for recurring reports a
 </td>
 ```
 
-- [ ] **Step 5: Web test.** Extend an existing ReportsList test file (or add `ReportsList.schedule.test.tsx` following `ReportsList.templates.test.tsx`'s fetch-mock setup): a monthly report with `config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'c@d.co'] }` renders text matching `/Next: .+/` and the recipient count `2`; a `one_time` report renders no "Next:" line. Run web reports tests.
+- [ ] **Step 5: Web test.** Extend an existing ReportsList test file (or add `ReportsList.schedule.test.tsx` following `ReportsList.templates.test.tsx`'s fetch-mock setup): a monthly report with `config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'second@example.com'] }` renders text matching `/Next: .+/` and the recipient count `2`; a `one_time` report renders no "Next:" line. Run web reports tests.
 
 - [ ] **Step 6: Commit** — `feat(reports): next-run time and recipient count on report rows`
 

--- a/docs/superpowers/plans/2026-07-01-reports-pdf-enhancements.md
+++ b/docs/superpowers/plans/2026-07-01-reports-pdf-enhancements.md
@@ -1,0 +1,978 @@
+# Reports PDF Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scheduled report emails attach the real branded PDF, the executive summary gets the posture-style designed cover, report rows show next-run + recipients, runs carry trend baselines ("79, up from 74"), and partner-level cross-org reports get a design doc.
+
+**Architecture:** `reportPdf.ts` (pure jsPDF renderer, dependency-clean by design) lifts from `apps/web` into `packages/shared` under a new `./reportPdf` export subpath (NOT the root barrel, so jsPDF never rides along with ordinary shared imports). The API's `reportScheduleWorker` then builds the same branded PDF server-side and attaches it. Executive summary gains a canonical shared type + a designed cover reusing the posture primitives (scorecard, metric grid, recommended actions). Trend baselines are attached to `report_runs.result.previous` at generation time so snapshots stay self-contained. No DB migrations are needed for any task — everything rides in existing `config`/`result` JSONB.
+
+**Tech Stack:** TypeScript, Hono, Drizzle, BullMQ, jsPDF 4 + jspdf-autotable 5 (proven to run headless in Node), Zod 4, React, Vitest.
+
+**Branch context:** This branch (`ToddHebebrand/reports-pdf-enhanements`) is stacked on `origin/ToddHebebrand/reports-improvements` (PR #2148, pending merge). After #2148 squash-merges, rebase with `git rebase --onto main origin/ToddHebebrand/reports-improvements`.
+
+## Global Constraints
+
+- Zod 4 idioms: `z.string().guid()` (not `.uuid()`), `z.string().email()` is fine (repo precedent `apps/api/src/routes/users.ts:101`), `z.looseObject({...})` for passthrough objects.
+- `@breeze/shared` ships raw TS source (no build). jsPDF must NOT be re-exported from the root barrel `packages/shared/src/index.ts` — only via the `./reportPdf` subpath.
+- `apps/api` tsup config bundles `@breeze/shared` via `noExternal` — the pattern must also match the new subpath import (use `/^@breeze\/shared/` regex).
+- Never edit shipped migrations; this plan requires **no** migrations.
+- Report renderer stays pure: no network, no DOM, no path-alias imports. `Intl` is allowed.
+- All timestamps shown to users are formatted in the report's timezone (org → partner → UTC chain).
+- API tests use the Drizzle mock patterns from the existing `apps/api/src/jobs/reportScheduleWorker.test.ts`. Web tests are Vitest + jsdom. Run per-package: `pnpm --filter @breeze/api test <file>`, `pnpm --filter @breeze/shared test <file>`, `pnpm --filter @breeze/web test <file>` (web package name may be `web` — check `apps/web/package.json` if the filter misses).
+- Commit after each task with a `feat(reports):`/`fix(reports):` message.
+
+---
+
+### Task 1: Stop stripping `config.schedule` / `config.emailRecipients` on create (bug fix)
+
+`POST /reports` persists `c.req.valid('json').config` — a plain `z.object` that doesn't declare `schedule`, `emailRecipients`, or any of the builder's metadata keys. Zod strips unknown keys, so **reports created via POST lose their cadence detail and recipients** (the schedule worker then falls back to 09:00/monday/1st defaults and never emails anyone). `PUT` used `config: z.any()` so edits survived — which is also a validation gap (memory: validate per-field, don't `z.any()`).
+
+**Files:**
+- Modify: `apps/api/src/routes/reports/schemas.ts`
+- Create: `apps/api/src/routes/reports/schemas.config.test.ts`
+
+**Interfaces:**
+- Produces: `reportConfigSchema` (exported for tests), used by `createReportSchema.config` and `updateReportSchema.config`. Task 3's worker relies on `config.schedule.{time,day,date}` and `config.emailRecipients` surviving create.
+
+- [ ] **Step 1: Write the failing test** — `apps/api/src/routes/reports/schemas.config.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createReportSchema, updateReportSchema } from './schemas';
+
+const builderConfig = {
+  builderType: 'device_inventory',
+  dataSource: 'devices',
+  columns: ['hostname'],
+  filterConditions: [{ field: 'status', operator: 'eq', value: 'online' }],
+  schedule: { time: '09:00', day: 'monday', date: '1' },
+  exportFormats: ['pdf'],
+  emailRecipients: ['client@example.com', 'msp@example.com'],
+};
+
+describe('report config schema', () => {
+  it('preserves schedule detail and emailRecipients on create', () => {
+    const parsed = createReportSchema.parse({
+      name: 'Monthly posture',
+      type: 'security_compliance_posture',
+      schedule: 'monthly',
+      format: 'pdf',
+      config: builderConfig,
+    });
+    expect(parsed.config.schedule).toEqual({ time: '09:00', day: 'monday', date: '1' });
+    expect(parsed.config.emailRecipients).toEqual(['client@example.com', 'msp@example.com']);
+    // Builder metadata must round-trip for the edit page.
+    expect((parsed.config as Record<string, unknown>).builderType).toBe('device_inventory');
+    expect((parsed.config as Record<string, unknown>).exportFormats).toEqual(['pdf']);
+  });
+
+  it('rejects malformed recipients and times', () => {
+    expect(() =>
+      createReportSchema.parse({
+        name: 'x', type: 'compliance',
+        config: { emailRecipients: ['not-an-email'] },
+      })
+    ).toThrow();
+    expect(() =>
+      createReportSchema.parse({
+        name: 'x', type: 'compliance',
+        config: { schedule: { time: '25:99' } },
+      })
+    ).toThrow();
+  });
+
+  it('validates config on update too (was z.any())', () => {
+    expect(() =>
+      updateReportSchema.parse({ config: { emailRecipients: ['nope'] } })
+    ).toThrow();
+    const ok = updateReportSchema.parse({ config: builderConfig });
+    expect(ok.config?.emailRecipients).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run it** — `pnpm --filter @breeze/api test src/routes/reports/schemas.config.test.ts` — expect FAIL (schedule/emailRecipients stripped; update accepts anything).
+
+- [ ] **Step 3: Implement** in `apps/api/src/routes/reports/schemas.ts`. Add above `createReportSchema`:
+
+```ts
+/**
+ * Cadence detail + delivery config persisted inside `config`. The builder
+ * writes these and reportScheduleWorker reads them; they must be declared here
+ * because zod strips unknown object keys — before this schema existed, creates
+ * silently dropped schedule times and email recipients (edits survived only
+ * because update used z.any()).
+ */
+const reportScheduleDetailSchema = z.object({
+  // 24h "HH:MM"
+  time: z.string().regex(/^([01]?\d|2[0-3]):[0-5]\d$/).optional(),
+  // weekday name; the worker lowercases, so accept any case
+  day: z.string().max(16).optional(),
+  // day-of-month "1".."31" as string (builder sends strings)
+  date: z.string().regex(/^([1-9]|[12]\d|3[01])$/).optional()
+});
+
+const reportConfigFields = {
+  dateRange: z.object({
+    start: z.string().optional(),
+    end: z.string().optional(),
+    preset: z.enum(['last_7_days', 'last_30_days', 'last_90_days', 'custom']).optional()
+  }).optional(),
+  filters: z.object({
+    siteIds: z.array(z.string().guid()).optional(),
+    deviceIds: z.array(z.string().guid()).optional(),
+    osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
+    status: z.array(z.string()).optional(),
+    severity: z.array(z.string()).optional()
+  }).optional(),
+  columns: z.array(z.string()).optional(),
+  groupBy: z.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+  schedule: reportScheduleDetailSchema.optional(),
+  emailRecipients: z.array(z.string().email().max(254)).max(50).optional(),
+  ...securityCompliancePostureConfigFields
+};
+
+// Loose: the builder round-trips presentation metadata (builderType, dataSource,
+// filterConditions, aggregation, chartType, exportFormats, templateName…)
+// through config; declared keys above are validated, unknown keys pass through.
+export const reportConfigSchema = z.looseObject(reportConfigFields);
+```
+
+Then in `createReportSchema` replace the inline `config: z.object({...}).optional().default({})` with `config: reportConfigSchema.optional().default({})`, and in `updateReportSchema` replace `config: z.any().optional()` with `config: reportConfigSchema.optional()`. Leave `generateReportSchema` as-is (ad-hoc runs don't persist config).
+
+- [ ] **Step 4: Run tests + typecheck** — `pnpm --filter @breeze/api test src/routes/reports/` and `pnpm --filter @breeze/api typecheck`. Expect PASS. (If `z.looseObject` is unavailable in the pinned Zod, use `z.object(reportConfigFields).passthrough()`.)
+
+- [ ] **Step 5: Commit** — `fix(reports): persist schedule detail + emailRecipients through create validation`
+
+---
+
+### Task 2: Lift `reportPdf.ts` into `packages/shared` (+ Node smoke test)
+
+The renderer is already dependency-clean ("no network, no DOM, no path-alias deps"). Move it verbatim; only its one import changes.
+
+**Files:**
+- Move: `apps/web/src/components/reports/reportPdf.ts` → `packages/shared/src/reportPdf/reportPdf.ts` (via `git mv`)
+- Create: `packages/shared/src/reportPdf/index.ts`, `packages/shared/src/reportPdf/reportPdf.test.ts`
+- Modify: `packages/shared/package.json`, `apps/api/package.json`, `apps/api/tsup.config.ts`, `apps/web/src/components/reports/reportExport.ts`, `apps/web/src/components/reports/reportExport.posture.test.tsx`
+
+**Interfaces:**
+- Produces: `import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf'` — `buildReportPdf(rows: unknown[], opts: BuildOpts): jsPDF`. Also export `type BuildOpts`. Tasks 3, 5, 6 build on this module.
+- Do NOT touch `packages/shared/src/index.ts` (root barrel must stay jsPDF-free).
+
+- [ ] **Step 1: Move the file and fix its one cross-package import**
+
+```bash
+mkdir -p packages/shared/src/reportPdf
+git mv apps/web/src/components/reports/reportPdf.ts packages/shared/src/reportPdf/reportPdf.ts
+```
+
+In the moved file change line 3 `import type { PostureSummary } from '@breeze/shared';` → `import type { PostureSummary } from '../types/postureReport';` and export `BuildOpts` (`type BuildOpts` → `export type BuildOpts`). Create `packages/shared/src/reportPdf/index.ts`:
+
+```ts
+export { buildReportPdf } from './reportPdf';
+export type { ReportBranding, BuildOpts } from './reportPdf';
+```
+
+- [ ] **Step 2: Wire packages.** `packages/shared/package.json`: add to `exports`: `"./reportPdf": "./src/reportPdf/index.ts"`; add to `dependencies`: `"jspdf": "^4.2.1", "jspdf-autotable": "^5.0.8"`. `apps/api/package.json`: add the same two to `dependencies` (tsup externalizes node_modules imports found inside bundled shared source; the API must resolve them at runtime). `apps/api/tsup.config.ts`: change `noExternal: ['@breeze/shared', 'dotenv']` → `noExternal: [/^@breeze\/shared/, 'dotenv']` (the string form doesn't match the `/reportPdf` subpath). Run `pnpm install`.
+
+- [ ] **Step 3: Update web importers.** `apps/web/src/components/reports/reportExport.ts` line 6: `import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';`. `reportExport.posture.test.tsx` line 48: `import type { ReportBranding } from '@breeze/shared/reportPdf';`.
+
+- [ ] **Step 4: Node smoke test** — `packages/shared/src/reportPdf/reportPdf.test.ts` (runs in shared's default Node environment — this is the proof the worker can render):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildReportPdf } from './reportPdf';
+import type { PostureSummary } from '../types/postureReport';
+
+const postureSummary: PostureSummary = {
+  org: { id: 'o1', name: 'Acme Corp' },
+  deviceCount: 2,
+  postureScore: 79,
+  controls: { edrCoveragePct: 50, anyAvCoveragePct: 100, unprotectedCount: 0, encryptionPct: 50, firewallPct: 100, patchCurrentPct: 50 },
+  privilegedAccess: { uacInterceptionEnabled: true, activePamRules: 1 },
+  securityProducts: [{ product: 'Defender', category: 'edr', active: true }],
+};
+const postureRows = [
+  { hostname: 'PC-1', os: 'windows', site: 'HQ', protection: 'Defender', firewall: true, encryption: 'Encrypted', pendingPatches: 0, criticalPatches: 0, openVulnHigh: 0, openVulnCritical: 0, protectionManaged: true },
+  { hostname: 'PC-2', os: 'macos', site: 'HQ', protection: 'No data', firewall: false, encryption: 'Unencrypted', pendingPatches: 3, criticalPatches: 1, openVulnHigh: 2, openVulnCritical: 0, protectionManaged: false },
+];
+const opts = { generatedAt: 'Jul 1, 2026, 9:00 AM', timezone: 'UTC' };
+
+describe('buildReportPdf in Node (no DOM)', () => {
+  it('renders the posture cover + device table', () => {
+    const doc = buildReportPdf(postureRows, { ...opts, reportType: 'security_compliance_posture', summary: postureSummary });
+    expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(1000);
+  });
+
+  it('renders a generic table for row reports', () => {
+    const doc = buildReportPdf([{ hostname: 'PC-1', status: 'online' }], { ...opts, reportType: 'device_inventory' });
+    expect(doc.getNumberOfPages()).toBe(1);
+  });
+
+  it('renders branded chrome with a partner name', () => {
+    const doc = buildReportPdf([], { ...opts, reportType: 'compliance', branding: { name: 'Olive MSP', logoDataUrl: null, logoAspect: null } });
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(500);
+  });
+});
+```
+
+- [ ] **Step 5: Verify everything still builds** — `pnpm --filter @breeze/shared test src/reportPdf`, `pnpm --filter @breeze/shared typecheck`, web tests `pnpm --filter web test src/components/reports` (reportExport + posture tests must stay green), `pnpm --filter @breeze/api build` (proves tsup bundles the subpath). Expect PASS.
+
+- [ ] **Step 6: Commit** — `feat(reports): lift branded PDF renderer into @breeze/shared/reportPdf`
+
+---
+
+### Task 3: Scheduled emails attach the branded PDF
+
+PDF-format reports currently get a link only (`reportScheduleWorker.ts:289` skips attachment for `format === 'pdf'`). Attach the real branded PDF, rendered server-side with partner branding and the report's timezone.
+
+**Files:**
+- Create: `apps/api/src/services/reportBranding.ts`, `apps/api/src/services/reportBranding.test.ts`
+- Modify: `apps/api/src/jobs/reportScheduleWorker.ts` (`emailReportRun`, `processRunScheduledReport`), `apps/api/src/jobs/reportScheduleWorker.test.ts`
+
+**Interfaces:**
+- Consumes: `buildReportPdf`, `ReportBranding` from `@breeze/shared/reportPdf` (Task 2).
+- Produces: `loadReportBrandingForOrg(orgId: string): Promise<ReportBranding>` and `pngAspectFromDataUrl(dataUrl: string): number | null` in `reportBranding.ts`. `emailReportRun` gains `summary`, `branding`, `timezone` fields (Task 6 adds `previous`).
+
+- [ ] **Step 1: Write failing tests for branding helper** — `apps/api/src/services/reportBranding.test.ts`. Mock `../db` like the worker test does. Cases: (a) partner with a `data:image/png;base64,...` logo (use a real 1×2 PNG fixture, e.g. build one with `Buffer` from the canonical 8-byte signature + IHDR — assert `logoAspect === 0.5`); (b) partner with an external `https://` logo URL → `logoDataUrl: null`, name still set (server can't guarantee format; name-only branding is the safe fallback); (c) org with no partner → all-null branding. To make a valid fixture: `const png = (w: number, h: number) => { const b = Buffer.alloc(24); b.write('\x89PNG\r\n\x1a\n', 0, 'binary'); b.writeUInt32BE(13, 8); b.write('IHDR', 12); b.writeUInt32BE(w, 16); b.writeUInt32BE(h, 20); return 'data:image/png;base64,' + b.toString('base64'); };`
+
+- [ ] **Step 2: Implement** `apps/api/src/services/reportBranding.ts`:
+
+```ts
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { organizations, partners } from '../db/schema';
+import type { ReportBranding } from '@breeze/shared/reportPdf';
+
+/** Parse intrinsic width/height from a PNG data URL (IHDR is always the first
+ * chunk: width at byte 16, height at byte 20). Returns null for non-PNG data. */
+export function pngAspectFromDataUrl(dataUrl: string): number | null {
+  if (!dataUrl.startsWith('data:image/png;base64,')) return null;
+  try {
+    const buf = Buffer.from(dataUrl.slice(dataUrl.indexOf(',') + 1), 'base64');
+    if (buf.length < 24 || buf.toString('latin1', 12, 16) !== 'IHDR') return null;
+    const w = buf.readUInt32BE(16);
+    const h = buf.readUInt32BE(20);
+    return w > 0 && h > 0 ? w / h : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Partner branding for server-rendered report PDFs. Mirrors the web's
+ * loadPartnerBranding (reportExport.ts) but headless: only uploaded PNG data
+ * URLs are embeddable (no canvas to re-encode external images); anything else
+ * degrades to name-only branding, matching the renderer's fallback chain.
+ */
+export async function loadReportBrandingForOrg(orgId: string): Promise<ReportBranding> {
+  const empty: ReportBranding = { name: null, logoDataUrl: null, logoAspect: null };
+  const [row] = await db
+    .select({ partnerName: partners.name, partnerSettings: partners.settings })
+    .from(organizations)
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!row?.partnerName) return empty;
+  const settings = (row.partnerSettings ?? {}) as { branding?: { logoUrl?: string } };
+  const logoUrl = settings.branding?.logoUrl ?? null;
+  const aspect = logoUrl ? pngAspectFromDataUrl(logoUrl) : null;
+  return {
+    name: row.partnerName,
+    logoDataUrl: aspect != null ? logoUrl : null,
+    logoAspect: aspect,
+  };
+}
+```
+
+- [ ] **Step 3: Run branding tests** — expect PASS.
+
+- [ ] **Step 4: Write failing worker test.** In `reportScheduleWorker.test.ts`, add a `processRunScheduledReport` case: report with `format: 'pdf'`, config `{ emailRecipients: ['a@b.co'] }`, `generateReportMock` returning `{ rows: [{ hostname: 'PC-1' }], rowCount: 1 }`; mock `../services/reportBranding` → `{ loadReportBrandingForOrg: vi.fn(async () => ({ name: 'Olive MSP', logoDataUrl: null, logoAspect: null })) }`. Assert `sendEmailMock` was called with one attachment whose `filename` ends `.pdf`, `contentType === 'application/pdf'`, and `content` is a Buffer starting with `%PDF` (`content.subarray(0, 4).toString() === '%PDF'` — real jsPDF output, NOT mocked; this is the end-to-end Node proof). Also assert the csv path is unchanged (existing csv test still passes).
+
+- [ ] **Step 5: Implement in the worker.** In `reportScheduleWorker.ts`:
+  - Add imports: `import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';` and `import { loadReportBrandingForOrg } from '../services/reportBranding';` and extend the existing schema import with nothing new (org/partner already imported).
+  - In `processRunScheduledReport`, after loading the report, resolve timezone + branding once:
+
+```ts
+  const [tzRow] = await db
+    .select({ orgSettings: organizations.settings, partnerTimezone: partners.timezone, partnerSettings: partners.settings })
+    .from(organizations)
+    .leftJoin(partners, eq(organizations.partnerId, partners.id))
+    .where(eq(organizations.id, report.orgId))
+    .limit(1);
+  const timeZone = timezoneFor(tzRow?.orgSettings ?? null, tzRow?.partnerTimezone ?? null, tzRow?.partnerSettings ?? null);
+```
+
+  and in the email call pass `format`, `rows`, plus new fields `summary: result.summary`, `timezone: timeZone`, `branding: await loadReportBrandingForOrg(report.orgId)` (fetch branding lazily inside the `recipients.length > 0` block — don't query it when nobody gets email).
+  - Rework `emailReportRun`'s attachment block:
+
+```ts
+async function emailReportRun(opts: {
+  reportName: string;
+  reportType: string;
+  format: string;
+  recipients: string[];
+  rows: unknown[];
+  summary?: Record<string, unknown>;
+  timezone: string;
+  branding: ReportBranding;
+}): Promise<void> {
+  const email = getEmailService();
+  if (!email) {
+    console.warn('[ReportScheduleWorker] Email service not configured; skipping recipients for', opts.reportName);
+    return;
+  }
+  const base = (process.env.DASHBOARD_URL || process.env.PUBLIC_APP_URL || 'http://localhost:4321').replace(/\/$/, '');
+  const link = `${base}/reports`;
+  const dateStr = new Date().toISOString().split('T')[0];
+
+  const attachments = [] as Array<{ filename: string; content: Buffer; contentType?: string }>;
+  if (opts.format === 'pdf') {
+    // The branded PDF is the deliverable an MSP wants landing in the client's
+    // inbox — render it here exactly as the web does (same shared renderer).
+    try {
+      const generatedAt = new Intl.DateTimeFormat('en-US', {
+        timeZone: opts.timezone, dateStyle: 'medium', timeStyle: 'short',
+      }).format(new Date());
+      const doc = buildReportPdf(opts.rows, {
+        reportType: opts.reportType,
+        generatedAt,
+        timezone: opts.timezone,
+        summary: opts.summary as never,
+        branding: opts.branding,
+      });
+      const content = Buffer.from(doc.output('arraybuffer'));
+      if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
+        attachments.push({ filename: `${opts.reportType}-report-${dateStr}.pdf`, content, contentType: 'application/pdf' });
+      }
+    } catch (err) {
+      // A render failure must not block delivery — fall back to the link-only email.
+      console.error('[ReportScheduleWorker] PDF render failed; sending link-only email:', err);
+    }
+  } else if (opts.rows.length > 0) {
+    const csv = rowsToCsv(opts.rows);
+    const content = Buffer.from(csv, 'utf8');
+    if (content.byteLength <= MAX_ATTACHMENT_BYTES) {
+      attachments.push({ filename: `${opts.reportType}-report-${dateStr}.csv`, content, contentType: 'text/csv' });
+    }
+  }
+
+  const bodyText =
+    opts.rows.length > 0
+      ? `Your scheduled report "${opts.reportName}" has been generated with ${opts.rows.length} record${opts.rows.length === 1 ? '' : 's'}.`
+      : `Your scheduled report "${opts.reportName}" has been generated.`;
+  const attachmentNote =
+    attachments.length === 0
+      ? 'Open Breeze to view and download the formatted report.'
+      : attachments[0]!.contentType === 'application/pdf'
+        ? 'The formatted report is attached as a PDF.'
+        : 'The data is attached as CSV; open Breeze for the fully formatted report.';
+  // ... sendEmail call unchanged (subject/html/text/attachments)
+}
+```
+
+  Keep the existing `sendEmail` call. Note the `rows.length` body line: for row-less summary reports (executive summary) prefer the bare "has been generated." line — the `rows.length > 0` ternary already does this.
+
+- [ ] **Step 6: Run worker tests** — `pnpm --filter @breeze/api test src/jobs/reportScheduleWorker.test.ts` — expect PASS (including the `%PDF` magic-byte assertion). Then `pnpm --filter @breeze/api typecheck && pnpm --filter @breeze/api build`.
+
+- [ ] **Step 7: Commit** — `feat(reports): attach branded PDF to scheduled report emails`
+
+---
+
+### Task 4: Canonical `ExecutiveSummary` type + org name in the generator
+
+The exec summary snapshot crosses the API→shared-renderer boundary and is persisted, so it gets the same single-sourced-type treatment as `PostureSummary`. The generator currently omits the org name the cover needs.
+
+**Files:**
+- Create: `packages/shared/src/types/executiveSummaryReport.ts`
+- Modify: `packages/shared/src/types/index.ts` (add `export * from './executiveSummaryReport';` beside the postureReport export), `apps/api/src/services/reportGenerationService.ts` (`generateExecutiveSummaryReport`)
+- Create: `apps/api/src/services/reportGenerationService.execSummary.test.ts`
+
+**Interfaces:**
+- Produces: `ExecutiveSummary` type importable from `@breeze/shared` (types are erased — safe in the root barrel). Generator returns `{ summary: ExecutiveSummary; generatedAt: string }` with `org.name` populated. Task 5's renderer consumes this type.
+
+- [ ] **Step 1: Create the type** — `packages/shared/src/types/executiveSummaryReport.ts`:
+
+```ts
+/**
+ * Canonical shape of the Executive Summary report's `summary` snapshot.
+ * Single-sourced (API produces with `satisfies`, the shared PDF renderer
+ * consumes) and persisted in report_runs.result, so all fields are optional —
+ * a legacy snapshot must still render. Mirrors postureReport.ts.
+ */
+export type ExecutiveSummaryDevices = {
+  total?: number;
+  online?: number;
+  offline?: number;
+  /** Share of managed devices online, 0-100. */
+  healthPercentage?: number;
+};
+
+export type ExecutiveSummaryAlerts = {
+  total?: number;
+  critical?: number;
+  high?: number;
+  resolved?: number;
+  /** Share of window alerts resolved, 0-100. */
+  resolutionRate?: number;
+};
+
+export type ExecutiveSummary = {
+  org?: { id?: string; name?: string };
+  devices?: ExecutiveSummaryDevices;
+  alerts?: ExecutiveSummaryAlerts;
+  osDistribution?: Record<string, number>;
+  siteBreakdown?: Array<{ site: string; count: number }>;
+};
+```
+
+- [ ] **Step 2: Write the failing generator test** — `reportGenerationService.execSummary.test.ts` with Drizzle `../db` mocks (follow the worker test's `selectMock` pattern; each `db.select()` call in the generator returns the next queued result — queue: org row `[{ id: 'org-1', name: 'Acme Corp' }]`, device stats, alert stats, os distribution, site breakdown). Assert `result.summary.org` equals `{ id: 'org-1', name: 'Acme Corp' }` and the existing numeric shape is unchanged (`devices.total`, `alerts.resolutionRate`, etc.). Note the org-name query must be added FIRST in the generator so mock ordering is stable.
+
+- [ ] **Step 3: Implement.** In `generateExecutiveSummaryReport`: import `organizations` into the service's schema import list and `import type { ExecutiveSummary } from '@breeze/shared';`. At the top of the function add:
+
+```ts
+  const [orgRow] = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+```
+
+Then in the return, add `org: { id: orgId, name: orgRow?.name ?? '' },` as the first key of `summary`, and change `summary: { ... }` to `summary: { ... } satisfies ExecutiveSummary`.
+
+- [ ] **Step 4: Run** — `pnpm --filter @breeze/api test src/services/reportGenerationService.execSummary.test.ts` + `pnpm --filter @breeze/shared typecheck` — expect PASS.
+
+- [ ] **Step 5: Commit** — `feat(reports): canonical ExecutiveSummary type with org identity`
+
+---
+
+### Task 5: Executive summary PDF — the posture treatment
+
+Today `executive_summary` PDFs render "No data available" (no `rows`, and the rich `summary` is ignored). Give it the designed cover: fleet-health scorecard, thematic metric grids, OS/site breakdowns, recommended actions. Same skeleton as posture, different data.
+
+**Files:**
+- Modify: `packages/shared/src/reportPdf/reportPdf.ts`
+- Modify: `packages/shared/src/reportPdf/reportPdf.test.ts`
+
+**Interfaces:**
+- Consumes: `ExecutiveSummary` (Task 4), posture primitives already in the file (`drawTitleBlock`, `drawScorecard`, `drawSectionHeading`, `drawMetricGrid`, `drawLegend`, `Recommendation`, `drawRecommendedActions` internals).
+- Produces: `BuildOpts.summary` widens to `PostureSummary | ExecutiveSummary`; `buildReportPdf` dispatches `executive_summary` → `renderExecutiveSummaryCover`. Web callers need no change (they already pass `data.summary` through for all types).
+
+- [ ] **Step 1: Failing test.** Add to `reportPdf.test.ts`:
+
+```ts
+import type { ExecutiveSummary } from '../types/executiveSummaryReport';
+
+const execSummary: ExecutiveSummary = {
+  org: { id: 'o1', name: 'Acme Corp' },
+  devices: { total: 42, online: 39, offline: 3, healthPercentage: 93 },
+  alerts: { total: 18, critical: 2, high: 5, resolved: 12, resolutionRate: 67 },
+  osDistribution: { windows: 30, macos: 10, linux: 2 },
+  siteBreakdown: [
+    { site: 'HQ', count: 25 },
+    { site: 'Warehouse', count: 12 },
+    { site: 'Remote', count: 5 },
+  ],
+};
+
+it('renders the executive summary cover from summary (no rows)', () => {
+  const doc = buildReportPdf([], { ...opts, reportType: 'executive_summary', summary: execSummary });
+  expect(doc.getNumberOfPages()).toBe(1);
+  expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(2000);
+});
+
+it('falls back to the generic empty page when an exec summary has no summary', () => {
+  const doc = buildReportPdf([], { ...opts, reportType: 'executive_summary' });
+  expect(doc.getNumberOfPages()).toBe(1);
+});
+```
+
+Run: `pnpm --filter @breeze/shared test src/reportPdf` — the first new test fails only after Step 2's size assertion (a blank "No data" page is small); verify it FAILS before implementing.
+
+- [ ] **Step 2: Implement the renderer.** In `reportPdf.ts`:
+  1. Change the import line to `import type { PostureSummary } from '../types/postureReport';` + `import type { ExecutiveSummary } from '../types/executiveSummaryReport';` and widen `BuildOpts.summary?: PostureSummary | ExecutiveSummary;`.
+  2. In `buildReportPdf`, keep the posture branch keying on `reportType === 'security_compliance_posture'` (cast `opts.summary as PostureSummary` where passed down), and add before the generic fallback:
+
+```ts
+  } else if (opts.reportType === 'executive_summary' && opts.summary && 'devices' in (opts.summary as object)) {
+    renderExecutiveSummaryCover(doc, opts.summary as ExecutiveSummary, opts);
+    drawHeaderBand(doc, opts);
+    drawFooter(doc, opts);
+  } else {
+```
+
+  3. Add the renderer + recommendations (place after the posture cover section):
+
+```ts
+// ----------------------------------------------------------------------------
+// Executive summary cover: the QBR artifact. Same designed skeleton as the
+// posture cover — fleet-health scorecard, thematic metric grids, recommended
+// actions — driven by the ExecutiveSummary snapshot instead of posture data.
+// ----------------------------------------------------------------------------
+
+function buildExecRecommendations(summary: ExecutiveSummary): Recommendation[] {
+  const d = summary.devices ?? {};
+  const a = summary.alerts ?? {};
+  const recs: Recommendation[] = [];
+  if ((d.offline ?? 0) > 0) {
+    recs.push({ severity: 'bad', text: `Investigate ${d.offline} offline device${d.offline === 1 ? '' : 's'} — offline endpoints are unmonitored and unpatched.` });
+  }
+  const unresolvedCritical = Math.max(0, (a.critical ?? 0) - (a.resolved ?? 0));
+  if ((a.critical ?? 0) > 0) {
+    recs.push({ severity: 'bad', text: `Triage the ${a.critical} critical alert${a.critical === 1 ? '' : 's'} raised in this reporting window${unresolvedCritical > 0 ? '' : ' (all resolved — verify root causes)'}.` });
+  }
+  if (a.resolutionRate != null && a.resolutionRate < 80 && (a.total ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Raise the alert resolution rate — ${a.resolutionRate}% of alerts were resolved against an 80% target.` });
+  }
+  if (d.healthPercentage != null && d.healthPercentage < 90 && (d.total ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Restore fleet health to 90%+ — ${d.healthPercentage}% of devices are currently online.` });
+  }
+  if ((a.high ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Review ${a.high} high-severity alert${a.high === 1 ? '' : 's'} for recurring patterns worth automating away.` });
+  }
+  return [...recs.filter((r) => r.severity === 'bad'), ...recs.filter((r) => r.severity === 'warn')];
+}
+
+function renderExecutiveSummaryCover(doc: jsPDF, summary: ExecutiveSummary, opts: BuildOpts): void {
+  const d = summary.devices ?? {};
+  const a = summary.alerts ?? {};
+  const total = d.total ?? 0;
+
+  let y = drawTitleBlock(
+    doc,
+    'Executive Summary',
+    summary.org?.name ?? '',
+    `Generated ${opts.generatedAt}   ·   ${total} managed device${total === 1 ? '' : 's'}`,
+    PAGE.bandH + 8,
+  );
+
+  if (d.healthPercentage != null) {
+    const offline = d.offline ?? 0;
+    const stats: ScoreStat[] = [
+      { label: 'Devices online', value: `${d.online ?? 0}/${total}`, tone: offline > 0 ? C.warning : C.success },
+      { label: 'Critical alerts', value: String(a.critical ?? 0), tone: (a.critical ?? 0) > 0 ? C.danger : C.success },
+      { label: 'Alerts resolved', value: a.resolutionRate == null ? 'N/A' : `${a.resolutionRate}%`, tone: (a.resolutionRate ?? 100) >= 80 ? C.success : C.warning },
+    ];
+    y = drawScorecard(doc, d.healthPercentage, 'Fleet health — share of managed devices online', stats, y);
+    set.text(doc, C.faint);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7);
+    doc.text(
+      'Fleet health: percentage of managed devices reporting online. Alert figures cover the configured reporting window.',
+      PAGE.mx,
+      y - 2.5,
+    );
+    y += 1.5;
+  }
+
+  const overviewHeadingY = y + 2;
+  y = drawSectionHeading(doc, 'Fleet & alert overview', overviewHeadingY);
+  drawLegend(doc, overviewHeadingY);
+  // Left column: device availability. Right column: alert activity.
+  // Column-major fill, so array order = reading order per column.
+  const deviceMetrics: Metric[] = [
+    { label: 'Managed devices', value: String(total), status: 'neutral' },
+    { label: 'Online now', value: String(d.online ?? 0), status: pctStatus(d.healthPercentage) },
+    { label: 'Offline', value: String(d.offline ?? 0), status: (d.offline ?? 0) > 0 ? 'warn' : 'good', target: 'none' },
+    { label: 'Fleet health', value: d.healthPercentage == null ? 'N/A' : `${d.healthPercentage}%`, status: pctStatus(d.healthPercentage), target: '>=90%' },
+  ];
+  const alertMetrics: Metric[] = [
+    { label: 'Alerts in window', value: String(a.total ?? 0), status: 'neutral' },
+    { label: 'Critical', value: String(a.critical ?? 0), status: (a.critical ?? 0) > 0 ? 'bad' : 'good', target: 'none' },
+    { label: 'High severity', value: String(a.high ?? 0), status: (a.high ?? 0) > 0 ? 'warn' : 'good', target: 'none' },
+    { label: 'Resolution rate', value: a.resolutionRate == null ? 'N/A' : `${a.resolutionRate}%`, status: pctStatus(a.resolutionRate, 80, 50), target: '>=80%' },
+  ];
+  y = drawMetricGrid(doc, [...deviceMetrics, ...alertMetrics], y);
+
+  // OS + site composition, side by side via the same two-column grid: left
+  // column = OS distribution, right column = largest sites. Pad the shorter
+  // list so column-major fill keeps each theme in its own column.
+  const osEntries = Object.entries(summary.osDistribution ?? {});
+  const sites = summary.siteBreakdown ?? [];
+  if (osEntries.length > 0 || sites.length > 0) {
+    y = drawSectionHeading(doc, 'Fleet composition', y + 2.5);
+    const MAX_COMPOSITION_ROWS = 5;
+    const osMetrics: Metric[] = osEntries
+      .sort(([, x], [, z]) => z - x)
+      .slice(0, MAX_COMPOSITION_ROWS)
+      .map(([os, count]) => ({
+        label: OS_LABELS[os.toLowerCase()] ?? titleCase(os),
+        value: `${count} device${count === 1 ? '' : 's'}`,
+        status: 'neutral' as MetricStatus,
+      }));
+    const shownSites = sites.slice(0, MAX_COMPOSITION_ROWS);
+    const siteMetrics: Metric[] = shownSites.map((s) => ({
+      label: s.site,
+      value: `${s.count} device${s.count === 1 ? '' : 's'}`,
+      status: 'neutral' as MetricStatus,
+    }));
+    if (sites.length > MAX_COMPOSITION_ROWS) {
+      const rest = sites.slice(MAX_COMPOSITION_ROWS).reduce((acc, s) => acc + s.count, 0);
+      siteMetrics[MAX_COMPOSITION_ROWS - 1] = {
+        label: `${shownSites[MAX_COMPOSITION_ROWS - 1]!.site} + ${sites.length - MAX_COMPOSITION_ROWS} more`,
+        value: `${(shownSites[MAX_COMPOSITION_ROWS - 1]!.count) + rest} devices`,
+        status: 'neutral',
+      };
+    }
+    const rows = Math.max(osMetrics.length, siteMetrics.length);
+    const pad = (arr: Metric[]): Metric[] =>
+      arr.concat(Array.from({ length: rows - arr.length }, () => ({ label: '', value: '', status: 'na' as MetricStatus })));
+    y = drawMetricGrid(doc, [...pad(osMetrics), ...pad(siteMetrics)], y);
+  }
+
+  // Recommended actions close the page — the reader leaves with next steps.
+  const recs = buildExecRecommendations(summary);
+  if (recs.length > 0) {
+    const rowH = 5.2;
+    const maxY = PAGE.footY - 4;
+    if (y + 5 + rowH <= maxY) {
+      const fit = Math.min(recs.length, 5, Math.floor((maxY - y - 5) / rowH));
+      y = drawSectionHeading(doc, 'Recommended actions', y + 2.5);
+      doc.setFontSize(9);
+      recs.slice(0, fit).forEach((rec, i) => {
+        set.text(doc, rec.severity === 'bad' ? C.danger : C.warning);
+        doc.setFont('helvetica', 'bold');
+        doc.text(`${i + 1}.`, PAGE.mx + 1, y);
+        set.text(doc, C.ink);
+        doc.setFont('helvetica', 'normal');
+        doc.text(rec.text, PAGE.mx + 6.5, y);
+        y += rowH;
+      });
+    }
+  }
+}
+```
+
+  Note: padding cells with `label: ''` renders empty grid slots (hairline only) — acceptable; if it looks noisy in visual verification, suppress the separator for empty labels inside `drawMetricGrid` (`if (!m.label) return;` before drawing).
+
+- [ ] **Step 3: Run shared tests** — expect PASS. Also `pnpm --filter web test src/components/reports` (download path already passes `summary` for every type — the old "harmless for other types" comment is now load-bearing; update it to say posture/exec covers consume it).
+
+- [ ] **Step 4: Visual verification (headless harness).** Write a scratchpad script (Node, run from repo root) that imports the shared renderer, renders (a) the exec fixture above and (b) the posture fixture, writes PDFs, then `pdftoppm -png -r 80`. Read the PNGs and check: no overlapping sections, legend right-aligned, composition columns read as two themes, recommendations visible. Iterate until clean.
+
+```bash
+cd packages/shared && node --experimental-strip-types /private/tmp/claude-501/-Users-toddhebebrand-orca-workspaces-breeze-reports-pdf-enhanements/9becc41b-da35-41ee-99b0-88dd3dd306f0/scratchpad/renderExec.mts
+pdftoppm -png -r 80 <out>.pdf <out>
+```
+
+- [ ] **Step 5: Commit** — `feat(reports): designed executive summary PDF cover (scorecard, composition, actions)`
+
+---
+
+### Task 6: Trend baselines — "score 79, up from 74 last month"
+
+Runs already persist snapshots in `report_runs.result`. Attach the prior run's summary as `result.previous` at generation time (snapshot stays self-contained), and surface deltas in the scorecards and the scheduled email.
+
+**Files:**
+- Modify: `apps/api/src/services/reportGenerationService.ts` (type + helper), `apps/api/src/routes/reports/runs.ts` (POST generate), `apps/api/src/jobs/reportScheduleWorker.ts` (worker path + email line), `packages/shared/src/reportPdf/reportPdf.ts` (BuildOpts + scorecard trend), `apps/web/src/components/reports/ReportsList.tsx` + `apps/web/src/components/reports/reportExport.ts` (pass-through)
+- Create: `apps/api/src/services/reportGenerationService.previous.test.ts`
+- Modify tests: `packages/shared/src/reportPdf/reportPdf.test.ts`, `apps/api/src/jobs/reportScheduleWorker.test.ts`
+
+**Interfaces:**
+- Produces: `ReportResult.previous?: { generatedAt: string | null; summary?: Record<string, unknown> }`; `previousBaselineFor(reportId: string): Promise<ReportResult['previous']>` exported from `reportGenerationService.ts`; `BuildOpts.previous?: { generatedAt?: string | null; summary?: unknown }`; `drawScorecard` gains optional `trend` param.
+
+- [ ] **Step 1: Failing helper test** — `reportGenerationService.previous.test.ts` (Drizzle mocks): prior completed run exists with `result: { summary: { postureScore: 74 }, generatedAt: '2026-06-01T09:00:00Z' }` → helper returns `{ generatedAt: '2026-06-01T09:00:00Z', summary: { postureScore: 74 } }`; no prior run → `undefined`; prior run without `summary` → `undefined`.
+
+- [ ] **Step 2: Implement helper.** In `reportGenerationService.ts` add `reportRuns` to the schema import and `desc` is already imported:
+
+```ts
+export type ReportResult = {
+  rows?: unknown[];
+  rowCount?: number;
+  summary?: Record<string, unknown>;
+  generatedAt?: string;
+  /** Slim baseline from the previous completed run of the same report, copied
+   * into the snapshot at generation time so trend deltas ("79, up from 74")
+   * render from the stored result alone. Only `summary` is copied — never
+   * `previous` — so baselines don't chain. */
+  previous?: { generatedAt: string | null; summary?: Record<string, unknown> };
+};
+
+/** Baseline from the most recent completed run of this report, if it captured
+ * a summary. Call BEFORE marking the new run completed. */
+export async function previousBaselineFor(reportId: string): Promise<ReportResult['previous']> {
+  const [prior] = await db
+    .select({ result: reportRuns.result, completedAt: reportRuns.completedAt })
+    .from(reportRuns)
+    .where(and(eq(reportRuns.reportId, reportId), eq(reportRuns.status, 'completed')))
+    .orderBy(desc(reportRuns.completedAt))
+    .limit(1);
+  const priorResult = prior?.result as ReportResult | null | undefined;
+  if (!priorResult?.summary || typeof priorResult.summary !== 'object') return undefined;
+  return {
+    generatedAt: priorResult.generatedAt ?? prior?.completedAt?.toISOString() ?? null,
+    summary: priorResult.summary,
+  };
+}
+```
+
+(`and` is already imported in the service.)
+
+- [ ] **Step 3: Wire both generation paths.** In `runs.ts` POST `/:id/generate`, after `const result = await generateReport(...)` add:
+
+```ts
+      const previous = await previousBaselineFor(report.id);
+      if (previous) result.previous = previous;
+```
+
+(import `previousBaselineFor` beside `generateReport`). Same two lines in the worker's `processRunScheduledReport` after its `generateReport` call, and pass `previous: result.previous` into `emailReportRun`.
+
+- [ ] **Step 4: Renderer deltas.** In `reportPdf.ts`:
+  1. `BuildOpts` gains `previous?: { generatedAt?: string | null; summary?: unknown };`.
+  2. `drawScorecard` signature gains a final optional param `trend?: { delta: number; sinceLabel: string } | null` and, after the band chip block, renders it:
+
+```ts
+  // Trend vs the previous run: "+5 since Jun 1" — the line that makes a
+  // recurring report feel alive. Muted date; signed delta carries the colour.
+  if (trend && trend.delta !== 0) {
+    const up = trend.delta > 0;
+    set.text(doc, up ? C.success : C.danger);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    const deltaStr = `${up ? '▲' : '▼'} ${up ? '+' : ''}${trend.delta}`;
+    const chipRight = x + 10 + chipW;
+    doc.text(deltaStr, chipRight + 4, top + 27.8);
+    set.text(doc, C.muted);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.text(trend.sinceLabel, chipRight + 4 + doc.getTextWidth(deltaStr) + 2, top + 27.8);
+  }
+```
+
+  (`chipW` is in scope in `drawScorecard`. If jsPDF's helvetica lacks the ▲/▼ glyphs — check the rendered PNG in Step 7 — use `'+5'`/`'-3'` alone.)
+  3. Add a small helper + use it in both covers:
+
+```ts
+function trendFor(opts: BuildOpts, current: number | null | undefined, pick: (s: Record<string, unknown>) => unknown): { delta: number; sinceLabel: string } | null {
+  const prevSummary = opts.previous?.summary;
+  if (current == null || !prevSummary || typeof prevSummary !== 'object') return null;
+  const prevRaw = pick(prevSummary as Record<string, unknown>);
+  const prev = typeof prevRaw === 'number' ? prevRaw : null;
+  if (prev == null) return null;
+  let since = 'vs previous run';
+  const iso = opts.previous?.generatedAt;
+  if (iso) {
+    const d = new Date(iso);
+    if (!isNaN(d.getTime())) {
+      since = `since ${new Intl.DateTimeFormat('en-US', { timeZone: opts.timezone, month: 'short', day: 'numeric' }).format(d)}`;
+    }
+  }
+  return { delta: current - prev, sinceLabel: since };
+}
+```
+
+  Posture cover: `y = drawScorecard(doc, summary.postureScore, caption, stats, y, trendFor(opts, summary.postureScore, (s) => (s as { postureScore?: unknown }).postureScore));`
+  Exec cover: `y = drawScorecard(doc, d.healthPercentage, '...', stats, y, trendFor(opts, d.healthPercentage, (s) => ((s as { devices?: { healthPercentage?: unknown } }).devices ?? {}).healthPercentage));`
+
+  4. Renderer test: posture fixture + `previous: { generatedAt: '2026-06-01T00:00:00Z', summary: { postureScore: 74 } }` renders without throwing and byte size exceeds the no-trend render (the delta text adds content).
+
+- [ ] **Step 5: Email trend line.** In the worker, build a summary line and prepend it to the email body when available:
+
+```ts
+function trendLineOf(result: ReportResult): string | null {
+  const s = result.summary as Record<string, unknown> | undefined;
+  const prev = result.previous?.summary as Record<string, unknown> | undefined;
+  const score = typeof s?.postureScore === 'number' ? (s.postureScore as number) : null;
+  if (score != null) {
+    const prevScore = typeof prev?.postureScore === 'number' ? (prev.postureScore as number) : null;
+    if (prevScore != null && prevScore !== score) {
+      return `Posture score ${score} — ${score > prevScore ? 'up' : 'down'} from ${prevScore} last run.`;
+    }
+    return `Posture score ${score}.`;
+  }
+  const health = (s?.devices as { healthPercentage?: unknown } | undefined)?.healthPercentage;
+  if (typeof health === 'number') {
+    const prevHealth = (prev?.devices as { healthPercentage?: unknown } | undefined)?.healthPercentage;
+    if (typeof prevHealth === 'number' && prevHealth !== health) {
+      return `Fleet health ${health}% — ${health > prevHealth ? 'up' : 'down'} from ${prevHealth}% last run.`;
+    }
+    return `Fleet health ${health}%.`;
+  }
+  return null;
+}
+```
+
+  `emailReportRun` gains `previous`/`summary` already (Task 3); pass the whole `result` or add `trendLine: trendLineOf(result)` and render it as an extra `renderParagraph` (and a line in `text:`). Worker test: posture run with previous → `sendEmailMock` html contains `up from 74`.
+
+- [ ] **Step 6: Web pass-through.** `reportExport.ts`: `exportReport` opts gain `previous?: { generatedAt?: string | null; summary?: unknown }` and forward to `buildReportPdf`. `ReportsList.tsx` `handleDownload`: `const data = payload.data as { rows?: unknown[]; summary?: unknown; previous?: { generatedAt?: string | null; summary?: unknown } } | undefined;` and pass `previous: data?.previous`.
+
+- [ ] **Step 7: Run all touched suites + visual check.** API service/worker tests, shared renderer tests, web reports tests. Re-run the Step-4/Task-5 harness with a `previous` baseline in the fixture and Read the PNG: delta chip sits beside the band chip without collision; glyphs render (else switch to `+5`).
+
+- [ ] **Step 8: Commit** — `feat(reports): trend baselines in run snapshots, scorecard deltas, email trend line`
+
+---
+
+### Task 7: Next-run + recipients in ReportsList
+
+Users can set a cadence but can't see when it fires next or who receives it. Both are derivable client-side: next run from `schedule` + `config.schedule` (the list endpoint returns full rows including `config`), recipients from `config.emailRecipients`.
+
+**Files:**
+- Create: `packages/shared/src/utils/reportSchedule.ts`, `packages/shared/src/utils/reportSchedule.test.ts`
+- Modify: `packages/shared/src/utils/index.ts` (add `export * from './reportSchedule';`), `apps/api/src/jobs/reportScheduleWorker.ts` (delete local math, re-import), `apps/web/src/components/reports/ReportsList.tsx`
+
+**Interfaces:**
+- Produces: in `@breeze/shared`: `type ScheduleCadence`, `type ScheduleConfig`, `wallClockIn`, `lastOccurrenceKey`, `isDue`, plus new `nextOccurrence(now: Date, cadence: ScheduleCadence, cfg: ScheduleConfig, timeZone: string): { y: number; m: number; d: number; hh: number; mm: number }` and `formatNextOccurrence(occ, opts?: { weekday?: boolean }): string` (e.g. "Mon, Jul 6, 9:00 AM").
+- The worker re-exports `wallClockIn`, `lastOccurrenceKey`, `isDue`, `ScheduleCadence`, `ScheduleConfig` so `reportScheduleWorker.test.ts` keeps importing them from `./reportScheduleWorker` unchanged.
+
+- [ ] **Step 1: Move the math.** Cut from `reportScheduleWorker.ts` the block from `export type ScheduleCadence` down through `isDue` (lines ~61-183: `ScheduleCadence`, `ScheduleConfig`, `DAY_INDEX`, `WEEKDAY_SHORT_INDEX`, `WallClock`, `wallClockIn`, `keyOf`, `shiftDays`, `daysInMonth`, `parseTime`, `lastOccurrenceKey`, `isDue`) into `packages/shared/src/utils/reportSchedule.ts` verbatim (keep the "Occurrence math" comment block). In the worker replace with:
+
+```ts
+import {
+  lastOccurrenceKey,
+  isDue,
+  type ScheduleCadence,
+  type ScheduleConfig,
+} from '@breeze/shared';
+
+// Re-exported so the occurrence-math tests colocated with this worker keep
+// importing from here; the implementation lives in @breeze/shared so the web
+// can compute "next run" from the same math.
+export { lastOccurrenceKey, isDue, wallClockIn } from '@breeze/shared';
+export type { ScheduleCadence, ScheduleConfig } from '@breeze/shared';
+```
+
+(dedupe: one import for use + one re-export is fine, or `export *`-style named re-export only — implementer's choice, keep `tsc` happy.)
+
+- [ ] **Step 2: Add the forward math + formatter** to `reportSchedule.ts`:
+
+```ts
+/**
+ * The next scheduled occurrence strictly after `now`, as wall-clock parts in
+ * `timeZone`. Forward mirror of lastOccurrenceKey — used by the web to show
+ * "Next: Mon, Jul 6, 9:00 AM" without inverse-timezone math (the parts are
+ * formatted directly, never converted back to an instant).
+ */
+export function nextOccurrence(
+  now: Date,
+  cadence: ScheduleCadence,
+  cfg: ScheduleConfig,
+  timeZone: string,
+): { y: number; m: number; d: number; hh: number; mm: number } {
+  const nowWc = wallClockIn(now, timeZone);
+  const nowKey = keyOf(nowWc.y, nowWc.m, nowWc.d, nowWc.hh, nowWc.mm);
+  const { hh, mm } = parseTime(cfg.time);
+
+  if (cadence === 'daily') {
+    let day = { y: nowWc.y, m: nowWc.m, d: nowWc.d };
+    if (keyOf(day.y, day.m, day.d, hh, mm) <= nowKey) day = shiftDays(day.y, day.m, day.d, 1);
+    return { ...day, hh, mm };
+  }
+
+  if (cadence === 'weekly') {
+    const target = DAY_INDEX[(cfg.day ?? 'monday').toLowerCase()] ?? 1;
+    const delta = (target - nowWc.weekday + 7) % 7;
+    let day = shiftDays(nowWc.y, nowWc.m, nowWc.d, delta);
+    if (keyOf(day.y, day.m, day.d, hh, mm) <= nowKey) day = shiftDays(day.y, day.m, day.d, 7);
+    return { ...day, hh, mm };
+  }
+
+  // monthly
+  const wanted = Math.max(1, Math.min(31, Number(cfg.date) || 1));
+  let y = nowWc.y;
+  let m = nowWc.m;
+  let d = Math.min(wanted, daysInMonth(y, m));
+  if (keyOf(y, m, d, hh, mm) <= nowKey) {
+    m += 1;
+    if (m === 13) { m = 1; y += 1; }
+    d = Math.min(wanted, daysInMonth(y, m));
+  }
+  return { y, m, d, hh, mm };
+}
+
+/** Format wall-clock occurrence parts as a display label ("Mon, Jul 6, 9:00 AM").
+ * The parts are already in the schedule's timezone, so format them as UTC to
+ * avoid any further conversion. */
+export function formatNextOccurrence(
+  occ: { y: number; m: number; d: number; hh: number; mm: number },
+  opts?: { weekday?: boolean },
+): string {
+  const instant = new Date(Date.UTC(occ.y, occ.m - 1, occ.d, occ.hh, occ.mm));
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    ...(opts?.weekday ? { weekday: 'short' } : {}),
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(instant);
+}
+```
+
+- [ ] **Step 3: Shared tests** — `reportSchedule.test.ts`: port two or three `lastOccurrenceKey` sanity cases from the worker test (they now live in shared as the canonical home; leave the worker's copies in place — they still pass via re-export) and add `nextOccurrence` cases: daily before/after today's time (2026-07-01T14:00Z, 'UTC', time 16:00 → same day; time 09:00 → Jul 2); weekly wrap (Wednesday now, target monday → Jul 6); monthly clamp (date '31' in June → Jun 30... use: now 2026-06-15, date '31' → {m: 6, d: 30}); year wrap (now 2026-12-20, monthly date '1' → 2027-01-01); `formatNextOccurrence({ y: 2026, m: 7, d: 6, hh: 9, mm: 0 }, { weekday: true })` → `'Mon, Jul 6, 9:00 AM'`. Run shared tests AND `pnpm --filter @breeze/api test src/jobs/reportScheduleWorker.test.ts` (re-exports must keep it green).
+
+- [ ] **Step 4: ReportsList UI.** In `ReportsList.tsx`: import `Mail` from lucide, and `import { nextOccurrence, formatNextOccurrence, type ScheduleCadence, type ScheduleConfig } from '@breeze/shared';`. Add helpers above the component:
+
+```ts
+function scheduleConfigOf(config: Record<string, unknown> | undefined): ScheduleConfig {
+  const raw = config?.schedule;
+  return raw && typeof raw === 'object' ? (raw as ScheduleConfig) : {};
+}
+
+function recipientCountOf(config: Record<string, unknown> | undefined): number {
+  const raw = config?.emailRecipients;
+  return Array.isArray(raw) ? raw.filter((r) => typeof r === 'string' && r.trim() !== '').length : 0;
+}
+```
+
+In the Schedule `<td>` (currently just the pill), render for recurring reports a second muted line. The next run is computed in the viewer's timezone — the worker fires in the org's timezone, so this is a close approximation, not a contract (note it in a code comment):
+
+```tsx
+<td className="px-4 py-3">
+  <span className={cn(/* existing pill unchanged */)}>
+    <Calendar className="h-3 w-3" />
+    {scheduleLabels[report.schedule]}
+  </span>
+  {report.schedule !== 'one_time' && (
+    <p className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+      <span>
+        Next: {formatNextOccurrence(
+          nextOccurrence(new Date(), report.schedule as ScheduleCadence, scheduleConfigOf(report.config), effectiveTimezone),
+          { weekday: report.schedule === 'weekly' }
+        )}
+      </span>
+      {recipientCountOf(report.config) > 0 && (
+        <span className="inline-flex items-center gap-1" title="Email recipients">
+          <Mail className="h-3 w-3" />
+          {recipientCountOf(report.config)}
+        </span>
+      )}
+    </p>
+  )}
+</td>
+```
+
+- [ ] **Step 5: Web test.** Extend an existing ReportsList test file (or add `ReportsList.schedule.test.tsx` following `ReportsList.templates.test.tsx`'s fetch-mock setup): a monthly report with `config: { schedule: { time: '09:00', date: '1' }, emailRecipients: ['a@b.co', 'c@d.co'] }` renders text matching `/Next: .+/` and the recipient count `2`; a `one_time` report renders no "Next:" line. Run web reports tests.
+
+- [ ] **Step 6: Commit** — `feat(reports): next-run time and recipient count on report rows`
+
+---
+
+### Task 8: Partner-level cross-org reports — design doc (no implementation)
+
+Bigger lift (new scope axis; partner-wide-first principle applies). Produce the design pass as its own doc for a follow-up PR.
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-07-01-partner-level-reports-design.md`
+
+- [ ] **Step 1: Write the design doc** covering, concretely against current code:
+  - **Problem:** `reports.orgId` is NOT NULL; partner users only get per-org reports. The MSP-shaped gap is a fleet-wide roll-up — one posture/patch table comparing all their client orgs (the report that sells the MSP's value upward).
+  - **Ownership axis:** follow the config-policy dual-owner precedent (`apps/api/src/db/schema/configurationPolicies.ts:64-81`): make `org_id` nullable, add nullable `partner_id` + one-owner CHECK constraint + indexes, migration `2026-07-XX-partner-owned-reports.sql` (idempotent). RLS: reports currently rides shape-1 auto-discovery on `org_id`; dual-owner needs the shape-4-style `breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)` policy pair and an entry in the RLS contract-test allowlists — call out the FK-child and dual-axis contract blindspots explicitly.
+  - **Report types:** new `fleet_posture_rollup` (and later `fleet_patch_rollup`) enum values; generator loops the partner's orgs (`organizations WHERE partner_id = $1`), reuses `generateSecurityCompliancePostureReport` per org under system context, and emits one row per org (`org, devices, postureScore, unprotected, criticalFindings, patchCurrentPct, …`) plus a partner-level summary (weighted average score, best/worst org). Renderer: one new cover in `@breeze/shared/reportPdf` reusing the scorecard + a per-ORG (not per-device) table; trend baselines from Task 6 apply unchanged.
+  - **Routes:** create accepts `ownerScope: 'partner'` with partner id derived from `auth.partnerId` (never client-supplied) and requires `orgAccess === 'all'` (mirror `configurationPolicies/crud.ts:57-105`); list/get/runs branch on owner axis; the schedule worker's due-query needs a partner-timezone branch for org-less reports.
+  - **Web:** `isPartnerScope` gate (`getJwtClaims()` pattern from `ConfigPolicyCreatePage.tsx:41-46`); builder gets an owner-scope selector shown only to partner-scope users; ReportsList badges partner-wide rows.
+  - **Cost note:** rollup fans out one posture generation per org — enqueue as a normal scheduled run (BullMQ concurrency 2 already throttles); cap orgs per rollup initially (e.g. 100) and log truncation.
+  - **Open questions:** per-org site filters in rollups (skip v1); org-level users must never see partner rollups (RLS + route double-gate); does the rollup email attach one PDF (yes — single artifact is the point).
+
+- [ ] **Step 2: Commit** — `docs(reports): design pass for partner-level cross-org reports`
+
+---
+
+### Task 9: Full verification sweep
+
+- [ ] **Step 1:** `pnpm --filter @breeze/shared test && pnpm --filter @breeze/shared typecheck`
+- [ ] **Step 2:** `pnpm --filter @breeze/api test src/routes/reports src/jobs/reportScheduleWorker.test.ts src/services/reportGenerationService.execSummary.test.ts src/services/reportGenerationService.previous.test.ts src/services/reportBranding.test.ts && pnpm --filter @breeze/api typecheck && pnpm --filter @breeze/api build`
+- [ ] **Step 3:** web: reports component tests + `pnpm --filter web typecheck` (or the repo's `astro check` equivalent — remember tsc skips `.astro`; the Type Check CI job includes test files).
+- [ ] **Step 4:** End-to-end headless render: posture WITH previous baseline + branding, exec summary WITH previous, generic report — `pdftoppm` each and visually Read every page (logo chip, delta chip, composition grids, footer attribution).
+- [ ] **Step 5:** Fix anything found; final commit.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,8 @@
     ".": "./src/index.ts",
     "./types": "./src/types/index.ts",
     "./validators": "./src/validators/index.ts",
-    "./constants": "./src/constants/index.ts"
+    "./constants": "./src/constants/index.ts",
+    "./reportPdf": "./src/reportPdf/index.ts"
   },
   "scripts": {
     "test": "vitest",
@@ -17,9 +18,12 @@
   },
   "dependencies": {
     "disposable-email-domains": "^1.0.62",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.3",
     "typescript": "^5.7.2",
     "vitest": "^4.1.9"
   }

--- a/packages/shared/src/reportPdf/index.ts
+++ b/packages/shared/src/reportPdf/index.ts
@@ -1,0 +1,2 @@
+export { buildReportPdf } from './reportPdf';
+export type { ReportBranding, BuildOpts } from './reportPdf';

--- a/packages/shared/src/reportPdf/reportPdf.test.ts
+++ b/packages/shared/src/reportPdf/reportPdf.test.ts
@@ -77,7 +77,7 @@ describe('buildReportPdf in Node (no DOM)', () => {
       summary: postureSummary,
     });
 
-    // The delta chip ("▲ +5 since Jun 1") is extra drawn content, so the
+    // The delta chip ("+5 since Jun 1") is extra drawn content, so the
     // trended render is strictly larger than the baseline-less one.
     expect(Buffer.from(withTrend.output('arraybuffer')).byteLength).toBeGreaterThan(
       Buffer.from(withoutTrend.output('arraybuffer')).byteLength,

--- a/packages/shared/src/reportPdf/reportPdf.test.ts
+++ b/packages/shared/src/reportPdf/reportPdf.test.ts
@@ -61,4 +61,70 @@ describe('buildReportPdf in Node (no DOM)', () => {
     const doc = buildReportPdf([], { ...opts, reportType: 'compliance', branding: { name: 'Olive MSP', logoDataUrl: null, logoAspect: null } });
     expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(500);
   });
+
+  it('renders a scorecard trend chip when a previous baseline is supplied', () => {
+    const withTrend = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary: postureSummary,
+      previous: { generatedAt: '2026-06-01T00:00:00Z', summary: { postureScore: 74 } },
+    });
+    expect(withTrend.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+
+    const withoutTrend = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary: postureSummary,
+    });
+
+    // The delta chip ("▲ +5 since Jun 1") is extra drawn content, so the
+    // trended render is strictly larger than the baseline-less one.
+    expect(Buffer.from(withTrend.output('arraybuffer')).byteLength).toBeGreaterThan(
+      Buffer.from(withoutTrend.output('arraybuffer')).byteLength,
+    );
+  });
+
+  it('renders an executive-summary trend chip from previous.summary.devices.healthPercentage', () => {
+    const withTrend = buildReportPdf([], {
+      ...opts,
+      reportType: 'executive_summary',
+      summary: execSummary,
+      previous: { generatedAt: '2026-06-01T00:00:00Z', summary: { devices: { healthPercentage: 88 } } },
+    });
+    const withoutTrend = buildReportPdf([], { ...opts, reportType: 'executive_summary', summary: execSummary });
+
+    expect(Buffer.from(withTrend.output('arraybuffer')).byteLength).toBeGreaterThan(
+      Buffer.from(withoutTrend.output('arraybuffer')).byteLength,
+    );
+  });
+
+  it('omits the trend chip when the delta is zero or the previous summary lacks the metric', () => {
+    // Same score as current: no chip drawn (delta === 0 is filtered out), so
+    // byte size matches the no-previous render exactly.
+    const sameScore = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary: postureSummary,
+      previous: { generatedAt: '2026-06-01T00:00:00Z', summary: { postureScore: 79 } },
+    });
+    const noPrevious = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary: postureSummary,
+    });
+    expect(Buffer.from(sameScore.output('arraybuffer')).byteLength).toBe(
+      Buffer.from(noPrevious.output('arraybuffer')).byteLength,
+    );
+
+    // Previous run captured a summary, but not this metric — no crash, no chip.
+    const missingMetric = buildReportPdf(postureRows, {
+      ...opts,
+      reportType: 'security_compliance_posture',
+      summary: postureSummary,
+      previous: { generatedAt: '2026-06-01T00:00:00Z', summary: { unrelated: true } },
+    });
+    expect(Buffer.from(missingMetric.output('arraybuffer')).byteLength).toBe(
+      Buffer.from(noPrevious.output('arraybuffer')).byteLength,
+    );
+  });
 });

--- a/packages/shared/src/reportPdf/reportPdf.test.ts
+++ b/packages/shared/src/reportPdf/reportPdf.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildReportPdf } from './reportPdf';
+import type { PostureSummary } from '../types/postureReport';
+
+const postureSummary: PostureSummary = {
+  org: { id: 'o1', name: 'Acme Corp' },
+  deviceCount: 2,
+  postureScore: 79,
+  controls: { edrCoveragePct: 50, anyAvCoveragePct: 100, unprotectedCount: 0, encryptionPct: 50, firewallPct: 100, patchCurrentPct: 50 },
+  privilegedAccess: { uacInterceptionEnabled: true, activePamRules: 1 },
+  securityProducts: [{ product: 'Defender', category: 'edr', active: true }],
+};
+const postureRows = [
+  { hostname: 'PC-1', os: 'windows', site: 'HQ', protection: 'Defender', firewall: true, encryption: 'Encrypted', pendingPatches: 0, criticalPatches: 0, openVulnHigh: 0, openVulnCritical: 0, protectionManaged: true },
+  { hostname: 'PC-2', os: 'macos', site: 'HQ', protection: 'No data', firewall: false, encryption: 'Unencrypted', pendingPatches: 3, criticalPatches: 1, openVulnHigh: 2, openVulnCritical: 0, protectionManaged: false },
+];
+const opts = { generatedAt: 'Jul 1, 2026, 9:00 AM', timezone: 'UTC' };
+
+describe('buildReportPdf in Node (no DOM)', () => {
+  it('renders the posture cover + device table', () => {
+    const doc = buildReportPdf(postureRows, { ...opts, reportType: 'security_compliance_posture', summary: postureSummary });
+    expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(1000);
+  });
+
+  it('renders a generic table for row reports', () => {
+    const doc = buildReportPdf([{ hostname: 'PC-1', status: 'online' }], { ...opts, reportType: 'device_inventory' });
+    expect(doc.getNumberOfPages()).toBe(1);
+  });
+
+  it('renders branded chrome with a partner name', () => {
+    const doc = buildReportPdf([], { ...opts, reportType: 'compliance', branding: { name: 'Olive MSP', logoDataUrl: null, logoAspect: null } });
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(500);
+  });
+});

--- a/packages/shared/src/reportPdf/reportPdf.test.ts
+++ b/packages/shared/src/reportPdf/reportPdf.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildReportPdf } from './reportPdf';
 import type { PostureSummary } from '../types/postureReport';
+import type { ExecutiveSummary } from '../types/executiveSummaryReport';
 
 const postureSummary: PostureSummary = {
   org: { id: 'o1', name: 'Acme Corp' },
@@ -14,6 +15,17 @@ const postureRows = [
   { hostname: 'PC-1', os: 'windows', site: 'HQ', protection: 'Defender', firewall: true, encryption: 'Encrypted', pendingPatches: 0, criticalPatches: 0, openVulnHigh: 0, openVulnCritical: 0, protectionManaged: true },
   { hostname: 'PC-2', os: 'macos', site: 'HQ', protection: 'No data', firewall: false, encryption: 'Unencrypted', pendingPatches: 3, criticalPatches: 1, openVulnHigh: 2, openVulnCritical: 0, protectionManaged: false },
 ];
+const execSummary: ExecutiveSummary = {
+  org: { id: 'o1', name: 'Acme Corp' },
+  devices: { total: 42, online: 39, offline: 3, healthPercentage: 93 },
+  alerts: { total: 18, critical: 2, high: 5, resolved: 12, resolutionRate: 67 },
+  osDistribution: { windows: 30, macos: 10, linux: 2 },
+  siteBreakdown: [
+    { site: 'HQ', count: 25 },
+    { site: 'Warehouse', count: 12 },
+    { site: 'Remote', count: 5 },
+  ],
+};
 const opts = { generatedAt: 'Jul 1, 2026, 9:00 AM', timezone: 'UTC' };
 
 describe('buildReportPdf in Node (no DOM)', () => {
@@ -25,6 +37,23 @@ describe('buildReportPdf in Node (no DOM)', () => {
 
   it('renders a generic table for row reports', () => {
     const doc = buildReportPdf([{ hostname: 'PC-1', status: 'online' }], { ...opts, reportType: 'device_inventory' });
+    expect(doc.getNumberOfPages()).toBe(1);
+  });
+
+  it('renders the executive summary cover from summary (no rows)', () => {
+    const doc = buildReportPdf([], { ...opts, reportType: 'executive_summary', summary: execSummary });
+    expect(doc.getNumberOfPages()).toBe(1);
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(2000);
+    // The designed cover (scorecard + grids + actions) must render appreciably
+    // more content than the bare "No data" fallback for the same report type.
+    const fallback = buildReportPdf([], { ...opts, reportType: 'executive_summary' });
+    expect(Buffer.from(doc.output('arraybuffer')).byteLength).toBeGreaterThan(
+      Buffer.from(fallback.output('arraybuffer')).byteLength,
+    );
+  });
+
+  it('falls back to the generic empty page when an exec summary has no summary', () => {
+    const doc = buildReportPdf([], { ...opts, reportType: 'executive_summary' });
     expect(doc.getNumberOfPages()).toBe(1);
   });
 

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -53,6 +53,10 @@ export type BuildOpts = {
   /** IANA timezone for formatting ISO date cells in generic tables. */
   timezone: string;
   summary?: PostureSummary | ExecutiveSummary;
+  /** Slim baseline from the previous completed run, when the caller supplied
+   * one (report_runs.result.previous) — drives the scorecard trend chip and
+   * its "since <date>" label. */
+  previous?: { generatedAt?: string | null; summary?: unknown };
   branding?: ReportBranding;
 };
 
@@ -249,6 +253,7 @@ function drawScorecard(
   caption: string,
   stats: ScoreStat[],
   top: number,
+  trend?: { delta: number; sinceLabel: string } | null,
 ): number {
   const x = PAGE.mx;
   const w = PAGE.w - PAGE.mx * 2; // full content width — no dead right half
@@ -279,6 +284,25 @@ function drawScorecard(
   doc.roundedRect(x + 10, top + 24.5, chipW, 4.8, 2.4, 2.4, 'F');
   set.text(doc, C.white);
   doc.text(chipLabel, x + 10 + chipW / 2, top + 27.8, { align: 'center' });
+
+  // Trend vs the previous run: "+5 since Jun 1" — the line that makes a
+  // recurring report feel alive. Muted date; signed delta carries the colour.
+  // Plain +/- text, not a ▲/▼ glyph: jsPDF's built-in helvetica doesn't carry
+  // those glyphs, so they rendered as garbage with a miscalculated width that
+  // overlapped the "since" label (visually confirmed via the PNG harness).
+  if (trend && trend.delta !== 0) {
+    const up = trend.delta > 0;
+    set.text(doc, up ? C.success : C.danger);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    const deltaStr = `${up ? '+' : ''}${trend.delta}`;
+    const chipRight = x + 10 + chipW;
+    doc.text(deltaStr, chipRight + 4, top + 27.8);
+    set.text(doc, C.muted);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.text(trend.sinceLabel, chipRight + 4 + doc.getTextWidth(deltaStr) + 2, top + 27.8);
+  }
 
   // Meter: caption above, track + filled portion, 0/50/100 ticks below.
   const meterX = x + 74;
@@ -330,6 +354,27 @@ function drawScorecard(
   }
 
   return top + h + 6;
+}
+
+/** Delta + "since <date>" label for the scorecard trend chip, derived from
+ * `opts.previous` — the slim baseline copied onto the run snapshot at
+ * generation time. Returns null when there's nothing to compare (no prior
+ * run, or the prior summary didn't capture this metric). */
+function trendFor(opts: BuildOpts, current: number | null | undefined, pick: (s: Record<string, unknown>) => unknown): { delta: number; sinceLabel: string } | null {
+  const prevSummary = opts.previous?.summary;
+  if (current == null || !prevSummary || typeof prevSummary !== 'object') return null;
+  const prevRaw = pick(prevSummary as Record<string, unknown>);
+  const prev = typeof prevRaw === 'number' ? prevRaw : null;
+  if (prev == null) return null;
+  let since = 'vs previous run';
+  const iso = opts.previous?.generatedAt;
+  if (iso) {
+    const d = new Date(iso);
+    if (!isNaN(d.getTime())) {
+      since = `since ${new Intl.DateTimeFormat('en-US', { timeZone: opts.timezone, month: 'short', day: 'numeric' }).format(d)}`;
+    }
+  }
+  return { delta: current - prev, sinceLabel: since };
 }
 
 function drawSectionHeading(doc: jsPDF, text: string, y: number): number {
@@ -483,7 +528,14 @@ function renderPostureCover(
       { label: 'Critical patches/vulns', value: String(agg.criticalCount), tone: agg.criticalCount > 0 ? C.danger : C.success },
       { label: 'Unprotected', value: String(unprotected), tone: unprotected > 0 ? C.danger : C.success },
     ];
-    y = drawScorecard(doc, summary.postureScore, caption, stats, y);
+    y = drawScorecard(
+      doc,
+      summary.postureScore,
+      caption,
+      stats,
+      y,
+      trendFor(opts, summary.postureScore, (s) => (s as { postureScore?: unknown }).postureScore),
+    );
     // Methodology in one muted line, so "79 — GOOD" is auditable rather than oracular.
     set.text(doc, C.faint);
     doc.setFont('helvetica', 'normal');
@@ -742,7 +794,14 @@ function renderExecutiveSummaryCover(doc: jsPDF, summary: ExecutiveSummary, opts
       { label: 'Critical alerts', value: String(a.critical ?? 0), tone: (a.critical ?? 0) > 0 ? C.danger : C.success },
       { label: 'Alerts resolved', value: a.resolutionRate == null ? 'N/A' : `${a.resolutionRate}%`, tone: (a.resolutionRate ?? 100) >= 80 ? C.success : C.warning },
     ];
-    y = drawScorecard(doc, d.healthPercentage, 'Fleet health — share of managed devices online', stats, y);
+    y = drawScorecard(
+      doc,
+      d.healthPercentage,
+      'Fleet health — share of managed devices online',
+      stats,
+      y,
+      trendFor(opts, d.healthPercentage, (s) => ((s as { devices?: { healthPercentage?: unknown } }).devices ?? {}).healthPercentage),
+    );
     set.text(doc, C.faint);
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(7);

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -1,6 +1,7 @@
 import { jsPDF } from 'jspdf';
 import autoTable, { type CellHookData } from 'jspdf-autotable';
 import type { PostureSummary } from '../types/postureReport';
+import type { ExecutiveSummary } from '../types/executiveSummaryReport';
 
 /**
  * Branded PDF design system for Breeze reports.
@@ -51,7 +52,7 @@ export type BuildOpts = {
   generatedAt: string;
   /** IANA timezone for formatting ISO date cells in generic tables. */
   timezone: string;
-  summary?: PostureSummary;
+  summary?: PostureSummary | ExecutiveSummary;
   branding?: ReportBranding;
 };
 
@@ -363,6 +364,9 @@ function drawMetricGrid(doc: jsPDF, metrics: Metric[], top: number): number {
   const rowH = 6.0;
   const rows = Math.ceil(metrics.length / 2);
   metrics.forEach((m, i) => {
+    // Padding slots (empty label, used to keep a shorter column aligned with a
+    // taller one under column-major fill) draw nothing — no stray dot/hairline.
+    if (!m.label) return;
     const col = Math.floor(i / rows);
     const row = i % rows;
     const x = PAGE.mx + col * (colW + 8);
@@ -689,6 +693,144 @@ function drawRecommendedActions(
 }
 
 // ----------------------------------------------------------------------------
+// Executive summary cover: the QBR artifact. Same designed skeleton as the
+// posture cover — fleet-health scorecard, thematic metric grids, recommended
+// actions — driven by the ExecutiveSummary snapshot instead of posture data.
+// ----------------------------------------------------------------------------
+
+function buildExecRecommendations(summary: ExecutiveSummary): Recommendation[] {
+  const d = summary.devices ?? {};
+  const a = summary.alerts ?? {};
+  const recs: Recommendation[] = [];
+  if ((d.offline ?? 0) > 0) {
+    recs.push({ severity: 'bad', text: `Investigate ${d.offline} offline device${d.offline === 1 ? '' : 's'} — offline endpoints are unmonitored and unpatched.` });
+  }
+  const unresolvedCritical = Math.max(0, (a.critical ?? 0) - (a.resolved ?? 0));
+  if ((a.critical ?? 0) > 0) {
+    recs.push({ severity: 'bad', text: `Triage the ${a.critical} critical alert${a.critical === 1 ? '' : 's'} raised in this reporting window${unresolvedCritical > 0 ? '' : ' (all resolved — verify root causes)'}.` });
+  }
+  if (a.resolutionRate != null && a.resolutionRate < 80 && (a.total ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Raise the alert resolution rate — ${a.resolutionRate}% of alerts were resolved against an 80% target.` });
+  }
+  if (d.healthPercentage != null && d.healthPercentage < 90 && (d.total ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Restore fleet health to 90%+ — ${d.healthPercentage}% of devices are currently online.` });
+  }
+  if ((a.high ?? 0) > 0) {
+    recs.push({ severity: 'warn', text: `Review ${a.high} high-severity alert${a.high === 1 ? '' : 's'} for recurring patterns worth automating away.` });
+  }
+  return [...recs.filter((r) => r.severity === 'bad'), ...recs.filter((r) => r.severity === 'warn')];
+}
+
+function renderExecutiveSummaryCover(doc: jsPDF, summary: ExecutiveSummary, opts: BuildOpts): void {
+  const d = summary.devices ?? {};
+  const a = summary.alerts ?? {};
+  const total = d.total ?? 0;
+
+  let y = drawTitleBlock(
+    doc,
+    'Executive Summary',
+    summary.org?.name ?? '',
+    `Generated ${opts.generatedAt}   ·   ${total} managed device${total === 1 ? '' : 's'}`,
+    PAGE.bandH + 8,
+  );
+
+  if (d.healthPercentage != null) {
+    const offline = d.offline ?? 0;
+    const stats: ScoreStat[] = [
+      { label: 'Devices online', value: `${d.online ?? 0}/${total}`, tone: offline > 0 ? C.warning : C.success },
+      { label: 'Critical alerts', value: String(a.critical ?? 0), tone: (a.critical ?? 0) > 0 ? C.danger : C.success },
+      { label: 'Alerts resolved', value: a.resolutionRate == null ? 'N/A' : `${a.resolutionRate}%`, tone: (a.resolutionRate ?? 100) >= 80 ? C.success : C.warning },
+    ];
+    y = drawScorecard(doc, d.healthPercentage, 'Fleet health — share of managed devices online', stats, y);
+    set.text(doc, C.faint);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7);
+    doc.text(
+      'Fleet health: percentage of managed devices reporting online. Alert figures cover the configured reporting window.',
+      PAGE.mx,
+      y - 2.5,
+    );
+    y += 1.5;
+  }
+
+  const overviewHeadingY = y + 2;
+  y = drawSectionHeading(doc, 'Fleet & alert overview', overviewHeadingY);
+  drawLegend(doc, overviewHeadingY);
+  // Left column: device availability. Right column: alert activity.
+  // Column-major fill, so array order = reading order per column.
+  const deviceMetrics: Metric[] = [
+    { label: 'Managed devices', value: String(total), status: 'neutral' },
+    { label: 'Online now', value: String(d.online ?? 0), status: pctStatus(d.healthPercentage) },
+    { label: 'Offline', value: String(d.offline ?? 0), status: (d.offline ?? 0) > 0 ? 'warn' : 'good', target: 'none' },
+    { label: 'Fleet health', value: d.healthPercentage == null ? 'N/A' : `${d.healthPercentage}%`, status: pctStatus(d.healthPercentage), target: '>=90%' },
+  ];
+  const alertMetrics: Metric[] = [
+    { label: 'Alerts in window', value: String(a.total ?? 0), status: 'neutral' },
+    { label: 'Critical', value: String(a.critical ?? 0), status: (a.critical ?? 0) > 0 ? 'bad' : 'good', target: 'none' },
+    { label: 'High severity', value: String(a.high ?? 0), status: (a.high ?? 0) > 0 ? 'warn' : 'good', target: 'none' },
+    { label: 'Resolution rate', value: a.resolutionRate == null ? 'N/A' : `${a.resolutionRate}%`, status: pctStatus(a.resolutionRate, 80, 50), target: '>=80%' },
+  ];
+  y = drawMetricGrid(doc, [...deviceMetrics, ...alertMetrics], y);
+
+  // OS + site composition, side by side via the same two-column grid: left
+  // column = OS distribution, right column = largest sites. Pad the shorter
+  // list so column-major fill keeps each theme in its own column.
+  const osEntries = Object.entries(summary.osDistribution ?? {});
+  const sites = summary.siteBreakdown ?? [];
+  if (osEntries.length > 0 || sites.length > 0) {
+    y = drawSectionHeading(doc, 'Fleet composition', y + 2.5);
+    const MAX_COMPOSITION_ROWS = 5;
+    const osMetrics: Metric[] = osEntries
+      .sort(([, x], [, z]) => z - x)
+      .slice(0, MAX_COMPOSITION_ROWS)
+      .map(([os, count]) => ({
+        label: OS_LABELS[os.toLowerCase()] ?? titleCase(os),
+        value: `${count} device${count === 1 ? '' : 's'}`,
+        status: 'neutral' as MetricStatus,
+      }));
+    const shownSites = sites.slice(0, MAX_COMPOSITION_ROWS);
+    const siteMetrics: Metric[] = shownSites.map((s) => ({
+      label: s.site,
+      value: `${s.count} device${s.count === 1 ? '' : 's'}`,
+      status: 'neutral' as MetricStatus,
+    }));
+    if (sites.length > MAX_COMPOSITION_ROWS) {
+      const rest = sites.slice(MAX_COMPOSITION_ROWS).reduce((acc, s) => acc + s.count, 0);
+      siteMetrics[MAX_COMPOSITION_ROWS - 1] = {
+        label: `${shownSites[MAX_COMPOSITION_ROWS - 1]!.site} + ${sites.length - MAX_COMPOSITION_ROWS} more`,
+        value: `${(shownSites[MAX_COMPOSITION_ROWS - 1]!.count) + rest} devices`,
+        status: 'neutral',
+      };
+    }
+    const rows = Math.max(osMetrics.length, siteMetrics.length);
+    const pad = (arr: Metric[]): Metric[] =>
+      arr.concat(Array.from({ length: rows - arr.length }, () => ({ label: '', value: '', status: 'na' as MetricStatus })));
+    y = drawMetricGrid(doc, [...pad(osMetrics), ...pad(siteMetrics)], y);
+  }
+
+  // Recommended actions close the page — the reader leaves with next steps.
+  const recs = buildExecRecommendations(summary);
+  if (recs.length > 0) {
+    const rowH = 5.2;
+    const maxY = PAGE.footY - 4;
+    if (y + 5 + rowH <= maxY) {
+      const fit = Math.min(recs.length, 5, Math.floor((maxY - y - 5) / rowH));
+      y = drawSectionHeading(doc, 'Recommended actions', y + 2.5);
+      doc.setFontSize(9);
+      recs.slice(0, fit).forEach((rec, i) => {
+        set.text(doc, rec.severity === 'bad' ? C.danger : C.warning);
+        doc.setFont('helvetica', 'bold');
+        doc.text(`${i + 1}.`, PAGE.mx + 1, y);
+        set.text(doc, C.ink);
+        doc.setFont('helvetica', 'normal');
+        doc.text(rec.text, PAGE.mx + 6.5, y);
+        y += rowH;
+      });
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
 // Per-device detail table (curated columns + per-cell colour for posture).
 // ----------------------------------------------------------------------------
 
@@ -1007,13 +1149,17 @@ export function buildReportPdf(rows: unknown[], opts: BuildOpts): jsPDF {
       },
       { criticalCount: 0, unprotectedCount: 0 },
     );
-    renderPostureCover(doc, opts.summary, opts, agg);
+    renderPostureCover(doc, opts.summary as PostureSummary, opts, agg);
     // Draw chrome on the cover page (no autotable runs on it).
     drawHeaderBand(doc, opts);
     drawFooter(doc, opts);
     if (records.length > 0) {
       renderPostureTable(doc, records, opts);
     }
+  } else if (opts.reportType === 'executive_summary' && opts.summary && 'devices' in (opts.summary as object)) {
+    renderExecutiveSummaryCover(doc, opts.summary as ExecutiveSummary, opts);
+    drawHeaderBand(doc, opts);
+    drawFooter(doc, opts);
   } else {
     renderGenericReport(doc, records, opts);
   }

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -1195,7 +1195,11 @@ export function buildReportPdf(rows: unknown[], opts: BuildOpts): jsPDF {
   const doc = new jsPDF({ orientation: 'landscape' });
   const records = rows as Record<string, unknown>[];
 
-  if (opts.reportType === 'security_compliance_posture' && opts.summary) {
+  // SAFE guard is intentionally asymmetric: a summary carrying an exec shape
+  // ('devices' key) must not enter the posture cover, but we don't require any
+  // posture-specific key here because legacy posture snapshots are all-optional
+  // and must keep rendering.
+  if (opts.reportType === 'security_compliance_posture' && opts.summary && !('devices' in (opts.summary as object))) {
     // Aggregate the per-device rows for the scorecard right-rail risk stats.
     const agg: PostureAggregates = records.reduce<PostureAggregates>(
       (acc, r) => {

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -705,9 +705,10 @@ function buildExecRecommendations(summary: ExecutiveSummary): Recommendation[] {
   if ((d.offline ?? 0) > 0) {
     recs.push({ severity: 'bad', text: `Investigate ${d.offline} offline device${d.offline === 1 ? '' : 's'} — offline endpoints are unmonitored and unpatched.` });
   }
-  const unresolvedCritical = Math.max(0, (a.critical ?? 0) - (a.resolved ?? 0));
   if ((a.critical ?? 0) > 0) {
-    recs.push({ severity: 'bad', text: `Triage the ${a.critical} critical alert${a.critical === 1 ? '' : 's'} raised in this reporting window${unresolvedCritical > 0 ? '' : ' (all resolved — verify root causes)'}.` });
+    // The snapshot's `resolved` count spans all severities, so we can't claim
+    // anything about *critical* resolution status — just flag the criticals.
+    recs.push({ severity: 'bad', text: `Triage the ${a.critical} critical alert${a.critical === 1 ? '' : 's'} raised in this reporting window.` });
   }
   if (a.resolutionRate != null && a.resolutionRate < 80 && (a.total ?? 0) > 0) {
     recs.push({ severity: 'warn', text: `Raise the alert resolution rate — ${a.resolutionRate}% of alerts were resolved against an 80% target.` });

--- a/packages/shared/src/reportPdf/reportPdf.ts
+++ b/packages/shared/src/reportPdf/reportPdf.ts
@@ -1,6 +1,6 @@
 import { jsPDF } from 'jspdf';
 import autoTable, { type CellHookData } from 'jspdf-autotable';
-import type { PostureSummary } from '@breeze/shared';
+import type { PostureSummary } from '../types/postureReport';
 
 /**
  * Branded PDF design system for Breeze reports.
@@ -45,7 +45,7 @@ export type ReportBranding = {
   logoAspect: number | null;
 };
 
-type BuildOpts = {
+export type BuildOpts = {
   reportType: string;
   /** Already-formatted, timezone-correct generation timestamp. */
   generatedAt: string;

--- a/packages/shared/src/types/executiveSummaryReport.ts
+++ b/packages/shared/src/types/executiveSummaryReport.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical shape of the Executive Summary report's `summary` snapshot.
+ * Single-sourced (API produces with `satisfies`, the shared PDF renderer
+ * consumes) and persisted in report_runs.result, so all fields are optional —
+ * a legacy snapshot must still render. Mirrors postureReport.ts.
+ */
+export type ExecutiveSummaryDevices = {
+  total?: number;
+  online?: number;
+  offline?: number;
+  /** Share of managed devices online, 0-100. */
+  healthPercentage?: number;
+};
+
+export type ExecutiveSummaryAlerts = {
+  total?: number;
+  critical?: number;
+  high?: number;
+  resolved?: number;
+  /** Share of window alerts resolved, 0-100. */
+  resolutionRate?: number;
+};
+
+export type ExecutiveSummary = {
+  org?: { id?: string; name?: string };
+  devices?: ExecutiveSummaryDevices;
+  alerts?: ExecutiveSummaryAlerts;
+  osDistribution?: Record<string, number>;
+  siteBreakdown?: Array<{ site: string; count: number }>;
+};

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -689,3 +689,4 @@ export * from './billing-enums';
 // ============================================
 
 export * from './postureReport';
+export * from './executiveSummaryReport';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './assuranceLevel';
 export * from './ticketTemplate';
 export * from './quoteMath';
 export * from './csvExport';
+export * from './reportSchedule';

--- a/packages/shared/src/utils/reportSchedule.test.ts
+++ b/packages/shared/src/utils/reportSchedule.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatNextOccurrence, isDue, lastOccurrenceKey, nextOccurrence } from './reportSchedule';
+
+describe('lastOccurrenceKey', () => {
+  it('daily: before today\'s time uses yesterday', () => {
+    const now = new Date('2026-07-01T09:00:00Z'); // 04:00 America/Chicago (CDT, UTC-5)
+    const key = lastOccurrenceKey(now, 'daily', { time: '09:00' }, 'America/Chicago');
+    expect(key).toBe(202606300900);
+  });
+
+  it('weekly: wednesday now, target monday', () => {
+    const now = new Date('2026-07-01T14:00:00Z'); // Wednesday UTC
+    expect(lastOccurrenceKey(now, 'weekly', { time: '09:00', day: 'monday' }, 'UTC')).toBe(202606290900);
+  });
+
+  it('monthly: clamps to month length', () => {
+    const marchFirst = new Date('2026-03-01T12:00:00Z');
+    const key = lastOccurrenceKey(marchFirst, 'monthly', { time: '09:00', date: '31' }, 'UTC');
+    expect(key).toBe(202602280900); // Feb 2026 has 28 days
+  });
+});
+
+describe('nextOccurrence', () => {
+  it('daily: time later today stays on today', () => {
+    const now = new Date('2026-07-01T14:00:00Z'); // 14:00 UTC
+    const occ = nextOccurrence(now, 'daily', { time: '16:00' }, 'UTC');
+    expect(occ).toEqual({ y: 2026, m: 7, d: 1, hh: 16, mm: 0 });
+  });
+
+  it('daily: time already passed today rolls to tomorrow', () => {
+    const now = new Date('2026-07-01T14:00:00Z'); // 14:00 UTC
+    const occ = nextOccurrence(now, 'daily', { time: '09:00' }, 'UTC');
+    expect(occ).toEqual({ y: 2026, m: 7, d: 2, hh: 9, mm: 0 });
+  });
+
+  it('weekly: wraps forward to next target weekday', () => {
+    const now = new Date('2026-07-01T14:00:00Z'); // Wednesday UTC
+    const occ = nextOccurrence(now, 'weekly', { time: '09:00', day: 'monday' }, 'UTC');
+    expect(occ).toEqual({ y: 2026, m: 7, d: 6, hh: 9, mm: 0 });
+  });
+
+  it('monthly: clamps date to month length', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const occ = nextOccurrence(now, 'monthly', { time: '09:00', date: '31' }, 'UTC');
+    expect(occ).toEqual({ y: 2026, m: 6, d: 30, hh: 9, mm: 0 });
+  });
+
+  it('monthly: wraps into next year', () => {
+    const now = new Date('2026-12-20T12:00:00Z');
+    const occ = nextOccurrence(now, 'monthly', { time: '09:00', date: '1' }, 'UTC');
+    expect(occ).toEqual({ y: 2027, m: 1, d: 1, hh: 9, mm: 0 });
+  });
+});
+
+describe('formatNextOccurrence', () => {
+  it('formats with weekday', () => {
+    expect(formatNextOccurrence({ y: 2026, m: 7, d: 6, hh: 9, mm: 0 }, { weekday: true })).toBe(
+      'Mon, Jul 6, 9:00 AM',
+    );
+  });
+
+  it('formats without weekday by default', () => {
+    expect(formatNextOccurrence({ y: 2026, m: 7, d: 6, hh: 9, mm: 0 })).toBe('Jul 6, 9:00 AM');
+  });
+});
+
+describe('isDue', () => {
+  it('is due when never generated', () => {
+    const occurrence = lastOccurrenceKey(new Date('2026-07-01T09:00:00Z'), 'daily', { time: '09:00' }, 'UTC');
+    expect(isDue(null, occurrence, 'UTC')).toBe(true);
+  });
+
+  it('is not due when generated at/after the occurrence', () => {
+    const occurrence = lastOccurrenceKey(new Date('2026-07-01T09:00:00Z'), 'daily', { time: '09:00' }, 'UTC');
+    expect(isDue(new Date('2026-07-01T09:00:00Z'), occurrence, 'UTC')).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/reportSchedule.ts
+++ b/packages/shared/src/utils/reportSchedule.ts
@@ -1,0 +1,190 @@
+/**
+ * Report schedule occurrence math. Shared between the API's report-schedule
+ * worker (which needs the *last* due occurrence to decide whether to enqueue
+ * a run) and the web UI (which needs the *next* occurrence to show "Next: ...").
+ */
+
+// ─── Occurrence math ─────────────────────────────────────────────────────────
+// All comparisons happen in wall-clock space for the report's timezone, encoded
+// as a sortable number (YYYYMMDDHHmm). This avoids DST/offset conversions: a
+// "daily at 09:00" report is due once the org's local clock passes 09:00,
+// whatever UTC instant that is.
+
+export type ScheduleCadence = 'daily' | 'weekly' | 'monthly';
+
+export type ScheduleConfig = {
+  /** 24h "HH:MM"; defaults to 09:00 (the builder's default). */
+  time?: string;
+  /** Weekly: lowercase weekday name; defaults to monday. */
+  day?: string;
+  /** Monthly: day-of-month "1".."31" (clamped to month length); defaults to 1. */
+  date?: string;
+};
+
+const DAY_INDEX: Record<string, number> = {
+  sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6,
+};
+
+const WEEKDAY_SHORT_INDEX: Record<string, number> = {
+  Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+};
+
+type WallClock = { y: number; m: number; d: number; hh: number; mm: number; weekday: number };
+
+/** Decompose a UTC instant into wall-clock parts for a timezone. */
+export function wallClockIn(instant: Date, timeZone: string): WallClock {
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
+      weekday: 'short',
+    }).formatToParts(instant);
+  } catch {
+    // Bad/unknown zone string in stored settings — fall back to UTC.
+    return wallClockIn(instant, 'UTC');
+  }
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
+  return {
+    y: Number(get('year')),
+    m: Number(get('month')),
+    d: Number(get('day')),
+    hh: Number(get('hour')),
+    mm: Number(get('minute')),
+    weekday: WEEKDAY_SHORT_INDEX[get('weekday')] ?? 0,
+  };
+}
+
+const keyOf = (y: number, m: number, d: number, hh: number, mm: number): number =>
+  ((y * 100 + m) * 100 + d) * 10000 + hh * 100 + mm;
+
+/** Pure calendar arithmetic (timezone-free): shift a Y/M/D by whole days. */
+function shiftDays(y: number, m: number, d: number, days: number): { y: number; m: number; d: number } {
+  const t = new Date(Date.UTC(y, m - 1, d + days));
+  return { y: t.getUTCFullYear(), m: t.getUTCMonth() + 1, d: t.getUTCDate() };
+}
+
+const daysInMonth = (y: number, m: number): number => new Date(Date.UTC(y, m, 0)).getUTCDate();
+
+function parseTime(time: string | undefined): { hh: number; mm: number } {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time ?? '');
+  const hh = match ? Number(match[1]) : 9;
+  const mm = match ? Number(match[2]) : 0;
+  if (!match || hh > 23 || mm > 59) return { hh: 9, mm: 0 };
+  return { hh, mm };
+}
+
+/**
+ * The most recent scheduled occurrence at or before `now`, as a wall-clock key
+ * in `timeZone`. A report is due when its lastGeneratedAt (in the same
+ * wall-clock space) predates this key.
+ */
+export function lastOccurrenceKey(
+  now: Date,
+  cadence: ScheduleCadence,
+  cfg: ScheduleConfig,
+  timeZone: string,
+): number {
+  const nowWc = wallClockIn(now, timeZone);
+  const nowKey = keyOf(nowWc.y, nowWc.m, nowWc.d, nowWc.hh, nowWc.mm);
+  const { hh, mm } = parseTime(cfg.time);
+
+  if (cadence === 'daily') {
+    let day = { y: nowWc.y, m: nowWc.m, d: nowWc.d };
+    if (keyOf(day.y, day.m, day.d, hh, mm) > nowKey) day = shiftDays(day.y, day.m, day.d, -1);
+    return keyOf(day.y, day.m, day.d, hh, mm);
+  }
+
+  if (cadence === 'weekly') {
+    const target = DAY_INDEX[(cfg.day ?? 'monday').toLowerCase()] ?? 1;
+    const delta = (nowWc.weekday - target + 7) % 7;
+    let day = shiftDays(nowWc.y, nowWc.m, nowWc.d, -delta);
+    if (keyOf(day.y, day.m, day.d, hh, mm) > nowKey) day = shiftDays(day.y, day.m, day.d, -7);
+    return keyOf(day.y, day.m, day.d, hh, mm);
+  }
+
+  // monthly
+  const wanted = Math.max(1, Math.min(31, Number(cfg.date) || 1));
+  let y = nowWc.y;
+  let m = nowWc.m;
+  let d = Math.min(wanted, daysInMonth(y, m));
+  if (keyOf(y, m, d, hh, mm) > nowKey) {
+    m -= 1;
+    if (m === 0) { m = 12; y -= 1; }
+    d = Math.min(wanted, daysInMonth(y, m));
+  }
+  return keyOf(y, m, d, hh, mm);
+}
+
+/** Due when the report has never run, or last ran before the latest occurrence. */
+export function isDue(
+  lastGeneratedAt: Date | null,
+  occurrenceKey: number,
+  timeZone: string,
+): boolean {
+  if (!lastGeneratedAt) return true;
+  const wc = wallClockIn(lastGeneratedAt, timeZone);
+  return keyOf(wc.y, wc.m, wc.d, wc.hh, wc.mm) < occurrenceKey;
+}
+
+/**
+ * The next scheduled occurrence strictly after `now`, as wall-clock parts in
+ * `timeZone`. Forward mirror of lastOccurrenceKey — used by the web to show
+ * "Next: Mon, Jul 6, 9:00 AM" without inverse-timezone math (the parts are
+ * formatted directly, never converted back to an instant).
+ */
+export function nextOccurrence(
+  now: Date,
+  cadence: ScheduleCadence,
+  cfg: ScheduleConfig,
+  timeZone: string,
+): { y: number; m: number; d: number; hh: number; mm: number } {
+  const nowWc = wallClockIn(now, timeZone);
+  const nowKey = keyOf(nowWc.y, nowWc.m, nowWc.d, nowWc.hh, nowWc.mm);
+  const { hh, mm } = parseTime(cfg.time);
+
+  if (cadence === 'daily') {
+    let day = { y: nowWc.y, m: nowWc.m, d: nowWc.d };
+    if (keyOf(day.y, day.m, day.d, hh, mm) <= nowKey) day = shiftDays(day.y, day.m, day.d, 1);
+    return { ...day, hh, mm };
+  }
+
+  if (cadence === 'weekly') {
+    const target = DAY_INDEX[(cfg.day ?? 'monday').toLowerCase()] ?? 1;
+    const delta = (target - nowWc.weekday + 7) % 7;
+    let day = shiftDays(nowWc.y, nowWc.m, nowWc.d, delta);
+    if (keyOf(day.y, day.m, day.d, hh, mm) <= nowKey) day = shiftDays(day.y, day.m, day.d, 7);
+    return { ...day, hh, mm };
+  }
+
+  // monthly
+  const wanted = Math.max(1, Math.min(31, Number(cfg.date) || 1));
+  let y = nowWc.y;
+  let m = nowWc.m;
+  let d = Math.min(wanted, daysInMonth(y, m));
+  if (keyOf(y, m, d, hh, mm) <= nowKey) {
+    m += 1;
+    if (m === 13) { m = 1; y += 1; }
+    d = Math.min(wanted, daysInMonth(y, m));
+  }
+  return { y, m, d, hh, mm };
+}
+
+/** Format wall-clock occurrence parts as a display label ("Mon, Jul 6, 9:00 AM").
+ * The parts are already in the schedule's timezone, so format them as UTC to
+ * avoid any further conversion. */
+export function formatNextOccurrence(
+  occ: { y: number; m: number; d: number; hh: number; mm: number },
+  opts?: { weekday?: boolean },
+): string {
+  const instant = new Date(Date.UTC(occ.y, occ.m - 1, occ.d, occ.hh, occ.mm));
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    ...(opts?.weekday ? { weekday: 'short' } : {}),
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(instant);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,12 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: ^5.0.8
+        version: 5.0.8(jspdf@4.2.1)
       nanoid:
         specifier: ^5.1.15
         version: 5.1.15
@@ -951,16 +957,25 @@ importers:
       disposable-email-domains:
         specifier: ^1.0.62
         version: 1.0.62
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: ^5.0.8
+        version: 5.0.8(jspdf@4.2.1)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -1705,10 +1720,6 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
@@ -11312,8 +11323,6 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
-  '@babel/runtime@7.29.2': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
@@ -17652,7 +17661,7 @@ snapshots:
 
   jspdf@4.2.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       fast-png: 6.4.0
       fflate: 0.8.2
     optionalDependencies:


### PR DESCRIPTION
> **Stacked on #2148** (`ToddHebebrand/reports-improvements`). After #2148 squash-merges, this branch will be rebased with `git rebase --onto main origin/ToddHebebrand/reports-improvements` and the PR retargets to `main` automatically.

Continues the reports work from #2148 with the next tranche of enhancements:

## What's in here

1. **Branded PDF attachments on scheduled emails.** `reportPdf.ts` (already dependency-clean by design) moves to `packages/shared/src/reportPdf/` behind a new `@breeze/shared/reportPdf` export subpath (jsPDF stays out of the root barrel), and the schedule worker now renders and attaches the real branded PDF for pdf-format reports — partner logo/name, org→partner→UTC timezone, 5MB cap, render failure degrades to a link-only email. CSV formats keep the CSV attachment.
2. **Executive summary gets the posture treatment.** New canonical `ExecutiveSummary` shared type; the generator now includes org identity; the PDF renders a designed cover (fleet-health scorecard, device/alert metric grids, OS + site composition, recommended actions) instead of "No data available".
3. **Trend deltas.** Both generation paths store the prior completed run's summary as `result.previous`, so snapshots are self-contained; scorecards render "+5 since Jun 1" chips and scheduled emails lead with "Posture score 79 — up from 74 last run."
4. **Next-run + recipients in ReportsList.** Occurrence math moved to `@breeze/shared` (worker re-exports keep its tests importing unchanged) with a new forward `nextOccurrence`; recurring rows now show "Next: Mon, Jul 6, 9:00 AM" and a recipient count.
5. **Partner-level cross-org reports design doc** (`docs/superpowers/plans/2026-07-01-partner-level-reports-design.md`) — design pass only, grounded in the dual-owner config-policy precedent, for a follow-up PR.

## Bug fixes found along the way

- **`POST /reports` was stripping `config.schedule` and `config.emailRecipients`** (Zod drops undeclared keys), so newly created schedules would silently never email anyone and cadence detail fell back to defaults. Config is now a validated loose object; `PUT` moved off `config: z.any()` onto the same schema. Recipient validation deliberately uses the same loose regex as the builder chips and the worker, so persistence never rejects what the builder accepted.
- Final-review hardening: `previousBaselineFor` projects `result->'summary'` instead of fetching whole snapshots and degrades to no-baseline on error; the worker's tz query moved inside the recipient branch (closing a permanent occurrence-skip window); branding-load failure degrades to unbranded instead of dropping the email; warn logs on oversized-attachment drops.

## Verification

- Shared: 964 tests + typecheck. API: targeted suites (routes/worker/services) + `tsc --noEmit` + `tsup` build. Web: 30 reports-component tests + `astro check`.
- The worker's PDF test asserts real `%PDF` magic bytes from the unmocked renderer in Node; a hoisted failure switch proves the link-only fallback via the actual catch path.
- Headless render matrix (posture with trend + PNG logo branding, exec summary with trend, generic inventory) rendered via `pdftoppm` and visually inspected — logo chip, delta chips, grids, footer attribution all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)