### PR TITLE
Partner-wide first phase 4: automations dual-ownership (org XOR partner)

### DIFF
--- a/apps/api/migrations/2026-07-02-automations-partner-ownership.sql
+++ b/apps/api/migrations/2026-07-02-automations-partner-ownership.sql
@@ -1,0 +1,150 @@
+-- Partner-owned standalone automations (epic #2135, issue #2133).
+--
+-- Until now an automations row was always owned by exactly one org (org_id
+-- NOT NULL), so an automation (e.g. "on device.offline run diagnostic
+-- script") could not be defined once and fire across every org under a
+-- partner — even though the scripts it invokes are already dual-ownership.
+-- This migration makes an automation ownable by EITHER an org (org_id set,
+-- partner_id NULL — the existing shape) OR a partner (partner_id set, org_id
+-- NULL — "partner-wide / all orgs"), enforced by an exactly-one-axis CHECK.
+-- Mirrors automation_policies (#2129) and maintenance_windows (#2131).
+--
+-- automation_runs has no ownership columns and reaches its tenant through a
+-- parent join (2026-05-30-fk-child-tables-rls.sql): EITHER
+-- automation_id -> automations OR config_policy_id -> configuration_policies.
+-- The automations branch checked breeze_has_org_access(a.org_id) only, which
+-- is FALSE for a partner-owned parent (org_id NULL) — so the policies are
+-- re-issued here with the dual-axis parent predicate on the automations
+-- branch (same shape as maintenance_occurrences Step 3 in
+-- 2026-07-01-maintenance-windows-partner-ownership.sql). The
+-- configuration_policies branch is untouched.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE automations
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE automations
+  ALTER COLUMN org_id DROP NOT NULL;
+
+-- Exactly one ownership axis must be set. (org_id IS NULL) <> (partner_id IS NULL)
+-- is true iff exactly one of the two is NULL — i.e. exactly one is set.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'automations_one_owner_chk'
+      AND conrelid = 'automations'::regclass
+  ) THEN
+    ALTER TABLE automations
+      ADD CONSTRAINT automations_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS automations_partner_id_idx
+  ON automations(partner_id);
+
+-- ============================================
+-- Step 2: RLS — automations dual-axis (org OR partner) + system short-circuit
+-- ============================================
+-- Replaces the four pure org-axis policies from 0001-baseline.sql with a
+-- single dual-axis policy, matching the automation_policies shape. ENABLE/FORCE
+-- are re-asserted for idempotence (the baseline already set them).
+
+ALTER TABLE automations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE automations FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON automations;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON automations;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON automations;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON automations;
+DROP POLICY IF EXISTS automations_isolation ON automations;
+CREATE POLICY automations_isolation
+  ON automations
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: RLS — automation_runs parent join gains the partner branch
+-- ============================================
+-- Same EXISTS shape and per-command policy names as the 2026-05-30 backstop,
+-- with the automations-parent predicate widened to the dual-axis form so runs
+-- of a partner-owned automation stay visible to the owning partner. The
+-- configuration_policies OR-branch is re-issued verbatim (unchanged).
+
+ALTER TABLE automation_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE automation_runs FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON automation_runs;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON automation_runs;
+CREATE POLICY breeze_org_isolation_select ON automation_runs FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM automations a
+    WHERE a.id = automation_runs.automation_id
+      AND (
+        (a.org_id IS NOT NULL AND public.breeze_has_org_access(a.org_id))
+        OR (a.partner_id IS NOT NULL AND public.breeze_has_partner_access(a.partner_id))
+      )
+  )
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_insert ON automation_runs FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM automations a
+    WHERE a.id = automation_runs.automation_id
+      AND (
+        (a.org_id IS NOT NULL AND public.breeze_has_org_access(a.org_id))
+        OR (a.partner_id IS NOT NULL AND public.breeze_has_partner_access(a.partner_id))
+      )
+  )
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_update ON automation_runs FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM automations a
+    WHERE a.id = automation_runs.automation_id
+      AND (
+        (a.org_id IS NOT NULL AND public.breeze_has_org_access(a.org_id))
+        OR (a.partner_id IS NOT NULL AND public.breeze_has_partner_access(a.partner_id))
+      )
+  )
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM automations a
+    WHERE a.id = automation_runs.automation_id
+      AND (
+        (a.org_id IS NOT NULL AND public.breeze_has_org_access(a.org_id))
+        OR (a.partner_id IS NOT NULL AND public.breeze_has_partner_access(a.partner_id))
+      )
+  )
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);
+CREATE POLICY breeze_org_isolation_delete ON automation_runs FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM automations a
+    WHERE a.id = automation_runs.automation_id
+      AND (
+        (a.org_id IS NOT NULL AND public.breeze_has_org_access(a.org_id))
+        OR (a.partner_id IS NOT NULL AND public.breeze_has_partner_access(a.partner_id))
+      )
+  )
+  OR EXISTS (SELECT 1 FROM configuration_policies cp WHERE cp.id = automation_runs.config_policy_id AND public.breeze_has_org_access(cp.org_id))
+);

--- a/apps/api/src/__tests__/integration/automationsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationsPartnerRls.integration.test.ts
@@ -1,0 +1,392 @@
+/**
+ * automations RLS — dual-axis (org OR partner) enforcement (#2133, epic #2135).
+ *
+ * Migration under test: 2026-07-02-automations-partner-ownership.sql.
+ *
+ * A standalone automation is owned by EITHER an org (org_id set, partner_id
+ * NULL — the original shape) OR a partner (partner_id set, org_id NULL —
+ * partner-wide / "all orgs"). automation_runs has no ownership columns and
+ * stays parent-join (its EXISTS policies gained the partner branch on the
+ * automations parent in the same migration). Same dual-axis contract-test
+ * blindspot as the sibling suites: this functional test through the REAL
+ * postgres.js driver (breeze_app role) is the guard that a partner cannot
+ * forge a partner_id for another partner.
+ *
+ * The second describe block proves the event-trigger fan-out (#1724 trap): a
+ * stored partner-wide automation must actually MATCH a device event raised in
+ * a member org — queueEventTriggers previously filtered by
+ * eq(automations.orgId, event.orgId), which silently matched ZERO rows for
+ * org_id NULL. Unit tests mock the query away, so this is the only place the
+ * real query shape is proven against Postgres (the BullMQ queue is mocked).
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+
+const { queueAddMock } = vi.hoisted(() => ({ queueAddMock: vi.fn() }));
+
+// queueEventTriggers hits real Postgres for its candidate query, but its
+// dispatch side is BullMQ. Mock the queue (and the connection factory it is
+// constructed from) so no Redis is needed; assertions run against add() calls.
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = queueAddMock;
+    getJob = async () => null;
+    getRepeatableJobs = async () => [];
+    removeRepeatableByKey = async () => undefined;
+    close = async () => undefined;
+  },
+  Worker: class {
+    on() { /* noop */ }
+    close = async () => undefined;
+  },
+}));
+vi.mock('../../services/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/redis')>();
+  return {
+    ...actual,
+    getBullMQConnection: () => ({}) as never,
+    isRedisAvailable: () => true,
+  };
+});
+
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { automationRuns, automations, devices, sites } from '../../db/schema';
+import { queueEventTriggers } from '../../jobs/automationWorker';
+import type { BreezeEvent } from '../../services/eventBus';
+import { createOrganization, createPartner } from './db-utils';
+
+const createdAutomations: string[] = [];
+const createdDevices: string[] = [];
+const createdSites: string[] = [];
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+beforeEach(() => {
+  queueAddMock.mockReset().mockResolvedValue({ id: 'job-1' });
+});
+
+afterEach(async () => {
+  if (createdAutomations.length === 0 && createdDevices.length === 0) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    if (createdAutomations.length > 0) {
+      await db
+        .delete(automationRuns)
+        .where(inArray(automationRuns.automationId, createdAutomations));
+    }
+    for (const id of createdAutomations) {
+      await db.delete(automations).where(eq(automations.id, id));
+    }
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdSites) {
+      await db.delete(sites).where(eq(sites.id, id));
+    }
+  });
+  createdAutomations.length = 0;
+  createdDevices.length = 0;
+  createdSites.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const BASE_AUTOMATION = {
+  name: 'Partner-wide offline diagnostic',
+  trigger: { type: 'event', eventType: 'device.offline' },
+  actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'Device went offline' }],
+  enabled: true,
+};
+
+async function seedPartnerAutomation(partnerId: string): Promise<string> {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(automations)
+      .values({ ...BASE_AUTOMATION, orgId: null, partnerId })
+      .returning(),
+  );
+  const id = rows[0]!.id;
+  createdAutomations.push(id);
+  return id;
+}
+
+describe('automations RLS — dual-axis (2026-07-02 migration)', () => {
+  it('partner scope can INSERT a partner-wide automation (org_id NULL, partner_id set)', async () => {
+    const partner = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(automations)
+        .values({ ...BASE_AUTOMATION, orgId: null, partnerId: partner.id })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partner.id);
+    if (rows[0]) createdAutomations.push(rows[0].id);
+  });
+
+  it('a different partner can neither see nor forge an automation attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerAutomation(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: automations.id }).from(automations).where(eq(automations.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // WITH CHECK denies the cross-partner forge (Postgres 42501 on the cause).
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(automations)
+          .values({ ...BASE_AUTOMATION, name: 'Forged partner-wide', orgId: null, partnerId: partnerA.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('an org-scope caller cannot see a partner-wide automation owned by its partner (the worker still fires it for the org, see fan-out below)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const id = await seedPartnerAutomation(partner.id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: automations.id }).from(automations).where(eq(automations.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+
+  it('org scope can still INSERT and SELECT an org-scoped automation (unchanged shape)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const inserted = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .insert(automations)
+        .values({ ...BASE_AUTOMATION, name: 'Org automation', orgId: org.id, partnerId: null })
+        .returning(),
+    );
+    if (inserted[0]) createdAutomations.push(inserted[0].id);
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.orgId).toBe(org.id);
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: automations.id })
+        .from(automations)
+        .where(eq(automations.id, inserted[0]!.id)),
+    );
+    expect(visible.map((r) => r.id)).toContain(inserted[0]?.id);
+  });
+
+  it('the one-owner CHECK rejects an automation that sets BOTH axes and one that sets NEITHER', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(automations)
+          .values({ ...BASE_AUTOMATION, name: 'Both axes', orgId: org.id, partnerId: partner.id })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(automations)
+          .values({ ...BASE_AUTOMATION, name: 'No axis', orgId: null, partnerId: null })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner scope can UPDATE and DELETE its own partner-wide automation, and its runs are partner-visible via the parent join', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerAutomation(partner.id);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .update(automations)
+        .set({ name: 'Renamed automation', enabled: false })
+        .where(eq(automations.id, id))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.enabled).toBe(false);
+
+    // A run of the partner-wide automation (inserted by the worker under
+    // system context) is visible to the owning partner through the widened
+    // automation_runs EXISTS policy — and invisible to another partner.
+    const [run] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(automationRuns)
+        .values({ automationId: id, triggeredBy: 'event:device.offline', status: 'running' })
+        .returning(),
+    );
+    const partnerVisibleRuns = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, run!.id)),
+    );
+    expect(partnerVisibleRuns.map((r) => r.id)).toEqual([run!.id]);
+
+    const otherPartner = await createPartner();
+    const otherVisibleRuns = await withDbAccessContext(partnerContext(otherPartner.id, []), () =>
+      db.select({ id: automationRuns.id }).from(automationRuns).where(eq(automationRuns.id, run!.id)),
+    );
+    expect(otherVisibleRuns).toEqual([]);
+
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      db.delete(automationRuns).where(eq(automationRuns.id, run!.id)),
+    );
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.delete(automations).where(eq(automations.id, id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+    createdAutomations.splice(createdAutomations.indexOf(id), 1);
+  });
+});
+
+// ============================================================
+// Event-trigger fan-out (#2133): the load-bearing SQL that makes a stored
+// partner-wide automation actually FIRE. queueEventTriggers previously
+// filtered by eq(automations.orgId, event.orgId), which silently matched ZERO
+// rows for org_id NULL — the #1724 trap. The worker runs this under a system
+// DB context (RLS bypass); mirror that here.
+// ============================================================
+
+describe('queueEventTriggers — partner-wide event fan-out (#2133)', () => {
+  async function seedDevice(orgId: string, hostname: string): Promise<string> {
+    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+    );
+    createdSites.push(site!.id);
+    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname,
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    createdDevices.push(device!.id);
+    return device!.id;
+  }
+
+  function offlineEvent(orgId: string, deviceId: string, eventId: string): BreezeEvent<Record<string, unknown>> {
+    return {
+      id: eventId,
+      type: 'device.offline',
+      orgId,
+      source: 'integration-test',
+      priority: 'normal',
+      payload: { deviceId },
+      metadata: { timestamp: new Date().toISOString() },
+    } as BreezeEvent<Record<string, unknown>>;
+  }
+
+  function queuedAutomationIds(): string[] {
+    return queueAddMock.mock.calls
+      .filter(([name]) => name === 'trigger-event')
+      .map(([, data]) => (data as { automationId: string }).automationId);
+  }
+
+  it('a device event in a member org matches the partner-wide automation (and an org-owned one); another partner never matches', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA1 = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
+    const orgB1 = await createOrganization({ partnerId: partnerB.id });
+
+    const deviceA1 = await seedDevice(orgA1.id, 'fanout-a1');
+    const deviceB1 = await seedDevice(orgB1.id, 'fanout-b1');
+
+    const partnerWideId = await seedPartnerAutomation(partnerA.id);
+
+    // Org-owned automation in the SAME member org — must keep matching.
+    const [orgOwned] = await withDbAccessContext(orgContext(orgA1.id), () =>
+      db
+        .insert(automations)
+        .values({ ...BASE_AUTOMATION, name: 'Org-owned offline', orgId: orgA1.id, partnerId: null })
+        .returning(),
+    );
+    createdAutomations.push(orgOwned!.id);
+
+    // Event raised in member org A1 (the worker's system context).
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      queueEventTriggers(offlineEvent(orgA1.id, deviceA1, 'evt-a1')),
+    );
+    expect(queuedAutomationIds()).toEqual(
+      expect.arrayContaining([partnerWideId, orgOwned!.id]),
+    );
+
+    // Event in a SECOND member org still matches the partner-wide automation
+    // (but not org A1's own automation).
+    queueAddMock.mockClear();
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      queueEventTriggers(offlineEvent(orgA2.id, deviceA1, 'evt-a2')),
+    );
+    expect(queuedAutomationIds()).toContain(partnerWideId);
+    expect(queuedAutomationIds()).not.toContain(orgOwned!.id);
+
+    // Event in ANOTHER PARTNER's org never matches partner A's automations.
+    queueAddMock.mockClear();
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      queueEventTriggers(offlineEvent(orgB1.id, deviceB1, 'evt-b1')),
+    );
+    expect(queuedAutomationIds()).not.toContain(partnerWideId);
+    expect(queuedAutomationIds()).not.toContain(orgOwned!.id);
+  });
+
+  it('a disabled partner-wide automation does not match', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const device = await seedDevice(org.id, 'fanout-disabled');
+
+    const id = await seedPartnerAutomation(partner.id);
+    await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.update(automations).set({ enabled: false }).where(eq(automations.id, id)),
+    );
+
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      queueEventTriggers(offlineEvent(org.id, device, 'evt-disabled')),
+    );
+    expect(queuedAutomationIds()).not.toContain(id);
+  });
+});

