### PR TITLE
Partner-wide first phase 3: alert delivery rails dual-ownership (channels, routing, escalation)

### DIFF
--- a/apps/api/migrations/2026-07-01-notification-rails-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-01-notification-rails-partner-ownership.sql
@@ -1,0 +1,165 @@
+-- Partner-owned alert delivery rails (epic #2135, issue #2130).
+--
+-- Until now notification_channels, notification_routing_rules, and
+-- escalation_policies were always owned by exactly one org (org_id NOT NULL),
+-- so even a partner-wide alert rule (#2128) could not route to the MSP's own
+-- Slack/PSA/email without per-org channel setup. This migration makes each
+-- rail ownable by EITHER an org (org_id set, partner_id NULL — the existing
+-- shape) OR a partner (partner_id set, org_id NULL — "partner-wide / all
+-- orgs"), enforced by an exactly-one-axis CHECK per table. Mirrors
+-- software_policies (#2126) and automation_policies (#2129).
+--
+-- alert_notifications is unchanged: it has no ownership columns and reaches
+-- its tenant through the alert join (alerts.org_id — always the firing
+-- device's concrete org), which is correct for partner-wide rails too.
+--
+-- notification_channels.config is an encrypted column whose AAD is bound to
+-- the table/column (encryptedColumnRegistry), NOT to the org — safe for
+-- org_id NULL rows.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECKs, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- notification_channels
+-- ============================================
+
+ALTER TABLE notification_channels
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE notification_channels
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'notification_channels_one_owner_chk'
+      AND conrelid = 'notification_channels'::regclass
+  ) THEN
+    ALTER TABLE notification_channels
+      ADD CONSTRAINT notification_channels_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS notification_channels_partner_id_idx
+  ON notification_channels(partner_id);
+
+ALTER TABLE notification_channels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_channels FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON notification_channels;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON notification_channels;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON notification_channels;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON notification_channels;
+DROP POLICY IF EXISTS notification_channels_isolation ON notification_channels;
+CREATE POLICY notification_channels_isolation
+  ON notification_channels
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- notification_routing_rules
+-- ============================================
+-- The four breeze_org_isolation_* policies were re-issued (same names) by
+-- 2026-04-11-bucket-a-rls-policies.sql; the DROPs below cover both origins.
+
+ALTER TABLE notification_routing_rules
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE notification_routing_rules
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'notification_routing_rules_one_owner_chk'
+      AND conrelid = 'notification_routing_rules'::regclass
+  ) THEN
+    ALTER TABLE notification_routing_rules
+      ADD CONSTRAINT notification_routing_rules_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS notification_routing_rules_partner_id_idx
+  ON notification_routing_rules(partner_id);
+
+ALTER TABLE notification_routing_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_routing_rules FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON notification_routing_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON notification_routing_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON notification_routing_rules;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON notification_routing_rules;
+DROP POLICY IF EXISTS notification_routing_rules_isolation ON notification_routing_rules;
+CREATE POLICY notification_routing_rules_isolation
+  ON notification_routing_rules
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- escalation_policies
+-- ============================================
+
+ALTER TABLE escalation_policies
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE escalation_policies
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'escalation_policies_one_owner_chk'
+      AND conrelid = 'escalation_policies'::regclass
+  ) THEN
+    ALTER TABLE escalation_policies
+      ADD CONSTRAINT escalation_policies_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS escalation_policies_partner_id_idx
+  ON escalation_policies(partner_id);
+
+ALTER TABLE escalation_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE escalation_policies FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON escalation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON escalation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON escalation_policies;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON escalation_policies;
+DROP POLICY IF EXISTS escalation_policies_isolation ON escalation_policies;
+CREATE POLICY escalation_policies_isolation
+  ON escalation_policies
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );

--- a/apps/api/src/__tests__/integration/notificationRailsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/notificationRailsPartnerRls.integration.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Alert delivery rails RLS — dual-axis (org OR partner) enforcement
+ * (#2130, epic #2135).
+ *
+ * Migration under test: 2026-07-01-notification-rails-partner-ownership.sql,
+ * covering notification_channels, notification_routing_rules, and
+ * escalation_policies. alert_notifications stay alert-join (the firing
+ * device's org) and are unchanged.
+ *
+ * Same dual-axis contract-test blindspot as the sibling suites: this
+ * functional test through the REAL postgres.js driver (breeze_app role) is
+ * the guard that a partner cannot forge a partner_id for another partner.
+ *
+ * The second describe block proves the dispatcher fan-out (#1724 trap): the
+ * routing/channel lookups previously filtered eq(orgId, alert.orgId), so a
+ * stored partner-wide rule/channel would silently never deliver anything.
+ */
+import './setup';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  alertRules,
+  alertTemplates,
+  alerts,
+  devices,
+  escalationPolicies,
+  notificationChannels,
+  notificationRoutingRules,
+  sites,
+} from '../../db/schema';
+import { processAlertNotifications, shutdownNotificationDispatcher } from '../../services/notificationDispatcher';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdChannels: string[] = [];
+const createdRules: string[] = [];
+const createdPolicies: string[] = [];
+const createdAlerts: string[] = [];
+const createdAlertRules: string[] = [];
+const createdTemplates: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+// The dispatcher lazily opens a BullMQ queue; close it so vitest can exit.
+afterAll(async () => {
+  await shutdownNotificationDispatcher();
+});
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+afterEach(async () => {
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    if (createdAlerts.length > 0) {
+      await db.delete(alerts).where(inArray(alerts.id, createdAlerts));
+    }
+    for (const id of createdAlertRules) {
+      await db.delete(alertRules).where(eq(alertRules.id, id));
+    }
+    for (const id of createdTemplates) {
+      await db.delete(alertTemplates).where(eq(alertTemplates.id, id));
+    }
+    for (const id of createdRules) {
+      await db.delete(notificationRoutingRules).where(eq(notificationRoutingRules.id, id));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(escalationPolicies).where(eq(escalationPolicies.id, id));
+    }
+    for (const id of createdChannels) {
+      await db.delete(notificationChannels).where(eq(notificationChannels.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdChannels.length = 0;
+  createdRules.length = 0;
+  createdPolicies.length = 0;
+  createdAlerts.length = 0;
+  createdAlertRules.length = 0;
+  createdTemplates.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+async function seedPartnerChannel(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(notificationChannels)
+      .values({
+        orgId: null,
+        partnerId,
+        name: 'Partner NOC Slack',
+        type: 'slack',
+        config: { webhookUrl: 'https://hooks.slack.example/noc' },
+        enabled: true,
+      })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdChannels.push(id);
+  return id;
+}
+
+// The three rails share one migration and one policy shape — exercise the
+// forge/XOR/isolation contract per table without triplicating prose.
+const RAIL_CASES = [
+  {
+    label: 'notification_channels',
+    insert: (owner: { orgId: string | null; partnerId: string | null }) =>
+      db.insert(notificationChannels).values({
+        ...owner,
+        name: 'Rail case channel',
+        type: 'slack',
+        config: { webhookUrl: 'https://hooks.slack.example/x' },
+        enabled: true,
+      }).returning({ id: notificationChannels.id, orgId: notificationChannels.orgId, partnerId: notificationChannels.partnerId }),
+    selectById: (id: string) =>
+      db.select({ id: notificationChannels.id }).from(notificationChannels).where(eq(notificationChannels.id, id)),
+    track: createdChannels,
+  },
+  {
+    label: 'notification_routing_rules',
+    insert: (owner: { orgId: string | null; partnerId: string | null }) =>
+      db.insert(notificationRoutingRules).values({
+        ...owner,
+        name: 'Rail case rule',
+        priority: 10,
+        conditions: { severities: ['critical'] },
+        channelIds: [],
+        enabled: true,
+      }).returning({ id: notificationRoutingRules.id, orgId: notificationRoutingRules.orgId, partnerId: notificationRoutingRules.partnerId }),
+    selectById: (id: string) =>
+      db.select({ id: notificationRoutingRules.id }).from(notificationRoutingRules).where(eq(notificationRoutingRules.id, id)),
+    track: createdRules,
+  },
+  {
+    label: 'escalation_policies',
+    insert: (owner: { orgId: string | null; partnerId: string | null }) =>
+      db.insert(escalationPolicies).values({
+        ...owner,
+        name: 'Rail case escalation',
+        steps: [{ delayMinutes: 15, channelIds: [] }],
+      }).returning({ id: escalationPolicies.id, orgId: escalationPolicies.orgId, partnerId: escalationPolicies.partnerId }),
+    selectById: (id: string) =>
+      db.select({ id: escalationPolicies.id }).from(escalationPolicies).where(eq(escalationPolicies.id, id)),
+    track: createdPolicies,
+  },
+] as const;
+
+describe.each(RAIL_CASES)('$label RLS — dual-axis (2026-07-01 migration)', (rail) => {
+  it('partner scope can INSERT and SELECT a partner-wide row; another partner can neither see nor forge it', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      rail.insert({ orgId: null, partnerId: partnerA.id }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partnerA.id);
+    const id = rows[0]!.id;
+    rail.track.push(id);
+
+    const visibleToA = await withDbAccessContext(partnerContext(partnerA.id, []), () => rail.selectById(id));
+    expect(visibleToA).toHaveLength(1);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () => rail.selectById(id));
+    expect(visibleToB).toEqual([]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        rail.insert({ orgId: null, partnerId: partnerA.id }),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide row; org-owned rows keep the original shape', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const partnerRows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      rail.insert({ orgId: null, partnerId: partner.id }),
+    );
+    rail.track.push(partnerRows[0]!.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () => rail.selectById(partnerRows[0]!.id));
+    expect(visibleToOrg).toEqual([]);
+
+    const orgRows = await withDbAccessContext(orgContext(org.id), () =>
+      rail.insert({ orgId: org.id, partnerId: null }),
+    );
+    rail.track.push(orgRows[0]!.id);
+    expect(orgRows[0]?.orgId).toBe(org.id);
+  });
+
+  it('the one-owner CHECK rejects a row that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () => rail.insert({ orgId: org.id, partnerId: partner.id })),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () => rail.insert({ orgId: null, partnerId: null })),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+});
+
+// ============================================================
+// Dispatcher fan-out (#2130): the load-bearing SQL that makes a stored
+// partner-wide rail actually DELIVER. processAlertNotifications previously
+// filtered routing rules and channels by eq(orgId, alert.orgId), which
+// silently never matched org_id NULL rows — the #1724 trap. The worker runs
+// under system context, so RLS was never the filter; these prove the app
+// queries.
+// ============================================================
+
+describe('processAlertNotifications — partner-wide rail fan-out (#2130)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  async function seedAlert(orgId: string, deviceId: string): Promise<string> {
+    const [alert] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(alerts)
+        .values({
+          orgId,
+          deviceId,
+          severity: 'critical',
+          status: 'active',
+          title: 'Rail fan-out test alert',
+          message: 'CPU on fire',
+        })
+        .returning(),
+    );
+    createdAlerts.push(alert!.id);
+    return alert!.id;
+  }
+
+  it("a partner-wide routing rule + channel deliver a member org's alert; a FOREIGN partner's rails never match", async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+
+    const deviceA = await seedDevice(orgA.id, 'rail-fanout-a');
+    const alertA = await seedAlert(orgA.id, deviceA);
+
+    // Partner A: partner-wide channel + partner-wide routing rule for critical.
+    const channelA = await seedPartnerChannel(partnerA.id);
+    const [ruleA] = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      db
+        .insert(notificationRoutingRules)
+        .values({
+          orgId: null,
+          partnerId: partnerA.id,
+          name: 'Criticals to partner NOC',
+          priority: 5,
+          conditions: { severities: ['critical'] },
+          channelIds: [channelA],
+          enabled: true,
+        })
+        .returning(),
+    );
+    createdRules.push(ruleA!.id);
+
+    // Partner B: a decoy partner-wide rule + channel that must NEVER match
+    // an org-A alert.
+    const channelB = await seedPartnerChannel(partnerB.id);
+    const [ruleB] = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .insert(notificationRoutingRules)
+        .values({
+          orgId: null,
+          partnerId: partnerB.id,
+          name: 'Foreign partner rule',
+          priority: 1,
+          conditions: { severities: ['critical'] },
+          channelIds: [channelB],
+          enabled: true,
+        })
+        .returning(),
+    );
+    createdRules.push(ruleB!.id);
+
+    // The dispatcher worker runs under system context — mirror that.
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      processAlertNotifications({ type: 'process-alert', alertId: alertA }),
+    );
+
+    // Exactly the partner-wide channel of the alert org's OWN partner is
+    // queued: rule A matched (despite org_id NULL) and its channel survived
+    // the dual-axis validation; partner B's higher-priority rule never
+    // entered the candidate set.
+    expect(result.queued).toBe(1);
+  });
+
+  it("a partner-wide channel participates in the no-rules fallback for member-org alerts only", async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    const deviceA = await seedDevice(orgA.id, 'rail-fallback-a');
+    const deviceB = await seedDevice(orgB.id, 'rail-fallback-b');
+    const alertA = await seedAlert(orgA.id, deviceA);
+    const alertB = await seedAlert(orgB.id, deviceB);
+
+    // Only partner A has a (partner-wide) channel; no routing rules at all.
+    await seedPartnerChannel(partnerA.id);
+
+    const resultA = await withDbAccessContext(SYSTEM_CTX, () =>
+      processAlertNotifications({ type: 'process-alert', alertId: alertA }),
+    );
+    expect(resultA.queued).toBe(1); // fallback found the partner-wide channel
+
+    const resultB = await withDbAccessContext(SYSTEM_CTX, () =>
+      processAlertNotifications({ type: 'process-alert', alertId: alertB }),
+    );
+    expect(resultB.queued).toBe(0); // another partner's channel NEVER leaks in
+  });
+
+  it('a partner-wide escalation policy schedules delayed sends for a member-org alert', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const deviceId = await seedDevice(org.id, 'rail-escalation');
+
+    const channelId = await seedPartnerChannel(partner.id);
+
+    // Partner-wide escalation policy whose step routes to the partner channel.
+    const [policy] = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(escalationPolicies)
+        .values({
+          orgId: null,
+          partnerId: partner.id,
+          name: 'Partner NOC escalation',
+          steps: [{ delayMinutes: 15, channelIds: [channelId] }],
+        })
+        .returning(),
+    );
+    createdPolicies.push(policy!.id);
+
+    // Org-owned alert rule binding the partner-wide escalation policy + channel.
+    const [template] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(alertTemplates)
+        .values({
+          orgId: org.id,
+          name: 'Escalation template',
+          conditions: { type: 'metric', metric: 'cpu', operator: '>', threshold: 95 },
+          severity: 'critical',
+          titleTemplate: 'High CPU',
+          messageTemplate: 'CPU exceeded threshold',
+        })
+        .returning(),
+    );
+    createdTemplates.push(template!.id);
+
+    const [rule] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(alertRules)
+        .values({
+          orgId: org.id,
+          templateId: template!.id,
+          name: 'Escalating rule',
+          targetType: 'org',
+          targetId: org.id,
+          overrideSettings: {
+            notificationChannelIds: [channelId],
+            escalationPolicyId: policy!.id,
+          },
+        })
+        .returning(),
+    );
+    createdAlertRules.push(rule!.id);
+
+    const [alert] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(alerts)
+        .values({
+          orgId: org.id,
+          deviceId,
+          ruleId: rule!.id,
+          severity: 'critical',
+          status: 'active',
+          title: 'Escalation fan-out test alert',
+          message: 'CPU on fire',
+        })
+        .returning(),
+    );
+    createdAlerts.push(alert!.id);
+
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      processAlertNotifications({ type: 'process-alert', alertId: alert!.id }),
+    );
+
+    // The immediate send used the partner-wide channel (rule override), and
+    // scheduleEscalation found the PARTNER-WIDE policy (org_id NULL) and
+    // validated its step channel dual-axis — previously both lookups were
+    // eq(orgId, alert.orgId) and would have silently no-opped.
+    expect(result.queued).toBe(1);
+
+    const { getNotificationQueue } = await import('../../services/notificationDispatcher');
+    const delayed = await getNotificationQueue().getDelayed();
+    const escalationJobs = delayed.filter(
+      (job) => job.data?.alertId === alert!.id && job.data?.escalationStep,
+    );
+    expect(escalationJobs.length).toBe(1);
+    expect(escalationJobs[0]!.data.channelId).toBe(channelId);
+    for (const job of escalationJobs) {
+      await job.remove();
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -294,6 +294,16 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // cross-partner forge + enforcement fan-out proof:
   // maintenanceWindowsPartnerRls.integration.test.ts.
   'maintenance_windows',
+  // Alert delivery rails (#2130, epic #2135): org-scoped OR partner-wide
+  // notification channel / routing rule / escalation policy.
+  // alert_notifications stay alert-join (the firing device's org).
+  // Converted in 2026-07-01-notification-rails-partner-ownership. CHECK
+  // *_one_owner_chk enforces exactly one axis per table. Functional
+  // cross-partner forge + dispatcher fan-out proof:
+  // notificationRailsPartnerRls.integration.test.ts.
+  'notification_channels',
+  'notification_routing_rules',
+  'escalation_policies',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/db/schema/alerts.ts
+++ b/apps/api/src/db/schema/alerts.ts
@@ -147,9 +147,16 @@ export const alertCorrelationMembers = pgTable('alert_correlation_members', {
   orgGroupIdx: index('alert_correlation_members_org_group_idx').on(table.orgId, table.groupId)
 }));
 
