### PR TITLE
fix(auth): allow passkey as alternate MFA when authenticator is primary (#2153)

### DIFF
--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -31,6 +31,7 @@ import {
   setRefreshTokenCookie,
   toPublicTokens,
   userRequiresSetup,
+  userHasUsablePasskey,
 } from '../routes/auth/helpers';
 import { readMobileDeviceId } from '../services/mobileDeviceBinding';
 
@@ -152,15 +153,21 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
     }
     const tempToken = nanoid(32);
     const mfaMethod = user.mfaMethod || 'totp';
+    // #2153: mirror the password /login handler — a passkey is an accepted
+    // ALTERNATE second factor here too, even when the primary method is
+    // totp/sms. The helper fails closed, so a probe error just hides the
+    // alternate rather than blocking this CF-Access MFA challenge.
+    const passkeyAvailable = await userHasUsablePasskey(user.id);
     await redis.setex(
       `mfa:pending:${tempToken}`,
       300,
-      JSON.stringify({ userId: user.id, mfaMethod })
+      JSON.stringify({ userId: user.id, mfaMethod, passkeyAvailable })
     );
     return c.json({
       mfaRequired: true,
       tempToken,
       mfaMethod,
+      passkeyAvailable,
       phoneLast4: user.phoneNumber?.slice(-4) || null,
       user: null,
       tokens: null,

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -465,6 +465,10 @@ describe('passkey MFA auth routes', () => {
       300,
       expect.stringContaining('"passkeyAvailable":true'),
     );
+    // The passkey probe must run under system DB context (pre-auth); otherwise
+    // the RLS user_passkeys read returns 0 rows and silently hides the option.
+    // Two+ system-scoped reads: the login user lookup + the passkey probe.
+    expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('reports passkeyAvailable=false at login for a TOTP user with no passkey', async () => {
@@ -568,6 +572,50 @@ describe('passkey MFA auth routes', () => {
       expect.objectContaining({ refreshFam: 'family-passkey' }),
     );
     expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+  });
+
+  // #2153 security guard: the token-minting /verify endpoint must REFUSE a
+  // non-passkey session that does not flag a passkey as available. This is the
+  // half of pendingAllowsPasskey that mints tokens — regressing it to accept
+  // any session would be a bypass, so it needs its own explicit test.
+  it('rejects /mfa/passkey/verify for a TOTP session with no available passkey', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+    }));
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(rateLimiter).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  // #2153 backward-compat: a legacy pre-JSON pending token (bare userId string,
+  // not valid JSON) must be treated as a TOTP session with NO passkey available,
+  // so in-flight sessions during a deploy can't reach the passkey path.
+  it('treats a legacy bare-string pending token as passkey-unavailable', async () => {
+    redisMock.get.mockResolvedValueOnce('user-123');
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
   });
 
   it('returns passkey authentication options for a pending passkey MFA login', async () => {

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -427,6 +427,149 @@ describe('passkey MFA auth routes', () => {
     );
   });
 
+  // #2153: a TOTP-primary account with a registered passkey must be offered the
+  // passkey as an ALTERNATE factor — login advertises passkeyAvailable and the
+  // pending token records it, without changing the primary mfaMethod.
+  it('advertises passkeyAvailable at login for a TOTP user who also has a passkey', async () => {
+    authState.requireAuthorizationHeader = false;
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    const totpUser = {
+      ...user,
+      mfaMethod: 'totp',
+      mfaSecret: 'enc-secret',
+    };
+    dbState.selectQueue.push(
+      [totpUser],
+      [{ partnerId: 'partner-1', roleId: 'role-1' }],
+      // passkey-availability probe → one active passkey exists
+      [{ id: 'passkey-credential-1' }],
+    );
+
+    const res = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com', password: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mfaRequired: true,
+      mfaMethod: 'totp',
+      passkeyAvailable: true,
+      user: null,
+      tokens: null,
+    });
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      expect.stringMatching(/^mfa:pending:/),
+      300,
+      expect.stringContaining('"passkeyAvailable":true'),
+    );
+  });
+
+  it('reports passkeyAvailable=false at login for a TOTP user with no passkey', async () => {
+    authState.requireAuthorizationHeader = false;
+    vi.mocked(verifyPassword).mockResolvedValueOnce(true);
+    const totpUser = {
+      ...user,
+      mfaMethod: 'totp',
+      mfaSecret: 'enc-secret',
+    };
+    dbState.selectQueue.push(
+      [totpUser],
+      [{ partnerId: 'partner-1', roleId: 'role-1' }],
+      // passkey-availability probe → no passkeys
+      [],
+    );
+
+    const res = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com', password: 'correct-password' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      mfaRequired: true,
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+    });
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      expect.stringMatching(/^mfa:pending:/),
+      300,
+      expect.stringContaining('"passkeyAvailable":false'),
+    );
+  });
+
+  // #2153: the passkey MFA endpoints must accept a pending session whose PRIMARY
+  // method is totp/sms as long as the session flags a passkey as available.
+  it('returns passkey options for a TOTP-primary pending session flagged passkeyAvailable', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'totp',
+      passkeyAvailable: true,
+    }));
+    dbState.selectQueue.push([
+      {
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+      },
+    ]);
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      options: { challenge: 'login-challenge' },
+    });
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).toHaveBeenCalled();
+  });
+
+  it('verifies a passkey for a TOTP-primary pending session flagged passkeyAvailable', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({
+      userId: 'user-123',
+      mfaMethod: 'totp',
+      passkeyAvailable: true,
+    }));
+    dbState.selectQueue.push(
+      [{ ...user, mfaMethod: 'totp', mfaSecret: 'enc-secret' }],
+      [{
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+        disabledAt: null,
+      }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+    );
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(createTokenPair).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'user-123', mfa: true }),
+      expect.objectContaining({ refreshFam: 'family-passkey' }),
+    );
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+  });
+
   it('returns passkey authentication options for a pending passkey MFA login', async () => {
     redisMock.get.mockResolvedValueOnce(JSON.stringify({
       userId: 'user-123',

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { users, partnerUsers, organizationUsers, organizations } from '../../db/schema';
+import { users, partnerUsers, organizationUsers, organizations, userPasskeys } from '../../db/schema';
 import {
   verifyToken,
   isUserTokenRevoked,
@@ -41,6 +41,40 @@ export const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T>
   const withSystem = dbModule.withSystemDbAccessContext;
   return typeof withSystem === 'function' ? withSystem(fn) : fn();
 };
+
+/**
+ * #2153: does the account have at least one usable (non-disabled) passkey?
+ *
+ * Both callers (the password /login handler and the CF-Access login
+ * middleware) use this to advertise a passkey as an ALTERNATE second factor
+ * even when the account's primary `mfaMethod` is totp/sms — registering a
+ * passkey intentionally does not clobber an existing totp/sms method
+ * (passkeys.ts), so login must detect the passkey independently.
+ *
+ * Runs under system DB access because both callers are PRE-AUTH (no request
+ * RLS context): an org-scoped read under `breeze_app` would return 0 rows and
+ * silently hide the option.
+ *
+ * NEVER throws. This is an optional affordance layered on top of the essential
+ * login flow — a transient DB error here must not 500 a correctly-authenticated
+ * user out of login, so a probe failure fails closed (returns false: the
+ * primary factor's prompt is still shown, the passkey alternate is just hidden).
+ */
+export async function userHasUsablePasskey(userId: string): Promise<boolean> {
+  try {
+    const rows = await runWithSystemDbAccess(() =>
+      db
+        .select({ id: userPasskeys.id })
+        .from(userPasskeys)
+        .where(and(eq(userPasskeys.userId, userId), isNull(userPasskeys.disabledAt)))
+        .limit(1)
+    );
+    return rows.length > 0;
+  } catch (err) {
+    console.error('[auth] passkey-availability probe failed; hiding passkey alternate:', err);
+    return false;
+  }
+}
 
 // ============================================
 // Cookie helpers

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -1,8 +1,8 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { users } from '../../db/schema';
+import { userPasskeys, users } from '../../db/schema';
 import {
   createTokenPair,
   verifyToken,
@@ -414,9 +414,32 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
   if (ENABLE_2FA && user.mfaEnabled && (user.mfaSecret || user.mfaMethod === 'sms' || user.mfaMethod === 'passkey')) {
     const tempToken = nanoid(32);
     const mfaMethod = user.mfaMethod || 'totp';
+
+    // #2153: a passkey is a valid ALTERNATE second factor even when the
+    // account's primary `mfaMethod` is totp/sms. Registering a passkey
+    // deliberately does NOT clobber an existing totp/sms `mfaMethod` (see
+    // passkeys.ts register/verify — that would strand the working
+    // authenticator and risk lockout), so login must independently detect
+    // whether the account has any usable passkey and offer it as a choice.
+    // This ADDS an option; it never removes the primary factor's prompt.
+    // Pre-auth read → system scope, or the RLS `user_passkeys` SELECT under
+    // breeze_app returns 0 rows and the option silently disappears.
+    const passkeyAvailable = (await withSystemDbAccessContext(async () =>
+      db
+        .select({ id: userPasskeys.id })
+        .from(userPasskeys)
+        .where(and(eq(userPasskeys.userId, user.id), isNull(userPasskeys.disabledAt)))
+        .limit(1)
+    )).length > 0;
+
     await getRedis()!.setex(`mfa:pending:${tempToken}`, 300, JSON.stringify({
       userId: user.id,
-      mfaMethod
+      mfaMethod,
+      // Server-authoritative: the passkey MFA endpoints gate on this flag, so
+      // the client can't self-elevate to the passkey path without an actually
+      // registered credential (and /verify still re-checks credential
+      // ownership + assertion regardless).
+      passkeyAvailable
     }));
 
     // Task 10: the password was verified correctly — clear the per-account
@@ -440,6 +463,9 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       mfaRequired: true,
       tempToken,
       mfaMethod,
+      // #2153: lets the login MFA screen offer "use a passkey instead" alongside
+      // the primary factor's prompt when the account has a registered passkey.
+      passkeyAvailable,
       phoneLast4: user.phoneNumber?.slice(-4) || null,
       user: null,
       tokens: null

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -1,8 +1,8 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, isNull } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { userPasskeys, users } from '../../db/schema';
+import { users } from '../../db/schema';
 import {
   createTokenPair,
   verifyToken,
@@ -50,7 +50,8 @@ import {
   NoTenantMembershipError,
   auditUserLoginFailure,
   auditLogin,
-  userRequiresSetup
+  userRequiresSetup,
+  userHasUsablePasskey
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
 import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDeviceBinding';
@@ -422,15 +423,9 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     // authenticator and risk lockout), so login must independently detect
     // whether the account has any usable passkey and offer it as a choice.
     // This ADDS an option; it never removes the primary factor's prompt.
-    // Pre-auth read → system scope, or the RLS `user_passkeys` SELECT under
-    // breeze_app returns 0 rows and the option silently disappears.
-    const passkeyAvailable = (await withSystemDbAccessContext(async () =>
-      db
-        .select({ id: userPasskeys.id })
-        .from(userPasskeys)
-        .where(and(eq(userPasskeys.userId, user.id), isNull(userPasskeys.disabledAt)))
-        .limit(1)
-    )).length > 0;
+    // The helper reads under system scope (pre-auth) and fails closed — a
+    // probe error hides the alternate, it never blocks this login.
+    const passkeyAvailable = await userHasUsablePasskey(user.id);
 
     await getRedis()!.setex(`mfa:pending:${tempToken}`, 300, JSON.stringify({
       userId: user.id,

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -77,7 +77,24 @@ const deletePasskeySchema = z.object({
 type PendingPasskeyMfa = {
   userId: string;
   mfaMethod: string;
+  // #2153: true when the account has a registered passkey usable as an
+  // alternate second factor, even if the PRIMARY mfaMethod is totp/sms.
+  // Set server-side at login (login.ts) from a system-scoped user_passkeys
+  // read. Absent on pre-#2153 pending tokens → treated as false (falls back
+  // to the old "primary method is passkey" gate, so in-flight sessions during
+  // a deploy don't regress).
+  passkeyAvailable?: boolean;
 };
+
+// A pending MFA session may use the passkey endpoints when passkey is either
+// the account's primary method OR an available alternate factor. Both /options
+// and /verify still independently re-verify that a matching, non-disabled
+// credential is owned by the user and that the WebAuthn assertion checks out,
+// so this gate only decides whether the passkey path is OFFERED — it never
+// substitutes for credential/assertion verification.
+function pendingAllowsPasskey(pending: PendingPasskeyMfa): boolean {
+  return pending.mfaMethod === 'passkey' || pending.passkeyAvailable === true;
+}
 
 type PasskeyRow = typeof userPasskeys.$inferSelect;
 
@@ -214,7 +231,7 @@ passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsS
   if (!pending) {
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
-  if (pending.mfaMethod !== 'passkey') {
+  if (!pendingAllowsPasskey(pending)) {
     return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
   }
 
@@ -261,7 +278,7 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
   if (!pending) {
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
-  if (pending.mfaMethod !== 'passkey') {
+  if (!pendingAllowsPasskey(pending)) {
     return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
   }
 
@@ -488,12 +505,14 @@ async function readPendingPasskeyMfa(tempToken: string): Promise<PendingPasskeyM
     if (typeof parsed.userId !== 'string') return null;
     return {
       userId: parsed.userId,
-      mfaMethod: parsed.mfaMethod || 'totp'
+      mfaMethod: parsed.mfaMethod || 'totp',
+      passkeyAvailable: parsed.passkeyAvailable === true
     };
   } catch {
     return {
       userId: raw,
-      mfaMethod: 'totp'
+      mfaMethod: 'totp',
+      passkeyAvailable: false
     };
   }
 }

--- a/apps/web/src/components/auth/LoginPage.passkeys.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.passkeys.test.tsx
@@ -81,4 +81,49 @@ describe('LoginPage passkey MFA', () => {
     expect(apiVerifyPasskeyMFAMock).toHaveBeenCalledWith('temp-passkey');
     expect(navigateTo).toHaveBeenCalledWith('/oauth/consent?uid=abc');
   });
+
+  // #2153: when the primary method is TOTP but the account also has a passkey,
+  // the code form still renders AND an "or use a passkey" affordance appears.
+  it('offers a passkey alternate alongside the code form when login returns passkeyAvailable', async () => {
+    vi.mocked(apiLogin).mockResolvedValueOnce({
+      success: true,
+      mfaRequired: true,
+      tempToken: 'temp-totp',
+      mfaMethod: 'totp',
+      passkeyAvailable: true,
+    } as any);
+    apiVerifyPasskeyMFAMock.mockResolvedValueOnce(baseLoginSuccess);
+
+    render(<LoginPage next="/oauth/consent?uid=abc" />);
+
+    await fillAndSubmit();
+
+    // The authenticator-code form is still the primary prompt...
+    expect(await screen.findByTestId('mfa-digit-0')).toBeTruthy();
+    // ...and the passkey alternate is offered.
+    const alternate = await screen.findByTestId('mfa-passkey-alternate');
+    fireEvent.click(alternate);
+
+    await waitFor(() => expect(apiVerifyPasskeyMFAMock).toHaveBeenCalled());
+    expect(apiVerifyPasskeyMFAMock).toHaveBeenCalledWith('temp-totp');
+    expect(navigateTo).toHaveBeenCalledWith('/oauth/consent?uid=abc');
+  });
+
+  // Guard: no passkey alternate when the account has none.
+  it('does not offer a passkey alternate when passkeyAvailable is false', async () => {
+    vi.mocked(apiLogin).mockResolvedValueOnce({
+      success: true,
+      mfaRequired: true,
+      tempToken: 'temp-totp',
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+    } as any);
+
+    render(<LoginPage next="/" />);
+
+    await fillAndSubmit();
+
+    expect(await screen.findByTestId('mfa-digit-0')).toBeTruthy();
+    expect(screen.queryByTestId('mfa-passkey-alternate')).toBeNull();
+  });
 });

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -69,6 +69,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   const [mfaRequired, setMfaRequired] = useState(false);
   const [tempToken, setTempToken] = useState<string>();
   const [mfaMethod, setMfaMethod] = useState<MfaMethod>('totp');
+  const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [phoneLast4, setPhoneLast4] = useState<string>();
   const [smsSending, setSmsSending] = useState(false);
   const [smsSent, setSmsSent] = useState(false);
@@ -126,6 +127,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
       setMfaRequired(true);
       setTempToken(result.tempToken);
       setMfaMethod(result.mfaMethod || 'totp');
+      setPasskeyAvailable(result.passkeyAvailable === true);
       setPhoneLast4(result.phoneLast4);
       setSmsSent(false);
       setLoading(false);
@@ -228,6 +230,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
           errorMessage={error}
           loading={loading}
           mfaMethod={mfaMethod}
+          passkeyAvailable={passkeyAvailable}
           phoneLast4={phoneLast4}
           onSendSmsCode={handleSendSmsCode}
           smsSending={smsSending}

--- a/apps/web/src/components/auth/MFAVerifyForm.tsx
+++ b/apps/web/src/components/auth/MFAVerifyForm.tsx
@@ -11,6 +11,12 @@ type MFAVerifyFormProps = {
   submitLabel?: string;
   loading?: boolean;
   mfaMethod?: MfaMethod;
+  /**
+   * #2153: true when the account has a passkey registered as an ALTERNATE
+   * second factor while the primary method is totp/sms. Surfaces a "use a
+   * passkey instead" affordance without changing the primary prompt.
+   */
+  passkeyAvailable?: boolean;
   phoneLast4?: string;
   onSendSmsCode?: () => Promise<void>;
   smsSending?: boolean;
@@ -24,6 +30,7 @@ export default function MFAVerifyForm({
   submitLabel = 'Verify',
   loading,
   mfaMethod = 'totp',
+  passkeyAvailable = false,
   phoneLast4,
   onSendSmsCode,
   smsSending,
@@ -38,6 +45,9 @@ export default function MFAVerifyForm({
   const code = digits.join('');
   const isSms = mfaMethod === 'sms';
   const isPasskey = mfaMethod === 'passkey';
+  // #2153: offer the passkey as an alternate factor when the primary method is
+  // the code-based totp/sms flow but the account also has a passkey.
+  const showPasskeyAlternate = !isPasskey && passkeyAvailable && Boolean(onPasskeyVerify);
 
   // Resend cooldown timer
   useEffect(() => {
@@ -235,6 +245,25 @@ export default function MFAVerifyForm({
         >
           {isLoading ? 'Verifying...' : submitLabel}
         </button>
+      )}
+
+      {showPasskeyAlternate && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">or</span>
+            <span className="h-px flex-1 bg-border" />
+          </div>
+          <button
+            type="button"
+            data-testid="mfa-passkey-alternate"
+            onClick={handlePasskeyVerify}
+            disabled={isLoading}
+            className="flex h-11 w-full items-center justify-center rounded-md border text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Use a passkey instead
+          </button>
+        </div>
       )}
     </form>
   );

--- a/apps/web/src/stores/auth.passkeys.test.ts
+++ b/apps/web/src/stores/auth.passkeys.test.ts
@@ -65,6 +65,8 @@ describe('auth store passkey MFA helpers', () => {
       mfaRequired: true,
       tempToken: 'temp-passkey',
       mfaMethod: 'passkey',
+      // #2153: normalized to false when the login body omits the flag.
+      passkeyAvailable: false,
       phoneLast4: undefined,
     });
   });

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -393,7 +393,31 @@ describe('auth API helpers', () => {
       mfaRequired: true,
       tempToken: 'temp-1',
       mfaMethod: 'sms',
+      // #2153: response now always reports whether a passkey alternate exists;
+      // a login body without the flag normalizes to false.
+      passkeyAvailable: false,
       phoneLast4: '1234'
+    });
+  });
+
+  it('apiLogin surfaces passkeyAvailable when the account has an alternate passkey', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeResponse({
+        mfaRequired: true,
+        tempToken: 'temp-2',
+        mfaMethod: 'totp',
+        passkeyAvailable: true
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await apiLogin('user@example.com', 'password');
+
+    expect(result).toMatchObject({
+      success: true,
+      mfaRequired: true,
+      mfaMethod: 'totp',
+      passkeyAvailable: true
     });
   });
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -638,6 +638,7 @@ export async function apiLogin(email: string, password: string): Promise<{
   mfaRequired?: boolean;
   tempToken?: string;
   mfaMethod?: MfaMethod;
+  passkeyAvailable?: boolean;
   phoneLast4?: string;
   user?: User;
   tokens?: Tokens;
@@ -664,6 +665,9 @@ export async function apiLogin(email: string, password: string): Promise<{
         mfaRequired: true,
         tempToken: data.tempToken,
         mfaMethod: data.mfaMethod || 'totp',
+        // #2153: whether a passkey can be used as an alternate factor for this
+        // login even when the primary method is totp/sms.
+        passkeyAvailable: data.passkeyAvailable === true,
         phoneLast4: data.phoneLast4
       };
     }


### PR DESCRIPTION
## Summary

Fixes #2153 — a passkey added to an account that already has authenticator (TOTP) or SMS MFA was listed in **Profile → Passkeys** but was never usable at sign-in.

**Root cause:** registering a passkey intentionally does *not* overwrite an existing `users.mfa_method` (`totp`/`sms`) — clobbering it to `passkey` would strand the working authenticator and risk lockout if the passkey device is lost. But login routed only to that single stored `mfaMethod`, and the passkey MFA endpoints gated on `pending.mfaMethod === 'passkey'`. So a TOTP-primary user with a passkey was always shown the authenticator-code flow with no way to use the passkey.

## Fix (adds an alternate factor — does not weaken anything)

- **`login.ts`** — in the MFA-required branch, independently probe for a usable, non-disabled passkey (system-scoped `user_passkeys` read, required so RLS under `breeze_app` doesn't hide the row pre-auth). Record `passkeyAvailable` on the pending MFA session **and** the login response. The primary `mfaMethod` is unchanged.
- **`passkeys.ts`** — `/mfa/passkey/options` and `/mfa/passkey/verify` now gate on `mfaMethod === 'passkey' OR passkeyAvailable` (new `pendingAllowsPasskey` helper). `/verify` still re-checks credential ownership + non-disabled + WebAuthn assertion + rate limit + account-still-active — this flag only decides whether the passkey path is *offered*, never substitutes for verification.
- **Web** — `apiLogin` surfaces `passkeyAvailable`; `LoginPage` threads it into `MFAVerifyForm`, which renders a **"Use a passkey instead"** button beside the code form (reusing the existing `apiVerifyPasskeyMFA` handler). Passkey-primary UI is unchanged.

## Security notes

- **No requirement is weakened.** A passkey is itself a strong second factor; this offers it *in addition* to the primary prompt. TOTP/SMS users still complete the exact same code flow.
- The `passkeyAvailable` flag is **server-authoritative** (set at login from the DB). A client cannot self-elevate to the passkey path, and even if the flag were wrong, `/verify` independently requires a matching non-disabled credential owned by the user plus a valid assertion.
- **Backward compatible across deploys:** pending tokens minted before this change lack the flag → `readPendingPasskeyMfa` normalizes it to `false` → falls back to the old `mfaMethod === 'passkey'` gate, so in-flight MFA sessions during rollout don't regress.

The existing Profile copy ("passkeys that can be used as multi-factor authentication") becomes accurate with this functional fix, so no copy change was needed.

## Tests

- **API** `auth.passkeys.test.ts` (+4): login advertises `passkeyAvailable` for a TOTP user with a passkey (and `false` without); `/options` and `/verify` accept a TOTP-primary pending session flagged `passkeyAvailable`. Existing "not-a-passkey-session → 400" guard (no flag) still holds.
- **Web** `LoginPage.passkeys.test.tsx` (+2): passkey alternate rendered + wired when `passkeyAvailable`; absent when false. `auth.test.ts` / `auth.passkeys.test.ts` updated for the new response field (+ a new coverage case).
- `apps/api` + `apps/web` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)