### PR TITLE
fix(web): gate device action bar on status!=='online' not =='offline' (#2078)

### DIFF
--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -42,6 +42,19 @@ const maintenanceDevice: Device = { ...baseDevice, status: 'maintenance' };
 const updatingDevice: Device = { ...baseDevice, status: 'updating' };
 const quarantinedDevice: Device = { ...baseDevice, status: 'quarantined' };
 
+// A policy that forbids remote tools, so we can exercise the `offlineTitle ??
+// (policy message)` tooltip precedence introduced by #2078.
+const remoteToolsDeniedPolicy = {
+  webrtcDesktop: true,
+  vncRelay: true,
+  remoteTools: false,
+  clipboardHostToViewer: false,
+  clipboardViewerToHost: true,
+  enableProxy: false,
+  policyName: 'Locked Down',
+  policyId: 'policy-1',
+};
+
 // Native disabled buttons aren't reported as disabled via getByRole's name in
 // every jsdom case, so query the DOM element directly and read its props.
 const button = (name: RegExp) => screen.getByRole('button', { name });
@@ -145,6 +158,31 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
     });
   });
 
+  // The Remote Tools tooltip is the one predicate whose SHAPE changed in #2078:
+  // it went from `offline ? "offline" : policy ? "…policy…" : undefined` to
+  // `offlineTitle ?? (policy ? "…policy…" : undefined)`. Lock both branches of
+  // that `??` so a future refactor can't silently drop the policy message or
+  // flip the precedence.
+  describe('Remote Tools policy tooltip precedence — issue #2078', () => {
+    it('shows the policy tooltip (not a status one) when online but remote tools are policy-disabled', () => {
+      const device: Device = { ...onlineDevice, remoteAccessPolicy: remoteToolsDeniedPolicy };
+      render(<DeviceActions device={device} />);
+
+      const remoteTools = button(/remote tools/i);
+      expect(remoteTools).toBeDisabled();
+      expect(remoteTools).toHaveAttribute('title', 'Remote tools disabled by policy "Locked Down"');
+    });
+
+    it('prefers the status tooltip over the policy tooltip when the device is also not online', () => {
+      const device: Device = { ...maintenanceDevice, remoteAccessPolicy: remoteToolsDeniedPolicy };
+      render(<DeviceActions device={device} />);
+
+      const remoteTools = button(/remote tools/i);
+      expect(remoteTools).toBeDisabled();
+      expect(remoteTools).toHaveAttribute('title', 'Device is in maintenance mode');
+    });
+  });
+
   // The compact variant duplicates the gating logic in its own menu, so it gets
   // its own coverage. The menu is collapsed until the trigger is clicked.
   describe('compact variant', () => {
@@ -169,6 +207,22 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
       fireEvent.click(screen.getByRole('button'));
 
       expect(button(/^connect desktop$/i)).not.toBeDisabled();
+    });
+
+    // `offline` satisfies BOTH the old `=== 'offline'` and the new
+    // `!== 'online'` predicate, so an offline-only compact test can't tell the
+    // fix from the bug. An intermediate status can — the compact menu must
+    // disable session/command actions and show the status-accurate tooltip.
+    it('disables session/command actions for an intermediate status (maintenance) and shows the status tooltip', () => {
+      render(<DeviceActions device={maintenanceDevice} compact />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(button(/run script/i)).toBeDisabled();
+      const connect = button(/^connect desktop$/i);
+      expect(connect).toBeDisabled();
+      expect(connect).toHaveAttribute('title', 'Device is in maintenance mode');
+      expect(screen.queryByRole('button', { name: /^wake$/i })).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/devices/DeviceActions.test.tsx
+++ b/apps/web/src/components/devices/DeviceActions.test.tsx
@@ -38,6 +38,9 @@ const baseDevice: Device = {
 
 const onlineDevice: Device = { ...baseDevice, status: 'online' };
 const offlineDevice: Device = { ...baseDevice, status: 'offline' };
+const maintenanceDevice: Device = { ...baseDevice, status: 'maintenance' };
+const updatingDevice: Device = { ...baseDevice, status: 'updating' };
+const quarantinedDevice: Device = { ...baseDevice, status: 'quarantined' };
 
 // Native disabled buttons aren't reported as disabled via getByRole's name in
 // every jsdom case, so query the DOM element directly and read its props.
@@ -99,6 +102,46 @@ describe('DeviceActions — offline gating (issue #2013)', () => {
       const wake = button(/^wake$/i);
       expect(wake).toBeInTheDocument();
       expect(wake).not.toBeDisabled();
+    });
+  });
+
+  // Intermediate statuses (maintenance/updating/quarantined/decommissioned/pending)
+  // are NOT online, so the agent can't service a live session or command. Before
+  // #2078 the action bar gated on `=== 'offline'`, leaving these buttons enabled
+  // and firing requests the API rejects with "Device is not online". They must
+  // now be disabled — with a status-accurate tooltip, not the wrong "offline" copy.
+  describe('intermediate (non-online, non-offline) statuses — issue #2078', () => {
+    it('disables session/command buttons for a device in maintenance mode', () => {
+      render(<DeviceActions device={maintenanceDevice} />);
+
+      expect(button(/run script/i)).toBeDisabled();
+      expect(button(/^connect desktop$/i)).toBeDisabled();
+      expect(button(/remote tools/i)).toBeDisabled();
+      expect(button(/^power$/i)).toBeDisabled();
+    });
+
+    it('uses a status-accurate tooltip (not "Device is offline") for maintenance', () => {
+      render(<DeviceActions device={maintenanceDevice} />);
+
+      const connect = button(/^connect desktop$/i);
+      expect(connect).toHaveAttribute('title', 'Device is in maintenance mode');
+      expect(button(/^power$/i)).toHaveAttribute('title', 'Device is in maintenance mode');
+    });
+
+    it('uses a status-accurate tooltip for an updating device', () => {
+      render(<DeviceActions device={updatingDevice} />);
+
+      expect(button(/run script/i)).toBeDisabled();
+      expect(button(/run script/i)).toHaveAttribute('title', 'Device is updating');
+    });
+
+    it('does not render the Wake button for a non-offline unavailable status', () => {
+      render(<DeviceActions device={quarantinedDevice} />);
+
+      // Wake is Wake-on-LAN — only meaningful for a genuinely offline device.
+      expect(screen.queryByRole('button', { name: /^wake$/i })).toBeNull();
+      expect(button(/run script/i)).toBeDisabled();
+      expect(button(/run script/i)).toHaveAttribute('title', 'Device is quarantined');
     });
   });
 

--- a/apps/web/src/components/devices/DeviceActions.tsx
+++ b/apps/web/src/components/devices/DeviceActions.tsx
@@ -16,9 +16,43 @@ import {
   Zap,
   ChevronDown
 } from 'lucide-react';
-import type { Device } from './DeviceList';
+import type { Device, DeviceStatus } from './DeviceList';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+
+// Live sessions and agent commands (Connect Desktop, Run Script, Remote Tools,
+// Power, Reboot, Refresh, …) require an actively-connected agent — i.e.
+// status === 'online'. Every other status (offline, maintenance,
+// decommissioned, quarantined, updating, pending) means the agent can't service
+// the request, so the API rejects it with "Device is not online". Gate on
+// `!== 'online'` (matching DeviceList.tsx) rather than `=== 'offline'` so
+// intermediate states don't fire doomed requests (#2078). Wake (Wake-on-LAN) is
+// the deliberate exception — it targets offline devices and stays reachable.
+function isDeviceOnline(device: Device): boolean {
+  return device.status === 'online';
+}
+
+// Status-accurate tooltip for a disabled session/command button. The old copy
+// hard-coded "Device is offline", which was wrong for e.g. a quarantined or
+// updating device.
+function unavailableTitle(status: DeviceStatus): string {
+  switch (status) {
+    case 'offline':
+      return 'Device is offline';
+    case 'maintenance':
+      return 'Device is in maintenance mode';
+    case 'decommissioned':
+      return 'Device is decommissioned';
+    case 'quarantined':
+      return 'Device is quarantined';
+    case 'updating':
+      return 'Device is updating';
+    case 'pending':
+      return 'Device is pending enrollment';
+    default:
+      return 'Device is not online';
+  }
+}
 
 type DeviceActionsProps = {
   device: Device;
@@ -99,6 +133,11 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
   const [modalType, setModalType] = useState<ModalType>('none');
   const [loading, setLoading] = useState(false);
 
+  // Session/command buttons are unavailable unless the agent is online. Wake
+  // (Wake-on-LAN) is intentionally exempt and gated on `=== 'offline'`.
+  const online = isDeviceOnline(device);
+  const offlineTitle = online ? undefined : unavailableTitle(device.status);
+
   const closeMenus = () => {
     setMenuOpen(false);
     setPowerMenuOpen(false);
@@ -156,18 +195,18 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('run-script')}
-                disabled={device.status === 'offline'}
+                disabled={!online}
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Play className="h-4 w-4" />
                 Run Script
               </button>
-              <ConnectDesktopButton deviceId={device.id} compact disabled={device.status === 'offline'} disabledTitle="Device is offline" isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
+              <ConnectDesktopButton deviceId={device.id} compact disabled={!online} disabledTitle={offlineTitle} isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
               <button
                 type="button"
                 onClick={() => handleAction('remote-tools')}
-                disabled={device.status === 'offline' || device.remoteAccessPolicy?.remoteTools === false}
-                title={device.remoteAccessPolicy?.remoteTools === false ? `Remote tools disabled by policy${device.remoteAccessPolicy?.policyName ? ` "${device.remoteAccessPolicy.policyName}"` : ''}` : undefined}
+                disabled={!online || device.remoteAccessPolicy?.remoteTools === false}
+                title={offlineTitle ?? (device.remoteAccessPolicy?.remoteTools === false ? `Remote tools disabled by policy${device.remoteAccessPolicy?.policyName ? ` "${device.remoteAccessPolicy.policyName}"` : ''}` : undefined)}
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Wrench className="h-4 w-4" />
@@ -176,7 +215,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('refresh')}
-                disabled={device.status === 'offline'}
+                disabled={!online}
                 title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
@@ -186,7 +225,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('reboot')}
-                disabled={device.status === 'offline'}
+                disabled={!online}
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RotateCcw className="h-4 w-4" />
@@ -206,7 +245,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
                 <button
                   type="button"
                   onClick={() => handleAction('reboot_safe_mode')}
-                  disabled={device.status === 'offline'}
+                  disabled={!online}
                   className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-warning hover:bg-warning/10 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <Shield className="h-4 w-4" />
@@ -296,19 +335,19 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
         <button
           type="button"
           onClick={() => handleAction('run-script')}
-          disabled={device.status === 'offline' || loading}
-          title={device.status === 'offline' ? 'Device is offline' : undefined}
+          disabled={!online || loading}
+          title={offlineTitle}
           className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Play className="h-4 w-4" />
           Run Script
         </button>
-        <ConnectDesktopButton deviceId={device.id} disabled={device.status === 'offline'} disabledTitle="Device is offline" isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
+        <ConnectDesktopButton deviceId={device.id} disabled={!online} disabledTitle={offlineTitle} isHeadless={device.isHeadless} desktopAccess={device.desktopAccess} remoteAccessPolicy={device.remoteAccessPolicy} />
         <button
           type="button"
           onClick={() => handleAction('remote-tools')}
-          disabled={device.status === 'offline' || loading || device.remoteAccessPolicy?.remoteTools === false}
-          title={device.status === 'offline' ? 'Device is offline' : device.remoteAccessPolicy?.remoteTools === false ? `Remote tools disabled by policy${device.remoteAccessPolicy?.policyName ? ` "${device.remoteAccessPolicy.policyName}"` : ''}` : undefined}
+          disabled={!online || loading || device.remoteAccessPolicy?.remoteTools === false}
+          title={offlineTitle ?? (device.remoteAccessPolicy?.remoteTools === false ? `Remote tools disabled by policy${device.remoteAccessPolicy?.policyName ? ` "${device.remoteAccessPolicy.policyName}"` : ''}` : undefined)}
           className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Wrench className="h-4 w-4" />
@@ -318,8 +357,8 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
           <button
             type="button"
             onClick={() => { setPowerMenuOpen(!powerMenuOpen); setMenuOpen(false); }}
-            disabled={device.status === 'offline' || loading}
-            title={device.status === 'offline' ? 'Device is offline' : undefined}
+            disabled={!online || loading}
+            title={offlineTitle}
             aria-haspopup="true"
             aria-expanded={powerMenuOpen}
             className="flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
@@ -333,7 +372,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('reboot')}
-                disabled={device.status === 'offline'}
+                disabled={!online}
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RotateCcw className="h-4 w-4" />
@@ -343,7 +382,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
                 <button
                   type="button"
                   onClick={() => handleAction('reboot_safe_mode')}
