### PR TITLE
docs(partner-wide): backup template/binding design (#2132) + automations conversion mapping (#2133)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-automations-partner-ownership-mapping.md
+++ b/docs/superpowers/plans/2026-07-02-automations-partner-ownership-mapping.md
@@ -1,0 +1,161 @@
+# Partner-Wide Automations: Call-Site Mapping (#2133)
+
+> Pre-implementation mapping for converting the standalone `automations` table to
+> dual-ownership (org XOR partner) per the partner-wide-first playbook (epic #2135).
+> Produced 2026-07-02 by a repo-wide sweep; line numbers are as of main @ `01e46a73e`.
+
+## 0. Scope disambiguation — three "automation" concepts
+
+| System | Tables | Ownership today | Status |
+|---|---|---|---|
+| **Standalone automations** (this issue) | `automations`, `automation_runs` | `org_id` NOT NULL | Not converted; CRUD route deprecated but trigger runtime fully active |
+| Config-policy "automation" feature | `config_policy_automations` (inline under `configuration_policies`) | inherits dual-axis from parent | Already partner-wide (2026-06-27 migration) |
+| Compliance rule sets (`automationPolicies`, same schema file) | `automation_policies`, `automation_policy_compliance` | dual-owned | Already converted (#2129) — **closest reference implementation** |
+
+## 1. Schema — `apps/api/src/db/schema/automations.ts`
+
+- `automations` (L13-29): `orgId NOT NULL` → the table to convert; no `partnerId` yet.
+- `automationRuns` (L31-44): child, nullable FK to `automations` (config-policy runs
+  use `configPolicyId` instead); no own `orgId` — tenant via parent join.
+- `automationPolicies` (L52-71): already dual-owned — copy-paste template.
+
+## 2. `automations.orgId` call sites
+
+### Routes — `apps/api/src/routes/automations.ts`
+- L427-446: list-route scope filtering — partner-scope caller silently **excludes
+  partner-wide rows** today (uses `accessibleOrgIds` only).
+- L239-256 `getAutomationWithOrgCheck`: `auth.canAccessOrg(automation.orgId)` —
+  needs a partner-wide branch (`canAccessOrg(null)` always denies).
+- L658-736, 854-858, 930-936: create/update/delete keyed by resolved orgId; create
+  (deprecated route) has no `ownerScope` field.
+- L499-521 `/runs/:runId`: already treats `configurationPolicies.orgId === null`
+  (partner-wide policy) deliberately as 404 on the org-scoped path — precedent to copy.
+- L1039-1150 webhook trigger: loads by id, no org gate — unaffected.
+
+### AI tool — `apps/api/src/services/aiToolsFleet.ts` (`manage_automations`)
+- L1188-1319: plain `orgWhere(auth, automations.orgId)` on list/get/enable/disable/
+  delete/run. Copy the dual-axis idiom already in the same file: `alertRuleWhere`
+  (L85-95) / `notificationChannelWhere` (L100-105), gated on `auth.scope === 'partner'`.
+- Create/update/delete are disabled in this tool ("manage through configuration
+  policies") — narrows the write-side blast radius.
+
+### MCP resource — `apps/api/src/routes/mcpServer.ts:1464`
+- `readOrgScopedResource(..., orgCond(automations.orgId))` — org-only. NOTE: the
+  `scripts` resource read (L1455) has the same gap even though scripts are already
+  dual-owned — fix both while here.
+
+### Policy remediation bridge — `apps/api/src/services/policyEvaluationService.ts`
+The most consequential seam (playbook item 5):
+- L940-961 `resolvePolicyRemediationAutomationIdForOrg`: `eq(automations.orgId, orgId)`
+  — must also search partner-wide automations owned by the device org's partner.
+- L1078-1100 `triggerRemediationAutomation`: `eq(automations.orgId, device.orgId)` —
+  the exact playbook anti-pattern.
+- L1765-1861 `triggerConfigPolicyRemediation`: same bug duplicated (L1782, L1818).
+- L1221-1236 `evaluatePolicy`: already memoizes remediation lookup per DEVICE org
+  (`remediationIdByOrg`) — the fan-out entry point to extend.
+
+### Manual remediation — `apps/api/src/routes/policyManagement/actions.ts:189-215`
+Partner-aware for the *policy* axis (inArray over partner's orgs) but still assumes
+the *automation* is org-owned — a partner-wide automation matches neither branch →
+404. Add `OR (automations.orgId IS NULL AND automations.partnerId = ...)`.
+
+### No-change call sites
+- `services/encryptedColumnRegistry.ts:58` (`automations.trigger` encrypted column).
+- `services/tenantCascade.ts:89`: `automations` in `ORG_CASCADE_DELETE_ORDER` —
+  partner-wide rows correctly survive org erasure; `purgeSyntheticPartner`
+  auto-discovers `partner_id` columns, so no static list update.
+- Permission labels / guardrail tiers / output truncation lists (aiGuardrails,
+  aiToolSchemasFleet, aiToolOutput, roles.ts, permissionsCatalog.ts).
+
+## 3. Trigger evaluation — `apps/api/src/jobs/automationWorker.ts`
+
+**Already runs under system DB context** (`runWithSystemDbAccess` wraps the BullMQ
+processor at L664-700 and the event-bus callback at L821-840) — RLS is not the
+blocker; the blocker is app-layer `eq(automations.orgId, ...)` returning zero rows
+for partner-wide automations.
+
+| Site | Line | Gap |
+|---|---|---|
+| `processScanSchedules` | L324-327 | none — scans ALL enabled automations globally; partner-wide rows flow through once schema allows |
+| `processTriggerSchedule` / `processTriggerEvent` | L404-409 / L445-450 | none — id lookups |
+| **`queueEventTriggers`** | **L730-733** | **THE fan-out hook**: `eq(automations.orgId, event.orgId)` — needs resolve event org → partner, `OR (org_id IS NULL AND partner_id = <partner>)` |
+| `resolveDeviceIdsForAssignment` | L504-563 | existing `'partner'` case = reference fan-out implementation to copy |
+
+## 4. RLS
+
+- `automations`: four per-command `breeze_org_isolation_*` policies in
+  `0001-baseline.sql` (L15432/16293/17154/18015) → replace with ONE dual-axis
+  `automations_isolation` policy, per `2026-07-01-automation-policies-partner-ownership.sql`.
+- `automation_runs`: dual-parent EXISTS policies in
+  `2026-05-30-fk-child-tables-rls.sql:46-69`. The `automations` branch needs the
+  dual-axis parent predicate (`(a.org_id IS NOT NULL AND breeze_has_org_access(a.org_id))
+  OR (a.partner_id IS NOT NULL AND breeze_has_partner_access(a.partner_id))`) —
+  same shape as `maintenance_occurrences` Step 3 in
+  `2026-07-01-maintenance-windows-partner-ownership.sql`. The
+  `configuration_policies` branch is already dual-axis-correct.
+
+## 5. Org-specific references inside automation definitions (`services/automationRuntime.ts`)
+
+| Concern | Location | Fix |
+|---|---|---|
+| Notification channels | `notificationChannelOwnershipCondition(orgId: string)` L40-55, called L1458 with `automation.orgId` | Already dual-axis for #2130 channels but requires a non-null org — accept `{orgId, partnerId}` derived from device context |
+| **Alert row org** | `executeCreateAlertAction` L1044-1081 | `alerts.orgId = automation.orgId` violates playbook rule 5 (child rows take the DEVICE's org; NULL would fail NOT NULL). Add `orgId` to `ActionExecutionContext.device` (L735-741) |
+| Notification payload orgId | L1009, L892 | derive from device, not automation (cosmetic today) |
+| Target resolution | `resolveAutomationTargetDeviceIds` L519-548, `resolveLegacyConditionTargets` L426-517, `checkAutomationTargetsWithinSiteScope` L616-619 | all `eq(devices.orgId, automation.orgId)` — central fan-out gap; copy `resolveDeviceIdsForAssignment`'s partner case |
+| Deployment targets | L520-524 → `deploymentTargetResolver.ts:9-11` | `ResolveTargetOptions.orgId` is hard non-null and shared — loop per partner org and merge, don't change the shared contract |
+| `run_script` script lookup | L1425-1436, L1900-1907 | no org filter (by id only); scripts already dual-owned — no new logic, but note there's no execution-time ownership check |
+| Run-started event | `createAutomationRunRecord` L1346-1356 | `publishEvent('automation.started', automation.orgId)` — NULL for partner-wide; decide: per-device-org events, or skip |
+
+## 6. Web UI
+
+- `apps/web/src/components/automations/AutomationForm.tsx` / `AutomationList.tsx` /
+  `AutomationEditPage.tsx`: no org/ownerScope references today — add create-only
+  ownerScope selector + "All orgs" badge.
+- **Copy from** `software/PolicyForm.tsx` (L14-22, 42-49, 88-111) and
+  `software/ComplianceDashboard.tsx:424-427` — NOT from
+  `automations/PolicyForm.tsx` (the #2129 UI never got its ownerScope selector;
+  its list shows the badge but creates are org-only — flagged as a #2129 UI
+  follow-up gap).
+
+## 7. Config-policy linkage
+
+None needed: the config-policy `automation` feature stores rows inline in
+`config_policy_automations`, not via `featurePolicyId` → `automations`. Do NOT add
+`automation` to `FEATURE_TABLE_MAP` / `PARTNER_LINKABLE_FEATURE_TYPES`.
+
+## 8. Tests
+
+- Add `automations` to `DUAL_AXIS_TENANT_TABLES`
+  (`rls-coverage.integration.test.ts:204-307`), comment style per the
+  `automation_policies` entry (L265-273).
+- `PARENT_FK_JOIN_POLICY_TABLES` entry for `automation_runs` stays (still
+  two-parent child); underlying policy gains the dual-axis predicate.
+- New `automationsPartnerRls.integration.test.ts` mirroring
+  `automationPoliciesPartnerRls.integration.test.ts` (L102-227 forge/XOR/isolation;
+  L228-328 fan-out) — the fan-out block must prove `queueEventTriggers` matches a
+  partner-wide automation for a device event in a member org, against real Postgres.
+- Existing unit suites to extend: `routes/automations.test.ts`,
+  `automationRuntime*.test.ts`, `automationWorker.test.ts` (no dual-axis cases today).
+
+## 9. Migration plan
+
+New `2026-07-0X-automations-partner-ownership.sql` combining:
+- Step 1+2 of `2026-07-01-automation-policies-partner-ownership.sql`
+  (`partner_id` column, `org_id` DROP NOT NULL, `automations_one_owner_chk`,
+  `automations_partner_id_idx`, single `automations_isolation` dual-axis policy).
+- Step 3 of `2026-07-01-maintenance-windows-partner-ownership.sql` shape for the
+  `automation_runs` EXISTS-join policies (re-issue same policy names; keep the
+  `configuration_policies` OR-branch untouched).
+
+## 10. Implementation sweep checklist (playbook item 7)
+
+1. `routes/automations.ts` — ownerScope + dual-axis reads gated on partner scope
+2. `services/aiToolsFleet.ts` — `automationWhere` per `alertRuleWhere`
+3. `routes/mcpServer.ts` — automations resource (+ fix the same gap on scripts)
+4. `services/policyEvaluationService.ts` — three `eq(automations.orgId, deviceOrg)` sites
+5. `routes/policyManagement/actions.ts` — partner-wide-automation OR-branch
+6. `jobs/automationWorker.ts` `queueEventTriggers` — core event fan-out + integration test
+7. `services/automationRuntime.ts` — target resolution fan-out; device-org child rows;
+   channel condition signature; run-started event shape
+8. Web UI ownerScope + badge
+9. `rls-coverage` allowlist + new partner RLS integration suite

--- a/docs/superpowers/plans/2026-07-02-backup-template-binding-split.md
+++ b/docs/superpowers/plans/2026-07-02-backup-template-binding-split.md
@@ -1,0 +1,193 @@
+# Partner-Wide Backup: Template/Binding Split — Design (#2132)
+
+> Part of the partner-wide-first epic (#2135). Backup is one of two features
+> (`backup`, `onedrive_helper`) excluded from the dual-ownership playbook because
+> `backup_configs` carries per-org storage credentials. This doc designs the split
+> that lets partner-wide config policies drive backup anyway: a partner-ownable
+> **TEMPLATE** (schedule/retention/mode — no secrets) resolved per-org against an
+> org-owned storage **BINDING** (provider + credentials). Devices in orgs without a
+> binding surface as "backup not configured" instead of being silently skipped.
+>
+> Status: **design — not implemented**. Research notes: session 2026-07-02.
+
+---
+
+## 1. Current state (what makes backup special)
+
+- `backup_configs` (`apps/api/src/db/schema/backup.ts:60`) conflates both halves in
+  one org-owned row: template-ish fields (`type`, legacy `schedule`/`retention`,
+  `compression`, `encryption`) AND the binding (`provider`, `providerConfig` jsonb
+  with plaintext bucket/keys, `providerCapabilities`, `isActive`).
+- The de facto template already exists elsewhere: `config_policy_backup_settings`
+  (`schema/configurationPolicies.ts:251`) holds `schedule`, `retention`, `paths`,
+  `backupMode`, `targets`, 1:1 with a `config_policy_feature_links` row — but is
+  forced `org_id NOT NULL` purely as an artifact of feature-link ownership. The
+  feature link's `featurePolicyId` points at `backup_configs.id` (the binding!).
+- `backupWorker.processCheckSchedules` fans out per org with an active backup
+  feature link, resolves per-device via `resolveAllBackupAssignedDevices(orgId)`,
+  and **warn-and-skips** devices whose resolution yields no `configId`
+  (`jobs/backupWorker.ts:161`) — the silent-skip behavior #2132 wants replaced.
+- Partner-wide is blocked in three places today: `ORG_SCOPED_ONLY_FEATURES`
+  (`routes/configurationPolicies/featureLinks.ts:45`), a throw in
+  `decomposeInlineSettings` case `'backup'` (`services/configurationPolicy.ts:576`),
+  and `backup` absent from `PARTNER_LINKABLE_FEATURE_TYPES`.
+- Execution tables (`backup_jobs`, `backup_snapshots`, `backup_chains`,
+  `restore_jobs`, `c2c_backup_configs.storage_config_id`, BMR/recovery services,
+  retention, AI tools, compliance report) all FK or query `backup_configs`
+  directly, independent of the config-policy system. **Restructuring
+  `backup_configs` is therefore off the table** — it stays, as the binding.
+
+## 2. Design
+
+### 2.1 New table: `backup_templates` (the partner-linkable template)
+
+Dual-ownership per the epic playbook (`org_id XOR partner_id`, `_one_owner_chk`
+CHECK, dual-axis RLS, partner index — copy a `2026-07-01-*-partner-ownership.sql`
+migration):
+
+```
+backup_templates
+  id              uuid PK
+  org_id          uuid NULL FK organizations   -- XOR
+  partner_id      uuid NULL FK partners        -- XOR
+  name            varchar(200) NOT NULL
+  backup_mode     backup_mode enum NOT NULL    -- file | hyperv | mssql | system_image
+  schedule        jsonb NOT NULL
+  retention       jsonb NOT NULL
+  paths           jsonb
+  targets         jsonb
+  compression     boolean NOT NULL DEFAULT true
+  require_encryption boolean NOT NULL DEFAULT false
+  created_at / updated_at
+```
+
+Notes:
+- `backup_mode` (the enum `config_policy_backup_settings` uses) is the operative
+  "kind of backup" — `backup_configs.type` is not used for dispatch decisions and
+  is left alone (deprecate later, out of scope).
+- `compression` moves to the template (behavior intent). `require_encryption` is
+  the template's *intent*; the binding's `providerCapabilities` is the *capability*
+  it is validated against at dispatch (mismatch = per-device failure state, §2.4).
+- Registered in `PARTNER_LINKABLE_FEATURE_TYPES` + the dual-axis branch of
+  `validateFeaturePolicyExists`; removed from `FEATURE_TABLE_MAP` org-only path and
+  from `ORG_SCOPED_ONLY_FEATURES`. `config_policy_feature_links.featurePolicyId`
+  for `backup` links now points at `backup_templates.id`, **not** `backup_configs.id`.
+- Writes gated on `canManagePartnerWidePolicies` for partner-owned rows; create
+  routes take `ownerScope`; update schema `.omit({ ownerScope: true })` — the
+  standard playbook.
+
+### 2.2 `backup_configs` becomes the BINDING — minimal change
+
+Stays org-owned (`org_id NOT NULL`), single-axis org RLS, all existing FKs intact
+(`backup_jobs.configId`, `backup_snapshots.configId`, `backup_chains`, c2c org-match
+trigger, BMR/recovery reads). Additions:
+
+- `is_default boolean NOT NULL DEFAULT false` + partial unique index
+  `ON backup_configs (org_id) WHERE is_default AND is_active` — each org designates
+  one default storage destination.
+- Legacy `schedule`/`retention` columns: stop writing them; the two remaining
+  fallback readers (`recoveryBootstrap.ts:210`, `aiToolsBackup.ts`) are migrated to
+  template-based resolution. Columns dropped in a later cleanup migration.
+- `encryption_key` (text) is dead (no readers/writers) — drop in the same cleanup.
+
+### 2.3 Binding resolution: org default, mapping table later if needed
+
+**v1 rule: template → device's org → that org's default active binding.** One
+storage destination per org matches the MSP reality (one storage account per
+client) and keeps the resolver trivial. A per-template override table
+(`backup_template_bindings(template_id, org_id, config_id)` unique on
+`(template_id, org_id)`) is the designed escape hatch if a partner ever needs
+"SQL backups to a different bucket" — the resolver gets a single seam
+(`resolveBindingForOrg(templateId, orgId)`) so adding the override later is
+additive, not a rework.
+
+### 2.4 Worker/dispatch changes + "backup not configured"
+
+`processCheckSchedules` (partner fan-out follows the patch-rings precedent,
+`services/configPolicyPatching.ts` — partner template, per-device-org execution):
+
+1. Enumerate orgs with an active backup feature link **including partner-wide
+   policies fanned out to the partner's orgs** (never `eq(orgId, ...)` alone).
+2. Per device: resolve template (feature-link hierarchy, unchanged mechanics) →
+   resolve binding via `resolveBindingForOrg`.
+3. Template resolved but **no binding** → do NOT create a job; record the device in
+   the org's coverage-gap set. No more warn-and-skip.
+4. Template + binding → create `backup_jobs` row exactly as today
+   (`configId` = the resolved binding id — execution rows keep the DEVICE org,
+   matching the sensitive-data precedent from phase 2).
+5. Dispatch validates `require_encryption` against the binding's
+   `providerCapabilities`; failure = failed job with an explicit error, not a skip.
+
+Because partner-wide feature links resolve inside worker paths, the resolver runs
+under a **system DB context** (the heartbeat probe-config pattern, #1105) — an
+org-scoped RLS context cannot see partner-owned template rows.
+
+**Surfacing** (extend, don't invent): `GET /backup/status/:deviceId`
+(`routes/backup/dashboard.ts:252`) grows a reason discriminator —
+`coverage: 'protected' | 'no_template' | 'no_binding'` (keep `protected: boolean`
+for back-compat). Org dashboard adds an `unboundDevices` count next to
+`protectedDevices`. `DeviceBackupTab.tsx` renders "Backup policy assigned — no
+storage destination configured for this organization" with a CTA to the org's
+destination settings; `BackupDashboard.tsx` shows the gap count. A synthetic
+"backup not configured" alert-rule condition is possible later but not v1.
+
+### 2.5 UI
+
+- **Policy editor** (`featureTabs/BackupTab.tsx`): stops picking a `backup_configs`
+  row; edits the linked `backup_templates` row (schedule/retention/mode/paths/
+  targets/compression/require_encryption). Standard create-only ownerScope selector
+  + "All orgs" badge (pattern: `components/software/PolicyForm.tsx`). Works on
+  partner-wide policies — the 400 gate is removed.
+- **Org settings → Backup destination**: existing backup-config CRUD UI reframed as
+  the org's storage destination(s), with a "default destination" toggle. Secrets
+  redaction behavior (`redactProviderConfig`/`preserveSecretFields`) unchanged.
+
+### 2.6 Migration & back-compat
+
+One migration (idempotent, playbook shape) + a code cutover in the same PR:
+
+1. Create `backup_templates` + RLS + CHECK; add `backup_configs.is_default` and
+   backfill `is_default = true` for each org's single active config (oldest active
+   row wins when an org has several; `RAISE WARNING` with counts).
+2. For every existing backup feature link: synthesize a `backup_templates` row
+   (org-owned) from its `config_policy_backup_settings` row (fallback: the linked
+   `backup_configs.schedule/retention` legacy columns), repoint
+   `featurePolicyId` → new template id. Report row counts.
+3. `config_policy_backup_settings` stops being written for new links (template owns
+   the fields); rows retained for forensic/back-compat, dropped in a later cleanup.
+   `decomposeInlineSettings`/`assembleInlineSettings` case `'backup'` route to the
+   template table.
+4. Existing per-device behavior is preserved by construction: every org that had a
+   working link ends with template + default binding = same jobs as before.
+
+### 2.7 Explicitly out of scope (follow-up issues)
+
+- **Encrypting `providerConfig` at rest.** It is plaintext jsonb today; the
+  `secretCrypto.ts` AES-256-GCM column pattern (used by `psa_connections.credentials`)
+  is the right target, but re-encrypting existing rows is separable scope. File as
+  its own issue — the binding table boundary makes it a clean drop-in later.
+- Dropping `backup_configs.type`, legacy `schedule`/`retention`, `encryption_key`;
+  deleting deprecated `backup_policies`.
+- Per-template binding overrides (§2.3 escape hatch).
+- `onedrive_helper` gets the same treatment in a separate design if wanted.
+
+## 3. Tests (per playbook)
+
+- `DUAL_AXIS_TENANT_TABLES` registration for `backup_templates` +
+  `backupTemplatesPartnerRls.integration.test.ts` (cross-partner forge 42501, XOR
+  23514, org isolation).
+- **Fan-out integration test** against real Postgres: partner-owned template +
+  org A with default binding + org B without → scheduler creates a job for A's
+  device (org = device's org), creates NO job for B's device, and B's device
+  reports `coverage: 'no_binding'`.
+- Unit: `resolveBindingForOrg` (default selection, inactive excluded, none),
+  require_encryption vs capabilities validation, migration backfill idempotency.
+
+## 4. Open questions for review
+
+1. Is one default binding per org acceptable for v1 (§2.3), or do we want the
+   override mapping table from day one?
+2. Keep `config_policy_backup_settings` rows for back-compat (§2.6.3) or migrate +
+   drop the table in the same release?
+3. Should `no_binding` devices also raise a synthetic alert in v1, or is
+   dashboard/status surfacing enough?


### PR DESCRIPTION
Two pre-implementation artifacts for the partner-wide-first epic (#2135).

**Backup template/binding design** (`docs/superpowers/plans/2026-07-02-backup-template-binding-split.md`) — Closes #2132.

- New dual-ownership `backup_templates` table (schedule/retention/mode/paths/targets, no secrets) becomes the partner-linkable feature-policy target; `backup_configs` stays org-owned unchanged as the storage BINDING (every execution table FKs it directly — restructuring it is explicitly rejected).
- v1 binding resolution: template → device's org → the org's default active binding (`backup_configs.is_default`, partial unique index); a per-template override mapping table is the designed escape hatch, additive later.
- Worker fan-out follows the patch-rings precedent; template-resolved-but-no-binding devices stop being warn-and-skipped and surface as `coverage: 'no_binding'` on the existing status/dashboard endpoints and DeviceBackupTab empty state.
- Migration synthesizes templates from existing `config_policy_backup_settings` rows and repoints feature links; per-device behavior preserved by construction.
- Explicitly out of scope: encrypting `providerConfig` at rest (it is plaintext jsonb today — flagged as a follow-up with the `secretCrypto.ts` pattern), legacy column drops, `onedrive_helper`.
- §4 lists three open questions for review (one-default-binding-per-org sufficiency, `config_policy_backup_settings` retention, synthetic alert in v1).

**Automations conversion mapping** (`docs/superpowers/plans/2026-07-02-automations-partner-ownership-mapping.md`) — Refs #2133 (mapping only; implementation follows separately).

- Repo-wide sweep of every `automations.orgId` call site with the fix each needs. Headlines: `queueEventTriggers` (automationWorker.ts:730) is the single event-dispatch fan-out gap; `policyEvaluationService.ts` has three near-duplicate `eq(automations.orgId, device.orgId)` anti-pattern sites; `executeCreateAlertAction` writes alert rows with the AUTOMATION's org instead of the device's (playbook rule 5 violation once partner-wide).
- Also flags two adjacent pre-existing gaps found during the sweep: the MCP `scripts` resource read never got the dual-axis sweep despite scripts being dual-owned, and the #2129 `automations/PolicyForm.tsx` UI never got its ownerScope selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)