### PR TITLE
fix(reliability): credit boot spans as uptime, stop recovered-self credit double-dip

### DIFF
--- a/apps/api/src/services/reliabilityScoring.test.ts
+++ b/apps/api/src/services/reliabilityScoring.test.ts
@@ -21,6 +21,7 @@ function makeBucket(overrides: Record<string, unknown>) {
     serviceFailureCount: 0,
     recoveredServiceCount: 0,
     selfServiceFailureCount: 0,
+    recoveredSelfServiceCount: 0,
     hardwareErrorCount: 0,
     hardwareCriticalCount: 0,
     hardwareErrorSeverityCount: 0,
@@ -136,6 +137,24 @@ describe('reliabilityScoringInternals', () => {
     const now = new Date('2026-02-21T00:00:00.000Z');
     const buckets = [makeBucket({ date: '2026-02-20', crashCount: 9 })] as any[];
     expect(reliabilityScoringInternals.computeMtbfHours(buckets, 0, now)).toBeNull();
+  });
+
+  it('excludes Breeze self service failures from MTBF (restarts we caused are not device failures)', () => {
+    const now = new Date('2026-02-21T00:00:00.000Z');
+    // 9 service failures but 3 are Breeze's own → 6 genuine failures over
+    // 90 up-days (2160h) → 360h, not 240h.
+    const buckets = [
+      makeBucket({ date: '2026-02-20', serviceFailureCount: 9, selfServiceFailureCount: 3 }),
+    ] as any[];
+    expect(reliabilityScoringInternals.computeMtbfHours(buckets, 90, now)).toBe(360);
+  });
+
+  it('returns null MTBF when every failure is self-inflicted', () => {
+    const now = new Date('2026-02-21T00:00:00.000Z');
+    const buckets = [
+      makeBucket({ date: '2026-02-20', serviceFailureCount: 4, selfServiceFailureCount: 4 }),
+    ] as any[];
+    expect(reliabilityScoringInternals.computeMtbfHours(buckets, 90, now)).toBeNull();
   });
 
   it('parses stored aggregate state and prunes out-of-window buckets', () => {
@@ -700,6 +719,70 @@ describe('computeUptimePercent', () => {
   });
 });
 
+describe('bootSpanUpDayKeys', () => {
+  const { bootSpanUpDayKeys, computeUptimePercent } = reliabilityScoringInternals;
+  const now = new Date('2026-02-20T00:00:00.000Z');
+  const DAY = 24 * 60 * 60 * 1000;
+  const windowStart = new Date(now.getTime() - 90 * DAY);
+
+  function dayKeyOffset(daysAgo: number): string {
+    return new Date(now.getTime() - daysAgo * DAY).toISOString().slice(0, 10);
+  }
+
+  function row(bootDaysAgo: number, collectedDaysAgo: number) {
+    return {
+      bootTime: new Date(now.getTime() - bootDaysAgo * DAY),
+      collectedAt: new Date(now.getTime() - collectedDaysAgo * DAY),
+    };
+  }
+
+  it('credits every day of a row\'s continuous boot span, not just the collection day', () => {
+    // A row posted 40 days ago whose boot was 52 days ago proves the device was
+    // up on all 13 calendar days in between — even though no samples were posted
+    // on days 41..52.
+    const days = bootSpanUpDayKeys([row(52, 40)], windowStart, now);
+    for (let d = 40; d <= 52; d += 1) {
+      expect(days.has(dayKeyOffset(d)), `day -${d} should be covered`).toBe(true);
+    }
+    expect(days.has(dayKeyOffset(53))).toBe(false);
+    expect(days.has(dayKeyOffset(39))).toBe(false);
+  });
+
+  it('clamps span starts to the lookback window start', () => {
+    // Boot 200 days ago, sample 89 days ago: only in-window days are emitted.
+    const days = bootSpanUpDayKeys([row(200, 89)], windowStart, now);
+    expect(days.has(dayKeyOffset(89))).toBe(true);
+    expect(days.has(dayKeyOffset(90))).toBe(true); // window-start day itself
+    expect(days.has(dayKeyOffset(91))).toBe(false);
+  });
+
+  it('ignores rows with bootTime after collectedAt (clock skew / bogus data)', () => {
+    const days = bootSpanUpDayKeys([row(1, 5)], windowStart, now);
+    expect(days.size).toBe(0);
+  });
+
+  it('bridges an agent posting gap inside an unbroken boot span (prod repro)', () => {
+    // The win-build case: samples exist every window day EXCEPT a 9-day posting
+    // gap (days 61..69 ago), but the first post-gap row carries the same
+    // bootTime from before the gap — the machine never went down. Boot-span
+    // crediting must lift uptime90d from ~88.6% (below the 90% score cliff) to 100%.
+    const enrolledAt = new Date(now.getTime() - 200 * DAY);
+    const observed = new Set<string>();
+    for (let d = 0; d <= 90; d += 1) {
+      if (d < 61 || d > 69) observed.add(dayKeyOffset(d));
+    }
+    // Without span crediting the gap reads as downtime.
+    const latest = { collectedAt: now, uptimeSeconds: 5 * 24 * 60 * 60, bootTime: new Date(now.getTime() - 5 * DAY) };
+    const before = computeUptimePercent(latest, observed, 90, now, enrolledAt);
+    expect(before).toBeLessThan(95);
+
+    // Row posted the day after the gap ended, booted before the gap started.
+    const spanDays = bootSpanUpDayKeys([row(75, 60)], windowStart, now);
+    for (const key of spanDays) observed.add(key);
+    expect(computeUptimePercent(latest, observed, 90, now, enrolledAt)).toBe(100);
+  });
+});
+
 // Issue #1908: saturating curve helper — the foundation for all factor scorers.
 describe('saturatingScore', () => {
   const { saturatingScore } = reliabilityScoringInternals;
@@ -827,6 +910,19 @@ describe('scoreServiceFailures', () => {
     expect(scoreServiceFailures(6, 0, 30, 1)).toBe(scoreServiceFailures(5, 0, 30));
     // Omitting the argument keeps legacy behavior (nothing excluded).
     expect(scoreServiceFailures(5, 0, 30)).toBe(37);
+  });
+  // A recovered failure that is ALSO one of Breeze's own must not earn the
+  // half-weight recovery credit on top of the full self exclusion — that would
+  // hand out -0.5 net credit per agent auto-update (SCM 7031 + Windows restart
+  // = recovered self failure) and quietly offset genuine failures.
+  it('recovered self failures do not double-dip (self exclusion + recovery credit)', () => {
+    // 6 total: 5 genuine unrecovered + 1 self recovered. Must score exactly
+    // like 5 genuine failures, not 5 - 0.5 weighted.
+    expect(scoreServiceFailures(6, 1, 30, 1, 1)).toBe(scoreServiceFailures(5, 0, 30));
+    // Genuine recoveries still earn the credit when a self recovery coexists.
+    expect(scoreServiceFailures(7, 2, 30, 1, 1)).toBe(scoreServiceFailures(6, 1, 30));
+    // Defensive: recoveredSelf exceeding recovered clamps instead of inflating.
+    expect(scoreServiceFailures(5, 1, 30, 3, 3)).toBe(scoreServiceFailures(2, 0, 30));
   });
 });
 
@@ -972,6 +1068,20 @@ describe('scoreDailyBucket', () => {
 
   it('a bucket whose service failures are all Breeze self-failures scores clean', () => {
     expect(scoreDailyBucket(emptyBucket({ serviceFailureCount: 2, selfServiceFailureCount: 2 }))).toBe(100);
+  });
+
+  it('a recovered self failure does not earn recovery credit on top of the self exclusion', () => {
+    // 3 total: 2 genuine unrecovered + 1 self recovered. The self failure is
+    // excluded outright; its recovery must not also shave 0.5 off the genuine
+    // load. Expected = same day-score as 2 genuine failures.
+    const withRecoveredSelf = scoreDailyBucket(emptyBucket({
+      serviceFailureCount: 3,
+      selfServiceFailureCount: 1,
+      recoveredServiceCount: 1,
+      recoveredSelfServiceCount: 1,
+    }));
+    const twoGenuine = scoreDailyBucket(emptyBucket({ serviceFailureCount: 2 }));
+    expect(withRecoveredSelf).toBe(twoGenuine);
   });
 
   it('a bucket with more service failures scores strictly lower (no plateau)', () => {

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -107,6 +107,9 @@ type DailyAggregateBucket = {
   serviceFailureCount: number;
   recoveredServiceCount: number;
   selfServiceFailureCount: number;
+  // Overlap of the two subsets above: recovered failures that are also Breeze's
+  // own. Needed so the recovery credit can be limited to non-self recoveries.
+  recoveredSelfServiceCount: number;
   hardwareErrorCount: number;
   hardwareCriticalCount: number;
   hardwareErrorSeverityCount: number;
@@ -381,9 +384,43 @@ function observedUpDayKeys(dailyBuckets: DailyAggregateBucket[]): Set<string> {
   return days;
 }
 
+// A history row also proves the device was up for the whole continuous boot
+// span [bootTime, collectedAt] it reports: the OS accreted uptimeSeconds across
+// days where the agent never posted (agent stopped, network outage, API
+// unreachable). Without this, a multi-day posting gap inside an unbroken boot
+// span reads as downtime and craters uptime90d even though the machine never
+// went down (win-build: a 9-day gap → 88.6% → below the 90% cliff → 0/30 pts
+// while the 30d figure showed 100%). Spans are clamped to the lookback window
+// so a long-lived boot never walks further back than any scoring window sees,
+// and rows with bootTime after collectedAt (clock skew / bogus data) are skipped.
+function bootSpanUpDayKeys(
+  rows: Array<Pick<HistoryRow, 'bootTime' | 'collectedAt'>>,
+  windowStart: Date,
+  now: Date
+): Set<string> {
+  const days = new Set<string>();
+  const windowStartMs = windowStart.getTime();
+  const nowMs = now.getTime();
+  for (const row of rows) {
+    const bootMs = row.bootTime.getTime();
+    const collectedMs = row.collectedAt.getTime();
+    if (!Number.isFinite(bootMs) || !Number.isFinite(collectedMs)) continue;
+    if (bootMs > collectedMs) continue;
+    const spanStartMs = Math.max(bootMs, windowStartMs);
+    const spanEndMs = Math.min(collectedMs, nowMs);
+    if (spanEndMs < spanStartMs) continue; // span lies entirely outside the window
+    const endKey = toDayKey(new Date(spanEndMs));
+    for (let ms = spanStartMs; toDayKey(new Date(ms)) <= endKey; ms += DAY_MS) {
+      days.add(toDayKey(new Date(ms)));
+    }
+  }
+  return days;
+}
+
 // Uptime is real availability over the (enrollment-clamped) window: the fraction
 // of calendar days the device was up. A day counts as "up" when EITHER we
-// observed a reliability sample that day (the device reported, so it was online)
+// observed a reliability sample that day (the device reported, so it was online),
+// OR the day falls inside any reported boot span (see bootSpanUpDayKeys),
 // OR the day falls inside the current continuous boot span [bootTime, now].
 //
 // This replaces the old single-boot-snapshot model, where uptime% was
@@ -486,16 +523,22 @@ function scoreServiceFailures(
   serviceFailureCount30d: number,
   recoveredCount30d: number,
   observedUpDays30: number = RELIABILITY_RATE_REFERENCE_DAYS,
-  selfServiceFailureCount30d = 0
+  selfServiceFailureCount30d = 0,
+  recoveredSelfServiceCount30d = 0
 ): number {
   // Issue #1908: recovered failures get half-weight credit. Math.max(0, ...)
   // floors the case where recoveries exceed failures (weightedCount 0 → rate 0 →
   // score 100) before the divide. Rate-normalized; k_rate = K_SERVICES / REFERENCE.
   // Breeze's own service failures (a subset of the 30d count) are excluded from
   // the score entirely — restarts we caused must not read as device instability.
+  // A recovered SELF failure (agent auto-update: SCM 7031 + Windows restart) is
+  // already fully excluded, so its recovery must not ALSO earn the half-weight
+  // credit — that double-dip would hand out -0.5 net credit per auto-update and
+  // quietly offset genuine failures. Only non-self recoveries earn credit.
+  const nonSelfRecovered = Math.max(0, recoveredCount30d - recoveredSelfServiceCount30d);
   const weightedCount = Math.max(
     0,
-    serviceFailureCount30d - selfServiceFailureCount30d - recoveredCount30d * 0.5
+    serviceFailureCount30d - selfServiceFailureCount30d - nonSelfRecovered * 0.5
   );
   return saturatingRateScore(weightedCount, K_SERVICES, observedUpDays30);
 }
@@ -592,6 +635,7 @@ function createEmptyBucket(date: string): DailyAggregateBucket {
     serviceFailureCount: 0,
     recoveredServiceCount: 0,
     selfServiceFailureCount: 0,
+    recoveredSelfServiceCount: 0,
     hardwareErrorCount: 0,
     hardwareCriticalCount: 0,
     hardwareErrorSeverityCount: 0,
@@ -626,6 +670,7 @@ function normalizeBucketRecord(raw: unknown, dateOverride?: string): DailyAggreg
     serviceFailureCount: coerceCount(obj.serviceFailureCount),
     recoveredServiceCount: coerceCount(obj.recoveredServiceCount),
     selfServiceFailureCount: coerceCount(obj.selfServiceFailureCount),
+    recoveredSelfServiceCount: coerceCount(obj.recoveredSelfServiceCount),
     hardwareErrorCount: coerceCount(obj.hardwareErrorCount),
     hardwareCriticalCount: coerceCount(obj.hardwareCriticalCount),
     hardwareErrorSeverityCount: coerceCount(obj.hardwareErrorSeverityCount),
@@ -685,6 +730,7 @@ function serializeDailyBuckets(dailyBuckets: DailyAggregateBucket[]): DailyAggre
     serviceFailureCount: bucket.serviceFailureCount,
     recoveredServiceCount: bucket.recoveredServiceCount,
     selfServiceFailureCount: bucket.selfServiceFailureCount,
+    recoveredSelfServiceCount: bucket.recoveredSelfServiceCount,
     hardwareErrorCount: bucket.hardwareErrorCount,
     hardwareCriticalCount: bucket.hardwareCriticalCount,
     hardwareErrorSeverityCount: bucket.hardwareErrorSeverityCount,
@@ -880,7 +926,12 @@ function mergeRowsIntoDailyBuckets(
       // separately so the score can exclude self-inflicted failures (an agent
       // auto-update lands as SCM 7031 "terminated unexpectedly") while the
       // headline tile still shows every failure.
-      if (isBreezeSelfServiceFailure(event.serviceName)) bucket.selfServiceFailureCount += 1;
+      if (isBreezeSelfServiceFailure(event.serviceName)) {
+        bucket.selfServiceFailureCount += 1;
+        // Overlap counter: a recovered self failure must not also earn the
+        // recovery credit (the self exclusion already zeroes it out).
+        if (event.recovered) bucket.recoveredSelfServiceCount += 1;
+      }
       bucket.lastServiceFailureAt = maxTimestamp([bucket.lastServiceFailureAt, event.timestamp ?? fallbackTimestamp]);
     }
 
@@ -957,7 +1008,14 @@ function scoreDailyBucket(bucket: DailyAggregateBucket): number {
     lost(saturatingScore(effectiveCrashLoad(bucket.crashCount, bucket.appCrashCount), K_CRASHES))
     + lost(saturatingScore(bucket.hangCount + bucket.unresolvedHangCount, K_HANGS))
     + lost(saturatingScore(
-      Math.max(0, bucket.serviceFailureCount - bucket.selfServiceFailureCount - bucket.recoveredServiceCount * 0.5),
+      // Same non-self-recovery rule as scoreServiceFailures: a recovered self
+      // failure is already excluded outright and earns no recovery credit.
+      Math.max(
+        0,
+        bucket.serviceFailureCount
+          - bucket.selfServiceFailureCount
+          - Math.max(0, bucket.recoveredServiceCount - bucket.recoveredSelfServiceCount) * 0.5,
+      ),
       K_SERVICES,
     ))
     + lost(saturatingScore(
@@ -1020,7 +1078,14 @@ function computeTrend(dailyBuckets: DailyAggregateBucket[], now: Date): { direct
 function computeMtbfHours(dailyBuckets: DailyAggregateBucket[], upDays90: number, now: Date): number | null {
   const crashes90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.crashCount);
   const hangs90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.hangCount);
-  const service90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.serviceFailureCount);
+  // Breeze's own service restarts (agent auto-updates) are not device failures —
+  // exclude them from MTBF the same way the service-failure score excludes them.
+  const service90d = sumBucketsInWindow(
+    dailyBuckets,
+    90,
+    now,
+    (bucket) => Math.max(0, bucket.serviceFailureCount - bucket.selfServiceFailureCount)
+  );
   const hardware90d = sumBucketsInWindow(dailyBuckets, 90, now, (bucket) => bucket.hardwareErrorCount);
   const failures = crashes90d + hangs90d + service90d + hardware90d;
   if (failures <= 0) return null;
@@ -1295,6 +1360,9 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
 
   const enrolledAt = device.enrolledAt ?? null;
   const observedDays = observedUpDayKeys(dailyBuckets);
+  // Credit days covered by any reported boot span: an agent posting gap inside
+  // an unbroken boot is proof of uptime, not downtime (see bootSpanUpDayKeys).
+  for (const key of bootSpanUpDayKeys(allRows, lookbackStart, now)) observedDays.add(key);
   const observedUpDays30 = countObservedUpDaysInWindow(dailyBuckets, 30, now);
   const uptime7d = computeUptimePercent(latest, observedDays, 7, now, enrolledAt);
   const uptime30d = computeUptimePercent(latest, observedDays, 30, now, enrolledAt);
@@ -1315,6 +1383,7 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
   const serviceFailureCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.serviceFailureCount);
   const recoveredServiceCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.recoveredServiceCount);
   const selfServiceFailureCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.selfServiceFailureCount);
+  const recoveredSelfServiceCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.recoveredSelfServiceCount);
 
   const hardwareErrorCount7d = sumBucketsInWindow(dailyBuckets, 7, now, (bucket) => bucket.hardwareErrorCount);
   const hardwareErrorCount30d = sumBucketsInWindow(dailyBuckets, 30, now, (bucket) => bucket.hardwareErrorCount);
@@ -1333,7 +1402,8 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
     serviceFailureCount30d,
     recoveredServiceCount30d,
     observedUpDays30,
-    selfServiceFailureCount30d
+    selfServiceFailureCount30d,
+    recoveredSelfServiceCount30d
   );
   const hardwareErrorScore = scoreHardwareErrors(
     criticalHardwareCount30d,
@@ -1394,6 +1464,8 @@ export async function computeAndPersistDeviceReliability(deviceId: string): Prom
         // Subset of serviceFailureCount30d excluded from the score (Breeze's own
         // services); recorded so drill-downs can explain count vs. score.
         selfServiceFailureCount30d,
+        // Overlap of recovered ∩ self — recoveries that earned no credit.
+        recoveredSelfServiceCount30d,
       },
       hardwareErrors: {
         score: hardwareErrorScore,
@@ -2057,6 +2129,7 @@ export const reliabilityScoringInternals = {
   computeUptimePercent,
   computeUptimeAvailability,
   observedUpDayKeys,
+  bootSpanUpDayKeys,
   scoreUptime,
   scoreCrashes,
   scoreHangs,

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.test.tsx
@@ -450,6 +450,35 @@ describe('DeviceReliabilityPanel', () => {
     expect(screen.queryByTestId('reliability-top-drag')).toBeNull();
   });
 
+  // The uptime factor is scored from the 90d window; the evidence line must
+  // lead with the scored figure so "0/30 pts" can't sit next to a bare
+  // "100.0% in 30d" (the win-build confusion).
+  it('shows the scored 90d uptime figure ahead of the 30d context figure', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        snapshot: baseSnapshot({
+          uptime30d: 100,
+          drivers: [
+            {
+              factor: 'uptime',
+              label: 'Uptime',
+              score: 0,
+              weight: 30,
+              lostPoints: 30,
+              evidence: { uptime90d: 88.6, uptime30d: 100 },
+            },
+          ],
+        }),
+        history: [],
+      }),
+    );
+
+    render(<DeviceReliabilityPanel deviceId="dev-1" />);
+
+    await screen.findByTestId('reliability-uptime-window');
+    expect(screen.getByText(/88\.6% in 90d \(scored window\) · 100\.0% in 30d/)).toBeInTheDocument();
+  });
+
   it('keeps the fixed 30d window phrasing on a young device (no since-enroll labels)', async () => {
     const enrolledAt = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
     fetchWithAuthMock.mockResolvedValue(

--- a/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
+++ b/apps/web/src/components/devices/DeviceReliabilityPanel.tsx
@@ -217,8 +217,17 @@ function factorEvidenceText(
       break;
     }
     case 'uptime': {
+      // The uptime factor is scored from 90-day availability, not the 30d
+      // headline — lead with the scored figure so a 0-point row can't sit next
+      // to "100.0% in 30d" with no explanation; keep 30d as context.
+      const uptime90 = pick('uptime90d');
       const uptime30 = pick('uptime30d') ?? snapshot.uptime30d;
-      parts.push(`${uptime30.toFixed(1)}% ${windowPhrase}`);
+      if (uptime90 !== null) {
+        parts.push(`${uptime90.toFixed(1)}% in 90d (scored window)`);
+        if (uptime90 !== uptime30) parts.push(`${uptime30.toFixed(1)}% ${windowPhrase}`);
+      } else {
+        parts.push(`${uptime30.toFixed(1)}% ${windowPhrase}`);
+      }
       break;
     }
     default:


### PR DESCRIPTION
## Summary

Investigating a prod device showing **0/30 pts uptime** next to **30d uptime 100.0%** surfaced three scoring defects, all fixed here.

### 1. Agent posting gaps inside an unbroken boot span read as downtime
The uptime factor is scored from the **90d** window (`scoreUptime(uptime90d)`, hard cliff: ≤90% → 0 pts), but `computeUptimeAvailability` only credited days with a posted sample or days inside the **latest** boot span. The prod device had a 9-day agent posting gap (Apr 23–May 1) inside one continuous boot — the row after the gap carries the same `bootTime` with `uptimeSeconds` accreted straight through it, proving the machine never went down. Result: 70/79 up-days = 88.6% → 0/30 pts while the card showed "100.0% in 30d".

New `bootSpanUpDayKeys()`: every history row credits its whole `[bootTime, collectedAt]` span (clamped to the 90d lookback; bootTime>collectedAt rows skipped as clock skew). Regression test reproduces the exact prod case.

### 2. Recovered self failures double-dipped
`scoreServiceFailures` subtracted Breeze's own failures fully AND gave recovered failures half-weight credit. A recovered **self** failure — which is what every agent auto-update produces (SCM 7031 + Windows auto-restart) — netted **−0.5 credit**, quietly offsetting genuine failures fleet-wide. New `recoveredSelfServiceCount` overlap counter in the daily buckets; only non-self recoveries earn credit, in both the headline scorer and the per-day trend score.

### 3. MTBF counted our own restarts as device failures
Self service failures are now excluded from the MTBF failure count, matching the score's treatment (all-self → null MTBF).

### UI
The uptime factor evidence line now leads with the scored figure — `88.6% in 90d (scored window) · 100.0% in 30d` — so a 0-point row can never again sit next to an unexplained perfect 30d number. `uptime90d` was already persisted in driver evidence, so this renders for existing snapshots.

## Checked and deliberately unchanged
- **Rate-normalization denominator** (sample-days only) is correct: the agent's restart lookback is 24h, so events during multi-day gaps are never backfilled — crediting gap days would understate fault rates.
- The 90%-cliff in `scoreUptime` is intentional de-saturation; with boot-span crediting it can no longer be triggered by reporting gaps alone.

## Rollout
No migration, no purge: buckets rebuild from full 90d raw history on every compute (#1904) and `normalizeBucketRecord` coerces the missing legacy field to 0. Scores self-correct on the next recompute after deploy.

## Testing
- 141 API scoring tests pass (9 new, written failing-first, incl. the prod repro)
- 27 web panel tests pass (1 new)
- API + web typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)