### PR TITLE
Config policies: org ownership badge + locked org assignment target

### DIFF
--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -29,7 +29,7 @@ import {
   sensitiveDataPolicies,
   peripheralPolicies,
 } from '../db/schema';
-import { and, eq, desc, or, sql, inArray, asc, SQL } from 'drizzle-orm';
+import { and, eq, desc, or, sql, inArray, asc, getTableColumns, SQL } from 'drizzle-orm';
 import { canManagePartnerWidePolicies, PartnerWideWriteDeniedError } from './partnerWideAccess';
 import { z } from 'zod';
 import { eventLogInlineSettingsSchema, monitoringInlineSettingsSchema } from '@breeze/shared/validators';
@@ -192,9 +192,12 @@ export async function getConfigPolicy(id: string, auth: AuthContext) {
   const accessCond = policyAccessCondition(auth);
   if (accessCond) conditions.push(accessCond);
 
+  // orgName lets the UI label org-owned policies with their owning org
+  // (partner-wide rows have orgId NULL, so orgName comes back NULL too).
   const [policy] = await db
-    .select()
+    .select({ ...getTableColumns(configurationPolicies), orgName: organizations.name })
     .from(configurationPolicies)
+    .leftJoin(organizations, eq(configurationPolicies.orgId, organizations.id))
     .where(and(...conditions))
     .limit(1);
 
@@ -257,8 +260,9 @@ export async function listConfigPolicies(
   const offset = (pagination.page - 1) * pagination.limit;
 
   const rows = await db
-    .select()
+    .select({ ...getTableColumns(configurationPolicies), orgName: organizations.name })
     .from(configurationPolicies)
+    .leftJoin(organizations, eq(configurationPolicies.orgId, organizations.id))
     .where(whereCondition)
     .orderBy(desc(configurationPolicies.updatedAt))
     .limit(pagination.limit)

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.test.tsx
@@ -114,22 +114,17 @@ describe('AssignmentsTab — org-owned policy', () => {
     expect(optionValues).not.toContain('partner');
   });
 
-  it('POSTs an organization-level assignment with the selected targetId', async () => {
-    // Route by URL: assignments list is empty, the organization target list has one org.
-    fetchWithAuth.mockImplementation((url: string) => {
-      if (String(url).includes('/orgs/organizations')) {
-        return Promise.resolve(jsonResponse({ data: [{ id: ORG_ID, name: 'Acme Inc' }] }));
-      }
-      return Promise.resolve(jsonResponse({ data: [] }));
-    });
+  it('locks the organization-level target to the owning org and POSTs it without a picker', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} orgName="Acme Inc" partnerId={null} />);
 
-    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} partnerId={null} />);
-
-    // Open the target dropdown and pick the org once it has loaded.
-    await waitFor(() => expect(screen.getByText(/Select a target/i)).toBeInTheDocument());
-    fireEvent.click(screen.getByText(/Select a target/i));
-    await waitFor(() => expect(screen.getByText('Acme Inc')).toBeInTheDocument());
-    fireEvent.click(screen.getByText('Acme Inc'));
+    // The target is pre-filled and locked to the owning org — no dropdown.
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-org-target')).toHaveTextContent('Acme Inc')
+    );
+    expect(screen.queryByText(/Select a target/i)).not.toBeInTheDocument();
+    // The all-orgs list must never be fetched — the target is fixed.
+    const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/orgs/organizations'))).toBe(false);
 
     fetchWithAuth.mockResolvedValueOnce(jsonResponse({ id: 'a1', level: 'organization' }, 201));
     fireEvent.click(screen.getByRole('button', { name: /^Assign$/i }));
@@ -140,6 +135,25 @@ describe('AssignmentsTab — org-owned policy', () => {
       const body = JSON.parse(String((post![1] as RequestInit).body));
       expect(body.level).toBe('organization');
       expect(body.targetId).toBe(ORG_ID);
+    });
+  });
+
+  it('falls back to the org id in the locked target when no orgName is provided', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} partnerId={null} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-org-target')).toHaveTextContent(ORG_ID)
+    );
+  });
+
+  it('scopes device-level target options to the owning org', async () => {
+    render(<AssignmentsTab policyId={POLICY_ID} orgId={ORG_ID} orgName="Acme Inc" partnerId={null} />);
+    await waitFor(() => expect(screen.getByDisplayValue('Organization')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByDisplayValue('Organization'), { target: { value: 'device' } });
+
+    await waitFor(() => {
+      const urls = fetchWithAuth.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes(`/devices?orgId=${ORG_ID}`))).toBe(true);
     });
   });
 });

