### PR TITLE
refactor(billing): shared list chrome, pill-role layering, plus follow-up tests (#2151)

### DIFF
--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -300,6 +300,29 @@ describe('InvoiceEditor', () => {
     await waitFor(() => expect(notes).not.toBeDisabled());
   });
 
+  it('disables the terms textarea while its own save is in flight (busy cue)', async () => {
+    // Symmetric with the notes field — the terms disable also reflects
+    // isPending('terms').
+    let releasePatch: (v: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') {
+        return new Promise<Response>((resolve) => { releasePatch = resolve; });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const terms = screen.getByTestId('invoice-terms');
+    fireEvent.change(terms, { target: { value: 'Net 30' } });
+    fireEvent.blur(terms); // dirty → saveTerms → PATCH held open
+
+    await waitFor(() => expect(terms).toBeDisabled());
+    releasePatch(json({ data: {} }));
+    await waitFor(() => expect(terms).not.toBeDisabled());
+  });
+
   it('editing the T&C textarea and blurring issues PATCH /invoices/:id with { termsAndConditions }', async () => {
     const onChanged = vi.fn();
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -247,6 +247,59 @@ describe('InvoiceEditor', () => {
     expect(screen.getByTestId('invoice-line-qty-line-1')).toHaveValue(9);
   });
 
+  it('a background refresh does not clobber a price field being edited', async () => {
+    // The price resync guard is symmetric with qty's (its own `priceEdited` ref),
+    // so a mid-type unit price must likewise survive a server echo.
+    const { rerender } = render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const price = screen.getByTestId('invoice-line-price-line-1');
+    fireEvent.change(price, { target: { value: '75' } }); // mid-edit, not yet blurred
+
+    const serverEcho = { ...manualLine, unitPrice: '50.00', lineTotal: '100.00' };
+    rerender(<InvoiceEditor detail={draft([serverEcho])} onChanged={vi.fn()} />);
+
+    // The user's in-progress "75" survives; the server's 50 does not clobber it.
+    expect(screen.getByTestId('invoice-line-price-line-1')).toHaveValue(75);
+  });
+
+  it('a settled price field DOES re-adopt a new server value on refresh', async () => {
+    // The guard only protects an ACTIVELY-edited field: an untouched price must
+    // still track the server's canonical value when a background poll lands.
+    const { rerender } = render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-line-price-line-1')).toHaveValue(50);
+
+    const serverEcho = { ...manualLine, unitPrice: '65.00', lineTotal: '130.00' };
+    rerender(<InvoiceEditor detail={draft([serverEcho])} onChanged={vi.fn()} />);
+
+    expect(screen.getByTestId('invoice-line-price-line-1')).toHaveValue(65);
+  });
+
+  it('disables the notes textarea while its own save is in flight (busy cue)', async () => {
+    // Visual busy-cue parity with the quote editor's terms field: the textarea
+    // reflects isPending('notes'). The inFlight guard already blocks a double
+    // PATCH; this just makes the in-flight window visible.
+    let releasePatch: (v: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') {
+        return new Promise<Response>((resolve) => { releasePatch = resolve; });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const notes = screen.getByTestId('invoice-notes');
+    fireEvent.change(notes, { target: { value: 'A note' } });
+    fireEvent.blur(notes); // dirty → saveNotes → PATCH held open
+
+    await waitFor(() => expect(notes).toBeDisabled());
+    releasePatch(json({ data: {} }));
+    await waitFor(() => expect(notes).not.toBeDisabled());
+  });
+
   it('editing the T&C textarea and blurring issues PATCH /invoices/:id with { termsAndConditions }', async () => {
     const onChanged = vi.fn();
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -477,7 +477,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               // readOnly field is still focusable, so if canWrite flipped false
               // mid-edit the onBlur guard would silently drop the typed note.
               onBlur={() => { if (canWrite) void saveNotes(); }}
-              disabled={!canWrite}
+              // Also disable while the field's own save is in flight (matches the
+              // quote editor's terms field) — a visual busy-cue; the inFlight guard
+              // in runScoped already prevents a double-PATCH.
+              disabled={!canWrite || isPending('notes')}
               data-testid="invoice-notes"
               rows={3}
               className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(notesDirty, notesSaved)}`}
@@ -494,7 +497,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               value={terms}
               onChange={(e) => { setTerms(e.target.value); setTermsDirty(true); }}
               onBlur={() => { if (canWrite) void saveTerms(); }}
-              disabled={!canWrite}
+              disabled={!canWrite || isPending('terms')}
               data-testid="invoice-terms"
               rows={3}
               className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -116,6 +116,25 @@ describe('InvoicesPage', () => {
     expect(screen.getByTestId('invoices-status-inv-2')).toHaveTextContent('Draft');
   });
 
+  it('mobile card mirrors the em-dash draft link and its accessible name', async () => {
+    // The stacked mobile card renders its own `invoices-card-link-*` anchor with
+    // the same unnumbered-draft treatment as the desktop row — assert it here so
+    // the two surfaces can't drift.
+    wireDefault();
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-table')).toBeInTheDocument());
+
+    const cardLink = screen.getByTestId('invoices-card-link-inv-2');
+    expect(cardLink.tagName).toBe('A');
+    expect(cardLink).toHaveAttribute('href', '/billing/invoices/inv-2');
+    expect(cardLink).toHaveTextContent('—');
+    expect(within(cardLink).queryByText('Draft')).not.toBeInTheDocument();
+    expect(cardLink).toHaveAttribute('aria-label', 'Draft invoice');
+    // A numbered invoice's card link carries NO draft aria-label (its number is
+    // its accessible name).
+    expect(screen.getByTestId('invoices-card-link-inv-1')).not.toHaveAttribute('aria-label');
+  });
+
   it('writes filter selections to the URL hash', async () => {
     wireDefault();
     render(<InvoicesPage />);

--- a/apps/web/src/components/billing/InvoicesPage.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.test.tsx
@@ -217,7 +217,9 @@ describe('InvoicesPage', () => {
     expect(screen.queryByTestId('invoices-filters-clear')).not.toBeInTheDocument();
     fireEvent.change(screen.getByTestId('invoices-filter-status'), { target: { value: 'overdue' } });
     fireEvent.click(screen.getByTestId('invoices-filters-clear'));
-    expect(window.location.hash).toBe('');
+    // Assert on href (not `location.hash`, which jsdom reports '' even with a
+    // dangling '#'): the shared writeHashFilters clear must leave no residual '#'.
+    expect(window.location.href).not.toContain('#');
     expect(screen.getByTestId('invoices-filter-status')).toHaveValue('');
   });
 

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -23,6 +23,7 @@ import {
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
 import { StatCard } from './shared/StatCard';
+import { ROW_LINK_CLASS, writeHashFilters } from './shared/listChrome';
 import { INVOICE_STATUSES, BULK_ID_LIMIT } from '@breeze/shared';
 
 interface Organization {
@@ -64,20 +65,12 @@ function readFilters(): Filters {
 }
 
 function writeFilters(f: Filters): void {
-  if (typeof window === 'undefined') return;
   const params = new URLSearchParams();
   if (f.orgId) params.set('orgId', f.orgId);
   if (f.status) params.set('status', f.status);
   if (f.from) params.set('from', f.from);
   if (f.to) params.set('to', f.to);
-  const next = params.toString();
-  if (next) {
-    window.location.hash = `#${next}`;
-  } else if (window.location.hash) {
-    // Clearing: plain `location.hash = ''` can leave a bare '#' dangling in the
-    // URL. replaceState strips the fragment cleanly without a history entry.
-    history.replaceState(null, '', window.location.pathname + window.location.search);
-  }
+  writeHashFilters(params);
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -560,7 +553,7 @@ export function InvoicesPage() {
                               // was redundant). The dash is decorative — give the link
                               // an accessible name so it doesn't read as just "—".
                               aria-label={inv.invoiceNumber ? undefined : 'Draft invoice'}
-                              className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                              className={ROW_LINK_CLASS}
                             >
                               {inv.invoiceNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                             </a>
@@ -617,7 +610,7 @@ export function InvoicesPage() {
                           onClick={(e) => e.stopPropagation()}
                           data-testid={`invoices-card-link-${inv.id}`}
                           aria-label={inv.invoiceNumber ? undefined : 'Draft invoice'}
-                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                          className={ROW_LINK_CLASS}
                         >
                           {inv.invoiceNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                         </a>

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -137,7 +137,7 @@ export const STATUS_LABELS: Record<InvoiceStatus, string> = {
 };
 
 // The semantic pill vocabulary (STATUS_PILL roles + StatusPillRole) now lives in
-// ./shared/statusPill — the shared sub-layer non-component modules (e.g.
+// ./shared/statusPillRoles — the shared sub-layer non-component modules (e.g.
 // lib/api/contracts) can import from without reaching into invoice-specific
 // component types. Re-exported here so existing './invoiceTypes' consumers are
 // unaffected.

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -136,34 +136,14 @@ export const STATUS_LABELS: Record<InvoiceStatus, string> = {
   void: 'Void',
 };
 
-/**
- * Status-pill color roles, built from the app's semantic tokens (success /
- * warning / info / destructive) rather than raw Tailwind palette hues. Shared by
- * both the invoice and quote status pills (imported by quoteTypes) so the
- * vocabulary can't drift between the two sibling surfaces.
- *
- * Five roles, not a per-status rainbow: meaning drives the hue (neutral = not
- * sent, info = awaiting the customer, success = won/paid, warning = lapsing,
- * danger = lost/overdue). The text label carries the finer distinction (Sent vs
- * Viewed, Accepted vs Converted), so colour stays scannable.
- *
- * `info`/`success` base tokens are dark enough (L≈37-38%) to read on their own
- * 10% tint; `warning`/`danger` base tokens (amber L50% / red L56%) fail WCAG as
- * text on a light tint, so light mode uses a darker shade of the SAME token hue
- * and dark mode (where the bg is dark) uses the token directly.
- */
-export const STATUS_PILL = {
-  neutral: 'border-border bg-muted text-muted-foreground',
-  info: 'border-info/30 bg-info/10 text-info',
-  success: 'border-success/30 bg-success/10 text-success',
-  warning: 'border-warning/40 bg-warning/15 text-[hsl(36_92%_28%)] dark:text-warning',
-  danger: 'border-destructive/40 bg-destructive/10 text-[hsl(4_74%_42%)] dark:text-destructive',
-} as const;
-
-/** The five semantic pill roles (keys of STATUS_PILL). Consumed by the shared
- *  `<StatusPill role>` and by the per-domain status→role maps below and in
- *  quoteTypes / contracts. */
-export type StatusPillRole = keyof typeof STATUS_PILL;
+// The semantic pill vocabulary (STATUS_PILL roles + StatusPillRole) now lives in
+// ./shared/statusPill — the shared sub-layer non-component modules (e.g.
+// lib/api/contracts) can import from without reaching into invoice-specific
+// component types. Re-exported here so existing './invoiceTypes' consumers are
+// unaffected.
+export { STATUS_PILL } from './shared/statusPillRoles';
+export type { StatusPillRole } from './shared/statusPillRoles';
+import { STATUS_PILL, type StatusPillRole } from './shared/statusPillRoles';
 
 /** Source-of-truth status → { role, extra className } map. `STATUS_COLORS` (the
  *  class-string form) is derived from it so the two can't drift, and the status

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -21,6 +21,7 @@ import {
 } from './quoteTypes';
 import { StatusPill } from '../shared/StatusPill';
 import { StatCard } from '../shared/StatCard';
+import { ROW_LINK_CLASS, writeHashFilters } from '../shared/listChrome';
 import AccessDenied from '../../shared/AccessDenied';
 import { BULK_ID_LIMIT } from '@breeze/shared';
 
@@ -65,18 +66,10 @@ function readFilters(): Filters {
 }
 
 function writeFilters(f: Filters): void {
-  if (typeof window === 'undefined') return;
   const params = new URLSearchParams();
   if (f.orgId) params.set('orgId', f.orgId);
   if (f.status) params.set('status', f.status);
-  const next = params.toString();
-  if (next) {
-    window.location.hash = `#${next}`;
-  } else if (window.location.hash) {
-    // Clearing: plain `location.hash = ''` can leave a bare '#' dangling in the
-    // URL. replaceState strips the fragment cleanly without a history entry.
-    history.replaceState(null, '', window.location.pathname + window.location.search);
-  }
+  writeHashFilters(params);
 }
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -487,7 +480,7 @@ export function QuotesPage() {
                           // was redundant). The dash is decorative — give the link
                           // an accessible name so it doesn't read as just "—".
                           aria-label={qt.quoteNumber ? undefined : 'Draft quote'}
-                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                          className={ROW_LINK_CLASS}
                         >
                           {qt.quoteNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                         </a>

--- a/apps/web/src/components/billing/shared/StatusPill.tsx
+++ b/apps/web/src/components/billing/shared/StatusPill.tsx
@@ -1,4 +1,4 @@
-import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
+import { STATUS_PILL, type StatusPillRole } from './statusPillRoles';
 
 const BASE = 'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium';
 

--- a/apps/web/src/components/billing/shared/listChrome.ts
+++ b/apps/web/src/components/billing/shared/listChrome.ts
@@ -1,0 +1,24 @@
+// Shared chrome for the billing list surfaces (quotes / invoices / contracts).
+
+/** className for a row-title link inside a clickable table or card row. The
+ *  `focus-visible` ring gives keyboard users a clear affordance; the anchor
+ *  `stopPropagation`s at the call site so it navigates natively instead of
+ *  firing the row's SPA onClick. Kept in one place so the quotes, invoices and
+ *  contracts lists can't drift. */
+export const ROW_LINK_CLASS =
+  'rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+/** Write hash-based list filters to the URL. With active filters, set
+ *  `#key=value&…`; when cleared, strip the fragment cleanly via `replaceState`
+ *  (a bare `location.hash = ''` leaves a dangling `#` in the URL). Shared by the
+ *  quotes, invoices and contracts lists so the clear-residue fix can't regress
+ *  on one surface. */
+export function writeHashFilters(params: URLSearchParams): void {
+  if (typeof window === 'undefined') return;
+  const next = params.toString();
+  if (next) {
+    window.location.hash = `#${next}`;
+  } else if (window.location.hash) {
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+}

--- a/apps/web/src/components/billing/shared/statusPillRoles.ts
+++ b/apps/web/src/components/billing/shared/statusPillRoles.ts
@@ -1,0 +1,34 @@
+/**
+ * Status-pill color roles, built from the app's semantic tokens (success /
+ * warning / info / destructive) rather than raw Tailwind palette hues. Shared by
+ * the invoice, quote AND contract status pills (imported by invoiceTypes,
+ * quoteTypes and the contracts API layer) so the vocabulary can't drift between
+ * the sibling surfaces.
+ *
+ * This lives in `billing/shared/` — not `invoiceTypes.ts` — so non-component
+ * layers (e.g. `lib/api/contracts.ts`) can type against `StatusPillRole` without
+ * reaching up into an invoice-specific component module (an api→components
+ * layering smell).
+ *
+ * Five roles, not a per-status rainbow: meaning drives the hue (neutral = not
+ * sent, info = awaiting the customer, success = won/paid, warning = lapsing,
+ * danger = lost/overdue). The text label carries the finer distinction (Sent vs
+ * Viewed, Accepted vs Converted), so colour stays scannable.
+ *
+ * `info`/`success` base tokens are dark enough (L≈37-38%) to read on their own
+ * 10% tint; `warning`/`danger` base tokens (amber L50% / red L56%) fail WCAG as
+ * text on a light tint, so light mode uses a darker shade of the SAME token hue
+ * and dark mode (where the bg is dark) uses the token directly.
+ */
+export const STATUS_PILL = {
+  neutral: 'border-border bg-muted text-muted-foreground',
+  info: 'border-info/30 bg-info/10 text-info',
+  success: 'border-success/30 bg-success/10 text-success',
+  warning: 'border-warning/40 bg-warning/15 text-[hsl(36_92%_28%)] dark:text-warning',
+  danger: 'border-destructive/40 bg-destructive/10 text-[hsl(4_74%_42%)] dark:text-destructive',
+} as const;
+
+/** The five semantic pill roles (keys of STATUS_PILL). Consumed by the shared
+ *  `<StatusPill role>` and by the per-domain status→role maps in
+ *  invoiceTypes / quoteTypes / contracts. */
+export type StatusPillRole = keyof typeof STATUS_PILL;

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -325,6 +325,27 @@ describe('ContractEditor — immediate-commit controls lock while their PATCH is
     expect(box).toBeChecked(); // success — the optimistic value stands
   });
 
+  it('disables the auto-renew checkbox until its PATCH settles', async () => {
+    // Same lock as auto-issue, on the renew toggle's own 'autoRenew' pending key:
+    // a rapid re-toggle mid-flight would otherwise capture the optimistic value
+    // as `prev` and silently drop the second action.
+    let resolvePatch!: (v: Response) => void;
+    (api.updateContract as any).mockReturnValue(new Promise<Response>((r) => { resolvePatch = r; }));
+
+    const renewing: ContractDetail = {
+      ...draftDetail,
+      contract: { ...draftDetail.contract, endDate: '2027-06-01', autoRenew: true, renewalTermMonths: 12 },
+    };
+    render(<ContractEditor detail={renewing} onChanged={vi.fn()} />);
+    const box = (await screen.findByTestId('contract-auto-renew-toggle')).querySelector('input')!;
+    fireEvent.click(box); // uncheck → immediate autoRenew:false PATCH
+
+    await waitFor(() => expect(box).toBeDisabled());
+    resolvePatch(resp({ data: {} }));
+    await waitFor(() => expect(box).not.toBeDisabled());
+    expect(box).not.toBeChecked(); // success — the optimistic uncheck stands
+  });
+
   it('disables the billing-timing select until the PATCH settles', async () => {
     let resolvePatch!: (v: Response) => void;
     (api.updateContract as any).mockReturnValue(new Promise<Response>((r) => { resolvePatch = r; }));

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -203,8 +203,11 @@ describe('ContractsList — search, sort & skeleton', () => {
     expect(window.location.hash).toContain('status=active');
 
     fireEvent.change(screen.getByTestId('contracts-filter-status'), { target: { value: '' } });
-    // No residual '#': the fragment is gone entirely, not left as a bare hash.
-    expect(window.location.hash).toBe('');
+    // Assert on the full href, NOT `location.hash`: jsdom reports `location.hash`
+    // as '' even when a bare '#' dangles on the href, so a `.hash` check would
+    // pass against the old buggy `location.hash = ''` clear too (vacuous). The
+    // residue lives on the href, so that's what must be free of '#'.
+    expect(window.location.href).not.toContain('#');
   });
 
   // Only the `name` comparator was covered above; the org/status/estimate/start

--- a/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
+++ b/apps/web/src/components/contracts/ContractsList.search-sort.test.tsx
@@ -189,4 +189,113 @@ describe('ContractsList — search, sort & skeleton', () => {
       expect(screen.getByTestId('contracts-sort-name').closest('th')).toHaveAttribute('aria-sort', 'ascending');
     });
   });
+
+  it('clears the URL fragment cleanly (no bare "#") when filters are reset', async () => {
+    // Regression for the shared writeHashFilters residue fix: setting a filter
+    // writes `#status=…`; clearing it must strip the fragment via replaceState,
+    // not leave a dangling `#` (quotes/invoices already had this; contracts now
+    // shares the helper).
+    listContracts.mockResolvedValue(json({ data: [ALPHA, ZETA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.change(screen.getByTestId('contracts-filter-status'), { target: { value: 'active' } });
+    expect(window.location.hash).toContain('status=active');
+
+    fireEvent.change(screen.getByTestId('contracts-filter-status'), { target: { value: '' } });
+    // No residual '#': the fragment is gone entirely, not left as a bare hash.
+    expect(window.location.hash).toBe('');
+  });
+
+  // Only the `name` comparator was covered above; the org/status/estimate/start
+  // comparators are exercised here so a regression in any one can't hide.
+  const orderedIds = () =>
+    screen.getAllByTestId(/^contract-row-(?!link)/).map((r) => r.getAttribute('data-testid'));
+
+  it('sorts by organization NAME (not org id) when the Organization header is clicked', async () => {
+    // ALPHA→'Acme Corp' (o1), ZETA→'Globex' (o2). Sorting on the resolved name
+    // must put Acme before Globex regardless of the incoming row order.
+    listContracts.mockResolvedValue(json({ data: [ZETA, ALPHA] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.click(screen.getByTestId('contracts-sort-org'));
+    await waitFor(() => {
+      expect(orderedIds()).toEqual([`contract-row-${ALPHA.id}`, `contract-row-${ZETA.id}`]);
+    });
+
+    fireEvent.click(screen.getByTestId('contracts-sort-org')); // toggle → desc
+    await waitFor(() => {
+      expect(orderedIds()).toEqual([`contract-row-${ZETA.id}`, `contract-row-${ALPHA.id}`]);
+    });
+  });
+
+  it('sorts by status alphabetically when the Status header is clicked', async () => {
+    const activeC = { ...ALPHA, status: 'active' as const };
+    const draftC = { ...ZETA, status: 'draft' as const };
+    listContracts.mockResolvedValue(json({ data: [draftC, activeC] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.click(screen.getByTestId('contracts-sort-status'));
+    // asc → 'active' before 'draft'
+    await waitFor(() => {
+      expect(orderedIds()).toEqual([`contract-row-${activeC.id}`, `contract-row-${draftC.id}`]);
+    });
+  });
+
+  it('sorts numerically by estimated period value (not string order) on the Est./period header', async () => {
+    // '100.00' vs '900.00' — a string sort would agree here, so use values where
+    // lexical and numeric order diverge: 90 < 100 numerically, but '100' < '90'
+    // as strings. Numeric comparator must put 90 first ascending.
+    const small = { ...ALPHA, estimatedPeriodValue: '90.00' };
+    const big = { ...ZETA, estimatedPeriodValue: '100.00' };
+    listContracts.mockResolvedValue(json({ data: [big, small] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.click(screen.getByTestId('contracts-sort-estimate'));
+    await waitFor(() => {
+      expect(orderedIds()).toEqual([`contract-row-${small.id}`, `contract-row-${big.id}`]);
+    });
+  });
+
+  it('sorts by start date on the Start date header, keeping null starts last in both directions', async () => {
+    const early = { ...ALPHA, startDate: '2026-01-01' };
+    const late = { ...ZETA, startDate: '2026-06-01' };
+    const undated = {
+      ...base,
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      orgId: 'o1',
+      name: 'No Start',
+      status: 'draft' as const,
+      intervalMonths: 1,
+      nextBillingAt: null,
+      startDate: null,
+      estimatedPeriodValue: '50.00',
+    };
+    listContracts.mockResolvedValue(json({ data: [late, undated, early] }));
+    render(<ContractsList />);
+
+    await screen.findByTestId('contracts-list');
+    fireEvent.click(screen.getByTestId('contracts-sort-start'));
+    // asc → early, late, then the null-start row (nulls are pinned last).
+    await waitFor(() => {
+      expect(orderedIds()).toEqual([
+        `contract-row-${early.id}`,
+        `contract-row-${late.id}`,
+        `contract-row-${undated.id}`,
+      ]);
+    });
+
+    fireEvent.click(screen.getByTestId('contracts-sort-start')); // toggle → desc
+    await waitFor(() => {
+      // Dated rows reverse; the null-start row stays pinned last, not first.
+      expect(orderedIds()).toEqual([
+        `contract-row-${late.id}`,
+        `contract-row-${early.id}`,
+        `contract-row-${undated.id}`,
+      ]);
+    });
+  });
 });

--- a/apps/web/src/components/contracts/ContractsList.tsx
+++ b/apps/web/src/components/contracts/ContractsList.tsx
@@ -16,6 +16,7 @@ import { StatusPill } from '../billing/shared/StatusPill';
 import { StatCard } from '../billing/shared/StatCard';
 import { SortableTh } from '../billing/shared/SortableTh';
 import { TableSkeleton } from '../billing/shared/TableSkeleton';
+import { ROW_LINK_CLASS, writeHashFilters } from '../billing/shared/listChrome';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { useBulkSelection } from '../billing/bulk/useBulkSelection';
@@ -55,12 +56,12 @@ function readFilters(): Filters {
 }
 
 function writeFilters(f: Filters): void {
-  if (typeof window === 'undefined') return;
   const params = new URLSearchParams();
   if (f.orgId) params.set('orgId', f.orgId);
   if (f.status) params.set('status', f.status);
-  const next = params.toString();
-  window.location.hash = next ? `#${next}` : '';
+  // Shared writer: clearing strips the fragment via replaceState so no bare '#'
+  // is left dangling (quotes/invoices carried this fix; contracts now shares it).
+  writeHashFilters(params);
 }
 
 // ---- client-side sort ----------------------------------------------------
@@ -159,6 +160,11 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
 
   const newContractHref = lockedOrgId ? `/contracts/new#orgId=${lockedOrgId}` : '/contracts/new';
 
+  // A fresh column sorts ASCending first (A→Z / oldest / smallest), then toggles.
+  // This is intentionally the opposite of the quotes/invoices lists (which open
+  // DESC-first): those lead with money/recency where "biggest/newest first" is
+  // the useful default, whereas contracts lead with a name column where A→Z reads
+  // more naturally.
   const toggleSort = (key: SortKey) =>
     setSort((s) => (s?.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }));
 
@@ -442,7 +448,7 @@ export function ContractsList({ lockedOrgId }: Props = {}) {
                           href={`/contracts/${ctr.id}`}
                           onClick={(e) => e.stopPropagation()}
                           data-testid={`contract-row-link-${ctr.id}`}
-                          className="rounded-xs text-foreground hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                          className={ROW_LINK_CLASS}
                         >
                           {ctr.name}
                         </a>

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -12,7 +12,7 @@
 // (e.g. '150.00'), matching the invoice client's string-money convention.
 
 import { fetchWithAuth } from '../../stores/auth';
-import type { StatusPillRole } from '../../components/billing/invoiceTypes';
+import type { StatusPillRole } from '../../components/billing/shared/statusPillRoles';
 
 export type ContractStatus = 'draft' | 'active' | 'paused' | 'cancelled' | 'expired';
 export type ContractBillingTiming = 'advance' | 'arrears';


### PR DESCRIPTION
Bundled the **well-scoped** items from the #2150 polishing round-2 punch list (#2151). None blocked the merge; each is small and independent.

## Done

**Small refactors**
- **Shared row-link className** — extracted the anchor class (duplicated 4× across QuotesPage/InvoicesPage/ContractsList) into `ROW_LINK_CLASS` in a new `billing/shared/listChrome.ts`.
- **Shared `writeHashFilters` helper** — the quotes/invoices bare-`#` clear-residue fix (strip the fragment via `replaceState` instead of leaving a dangling `#`) is now a shared helper. **ContractsList's `writeFilters` never got that fix** — it did, so contracts no longer leaves a bare `#` on clear. (Regression test added.)
- **`StatusPillRole` / `STATUS_PILL` moved** out of the invoice-specific `components/billing/invoiceTypes.ts` into `billing/shared/statusPillRoles.ts`, so `lib/api/contracts.ts` type-imports from the shared sub-layer rather than an api→components layering violation. `invoiceTypes` re-exports both, so existing consumers are unaffected. (Filename is `statusPillRoles.ts`, not `statusPill.ts`, to avoid a case-insensitive-FS collision with `StatusPill.tsx`.)

**Visual/a11y**
- Invoice notes/terms textareas now include `isPending(...)` in their `disabled` expression (busy cue, matching the quote editor's terms field). The inFlight guard already prevents a double-PATCH; this just makes the window visible.

**Tests added**
- Contracts sort comparators `org` / `status` / `estimate` / `start` (only `name` was covered) — org sorts by resolved name, estimate is numeric (90 < 100, not string order), start keeps null-start rows last in **both** directions. Plus the clear-residue regression, and a one-line comment on the intentional asc-first toggle (siblings are desc-first).
- Auto-renew checkbox in-flight-disable lock (the describe block covered auto-issue/timing/interval but not auto-renew).
- Invoice price resync guard — mid-edit price survives a server echo; a settled field still re-adopts the server value — plus the notes busy-cue disable.
- Mobile invoice-card em-dash draft link + accessible name (`invoices-card-link-*` draft case; only the desktop row was tested).

## Deferred (left for the issue / follow-ups)
These are larger, vaguer, or need a design call — intentionally **not** in this PR so #2151 can stay open or spawn follow-ups:
- Duplicate `aria-label="Quantity"` across pick/manual/line inputs — a broader a11y pass over a pre-existing pattern.
- Quote editor's live-totals SR announcement firing once on mount (~800ms after load) — a behavior change needing its own consideration.
- Global toast container `lg:bottom-24` shared-container smell — architectural, not worth a point fix.
- Invoice PDF fallback wordmark `'Invoice'` vs preview's `'Proposal'` — unreachable under partner scope in practice; cosmetic.
- Quote editor line grid horizontal scroll at 1280px with the sidebar open — the issue itself notes "a real fix needs column-priority restructuring."

## Verification
- Affected suites green (single run): `ContractsList.search-sort`, `ContractEditor.autosave`, `InvoiceEditor`, `InvoicesPage`, `StatusPill`, `QuotesPage`(+bulk), `invoiceTypes`, `no-silent-mutations` — 153 tests passed.
- `tsc --noEmit` clean (0 errors); ESLint clean on touched files.

Refs #2151 (partial — deferred items listed above remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