--- a/apps/api/src/__tests__/integration/automationsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationsPartnerRls.integration.test.ts
@@ -50,9 +50,24 @@ vi.mock('../../services/redis', async (importOriginal) => {
   };
 });
 
+// publishEvent writes to a Redis stream — mock it (no Redis in this
+// environment) and use the captured calls to assert the per-device-org
+// lifecycle fan-out for partner-wide runs.
+const { publishEventMock } = vi.hoisted(() => ({ publishEventMock: vi.fn() }));
+vi.mock('../../services/eventBus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/eventBus')>();
+  return {
+    ...actual,
+    publishEvent: publishEventMock,
+    getEventBus: () => ({ subscribe: () => () => undefined }) as never,
+  };
+});
+
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { automationRuns, automations, devices, sites } from '../../db/schema';
+import { alertRules, alerts, alertTemplates, automationRuns, automations, devices, sites } from '../../db/schema';
 import { queueEventTriggers } from '../../jobs/automationWorker';
+import { createAutomationRunRecord, executeAutomationRun } from '../../services/automationRuntime';
+import { resolvePolicyRemediationAutomationIdForOrg } from '../../services/policyEvaluationService';
 import type { BreezeEvent } from '../../services/eventBus';
 import { createOrganization, createPartner } from './db-utils';
 
@@ -70,6 +85,7 @@ const SYSTEM_CTX: DbAccessContext = {
 
 beforeEach(() => {
   queueAddMock.mockReset().mockResolvedValue({ id: 'job-1' });
+  publishEventMock.mockReset().mockResolvedValue('evt-mock');
 });
 
 afterEach(async () => {
@@ -82,6 +98,11 @@ afterEach(async () => {
     }
     for (const id of createdAutomations) {
       await db.delete(automations).where(eq(automations.id, id));
+    }
+    if (createdDevices.length > 0) {
+      // Alert rows (created by the execution-attribution tests) hold a device
+      // FK — remove them before their devices.
+      await db.delete(alerts).where(inArray(alerts.deviceId, createdDevices));
     }
     for (const id of createdDevices) {
       await db.delete(devices).where(eq(devices.id, id));
@@ -284,31 +305,31 @@ describe('automations RLS — dual-axis (2026-07-02 migration)', () => {
 // DB context (RLS bypass); mirror that here.
 // ============================================================
 
-describe('queueEventTriggers — partner-wide event fan-out (#2133)', () => {
-  async function seedDevice(orgId: string, hostname: string): Promise<string> {
-    const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
-      db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
-    );
-    createdSites.push(site!.id);
-    const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
-      db
-        .insert(devices)
-        .values({
-          orgId,
-          siteId: site!.id,
-          agentId: `agent-${site!.id.slice(0, 18)}`,
-          hostname,
-          osType: 'windows',
-          osVersion: '10.0',
-          architecture: 'x64',
-          agentVersion: '1.0.0',
-        })
-        .returning(),
-    );
-    createdDevices.push(device!.id);
-    return device!.id;
-  }
+async function seedDevice(orgId: string, hostname: string): Promise<string> {
+  const [site] = await withDbAccessContext(SYSTEM_CTX, () =>
+    db.insert(sites).values({ orgId, name: 'HQ' }).returning(),
+  );
+  createdSites.push(site!.id);
+  const [device] = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId: site!.id,
+        agentId: `agent-${site!.id.slice(0, 18)}`,
+        hostname,
+        osType: 'windows',
+        osVersion: '10.0',
+        architecture: 'x64',
+        agentVersion: '1.0.0',
+      })
+      .returning(),
+  );
+  createdDevices.push(device!.id);
+  return device!.id;
+}
 
+describe('queueEventTriggers — partner-wide event fan-out (#2133)', () => {
   function offlineEvent(orgId: string, deviceId: string, eventId: string): BreezeEvent<Record<string, unknown>> {
     return {
       id: eventId,
@@ -388,5 +409,145 @@ describe('queueEventTriggers — partner-wide event fan-out (#2133)', () => {
       queueEventTriggers(offlineEvent(org.id, device, 'evt-disabled')),
     );
     expect(queuedAutomationIds()).not.toContain(id);
+  });
+});
+
+// ============================================================
+// Execution attribution (#2133, playbook rule 5): worker-created child rows
+// take the DEVICE's org, never the automation owner's. A partner-wide
+// automation has NO org of its own — a regression back to automation.orgId
+// would insert alerts with org_id NULL (RLS/NOT NULL failure) or, worse,
+// attribute them to the wrong tenant. Lifecycle events must publish once per
+// distinct target-device org (publishEvent is mocked; Postgres is real).
+// ============================================================
+
+describe('executeAutomationRun — partner-wide child-row org attribution (#2133)', () => {
+  it('create_alert lands one alert per device carrying that DEVICE\'s org; lifecycle events publish per distinct device org', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const deviceA = await seedDevice(orgA.id, 'attr-a');
+    const deviceB = await seedDevice(orgB.id, 'attr-b');
+
+    const [automation] = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(automations)
+        .values({
+          name: 'Partner-wide alerting automation',
+          orgId: null,
+          partnerId: partner.id,
+          trigger: { type: 'manual' },
+          actions: [{ type: 'create_alert', alertSeverity: 'high', alertMessage: 'Cross-org alert' }],
+          enabled: true,
+        })
+        .returning(),
+    );
+    createdAutomations.push(automation!.id);
+
+    // The worker executes under system context — mirror that.
+    const { run, targetDeviceIds } = await withDbAccessContext(SYSTEM_CTX, () =>
+      createAutomationRunRecord({ automation: automation!, triggeredBy: 'manual:test' }),
+    );
+    expect(targetDeviceIds.sort()).toEqual([deviceA, deviceB].sort());
+
+    const result = await withDbAccessContext(SYSTEM_CTX, () =>
+      executeAutomationRun(run.id, targetDeviceIds),
+    );
+    expect(result.status).toBe('completed');
+    expect(result.devicesSucceeded).toBe(2);
+
+    // Each alert carries its own device's org — NOT the (NULL) automation org.
+    const alertRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ deviceId: alerts.deviceId, orgId: alerts.orgId })
+        .from(alerts)
+        .where(inArray(alerts.deviceId, [deviceA, deviceB])),
+    );
+    expect(alertRows).toHaveLength(2);
+    const orgByDevice = new Map(alertRows.map((row) => [row.deviceId, row.orgId]));
+    expect(orgByDevice.get(deviceA)).toBe(orgA.id);
+    expect(orgByDevice.get(deviceB)).toBe(orgB.id);
+
+    // The backing rule/template are created in each DEVICE org.
+    const ruleRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ orgId: alertRules.orgId })
+        .from(alertRules)
+        .where(inArray(alertRules.orgId, [orgA.id, orgB.id])),
+    );
+    expect(ruleRows.map((r) => r.orgId).sort()).toEqual([orgA.id, orgB.id].sort());
+    const templateRows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ orgId: alertTemplates.orgId })
+        .from(alertTemplates)
+        .where(inArray(alertTemplates.orgId, [orgA.id, orgB.id])),
+    );
+    expect(templateRows).toHaveLength(2);
+
+    // Lifecycle events fan out per distinct device org.
+    const startedOrgs = publishEventMock.mock.calls
+      .filter(([type]) => type === 'automation.started')
+      .map(([, orgId]) => orgId);
+    expect(startedOrgs.sort()).toEqual([orgA.id, orgB.id].sort());
+    const completedOrgs = publishEventMock.mock.calls
+      .filter(([type]) => type === 'automation.completed')
+      .map(([, orgId]) => orgId);
+    expect(completedOrgs.sort()).toEqual([orgA.id, orgB.id].sort());
+    // alert.triggered also carries each DEVICE's org.
+    const alertEventOrgs = publishEventMock.mock.calls
+      .filter(([type]) => type === 'alert.triggered')
+      .map(([, orgId]) => orgId);
+    expect(alertEventOrgs.sort()).toEqual([orgA.id, orgB.id].sort());
+  });
+});
+
+// ============================================================
+// Remediation resolution (#2133): a partner-wide automation whose actions
+// reference a policy's remediationScriptId must be found when remediation is
+// anchored to a member-org device — resolvePolicyRemediationAutomationIdForOrg
+// previously filtered by eq(automations.orgId, orgId), silently never matching
+// org_id NULL rows.
+// ============================================================
+
+describe('resolvePolicyRemediationAutomationIdForOrg — partner-wide matching (#2133)', () => {
+  const SCRIPT_ID = '00000000-0000-4000-8000-00000000cafe';
+
+  function policyWithRemediationScript() {
+    // Only .rules and .remediationScriptId are read by the resolver.
+    return { rules: [], remediationScriptId: SCRIPT_ID } as never;
+  }
+
+  it('matches a partner-wide automation for a member org, and never for another partner\'s org', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA1 = await createOrganization({ partnerId: partnerA.id });
+    const orgB1 = await createOrganization({ partnerId: partnerB.id });
+
+    const [automation] = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      db
+        .insert(automations)
+        .values({
+          name: 'Partner-wide remediation automation',
+          orgId: null,
+          partnerId: partnerA.id,
+          trigger: { type: 'manual' },
+          actions: [{ type: 'run_script', scriptId: SCRIPT_ID }],
+          enabled: true,
+        })
+        .returning(),
+    );
+    createdAutomations.push(automation!.id);
+
+    // Anchored to a member org of the owning partner → found.
+    const resolvedForMember = await withDbAccessContext(SYSTEM_CTX, () =>
+      resolvePolicyRemediationAutomationIdForOrg(policyWithRemediationScript(), orgA1.id),
+    );
+    expect(resolvedForMember).toBe(automation!.id);
+
+    // Anchored to another partner's org → never matches.
+    const resolvedForStranger = await withDbAccessContext(SYSTEM_CTX, () =>
+      resolvePolicyRemediationAutomationIdForOrg(policyWithRemediationScript(), orgB1.id),
+    );
+    expect(resolvedForStranger).toBeNull();
   });
 });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -271,6 +271,16 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // cross-partner forge + evaluation fan-out proof:
   // automationPoliciesPartnerRls.integration.test.ts.
   'automation_policies',
