### PR TITLE
fix(remote-terminal): stop auto-reconnect after manual Disconnect (#2137)

### DIFF
--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RemoteTerminal from './RemoteTerminal';
+import { fetchWithAuth } from '@/stores/auth';
+
+// --- xterm.js dynamic-import mocks -----------------------------------------
+// RemoteTerminal lazy-imports xterm and its addons inside initTerminal(); the
+// real modules touch canvas/DOM APIs jsdom lacks, so stub them out. These use
+// plain functions/methods (not vi.fn) so the suite's clearMocks/restoreMocks
+// can't wipe the constructor return values between tests.
+const makeTerminalStub = () => ({
+  loadAddon() {},
+  open() {},
+  write() {},
+  writeln() {},
+  onData() {
+    return { dispose() {} };
+  },
+  onResize() {
+    return { dispose() {} };
+  },
+  dispose() {},
+  focus() {},
+  clear() {},
+  rows: 24,
+  cols: 80,
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: function () {
+    return makeTerminalStub();
+  },
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: function () {
+    return {
+      fit() {},
+      proposeDimensions() {
+        return { cols: 80, rows: 24 };
+      },
+    };
+  },
+}));
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: function () {
+    return {};
+  },
+}));
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeResponse = (payload: unknown = {}, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+
+// --- WebSocket mock ---------------------------------------------------------
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.OPEN;
+  sent: string[] = [];
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+    // Fire open asynchronously so handlers assigned after construction win.
+    queueMicrotask(() => this.onopen?.({}));
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close(code?: number) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: code ?? 1000 });
+  }
+}
+
+/** Drive the mock socket to the "server ready" state the UI treats as connected. */
+const fireConnected = (ws: MockWebSocket) => {
+  act(() => {
+    ws.onmessage?.({ data: JSON.stringify({ type: 'connected' }) });
+  });
+};
+
+const sessionPostCount = () =>
+  fetchMock.mock.calls.filter(
+    ([url, opts]) => url === '/remote/sessions' && (opts as RequestInit | undefined)?.method === 'POST',
+  ).length;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+    if (url === '/remote/sessions' && opts?.method === 'POST') {
+      return makeResponse({ id: `session-${sessionPostCount()}` });
+    }
+    if (/\/ws-ticket$/.test(url)) {
+      return makeResponse({ ticket: 'TKT-abc' });
+    }
+    if (/\/end$/.test(url)) {
+      return makeResponse({});
+    }
+    return makeResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const renderTerminal = () =>
+  render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" />);
+
+describe('RemoteTerminal auto-connect / disconnect (#2137)', () => {
+  it('auto-connects exactly once on mount', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    expect(sessionPostCount()).toBe(1);
+  });
+
+  it('does NOT reconnect after the user clicks Disconnect', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    fireConnected(MockWebSocket.instances[0]!);
+
+    const disconnectBtn = await screen.findByRole('button', { name: /disconnect/i });
+    await userEvent.click(disconnectBtn);
+
+    // The Disconnect click closes the socket (code 1000) → status 'disconnected',
+    // sessionId cleared. The pre-fix bug: the auto-connect effect re-fires here.
+    // Give it well past the 500ms auto-connect delay and assert nothing reconnects.
+    await new Promise((r) => setTimeout(r, 700));
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(sessionPostCount()).toBe(1);
+    // And an explicit Reconnect affordance is offered instead.
+    expect(await screen.findByRole('button', { name: /reconnect/i })).toBeInTheDocument();
+  });
+
+  it('reconnects only when the user clicks Reconnect', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    fireConnected(MockWebSocket.instances[0]!);
+
+    await userEvent.click(await screen.findByRole('button', { name: /disconnect/i }));
+
+    const reconnectBtn = await screen.findByRole('button', { name: /reconnect/i });
+    await userEvent.click(reconnectBtn);
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 2000 });
+    expect(sessionPostCount()).toBe(2);
+  });
+});

--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -144,6 +144,9 @@ describe('RemoteTerminal auto-connect / disconnect (#2137)', () => {
     renderTerminal();
 
     await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    // Settle past the 500ms auto-connect delay to prove it does not fire again.
+    await new Promise((r) => setTimeout(r, 700));
+    expect(MockWebSocket.instances).toHaveLength(1);
     expect(sessionPostCount()).toBe(1);
   });
 