+// Delivery rails (#2131 sibling, issue #2130): a channel / routing rule /
+// escalation policy is owned by EITHER an org (orgId set, partnerId NULL —
+// the original shape) OR a partner (partnerId set, orgId NULL — "partner-wide
+// / all orgs", epic #2135). Exactly one axis per row; CHECK constraints
+// `*_one_owner_chk` (migration 2026-07-01) enforce it. alert_notifications
+// stay alert-join (the alert's org) and are unchanged.
 export const notificationChannels = pgTable('notification_channels', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   type: notificationChannelTypeEnum('type').notNull(),
   config: jsonb('config').notNull(),
@@ -162,11 +169,14 @@ export const notificationChannels = pgTable('notification_channels', {
   throttleWindowSeconds: integer('throttle_window_seconds').default(3600),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  partnerIdIdx: index('notification_channels_partner_id_idx').on(table.partnerId),
+}));
 
 export const notificationRoutingRules = pgTable('notification_routing_rules', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   priority: integer('priority').notNull(),
   conditions: jsonb('conditions').notNull(), // { severities?, conditionTypes?, deviceTags?, siteIds? }
@@ -176,17 +186,21 @@ export const notificationRoutingRules = pgTable('notification_routing_rules', {
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 }, (table) => ({
   orgIdIdx: index('notification_routing_rules_org_id_idx').on(table.orgId),
-  priorityIdx: index('notification_routing_rules_priority_idx').on(table.orgId, table.priority)
+  priorityIdx: index('notification_routing_rules_priority_idx').on(table.orgId, table.priority),
+  partnerIdIdx: index('notification_routing_rules_partner_id_idx').on(table.partnerId),
 }));
 
 export const escalationPolicies = pgTable('escalation_policies', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   steps: jsonb('steps').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  partnerIdIdx: index('escalation_policies_partner_id_idx').on(table.partnerId),
+}));
 
 export const alertNotifications = pgTable('alert_notifications', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/routes/alerts.test.ts
+++ b/apps/api/src/routes/alerts.test.ts
@@ -616,6 +616,14 @@ describe('alert routes', () => {
             })
           })
         } as any)
+        // validateAlertRuleNotificationBindings: org → partnerId lookup (dual-axis #2130)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ partnerId: '99999999-9999-9999-9999-999999999999' }])
+            })
+          })
+        } as any)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([])
@@ -648,6 +656,14 @@ describe('alert routes', () => {
                 name: 'CPU Rule',
                 overrideSettings: {}
               }])