+  // automations (#2133, epic #2135): org-scoped OR partner-wide standalone
+  // automation ("on device.offline run diagnostic script" across all orgs).
+  // automation_runs stays parent-join (its EXISTS policies gained the partner
+  // branch on the automations parent in the same migration); worker-created
+  // child rows (alerts, deployments) always take the DEVICE's org. Converted
+  // in 2026-07-02-automations-partner-ownership. CHECK
+  // automations_one_owner_chk enforces exactly one axis. Functional
+  // cross-partner forge + event-trigger fan-out proof:
+  // automationsPartnerRls.integration.test.ts.
+  'automations',
   // sensitive_data_policies (#2131, epic #2135): org-scoped OR partner-wide
   // data-discovery policy. Scans/findings stay org-owned by the scanned
   // DEVICE's org (the scheduler sources scan org_id from the device).

--- a/apps/api/src/db/schema/automations.ts
+++ b/apps/api/src/db/schema/automations.ts
@@ -10,9 +10,15 @@ export const automationRunStatusEnum = pgEnum('automation_run_status', ['running
 export const policyEnforcementEnum = pgEnum('policy_enforcement', ['monitor', 'warn', 'enforce']);
 export const complianceStatusEnum = pgEnum('compliance_status', ['compliant', 'non_compliant', 'pending', 'error']);
 
+// A standalone automation is owned by EITHER an org (orgId set, partnerId
+// NULL — the original shape) OR a partner (partnerId set, orgId NULL —
+// "partner-wide / all orgs", epic #2135 / #2133). Exactly one axis is set per
+// row; the CHECK constraint `automations_one_owner_chk` (migration 2026-07-02)
+// enforces it. Mirrors automationPolicies (#2129) below.
 export const automations = pgTable('automations', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   name: varchar('name', { length: 255 }).notNull(),
   description: text('description'),
   enabled: boolean('enabled').notNull().default(true),
@@ -26,7 +32,9 @@ export const automations = pgTable('automations', {
   createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (table) => ({
+  partnerIdIdx: index('automations_partner_id_idx').on(table.partnerId),
+}));
 
 export const automationRuns = pgTable('automation_runs', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/apps/api/src/jobs/automationWorker.eventFanout.test.ts
+++ b/apps/api/src/jobs/automationWorker.eventFanout.test.ts
@@ -1,0 +1,164 @@
+/**
+ * queueEventTriggers — dual-ownership event fan-out wiring (#2133).
+ *
+ * A partner-wide automation (org_id NULL, partner_id set) must be matched
+ * when a device event fires in ANY member org of the owning partner. The
+ * real SQL shape is proven against Postgres in
+ * automationsPartnerRls.integration.test.ts; these mocked tests pin the
+ * wiring — the event-org partner lookup and the trigger-event enqueue.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { queueAddMock } = vi.hoisted(() => ({ queueAddMock: vi.fn() }));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = queueAddMock;
+    getJob = async () => null;
+    getRepeatableJobs = async () => [];
+    removeRepeatableByKey = async () => undefined;
+    close = async () => undefined;
+  },
+  Worker: class {
+    on() { /* noop */ }
+    close = async () => undefined;
+  },
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({})),
+  isRedisAvailable: vi.fn(() => true),
+  getRedis: vi.fn(() => null),
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  automations: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', enabled: 'enabled' },
+  configPolicyAutomations: { id: 'id', enabled: 'enabled' },
+  devices: { id: 'id', orgId: 'orgId', siteId: 'siteId' },
+  deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+
+vi.mock('../services/automationRuntime', () => ({
+  createAutomationRunRecord: vi.fn(),
+  executeAutomationRun: vi.fn(),
+  executeConfigPolicyAutomationRun: vi.fn(),
+  formatScheduleTriggerKey: vi.fn(() => '202601011000'),
+  isCronDue: vi.fn(() => false),
+  // Pass-through: queueEventTriggers only reads trigger.type / eventType / filter.
+  normalizeAutomationTrigger: vi.fn((trigger) => trigger),
+}));
+
+vi.mock('../services/featureConfigResolver', () => ({
+  scanScheduledAutomations: vi.fn(async () => []),
+  resolveAutomationsForDevice: vi.fn(async () => []),
+  resolveMaintenanceConfigForDevice: vi.fn(async () => null),
+  isInMaintenanceWindow: vi.fn(() => ({ active: false, suppressAutomations: false })),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+import { db } from '../db';
+import { queueEventTriggers } from './automationWorker';
+import type { BreezeEvent } from '../services/eventBus';
+
+const PARTNER_WIDE_AUTOMATION = {
+  id: 'auto-pw',
+  orgId: null,
+  partnerId: 'partner-1',
+  enabled: true,
+  trigger: { type: 'event', eventType: 'device.offline' },
+};
+
+function offlineEvent(orgId: string): BreezeEvent<Record<string, unknown>> {
+  return {
+    id: 'evt-1',
+    type: 'device.offline',
+    orgId,
+    source: 'test',
+    priority: 'normal',
+    payload: {},
+    metadata: { timestamp: '2026-07-02T00:00:00.000Z' },
+  } as BreezeEvent<Record<string, unknown>>;
+}
+
+/** db.select().from().where().limit() → rows (the event-org partner lookup). */
+function mockOrgLookupOnce(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as never);
+}
+
+/** db.select().from().where() → rows (the automation candidates query). */
+function mockCandidatesOnce(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.mocked(db.select).mockReset();
+  queueAddMock.mockReset().mockResolvedValue({ id: 'job-1' });
+});
+
+describe('queueEventTriggers — partner-wide fan-out wiring (#2133)', () => {
+  it('resolves the event org partner and enqueues a trigger-event job for a matching partner-wide automation', async () => {
+    mockOrgLookupOnce([{ partnerId: 'partner-1' }]);
+    mockCandidatesOnce([PARTNER_WIDE_AUTOMATION]);
+
+    await queueEventTriggers(offlineEvent('org-member-1'));
+
+    expect(queueAddMock).toHaveBeenCalledWith(
+      'trigger-event',
+      expect.objectContaining({
+        type: 'trigger-event',
+        automationId: 'auto-pw',
+        eventType: 'device.offline',
+      }),
+      expect.objectContaining({ jobId: 'automation-event-auto-pw-evt-1' }),
+    );
+  });
+
+  it('does not enqueue when the candidate trigger does not match the event type', async () => {
+    mockOrgLookupOnce([{ partnerId: 'partner-1' }]);
+    mockCandidatesOnce([
+      { ...PARTNER_WIDE_AUTOMATION, trigger: { type: 'event', eventType: 'device.online' } },
+    ]);
+
+    await queueEventTriggers(offlineEvent('org-member-1'));
+
+    expect(queueAddMock).not.toHaveBeenCalled();
+  });
+
+  it('still works for an event org without a partner (org-owned candidates only)', async () => {
+    mockOrgLookupOnce([]);
+    mockCandidatesOnce([
+      { id: 'auto-org', orgId: 'org-1', partnerId: null, enabled: true, trigger: { type: 'event', eventType: 'device.offline' } },
+    ]);
+
+    await queueEventTriggers(offlineEvent('org-1'));
+
+    expect(queueAddMock).toHaveBeenCalledWith(
+      'trigger-event',
+      expect.objectContaining({ automationId: 'auto-org' }),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/api/src/jobs/automationWorker.ts
+++ b/apps/api/src/jobs/automationWorker.ts
@@ -8,7 +8,7 @@
  */
 
 import { Job, Queue, Worker } from 'bullmq';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import * as dbModule from '../db';
 import { automations, configPolicyAutomations, devices, deviceGroupMemberships, organizations } from '../db/schema';
 import { type BreezeEvent, getEventBus } from '../services/eventBus';
@@ -723,14 +723,33 @@ async function scheduleAutomationScans(): Promise<void> {
   );
 }
 
-async function queueEventTriggers(event: BreezeEvent<Record<string, unknown>>): Promise<void> {
+// Exported for the partner-RLS integration suite, which proves the dual-axis
+// fan-out query against real Postgres (the BullMQ queue is mocked there).
+export async function queueEventTriggers(event: BreezeEvent<Record<string, unknown>>): Promise<void> {
   const queue = getAutomationQueue();
 
   // --- Legacy standalone automations ---
+  // Dual-ownership fan-out (#2133): match the event org's own automations OR
+  // partner-wide automations (org_id NULL) owned by that org's partner. This
+  // callback already runs under a system DB context, so RLS is not the filter
+  // — a plain eq(orgId, ...) would silently never match partner-wide rows.
+  const [eventOrg] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, event.orgId))
+    .limit(1);
+
+  const ownershipCondition = eventOrg?.partnerId
+    ? or(
+        eq(automations.orgId, event.orgId),
+        and(isNull(automations.orgId), eq(automations.partnerId, eventOrg.partnerId)),
+      )
+    : eq(automations.orgId, event.orgId);
+
   const candidates = await db
     .select()
     .from(automations)
-    .where(and(eq(automations.orgId, event.orgId), eq(automations.enabled, true)));
+    .where(and(ownershipCondition, eq(automations.enabled, true)));
 
   const payload = normalizePayload(event.payload);
 

--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -86,11 +86,11 @@ vi.mock('../services/auditEvents', () => ({
   writeAuditEvent: vi.fn(),
 }));
 
-const mockState: { permissions: any } = { permissions: undefined };
+const mockState: { permissions: any; auth: any } = { permissions: undefined, auth: undefined };
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
-    c.set('auth', {
+    c.set('auth', mockState.auth ?? {
       user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
       scope: 'organization',
       partnerId: null,
@@ -118,6 +118,7 @@ describe('automations routes', () => {
 	  beforeEach(() => {
 	    vi.clearAllMocks();
 	    mockState.permissions = undefined;
+	    mockState.auth = undefined;
 	    vi.mocked(checkAutomationTargetsWithinSiteScope).mockResolvedValue({
 	      ok: true,
 	      outOfScopeDeviceIds: [],
@@ -1213,5 +1214,238 @@ describe('automations routes', () => {
         }),
       }),
     );
+  });
+});
+
+// ============================================================
+// Dual-ownership (#2133): partner-wide automations (org_id NULL,
+// partner_id set). Create is gated on canManagePartnerWidePolicies;
+// loaded-row access allows the owning partner and system, never org
+// tokens; mutations/trigger on partner-wide rows require the capability.
+// ============================================================
+
+describe('automations routes — partner-wide dual-ownership (#2133)', () => {
+  let app: Hono;
+
+  const partnerAdminAuth = {
+    user: { id: 'user-123', email: 'admin@example.com', name: 'Partner Admin' },
+    scope: 'partner',
+    partnerId: 'partner-1',
+    partnerOrgAccess: 'all',
+    orgId: null,
+    token: { sub: 'user-123' },
+    accessibleOrgIds: ['org-123'],
+    canAccessOrg: (orgId: string) => orgId === 'org-123',
+  };
+
+  const partnerSelectedAuth = {
+    ...partnerAdminAuth,
+    partnerOrgAccess: 'selected',
+  };
+
+  const partnerWideAutomation = {
+    id: 'auto-pw',
+    name: 'Partner-wide automation',
+    orgId: null,
+    partnerId: 'partner-1',
+    trigger: { type: 'event', eventType: 'device.offline' },
+    conditions: null,
+    actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'x' }],
+    onFailure: 'stop',
+    notificationTargets: {},
+    enabled: true,
+    runCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  function mockSelectAutomationOnce(row: Record<string, unknown> | undefined) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(row ? [row] : []),
+        }),
+      }),
+    } as any);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.permissions = undefined;
+    mockState.auth = undefined;
+    app = new Hono();
+    app.route('/automations', automationRoutes);
+  });
+
+  it('creates a partner-wide automation (orgId NULL, partnerId from token) for a full partner admin', async () => {
+    mockState.auth = partnerAdminAuth;
+    const valuesSpy = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([partnerWideAutomation]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: valuesSpy } as any);
+
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        ownerScope: 'partner',
+        name: 'Partner-wide automation',
+        trigger: { type: 'event', eventType: 'device.offline' },
+        actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'x' }],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: null, partnerId: 'partner-1' }),
+    );
+  });
+
+  it('rejects ownerScope=partner for a partner user without full org access (403)', async () => {
+    mockState.auth = partnerSelectedAuth;
+
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        ownerScope: 'partner',
+        name: 'Denied',
+        trigger: { type: 'manual' },
+        actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'x' }],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('rejects ownerScope=partner for an org-scope caller (403)', async () => {
+    const res = await app.request('/automations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        ownerScope: 'partner',
+        name: 'Denied',
+        trigger: { type: 'manual' },
+        actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'x' }],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('an org-scope caller gets 404 for a partner-wide automation (no existence oracle)', async () => {
+    mockSelectAutomationOnce(partnerWideAutomation);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('the owning partner can read its partner-wide automation', async () => {
+    mockState.auth = partnerAdminAuth;
+    mockSelectAutomationOnce(partnerWideAutomation);
+    // recent runs + run stats queries
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ totalRuns: 0, completedRuns: 0, failedRuns: 0, partialRuns: 0 }]),
+        }),
+      } as any);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('auto-pw');
+    expect(body.orgId).toBeNull();
+  });
+
+  it('a DIFFERENT partner gets 404 for a partner-wide automation', async () => {
+    mockState.auth = { ...partnerAdminAuth, partnerId: 'partner-2' };
+    mockSelectAutomationOnce(partnerWideAutomation);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('a partner user WITHOUT full org access can see but not update a partner-wide automation (403)', async () => {
+    mockState.auth = partnerSelectedAuth;
+    mockSelectAutomationOnce(partnerWideAutomation);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+  });
+
+  it('a partner user WITHOUT full org access cannot delete a partner-wide automation (403)', async () => {
+    mockState.auth = partnerSelectedAuth;
+    mockSelectAutomationOnce(partnerWideAutomation);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(db.delete)).not.toHaveBeenCalled();
+  });
+
+  it('a partner user WITHOUT full org access cannot manually trigger a partner-wide automation (403)', async () => {
+    mockState.auth = partnerSelectedAuth;
+    mockSelectAutomationOnce(partnerWideAutomation);
+
+    const res = await app.request('/automations/auto-pw/trigger', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(createAutomationRunRecord)).not.toHaveBeenCalled();
+  });
+
+  it('a full partner admin CAN update its partner-wide automation', async () => {
+    mockState.auth = partnerAdminAuth;
+    mockSelectAutomationOnce(partnerWideAutomation);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ ...partnerWideAutomation, name: 'Renamed' }]),
+        }),
+      }),
+    } as any);
+
+    const res = await app.request('/automations/auto-pw', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe('Renamed');
   });
 });

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   automations,
@@ -25,6 +25,10 @@ import {
   withWebhookDefaults,
 } from '../services/automationRuntime';
 import { enqueueAutomationRun } from '../jobs/automationWorker';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 
 export const automationRoutes = new Hono();
 export const automationWebhookRoutes = new Hono();