@@ -177,6 +180,47 @@ describe('RemoteTerminal auto-connect / disconnect (#2137)', () => {
 
     const reconnectBtn = await screen.findByRole('button', { name: /reconnect/i });
     await userEvent.click(reconnectBtn);
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 2000 });
+    expect(sessionPostCount()).toBe(2);
+  });
+
+  it('does NOT reconnect on a clean server-side session end (close 1000)', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    fireConnected(MockWebSocket.instances[0]!);
+    await screen.findByRole('button', { name: /disconnect/i });
+
+    // Server ends the session cleanly (no user click) — same disconnected+no-
+    // session state a manual Disconnect produces. Must not auto-reconnect.
+    act(() => {
+      MockWebSocket.instances[0]!.close(1000);
+    });
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(sessionPostCount()).toBe(1);
+    expect(await screen.findByRole('button', { name: /reconnect/i })).toBeInTheDocument();
+  });
+
+  it('surfaces a failed connection with a Retry button that reconnects', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+
+    // An unexpected close (code !== 1000) marks the connection failed.
+    act(() => {
+      MockWebSocket.instances[0]!.close(1006);
+    });
+
+    const retryBtn = await screen.findByRole('button', { name: /retry/i });
+
+    // Retry must not have auto-reconnected on its own before the click.
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    await userEvent.click(retryBtn);
 
     await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 2000 });
     expect(sessionPostCount()).toBe(2);

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -68,15 +68,17 @@ export default function RemoteTerminal({
   const webSocketRef = useRef<WebSocket | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const disconnectFiredRef = useRef(false);
-  // Guards the auto-connect effect so it fires exactly once, on initial mount.
-  // Without this, the disconnected+no-session state produced by a manual
-  // Disconnect (or a clean server-side session end) re-satisfies the effect's
-  // condition and it silently reconnects — defeating the Disconnect button
-  // (issue #2137). After the first attempt, reconnecting requires an explicit
-  // user action (the Reconnect / Retry button).
-  const autoConnectAttemptedRef = useRef(false);
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+  // Tracks whether the one-shot auto-connect has already fired. This gates the
+  // auto-connect effect so it runs exactly once, on initial mount: without it,
+  // the disconnected+no-session state produced by a manual Disconnect (or a
+  // clean server-side session end) re-satisfies the effect's condition and it
+  // silently reconnects — defeating the Disconnect button (issue #2137). After
+  // the first attempt, reconnecting requires an explicit user action (the
+  // Reconnect / Retry button). It is state (not a ref) so the same flag also
+  // reactively drives the Reconnect button's visibility.
+  const [autoConnectAttempted, setAutoConnectAttempted] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(initialSessionId || null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [connectionTime, setConnectionTime] = useState<Date | null>(null);
@@ -358,6 +360,12 @@ export default function RemoteTerminal({
     }
 
     setStatus('disconnected');
+    // Clear the session id synchronously here rather than relying on the async
+    // ws.onclose handler: disconnect() flips status to 'disconnected'
+    // immediately (revealing the Reconnect button), so if the user clicks
+    // Reconnect before onclose flushes, connect() would otherwise reuse the
+    // just-ended sessionId and mint a ws-ticket for a dead session.
+    setSessionId(null);
     setConnectionTime(null);
     if (!disconnectFiredRef.current) {
       disconnectFiredRef.current = true;
@@ -408,15 +416,15 @@ export default function RemoteTerminal({
   // terminal never auto-reconnects — a manual Disconnect or a clean session
   // end leaves it disconnected until the user explicitly reconnects (#2137).
   useEffect(() => {
-    if (terminalReady && status === 'disconnected' && !sessionId && !autoConnectAttemptedRef.current) {
+    if (terminalReady && status === 'disconnected' && !sessionId && !autoConnectAttempted) {
       // Small delay to ensure terminal is ready
       const timer = setTimeout(() => {
-        autoConnectAttemptedRef.current = true;
+        setAutoConnectAttempted(true);
         connect();
       }, 500);
       return () => clearTimeout(timer);
     }
-  }, [terminalReady, status, sessionId, connect]);
+  }, [terminalReady, status, sessionId, autoConnectAttempted, connect]);
 
   // Format connection duration
   const getConnectionDuration = () => {
@@ -527,7 +535,7 @@ export default function RemoteTerminal({
               <RefreshCw className="h-4 w-4" />
               Retry
             </button>
-          ) : status === 'disconnected' && autoConnectAttemptedRef.current ? (
+          ) : status === 'disconnected' && autoConnectAttempted ? (
             // Shown only after the initial auto-connect has run, i.e. the user
             // has landed on a real disconnected state (manual Disconnect or a
             // clean session end) rather than the brief pre-connect window on

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -68,6 +68,13 @@ export default function RemoteTerminal({
   const webSocketRef = useRef<WebSocket | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const disconnectFiredRef = useRef(false);
+  // Guards the auto-connect effect so it fires exactly once, on initial mount.
+  // Without this, the disconnected+no-session state produced by a manual
+  // Disconnect (or a clean server-side session end) re-satisfies the effect's
+  // condition and it silently reconnects — defeating the Disconnect button
+  // (issue #2137). After the first attempt, reconnecting requires an explicit
+  // user action (the Reconnect / Retry button).
+  const autoConnectAttemptedRef = useRef(false);
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
   const [sessionId, setSessionId] = useState<string | null>(initialSessionId || null);
@@ -394,11 +401,17 @@ export default function RemoteTerminal({
     };
   }, [initTerminal]);
 
-  // Auto-connect after terminal is initialized
+  // Auto-connect exactly once, on initial mount. The attempt flag is only set
+  // when the timer actually fires (not when scheduled), so an effect re-run
+  // caused by a changing `connect` identity during the delay reschedules
+  // rather than dropping the initial connection. After this first attempt the
+  // terminal never auto-reconnects — a manual Disconnect or a clean session
+  // end leaves it disconnected until the user explicitly reconnects (#2137).
   useEffect(() => {
-    if (terminalReady && status === 'disconnected' && !sessionId) {
+    if (terminalReady && status === 'disconnected' && !sessionId && !autoConnectAttemptedRef.current) {
       // Small delay to ensure terminal is ready
       const timer = setTimeout(() => {
+        autoConnectAttemptedRef.current = true;
         connect();
       }, 500);
       return () => clearTimeout(timer);
@@ -513,6 +526,20 @@ export default function RemoteTerminal({
             >
               <RefreshCw className="h-4 w-4" />
               Retry
+            </button>
+          ) : status === 'disconnected' && autoConnectAttemptedRef.current ? (
+            // Shown only after the initial auto-connect has run, i.e. the user
+            // has landed on a real disconnected state (manual Disconnect or a
+            // clean session end) rather than the brief pre-connect window on
+            // mount. Gives an explicit reconnect affordance now that we no
+            // longer auto-reconnect (#2137).
+            <button
+              type="button"
+              onClick={connect}
+              className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Reconnect
             </button>
           ) : null}
         </div>


### PR DESCRIPTION
## Problem

Closes #2137.

The Remote Tools **Terminal** did not stay disconnected after clicking **Disconnect** — it immediately created a new session and reconnected, making the button ineffective as a manual stop.

## Root cause

`RemoteTerminal`'s auto-connect effect ran whenever `terminalReady && status === 'disconnected' && !sessionId`. That condition is correct for the initial mount, but it is **also the exact state produced by a manual disconnect**: `disconnect()` closes the WebSocket, the `onclose` (code 1000) handler clears `sessionId` and sets status back to `disconnected`, and since `terminalReady` stays `true` the effect fires again and calls `connect()` after ~500 ms.

## Fix

- Gate the auto-connect effect on a new `autoConnectAttemptedRef` so it fires **exactly once, on initial mount**. The flag is set when the delayed timer actually fires (not when scheduled), so an effect re-run caused by a changing `connect` identity during the delay reschedules rather than dropping the first connection. After the first attempt the terminal never auto-reconnects — a manual Disconnect *or* a clean server-side session end leaves it disconnected until the user explicitly reconnects.
- A disconnected terminal previously rendered **no** action button (only `connected`→Disconnect, `failed`→Retry). Added an explicit **Reconnect** button, shown once the initial auto-connect has run, so users retain an on-demand reconnect path.

## Tests

New `RemoteTerminal.test.tsx` (mocks xterm dynamic imports, `fetchWithAuth`, and `WebSocket`):
- auto-connects exactly once on mount,
- does **not** reconnect after clicking Disconnect (session-POST count stays at 1) and surfaces a Reconnect button,
- reconnects only when Reconnect is clicked (new session created).

`vitest run` green (3/3); `tsc --noEmit` clean for `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)