-                  disabled={device.status === 'offline'}
+                  disabled={!online}
                   className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-warning hover:bg-warning/10 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <Shield className="h-4 w-4" />
@@ -353,7 +392,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('shutdown')}
-                disabled={device.status === 'offline'}
+                disabled={!online}
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Power className="h-4 w-4" />
@@ -376,7 +415,7 @@ export default function DeviceActions({ device, onAction, compact = false }: Dev
               <button
                 type="button"
                 onClick={() => handleAction('refresh')}
-                disabled={device.status === 'offline' || loading}
+                disabled={!online || loading}
                 title="Re-run agent inventory collectors so the UI sees fresh hardware/software/network data without waiting for the next heartbeat cycle"
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >


### PR DESCRIPTION
## Summary

The device action bar (`apps/web/src/components/devices/DeviceActions.tsx`) gated its session/command buttons on `device.status === 'offline'`, while the device-list row (`DeviceList.tsx:1352`) gates the same actions on `device.status !== 'online'`.

`DeviceStatus` has **seven** values (`online | offline | maintenance | decommissioned | quarantined | updating | pending`). So for a device in an *intermediate* state (maintenance/decommissioned/quarantined/updating/pending), the action bar left **Connect Desktop, Run Script, Remote Tools, and Power** enabled — clicking them fired a request the API rejects with `"Device is not online"`, the same doomed-request UX #2013 fixed for the offline case.

## Fix

- Align every session/command predicate in `DeviceActions.tsx` on `!== 'online'` (via an `online`/`isDeviceOnline` helper), matching `DeviceList.tsx` — covers both the full and `compact` variants, and the Power/Reboot/Shutdown/Refresh menu items.
- Replace the hard-coded `"Device is offline"` tooltip with a **status-accurate** message (`unavailableTitle`) — e.g. "Device is in maintenance mode", "Device is updating", "Device is quarantined".
- **Wake (Wake-on-LAN) is unchanged** — it stays gated on `=== 'offline'` because it deliberately targets offline devices (per #2013), and does not render for other unavailable statuses.

## Tests

Extended `DeviceActions.test.tsx` with an "intermediate statuses" suite: maintenance/updating/quarantined devices disable the session/command buttons, show the status-accurate tooltip, and do **not** render Wake. Existing offline/online coverage unchanged.

- `vitest run DeviceActions.test.tsx` → 12 passed
- `tsc --noEmit` (apps/web) → clean

Closes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)