+            })
+          })
+        } as any)
+        // validateAlertRuleNotificationBindings: org → partnerId lookup (dual-axis #2130)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ partnerId: '99999999-9999-9999-9999-999999999999' }])
             })
           })
         } as any)

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, or, eq, sql, desc, gte, lte, inArray, isNull, type SQL } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import {
   alertCorrelationGroups,
   alertCorrelationMembers,
@@ -842,22 +842,29 @@ alertsRoutes.get(
       .where(eq(alertRules.id, alert.ruleId))
       .limit(1) : [undefined];
 
-    // Get notification history
-    const notifications = await db
-      .select({
-        id: alertNotifications.id,
-        channelId: alertNotifications.channelId,
-        status: alertNotifications.status,
-        sentAt: alertNotifications.sentAt,
-        errorMessage: alertNotifications.errorMessage,
-        createdAt: alertNotifications.createdAt,
-        channelName: notificationChannels.name,
-        channelType: notificationChannels.type
-      })
-      .from(alertNotifications)
-      .leftJoin(notificationChannels, eq(alertNotifications.channelId, notificationChannels.id))
-      .where(eq(alertNotifications.alertId, alertId))
-      .orderBy(desc(alertNotifications.createdAt));
+    // Get notification history. Runs in a short system-context block: a
+    // delivery may have gone through a PARTNER-WIDE channel (org_id NULL,
+    // #2130), which is RLS-invisible to org-scoped callers — the left join
+    // would silently null out channelName/channelType. The alert itself was
+    // already access-checked above (getAlertWithOrgCheck), and only display
+    // fields of the joined channel are exposed; no tenant pivot.
+    const notifications = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db
+        .select({
+          id: alertNotifications.id,
+          channelId: alertNotifications.channelId,
+          status: alertNotifications.status,
+          sentAt: alertNotifications.sentAt,
+          errorMessage: alertNotifications.errorMessage,
+          createdAt: alertNotifications.createdAt,
+          channelName: notificationChannels.name,
+          channelType: notificationChannels.type
+        })
+        .from(alertNotifications)
+        .leftJoin(notificationChannels, eq(alertNotifications.channelId, notificationChannels.id))
+        .where(eq(alertNotifications.alertId, alertId))
+        .orderBy(desc(alertNotifications.createdAt))
+    ));
 
     return c.json(withMlAlertContext({
       ...alert,

--- a/apps/api/src/routes/alerts/channels.test.ts
+++ b/apps/api/src/routes/alerts/channels.test.ts
@@ -226,6 +226,19 @@ describe('notification channels — partner-wide gating (#2130)', () => {
     });
   });
 
+  describe('POST /alerts/channels/:id/test', () => {
+    it('403s a partner-wide channel without the partner-wide capability — test-send fires REAL external notifications', async () => {
+      setPartnerAuth('selected');
+      existingRowRef.current = { ...PARTNER_WIDE_CHANNEL };
+
+      const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}/test`, { method: 'POST' });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+    });
+  });
+
   describe('POST /alerts/channels (ownerScope: partner)', () => {
     const partnerWideBody = {
       ownerScope: 'partner',

--- a/apps/api/src/routes/alerts/channels.test.ts
+++ b/apps/api/src/routes/alerts/channels.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Unit tests for partner-wide gating (#2130) on
+// apps/api/src/routes/alerts/channels.ts. getNotificationChannelWithOrgCheck
+// (./helpers) is dual-axis and deliberately left UNMOCKED so a partner-scope
+// caller on the matching partner can LOAD a partner-wide row (orgId NULL,
+// partnerId set) via the real logic; the 403 on PUT/DELETE comes from the
+// canManagePartnerWidePolicies gate in the route itself, not from the lookup.
+// partnerWideAccess.ts is a dependency-free leaf and intentionally NOT mocked
+// (per CLAUDE.md / the repo's app-layer-gate testing convention).
+
+const { authRef, insertedRef, existingRowRef, updateSetRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Org User', email: 'user@org.example' },
+      partnerId: null as string | null,
+      partnerOrgAccess: undefined as 'all' | 'selected' | 'none' | undefined,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  insertedRef: { current: undefined as Record<string, unknown> | undefined },
+  existingRowRef: { current: undefined as Record<string, unknown> | undefined },
+  updateSetRef: { current: undefined as Record<string, unknown> | undefined },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    if (!authRef.current) return c.json({ error: 'Not authenticated' }, 401);
+    c.set('auth', authRef.current);
+    await next();
+  },
+  // RBAC (ALERTS_WRITE) is covered elsewhere; always granted here so the
+  // partner-wide capability gate is what's under test.
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  // Referenced (unused) by ./helpers' import of siteAccessCheck; not invoked
+  // by any path these tests exercise.
+  siteAccessCheck: () => () => true,
+}));
+
+// Minimal insert/update/select builder — shared across insert/update/select
+// because the route issues at most one lookup followed by at most one
+// mutation per request (mirrors the routing.writes.test.ts convention).
+vi.mock('../../db', () => {
+  const builder: any = {
+    values: (vals: Record<string, unknown>) => {
+      insertedRef.current = vals;
+      return builder;
+    },
+    set: (vals: Record<string, unknown>) => {
+      updateSetRef.current = vals;
+      return builder;
+    },
+    from: () => builder,
+    where: () => builder,
+    limit: () => Promise.resolve(existingRowRef.current ? [existingRowRef.current] : []),
+    returning: () => {
+      if (insertedRef.current) {
+        return Promise.resolve([{
+          id: 'new-channel',
+          createdAt: new Date('2026-07-01T00:00:00Z'),
+          updatedAt: new Date('2026-07-01T00:00:00Z'),
+          lastTestedAt: null,
+          lastTestStatus: null,
+          throttleMaxPerWindow: null,
+          throttleWindowSeconds: 3600,
+          ...insertedRef.current,
+        }]);
+      }
+      return Promise.resolve([{ ...(existingRowRef.current ?? {}), ...(updateSetRef.current ?? {}) }]);
+    },
+  };
+  return {
+    db: {
+      insert: () => builder,
+      update: () => builder,
+      delete: () => ({ where: () => Promise.resolve(undefined) }),
+      select: () => builder,
+    },
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('../../db/schema', () => ({
+  notificationChannels: {
+    id: { name: 'id' },
+    orgId: { name: 'org_id' },
+    partnerId: { name: 'partner_id' },
+    type: { name: 'type' },
+    name: { name: 'name' },
+    enabled: { name: 'enabled' },
+    config: { name: 'config' },
+    updatedAt: { name: 'updated_at' },
+    createdAt: { name: 'created_at' },
+  },
+  organizations: { id: { name: 'id' }, partnerId: { name: 'partner_id' } },
+  partners: { id: { name: 'id' }, settings: { name: 'settings' } },
+  // Referenced (unused) by ./helpers' unrelated exports; not exercised here.
+  alertRules: {},
+  alertTemplates: {},
+  alerts: {},
+  devices: {},
+  escalationPolicies: {},
+}));
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+// Bypass real crypto — these tests exercise partner-wide gating, not the
+// secrets pipeline (already covered by aiToolsAlerts.channelSecrets.test.ts
+// and the notificationChannelSecrets suite).
+vi.mock('../../services/notificationChannelSecrets', () => ({
+  encryptNotificationChannelConfig: vi.fn((_type: string, config: unknown) => config),
+  decryptNotificationChannelConfig: vi.fn((_type: string, config: unknown) => config),
+  redactNotificationChannelConfig: vi.fn((_type: string, config: unknown) => config),
+}));
+
+import { channelsRoutes } from './channels';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', channelsRoutes);
+  return app;
+}
+
+const CHANNEL_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+
+function setPartnerAuth(partnerOrgAccess: 'all' | 'selected' | 'none') {
+  authRef.current = {
+    scope: 'partner',
+    user: { id: 'u-1', name: 'Partner Admin', email: 'admin@msp.example' },
+    partnerId: PARTNER_ID,
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: ['org-1'],
+    canAccessOrg: () => true,
+  } as typeof authRef.current;
+}
+
+const PARTNER_WIDE_CHANNEL = {
+  id: CHANNEL_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  name: 'Fleet Webhook',
+  type: 'webhook',
+  config: { url: 'https://hooks.example.com/x', method: 'POST' },
+  enabled: true,
+  throttleMaxPerWindow: null,
+  throttleWindowSeconds: 3600,
+  lastTestedAt: null,
+  lastTestStatus: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+describe('notification channels — partner-wide gating (#2130)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRef.current = undefined;
+    existingRowRef.current = undefined;
+    updateSetRef.current = undefined;
+  });
+
+  describe('PUT /alerts/channels/:id', () => {
+    it('403s a partner-wide channel without the partner-wide capability (orgAccess selected)', async () => {
+      setPartnerAuth('selected');
+      existingRowRef.current = { ...PARTNER_WIDE_CHANNEL };
+
+      const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Hijacked' }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(updateSetRef.current).toBeUndefined();
+    });
+
+    it('allows updating a partner-wide channel with full partner org access (orgAccess all)', async () => {
+      setPartnerAuth('all');
+      existingRowRef.current = { ...PARTNER_WIDE_CHANNEL };
+
+      const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed Fleet Webhook' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string };
+      expect(body.name).toBe('Renamed Fleet Webhook');
+      expect(updateSetRef.current?.name).toBe('Renamed Fleet Webhook');
+    });
+  });
+
+  describe('DELETE /alerts/channels/:id', () => {
+    it('403s a partner-wide channel without the partner-wide capability (orgAccess none)', async () => {
+      setPartnerAuth('none');
+      existingRowRef.current = { ...PARTNER_WIDE_CHANNEL };
+
+      const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+    });
+
+    it('allows deleting a partner-wide channel with full partner org access (orgAccess all)', async () => {
+      setPartnerAuth('all');
+      existingRowRef.current = { ...PARTNER_WIDE_CHANNEL };
+
+      const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}`, { method: 'DELETE' });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('POST /alerts/channels (ownerScope: partner)', () => {
+    const partnerWideBody = {
+      ownerScope: 'partner',
+      name: 'Fleet Webhook',
+      type: 'webhook',
+      config: { url: 'https://hooks.example.com/x', method: 'POST' },
+      enabled: true,
+    };
+
+    it('403s without the partner-wide capability (orgAccess selected)', async () => {
+      setPartnerAuth('selected');
+
+      const res = await makeApp().request('/alerts/channels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(partnerWideBody),
+      });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(insertedRef.current).toBeUndefined();
+    });
+
+    it('201s with full partner org access and inserts { orgId: null, partnerId } (orgAccess all)', async () => {
+      setPartnerAuth('all');
+
+      const res = await makeApp().request('/alerts/channels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(partnerWideBody),
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertedRef.current?.orgId).toBeNull();
+      expect(insertedRef.current?.partnerId).toBe(PARTNER_ID);
+      const body = (await res.json()) as { name: string };
+      expect(body.name).toBe('Fleet Webhook');
+    });
+  });
+});

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -1,10 +1,14 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { notificationChannels, organizations, partners } from '../../db/schema';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../../services/partnerWideAccess';
 import {
   decryptNotificationChannelConfig,
   encryptNotificationChannelConfig,
@@ -82,14 +86,25 @@ channelsRoutes.get(
         }
         conditions.push(eq(notificationChannels.orgId, query.orgId));
       } else {
+        // "All orgs" view: org-owned channels across accessible orgs PLUS
+        // this partner's own partner-wide channels (org_id NULL, #2130).
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        const orgCondition = orgIds.length > 0
+          ? inArray(notificationChannels.orgId, orgIds)
+          : undefined;
+        const partnerCondition = auth.partnerId
+          ? and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, auth.partnerId))
+          : undefined;
+        const ownership = orgCondition && partnerCondition
+          ? or(orgCondition, partnerCondition)
+          : (orgCondition ?? partnerCondition);
+        if (!ownership) {
           return c.json({
             data: [],
             pagination: { page, limit, total: 0 }
           });
         }
