### PR TITLE
fix(web): honor partner effective session timeout in idle logout (#2147)

### DIFF
--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -103,4 +103,46 @@ describe('AdminSessionManager idle timeout source', () => {
     expect(apiLogoutMock).toHaveBeenCalledTimes(1);
     expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
   });
+
+  it('keeps the 60-minute default when effective settings omit sessionTimeout', async () => {
+    // Neither partner nor org set security.sessionTimeout — the guard must
+    // reject the absent/zero value rather than produce a 1-minute timeout.
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: {} }, locked: [] })
+    );
+
+    render(<AdminSessionManager />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Well past any short timeout but under the 60-minute default — no logout.
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default timeout when the effective-settings request fails', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 500));
+
+    render(<AdminSessionManager />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // A 500 must not crash or zero the timer — the default 60 min still applies.
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -1,0 +1,106 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AdminSessionManager from './AdminSessionManager';
+import {
+  apiLogout,
+  fetchWithAuth,
+  restoreAccessTokenFromCookie,
+  useAuthStore
+} from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
+import { navigateTo } from '../../lib/navigation';
+
+vi.mock('../../stores/auth', () => ({
+  apiLogout: vi.fn().mockResolvedValue(undefined),
+  fetchWithAuth: vi.fn(),
+  restoreAccessTokenFromCookie: vi.fn().mockResolvedValue(false),
+  useAuthStore: vi.fn()
+}));
+
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: vi.fn()
+}));
+
+vi.mock('../../lib/navigation', () => ({
+  navigateTo: vi.fn().mockResolvedValue(undefined)
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+const apiLogoutMock = vi.mocked(apiLogout);
+const navigateToMock = vi.mocked(navigateTo);
+const useAuthStoreMock = vi.mocked(useAuthStore);
+const useOrgStoreMock = vi.mocked(useOrgStore);
+
+const ORG_ID = 'org-123';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+describe('AdminSessionManager idle timeout source', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useAuthStoreMock.mockImplementation((selector: any) => selector({ isAuthenticated: true }));
+    useOrgStoreMock.mockImplementation((selector: any) => selector({ currentOrgId: ORG_ID }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads the idle timeout from the effective-settings endpoint, not the raw org record', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: { sessionTimeout: 120 } }, locked: [] })
+    );
+
+    render(<AdminSessionManager />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG_ID}/effective-settings`
+    );
+    // It must NOT read the raw org record (that path misses partner defaults).
+    expect(fetchWithAuthMock).not.toHaveBeenCalledWith(`/orgs/organizations/${ORG_ID}`);
+  });
+
+  it('enforces a partner-level effective session timeout for idle logout', async () => {
+    // Partner default of 2 minutes, delivered via effective settings only —
+    // the org has no local override.
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ effective: { security: { sessionTimeout: 2 } }, locked: ['security.sessionTimeout'] })
+    );
+
+    render(<AdminSessionManager />);
+
+    // Let the effective-settings fetch resolve and apply the 2-minute timeout.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Just under 2 minutes idle — no logout yet.
+    await act(async () => {
+      vi.advanceTimersByTime(90_000);
+      await Promise.resolve();
+    });
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+
+    // Cross the 2-minute threshold — the heartbeat must log out.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiLogoutMock).toHaveBeenCalledTimes(1);
+    expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+});

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -81,6 +81,13 @@ export default function AdminSessionManager() {
           `/orgs/organizations/${currentOrgId}/effective-settings`
         );
         if (!response.ok) {
+          // Surface the failure: this is the path that enforces a possibly
+          // partner-locked idle timeout, so a silent fall-back to the frontend
+          // default must at least be diagnosable (matches OrgSettingsPage).
+          console.warn(
+            '[AdminSessionManager] Failed to load effective session timeout:',
+            response.status
+          );
           return;
         }
         const data = await response.json();
@@ -88,8 +95,9 @@ export default function AdminSessionManager() {
         if (!cancelled && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
           setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
         }
-      } catch {
+      } catch (err) {
         // Keep current timeout fallback when effective settings cannot be loaded.
+        console.warn('[AdminSessionManager] Error loading effective session timeout:', err);
       }
     };
 

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -73,17 +73,23 @@ export default function AdminSessionManager() {
 
     const loadOrgSessionTimeout = async () => {
       try {
-        const response = await fetchWithAuth(`/orgs/organizations/${currentOrgId}`);
+        // Use effective settings so a partner-level `security.sessionTimeout`
+        // default is honored by the idle-logout runtime, matching what the
+        // settings UI shows as effective/locked. Reading the raw org record
+        // missed partner defaults the org hadn't overridden locally (#2147).
+        const response = await fetchWithAuth(
+          `/orgs/organizations/${currentOrgId}/effective-settings`
+        );
         if (!response.ok) {
           return;
         }
         const data = await response.json();
-        const configuredMinutes = Number(data?.settings?.security?.sessionTimeout);
+        const configuredMinutes = Number(data?.effective?.security?.sessionTimeout);
         if (!cancelled && Number.isFinite(configuredMinutes) && configuredMinutes > 0) {
           setIdleTimeoutMs(Math.max(1, configuredMinutes) * 60 * 1000);
         }
       } catch {
-        // Keep current timeout fallback when org settings cannot be loaded.
+        // Keep current timeout fallback when effective settings cannot be loaded.
       }
     };
 


### PR DESCRIPTION
## Summary

The dashboard idle-logout manager (`AdminSessionManager`) loaded its timeout from the **raw** organization record (`/orgs/organizations/:id` → `settings.security.sessionTimeout`). A partner-level `security.sessionTimeout` default was therefore ignored whenever the org had no local override — even though the settings UI treats that partner value as effective/locked. Result: the timeout the UI presents as effective did not match the timeout the runtime idle logout actually enforced.

## Fix

Switch the idle manager to the existing effective-settings endpoint (`/orgs/organizations/:id/effective-settings`, served by `getEffectiveOrgSettings()`, which merges partner defaults over org settings) and read `effective.security.sessionTimeout`. Now:

- A partner-configured session timeout applies to orgs that haven't overridden it.
- An org's own (unlocked) value still applies where set — the merge already handles precedence.
- The frontend default is still used as a fallback when effective settings can't be loaded.

Only the read source changed (one endpoint swap + response path `settings.` → `effective.`). No token-issuance code is touched.

## Scope note

Independent of `JWT_EXPIRES_IN` / `/auth/refresh` (access-token lifetime & silent renewal). Token issuance is being handled separately under #2146 — this PR deliberately does not change it.

## Tests

Added `AdminSessionManager.test.tsx`:
- asserts the manager calls the `/effective-settings` endpoint and **not** the raw org record;
- asserts a partner-level effective timeout (delivered only via effective settings) actually drives idle logout (`apiLogout` + redirect to `/login`).

`apps/web` affected suite green; `tsc --noEmit` clean.

Closes #2147

🤖 Generated with [Claude Code](https://claude.com/claude-code)