### PR TITLE
fix(installer): honor device-enrollment-limit on Windows MSI bootstrap token (#2161)

### DIFF
--- a/apps/api/migrations/2026-07-02-installer-bootstrap-token-multi-use.sql
+++ b/apps/api/migrations/2026-07-02-installer-bootstrap-token-multi-use.sql
@@ -6,8 +6,10 @@
 -- install "succeeded" but the device never appeared in the portal. The CLI path
 -- was unaffected because it mints a genuinely multi-use enrollment key.
 --
--- max_usage already existed on the token but was never consulted. Add an
--- explicit consumed_count so redemption can allow up to max_usage redemptions
+-- max_usage already existed on the token but was only ever copied onto the
+-- minted child key (governing that one key's fan-out), never consulted to gate
+-- how many times the token itself could be redeemed. Add an explicit
+-- consumed_count so redemption can allow up to max_usage redemptions
 -- (one fresh single-use child enrollment key minted per redemption). A token
 -- with max_usage = 1 keeps its exact prior single-use behavior.
 ALTER TABLE installer_bootstrap_tokens

--- a/apps/api/migrations/2026-07-02-installer-bootstrap-token-multi-use.sql
+++ b/apps/api/migrations/2026-07-02-installer-bootstrap-token-multi-use.sql
@@ -1,0 +1,31 @@
+-- #2161: the Windows MSI filename-bootstrap token was single-use (redemption
+-- gated purely on consumed_at), so the "device enrollment limit" the admin set
+-- when building the installer was silently ignored. One downloaded .msi carries
+-- one token in its filename; the first machine to redeem it enrolled, and every
+-- other machine replayed the same now-consumed token and got a 404 -- so the
+-- install "succeeded" but the device never appeared in the portal. The CLI path
+-- was unaffected because it mints a genuinely multi-use enrollment key.
+--
+-- max_usage already existed on the token but was never consulted. Add an
+-- explicit consumed_count so redemption can allow up to max_usage redemptions
+-- (one fresh single-use child enrollment key minted per redemption). A token
+-- with max_usage = 1 keeps its exact prior single-use behavior.
+ALTER TABLE installer_bootstrap_tokens
+  ADD COLUMN IF NOT EXISTS consumed_count integer NOT NULL DEFAULT 0;
+
+-- Backfill: any token that was already consumed counts as one redemption, so
+-- previously-burned tokens stay burned (consumed_count = max_usage = 1). Guard
+-- on consumed_count = 0 so re-applying this migration is a no-op. Report the
+-- count so the change is auditable in the Postgres log.
+DO $$
+DECLARE n bigint;
+BEGIN
+  UPDATE installer_bootstrap_tokens
+     SET consumed_count = 1
+   WHERE consumed_at IS NOT NULL
+     AND consumed_count = 0;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'backfilled consumed_count=1 for % already-consumed installer_bootstrap_tokens', n;
+  END IF;
+END $$;

--- a/apps/api/src/db/schema/installerBootstrapTokens.ts
+++ b/apps/api/src/db/schema/installerBootstrapTokens.ts
@@ -36,6 +36,13 @@ export const installerBootstrapTokens = pgTable(
     }),
     /** Must be >= 1; enforced by DB CHECK installer_bootstrap_tokens_max_usage_positive */
     maxUsage: integer("max_usage").notNull().default(1),
+    /**
+     * Redemptions so far. The token is spendable while consumed_count <
+     * max_usage; each redemption mints one fresh single-use child enrollment
+     * key. Gating on this (not the consumed_at boolean) is what lets one
+     * downloaded installer with a device-limit of N enroll N devices (#2161).
+     */
+    consumedCount: integer("consumed_count").notNull().default(0),
     createdBy: uuid("created_by").references(() => users.id, {
       onDelete: "set null",
     }),