--- a/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
+++ b/apps/web/src/components/configurationPolicies/AssignmentsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Plus, Trash2, Search, ChevronDown } from 'lucide-react';
+import { Plus, Trash2, Search, ChevronDown, Lock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { extractApiError } from '@/lib/apiError';
 import { fetchWithAuth } from '../../stores/auth';
@@ -43,11 +43,14 @@ type Props = {
   policyId: string;
   // null for partner-owned ("all organizations") policies.
   orgId: string | null;
+  // Owning org's name (org-owned policies only) — shown in the locked
+  // organization-level target field.
+  orgName?: string | null;
   // Set when the policy is partner-OWNED (all-orgs). Drives the partner-wide UI.
   partnerId?: string | null;
 };
 
-export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
+export default function AssignmentsTab({ policyId, orgId, orgName, partnerId }: Props) {
   const isPartnerOwned = !!partnerId;
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [assignmentsLoading, setAssignmentsLoading] = useState(false);
@@ -107,20 +110,29 @@ export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
     }
     setLoadingTargets(true);
     setTargetOptions([]);
-    // site / device_group targets are scoped to the owning org. This branch is
-    // only reached for org-owned policies (partner-owned uses the no-picker
-    // flow), which always have an orgId — but guard rather than interpolate
+    // Every target level here is scoped to the owning org. This branch is only
+    // reached for org-owned policies (partner-owned uses the no-picker flow),
+    // which always have an orgId — but guard rather than interpolate
     // `orgId=null` into the URL if the ownership invariant is ever violated.
-    if ((level === 'site' || level === 'device_group') && !orgId) {
+    if (!orgId) {
       setLoadingTargets(false);
-      setError('This policy has no organization, so sites and device groups cannot be listed.');
+      setError('This policy has no organization, so assignment targets cannot be listed.');
+      return;
+    }
+    // Organization level: an org-owned policy can only be assigned to its own
+    // org, so there's nothing to pick — lock the target to the owning org.
+    if (level === 'organization') {
+      const name = orgName || orgId;
+      setTargetOptions([{ id: orgId, name }]);
+      setTargetNameCache((prev) => ({ ...prev, [orgId]: name }));
+      setNewTargetId(orgId);
+      setLoadingTargets(false);
       return;
     }
     const endpointMap: Record<string, string> = {
-      organization: '/orgs/organizations?limit=200',
       site: `/orgs/sites?orgId=${orgId}&limit=200`,
       device_group: `/device-groups?orgId=${orgId}&limit=200`,
-      device: '/devices?limit=200',
+      device: `/devices?orgId=${orgId}&limit=200`,
     };
     try {
       const url = endpointMap[level];
@@ -149,12 +161,14 @@ export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
     } finally {
       setLoadingTargets(false);
     }
-  }, [orgId]);
+  }, [orgId, orgName]);
 
   useEffect(() => {
-    fetchTargetOptions(newLevel);
+    // Reset BEFORE fetching — the organization branch of fetchTargetOptions
+    // pre-selects the owning org synchronously and must not be cleared.
     setNewTargetId('');
     setTargetSearch('');
+    fetchTargetOptions(newLevel);
   }, [newLevel, fetchTargetOptions]);
 
   // Close dropdown on outside click
@@ -537,6 +551,21 @@ export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
               ))}
             </select>
           </div>