@@ -236,6 +240,24 @@ async function enforceAutomationSiteScope(
   return null;
 }
 
+// Dual-ownership (#2133): an automation is org-owned (orgId set) or
+// partner-wide (orgId NULL, partnerId set).
+
+// Access to a LOADED automation row: org-owned keeps the org check; partner-
+// wide rows are visible to system scope and the owning partner's own tokens.
+// Org tokens never see partner-wide automations (RLS is stricter than the app
+// layer — org contexts never pass breeze_has_partner_access).
+function canAccessAutomation(
+  auth: AuthContext,
+  automation: { orgId: string | null; partnerId: string | null },
+): boolean {
+  if (automation.orgId !== null) {
+    return auth.canAccessOrg(automation.orgId);
+  }
+  if (auth.scope === 'system') return true;
+  return auth.scope === 'partner' && !!auth.partnerId && automation.partnerId === auth.partnerId;
+}
+
 async function getAutomationWithOrgCheck(automationId: string, auth: AuthContext) {
   const [automation] = await db
     .select()
@@ -247,8 +269,7 @@ async function getAutomationWithOrgCheck(automationId: string, auth: AuthContext
     return null;
   }
 
-  const hasAccess = ensureOrgAccess(automation.orgId, auth);
-  if (!hasAccess) {
+  if (!canAccessAutomation(auth, automation)) {
     return null;
   }
 
@@ -369,6 +390,10 @@ const triggerTypeSchema = z.enum(['schedule', 'event', 'webhook', 'manual']);
 
 const createAutomationSchema = z.object({
   orgId: z.string().guid().optional(),
+  // 'partner' creates a partner-wide ("all orgs") automation: orgId NULL,
+  // partnerId = caller's partner (#2133). Create-only — ownership never
+  // changes after creation (updateAutomationSchema has no ownerScope).
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1).max(255),
   description: z.string().optional(),
   enabled: z.boolean().default(true),
@@ -426,21 +451,35 @@ automationRoutes.get(
       }
       conditions.push(eq(automations.orgId, auth.orgId));
     } else if (auth.scope === 'partner') {
+      // Dual-axis (#2133): partner-scope callers also see their own
+      // partner-wide automations (orgId NULL). Org tokens never get this
+      // branch — they carry a partnerId but never pass partner access.
+      const partnerWideCondition = auth.partnerId
+        ? and(isNull(automations.orgId), eq(automations.partnerId, auth.partnerId))
+        : undefined;
       if (query.orgId) {
         const hasAccess = ensureOrgAccess(query.orgId, auth);
         if (!hasAccess) {
           return c.json({ error: 'Access to this organization denied' }, 403);
         }
-        conditions.push(eq(automations.orgId, query.orgId));
+        conditions.push(
+          partnerWideCondition
+            ? (or(eq(automations.orgId, query.orgId), partnerWideCondition) as SQL)
+            : eq(automations.orgId, query.orgId),
+        );
       } else {
         const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
+        if (orgIds.length === 0 && !partnerWideCondition) {
           return c.json({
             data: [],
             pagination: { page, limit, total: 0 },
           });
         }
-        conditions.push(inArray(automations.orgId, orgIds));
+        const orgCondition = orgIds.length > 0 ? inArray(automations.orgId, orgIds) : undefined;
+        const combined = orgCondition && partnerWideCondition
+          ? (or(orgCondition, partnerWideCondition) as SQL)
+          : orgCondition ?? partnerWideCondition;
+        if (combined) conditions.push(combined);
       }
     } else if (auth.scope === 'system' && query.orgId) {
       conditions.push(eq(automations.orgId, query.orgId));
@@ -655,28 +694,39 @@ automationRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    let orgId = data.orgId;
+    // Resolve the ownership axis (#2133): partner-wide creation requires the
+    // partner-wide capability; the default path stays org-owned.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (data.ownerScope === 'partner') {
+      if (!canManagePartnerWidePolicies(auth) || !auth.partnerId) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      let orgId = data.orgId;
 
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) {
-        return c.json({ error: 'Organization context required' }, 403);
-      }
-      orgId = auth.orgId;
-    } else if (auth.scope === 'partner') {
-      if (!orgId) {
-        const singleOrg = auth.accessibleOrgIds?.[0];
-        if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
-          orgId = singleOrg;
-        } else {
-          return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) {
+          return c.json({ error: 'Organization context required' }, 403);
         }
+        orgId = auth.orgId;
+      } else if (auth.scope === 'partner') {
+        if (!orgId) {
+          const singleOrg = auth.accessibleOrgIds?.[0];
+          if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
+            orgId = singleOrg;
+          } else {
+            return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+          }
+        }
+        const hasAccess = ensureOrgAccess(orgId, auth);
+        if (!hasAccess) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+      } else if (auth.scope === 'system' && !orgId) {
+        return c.json({ error: 'orgId is required' }, 400);
       }
-      const hasAccess = ensureOrgAccess(orgId, auth);
-      if (!hasAccess) {
-        return c.json({ error: 'Access to this organization denied' }, 403);
-      }
-    } else if (auth.scope === 'system' && !orgId) {
-      return c.json({ error: 'orgId is required' }, 400);
+      owner = { orgId: orgId!, partnerId: null };
     }
 
     const triggerInput = normalizeIncomingTrigger(data);
@@ -710,7 +760,8 @@ automationRoutes.post(
       // whose resolvable target set escapes their allowlist. This is the only
       // gate for unattended schedule/event triggers (no caller context later).
       const siteScopeDenied = await enforceAutomationSiteScope(c, {
-        orgId: orgId!,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         conditions: data.conditions,
         trigger: storedTrigger,
       } as Parameters<typeof checkAutomationTargetsWithinSiteScope>[0]);
@@ -722,7 +773,8 @@ automationRoutes.post(
         .insert(automations)
         .values({
           id: automationId,
-          orgId: orgId!,
+          orgId: owner.orgId,
+          partnerId: owner.partnerId,
           name: data.name,
           description: data.description,
           enabled: data.enabled,
@@ -776,6 +828,12 @@ async function handleUpdateAutomation(c: Context) {
   const automation = await getAutomationWithOrgCheck(automationId, auth);
   if (!automation) {
     return c.json({ error: 'Automation not found' }, 404);
+  }
+
+  // Partner-wide automations mutate behavior across every org under the
+  // partner — administrable only with the partner-wide capability (#2133).
+  if (automation.orgId === null && !canManagePartnerWidePolicies(auth)) {
+    return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
   }
 
   try {
@@ -914,6 +972,11 @@ automationRoutes.delete(
       return c.json({ error: 'Automation not found' }, 404);
     }
 
+    // Deleting a partner-wide automation affects every org under the partner.
+    if (automation.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
     const runningRuns = await db
       .select({ count: sql<number>`count(*)` })
       .from(automationRuns)
@@ -962,6 +1025,13 @@ async function triggerAutomationRun(
   const automation = await getAutomationWithOrgCheck(automationId, auth);
   if (!automation) {
     return c.json({ error: 'Automation not found' }, 404);
+  }
+
+  // Manually triggering a partner-wide automation fans actions out to devices
+  // in EVERY org under the partner — gate it like the mutators (#2133,
+  // matching the policy-evaluate precedent from the #2149 review).
+  if (automation.orgId === null && !canManagePartnerWidePolicies(auth)) {
+    return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
   }
 
   if (!automation.enabled) {

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -26,7 +26,7 @@ import { getToolDefinitions, executeTool, getToolTier } from '../services/aiTool
 import { checkGuardrails, checkToolPermission, checkToolRateLimit } from '../services/aiGuardrails';
 import { db } from '../db';
 import { devices, alerts, scripts, automations, partners, organizations } from '../db/schema';
-import { eq, and, asc, desc, inArray, isNull, getTableColumns, type SQL } from 'drizzle-orm';
+import { eq, and, asc, desc, inArray, isNull, or, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { AuthContext } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
@@ -1377,6 +1377,28 @@ async function readOrgScopedResource(
   });
 }
 
+/**
+ * Dual-axis read condition for a dual-ownership table (org XOR partner —
+ * scripts, automations #2133). Partner-scope callers also see partner-wide
+ * rows (org_id NULL) owned by their OWN partner; org tokens carry a partnerId
+ * but never pass breeze_has_partner_access, so they get the org branch only
+ * (the app layer must never be looser than RLS).
+ */
+function dualAxisResourceCondition(
+  auth: AuthContext,
+  orgCondition: SQL | undefined,
+  table: { orgId: PgColumn; partnerId: PgColumn },
+): SQL | undefined {
+  if (!orgCondition) return undefined; // system scope — no tenant filter
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return or(
+      orgCondition,
+      and(isNull(table.orgId), eq(table.partnerId, auth.partnerId)),
+    ) as SQL;
+  }
+  return orgCondition;
+}
+
 async function handleResourcesRead(
   id: string | number,
   params: Record<string, unknown>,
@@ -1452,23 +1474,28 @@ async function handleResourcesRead(
     }
 
     if (uri === 'breeze://scripts') {
+      // Scripts are dual-owned — include the caller's partner-wide scripts.
       return await readOrgScopedResource(id, uri, scripts, {
         id: scripts.id,
         name: scripts.name,
         description: scripts.description,
         language: scripts.language,
         category: scripts.category
-      }, orgCond(scripts.orgId), { extraConditions: [isNull(scripts.deletedAt)], limit: 200 });
+      }, dualAxisResourceCondition(auth, orgCond(scripts.orgId), scripts), {
+        extraConditions: [isNull(scripts.deletedAt)],
+        limit: 200
+      });
     }
 
     if (uri === 'breeze://automations') {
+      // Automations are dual-owned (#2133) — include partner-wide rows.
       return await readOrgScopedResource(id, uri, automations, {
         id: automations.id,
         name: automations.name,
         description: automations.description,
         enabled: automations.enabled,
         trigger: automations.trigger
-      }, orgCond(automations.orgId), { limit: 200 });
+      }, dualAxisResourceCondition(auth, orgCond(automations.orgId), automations), { limit: 200 });
     }
 
     // Handle dynamic resource URIs: breeze://devices/{id}

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { automationPolicies, automationRuns, automations, organizations } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
@@ -186,18 +186,36 @@ actionRoutes.post(
       }, 400);
     }
 
-    // Automations are org-owned. An org-owned policy anchors the lookup to its
-    // own org; a partner-wide policy (org_id NULL, #2129) accepts an explicit
-    // automation from any org under the owning partner.
-    const automationOwnerCondition = policy.orgId
-      ? eq(automations.orgId, policy.orgId)
-      : inArray(
+    // Automations are dual-owned (#2133). An org-owned policy anchors the
+    // lookup to its own org OR its partner's partner-wide automations; a
+    // partner-wide policy (org_id NULL, #2129) accepts an explicit automation
+    // from any org under the owning partner OR the partner's own
+    // partner-wide automations.
+    let automationOwnerCondition;
+    if (policy.orgId) {
+      const [policyOrg] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, policy.orgId))
+        .limit(1);
+      automationOwnerCondition = policyOrg?.partnerId
+        ? or(
+            eq(automations.orgId, policy.orgId),
+            and(isNull(automations.orgId), eq(automations.partnerId, policyOrg.partnerId))
+          )
+        : eq(automations.orgId, policy.orgId);
+    } else {
+      automationOwnerCondition = or(
+        inArray(
           automations.orgId,
           db
             .select({ id: organizations.id })
             .from(organizations)
             .where(eq(organizations.partnerId, policy.partnerId ?? ''))
-        );
+        ),
+        and(isNull(automations.orgId), eq(automations.partnerId, policy.partnerId ?? ''))
+      );
+    }
 
     const [automation] = await db
       .select()

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -1279,6 +1279,13 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         const [existing] = await db.select().from(automations).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Automation not found or access denied' });
 