-        conditions.push(inArray(notificationChannels.orgId, orgIds));
+        conditions.push(ownership as ReturnType<typeof eq>);
       }
     } else if (auth.scope === 'system' && query.orgId) {
       conditions.push(eq(notificationChannels.orgId, query.orgId));
@@ -140,13 +155,23 @@ channelsRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    const orgId = data.orgId ?? auth.orgId;
-    if (!orgId) {
-      return c.json({ error: 'Organization context required' }, 403);
-    }
-
-    if (!auth.canAccessOrg(orgId)) {
-      return c.json({ error: 'Access to this organization denied' }, 403);
+    // Resolve the ownership axis (#2130): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (data.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgId = data.orgId ?? auth.orgId;
+      if (!orgId) {
+        return c.json({ error: 'Organization context required' }, 403);
+      }
+      if (!auth.canAccessOrg(orgId)) {
+        return c.json({ error: 'Access to this organization denied' }, 403);
+      }
+      owner = { orgId, partnerId: null };
     }
 
     const configErrors = validateNotificationChannelConfig(data.type, data.config);
@@ -158,7 +183,7 @@ channelsRoutes.post(
     }
 
     if (data.type === 'pushover') {
-      const inheritanceError = await validatePushoverChannelInheritance(orgId, data.config);
+      const inheritanceError = await validatePushoverChannelInheritance(owner, data.config);
       if (inheritanceError) {
         return c.json({
           error: `Invalid ${data.type} channel configuration`,
@@ -170,7 +195,8 @@ channelsRoutes.post(
     const [channel] = await db
       .insert(notificationChannels)
       .values({
-        orgId,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: data.name,
         type: data.type,
         config: encryptNotificationChannelConfig(data.type, data.config),
@@ -184,7 +210,7 @@ channelsRoutes.post(
     }
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: owner.orgId,
       action: 'notification_channel.create',
       resourceType: 'notification_channel',
       resourceId: channel.id,
@@ -220,6 +246,12 @@ channelsRoutes.put(
       return c.json({ error: 'Notification channel not found' }, 404);
     }
 
+    // Partner-wide channels are administrable only with the partner-wide
+    // capability (#2130).
+    if (channel.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     if (data.config !== undefined) {
       const configForValidation = decryptNotificationChannelConfig(
         channel.type,
@@ -234,7 +266,7 @@ channelsRoutes.put(
       }
 
       if (channel.type === 'pushover') {
-        const inheritanceError = await validatePushoverChannelInheritance(channel.orgId, configForValidation);
+        const inheritanceError = await validatePushoverChannelInheritance(channel, configForValidation);
         if (inheritanceError) {
           return c.json({
             error: `Invalid ${channel.type} channel configuration`,
@@ -296,6 +328,12 @@ channelsRoutes.delete(
     const channel = await getNotificationChannelWithOrgCheck(channelId, auth);
     if (!channel) {
       return c.json({ error: 'Notification channel not found' }, 404);
+    }
+
+    // Partner-wide channels are administrable only with the partner-wide
+    // capability (#2130).
+    if (channel.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     await db
@@ -413,7 +451,9 @@ channelsRoutes.post(
               alertName: testMessage.title,
               severity: testMessage.severity,
               summary: testMessage.message,
-              orgId: channel.orgId,
+              // Partner-wide channels (#2130) have no owning org; the test
+              // payload's orgId is informational only.
+              orgId: channel.orgId ?? channel.partnerId ?? 'partner-wide',
               orgName: 'Breeze',
               triggeredAt: new Date().toISOString(),
               context: { dashboardUrl: dashboardUrl ? ` ${dashboardUrl}` : '' }
@@ -441,7 +481,9 @@ channelsRoutes.post(
               alertName: testMessage.title,
               severity: testMessage.severity as AlertSeverity,
               summary: testMessage.message,
-              orgId: channel.orgId,
+              // Partner-wide channels (#2130) have no owning org; the test
+              // payload's orgId is informational only.
+              orgId: channel.orgId ?? channel.partnerId ?? 'partner-wide',
               orgName: 'Breeze',
               triggeredAt: new Date().toISOString(),
               dashboardUrl
@@ -474,18 +516,24 @@ channelsRoutes.post(
             // partner row is silently filtered and inheritance fails open
             // with a misleading "token required" error.
             const inherited = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-              const [orgRow] = await db
-                .select({ partnerId: organizations.partnerId })
-                .from(organizations)
-                .where(eq(organizations.id, channel.orgId))
-                .limit(1);
-              if (!orgRow?.partnerId) {
+              // Partner-wide channels (#2130) carry the partner directly;
+              // org-owned channels derive it from their org.
+              let partnerId = channel.partnerId ?? null;
+              if (!partnerId && channel.orgId) {
+                const [orgRow] = await db
+                  .select({ partnerId: organizations.partnerId })
+                  .from(organizations)
+                  .where(eq(organizations.id, channel.orgId))
+                  .limit(1);
+                partnerId = orgRow?.partnerId ?? null;
+              }
+              if (!partnerId) {
                 return null;
               }
               const [partner] = await db
                 .select({ settings: partners.settings })
                 .from(partners)
-                .where(eq(partners.id, orgRow.partnerId))
+                .where(eq(partners.id, partnerId))
                 .limit(1);
               return (partner?.settings as { notifications?: Record<string, unknown> } | null)?.notifications ?? null;
             }));
@@ -511,7 +559,8 @@ channelsRoutes.post(
             alertName: testMessage.title,
             severity: testMessage.severity as AlertSeverity,
             summary: testMessage.message,
-            orgId: channel.orgId,
+            // Partner-wide channels (#2130) have no owning org; informational.
+            orgId: channel.orgId ?? channel.partnerId ?? 'partner-wide',
             orgName: 'Breeze',
             triggeredAt: new Date().toISOString(),
             dashboardUrl

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -366,6 +366,15 @@ channelsRoutes.post(
     if (!channel) {
       return c.json({ error: 'Notification channel not found' }, 404);
     }
+
+    // Test-send is a mutator in effect: it fires a REAL external notification
+    // (Slack/PagerDuty/SMS/...) on the shared destination and overwrites the
+    // channel's lastTestedAt/lastTestStatus for every org under the partner —
+    // gate partner-wide channels like the sibling PUT/DELETE (#2130 review).
+    if (channel.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const channelConfig = decryptNotificationChannelConfig(channel.type, channel.config);
     const redactedChannelConfig = redactNotificationChannelConfig(channel.type, channel.config);
 

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import type { NotificationChannelType } from '@breeze/shared';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import {
@@ -175,7 +175,10 @@ export async function getAlertWithOrgCheck(
   return alert;
 }
 
-export async function getNotificationChannelWithOrgCheck(channelId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {
+export async function getNotificationChannelWithOrgCheck(
+  channelId: string,
+  auth: { canAccessOrg: (orgId: string) => boolean; scope?: string; partnerId?: string | null }
+) {
   const [channel] = await db
     .select()
     .from(notificationChannels)
@@ -186,7 +189,13 @@ export async function getNotificationChannelWithOrgCheck(channelId: string, auth
     return null;
   }
 
-  const hasAccess = ensureOrgAccess(channel.orgId, auth);
+  // Dual-axis access (#2130, same shape as getAlertRuleWithOrgCheck): org-owned
+  // channels via org access; partner-wide channels (orgId NULL) via the
+  // caller's own partner (or system scope). Writes are additionally gated on
+  // canManagePartnerWidePolicies at the routes.
+  const hasAccess = channel.orgId !== null
+    ? ensureOrgAccess(channel.orgId, auth)
+    : auth.scope === 'system' || (!!auth.partnerId && channel.partnerId === auth.partnerId);
   if (!hasAccess) {
     return null;
   }
@@ -194,7 +203,10 @@ export async function getNotificationChannelWithOrgCheck(channelId: string, auth
   return channel;
 }
 
-export async function getEscalationPolicyWithOrgCheck(policyId: string, auth: { canAccessOrg: (orgId: string) => boolean }) {
+export async function getEscalationPolicyWithOrgCheck(
+  policyId: string,
+  auth: { canAccessOrg: (orgId: string) => boolean; scope?: string; partnerId?: string | null }
+) {
   const [policy] = await db
     .select()
     .from(escalationPolicies)
@@ -205,7 +217,10 @@ export async function getEscalationPolicyWithOrgCheck(policyId: string, auth: { 
     return null;
   }
 
-  const hasAccess = ensureOrgAccess(policy.orgId, auth);
+  // Dual-axis access (#2130) — see getNotificationChannelWithOrgCheck.
+  const hasAccess = policy.orgId !== null
+    ? ensureOrgAccess(policy.orgId, auth)
+    : auth.scope === 'system' || (!!auth.partnerId && policy.partnerId === auth.partnerId);
   if (!hasAccess) {
     return null;
   }
@@ -328,7 +343,7 @@ export function validateNotificationChannelConfig(
  * out, the channel would save with no token, and alerts would drop silently.
  */
 export async function validatePushoverChannelInheritance(
-  orgId: string,
+  owner: { orgId: string | null; partnerId?: string | null },
   config: unknown
 ): Promise<string | null> {
   if (!isRecord(config)) {
@@ -342,18 +357,24 @@ export async function validatePushoverChannelInheritance(
   }
 
   const inherited = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-    const [orgRow] = await db
-      .select({ partnerId: organizations.partnerId })
-      .from(organizations)
-      .where(eq(organizations.id, orgId))
-      .limit(1);
-    if (!orgRow?.partnerId) {
+    // Partner-wide channels (#2130) carry the partner directly; org-owned
+    // channels derive it from their org.
+    let partnerId = owner.partnerId ?? null;
+    if (!partnerId && owner.orgId) {
+      const [orgRow] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, owner.orgId))
+        .limit(1);
+      partnerId = orgRow?.partnerId ?? null;
+    }
+    if (!partnerId) {
       return null;
     }
     const [partner] = await db
       .select({ settings: partners.settings })
       .from(partners)
-      .where(eq(partners.id, orgRow.partnerId))
+      .where(eq(partners.id, partnerId))
       .limit(1);
     return (partner?.settings as { notifications?: Record<string, unknown> } | null)?.notifications ?? null;
   }));
@@ -375,36 +396,67 @@ export async function validateAlertRuleNotificationBindings(
   overrides: AlertRuleOverrides
 ): Promise<string | null> {
   const requestedChannelIds = [...new Set(getNotificationChannelIds(overrides).filter(Boolean))];
+  const needsPartnerAxis = requestedChannelIds.length > 0
+    || (typeof overrides.escalationPolicyId === 'string' && overrides.escalationPolicyId.length > 0);
+
+  // Dual-axis (#2130): a rule may bind the org's own rails OR partner-wide
+  // rails (org_id NULL) owned by the org's partner. Partner-wide rows are
+  // RLS-invisible to org-scope callers, so for them this still resolves to
+  // "same organization" — which is also what their UI offers.
+  let orgPartnerId: string | null = null;
+  if (needsPartnerAxis) {
+    const [orgRow] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    orgPartnerId = orgRow?.partnerId ?? null;
+  }
+
+  const channelOwnership = orgPartnerId
+    ? or(
+        eq(notificationChannels.orgId, orgId),
+        and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, orgPartnerId))
+      )
+    : eq(notificationChannels.orgId, orgId);
+
   if (requestedChannelIds.length > 0) {
     const channels = await db
       .select({ id: notificationChannels.id })
       .from(notificationChannels)
       .where(
         and(
-          eq(notificationChannels.orgId, orgId),
+          channelOwnership,
           inArray(notificationChannels.id, requestedChannelIds)
         )
       );
 
     if (channels.length !== requestedChannelIds.length) {
-      return 'Notification channels must belong to the same organization as the alert rule';
+      return 'Notification channels must belong to the same organization as the alert rule or its partner';
     }
   }
 
   if (typeof overrides.escalationPolicyId === 'string' && overrides.escalationPolicyId.length > 0) {
+    const policyOwnership = orgPartnerId
+      ? or(
+          eq(escalationPolicies.orgId, orgId),
+          and(isNull(escalationPolicies.orgId), eq(escalationPolicies.partnerId, orgPartnerId))
+        )
+      : eq(escalationPolicies.orgId, orgId);
+
     const [policy] = await db
       .select({ id: escalationPolicies.id })
       .from(escalationPolicies)
       .where(
         and(
           eq(escalationPolicies.id, overrides.escalationPolicyId),
-          eq(escalationPolicies.orgId, orgId)
+          policyOwnership
         )
       )
       .limit(1);
 
     if (!policy) {
-      return 'Escalation policy must belong to the same organization as the alert rule';
+      return 'Escalation policy must belong to the same organization as the alert rule or its partner';
     }
   }
 

--- a/apps/api/src/routes/alerts/policies.authz.test.ts
+++ b/apps/api/src/routes/alerts/policies.authz.test.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono';
 // Regression for Finding #6 (MEDIUM): escalation-policy mutations must gate on
 // ALERTS_WRITE in addition to scope tier.
 
-const { authRef, grantedRef } = vi.hoisted(() => ({
+const { authRef, grantedRef, insertedRef, updateSetRef } = vi.hoisted(() => ({
   authRef: {
     current: {
       scope: 'organization' as string,
@@ -16,6 +16,8 @@ const { authRef, grantedRef } = vi.hoisted(() => ({
     },
   },
   grantedRef: { current: new Set<string>() },
+  insertedRef: { current: undefined as Record<string, unknown> | undefined },
+  updateSetRef: { current: undefined as Record<string, unknown> | undefined },
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -34,7 +36,37 @@ vi.mock('../../middleware/auth', () => ({
   requireMfa: () => async (_c: any, next: any) => next(),
 }));
 
-vi.mock('../../db', () => ({ db: {} }));
+// db mock: a minimal insert/update/delete builder so the partner-wide gating
+// tests below can exercise POST (real insert) and PUT/DELETE (real update
+///delete against a row resolved via the mocked getEscalationPolicyWithOrgCheck)
+// without a real database. The Finding #6 tests above never reach these calls
+// (they 403 on the permission gate first), so they are unaffected.
+vi.mock('../../db', () => {
+  const builder: any = {
+    values: (vals: Record<string, unknown>) => {
+      insertedRef.current = vals;
+      return builder;
+    },
+    set: (vals: Record<string, unknown>) => {
+      updateSetRef.current = vals;
+      return builder;
+    },
+    where: () => builder,
+    returning: () => {
+      if (insertedRef.current) {
+        return Promise.resolve([{ id: 'new-policy', createdAt: new Date(), updatedAt: new Date(), ...(insertedRef.current ?? {}) }]);
+      }
+      return Promise.resolve([{ id: 'policy-1', ...(updateSetRef.current ?? {}) }]);
+    },
+  };
+  return {
+    db: {
+      insert: () => builder,
+      update: () => builder,
+      delete: () => ({ where: () => Promise.resolve(undefined) }),
+    },
+  };
+});
 vi.mock('../../db/schema', () => ({ escalationPolicies: {} }));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('./helpers', () => ({
@@ -44,6 +76,7 @@ vi.mock('./helpers', () => ({
 }));
 
 import { policiesRoutes } from './policies';
+import * as helpers from './helpers';
 
 function makeApp() {
   const app = new Hono();
@@ -93,5 +126,115 @@ describe('escalation policies authz (Finding #6)', () => {
     grantedRef.current.add(ALERTS_WRITE);
     const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, { method: 'DELETE' });
     expect(res.status).not.toBe(403);
+  });
+});
+
+// ============================================================
+// Partner-wide escalation policies (#2130)
+// ============================================================
+//
+// Partner-wide rows (orgId NULL, partnerId = owning partner) are administrable
+// only with canManagePartnerWidePolicies(auth) — system scope, or partner
+// scope with partnerOrgAccess 'all'. getEscalationPolicyWithOrgCheck is
+// dual-axis (mocked here per-test): a partner-scope caller on the matching
+// partner can LOAD the row; the 403 for PUT/DELETE comes from the
+// capability gate in the route itself, not from the lookup.
+// partnerWideAccess.ts is a dependency-free leaf and intentionally NOT mocked.
+
+describe('partner-wide escalation policies (#2130)', () => {
+  const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+
+  function setPartnerAuth(partnerOrgAccess: 'all' | 'selected' | 'none') {
+    grantedRef.current = new Set<string>([ALERTS_WRITE]);
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Partner Admin', email: 'admin@msp.example' },
+      partnerId: PARTNER_ID,
+      partnerOrgAccess,
+      orgId: null,
+      accessibleOrgIds: ['org-1'],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRef.current = undefined;
+    updateSetRef.current = undefined;
+  });
+
+  it('denies partner-wide create without full partner org access', async () => {
+    setPartnerAuth('selected');
+    const res = await makeApp().request('/alerts/policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ownerScope: 'partner', name: 'Fleet escalation', steps: [] }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+    expect(insertedRef.current).toBeUndefined();
+  });
+
+  it('creates a partner-wide policy with full partner org access ({ orgId: null, partnerId })', async () => {
+    setPartnerAuth('all');
+    const res = await makeApp().request('/alerts/policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ownerScope: 'partner', name: 'Fleet escalation', steps: [] }),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBeNull();
+    expect(insertedRef.current?.partnerId).toBe(PARTNER_ID);
+  });
+
+  it('denies PUT of a partner-wide policy without the partner-wide capability', async () => {
+    setPartnerAuth('selected');
+    vi.mocked(helpers.getEscalationPolicyWithOrgCheck).mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet escalation', steps: [],
+    } as never);
+
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('allows PUT of a partner-wide policy with full partner org access', async () => {
+    setPartnerAuth('all');
+    vi.mocked(helpers.getEscalationPolicyWithOrgCheck).mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet escalation', steps: [],
+    } as never);
+
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+    expect(res.status).toBe(200);
+    expect(updateSetRef.current?.name).toBe('Renamed');
+  });
+
+  it('denies DELETE of a partner-wide policy without the partner-wide capability', async () => {
+    setPartnerAuth('none');
+    vi.mocked(helpers.getEscalationPolicyWithOrgCheck).mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet escalation', steps: [],
+    } as never);
+
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('allows DELETE of a partner-wide policy with full partner org access', async () => {
+    setPartnerAuth('all');
+    vi.mocked(helpers.getEscalationPolicyWithOrgCheck).mockResolvedValue({
+      id: POLICY_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet escalation', steps: [],
+    } as never);
+
+    const res = await makeApp().request(`/alerts/policies/${POLICY_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/routes/alerts/policies.ts
+++ b/apps/api/src/routes/alerts/policies.ts
@@ -1,10 +1,14 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, inArray, isNull, or } from 'drizzle-orm';
 import { db } from '../../db';
 import { escalationPolicies } from '../../db/schema';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../../services/partnerWideAccess';
 import { listPoliciesSchema, createPolicySchema, updatePolicySchema } from './schemas';
 import { getPagination, ensureOrgAccess, getEscalationPolicyWithOrgCheck } from './helpers';
 import { PERMISSIONS } from '../../services/permissions';
@@ -40,14 +44,25 @@ policiesRoutes.get(
         }
         conditions.push(eq(escalationPolicies.orgId, query.orgId));
       } else {
+        // "All orgs" view: org-owned policies across accessible orgs PLUS
+        // this partner's own partner-wide policies (org_id NULL, #2130).
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        const orgCondition = orgIds.length > 0
+          ? inArray(escalationPolicies.orgId, orgIds)
+          : undefined;
+        const partnerCondition = auth.partnerId
+          ? and(isNull(escalationPolicies.orgId), eq(escalationPolicies.partnerId, auth.partnerId))
+          : undefined;
+        const ownership = orgCondition && partnerCondition
+          ? or(orgCondition, partnerCondition)
+          : (orgCondition ?? partnerCondition);
+        if (!ownership) {
           return c.json({
             data: [],
             pagination: { page, limit, total: 0 }
           });
         }
-        conditions.push(inArray(escalationPolicies.orgId, orgIds));
+        conditions.push(ownership as ReturnType<typeof eq>);
       }
     } else if (auth.scope === 'system' && query.orgId) {
       conditions.push(eq(escalationPolicies.orgId, query.orgId));
@@ -89,35 +104,45 @@ policiesRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    // Determine orgId
-    let orgId = data.orgId;
-
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) {
-        return c.json({ error: 'Organization context required' }, 403);
+    // Resolve the ownership axis (#2130): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (data.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
       }
-      orgId = auth.orgId;
-    } else if (auth.scope === 'partner') {
-      if (!orgId) {
-        const singleOrg = auth.accessibleOrgIds?.[0];
-        if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
-          orgId = singleOrg;
-        } else {
-          return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      let orgId = data.orgId;
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) {
+          return c.json({ error: 'Organization context required' }, 403);
         }
+        orgId = auth.orgId;
+      } else if (auth.scope === 'partner') {
+        if (!orgId) {
+          const singleOrg = auth.accessibleOrgIds?.[0];
+          if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
+            orgId = singleOrg;
+          } else {
+            return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+          }
+        }
+        const hasAccess = ensureOrgAccess(orgId, auth);
+        if (!hasAccess) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+      } else if (auth.scope === 'system' && !orgId) {
+        return c.json({ error: 'orgId is required' }, 400);
       }
-      const hasAccess = ensureOrgAccess(orgId, auth);
-      if (!hasAccess) {
-        return c.json({ error: 'Access to this organization denied' }, 403);
-      }
-    } else if (auth.scope === 'system' && !orgId) {
-      return c.json({ error: 'orgId is required' }, 400);
+      owner = { orgId: orgId!, partnerId: null };
     }
 
     const [policy] = await db
       .insert(escalationPolicies)
       .values({
-        orgId: orgId!,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         name: data.name,
         steps: data.steps
       })
@@ -160,6 +185,12 @@ policiesRoutes.put(
     const policy = await getEscalationPolicyWithOrgCheck(policyId, auth);
     if (!policy) {
       return c.json({ error: 'Escalation policy not found' }, 404);
+    }
+
+    // Partner-wide escalation policies are administrable only with the
+    // partner-wide capability (#2130).
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     // Build updates object
@@ -205,6 +236,12 @@ policiesRoutes.delete(
     const policy = await getEscalationPolicyWithOrgCheck(policyId, auth);
     if (!policy) {
       return c.json({ error: 'Escalation policy not found' }, 404);
+    }
+
+    // Partner-wide escalation policies are administrable only with the
+    // partner-wide capability (#2130).
+    if (policy.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     await db

--- a/apps/api/src/routes/alerts/routing.list.test.ts
+++ b/apps/api/src/routes/alerts/routing.list.test.ts
@@ -46,7 +46,9 @@ vi.mock('../../db', () => {
   };
   return { db: { select: () => builder } };
 });
-vi.mock('../../db/schema', () => ({ notificationRoutingRules: { orgId: { name: 'org_id' } } }));
+vi.mock('../../db/schema', () => ({
+  notificationRoutingRules: { orgId: { name: 'org_id' }, partnerId: { name: 'partner_id' } },
+}));
 vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 
 import { routingRoutes } from './routing';
@@ -64,7 +66,23 @@ describe('GET /alerts/routing-rules (list-on-load)', () => {
     rowsRef.current = [];
   });
 
-  it('returns 200 with an empty list for a partner with no accessible orgs (no orgId)', async () => {
+  it('returns 200 with an empty list for a partner with no accessible orgs and no partnerId (no orgId)', async () => {
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Pat', email: 'pat@partner.example' },
+      partnerId: null, orgId: null, accessibleOrgIds: [], canAccessOrg: () => true,
+    } as typeof authRef.current;
+
+    const res = await makeApp().request('/alerts/routing-rules');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+    // Short-circuited before touching the db — neither the org-accessible nor
+    // the partner-wide (#2130) condition applies, so there is nothing to query.
+    expect(capturedWhere.current).toBeUndefined();
+  });
+
+  it('queries for partner-wide rules when a partner has no accessible orgs but does have a partnerId (#2130)', async () => {
     authRef.current = {
       scope: 'partner',
       user: { id: 'u-1', name: 'Pat', email: 'pat@partner.example' },
@@ -75,8 +93,10 @@ describe('GET /alerts/routing-rules (list-on-load)', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ data: [] });
-    // Short-circuited before touching the db — no where-condition captured.
-    expect(capturedWhere.current).toBeUndefined();
+    // Not short-circuited: even with zero accessible orgs, a partner-scoped
+    // caller still owns their own partner-wide rules (org_id NULL), so the
+    // partner condition is queried.
+    expect(capturedWhere.current).toBeDefined();
   });
 
   it('returns 200 (not 400) for a partner with accessible orgs but no orgId selected', async () => {

--- a/apps/api/src/routes/alerts/routing.ts
+++ b/apps/api/src/routes/alerts/routing.ts
@@ -3,10 +3,14 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { db } from '../../db';
 import { notificationRoutingRules } from '../../db/schema';
-import { eq, and, asc, inArray } from 'drizzle-orm';
+import { eq, and, asc, inArray, isNull, or } from 'drizzle-orm';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { ensureOrgAccess, resolveWriteOrgId } from './helpers';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../../services/partnerWideAccess';
 import { PERMISSIONS } from '../../services/permissions';
 
 const listRoutingRulesSchema = z.object({
@@ -14,6 +18,9 @@ const listRoutingRulesSchema = z.object({
 });
 
 const createRoutingRuleSchema = z.object({
+  // 'partner' creates a partner-wide ("all orgs") routing rule: orgId NULL,
+  // partnerId = caller's partner (#2130). Create-only.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(255),
   priority: z.number().int().min(0),
   conditions: z.object({
@@ -43,6 +50,29 @@ export const routingRoutes = new Hono();
 
 const requireAlertWrite = requirePermission(PERMISSIONS.ALERTS_WRITE.resource, PERMISSIONS.ALERTS_WRITE.action);
 
+// Dual-axis by-id lookup (#2130): org-owned rules via org access; partner-wide
+// rules (orgId NULL) via the caller's own partner (or system scope). Writes are
+// additionally gated on canManagePartnerWidePolicies at the routes.
+async function getRoutingRuleWithAccess(
+  ruleId: string,
+  auth: { scope?: string; partnerId?: string | null; canAccessOrg: (orgId: string) => boolean }
+) {
+  const [rule] = await db
+    .select()
+    .from(notificationRoutingRules)
+    .where(eq(notificationRoutingRules.id, ruleId))
+    .limit(1);
+
+  if (!rule) {
+    return null;
+  }
+
+  const hasAccess = rule.orgId !== null
+    ? ensureOrgAccess(rule.orgId, auth)
+    : auth.scope === 'system' || (!!auth.partnerId && rule.partnerId === auth.partnerId);
+  return hasAccess ? rule : null;
+}
+
 routingRoutes.get(
   '/routing-rules',
   requireScope('organization', 'partner', 'system'),
@@ -69,11 +99,21 @@ routingRoutes.get(
         }
         orgFilter = eq(notificationRoutingRules.orgId, query.orgId);
       } else if (auth.scope === 'partner') {
+        // "All orgs" view: org-owned rules across accessible orgs PLUS this
+        // partner's own partner-wide rules (org_id NULL, #2130).
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        const orgCondition = orgIds.length > 0
+          ? inArray(notificationRoutingRules.orgId, orgIds)
+          : undefined;
+        const partnerCondition = auth.partnerId
+          ? and(isNull(notificationRoutingRules.orgId), eq(notificationRoutingRules.partnerId, auth.partnerId))
+          : undefined;
+        orgFilter = orgCondition && partnerCondition
+          ? or(orgCondition, partnerCondition)
+          : (orgCondition ?? partnerCondition);
+        if (!orgFilter) {
           return c.json({ data: [] });
         }
-        orgFilter = inArray(notificationRoutingRules.orgId, orgIds);
       }
       // system scope with no orgId falls through to no filter (sees all rules);
       // RLS still constrains what breeze_app can read.
@@ -101,18 +141,29 @@ routingRoutes.post(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
-      if (resolved.error) {
-        return c.json({ error: resolved.error }, resolved.status ?? 400);
-      }
-      const orgId = resolved.orgId!;
-
       const data = c.req.valid('json');
+
+      // Resolve the ownership axis (#2130): partner-wide creation requires
+      // the partner-wide capability; the default path stays org-owned.
+      let owner: { orgId: string | null; partnerId: string | null };
+      if (data.ownerScope === 'partner') {
+        if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+          return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+        }
+        owner = { orgId: null, partnerId: auth.partnerId };
+      } else {
+        const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
+        if (resolved.error) {
+          return c.json({ error: resolved.error }, resolved.status ?? 400);
+        }
+        owner = { orgId: resolved.orgId!, partnerId: null };
+      }
 
       const [rule] = await db
         .insert(notificationRoutingRules)
         .values({
-          orgId,
+          orgId: owner.orgId,
+          partnerId: owner.partnerId,
           name: data.name,
           priority: data.priority,
           conditions: data.conditions,
@@ -122,7 +173,7 @@ routingRoutes.post(
         .returning();
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: owner.orgId,
         action: 'notification_routing_rule.create',
         resourceType: 'notification_routing_rule',
         resourceId: rule?.id,
@@ -147,23 +198,18 @@ routingRoutes.patch(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
-      if (resolved.error) {
-        return c.json({ error: resolved.error }, resolved.status ?? 400);
-      }
-      const orgId = resolved.orgId!;
-
       const ruleId = c.req.param('id')!;
       const updates = c.req.valid('json');
 
-      const [existing] = await db
-        .select()
-        .from(notificationRoutingRules)
-        .where(and(eq(notificationRoutingRules.id, ruleId), eq(notificationRoutingRules.orgId, orgId)))
-        .limit(1);
-
+      const existing = await getRoutingRuleWithAccess(ruleId, auth);
       if (!existing) {
         return c.json({ error: 'Routing rule not found' }, 404);
+      }
+
+      // Partner-wide routing rules are administrable only with the
+      // partner-wide capability (#2130).
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
       }
 
       const setValues: Record<string, unknown> = { updatedAt: new Date() };
@@ -176,11 +222,11 @@ routingRoutes.patch(
       const [updated] = await db
         .update(notificationRoutingRules)
         .set(setValues)
-        .where(and(eq(notificationRoutingRules.id, ruleId), eq(notificationRoutingRules.orgId, orgId)))
+        .where(eq(notificationRoutingRules.id, ruleId))
         .returning();
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: existing.orgId,
         action: 'notification_routing_rule.update',
         resourceType: 'notification_routing_rule',
         resourceId: ruleId,
@@ -204,30 +250,25 @@ routingRoutes.delete(
   async (c) => {
     try {
       const auth = c.get('auth');
-      const resolved = resolveWriteOrgId(auth, c.req.query('orgId'));
-      if (resolved.error) {
-        return c.json({ error: resolved.error }, resolved.status ?? 400);
-      }
-      const orgId = resolved.orgId!;
-
       const ruleId = c.req.param('id')!;
 
-      const [existing] = await db
-        .select()
-        .from(notificationRoutingRules)
-        .where(and(eq(notificationRoutingRules.id, ruleId), eq(notificationRoutingRules.orgId, orgId)))
-        .limit(1);
-
+      const existing = await getRoutingRuleWithAccess(ruleId, auth);
       if (!existing) {
         return c.json({ error: 'Routing rule not found' }, 404);
       }
 
+      // Partner-wide routing rules are administrable only with the
+      // partner-wide capability (#2130).
+      if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+
       await db.delete(notificationRoutingRules).where(
-        and(eq(notificationRoutingRules.id, ruleId), eq(notificationRoutingRules.orgId, orgId))
+        eq(notificationRoutingRules.id, ruleId)
       );
 
       writeRouteAudit(c, {
-        orgId,
+        orgId: existing.orgId,
         action: 'notification_routing_rule.delete',
         resourceType: 'notification_routing_rule',
         resourceId: existing.id,

--- a/apps/api/src/routes/alerts/routing.writes.test.ts
+++ b/apps/api/src/routes/alerts/routing.writes.test.ts
@@ -225,3 +225,106 @@ describe('routing-rule writes — partner org resolution (#1633)', () => {
     expect(insertedRef.current?.orgId).toBe('org-x');
   });
 });
+
+// ============================================================
+// Partner-wide routing rules (#2130)
+// ============================================================
+//
+// Partner-wide rows (orgId NULL, partnerId = owning partner) are administrable
+// only with canManagePartnerWidePolicies(auth) — system scope, or partner
+// scope with partnerOrgAccess 'all'. The dual-axis by-id lookup
+// (getRoutingRuleWithAccess, local to routing.ts) lets a partner-scope caller
+// on the matching partner LOAD the row; the 403 for PATCH/DELETE comes from
+// the capability gate in the route itself. partnerWideAccess.ts is a
+// dependency-free leaf and intentionally NOT mocked.
+
+describe('routing-rule writes — partner-wide gating (#2130)', () => {
+  const PARTNER_ID = '99999999-9999-4999-8999-999999999999';
+
+  function setPartnerAuth(partnerOrgAccess: 'all' | 'selected' | 'none') {
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Partner Admin', email: 'admin@msp.example' },
+      partnerId: PARTNER_ID,
+      partnerOrgAccess,
+      orgId: null,
+      accessibleOrgIds: ['org-a'],
+      canAccessOrg: () => true,
+    } as typeof authRef.current;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRef.current = undefined;
+    capturedWhere.current = undefined;
+    existingRowRef.current = undefined;
+  });
+
+  it('denies partner-wide create without full partner org access', async () => {
+    setPartnerAuth('selected');
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner' }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+    expect(insertedRef.current).toBeUndefined();
+  });
+
+  it('creates a partner-wide routing rule with full partner org access ({ orgId: null, partnerId })', async () => {
+    setPartnerAuth('all');
+    const res = await makeApp().request('/alerts/routing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, ownerScope: 'partner' }),
+    });
+    expect(res.status).toBe(201);
+    expect(insertedRef.current?.orgId).toBeNull();
+    expect(insertedRef.current?.partnerId).toBe(PARTNER_ID);
+  });
+
+  it('denies PATCH of a partner-wide routing rule without the partner-wide capability', async () => {
+    setPartnerAuth('none');
+    existingRowRef.current = { id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet routing' };
+
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('allows PATCH of a partner-wide routing rule with full partner org access', async () => {
+    setPartnerAuth('all');
+    existingRowRef.current = { id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet routing' };
+
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed Fleet routing' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('denies DELETE of a partner-wide routing rule without the partner-wide capability', async () => {
+    setPartnerAuth('selected');
+    existingRowRef.current = { id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet routing' };
+
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).error).toMatch(/full partner org access/);
+  });
+
+  it('allows DELETE of a partner-wide routing rule with full partner org access', async () => {
+    setPartnerAuth('all');
+    existingRowRef.current = { id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Fleet routing' };
+
+    const res = await makeApp().request(`/alerts/routing-rules/${RULE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: { id: RULE_ID, deleted: true } });
+  });
+});

--- a/apps/api/src/routes/alerts/schemas.ts
+++ b/apps/api/src/routes/alerts/schemas.ts
@@ -133,6 +133,9 @@ export const listChannelsSchema = z.object({
 
 export const createChannelSchema = z.object({
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") channel: orgId NULL,
+  // partnerId = caller's partner (#2130). Create-only.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(255),
   type: z.enum(NOTIFICATION_CHANNEL_TYPES),
   config: z.record(z.string(), z.unknown()), // JSONB for type-specific config
@@ -159,6 +162,8 @@ export const listPoliciesSchema = z.object({
 
 export const createPolicySchema = z.object({
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") escalation policy (#2130).
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(255),
   steps: z.any() // JSONB for escalation steps
 });

--- a/apps/api/src/services/aiToolsAlerts.channelSecrets.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.channelSecrets.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   dbInsert: vi.fn(),
   dbSelect: vi.fn(),
   dbUpdate: vi.fn(),
+  dbDelete: vi.fn(),
   encryptNotificationChannelConfig: vi.fn(),
   decryptNotificationChannelConfig: vi.fn(),
   validateNotificationChannelConfig: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('../db', () => ({
     insert: mocks.dbInsert,
     select: mocks.dbSelect,
     update: mocks.dbUpdate,
+    delete: mocks.dbDelete,
   },
 }));
 
@@ -84,6 +86,30 @@ function makeAuth(orgId = 'org-1'): AuthContext {
     accessibleOrgIds: [orgId],
     orgCondition: () => undefined,
     canAccessOrg: (id: string) => id === orgId,
+  } as unknown as AuthContext;
+}
+
+// Partner-scoped caller (#2130): partnerOrgAccess gates administration of
+// partner-wide (orgId NULL) rows via canManagePartnerWidePolicies.
+function makePartnerAuth(
+  partnerOrgAccess: 'all' | 'selected' | 'none',
+  partnerId = 'partner-1',
+): AuthContext {
+  return {
+    user: {
+      id: '22222222-2222-4222-8222-222222222222',
+      email: 'partner-admin@msp.example',
+      name: 'Partner Admin',
+      isPlatformAdmin: false,
+    },
+    token: {} as never,
+    partnerId,
+    orgId: null,
+    scope: 'partner',
+    partnerOrgAccess,
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
   } as unknown as AuthContext;
 }
 
@@ -318,5 +344,119 @@ describe('manage_notification_channels — update action', () => {
     expect(result.error).toMatch(/not found/i);
     expect(mocks.encryptNotificationChannelConfig).not.toHaveBeenCalled();
     expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ---- tests: partner-wide gating (#2130) --------------------------------
+//
+// A partner-wide channel (orgId NULL, partnerId = owning partner) is visible
+// to any caller on that partner (dual-axis lookup, same as the HTTP route's
+// getNotificationChannelWithOrgCheck), but administrable only when
+// canManagePartnerWidePolicies(auth) is true — i.e. partnerOrgAccess 'all'.
+// partnerWideAccess.ts is a dependency-free leaf and intentionally NOT mocked.
+
+describe('manage_notification_channels — partner-wide gating (#2130)', () => {
+  let handler: AiTool['handler'];
+
+  const PARTNER_ID = 'partner-1';
+  const PARTNER_WIDE_CHANNEL = {
+    id: 'chan-partner-wide',
+    orgId: null,
+    partnerId: PARTNER_ID,
+    name: 'Fleet Slack',
+    type: 'slack',
+    config: { webhookUrl: ENCRYPTED_STUB },
+    enabled: true,
+  };
+
+  function mockChannelLookup(channel: unknown | null) {
+    mocks.dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue(channel ? [channel] : []),
+        })),
+      })),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = getHandler('manage_notification_channels');
+  });
+
+  it('update: denies a partner-wide channel without full partner org access', async () => {
+    mockChannelLookup(PARTNER_WIDE_CHANNEL);
+
+    const result = JSON.parse(
+      await handler(
+        { action: 'update', channelId: PARTNER_WIDE_CHANNEL.id, name: 'Hijacked' },
+        makePartnerAuth('selected', PARTNER_ID),
+      ) as string,
+    );
+
+    expect(result.error).toMatch(/partner-wide/i);
+    expect(result.error).toMatch(/full partner org access/i);
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('update: allows a partner-wide channel with full partner org access', async () => {
+    mockChannelLookup(PARTNER_WIDE_CHANNEL);
+    const setMock = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+    mocks.dbUpdate.mockReturnValue({ set: setMock });
+
+    const result = JSON.parse(
+      await handler(
+        { action: 'update', channelId: PARTNER_WIDE_CHANNEL.id, name: 'Renamed Fleet Slack' },
+        makePartnerAuth('all', PARTNER_ID),
+      ) as string,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbUpdate).toHaveBeenCalled();
+    const setCallArg = (setMock.mock.calls[0] as any)[0] as Record<string, unknown>;
+    expect(setCallArg.name).toBe('Renamed Fleet Slack');
+  });
+
+  it('delete: denies a partner-wide channel without full partner org access', async () => {
+    mocks.dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([PARTNER_WIDE_CHANNEL]),
+        })),
+      })),
+    });
+
+    const result = JSON.parse(
+      await handler(
+        { action: 'delete', channelId: PARTNER_WIDE_CHANNEL.id },
+        makePartnerAuth('none', PARTNER_ID),
+      ) as string,
+    );
+
+    expect(result.error).toMatch(/partner-wide/i);
+    expect(result.error).toMatch(/full partner org access/i);
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it('delete: allows a partner-wide channel with full partner org access', async () => {
+    mocks.dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([PARTNER_WIDE_CHANNEL]),
+        })),
+      })),
+    });
+    const deleteWhereMock = vi.fn().mockResolvedValue(undefined);
+    mocks.dbDelete.mockReturnValue({ where: deleteWhereMock });
+
+    const result = JSON.parse(
+      await handler(
+        { action: 'delete', channelId: PARTNER_WIDE_CHANNEL.id },
+        makePartnerAuth('all', PARTNER_ID),
+      ) as string,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbDelete).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -7,6 +7,7 @@
  */
 
 import { db } from '../db';
+import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { alerts, devices, notificationChannels } from '../db/schema';
 import { eq, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -383,8 +384,16 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 50);
 
         const conditions: SQL[] = [];
+        // Dual-axis (#2130): org-owned channels the caller can reach OR
+        // partner-wide channels (org_id NULL) owned by the caller's partner.
         const orgCond = auth.orgCondition(notificationChannels.orgId);
-        if (orgCond) conditions.push(orgCond);
+        if (orgCond) {
+          conditions.push(
+            auth.scope === 'partner' && auth.partnerId
+              ? sql`(${orgCond} OR (${notificationChannels.orgId} IS NULL AND ${notificationChannels.partnerId} = ${auth.partnerId}))`
+              : orgCond
+          );
+        }
 
         if (input.type) {
           conditions.push(eq(notificationChannels.type, input.type as typeof notificationChannels.type.enumValues[number]));
@@ -480,11 +489,24 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         if (!input.channelId) return JSON.stringify({ error: 'channelId is required for update' });
 
         const conditions: SQL[] = [eq(notificationChannels.id, input.channelId as string)];
+        // Dual-axis (#2130) — see the list action.
         const orgCond = auth.orgCondition(notificationChannels.orgId);
-        if (orgCond) conditions.push(orgCond);
+        if (orgCond) {
+          conditions.push(
+            auth.scope === 'partner' && auth.partnerId
+              ? sql`(${orgCond} OR (${notificationChannels.orgId} IS NULL AND ${notificationChannels.partnerId} = ${auth.partnerId}))`
+              : orgCond
+          );
+        }
 
         const [existing] = await db.select().from(notificationChannels).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Notification channel not found or access denied' });
+
+        // Partner-wide channels are administrable only with the partner-wide
+        // capability (same gate as the HTTP route, #2130).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide notification channel requires full partner org access (orgAccess must be "all")' });
+        }
 
         // Channel type is immutable after creation: the config crypto + validation
         // below all run under `existing.type`, so allowing a type change here would
@@ -519,11 +541,24 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         if (!input.channelId) return JSON.stringify({ error: 'channelId is required for delete' });
 
         const conditions: SQL[] = [eq(notificationChannels.id, input.channelId as string)];
+        // Dual-axis (#2130) — see the list action.
         const orgCond = auth.orgCondition(notificationChannels.orgId);
-        if (orgCond) conditions.push(orgCond);
+        if (orgCond) {
+          conditions.push(
+            auth.scope === 'partner' && auth.partnerId
+              ? sql`(${orgCond} OR (${notificationChannels.orgId} IS NULL AND ${notificationChannels.partnerId} = ${auth.partnerId}))`
+              : orgCond
+          );
+        }
 
-        const [existing] = await db.select({ id: notificationChannels.id, name: notificationChannels.name }).from(notificationChannels).where(and(...conditions)).limit(1);
+        const [existing] = await db.select({ id: notificationChannels.id, name: notificationChannels.name, orgId: notificationChannels.orgId }).from(notificationChannels).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Notification channel not found or access denied' });
+
+        // Partner-wide channels are administrable only with the partner-wide
+        // capability (same gate as the HTTP route, #2130).
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide notification channel requires full partner org access (orgAccess must be "all")' });
+        }
 
         await db.delete(notificationChannels).where(eq(notificationChannels.id, existing.id));
         return JSON.stringify({ success: true, message: `Channel "${existing.name}" deleted` });

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -94,6 +94,18 @@ function alertRuleWhere(auth: AuthContext): SQL | undefined {
   return oc;
 }
 
+// Dual-axis access for notification_channels (#2130): same shape as
+// alertRuleWhere — org-owned channels the caller can reach OR partner-wide
+// ones (org_id NULL) owned by the caller's own partner.
+function notificationChannelWhere(auth: AuthContext): SQL | undefined {
+  const oc = orgWhere(auth, notificationChannels.orgId);
+  if (!oc) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${oc} OR (${notificationChannels.orgId} IS NULL AND ${notificationChannels.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
 // Dual-axis access for maintenance_windows (#2131): same shape as
 // alertRuleWhere — org-owned windows the caller can reach OR partner-wide
 // ones (org_id NULL) owned by the caller's own partner.
@@ -1466,7 +1478,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list_channels') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, notificationChannels.orgId);
+        const oc = notificationChannelWhere(auth);
         if (oc) conditions.push(oc);
 
         const rows = await db.select({

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto';
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import type { DeploymentTargetConfig } from '@breeze/shared';
 import { db } from '../db';
 import {
@@ -12,6 +12,7 @@ import {
   deviceGroupMemberships,
   devices,
   notificationChannels,
+  organizations,
   scripts,
 } from '../db/schema';
 import { resolveDeploymentTargets } from './deploymentEngine';
@@ -28,6 +29,30 @@ import {
 // import chain into partial-mock test suites at module-load time.
 
 const ALERT_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
+
+/**
+ * Delivery rails are dual-owned (#2130): an automation's notify targets may
+ * reference the org's own channels OR partner-wide channels (org_id NULL)
+ * owned by the org's partner. A plain eq(orgId, ...) silently drops
+ * partner-wide channels (the #1724 trap; automation runs execute under
+ * system context, so RLS is not the filter here).
+ */
+async function notificationChannelOwnershipCondition(orgId: string): Promise<SQL> {
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!org?.partnerId) {
+    return eq(notificationChannels.orgId, orgId);
+  }
+
+  return or(
+    eq(notificationChannels.orgId, orgId),
+    and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, org.partnerId))
+  ) as SQL;
+}
 
 export type AlertSeverity = typeof ALERT_SEVERITIES[number];
 
@@ -1422,13 +1447,15 @@ export async function executeAutomationRun(
     notificationChannelIds.add(channelId);
   }
 
+  // Dual-axis (#2130): an automation's notify targets may reference the
+  // org's own channels OR partner-wide channels owned by the org's partner.
   const channelRows = notificationChannelIds.size > 0
     ? await db
       .select()
       .from(notificationChannels)
       .where(
         and(
-          eq(notificationChannels.orgId, automation.orgId),
+          await notificationChannelOwnershipCondition(automation.orgId),
           inArray(notificationChannels.id, [...notificationChannelIds]),
         ),
       )
@@ -1889,13 +1916,14 @@ export async function executeConfigPolicyAutomationRun(
     }
   }
 
+  // Dual-axis (#2130) — see the automation notify-channel lookup above.
   const channelRows = notificationChannelIds.size > 0
     ? await db
       .select()
       .from(notificationChannels)
       .where(
         and(
-          eq(notificationChannels.orgId, orgId),
+          await notificationChannelOwnershipCondition(orgId),
           inArray(notificationChannels.id, [...notificationChannelIds]),
         ),
       )

--- a/apps/api/src/services/notificationDispatcher.ts
+++ b/apps/api/src/services/notificationDispatcher.ts
@@ -340,6 +340,14 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
     .limit(1);
 
   if (!channel) {
+    // A resolved {success:false} completes the BullMQ job (no 'failed' event)
+    // and no alert_notifications row exists yet on this path — without a log
+    // this send (possibly a DELAYED escalation step whose channel/partner
+    // state drifted since scheduling) vanishes without a trace (#2130 review).
+    console.warn(
+      `[NotificationDispatcher] Channel ${data.channelId} not found (or disabled) for alert ${data.alertId}`
+      + `${data.escalationStep ? ` escalation step ${data.escalationStep}` : ''} — send dropped`
+    );
     return {
       success: false,
       channelType: 'unknown',
@@ -917,6 +925,13 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
     .limit(1);
 
   if (!policy) {
+    // The rule still references this policy but the dual-axis lookup missed —
+    // deleted policy, or the org's partner changed since the rule was bound.
+    // Silently dropping would erase the whole escalation chain (#2130 review).
+    console.warn(
+      `[NotificationDispatcher] Escalation policy ${policyId} not found for alert ${alertId} `
+      + `(org ${orgId}, partner ${orgPartnerId ?? 'none'}) — escalation skipped`
+    );
     return;
   }
 
@@ -926,6 +941,9 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
   }>;
 
   if (!Array.isArray(steps) || steps.length === 0) {
+    console.warn(
+      `[NotificationDispatcher] Escalation policy ${policyId} has no steps for alert ${alertId} — escalation skipped`
+    );
     return;
   }
 

--- a/apps/api/src/services/notificationDispatcher.ts
+++ b/apps/api/src/services/notificationDispatcher.ts
@@ -18,7 +18,7 @@ import {
   organizations,
   partners
 } from '../db/schema';
-import { eq, and, inArray, asc } from 'drizzle-orm';
+import { eq, and, inArray, asc, isNull, or, type SQL, type Column } from 'drizzle-orm';
 import { getRedis, getBullMQConnection, isRedisAvailable } from './redis';
 import { rateLimiter } from './rate-limit';
 import { checkNotificationThrottle } from './notificationThrottle';
@@ -108,9 +108,44 @@ export function createNotificationWorker(): Worker<NotificationJobData> {
 }
 
 /**
- * Process an alert and queue notifications to all configured channels
+ * Delivery rails are dual-owned (#2130): a channel / routing rule /
+ * escalation policy is org-owned (org_id set) OR partner-wide (org_id NULL,
+ * partner_id set). Every dispatcher lookup must match the alert org's own
+ * rows OR partner-wide rows owned by that org's partner — a plain
+ * eq(orgId, alert.orgId) silently never matches partner-wide rows (the #1724
+ * trap; the worker runs under system context, so RLS is not the filter here).
  */
-async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
+async function partnerIdForOrg(orgId: string): Promise<string | null> {
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  return org?.partnerId ?? null;
+}
+
+function railOwnershipCondition(
+  orgCol: Column,
+  partnerCol: Column,
+  orgId: string,
+  orgPartnerId: string | null
+): SQL {
+  if (!orgPartnerId) {
+    return eq(orgCol, orgId);
+  }
+  return or(
+    eq(orgCol, orgId),
+    and(isNull(orgCol), eq(partnerCol, orgPartnerId))
+  ) as SQL;
+}
+
+/**
+ * Process an alert and queue notifications to all configured channels.
+ * Exported for the notificationRailsPartnerRls integration suite, which
+ * proves the partner-wide rail fan-out (#2130) against real Postgres — every
+ * unit test mocks the rail lookups away.
+ */
+export async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
   queued: number;
   inAppSent: boolean;
   durationMs: number;
@@ -173,24 +208,29 @@ async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
     }
   }
 
+  // Dual-axis rail resolution (#2130): resolve the alert org's partner once,
+  // so routing/channel/escalation lookups can match partner-wide rows too.
+  const orgPartnerId = await partnerIdForOrg(alert.orgId);
+
   // Phase 5: Notification routing rules (currently evaluates severity; conditionTypes/deviceTags/siteIds matching planned)
   // Check routing rules before falling back to all channels
   if (channelIds.length === 0) {
-    const routedChannelIds = await resolveRoutingRules(alert.orgId, alert.severity);
+    const routedChannelIds = await resolveRoutingRules(alert.orgId, alert.severity, orgPartnerId);
     if (routedChannelIds.length > 0) {
       channelIds = routedChannelIds;
     }
   }
 
   // For config policy alerts (no ruleId) or rules without channel overrides and no routing rules,
-  // fall back to all enabled channels for the org
+  // fall back to all enabled channels for the org — including the partner's
+  // partner-wide channels, which are active for every member org by design.
   if (channelIds.length === 0) {
     const orgChannels = await db
       .select({ id: notificationChannels.id })
       .from(notificationChannels)
       .where(
         and(
-          eq(notificationChannels.orgId, alert.orgId),
+          railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, alert.orgId, orgPartnerId),
           eq(notificationChannels.enabled, true)
         )
       );
@@ -213,7 +253,7 @@ async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
     .from(notificationChannels)
     .where(
       and(
-        eq(notificationChannels.orgId, alert.orgId),
+        railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, alert.orgId, orgPartnerId),
         eq(notificationChannels.enabled, true),
         inArray(notificationChannels.id, requestedChannelIds)
       )
@@ -221,7 +261,7 @@ async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
   channelIds = validChannels.map((channel) => channel.id);
 
   if (channelIds.length === 0) {
-    console.log(`[NotificationDispatcher] No valid channels in alert org for alert ${data.alertId}`);
+    console.log(`[NotificationDispatcher] No valid channels in alert org or its partner for alert ${data.alertId}`);
     return { queued: 0, inAppSent, durationMs: Date.now() - startTime };
   }
 
@@ -247,7 +287,7 @@ async function processAlertNotifications(data: ProcessAlertJobData): Promise<{
   // Check for escalation policy (only applicable to rule-based alerts)
   const escalationPolicyId = ruleOverrides?.escalationPolicyId as string | undefined;
   if (escalationPolicyId) {
-    await scheduleEscalation(data.alertId, escalationPolicyId, alert.orgId);
+    await scheduleEscalation(data.alertId, escalationPolicyId, alert.orgId, orgPartnerId);
   }
 
   return {
@@ -284,14 +324,16 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
     };
   }
 
-  // Get channel
+  // Get channel — the alert org's own, or a partner-wide channel owned by
+  // that org's partner (#2130).
+  const sendOrgPartnerId = await partnerIdForOrg(alert.orgId);
   const [channel] = await db
     .select()
     .from(notificationChannels)
     .where(
       and(
         eq(notificationChannels.id, data.channelId),
-        eq(notificationChannels.orgId, alert.orgId),
+        railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, alert.orgId, sendOrgPartnerId),
         eq(notificationChannels.enabled, true)
       )
     )
@@ -301,7 +343,7 @@ async function processSendNotification(data: SendNotificationJobData): Promise<{
     return {
       success: false,
       channelType: 'unknown',
-      error: 'Channel not found for alert organization',
+      error: 'Channel not found for alert organization or its partner',
       durationMs: Date.now() - startTime
     };
   }
@@ -817,13 +859,17 @@ async function sendPushoverChannelNotification(
  * Returns channel IDs from the first matching routing rule (by priority).
  * Returns empty array if no routing rules match (falls through to default behavior).
  */
-async function resolveRoutingRules(orgId: string, severity: string): Promise<string[]> {
+async function resolveRoutingRules(orgId: string, severity: string, orgPartnerId: string | null): Promise<string[]> {
+  // Dual-axis (#2130): the org's own rules AND its partner's partner-wide
+  // rules compete in one priority ordering; the first match wins regardless
+  // of axis, so an org can pre-empt a partner-wide rule with a
+  // higher-priority org rule.
   const rules = await db
     .select()
     .from(notificationRoutingRules)
     .where(
       and(
-        eq(notificationRoutingRules.orgId, orgId),
+        railOwnershipCondition(notificationRoutingRules.orgId, notificationRoutingRules.partnerId, orgId, orgPartnerId),
         eq(notificationRoutingRules.enabled, true)
       )
     )
@@ -858,14 +904,14 @@ async function resolveRoutingRules(orgId: string, severity: string): Promise<str
 /**
  * Schedule escalation steps based on policy
  */
-async function scheduleEscalation(alertId: string, policyId: string, orgId: string): Promise<void> {
+async function scheduleEscalation(alertId: string, policyId: string, orgId: string, orgPartnerId: string | null): Promise<void> {
   const [policy] = await db
     .select()
     .from(escalationPolicies)
     .where(
       and(
         eq(escalationPolicies.id, policyId),
-        eq(escalationPolicies.orgId, orgId)
+        railOwnershipCondition(escalationPolicies.orgId, escalationPolicies.partnerId, orgId, orgPartnerId)
       )
     )
     .limit(1);
@@ -893,7 +939,7 @@ async function scheduleEscalation(alertId: string, policyId: string, orgId: stri
       .from(notificationChannels)
       .where(
         and(
-          eq(notificationChannels.orgId, orgId),
+          railOwnershipCondition(notificationChannels.orgId, notificationChannels.partnerId, orgId, orgPartnerId),
           eq(notificationChannels.enabled, true),
           inArray(notificationChannels.id, requestedChannelIds)
         )

--- a/apps/web/src/components/alerts/NotificationChannelList.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.tsx
@@ -22,6 +22,8 @@ export type { NotificationChannelType };
 
 export type NotificationChannel = {
   id: string;
+  // null = partner-wide ("All organizations") channel (#2130)
+  orgId?: string | null;
   name: string;
   type: NotificationChannelType;
   enabled: boolean;
@@ -250,7 +252,18 @@ export default function NotificationChannelList({
                       <Icon className="h-5 w-5" />
                     </div>
                     <div>
-                      <h3 className="text-sm font-semibold">{channel.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-sm font-semibold">{channel.name}</h3>
+                        {channel.orgId === null && (
+                          <span
+                            className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary"
+                            title="Partner-wide channel — receives alerts from every organization"
+                            data-testid="notification-channel-partner-wide-badge"
+                          >
+                            All orgs
+                          </span>
+                        )}
+                      </div>
                       <p className="text-xs text-muted-foreground">{typeConfig.label}</p>
                     </div>
                   </div>

--- a/apps/web/src/components/alerts/NotificationChannelsPage.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.tsx
@@ -5,6 +5,7 @@ import NotificationChannelForm, { type NotificationChannelFormValues } from './N
 import AlertsTabStrip from './AlertsTabStrip';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 import { extractApiError } from '@/lib/apiError';
 import { runAction, ActionError } from '../../lib/runAction';
@@ -71,7 +72,7 @@ export async function runChannelDelete(
 
 // Exported for unit-testing without mounting the full component.
 export async function runRoutingRuleSave(
-  rule: { id?: string; name: string; priority: number; conditions: unknown; channelIds: string[]; enabled: boolean },
+  rule: { id?: string; name: string; priority: number; conditions: unknown; channelIds: string[]; enabled: boolean; ownerScope?: 'organization' | 'partner' },
   deps: { onUnauthorized: () => void }
 ): Promise<void> {
   const isEdit = !!rule.id;
@@ -86,6 +87,8 @@ export async function runRoutingRuleSave(
         conditions: rule.conditions,
         channelIds: rule.channelIds,
         enabled: rule.enabled,
+        // Create-only (#2130): updates never move a rule between axes.
+        ...(!isEdit && rule.ownerScope ? { ownerScope: rule.ownerScope } : {}),
       }),
     }),
     successMessage: isEdit ? 'Routing rule saved' : 'Routing rule created',
@@ -111,6 +114,8 @@ type ModalMode = 'closed' | 'create' | 'edit' | 'delete';
 
 type RoutingRule = {
   id: string;
+  // null = partner-wide ("All organizations") rule (#2130)
+  orgId?: string | null;
   name: string;
   priority: number;
   conditions: {
@@ -128,7 +133,14 @@ export default function NotificationChannelsPage() {
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedChannel, setSelectedChannel] = useState<NotificationChannel | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const { currentOrgId } = useOrgStore();
+  const { currentOrgId, allOrgs } = useOrgStore();
+
+  // Ownership axis (#2130, mirrors AlertRuleEditPage #2128): partner-scope
+  // creators may own a channel/rule partner-wide ("all orgs"). Gate on the
+  // JWT scope; default to partner-wide when viewing All orgs. Create-only.
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const [channelOwnerScope, setChannelOwnerScope] = useState<'organization' | 'partner'>('organization');
 
   // Routing rules state
   const [routingRules, setRoutingRules] = useState<RoutingRule[]>([]);
@@ -181,6 +193,7 @@ export default function NotificationChannelsPage() {
   }, [fetchChannels, fetchRoutingRules]);
 
   const handleCreate = () => {
+    setChannelOwnerScope(isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization');
     setSelectedChannel(null);
     setModalMode('create');
   };
@@ -369,7 +382,12 @@ export default function NotificationChannelsPage() {
     const isCreate = modalMode === 'create';
     const url = isCreate ? '/alerts/channels' : `/alerts/channels/${selectedChannel?.id}`;
     const method = isCreate ? 'POST' : 'PUT';
-    const requestPayload = isCreate && currentOrgId ? { ...payload, orgId: currentOrgId } : payload;
+    const partnerWideCreate = isCreate && isPartnerScope && channelOwnerScope === 'partner';
+    const requestPayload = partnerWideCreate
+      ? { ...payload, ownerScope: 'partner' }
+      : isCreate && currentOrgId
+        ? { ...payload, orgId: currentOrgId }
+        : payload;
 
     try {
       await runChannelSave(
@@ -549,6 +567,15 @@ export default function NotificationChannelsPage() {
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-2">
                             <span className="text-sm font-medium">{rule.name}</span>
+                            {rule.orgId === null && (
+                              <span
+                                className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary"
+                                title="Partner-wide rule — routes alerts from every organization"
+                                data-testid="routing-rule-partner-wide-badge"
+                              >
+                                All orgs
+                              </span>
+                            )}
                             {!rule.enabled && (
                               <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Disabled</span>
                             )}
@@ -605,6 +632,8 @@ export default function NotificationChannelsPage() {
               <RoutingRuleForm
                 rule={editingRule}
                 channels={channels}
+                showOwnerScope={isPartnerScope}
+                defaultOwnerScope={isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization'}
                 onSave={handleSaveRoutingRule}
                 onCancel={() => { setShowRuleForm(false); setEditingRule(null); }}
               />
@@ -626,6 +655,30 @@ export default function NotificationChannelsPage() {
               <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 {error}
               </div>
+            )}
+            {/* Ownership scope — partner-scope creators only, create-only (#2130) */}
+            {modalMode === 'create' && isPartnerScope && (
+              <fieldset className="mb-4 space-y-2 rounded-md border bg-card p-4" data-testid="notification-channel-owner">
+                <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={channelOwnerScope === 'partner'}
+                    onChange={() => setChannelOwnerScope('partner')}
+                    data-testid="notification-channel-owner-partner"
+                  />
+                  All organizations <span className="text-muted-foreground">(partner-wide channel — receives alerts from every org)</span>
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    checked={channelOwnerScope === 'organization'}
+                    onChange={() => setChannelOwnerScope('organization')}
+                    data-testid="notification-channel-owner-org"
+                  />
+                  This organization only
+                </label>
+              </fieldset>
             )}
             <NotificationChannelForm
               onSubmit={handleSubmit}
@@ -685,12 +738,16 @@ const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low', 'info'];
 function RoutingRuleForm({
   rule,
   channels,
+  showOwnerScope = false,
+  defaultOwnerScope = 'organization',
   onSave,
   onCancel,
 }: {
   rule: RoutingRule | null;
   channels: NotificationChannel[];
-  onSave: (rule: Omit<RoutingRule, 'id'> & { id?: string }) => void;
+  showOwnerScope?: boolean;
+  defaultOwnerScope?: 'organization' | 'partner';
+  onSave: (rule: Omit<RoutingRule, 'id'> & { id?: string; ownerScope?: 'organization' | 'partner' }) => void;
   onCancel: () => void;
 }) {
   const [name, setName] = useState(rule?.name ?? '');
@@ -698,6 +755,7 @@ function RoutingRuleForm({
   const [severities, setSeverities] = useState<string[]>(rule?.conditions.severities ?? []);
   const [channelIds, setChannelIds] = useState<string[]>(rule?.channelIds ?? []);
   const [enabled, setEnabled] = useState(rule?.enabled ?? true);
+  const [ownerScope, setOwnerScope] = useState<'organization' | 'partner'>(defaultOwnerScope);
 
   const toggleSeverity = (sev: string) => {
     setSeverities((prev) =>
@@ -720,12 +778,39 @@ function RoutingRuleForm({
       conditions: { severities: severities.length > 0 ? severities : undefined },
       channelIds,
       enabled,
+      // Create-only (#2130): updates never move a rule between axes.
+      ...(!rule?.id && showOwnerScope ? { ownerScope } : {}),
     });
   };
 
   return (
     <div className="mt-4 rounded-md border bg-card p-4 space-y-4">
       <h3 className="text-sm font-semibold">{rule ? 'Edit Routing Rule' : 'New Routing Rule'}</h3>
+
+      {/* Ownership scope — partner-scope creators only, create-only (#2130) */}
+      {!rule && showOwnerScope && (
+        <fieldset className="space-y-2 rounded-md border p-3" data-testid="routing-rule-owner">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              checked={ownerScope === 'partner'}
+              onChange={() => setOwnerScope('partner')}
+              data-testid="routing-rule-owner-partner"
+            />
+            All organizations <span className="text-muted-foreground">(partner-wide rule)</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              checked={ownerScope === 'organization'}
+              onChange={() => setOwnerScope('organization')}
+              data-testid="routing-rule-owner-org"
+            />
+            This organization only
+          </label>
+        </fieldset>
+      )}
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>


### PR DESCRIPTION
Phase 3 of the partner-wide-first epic #2135, on top of the just-merged #2149. Converts the three alert delivery rails — `notification_channels`, `notification_routing_rules`, `escalation_policies` — to dual-ownership (org_id XOR partner_id), so an MSP can define one NOC Slack/PagerDuty/email destination, routing rule set, and escalation chain that serves every org.

Closes #2130

## What changed

- **Migration + RLS**: XOR CHECK + one dual-axis policy per table (routing's bucket-a re-issued policy names dropped too). `alert_notifications` stay alert-join — send records always take the firing device's org. Channel `config` encryption is column-AAD-bound, so partner-wide rows are safe.
- **Dispatcher fan-out** (the core fix): all six rail lookups in `notificationDispatcher` filtered `eq(orgId, alert.orgId)` — partner-wide rails would silently never deliver. They now match the alert org's rows OR its partner's partner-wide rows. Org and partner routing rules compete in one priority ordering; partner-wide channels participate in the no-rules fallback (live for every member org immediately).
- **Routes**: ownerScope creates gated by `canManagePartnerWidePolicies`, write gates on every mutator **including test-send** (it fires real external notifications on the shared destination), dual-axis lists and by-id helpers, partner-wide Pushover inheritance resolved directly from the channel, routing PATCH/DELETE moved to by-id + access check.
- **Hidden readers**: automationRuntime notify-channel validation ×2, aiToolsAlerts channel tool, aiToolsFleet `list_channels`, alert-rule notification bindings — all dual-axis now.
- **Review-round fixes** (multi-agent review ran pre-PR): the org-scoped `GET /alerts/:id` notification-history join silently nulled channel names for partner-wide deliveries (now a system-context block after the access check); silent drops in `scheduleEscalation` and `processSendNotification` now log.
- **Web**: create-only scope selectors + "All orgs" badges for channels and routing rules.

## Verification

`notificationRailsPartnerRls.integration.test.ts` (12 tests): per-rail forge 42501 / XOR 23514 / org isolation, plus three end-to-end fan-out proofs through the real `processAlertNotifications` — partner-wide rule+channel delivery with a foreign partner's higher-priority decoy never matching, fallback participation with foreign-partner exclusion, and partner-wide escalation scheduling delayed sends. Mocked-db unit tests cover every 403 write gate and ownerScope branch (the app-layer class required CI must catch). rls-coverage 50/50 with the three tables registered; drift clean; API+web tsc clean; ~170 touched unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)