+          {newLevel === 'organization' ? (
+            <div>
+              <label className="text-sm font-medium">
+                Target
+                <HelpTooltip text="An organization policy always targets its own organization. Pick a narrower level (site, device group, device) to scope it further." />
+              </label>
+              <div
+                className="mt-2 flex h-10 w-full items-center gap-2 rounded-md border bg-muted/40 px-3 text-sm"
+                data-testid="locked-org-target"
+              >
+                <Lock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">{selectedTargetName || orgName || 'This organization'}</span>
+              </div>
+            </div>
+          ) : (
           <div ref={dropdownRef} className="relative">
             <label className="text-sm font-medium">Target</label>
             <button
@@ -598,6 +627,7 @@ export default function AssignmentsTab({ policyId, orgId, partnerId }: Props) {
               </div>
             )}
           </div>
+          )}
           {priorityField}
         </div>
         <div className="mt-4">{filterFields}</div>

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.tsx
@@ -58,6 +58,8 @@ type PolicyDetail = {
   status: 'active' | 'inactive' | 'archived';
   orgId: string | null;
   partnerId: string | null;
+  // Owning org's name, joined in by the API for org-owned policies.
+  orgName?: string | null;
   createdAt?: string;
   updatedAt?: string;
   featureLinks: FeatureLink[];
@@ -438,7 +440,12 @@ export default function ConfigPolicyDetailPage({ policyId }: ConfigPolicyDetailP
 
       {/* Assignments Tab */}
       {activeTab === 'assignments' && policyId && policy && (
-        <AssignmentsTab policyId={policyId} orgId={policy.orgId} partnerId={policy.partnerId} />
+        <AssignmentsTab
+          policyId={policyId}
+          orgId={policy.orgId}
+          orgName={policy.orgName}
+          partnerId={policy.partnerId}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyList.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ConfigPolicyList, { type ConfigPolicy } from './ConfigPolicyList';
+
+const partnerWide: ConfigPolicy = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Default Workstation Policy',
+  status: 'active',
+  orgId: null,
+  partnerId: '33333333-3333-3333-3333-333333333333',
+  orgName: null,
+};
+
+const orgOwned: ConfigPolicy = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: 'Default Workstation Policy',
+  status: 'active',
+  orgId: '44444444-4444-4444-4444-444444444444',
+  orgName: 'OliveTech',
+};
+
+describe('ConfigPolicyList ownership badges', () => {
+  it('shows the All orgs badge only on partner-wide policies', () => {
+    render(<ConfigPolicyList policies={[partnerWide, orgOwned]} />);
+
+    const badges = screen.getAllByTestId('partner-wide-badge');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent('All orgs');
+  });
+
+  it('shows an org badge with the owning org name on org-owned policies', () => {
+    render(<ConfigPolicyList policies={[partnerWide, orgOwned]} />);
+
+    const badges = screen.getAllByTestId('org-badge');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent('OliveTech');
+  });
+
+  it('falls back to a generic label when the org name is missing', () => {
+    render(<ConfigPolicyList policies={[{ ...orgOwned, orgName: undefined }]} />);
+
+    expect(screen.getByTestId('org-badge')).toHaveTextContent('Organization');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Search, ChevronLeft, ChevronRight, Pencil, Trash2, Globe } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, Pencil, Trash2, Globe, Building2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export type ConfigPolicyStatus = 'active' | 'inactive' | 'archived';
@@ -11,6 +11,9 @@ export type ConfigPolicy = {
   status: ConfigPolicyStatus;
   // null = partner-wide ("All organizations") policy (#1724)
   orgId: string | null;
+  partnerId?: string | null;
+  // Owning org's name, joined in by the list API for org-owned policies.
+  orgName?: string | null;
   createdAt?: string;
   updatedAt?: string;
   featureLinks?: { id: string; featureType: string }[];
@@ -143,6 +146,16 @@ export default function ConfigPolicyList({
                         >
                           <Globe className="h-3 w-3" />
                           All orgs
+                        </span>
+                      )}
+                      {policy.orgId !== null && (
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full border bg-muted/60 px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                          title={`Organization policy — applies only to ${policy.orgName ?? 'its owning organization'}`}
+                          data-testid="org-badge"
+                        >
+                          <Building2 className="h-3 w-3" />
+                          {policy.orgName ?? 'Organization'}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

Follow-up UX polish for the partner-wide-first epic (#2135). Now that policies can be org-owned or partner-owned, the UI makes org ownership explicit and stops offering impossible assignment targets:

- **API** (`configurationPolicy.ts`): `getConfigPolicy` / `listConfigPolicies` left-join `organizations` and return `orgName` (NULL for partner-wide rows) so the UI can label org-owned policies.
- **List** (`ConfigPolicyList.tsx`): org-owned policies get a `Building2` badge with the owning org's name, complementing the existing "All orgs" badge on partner-wide rows.
- **Assignments tab** (`AssignmentsTab.tsx`): the organization-level target is locked to the owning org (an org-owned policy can only target its own org — no more fetching a 200-org picker for a single valid choice), and device-level target options are scoped to the owning org via `?orgId=`.

## Test plan

- `AssignmentsTab.test.tsx`: locked org target rendered without a picker, no all-orgs fetch, POST body carries the owning org id; fallback to org id when `orgName` missing; device target list scoped to owning org.
- `ConfigPolicyList.test.tsx` (new): ownership badges — "All orgs" only on partner-wide rows, org badge with org name, generic fallback.
- `apps/api` configurationPolicy service suites (62 tests) and `tsc --noEmit` on both packages pass locally.

Refs #2135

🤖 Generated with [Claude Code](https://claude.com/claude-code)