+        // Defense-in-depth (#2133): this action is disabled by the early
+        // return above, but if it is ever re-enabled, mutating a partner-wide
+        // automation must require the partner-wide capability.
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide automation requires full partner org access' });
+        }
+
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;
         if (typeof input.description === 'string') updates.description = input.description;
@@ -1300,6 +1307,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
         const [existing] = await db.select().from(automations).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Automation not found or access denied' });
+
+        // Defense-in-depth (#2133): see the update-action gate above.
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Deleting a partner-wide automation requires full partner org access' });
+        }
 
         await db.transaction(async (tx) => {
           await tx.delete(automationRuns).where(eq(automationRuns.automationId, existing.id));

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -130,6 +130,18 @@ function automationPolicyWhere(auth: AuthContext): SQL | undefined {
   return oc;
 }
 
+// Dual-axis access for automations (#2133): same shape as alertRuleWhere —
+// org-owned automations the caller can reach OR partner-wide ones (org_id
+// NULL) owned by the caller's own partner.
+function automationWhere(auth: AuthContext): SQL | undefined {
+  const oc = orgWhere(auth, automations.orgId);
+  if (!oc) return undefined; // system scope
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${oc} OR (${automations.orgId} IS NULL AND ${automations.partnerId} = ${auth.partnerId}))`;
+  }
+  return oc;
+}
+
 /** Wrap handler in try-catch so DB/runtime errors return JSON instead of crashing */
 function safeHandler(toolName: string, fn: FleetHandler): FleetHandler {
   return async (input, auth) => {
@@ -1185,7 +1197,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
         if (typeof input.triggerType === 'string') {
           conditions.push(sql`${automations.trigger}->>'type' = ${input.triggerType}`);
@@ -1213,7 +1225,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'get') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [auto] = await db.select().from(automations).where(and(...conditions)).limit(1);
@@ -1225,7 +1237,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'history') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [auto] = await db.select().from(automations).where(and(...conditions)).limit(1);
@@ -1261,7 +1273,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'update') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(automations).where(and(...conditions)).limit(1);
@@ -1283,7 +1295,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'delete') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(automations).where(and(...conditions)).limit(1);
@@ -1299,11 +1311,17 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'enable' || action === 'disable') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [existing] = await db.select().from(automations).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Automation not found or access denied' });
+
+        // Toggling a partner-wide automation mutates behavior across every
+        // org under the partner (#2133) — requires the partner-wide capability.
+        if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying a partner-wide automation requires full partner org access' });
+        }
 
         const enabled = action === 'enable';
         await db.update(automations)
@@ -1316,11 +1334,17 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'run') {
         if (!input.automationId) return JSON.stringify({ error: 'automationId is required' });
         const conditions: SQL[] = [eq(automations.id, input.automationId as string)];
-        const oc = orgWhere(auth, automations.orgId);
+        const oc = automationWhere(auth);
         if (oc) conditions.push(oc);
 
         const [auto] = await db.select().from(automations).where(and(...conditions)).limit(1);
         if (!auto) return JSON.stringify({ error: 'Automation not found or access denied' });
+
+        // Running a partner-wide automation fans actions out across every org
+        // under the partner (#2133) — requires the partner-wide capability.
+        if (auto.orgId === null && !canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Running a partner-wide automation requires full partner org access' });
+        }
 
         const [run] = await db.insert(automationRuns).values({
           automationId: auto.id,

--- a/apps/api/src/services/automationRuntime.deploySoftware.test.ts
+++ b/apps/api/src/services/automationRuntime.deploySoftware.test.ts
@@ -59,8 +59,8 @@ vi.mock('./notificationSenders', () => ({
 
 import { executeDeploySoftwareActions, normalizeAutomationActions } from './automationRuntime';
 
-const WIN = { id: 'd-win', osType: 'windows' as const };
-const MAC = { id: 'd-mac', osType: 'macos' as const };
+const WIN = { id: 'd-win', osType: 'windows' as const, orgId: 'org-1' };
+const MAC = { id: 'd-mac', osType: 'macos' as const, orgId: 'org-1' };
 
 beforeEach(() => {
   createDeploymentMock.mockReset().mockResolvedValue({ deploymentId: 'dep-1', status: 'pending', dispatchedDeviceIds: ['d-win'] });
@@ -99,7 +99,7 @@ describe('executeDeploySoftwareActions', () => {
   it('deploys to an eligible Windows device and records a deployed log', async () => {
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN], createdBy: null, runId: 'run-1',
     });
     expect(createDeploymentMock).toHaveBeenCalledTimes(1);
     expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(['d-win']);
@@ -110,7 +110,7 @@ describe('executeDeploySoftwareActions', () => {
   it('skips a device whose OS is unsupported and does not create a deployment', async () => {
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [MAC], createdBy: null, runId: 'run-1',
     });
     expect(createDeploymentMock).not.toHaveBeenCalled();
     expect(res.logs.some(l => /unsupported OS/i.test(l.message))).toBe(true);
@@ -123,7 +123,7 @@ describe('executeDeploySoftwareActions', () => {
     }]]));
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN, MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN, MAC], createdBy: null, runId: 'run-1',
     });
     expect(createDeploymentMock).toHaveBeenCalledTimes(1);
     expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(
@@ -139,7 +139,7 @@ describe('executeDeploySoftwareActions', () => {
     }]]));
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN, MAC], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN, MAC], createdBy: null, runId: 'run-1',
     });
     expect(createDeploymentMock).toHaveBeenCalledTimes(1);
     expect(createDeploymentMock.mock.calls[0]![0].deviceIds).toEqual(
@@ -152,7 +152,7 @@ describe('executeDeploySoftwareActions', () => {
     isCurrentMock.mockResolvedValue(true);
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN], createdBy: null, runId: 'run-1',
     });
     expect(createDeploymentMock).not.toHaveBeenCalled();
     expect(res.logs.some(l => /already current/i.test(l.message))).toBe(true);
@@ -162,10 +162,29 @@ describe('executeDeploySoftwareActions', () => {
     latestMapMock.mockResolvedValue(new Map());
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN], createdBy: null, runId: 'run-1',
     });
     expect(res.failed).toBe(true);
     expect(res.logs.some(l => /no latest version/i.test(l.message))).toBe(true);
+  });
+
+  it('creates one deployment per device org (partner-wide fan-out, #2133)', async () => {
+    latestMapMock.mockResolvedValueOnce(new Map([['cat-1', {
+      version: { id: 'ver-1', catalogId: 'cat-1', version: '1.0.0', supportedOs: null },
+      catalogName: 'CrossOrgTool',
+    }]]));
+    const winOrg2 = { id: 'd-win-2', osType: 'windows' as const, orgId: 'org-2' };
+    const res = await executeDeploySoftwareActions({
+      actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
+      devices: [WIN, winOrg2], createdBy: null, runId: 'run-1',
+    });
+    expect(createDeploymentMock).toHaveBeenCalledTimes(2);
+    const calls = createDeploymentMock.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ orgId: 'org-1', deviceIds: ['d-win'] }),
+      expect.objectContaining({ orgId: 'org-2', deviceIds: ['d-win-2'] }),
+    ]));
+    expect(res.failed).toBe(false);
   });
 
   it('marks failed when createSoftwareDeployment returns status "failed"', async () => {
@@ -174,7 +193,7 @@ describe('executeDeploySoftwareActions', () => {
     createDeploymentMock.mockResolvedValue({ deploymentId: 'dep-err', status: 'failed', message: 'db error', dispatchedDeviceIds: [] });
     const res = await executeDeploySoftwareActions({
       actions: [{ type: 'deploy_software', catalogId: 'cat-1' }],
-      devices: [WIN], orgId: 'org-1', createdBy: null, runId: 'run-1',
+      devices: [WIN], createdBy: null, runId: 'run-1',
     });
     expect(res.failed).toBe(true);
     expect(res.logs.some(l => /deploy_software failed/i.test(l.message))).toBe(true);

--- a/apps/api/src/services/automationRuntime.partnerFanout.test.ts
+++ b/apps/api/src/services/automationRuntime.partnerFanout.test.ts
@@ -1,0 +1,168 @@
+/**
+ * resolveAutomationTargetDeviceIds — dual-ownership fan-out (#2133).
+ *
+ * A partner-wide automation (orgId NULL, partnerId set) resolves targets
+ * across EVERY org under the owning partner; an org-owned automation keeps
+ * the single-org shape. The real SQL is proven against Postgres in
+ * automationsPartnerRls.integration.test.ts — these mocked tests pin the
+ * per-branch wiring (owner-org resolution, per-org deployment loop, merge).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { resolveDeploymentTargetsMock } = vi.hoisted(() => ({
+  resolveDeploymentTargetsMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    selectDistinct: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  automationRuns: { id: 'id', automationId: 'automationId', status: 'status' },
+  configPolicyAutomations: { featureLinkId: 'featureLinkId' },
+  configPolicyFeatureLinks: { id: 'id', configPolicyId: 'configPolicyId' },
+  configurationPolicies: { id: 'id', orgId: 'orgId' },
+  devices: { id: 'id', orgId: 'orgId', hostname: 'hostname', osType: 'osType', status: 'status', displayName: 'displayName' },
+  scripts: { id: 'id', deletedAt: 'deletedAt' },
+  notificationChannels: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' },
+  automations: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', runCount: 'runCount', lastRunAt: 'lastRunAt', updatedAt: 'updatedAt' },
+  alerts: { id: 'id' },
+  alertRules: { id: 'id', orgId: 'orgId', name: 'name', targetType: 'targetType', targetId: 'targetId' },
+  alertTemplates: { id: 'id', orgId: 'orgId', name: 'name' },
+  deviceGroupMemberships: { deviceId: 'deviceId', groupId: 'groupId' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+
+vi.mock('./eventBus', () => ({
+  publishEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./deploymentEngine', () => ({
+  resolveDeploymentTargets: resolveDeploymentTargetsMock,
+}));
+
+vi.mock('./commandQueue', () => ({
+  CommandTypes: { SCRIPT: 'script' },
+  queueCommandForExecution: vi.fn().mockResolvedValue({ command: null, error: 'mocked' }),
+}));
+
+vi.mock('./notificationSenders', () => ({
+  getEmailRecipients: vi.fn().mockReturnValue([]),
+  sendEmailNotification: vi.fn().mockResolvedValue({ success: false }),
+  sendWebhookNotification: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+import { db } from '../db';
+import { resolveAutomationTargetDeviceIds } from './automationRuntime';
+
+type AutomationRowLike = Parameters<typeof resolveAutomationTargetDeviceIds>[0];
+
+function baseAutomation(overrides: Partial<AutomationRowLike>): AutomationRowLike {
+  return {
+    id: 'auto-1',
+    orgId: null,
+    partnerId: null,
+    name: 'Test automation',
+    description: null,
+    enabled: true,
+    trigger: { type: 'event', eventType: 'device.offline' },
+    conditions: null,
+    actions: [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'x' }],
+    onFailure: 'stop',
+    notificationTargets: null,
+    lastRunAt: null,
+    runCount: 0,
+    createdBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as AutomationRowLike;
+}
+
+/** db.select().from().where() resolving to `rows`. */
+function mockSelectOnce(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.mocked(db.select).mockReset();
+  resolveDeploymentTargetsMock.mockReset();
+});
+
+describe('resolveAutomationTargetDeviceIds — dual-ownership fan-out (#2133)', () => {
+  it('org-owned automation resolves devices in its own org only (no org fan-out query)', async () => {
+    // Only ONE select: the org-device fallback (owner orgs = [orgId], no lookup).
+    mockSelectOnce([{ id: 'device-1' }, { id: 'device-2' }]);
+
+    const result = await resolveAutomationTargetDeviceIds(
+      baseAutomation({ orgId: 'org-1', partnerId: null }),
+    );
+
+    expect(result).toEqual(['device-1', 'device-2']);
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+  });
+
+  it('partner-wide automation fans out to devices across ALL member orgs', async () => {
+    // 1st select: member orgs of the owning partner; 2nd: their devices.
+    mockSelectOnce([{ id: 'org-1' }, { id: 'org-2' }]);
+    mockSelectOnce([{ id: 'device-1' }, { id: 'device-2' }, { id: 'device-3' }]);
+
+    const result = await resolveAutomationTargetDeviceIds(
+      baseAutomation({ orgId: null, partnerId: 'partner-1' }),
+    );
+
+    expect(result).toEqual(['device-1', 'device-2', 'device-3']);
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('partner-wide automation with a deployment target config loops resolveDeploymentTargets per member org and merges', async () => {
+    mockSelectOnce([{ id: 'org-1' }, { id: 'org-2' }]);
+    resolveDeploymentTargetsMock
+      .mockResolvedValueOnce(['device-1', 'device-shared'])
+      .mockResolvedValueOnce(['device-2', 'device-shared']);
+
+    const targetConfig = { type: 'filter', filter: { operator: 'and', conditions: [] } };
+    const result = await resolveAutomationTargetDeviceIds(
+      baseAutomation({ orgId: null, partnerId: 'partner-1', conditions: targetConfig }),
+    );
+
+    expect(resolveDeploymentTargetsMock).toHaveBeenCalledTimes(2);
+    expect(resolveDeploymentTargetsMock).toHaveBeenCalledWith({ orgId: 'org-1', targetConfig });
+    expect(resolveDeploymentTargetsMock).toHaveBeenCalledWith({ orgId: 'org-2', targetConfig });
+    expect(result.sort()).toEqual(['device-1', 'device-2', 'device-shared']);
+  });
+
+  it('partner-wide automation whose partner has no member orgs resolves zero devices', async () => {
+    mockSelectOnce([]);
+
+    const result = await resolveAutomationTargetDeviceIds(
+      baseAutomation({ orgId: null, partnerId: 'partner-1' }),
+    );
+
+    expect(result).toEqual([]);
+    // No device query when the owner resolves to no orgs.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+    expect(resolveDeploymentTargetsMock).not.toHaveBeenCalled();
+  });
+
+  it('bad legacy data (neither axis set) resolves zero devices instead of throwing', async () => {
+    const result = await resolveAutomationTargetDeviceIds(
+      baseAutomation({ orgId: null, partnerId: null }),
+    );
+
+    expect(result).toEqual([]);
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -64,8 +64,13 @@ async function notificationChannelOwnershipCondition(
   }
 
   // Partner-wide automation: the one-owner CHECK guarantees partnerId is set;
-  // guard against bad legacy data with an always-false condition.
+  // guard against bad legacy data with an always-false condition. Log loudly —
+  // if this ever fires, the symptom downstream is "notifications silently
+  // stopped", which is undebuggable without this line.
   if (!owner.partnerId) {
+    console.error(
+      '[AutomationRuntime] notificationChannelOwnershipCondition called with neither orgId nor partnerId — matching no channels',
+    );
     return sql`false`;
   }
 
@@ -95,7 +100,12 @@ async function automationOwnerOrgIds(
   }
 
   if (!automation.partnerId) {
-    // The one-owner CHECK makes this unreachable; guard against bad legacy data.
+    // The one-owner CHECK makes this unreachable; guard against bad legacy
+    // data. Log loudly — the downstream symptom is "automation targets zero
+    // devices and the run completes", a silent no-op.
+    console.error(
+      '[AutomationRuntime] automation has neither orgId nor partnerId — resolving zero target devices',
+    );
     return [];
   }
 
@@ -1438,6 +1448,13 @@ export async function createAutomationRunRecord(options: {
   const eventOrgIds = options.automation.orgId
     ? [options.automation.orgId]
     : await distinctDeviceOrgIds(targetDeviceIds);
+  if (eventOrgIds.length === 0) {
+    // Partner-wide run with zero resolved targets: there is no org to publish
+    // to, so lifecycle consumers see nothing. Leave a trace for operators.
+    console.warn(
+      `[AutomationRuntime] partner-wide automation ${options.automation.id} run ${run.id} resolved zero target devices — no automation.started event published`,
+    );
+  }
   for (const eventOrgId of eventOrgIds) {
     await publishEvent(
       'automation.started',
@@ -1670,6 +1687,11 @@ export async function executeAutomationRun(
   const completionOrgIds = automation.orgId
     ? [automation.orgId]
     : [...new Set(deviceRows.map((device) => device.orgId))];
+  if (completionOrgIds.length === 0) {
+    console.warn(
+      `[AutomationRuntime] partner-wide automation ${automation.id} run ${run.id} finished (${status}) with zero target devices — no completion event published`,
+    );
+  }
   for (const eventOrgId of completionOrgIds) {
     await publishEvent(
       status === 'completed' ? 'automation.completed' : 'automation.failed',

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -36,22 +36,75 @@ const ALERT_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
  * owned by the org's partner. A plain eq(orgId, ...) silently drops
  * partner-wide channels (the #1724 trap; automation runs execute under
  * system context, so RLS is not the filter here).
+ *
+ * Automations are dual-owned too (#2133), so the owner is `{orgId, partnerId}`
+ * (exactly one set). An org-owned automation reaches its org's channels plus
+ * the org's partner's partner-wide channels; a partner-wide automation reaches
+ * the partner's partner-wide channels plus any member org's channels — all of
+ * which stay inside the owning partner's tenancy.
  */
-async function notificationChannelOwnershipCondition(orgId: string): Promise<SQL> {
-  const [org] = await db
-    .select({ partnerId: organizations.partnerId })
-    .from(organizations)
-    .where(eq(organizations.id, orgId))
-    .limit(1);
+async function notificationChannelOwnershipCondition(
+  owner: { orgId: string | null; partnerId: string | null },
+): Promise<SQL> {
+  if (owner.orgId) {
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, owner.orgId))
+      .limit(1);
 
-  if (!org?.partnerId) {
-    return eq(notificationChannels.orgId, orgId);
+    if (!org?.partnerId) {
+      return eq(notificationChannels.orgId, owner.orgId);
+    }
+
+    return or(
+      eq(notificationChannels.orgId, owner.orgId),
+      and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, org.partnerId))
+    ) as SQL;
+  }
+
+  // Partner-wide automation: the one-owner CHECK guarantees partnerId is set;
+  // guard against bad legacy data with an always-false condition.
+  if (!owner.partnerId) {
+    return sql`false`;
   }
 
   return or(
-    eq(notificationChannels.orgId, orgId),
-    and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, org.partnerId))
+    and(isNull(notificationChannels.orgId), eq(notificationChannels.partnerId, owner.partnerId)),
+    inArray(
+      notificationChannels.orgId,
+      db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.partnerId, owner.partnerId)),
+    )
   ) as SQL;
+}
+
+/**
+ * Ownership → org fan-out (#2133). An org-owned automation targets devices in
+ * its own org; a partner-wide automation (orgId NULL) fans out to every org
+ * under the owning partner. Returns [] when the owner resolves to no orgs —
+ * i.e. zero target devices.
+ */
+async function automationOwnerOrgIds(
+  automation: Pick<AutomationRow, 'orgId' | 'partnerId'>,
+): Promise<string[]> {
+  if (automation.orgId) {
+    return [automation.orgId];
+  }
+
+  if (!automation.partnerId) {
+    // The one-owner CHECK makes this unreachable; guard against bad legacy data.
+    return [];
+  }
+
+  const orgRows = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.partnerId, automation.partnerId));
+
+  return orgRows.map((row) => row.id);
 }
 
 export type AlertSeverity = typeof ALERT_SEVERITIES[number];
@@ -423,13 +476,14 @@ function coerceToFilterValue(condition: Record<string, unknown>): string {
   return asString(condition.value) ?? '';
 }
 
-async function resolveLegacyConditionTargets(orgId: string, conditionsInput: unknown): Promise<string[]> {
+async function resolveLegacyConditionTargets(orgIds: string[], conditionsInput: unknown): Promise<string[]> {
+  if (orgIds.length === 0) return [];
   const conditions = normalizeLegacyConditions(conditionsInput);
   if (conditions.length === 0) {
     const orgDevices = await db
       .select({ id: devices.id })
       .from(devices)
-      .where(eq(devices.orgId, orgId));
+      .where(inArray(devices.orgId, orgIds));
     return orgDevices.map((device) => device.id);
   }
 
@@ -441,7 +495,7 @@ async function resolveLegacyConditionTargets(orgId: string, conditionsInput: unk
       tags: devices.tags,
     })
     .from(devices)
-    .where(eq(devices.orgId, orgId));
+    .where(inArray(devices.orgId, orgIds));
 
   const deviceIds = orgDevices.map((device) => device.id);
   const groupMembers = deviceIds.length > 0
@@ -517,15 +571,27 @@ async function resolveLegacyConditionTargets(orgId: string, conditionsInput: unk
 }
 
 export async function resolveAutomationTargetDeviceIds(automation: AutomationRow): Promise<string[]> {
+  // Dual-ownership fan-out (#2133): a partner-wide automation (orgId NULL)
+  // resolves targets across EVERY org under the owning partner.
+  const ownerOrgIds = await automationOwnerOrgIds(automation);
+  if (ownerOrgIds.length === 0) return [];
+
   if (isDeploymentTargetConfig(automation.conditions)) {
-    return resolveDeploymentTargets({
-      orgId: automation.orgId,
-      targetConfig: automation.conditions,
-    });
+    // resolveDeploymentTargets keeps its shared non-null-orgId contract —
+    // loop per owner org and merge instead of widening its signature.
+    const merged = new Set<string>();
+    for (const orgId of ownerOrgIds) {
+      const ids = await resolveDeploymentTargets({
+        orgId,
+        targetConfig: automation.conditions,
+      });
+      for (const id of ids) merged.add(id);
+    }
+    return [...merged];
   }
 
   if (Array.isArray(automation.conditions)) {
-    return resolveLegacyConditionTargets(automation.orgId, automation.conditions);
+    return resolveLegacyConditionTargets(ownerOrgIds, automation.conditions);
   }
 
   const trigger = isPlainRecord(automation.trigger) ? automation.trigger : null;
@@ -535,14 +601,14 @@ export async function resolveAutomationTargetDeviceIds(automation: AutomationRow
     const scopedDevices = await db
       .select({ id: devices.id })
       .from(devices)
-      .where(and(eq(devices.orgId, automation.orgId), inArray(devices.id, triggerDeviceIds)));
+      .where(and(inArray(devices.orgId, ownerOrgIds), inArray(devices.id, triggerDeviceIds)));
     return scopedDevices.map((device) => device.id);
   }
 
   const orgDevices = await db
     .select({ id: devices.id })
     .from(devices)
-    .where(eq(devices.orgId, automation.orgId));
+    .where(inArray(devices.orgId, ownerOrgIds));
 
   return orgDevices.map((device) => device.id);
 }
@@ -613,10 +679,13 @@ export async function checkAutomationTargetsWithinSiteScope(
     return { ok: true, outOfScopeDeviceIds: [], unbounded: false };
   }
 
-  const targetDevices = await db
-    .select({ id: devices.id, siteId: devices.siteId })
-    .from(devices)
-    .where(and(eq(devices.orgId, automation.orgId), inArray(devices.id, targetDeviceIds)));
+  const ownerOrgIds = await automationOwnerOrgIds(automation);
+  const targetDevices = ownerOrgIds.length > 0
+    ? await db
+      .select({ id: devices.id, siteId: devices.siteId })
+      .from(devices)
+      .where(and(inArray(devices.orgId, ownerOrgIds), inArray(devices.id, targetDeviceIds)))
+    : [];
 
   const outOfScopeDeviceIds = targetDevices
     .filter((device) => !(typeof device.siteId === 'string' && canAccessSite(perms as UserPermissions, device.siteId)))
@@ -734,6 +803,9 @@ type ActionExecutionContext = {
   runId: string;
   device: {
     id: string;
+    // Worker-created child rows (alerts, notifications) always take the
+    // DEVICE's org — a partner-wide automation has no org of its own (#2133).
+    orgId: string;
     hostname: string;
     displayName: string | null;
     osType: 'windows' | 'macos' | 'linux';
@@ -1006,7 +1078,8 @@ async function executeSendNotificationAction(
     title,
     message,
     severity,
-    orgId: context.automation.orgId,
+    // The DEVICE's org — a partner-wide automation's orgId is NULL (#2133).
+    orgId: context.device.orgId,
     alertId: syntheticAlertId,
     deviceId: context.device.id,
     deviceName: context.device.displayName ?? context.device.hostname,
@@ -1041,7 +1114,10 @@ async function executeCreateAlertAction(
   actionIndex: number,
   context: ActionExecutionContext,
 ): Promise<ActionExecutionResult> {
-  const ruleId = await ensureAutomationAlertRule(context.automation.orgId);
+  // Alert rows (and their backing rule/template) take the DEVICE's org —
+  // playbook rule 5: a partner-wide automation (orgId NULL) never owns child
+  // rows; each alert lands in the org whose device raised it (#2133).
+  const ruleId = await ensureAutomationAlertRule(context.device.orgId);
 
   const title = action.alertTitle ?? `${context.automation.name} automation alert`;
   const message = action.alertMessage;
@@ -1051,7 +1127,7 @@ async function executeCreateAlertAction(
     .values({
       ruleId,
       deviceId: context.device.id,
-      orgId: context.automation.orgId,
+      orgId: context.device.orgId,
       status: 'active',
       severity: action.alertSeverity,
       title,
@@ -1078,7 +1154,7 @@ async function executeCreateAlertAction(
 
   await publishEvent(
     'alert.triggered',
-    context.automation.orgId,
+    context.device.orgId,
     {
       alertId: createdAlert.id,
       ruleId,
@@ -1140,6 +1216,8 @@ async function sendOnFailureNotifications(
   details: {
     runId: string;
     deviceId: string;
+    /** The failing DEVICE's org — automation.orgId is NULL for partner-wide (#2133). */
+    deviceOrgId: string;
     message: string;
   },
 ): Promise<AutomationLogEntry[]> {
@@ -1160,7 +1238,7 @@ async function sendOnFailureNotifications(
       title: `${automation.name} action failed`,
       message: details.message,
       severity: 'high',
-      orgId: automation.orgId,
+      orgId: details.deviceOrgId,
       alertId: `${details.runId}:${details.deviceId}:failure`,
       deviceId: details.deviceId,
       deviceName: details.deviceId,
@@ -1211,8 +1289,11 @@ async function runWithConcurrency<T>(
  */
 export async function executeDeploySoftwareActions(args: {
   actions: AutomationAction[];
-  devices: Array<{ id: string; osType: 'windows' | 'macos' | 'linux' }>;
-  orgId: string;
+  // Devices carry their own orgId: deployments are org-owned child rows, so a
+  // partner-wide automation (#2133) creates ONE deployment per device org.
+  // For an org-owned automation every device shares its org — one deployment,
+  // exactly the previous behavior.
+  devices: Array<{ id: string; osType: 'windows' | 'macos' | 'linux'; orgId: string }>;
   createdBy: string | null;
   runId: string;
 }): Promise<{ logs: AutomationLogEntry[]; deployedDeviceIds: Set<string>; failed: boolean }> {
@@ -1247,7 +1328,9 @@ export async function executeDeploySoftwareActions(args: {
     const supportedOs: string[] = Array.isArray(info.version.supportedOs)
       ? (info.version.supportedOs as string[])
       : [];
-    const eligible: string[] = [];
+    // Deployments are org-owned: group eligible devices by their org so a
+    // partner-wide automation creates one deployment per member org (#2133).
+    const eligibleByOrg = new Map<string, string[]>();
     for (const device of args.devices) {
       if (supportedOs.length > 0 && !supportedOs.includes(device.osType)) {
         logs.push(logEntry(`Skipped ${info.catalogName}: unsupported OS`, 'info', {
@@ -1267,38 +1350,42 @@ export async function executeDeploySoftwareActions(args: {
         }));
         continue;
       }
-      eligible.push(device.id);
+      const bucket = eligibleByOrg.get(device.orgId) ?? [];
+      bucket.push(device.id);
+      eligibleByOrg.set(device.orgId, bucket);
     }
-    if (eligible.length === 0) continue;
+    if (eligibleByOrg.size === 0) continue;
 
-    const result = await createSoftwareDeployment({
-      orgId: args.orgId,
-      softwareVersionId: info.version.id,
-      deploymentType: 'install',
-      deviceIds: eligible,
-      scheduleType: 'immediate',
-      createdBy: args.createdBy,
-      name: `Automation: deploy ${info.catalogName}`,
-    });
-    if (result.status === 'failed') {
-      failed = true;
-      logs.push(logEntry(`deploy_software failed: ${result.message ?? 'unknown error'}`, 'error', {
-        actionType: action.type,
-        actionIndex,
-        details: { catalogId: action.catalogId, deploymentId: result.deploymentId },
-      }));
-      continue;
+    for (const [orgId, eligible] of eligibleByOrg) {
+      const result = await createSoftwareDeployment({
+        orgId,
+        softwareVersionId: info.version.id,
+        deploymentType: 'install',
+        deviceIds: eligible,
+        scheduleType: 'immediate',
+        createdBy: args.createdBy,
+        name: `Automation: deploy ${info.catalogName}`,
+      });
+      if (result.status === 'failed') {
+        failed = true;
+        logs.push(logEntry(`deploy_software failed: ${result.message ?? 'unknown error'}`, 'error', {
+          actionType: action.type,
+          actionIndex,
+          details: { catalogId: action.catalogId, deploymentId: result.deploymentId, orgId },
+        }));
+        continue;
+      }
+      for (const id of result.dispatchedDeviceIds) deployedDeviceIds.add(id);
+      logs.push(logEntry(
+        `Deploying ${info.catalogName} ${info.version.version} to ${eligible.length} device(s)`,
+        'info',
+        {
+          actionType: action.type,
+          actionIndex,
+          details: { deploymentId: result.deploymentId, deviceIds: eligible },
+        },
+      ));
     }
-    for (const id of result.dispatchedDeviceIds) deployedDeviceIds.add(id);
-    logs.push(logEntry(
-      `Deploying ${info.catalogName} ${info.version.version} to ${eligible.length} device(s)`,
-      'info',
-      {
-        actionType: action.type,
-        actionIndex,
-        details: { deploymentId: result.deploymentId, deviceIds: eligible },
-      },
-    ));
   }
   return { logs, deployedDeviceIds, failed };
 }
@@ -1343,19 +1430,38 @@ export async function createAutomationRunRecord(options: {
     })
     .where(eq(automations.id, options.automation.id));
 
-  await publishEvent(
-    'automation.started',
-    options.automation.orgId,
-    {
-      automationId: options.automation.id,
-      runId: run.id,
-      triggeredBy: options.triggeredBy,
-      devicesTargeted: targetDeviceIds.length,
-    },
-    'automation-runtime',
-  );
+  // Lifecycle events carry an org. An org-owned automation publishes to its
+  // own org (unchanged); a partner-wide automation (orgId NULL, #2133) has no
+  // org of its own, so publish once per distinct TARGET-device org — keeping
+  // org-scoped consumers (event-triggered automations, alert bridges) working
+  // in every member org the run touches.
+  const eventOrgIds = options.automation.orgId
+    ? [options.automation.orgId]
+    : await distinctDeviceOrgIds(targetDeviceIds);
+  for (const eventOrgId of eventOrgIds) {
+    await publishEvent(
+      'automation.started',
+      eventOrgId,
+      {
+        automationId: options.automation.id,
+        runId: run.id,
+        triggeredBy: options.triggeredBy,
+        devicesTargeted: targetDeviceIds.length,
+      },
+      'automation-runtime',
+    );
+  }
 
   return { run, targetDeviceIds };
+}
+
+async function distinctDeviceOrgIds(deviceIds: string[]): Promise<string[]> {
+  if (deviceIds.length === 0) return [];
+  const rows = await db
+    .selectDistinct({ orgId: devices.orgId })
+    .from(devices)
+    .where(inArray(devices.id, deviceIds));
+  return rows.map((row) => row.orgId);
 }
 
 export async function executeAutomationRun(
@@ -1413,6 +1519,7 @@ export async function executeAutomationRun(
     ? await db
       .select({
         id: devices.id,
+        orgId: devices.orgId,
         hostname: devices.hostname,
         displayName: devices.displayName,
         osType: devices.osType,
@@ -1447,15 +1554,19 @@ export async function executeAutomationRun(
     notificationChannelIds.add(channelId);
   }
 
-  // Dual-axis (#2130): an automation's notify targets may reference the
-  // org's own channels OR partner-wide channels owned by the org's partner.
+  // Dual-axis (#2130/#2133): an automation's notify targets may reference the
+  // owner org's channels, partner-wide channels of its partner, or — for a
+  // partner-wide automation — any member org's channels.
   const channelRows = notificationChannelIds.size > 0
     ? await db
       .select()
       .from(notificationChannels)
       .where(
         and(
-          await notificationChannelOwnershipCondition(automation.orgId),
+          await notificationChannelOwnershipCondition({
+            orgId: automation.orgId,
+            partnerId: automation.partnerId,
+          }),
           inArray(notificationChannels.id, [...notificationChannelIds]),
         ),
       )
@@ -1495,6 +1606,7 @@ export async function executeAutomationRun(
             {
               runId: run.id,
               deviceId: device.id,
+              deviceOrgId: device.orgId,
               message: result.log.message,
             },
           );
@@ -1517,8 +1629,7 @@ export async function executeAutomationRun(
   // Batched deploy_software pass — runs once per automation run, after the per-device loop
   const deployOutcome = await executeDeploySoftwareActions({
     actions: normalized.actions,
-    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType })),
-    orgId: automation.orgId,
+    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType, orgId: d.orgId })),
     createdBy: automation.createdBy ?? null,
     runId: run.id,
   });
@@ -1554,20 +1665,27 @@ export async function executeAutomationRun(
     })
     .where(eq(automationRuns.id, run.id));
 
-  await publishEvent(
-    status === 'completed' ? 'automation.completed' : 'automation.failed',
-    automation.orgId,
-    {
-      automationId: automation.id,
-      runId: run.id,
-      triggeredBy: run.triggeredBy,
-      status,
-      devicesTargeted: targetDeviceIds.length,
-      devicesSucceeded,
-      devicesFailed,
-    },
-    'automation-runtime',
-  );
+  // Same shape as automation.started: an org-owned automation publishes to
+  // its own org; a partner-wide one publishes per distinct target-device org.
+  const completionOrgIds = automation.orgId
+    ? [automation.orgId]
+    : [...new Set(deviceRows.map((device) => device.orgId))];
+  for (const eventOrgId of completionOrgIds) {
+    await publishEvent(
+      status === 'completed' ? 'automation.completed' : 'automation.failed',
+      eventOrgId,
+      {
+        automationId: automation.id,
+        runId: run.id,
+        triggeredBy: run.triggeredBy,
+        status,
+        devicesTargeted: targetDeviceIds.length,
+        devicesSucceeded,
+        devicesFailed,
+      },
+      'automation-runtime',
+    );
+  }
 
   return {
     status,
@@ -1887,6 +2005,7 @@ export async function executeConfigPolicyAutomationRun(
     ? await db
       .select({
         id: devices.id,
+        orgId: devices.orgId,
         hostname: devices.hostname,
         displayName: devices.displayName,
         osType: devices.osType,
@@ -1923,7 +2042,7 @@ export async function executeConfigPolicyAutomationRun(
       .from(notificationChannels)
       .where(
         and(
-          await notificationChannelOwnershipCondition(orgId),
+          await notificationChannelOwnershipCondition({ orgId, partnerId: null }),
           inArray(notificationChannels.id, [...notificationChannelIds]),
         ),
       )
@@ -1973,6 +2092,7 @@ export async function executeConfigPolicyAutomationRun(
             {
               runId: run.id,
               deviceId: device.id,
+              deviceOrgId: device.orgId,
               message: result.log.message,
             },
           );
@@ -1995,8 +2115,7 @@ export async function executeConfigPolicyAutomationRun(
   // Batched deploy_software pass — runs once per config-policy automation run, after the per-device loop
   const deployOutcome = await executeDeploySoftwareActions({
     actions,
-    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType })),
-    orgId,
+    devices: deviceRows.map((d) => ({ id: d.id, osType: d.osType, orgId: d.orgId })),
     createdBy: null,
     runId: run.id,
   });

--- a/apps/api/src/services/policyEvaluationService.ts
+++ b/apps/api/src/services/policyEvaluationService.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   automationPolicies,
@@ -933,9 +933,33 @@ export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): P
 }
 
 /**
- * Automations are org-owned, so script-based remediation matching must be
- * anchored to a specific org. For an org-owned policy that is policy.orgId;
- * for a partner-wide policy (#2129) evaluatePolicy resolves per DEVICE org.
+ * Automations reachable from a device org (#2133): the org's own automations
+ * OR partner-wide automations (org_id NULL) owned by the org's partner. A
+ * plain eq(orgId, ...) silently never matches partner-wide rows — evaluation
+ * runs under a system DB context, so RLS is not the filter here.
+ */
+async function automationOwnershipConditionForOrg(orgId: string): Promise<SQL> {
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!org?.partnerId) {
+    return eq(automations.orgId, orgId);
+  }
+
+  return or(
+    eq(automations.orgId, orgId),
+    and(isNull(automations.orgId), eq(automations.partnerId, org.partnerId))
+  ) as SQL;
+}
+
+/**
+ * Script-based remediation matching is anchored to a specific org: the
+ * device's own automations plus partner-wide automations of the org's partner
+ * (#2133). For an org-owned policy the anchor is policy.orgId; for a
+ * partner-wide policy (#2129) evaluatePolicy resolves per DEVICE org.
  */
 export async function resolvePolicyRemediationAutomationIdForOrg(
   policy: PolicyRow,
@@ -955,7 +979,7 @@ export async function resolvePolicyRemediationAutomationIdForOrg(
     .from(automations)
     .where(
       and(
-        eq(automations.orgId, orgId),
+        await automationOwnershipConditionForOrg(orgId),
         eq(automations.enabled, true)
       )
     );
@@ -1085,16 +1109,17 @@ async function triggerRemediationAutomation(
     return null;
   }
 
-  // Automations are org-owned: anchor the lookup to the DEVICE's org. For an
-  // org-owned policy that equals policy.orgId (resolveTargetDevices filters by
-  // it); for a partner-wide policy it is the only org that makes sense.
+  // Anchor the lookup to the DEVICE's org (plus its partner's partner-wide
+  // automations, #2133). For an org-owned policy that equals policy.orgId
+  // (resolveTargetDevices filters by it); for a partner-wide policy it is the
+  // only org that makes sense.
   const [automation] = await db
     .select()
     .from(automations)
     .where(
       and(
         eq(automations.id, remediationAutomationId),
-        eq(automations.orgId, device.orgId)
+        await automationOwnershipConditionForOrg(device.orgId)
       )
     )
     .limit(1);
@@ -1218,9 +1243,10 @@ export async function evaluatePolicy(
   const requestRemediation = options.requestRemediation ?? true;
   const wantsRemediation = requestRemediation && policy.enforcement === 'enforce';
 
-  // Remediation automations are org-owned, so a partner-wide policy resolves
-  // them per DEVICE org (memoized); an org-owned policy hits the cache with a
-  // single key — its own org — preserving the previous resolve-once behavior.
+  // Remediation automations are anchored per DEVICE org (org-owned rows plus
+  // the org's partner's partner-wide rows, #2133), so a partner-wide policy
+  // resolves them per DEVICE org (memoized); an org-owned policy hits the
+  // cache with a single key — its own org — preserving resolve-once behavior.
   const remediationIdByOrg = new Map<string, string | null>();
   const remediationAutomationIdForOrg = async (deviceOrgId: string): Promise<string | null> => {
     if (!wantsRemediation) {
@@ -1773,13 +1799,15 @@ async function triggerConfigPolicyRemediation(
     return false;
   }
 
-  // Find an automation that uses the remediation script
+  // Find an automation that uses the remediation script — the device org's
+  // own automations plus its partner's partner-wide ones (#2133).
+  const deviceOrgAutomationCondition = await automationOwnershipConditionForOrg(deviceRow.orgId);
   const candidates = await db
     .select({ id: automations.id, actions: automations.actions })
     .from(automations)
     .where(
       and(
-        eq(automations.orgId, deviceRow.orgId),
+        deviceOrgAutomationCondition,
         eq(automations.enabled, true)
       )
     );
@@ -1815,7 +1843,7 @@ async function triggerConfigPolicyRemediation(
     .where(
       and(
         eq(automations.id, automationId),
-        eq(automations.orgId, deviceRow.orgId)
+        deviceOrgAutomationCondition
       )
     )
     .limit(1);

--- a/apps/web/src/components/automations/AutomationEditPage.tsx
+++ b/apps/web/src/components/automations/AutomationEditPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import AutomationForm, { type ActionFormValues, type AutomationFormValues } from './AutomationForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { getJwtClaims } from '@/lib/authScope';
 import type { DeploymentTargetConfig } from '@breeze/shared';
 import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
@@ -112,6 +114,16 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
   const [scripts, setScripts] = useState<Script[]>([]);
   const [notificationChannels, setNotificationChannels] = useState<NotificationChannel[]>([]);
   const [softwareCatalog, setSoftwareCatalog] = useState<SoftwareCatalogItem[]>([]);
+
+  // Ownership axis (#2133, mirrors software/ComplianceDashboard #2126):
+  // partner-scope creators may own an automation partner-wide ("all orgs").
+  // Gate on the JWT scope; default to partner-wide when viewing All orgs.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+  const defaultOwnerScope: AutomationFormValues['ownerScope'] =
+    isPartnerScope && (allOrgs || !currentOrgId) ? 'partner' : 'organization';
 
   const fetchAutomation = useCallback(async () => {
     if (!automationId || isNew) return;
@@ -289,7 +301,12 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
       };
 
       if (isNew) {
-        Object.assign(payload, { enabled: true });
+        // ownerScope is create-only (#2133): ownership never changes after
+        // creation, and the server rejects it on non-partner callers.
+        Object.assign(payload, {
+          enabled: true,
+          ...(isPartnerScope && values.ownerScope ? { ownerScope: values.ownerScope } : {})
+        });
       }
 
       const url = isNew ? '/automations' : `/automations/${automationId}`;
@@ -377,8 +394,9 @@ export default function AutomationEditPage({ automationId, isNew = false }: Auto
       <AutomationForm
         onSubmit={handleSubmit}
         onCancel={handleCancel}
-        defaultValues={defaultValues}
+        defaultValues={isNew ? { ownerScope: defaultOwnerScope, ...defaultValues } : defaultValues}
         webhookUrl={webhookUrl}
+        showOwnerScope={isNew && isPartnerScope}
         submitLabel={isNew ? 'Create Automation' : 'Save Changes'}
         loading={saving}
         sites={sites}

--- a/apps/web/src/components/automations/AutomationForm.tsx
+++ b/apps/web/src/components/automations/AutomationForm.tsx
@@ -65,6 +65,11 @@ const actionSchema = z.object({
 
 const automationSchema = z.object({
   name: z.string().min(1, 'Automation name is required'),
+  // Ownership axis (#2133, mirrors software/PolicyForm): 'partner' =
+  // partner-wide / all-orgs automation. Only surfaced on create for
+  // partner-scope users (showOwnerScope); the server derives the partner
+  // from the caller's own token.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   description: z.string().optional(),
   triggerType: z.enum(['schedule', 'event', 'webhook', 'manual']),
   cronExpression: z.string().optional(),
@@ -99,6 +104,8 @@ type AutomationFormProps = {
   scripts?: Script[];
   notificationChannels?: NotificationChannel[];
   softwareCatalog?: SoftwareCatalogItem[];
+  /** Show the ownership-scope selector (create-only, partner-scope users). */
+  showOwnerScope?: boolean;
 };
 
 const triggerTypeOptions: { value: TriggerType; label: string; description: string; icon: typeof Clock }[] = [
@@ -191,7 +198,8 @@ export default function AutomationForm({
   groups = [],
   scripts = [],
   notificationChannels = [],
-  softwareCatalog = []
+  softwareCatalog = [],
+  showOwnerScope = false
 }: AutomationFormProps) {
   const [conditionsExpanded, setConditionsExpanded] = useState(true);
   const [conditionMode, setConditionMode] = useState<'simple' | 'advanced'>(
@@ -271,6 +279,31 @@ export default function AutomationForm({
       })}
       className="space-y-6 rounded-lg border bg-card p-6 shadow-xs"
     >
+      {/* Ownership scope — partner-scope creators only (#2133) */}
+      {showOwnerScope && (
+        <fieldset className="space-y-2 rounded-md border p-4" data-testid="automation-owner">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Scope</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="partner"
+              {...register('ownerScope')}
+              data-testid="automation-owner-partner"
+            />
+            All organizations <span className="text-muted-foreground">(partner-wide automation)</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="organization"
+              {...register('ownerScope')}
+              data-testid="automation-owner-org"
+            />
+            This organization only
+          </label>
+        </fieldset>
+      )}
+
       {/* Basic Information */}
       <div className="grid gap-6 md:grid-cols-2">
         <div className="space-y-2">

--- a/apps/web/src/components/automations/AutomationList.tsx
+++ b/apps/web/src/components/automations/AutomationList.tsx
@@ -14,6 +14,7 @@ import {
   CheckCircle,
   XCircle,
   AlertTriangle,
+  Globe,
   MoreHorizontal
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -34,6 +35,9 @@ export type AutomationRun = {
 export type Automation = {
   id: string;
   name: string;
+  // null = partner-wide ("all orgs") automation (#2133); undefined when the
+  // caller did not supply ownership info.
+  orgId?: string | null;
   description?: string;
   triggerType: TriggerType;
   triggerConfig?: {
@@ -231,7 +235,19 @@ export default function AutomationList({
                   <tr key={automation.id} className="transition hover:bg-muted/40">
                     <td className="px-4 py-3">
                       <div>
-                        <p className="text-sm font-medium">{automation.name}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium">{automation.name}</p>
+                          {automation.orgId === null && (
+                            <span
+                              className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                              title="Partner-wide automation — applies to every organization"
+                              data-testid="automation-partner-wide-badge"
+                            >
+                              <Globe className="h-3 w-3" />
+                              All orgs
+                            </span>
+                          )}
+                        </div>
                         {automation.description && (
                           <p className="text-xs text-muted-foreground truncate max-w-xs">
                             {automation.description}

--- a/apps/web/src/components/automations/AutomationsPage.tsx
+++ b/apps/web/src/components/automations/AutomationsPage.tsx
@@ -32,6 +32,8 @@ function toListAutomation(raw: unknown): Automation {
   return {
     id: asString(item.id) ?? '',
     name: asString(item.name) ?? 'Untitled Automation',
+    // orgId === null marks a partner-wide ("All orgs") automation (#2133).
+    orgId: item.orgId === null ? null : asString(item.orgId),
     description: asString(item.description),
     triggerType,
     triggerConfig: {


### PR DESCRIPTION
Closes #2133

Phase 4 of the partner-wide-first epic (#2135). The standalone `automations` table becomes dual-owned — org-owned (`org_id` set, `partner_id` NULL, the original shape) or partner-wide (`partner_id` set, `org_id` NULL, "all orgs") — so a partner can define one automation (e.g. "on device.offline run diagnostic script") that fires across every member org. Implements the pre-mapped call-site plan from `docs/superpowers/plans/2026-07-02-automations-partner-ownership-mapping.md` (PR #2157).

**Migration** — `2026-07-02-automations-partner-ownership.sql`: `partner_id` FK + `org_id` DROP NOT NULL + `automations_one_owner_chk` XOR CHECK + partner index; the four baseline org-axis policies replaced by ONE dual-axis `automations_isolation` policy; the `automation_runs` EXISTS-join policies re-issued with the dual-axis predicate on the `automations` parent branch (maintenance-occurrences Step-3 shape) — the `configuration_policies` OR-branch is re-issued verbatim. Idempotent, no inner BEGIN/COMMIT.

**Routes** (`routes/automations.ts`) — create takes create-only `ownerScope: 'organization' | 'partner'`, gated on `canManagePartnerWidePolicies`; loaded-row access (`getAutomationWithOrgCheck`) gains the partner-wide branch (system or owning partner only — org tokens never see partner-wide rows, matching RLS); list conditions are dual-axis for partner-scope callers only; update/delete/manual-trigger on a partner-wide row require the capability (trigger gated like policy-evaluate per the #2149 review precedent). The hand-written update schema has no ownerScope — ownership never changes after create.

**Event fan-out** (`jobs/automationWorker.ts`) — `queueEventTriggers` resolves the event org's partner and matches `org-owned OR (org_id IS NULL AND partner_id = <event org's partner>)`. The worker already runs under a system DB context; no RLS context changes.

**Runtime** (`services/automationRuntime.ts`) — target resolution fans out across the partner's member orgs (`resolveDeploymentTargets` keeps its non-null-orgId contract via a per-org loop); worker-created child rows always take the DEVICE's org: alerts (+ their backing rule/template), `deploy_software` deployments (now grouped one-per-device-org), and notification payloads; `notificationChannelOwnershipCondition` accepts the `{orgId, partnerId}` owner pair; `automation.started/completed/failed` publish once per distinct target-device org for partner-wide runs (org-owned behavior unchanged).

**Remediation bridge** (`services/policyEvaluationService.ts`, `routes/policyManagement/actions.ts`) — the three `eq(automations.orgId, deviceOrg)` sites and the manual-remediate owner condition now also match partner-wide automations owned by the device/policy org's partner.

**AI + MCP** — `automationWhere` in `aiToolsFleet.ts` (alertRuleWhere shape) with partner-wide write gates on enable/disable/run; `breeze://automations` MCP resource read is dual-axis, and the same pre-existing gap on the `breeze://scripts` resource is fixed as a drive-by (scripts have been dual-owned for a while).

**Web** — create-only ownerScope selector in `AutomationForm` (software/PolicyForm pattern) wired through `AutomationEditPage`, and the "All orgs" badge in `AutomationList`.

**Config-policy linkage** — none on purpose: the config-policy "automation" feature stores rows inline in `config_policy_automations`, so `FEATURE_TABLE_MAP` / `PARTNER_LINKABLE_FEATURE_TYPES` are untouched (mapping §7).

**Not changed** — `scripts/migrateToConfigPolicies.ts` (one-off legacy migration script) still iterates org-owned automations only; partner-wide rows are post-conversion data and by definition not legacy input to that script.

**Tests**
- `automations` added to `DUAL_AXIS_TENANT_TABLES` (rls-coverage, 50 passed).
- New `automationsPartnerRls.integration.test.ts` (8 passed vs real Postgres via `breeze_app`): cross-partner forge 42501, XOR 23514, org-token isolation, partner-visible runs via the widened parent join, and the `queueEventTriggers` fan-out proof — a device event in a member org matches the partner-wide automation, a sibling org still matches it, another partner never does.
- Unit: dual-ownership route cases (create gating, 404-not-403 oracle, capability gates), `resolveAutomationTargetDeviceIds` fan-out, per-org deploy grouping, `queueEventTriggers` wiring — 280 tests green across affected suites; sibling partner-RLS integration suites (automation_policies, maintenance_windows, notification rails) re-run green.
- `pnpm db:check-drift` clean; `tsc --noEmit` clean for apps/api and apps/web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)