--- a/apps/api/src/db/schema/installerBootstrapTokens.ts
+++ b/apps/api/src/db/schema/installerBootstrapTokens.ts
@@ -10,15 +10,19 @@ import { organizations, sites, enrollmentKeys } from "./orgs";
 import { users } from "./users";
 
 /**
- * Single-use, short-TTL token issued at installer-download time. The token
- * is delivered inside the macOS installer zip payload and exchanged for
- * enrollment values on first launch via POST `/api/v1/installer/bootstrap`.
- * Legacy raw enrollment-key query tokens are not accepted by public installer
- * downloads; callers must use the short-lived handle flow.
+ * Short-TTL token issued at installer-download time, redeemable up to
+ * max_usage times (once per device that installs the same downloaded
+ * installer — see consumed_count). The token is delivered inside the platform
+ * installer (macOS zip payload, or embedded in the Windows MSI download
+ * filename) and exchanged for enrollment values on first launch via POST
+ * `/api/v1/installer/bootstrap`. Legacy raw enrollment-key query tokens are
+ * not accepted by public installer downloads; callers must use the
+ * short-lived handle flow.
  *
  * Stored as plain text (not hashed) intentionally: tokens are ephemeral
- * (24h max), single-use, and hashing adds ceremony without a meaningful
- * security win for this lifetime. Compare by equality.
+ * (24h max) and hashing adds ceremony without a meaningful security win for
+ * this lifetime. Compare by equality. Note a leaked token is worth up to
+ * max_usage enrollments, so keep the TTL short and the max_usage bounded.
  */
 export const installerBootstrapTokens = pgTable(
   "installer_bootstrap_tokens",

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -95,7 +95,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
     errSpy.mockRestore();
   });
 
