### PR TITLE
fix(agents): fail closed when heartbeat update-policy lookup fails (#2125)

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1266,6 +1266,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   // would silently bypass Manual mode / a maintenance window on a DB hiccup).
   it('fails closed (withholds upgrade) when the policy lookup throws', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { captureException } = await import('../../services/sentry');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
     vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
@@ -1275,6 +1276,9 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     expect(resp.status).toBe(200);
     const body = await resp.json() as { upgradeTo?: string | null };
     expect(body.upgradeTo).toBeFalsy();
+    // A fleet-wide upgrade freeze must be loud: the lookup failure is reported
+    // to Sentry, not just logged (#2125).
+    expect(vi.mocked(captureException)).toHaveBeenCalled();
   });
 
   // A dev-push build (dev-*) must never be auto-upgraded back to a release,

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1260,7 +1260,11 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     expect(body.upgradeTo).toBeFalsy();
   });
 
-  it('fails open (offers upgrade) when the policy lookup throws', async () => {
+  // #2125 — the update policy is a control-plane safety setting. If the lookup
+  // throws the handler cannot prove auto-upgrades are allowed, so it must FAIL
+  // CLOSED and withhold the version-to-version agent upgradeTo (a fail-open here
+  // would silently bypass Manual mode / a maintenance window on a DB hiccup).
+  it('fails closed (withholds upgrade) when the policy lookup throws', async () => {
     const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
     vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
@@ -1270,7 +1274,7 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     const resp = await postAgentHeartbeat();
     expect(resp.status).toBe(200);
     const body = await resp.json() as { upgradeTo?: string | null };
-    expect(body.upgradeTo).toBe('0.66.0');
+    expect(body.upgradeTo).toBeFalsy();
   });
 
   // A dev-push build (dev-*) must never be auto-upgraded back to a release,
@@ -1393,6 +1397,42 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     expect(body.upgradeTo).toBeFalsy(); // agent version-to-version IS gated → withheld
     expect(body.helperUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
     expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite manual
+  });
+
+  // #2125 — a policy lookup failure must fail closed on the helper and watchdog
+  // version-to-version channels too, not just the main agent channel.
+  it('policy lookup failure → withholds helper and watchdog version-to-version upgrades (fail closed)', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+
+    const resp = await postWithInstalledComponents(deviceWithWatchdog);
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null };
+    expect(body.helperUpgradeTo).toBeFalsy();
+    expect(body.watchdogUpgradeTo).toBeFalsy();
+  });
+
+  // Fail-closed must not strand fresh devices: a missing helper/watchdog still
+  // bootstraps even when the policy lookup itself throws (bootstrap is ungated).
+  it('policy lookup failure → STILL bootstraps a missing helper and watchdog', async () => {
+    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.65.10', metrics: minimalHeartbeatBody.metrics }),
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as {
+      upgradeTo?: string | null; helperUpgradeTo?: string | null; watchdogUpgradeTo?: string | null;
+    };
+    expect(body.upgradeTo).toBeFalsy(); // agent version-to-version gated → withheld
+    expect(body.helperUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite lookup failure
+    expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite lookup failure
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -550,8 +550,13 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // all auto-upgrades; `auto`/`staged` honour the maintenance window when set.
   // Bootstrap installs (a component not yet present) are intentionally NOT
   // gated below — a device must be able to finish installing regardless.
-  // Fails open: if the lookup throws we behave as before (upgrades allowed).
-  let updateGateAllows = true;
+  // Fails CLOSED (#2125): the agent update policy is a control-plane safety
+  // setting, so if the lookup throws we cannot prove auto-upgrades are allowed
+  // and must withhold version-to-version targets rather than bypass Manual mode
+  // or a maintenance window. The gate therefore starts denied and is only
+  // opened by a successful policy evaluation. Missing-component bootstrap stays
+  // allowed via its own explicit branches below, which never read this gate.
+  let updateGateAllows = false;
   try {
     const updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
     const gate = shouldSendAgentUpgrade(updateSettings, new Date());
@@ -562,7 +567,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       );
     }
   } catch (err) {
-    console.error(`[agents] failed to resolve agent update policy for ${agentId}:`, err);
+    console.error(
+      `[agents] failed to resolve agent update policy for ${agentId}; ` +
+        `withholding version-to-version auto-upgrades (fail closed):`,
+      err,
+    );
   }
 
   let upgradeTo: string | null = null;

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -567,11 +567,17 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       );
     }
   } catch (err) {
+    // Fail-closed enlarges the blast radius of a persistent lookup failure: it
+    // would silently withhold every version-to-version upgrade for the org's
+    // fleet, invisible to the agent (indistinguishable from "already latest").
+    // Route to Sentry like every other genuine-failure catch in this file so
+    // that freeze is loudly observable, not just a per-heartbeat stdout line.
     console.error(
       `[agents] failed to resolve agent update policy for ${agentId}; ` +
         `withholding version-to-version auto-upgrades (fail closed):`,
       err,
     );
+    captureException(err);
   }
 
   let upgradeTo: string | null = null;


### PR DESCRIPTION
## Summary

The heartbeat update gate **failed open** when the org Agent Update Policy lookup threw. `updateGateAllows` was initialized to `true`, and if `getOrgAgentUpdatePolicy()` threw, the catch block only logged — leaving the gate open. A transient DB/query failure while resolving the policy could therefore **bypass Manual mode or a configured maintenance window** and still hand the agent/helper/watchdog a version-to-version `upgradeTo` (`upgradeTo` / `helperUpgradeTo` / `watchdogUpgradeTo`).

Agent Update Policy is a control-plane safety setting. If the API cannot determine whether auto-upgrades are allowed, it must **withhold** them rather than default to pushing update targets to privileged endpoint components.

## Change

- `updateGateAllows` now starts **denied** (`false`); only a successful policy evaluation opens it. On lookup failure the gate stays closed.
- The catch log now states that version-to-version auto-upgrades are being withheld (fail closed) so operators can diagnose the lookup problem.
- **Missing-component bootstrap is unchanged and remains explicitly allowed.** The bootstrap branches (`!data.helperVersion`, `!installedWatchdogVersion`) never read `updateGateAllows`, so a fresh device still installs its helper/watchdog even when the policy lookup itself throws — bootstrap is an explicit separate branch, not a side effect of fail-open.

## Scope

This addresses only the fail-open-on-lookup-failure behavior described in #2125. It does **not** redesign the update-policy modes (that's #1962) — the `manual`/`auto`/`staged` semantics and the maintenance-window parsing (which intentionally fails open on a legacy-malformed *window string*) are untouched.

## Tests

`apps/api/src/routes/agents/heartbeat.test.ts` — single-fork, 52 passed:

- Flipped the former `fails open (offers upgrade) when the policy lookup throws` assertion to **fail closed** (withholds agent `upgradeTo`).
- Added: policy lookup failure **withholds helper and watchdog** version-to-version upgrades.
- Added: policy lookup failure **still bootstraps** a missing helper and watchdog (bootstrap is ungated).

`tsc --noEmit --project apps/api/tsconfig.json` clean (exit 0).

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)