-  it("returns 404 for already-consumed token", async () => {
+  it("returns 404 for exhausted token (consumed_count >= max_usage)", async () => {
     vi.mocked(db.select).mockReturnValue({
       from: () => ({
         where: () => ({
@@ -107,7 +107,8 @@ describe("POST /api/v1/installer/bootstrap", () => {
                 orgId: "o1",
                 parentEnrollmentKeyId: "pk1",
                 siteId: "s1",
-                maxUsage: 1,
+                maxUsage: 2,
+                consumedCount: 2,
                 consumedAt: new Date(),
                 expiresAt: new Date(Date.now() + 60_000),
               },
@@ -137,6 +138,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
                 parentEnrollmentKeyId: "pk1",
                 siteId: "s1",
                 maxUsage: 1,
+                consumedCount: 0,
                 consumedAt: null,
                 expiresAt: new Date(Date.now() - 1000),
               },
@@ -153,7 +155,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(res.status).toBe(404);
   });
 
-  it("happy path: consumes token, creates child key, returns enrollment payload", async () => {
+  it("partially-consumed multi-use token still redeems and mints a single-use child key", async () => {
     process.env.PUBLIC_API_URL = "https://us.2breeze.app";
     process.env.AGENT_ENROLLMENT_SECRET = "shared-secret-test";
 
@@ -164,8 +166,9 @@ describe("POST /api/v1/installer/bootstrap", () => {
       parentEnrollmentKeyId: "pk1",
       siteId: "s1",
       maxUsage: 3,
+      consumedCount: 1,
       createdBy: "u1",
-      consumedAt: null,
+      consumedAt: new Date(Date.now() - 5_000),
       expiresAt: new Date(Date.now() + 60_000),
     };
     const parentKey = {
@@ -196,12 +199,16 @@ describe("POST /api/v1/installer/bootstrap", () => {
         }),
       } as any);
 
-    // INSERT child key
+    // INSERT child key — capture values to assert it is minted single-use.
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
     vi.mocked(db.insert).mockReturnValue({
-      values: () => ({
-        returning: () =>
-          Promise.resolve([{ id: "ck1", orgId: "o1", siteId: "s1" }]),
-      }),
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return {
+          returning: () =>
+            Promise.resolve([{ id: "ck1", orgId: "o1", siteId: "s1" }]),
+        };
+      },
     } as any);
 
     // UPDATE consume (returns consumed row)
@@ -226,6 +233,12 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(body.siteId).toBe("s1");
     expect(body.orgName).toBe("Acme Corp");
     expect(body.enrollmentKey).toMatch(/^[a-f0-9]{64}$/);
+    // Each redemption hands the child key to exactly one device, so it must be
+    // single-use regardless of the token's max_usage (#2161).
+    expect(capturedChildKeyValues).not.toBeNull();
+    expect(
+      (capturedChildKeyValues as unknown as Record<string, unknown>).maxUsage,
+    ).toBe(1);
   });
 
   it("propagates installer_platform from token to child enrollment key", async () => {
@@ -239,6 +252,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
       parentEnrollmentKeyId: "pk1",
       siteId: "s1",
       maxUsage: 1,
+      consumedCount: 0,
       createdBy: "u1",
       consumedAt: null,
       expiresAt: new Date(Date.now() + 60_000),

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -241,6 +241,78 @@ describe("POST /api/v1/installer/bootstrap", () => {
     ).toBe(1);
   });
 
+  it("lost race / exhausted-on-consume: deletes the pre-inserted child key and 404s", async () => {
+    // Token passes the pre-read guard (consumed_count < max_usage) and expiry,
+    // so redemption reaches the atomic consume UPDATE — but that UPDATE returns
+    // no row (a concurrent redemption took the last slot first). The child key
+    // inserted just before must be cleaned up, and the response must be 404.
+    const tokenRow = {
+      id: "t9",
+      token: "GGGGGGGGGG",
+      orgId: "o1",
+      parentEnrollmentKeyId: "pk1",
+      siteId: "s1",
+      maxUsage: 2,
+      consumedCount: 1,
+      createdBy: "u1",
+      consumedAt: new Date(Date.now() - 5_000),
+      expiresAt: new Date(Date.now() + 60_000),
+    };
+    const parentKey = {
+      id: "pk1",
+      name: "Acme parent",
+      orgId: "o1",
+      siteId: "s1",
+      keySecretHash: "parent-secret-hash",
+      expiresAt: new Date(Date.now() + 60_000 * 60),
+    };
+
+    // Select order: (1) token row, (2) parent key. Org select is never reached.
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([tokenRow]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([parentKey]) }),
+        }),
+      } as any);
+
+    // INSERT child key returns an id we expect to see deleted.
+    vi.mocked(db.insert).mockReturnValue({
+      values: () => ({
+        returning: () =>
+          Promise.resolve([{ id: "ck9", orgId: "o1", siteId: "s1" }]),
+      }),
+    } as any);
+
+    // Atomic consume UPDATE loses the race → returns no row.
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({
+        where: () => ({ returning: () => Promise.resolve([]) }),
+      }),
+    } as any);
+
+    // Capture the compensating DELETE.
+    let deleteCalled = false;
+    vi.mocked(db.delete).mockReturnValue({
+      where: () => {
+        deleteCalled = true;
+        return Promise.resolve([]);
+      },
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "GGGGGGGGGG" },
+    });
+    expect(res.status).toBe(404);
+    expect(deleteCalled).toBe(true);
+  });
+
   it("propagates installer_platform from token to child enrollment key", async () => {
     process.env.PUBLIC_API_URL = "https://us.2breeze.app";
     process.env.AGENT_ENROLLMENT_SECRET = "shared-secret-test";

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -37,7 +37,8 @@ function generateChildEnrollmentKey(): string {
 
 /**
  * Returns a short SHA-256 hash of a sensitive token for log correlation.
- * Never log raw bootstrap tokens — they grant single-use enrollment.
+ * Never log raw bootstrap tokens — they grant device enrollment up to the
+ * token's max_usage times, so a leaked token is worth that many enrollments.
  */
 function hashTokenForLog(token: string): string {
   return createHash("sha256").update(token).digest("hex").slice(0, 16);
@@ -157,7 +158,7 @@ async function redeemBootstrapToken(c: Context, token: string) {
       return null;
     }
 
-    // ── 3. INSERT child key BEFORE consuming the token (C1 reorder) ──
+    // ── 3. INSERT child key BEFORE recording the redemption (C1 reorder) ──
     // If the consume UPDATE loses a race, we'll DELETE this row below.
     const rawChildKey = generateChildEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
@@ -214,12 +215,29 @@ async function redeemBootstrapToken(c: Context, token: string) {
         ip,
       });
       if (childKey) {
+        // Safe to leave unchecked ONLY because this DELETE shares the redeem
+        // transaction with the INSERT above: a throw rolls both back (no
+        // orphan), and a 0-row delete is impossible (we just inserted the id).
+        // If the child INSERT is ever moved to its own transaction, this must
+        // become a checked/logged delete or it silently leaks enrollment keys.
         await db
           .delete(enrollmentKeys)
           .where(eq(enrollmentKeys.id, childKey.id));
       }
       return null;
     }
+
+    // Success audit: consumed_at/consumed_from_ip on the token row only retain
+    // the LAST redeemer, so record each redemption's IP + running count here —
+    // this is the only per-device forensic trail for a multi-use token.
+    console.log("[installer] bootstrap redeemed", {
+      reason: "redeemed",
+      tokenId: row.id,
+      consumedCount: updated.consumedCount,
+      maxUsage: row.maxUsage,
+      childKeyId: childKey?.id,
+      ip,
+    });
 
     // ── 5. Fetch org name for response ────────────────────────────────
     const [org] = await db

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from "hono";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, lt, sql } from "drizzle-orm";
 import { createHash, randomBytes } from "node:crypto";
 import { db, withSystemDbAccessContext } from "../db";
 import { installerBootstrapTokens } from "../db/schema/installerBootstrapTokens";
@@ -59,18 +59,23 @@ export const installerRoutes = new Hono();
 /**
  * Public bootstrap endpoint. The token IS the auth — no JWT, no API key,
  * no session. Resolves the token to an enrollment payload, atomically
- * marks it consumed, and lazily creates a short-lived child enrollment key.
+ * records one redemption, and lazily creates a short-lived child enrollment
+ * key for the calling device.
  *
- * Invalid / expired / already-used tokens all return the same 404 to
+ * The token is redeemable up to max_usage times — once per device that
+ * installs the same downloaded installer — with a fresh single-use child key
+ * minted each time (#2161). A max_usage = 1 token is effectively single-use.
+ *
+ * Invalid / expired / exhausted tokens all return the same 404 to
  * avoid leaking which condition was hit.
  *
- * C1 (atomicity): We INSERT the child enrollment key BEFORE marking the
- * token consumed. If the atomic UPDATE returns empty (concurrent consume),
- * we DELETE the child key we just created and return 404. This reorder
- * approach avoids nested transactions (withSystemDbAccessContext already
- * wraps everything in a Postgres transaction for RLS context injection),
- * while ensuring the token is never permanently burned without a usable
- * child key.
+ * C1 (atomicity): We INSERT the child enrollment key BEFORE incrementing the
+ * token's consumed_count. If the atomic UPDATE returns empty (concurrent
+ * redemption exhausted the last slot), we DELETE the child key we just
+ * created and return 404. This reorder approach avoids nested transactions
+ * (withSystemDbAccessContext already wraps everything in a Postgres
+ * transaction for RLS context injection), while ensuring a redemption is
+ * never counted without a usable child key.
  */
 async function redeemBootstrapToken(c: Context, token: string) {
   if (!BOOTSTRAP_TOKEN_PATTERN.test(token)) {
@@ -96,9 +101,9 @@ async function redeemBootstrapToken(c: Context, token: string) {
       return null;
     }
 
-    if (row.consumedAt) {
+    if (row.consumedCount >= row.maxUsage) {
       console.error("[installer] bootstrap 404", {
-        reason: "already_consumed",
+        reason: "exhausted",
         tokenId: row.id,
         ip,
       });
@@ -165,35 +170,46 @@ async function redeemBootstrapToken(c: Context, token: string) {
         name: `${parent.name} (${platformLabel} ${hashTokenForLog(token)})`,
         key: childKeyHash,
         keySecretHash: parent.keySecretHash,
-        maxUsage: row.maxUsage,
+        // Each redemption hands this single key to exactly one device, so it is
+        // itself single-use. The token's max_usage governs how many devices may
+        // redeem (i.e. how many child keys get minted), NOT the fan-out of any
+        // one child key — see the consume guard below (#2161).
+        maxUsage: 1,
         expiresAt: childExpiresAt,
         createdBy: row.createdBy,
         installerPlatform: row.installerPlatform ?? "macos",
       })
       .returning();
 
-    // ── 4. Atomic single-use consume guard ────────────────────────────
-    // Two concurrent requests both read row.consumedAt = null, but only one
-    // UPDATE will return a row (Postgres serializes the write).
+    // ── 4. Atomic consume guard (increment up to max_usage) ────────────
+    // The WHERE consumed_count < max_usage serializes concurrent redemptions:
+    // Postgres applies the increments one at a time, so exactly max_usage of
+    // them see a row that still satisfies the predicate and RETURNING is
+    // non-empty. The (max_usage + 1)-th finds consumed_count === max_usage and
+    // gets nothing back. This is what makes one downloaded installer enroll up
+    // to N devices instead of just the first (#2161). consumed_at tracks the
+    // most recent redemption (informational only now).
     const [updated] = await db
       .update(installerBootstrapTokens)
       .set({
+        consumedCount: sql`${installerBootstrapTokens.consumedCount} + 1`,
         consumedAt: new Date(),
         consumedFromIp: ip === "unknown" ? null : ip,
       })
       .where(
         and(
           eq(installerBootstrapTokens.id, row.id),
-          isNull(installerBootstrapTokens.consumedAt),
+          lt(installerBootstrapTokens.consumedCount, installerBootstrapTokens.maxUsage),
         ),
       )
       .returning();
 
     if (!updated) {
-      // Lost the race — delete the child key we just created so we don't
-      // leave orphaned enrollment keys accumulating on repeated replays.
+      // Lost the race, or the token was exhausted between the read above and
+      // this write — delete the child key we just created so we don't leave
+      // orphaned enrollment keys accumulating on repeated replays.
       console.error("[installer] bootstrap 404", {
-        reason: "lost_race",
+        reason: "exhausted_on_consume",
         tokenId: row.id,
         ip,
       });


### PR DESCRIPTION
## Problem

Closes #2161.

The reporter (on 0.88.0) built a Windows MSI installer, **raised the device enrollment limit**, installed it on several machines — install succeeded and showed in Programs & Features, but **no device enrolled**. The CLI/command-line method worked fine.

This is **not** the #2049 CA-delivery bug — I verified the reporter's own v0.88.0 signed MSI already carries the fixed `[OriginalDatabase]` `BootstrapEnroll` custom action (extracted the `CustomAction` table from the shipped `v0.86.0`/`v0.87.0`/`v0.88.0`/`v0.89.0` MSIs; only ≤0.86.0 has the broken `SetBootstrapData`→`[CustomActionData]` form).

The real cause: the Windows filename-bootstrap token lives **in the download filename** (`Breeze Agent (TOKEN@HOST).msi`) — identical MSI bytes for everyone, so **one downloaded file = one token**. `redeemBootstrapToken` gated redemption purely on the `consumed_at` boolean, i.e. **single-use**. The "device enrollment limit" (`count` → `childMaxUsage`) *was* stamped onto the token's `max_usage` (`enrollmentKeys.ts:1077` → `installerBootstrapTokenIssuance.ts:85`) but the redemption **never consulted it**. So copying one `.msi` to N machines:

- device 1 redeems → token `consumed_at` set → enrolls;
- devices 2..N replay the same token → uniform 404 → silently never enroll.

(If anything detonated the file first — AV/EDR sandbox, SmartScreen, a test run — even device 1's token is already burned, giving **zero** enrollments, which matches the report.) The **CLI path is unaffected** because `POST /devices/onboarding-token` mints a genuinely *multi-use* enrollment key.

## Fix

Make the bootstrap token redeemable up to `max_usage` times, minting one fresh **single-use** child enrollment key per redemption (one per device).

- **Migration** `2026-07-02-installer-bootstrap-token-multi-use.sql`: add `consumed_count integer NOT NULL DEFAULT 0`; backfill `= 1 WHERE consumed_at IS NOT NULL` (guarded on `= 0`, idempotent, row-count `RAISE WARNING`) so previously-burned tokens stay burned.
- **Schema**: `installerBootstrapTokens.consumedCount`.
- **`redeemBootstrapToken`**: early guard `consumed_count >= max_usage` → 404; atomic consume `UPDATE SET consumed_count = consumed_count + 1 ... WHERE id = ? AND consumed_count < max_usage RETURNING` (the `WHERE` serializes concurrent redemptions — exactly `max_usage` win, the rest self-clean their pre-inserted child key). Child key minted `maxUsage: 1` since each redemption serves exactly one device.
- A `max_usage = 1` token keeps its **exact prior single-use behavior**. macOS shares the same endpoint and benefits identically.

Net effect: one downloaded MSI with a device limit of N now enrolls up to N devices, matching the CLI behavior and the admin's expectation.

## Tests

`apps/api/src/routes/installer.test.ts` (9 pass):
- exhausted token (`consumed_count >= max_usage`) → 404;
- partially-consumed multi-use token still redeems **and** asserts the child key is minted `maxUsage === 1`.

Related suites green: `enrollmentKeys*`, `installerBootstrapToken`, `autoMigrate` (migration ordering).

**Not added:** a real-Postgres concurrency test of the atomic `WHERE consumed_count < max_usage` guard — this environment had no DB (drift check + integration DB both unreachable), and the pre-existing single-use guard also shipped with unit coverage only. Recommended follow-up: an integration test redeeming one token `max_usage` times and asserting the `(N+1)`-th 404s.

## Reporter comms

Posted a workaround + root-cause explanation on #2161 (use CLI or property-based `msiexec` with the multi-use key, or one installer per device) and asked for `agent.log` if a single fresh MSI on a single clean box also failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
