### PR TITLE
fix(agents): heartbeat update gate honors effective (partner+org) update policy (#2123)

### DIFF
--- a/apps/api/src/__tests__/integration/agentUpdatePolicyEffective.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentUpdatePolicyEffective.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test: getOrgAgentUpdatePolicy effective (partner→org) resolution
+ * against real Postgres + RLS (issue #2123).
+ *
+ * The unit tests (helpers.agentUpdatePolicy.test.ts) prove the MERGE LOGIC by
+ * seeding `{ orgSettings, partnerSettings }` straight into a db mock — they
+ * bypass both the org⋈partner LEFT JOIN and RLS. This suite pins the single
+ * runtime assumption the whole fix rests on, and the one this repo has been
+ * bitten by before ("RLS partner-axis read needs system context"):
+ *
+ *   1. Under a SYSTEM context, the join returns the parent partner's
+ *      settings.defaults, so a partner-locked policy actually reaches the gate.
+ *   2. Under the heartbeat's ORG-scoped context (accessiblePartnerIds: []), the
+ *      `partners` row is hidden by RLS, so the partner columns come back NULL
+ *      and the resolver degrades to the permissive default — i.e. exactly the
+ *      #2123 bug. This test therefore proves the system context is NECESSARY,
+ *      not incidental: if a future refactor moved the lookup back inside the
+ *      org transaction, assertion #2 would flip and fail.
+ *
+ * `partners` is FORCE ROW LEVEL SECURITY behind `breeze_has_partner_access(id)`
+ * (migrations/2026-04-11-partners-rls.sql), which is governed by
+ * `accessiblePartnerIds` — empty for the agent heartbeat path.
+ *
+ * Seeding runs under withSystemDbAccessContext so RLS does not hide the freshly
+ * inserted rows. Fixtures are re-seeded per test (setup.ts cleanupDatabase()
+ * TRUNCATEs partners/organizations CASCADE on beforeEach).
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { db, withSystemDbAccessContext, withDbAccessContext, type DbAccessContext } from '../../db';
+import { organizations, partners } from '../../db/schema';
+import { getOrgAgentUpdatePolicy } from '../../routes/agents/helpers';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Seed {
+  orgId: string;
+  partnerId: string;
+}
+
+/**
+ * Seed a partner → org, with arbitrary `settings.defaults` on each side.
+ * Mirrors what the settings UI writes: partner defaults live in
+ * partners.settings.defaults, org-local in organizations.settings.defaults.
+ */
+async function seed(
+  partnerDefaults: Record<string, unknown>,
+  orgDefaults: Record<string, unknown>,
+): Promise<Seed> {
+  return withSystemDbAccessContext(async () => {
+    const ts = Date.now();
+    const rand = Math.random().toString(36).slice(2, 7);
+
+    const [partner] = await db
+      .insert(partners)
+      .values({
+        name: `AUP Partner ${ts}-${rand}`,
+        slug: `aup-tp-${ts}-${rand}`,
+        type: 'msp',
+        plan: 'pro',
+        status: 'active',
+        settings: { defaults: partnerDefaults },
+      })
+      .returning({ id: partners.id });
+    if (!partner) throw new Error('seed: failed to insert partner');
+
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        partnerId: partner.id,
+        name: `AUP Org ${ts}-${rand}`,
+        slug: `aup-org-${ts}-${rand}`,
+        type: 'customer',
+        status: 'active',
+        settings: { defaults: orgDefaults },
+      })
+      .returning({ id: organizations.id });
+    if (!org) throw new Error('seed: failed to insert organization');
+
+    return { orgId: org.id, partnerId: partner.id };
+  });
+}
+
+/** The exact RLS context the agent heartbeat runs its org-scoped block under. */
+function orgHeartbeatContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: null,
+  };
+}
+
+describe('getOrgAgentUpdatePolicy — effective resolution against real Postgres + RLS (#2123)', () => {
+  runDb('system context resolves the partner-locked policy for an org with no local value', async () => {
+    const { orgId } = await seed({ agentUpdatePolicy: 'manual' }, {});
+    const result = await withSystemDbAccessContext(() => getOrgAgentUpdatePolicy(orgId));
+    expect(result).toEqual({ policy: 'manual', maintenanceWindow: null });
+  });
+
+  runDb('system context carries the partner-locked maintenance window into the gate', async () => {
+    const { orgId } = await seed(
+      { agentUpdatePolicy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' },
+      {},
+    );
+    const result = await withSystemDbAccessContext(() => getOrgAgentUpdatePolicy(orgId));
+    expect(result).toEqual({ policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00' });
+  });
+
+  runDb('partner-locked field wins over an org-local value (system context)', async () => {
+    const { orgId } = await seed({ agentUpdatePolicy: 'manual' }, { agentUpdatePolicy: 'auto' });
+    const result = await withSystemDbAccessContext(() => getOrgAgentUpdatePolicy(orgId));
+    expect(result.policy).toBe('manual');
+  });
+
+  runDb('org override is honored where the partner has NOT locked the field', async () => {
+    const { orgId } = await seed({}, { agentUpdatePolicy: 'manual' });
+    const result = await withSystemDbAccessContext(() => getOrgAgentUpdatePolicy(orgId));
+    expect(result.policy).toBe('manual');
+  });
+
+  // The load-bearing assertion: proves the system context is NECESSARY. The
+  // partner row is invisible under the heartbeat's org-scoped RLS context, so a
+  // naive in-block lookup would silently fall back to the permissive default —
+  // reintroducing #2123 with every unit test still green.
+  runDb('org-scoped heartbeat context CANNOT see the partner row → permissive default (system context is necessary)', async () => {
+    const { orgId } = await seed({ agentUpdatePolicy: 'manual' }, {});
+
+    // Sanity: the SAME call under a system context sees the partner lock.
+    const systemResult = await withSystemDbAccessContext(() => getOrgAgentUpdatePolicy(orgId));
+    expect(systemResult.policy).toBe('manual');
+
+    // Under the org-scoped context the partner row is RLS-hidden, so the
+    // partner-locked 'manual' is invisible and we degrade to staged + no window.
+    const orgResult = await withDbAccessContext(orgHeartbeatContext(orgId), () =>
+      getOrgAgentUpdatePolicy(orgId),
+    );
+    expect(orgResult).toEqual({ policy: 'staged', maintenanceWindow: null });
+  });
+});

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -23,8 +23,8 @@
  * PATCH /organizations/:id (org-local) and PATCH /partners/me (partner default,
  * which now reaches this gate: a partner-set field wins and locks, and the
  * org-local value applies only where the partner has not set it). Any legacy
- * malformed value still
- * fails open (no restriction) rather than permanently blocking, and is logged
+ * malformed value still fails open (no restriction) rather than permanently
+ * blocking, and is logged
  * the first time it is ignored per org (per process; see getOrgAgentUpdatePolicy)
  * so the lifted restriction is observable.
  *

--- a/apps/api/src/routes/agents/agentUpdatePolicy.ts
+++ b/apps/api/src/routes/agents/agentUpdatePolicy.ts
@@ -15,15 +15,18 @@
  * at any time. This preserves the historical behaviour for orgs that never
  * configured the policy.
  *
- * Timezone note: the org `maintenanceWindow` is a string with no timezone
+ * Timezone note: the `maintenanceWindow` is a string with no timezone
  * component (e.g. "Sun 02:00-04:00"), so it is evaluated against UTC server
- * time. This gate reads ORG settings only (getOrgAgentUpdatePolicy), so the
- * gate-relevant write path is PATCH /organizations/:id — validated at save time
- * as of issue #1963. (The partner route PATCH /partners/me validates the same
- * field too, but only for UX parity; partner settings never reach this gate.)
- * Any legacy malformed value still fails open (no restriction) rather than
- * permanently blocking, and is logged the first time it is ignored per org (per
- * process; see getOrgAgentUpdatePolicy) so the lifted restriction is observable.
+ * time. This gate reads the EFFECTIVE settings (getOrgAgentUpdatePolicy) —
+ * partner defaults applied on top of org-local values, matching the settings UI
+ * (issue #2123). Both write paths are validated at save time as of issue #1963:
+ * PATCH /organizations/:id (org-local) and PATCH /partners/me (partner default,
+ * which now reaches this gate: a partner-set field wins and locks, and the
+ * org-local value applies only where the partner has not set it). Any legacy
+ * malformed value still
+ * fails open (no restriction) rather than permanently blocking, and is logged
+ * the first time it is ignored per org (per process; see getOrgAgentUpdatePolicy)
+ * so the lifted restriction is observable.
  *
  * This module is pure and side-effect free so it can be unit tested without a
  * database. The DB read lives in `getOrgAgentUpdatePolicy` (helpers.ts).

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../db', () => ({
     callOrder.push('dbContext:released');
     return result;
   },
+  // Pass-through: the effective agent-update-policy lookup (#2123) and the
+  // policy-probe read both run in a system context. Invoke the callback so the
+  // mocked getOrgAgentUpdatePolicy / buildPolicyProbeConfigUpdate still run.
+  withSystemDbAccessContext: async (fn: () => Promise<unknown>) => fn(),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -21,17 +21,26 @@ vi.mock('../../db', () => ({
   },
   runOutsideDbContext: (...args: unknown[]) =>
     runOutsideDbContextMock(...(args as [any])),
-  // Pass-through that records when the scoped callback resolves — in
-  // production the org transaction is released at this point.
+  // Pass-through that records when the org-scoped context opens and when its
+  // callback resolves — in production the org transaction is released at the
+  // latter point.
   withDbAccessContext: async (_ctx: unknown, fn: () => Promise<unknown>) => {
+    callOrder.push('dbContext:opened');
     const result = await fn();
     callOrder.push('dbContext:released');
     return result;
   },
-  // Pass-through: the effective agent-update-policy lookup (#2123) and the
-  // policy-probe read both run in a system context. Invoke the callback so the
-  // mocked getOrgAgentUpdatePolicy / buildPolicyProbeConfigUpdate still run.
-  withSystemDbAccessContext: async (fn: () => Promise<unknown>) => fn(),
+  // Pass-through: the effective agent-update-policy lookup (#2123, BEFORE the
+  // org block) and the policy-probe read (AFTER it) both run in a system
+  // context. Invoke the callback so the mocked getOrgAgentUpdatePolicy /
+  // buildPolicyProbeConfigUpdate still run, and record enter/exit so tests can
+  // assert the update-policy context opens AND closes before the org context.
+  withSystemDbAccessContext: async (fn: () => Promise<unknown>) => {
+    callOrder.push('systemCtx:enter');
+    const result = await fn();
+    callOrder.push('systemCtx:exit');
+    return result;
+  },
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -1283,6 +1292,35 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
     // A fleet-wide upgrade freeze must be loud: the lookup failure is reported
     // to Sentry, not just logged (#2125).
     expect(vi.mocked(captureException)).toHaveBeenCalled();
+  });
+
+  // #2123 + #1105 — the effective-policy lookup reads the parent partners row,
+  // which the org-scoped RLS context (accessiblePartnerIds: []) cannot see, so
+  // it MUST run in a system context that opens AND closes BEFORE the org
+  // transaction opens (never holding two pooled connections at once). Without
+  // this ordering assertion, a regression that moved the lookup back inside the
+  // org block — reintroducing both the RLS bug and the #1105 hazard — would
+  // pass every other test in this file.
+  it('resolves the update policy in a system context that closes before the org context opens', async () => {
+    const { getOrgAgentUpdatePolicy } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+    callOrder.length = 0;
+
+    const resp = await postAgentHeartbeat();
+    expect(resp.status).toBe(200);
+
+    // First system context = the update-policy lookup; it must enter and exit
+    // before the org context opens. (A later system context is the post-block
+    // policy-probe read — that one legitimately runs after dbContext:released.)
+    const enter = callOrder.indexOf('systemCtx:enter');
+    const exit = callOrder.indexOf('systemCtx:exit');
+    const opened = callOrder.indexOf('dbContext:opened');
+    expect(enter).toBeGreaterThanOrEqual(0);
+    expect(opened).toBeGreaterThanOrEqual(0);
+    expect(enter).toBeLessThan(exit);
+    expect(exit).toBeLessThan(opened);
   });
 
   // A dev-push build (dev-*) must never be auto-upgraded back to a release,

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -114,6 +114,46 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     currentPartnerId: null,
   };
 
+  // Org > General > Agent update policy — governs whether we may hand the agent
+  // (or its helper/watchdog) an auto-upgrade target right now. `manual` blocks
+  // all auto-upgrades; `auto`/`staged` honour the maintenance window when set.
+  // Resolved as EFFECTIVE settings (partner defaults merged over org-local,
+  // issue #2123), so it must run in a SYSTEM context: the org-scoped block below
+  // has `accessiblePartnerIds: []` and cannot read the parent partners row under
+  // RLS, so a partner-locked policy would be silently invisible there. This
+  // short-lived context also opens and CLOSES before the org transaction below,
+  // so we never hold two pooled connections at once (#1105 mass-reconnect
+  // deadlock — same pattern as the policy-probe/trust-keyset reads at the end).
+  // Fails CLOSED (#2125): the gate starts denied and is only opened by a
+  // successful policy evaluation; a lookup failure withholds version-to-version
+  // targets rather than bypass Manual mode / a maintenance window. Bootstrap
+  // installs (a component not yet present) are NOT gated inside the block below.
+  let updateGateAllows = false;
+  try {
+    const updateSettings = await withSystemDbAccessContext(() =>
+      getOrgAgentUpdatePolicy(agent.orgId),
+    );
+    const gate = shouldSendAgentUpgrade(updateSettings, new Date());
+    updateGateAllows = gate.allow;
+    if (!gate.allow) {
+      console.log(
+        `[agents] auto-upgrade withheld for ${agentId} by org update policy (${gate.reason})`,
+      );
+    }
+  } catch (err) {
+    // Fail-closed enlarges the blast radius of a persistent lookup failure: it
+    // would silently withhold every version-to-version upgrade for the org's
+    // fleet, invisible to the agent (indistinguishable from "already latest").
+    // Route to Sentry like every other genuine-failure catch in this file so
+    // that freeze is loudly observable, not just a per-heartbeat stdout line.
+    console.error(
+      `[agents] failed to resolve agent update policy for ${agentId}; ` +
+        `withholding version-to-version auto-upgrades (fail closed):`,
+      err,
+    );
+    captureException(err);
+  }
+
   const scoped = await withDbAccessContext(
     dbContext,
     async (): Promise<Response | { deviceOrgId: string; mainResponse: Record<string, unknown> }> => {
@@ -545,41 +585,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // closes, under a system context — same #1105 pattern as the manifest
   // trust keyset below.
 
-  // Org > General > Agent update policy. Governs whether we may hand the agent
-  // (or its helper/watchdog) an auto-upgrade target right now. `manual` blocks
-  // all auto-upgrades; `auto`/`staged` honour the maintenance window when set.
-  // Bootstrap installs (a component not yet present) are intentionally NOT
-  // gated below — a device must be able to finish installing regardless.
-  // Fails CLOSED (#2125): the agent update policy is a control-plane safety
-  // setting, so if the lookup throws we cannot prove auto-upgrades are allowed
-  // and must withhold version-to-version targets rather than bypass Manual mode
-  // or a maintenance window. The gate therefore starts denied and is only
-  // opened by a successful policy evaluation. Missing-component bootstrap stays
-  // allowed via its own explicit branches below, which never read this gate.
-  let updateGateAllows = false;
-  try {
-    const updateSettings = await getOrgAgentUpdatePolicy(device.orgId);
-    const gate = shouldSendAgentUpgrade(updateSettings, new Date());
-    updateGateAllows = gate.allow;
-    if (!gate.allow) {
-      console.log(
-        `[agents] auto-upgrade withheld for ${agentId} by org update policy (${gate.reason})`,
-      );
-    }
-  } catch (err) {
-    // Fail-closed enlarges the blast radius of a persistent lookup failure: it
-    // would silently withhold every version-to-version upgrade for the org's
-    // fleet, invisible to the agent (indistinguishable from "already latest").
-    // Route to Sentry like every other genuine-failure catch in this file so
-    // that freeze is loudly observable, not just a per-heartbeat stdout line.
-    console.error(
-      `[agents] failed to resolve agent update policy for ${agentId}; ` +
-        `withholding version-to-version auto-upgrades (fail closed):`,
-      err,
-    );
-    captureException(err);
-  }
-
+  // `updateGateAllows` was resolved above (effective partner+org update policy,
+  // issue #2123) in a system context BEFORE this org-scoped block opened — see
+  // the comment there for why (RLS on partners + #1105 connection ordering). The
+  // agent / helper / watchdog version-to-version branches below read it; missing-
+  // component bootstrap branches never do, so a first install is never gated.
   let upgradeTo: string | null = null;
   const normalizedArch = normalizeAgentArchitecture(device.architecture);
   if (normalizedArch) {

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -1,17 +1,24 @@
 /**
- * Tests for getOrgAgentUpdatePolicy — the DB read that resolves the org-level
- * "Agent update policy" (Org > General) from organizations.settings.defaults.
+ * Tests for getOrgAgentUpdatePolicy — the DB read that resolves the EFFECTIVE
+ * "Agent update policy" (Org > General): partner defaults merged on top of
+ * org-local `settings.defaults`, matching the settings UI (issue #2123).
  *
  * The pure gating logic lives in agentUpdatePolicy.ts (tested separately); this
- * file pins the JSONB extraction + normalization seam that the heartbeat tests
- * mock away: nested settings.defaults lookup, isObject guards at both levels,
- * unknown-policy fallback to `staged`, and whitespace-trim-to-null of the
- * maintenance window. That seam is the one most likely to silently break (a
- * renamed key → permissive default) on a settings-schema change.
+ * file pins two seams the heartbeat tests mock away:
+ *   1. The JSONB extraction + normalization: nested settings.defaults lookup,
+ *      isObject guards at both levels, unknown-policy fallback to `staged`, and
+ *      whitespace-trim-to-null of the maintenance window.
+ *   2. The partner→org effective merge: a partner-set field wins and locks; the
+ *      org value fills the gap only where the partner has not set that field —
+ *      merged per field (issue #2123). This is the bug the issue reported: a
+ *      partner-locked Manual policy previously had zero runtime effect.
+ * Both are the seams most likely to silently break (a renamed key → permissive
+ * default, or a dropped partner merge → partner lock ignored) on a schema change.
  *
  * helpers.ts has a large import graph, so the mock harness below mirrors
  * helpers.pam.test.ts: a single-call db.select queue plus stubs for everything
- * the module references at load time.
+ * the module references at load time. The lookup is a single org⋈partner joined
+ * SELECT, so each `_set(...)` seeds the one row that join returns.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,6 +31,7 @@ const { dbMock } = vi.hoisted(() => {
   const makeSelectChain = () => {
     const chain: any = {
       from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
       where: vi.fn(() => chain),
       limit: vi.fn(() => Promise.resolve(nextResult)),
     };
@@ -52,7 +60,8 @@ vi.mock('../../db', () => ({
 }));
 
 vi.mock('../../db/schema', () => ({
-  organizations: { id: 'orgs.id', settings: 'orgs.settings' },
+  organizations: { id: 'orgs.id', settings: 'orgs.settings', partnerId: 'orgs.partner_id' },
+  partners: { id: 'partners.id', settings: 'partners.settings' },
   // Stub out everything else helpers.ts references so the module loads.
   devices: {},
   deviceGroupMemberships: {},
@@ -114,42 +123,52 @@ import { getOrgAgentUpdatePolicy, __resetMalformedWindowWarnCache } from './help
 
 const ORG_ID = '00000000-0000-4000-8000-000000000001';
 
-describe('getOrgAgentUpdatePolicy', () => {
+/** Seed the single org⋈partner join row. `partner` defaults to no partner row. */
+function seed(orgSettings: unknown, partnerSettings: unknown = null): void {
+  dbMock._setResult([{ orgSettings, partnerSettings }]);
+}
+
+/** Convenience: an org-local `settings.defaults` blob with no partner defaults. */
+function orgDefaults(defaults: Record<string, unknown>): void {
+  seed({ defaults }, null);
+}
+
+describe('getOrgAgentUpdatePolicy — org-local resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     __resetMalformedWindowWarnCache();
   });
 
   it('reads a fully configured policy + maintenance window', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'manual', maintenanceWindow: 'Sun 02:00-04:00',
     });
   });
 
   it('trims a maintenance window and passes through auto/staged', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '  02:00-04:00  ' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'auto', maintenanceWindow: '  02:00-04:00  ' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'auto', maintenanceWindow: '02:00-04:00',
     });
   });
 
   it('normalizes a whitespace-only window to null', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'staged', maintenanceWindow: '   ' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'staged', maintenanceWindow: '   ' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
   });
 
   it('normalizes the explicit "24/7" always-state to null (no restriction)', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '24/7' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'auto', maintenanceWindow: '24/7' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'auto', maintenanceWindow: null,
     });
   });
 
   it('normalizes "always"/"none" aliases to null', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'staged', maintenanceWindow: ' Always ' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'staged', maintenanceWindow: ' Always ' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
@@ -161,11 +180,11 @@ describe('getOrgAgentUpdatePolicy', () => {
     // silently-lifted restriction is observable. The read runs on the heartbeat
     // hot path, so the warn is deduped per org — two reads, one warn.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'auto', maintenanceWindow: 'Sundays 2am',
     });
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'auto', maintenanceWindow: 'Sundays 2am' });
     await getOrgAgentUpdatePolicy(ORG_ID); // second heartbeat read for the same org
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('malformed maintenance window'));
@@ -173,28 +192,28 @@ describe('getOrgAgentUpdatePolicy', () => {
   });
 
   it('normalizes a non-string window to null', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 42 } } }]);
+    orgDefaults({ agentUpdatePolicy: 'manual', maintenanceWindow: 42 });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'manual', maintenanceWindow: null,
     });
   });
 
   it('falls back to the permissive default (staged + null) for an unknown policy', async () => {
-    dbMock._setResult([{ settings: { defaults: { agentUpdatePolicy: 'bogus' } } }]);
+    orgDefaults({ agentUpdatePolicy: 'bogus' });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
   });
 
   it('defaults when defaults sub-object is absent', async () => {
-    dbMock._setResult([{ settings: { somethingElse: true } }]);
+    seed({ somethingElse: true }, null);
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
   });
 
   it('defaults when settings is absent / non-object', async () => {
-    dbMock._setResult([{ settings: null }]);
+    seed(null, null);
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
@@ -205,5 +224,94 @@ describe('getOrgAgentUpdatePolicy', () => {
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
       policy: 'staged', maintenanceWindow: null,
     });
+  });
+});
+
+describe('getOrgAgentUpdatePolicy — effective partner→org merge (issue #2123)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetMalformedWindowWarnCache();
+  });
+
+  it('applies the partner default when the org has no local value (the reported bug)', async () => {
+    // Partner locks Manual; org never set a policy. Before #2123 this org fell
+    // back to the permissive default (staged) and received auto-upgrades.
+    seed({ defaults: {} }, { defaults: { agentUpdatePolicy: 'manual' } });
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: null,
+    });
+  });
+
+  it('applies the partner default when the org has no settings blob at all', async () => {
+    seed(null, { defaults: { agentUpdatePolicy: 'manual', maintenanceWindow: 'Sun 02:00-04:00' } });
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: 'Sun 02:00-04:00',
+    });
+  });
+
+  it('partner-locked field wins over an org-local value', async () => {
+    // Org wants auto; partner locks manual. The partner lock must win at runtime,
+    // matching what the settings UI shows.
+    seed(
+      { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: '24/7' } },
+      { defaults: { agentUpdatePolicy: 'manual' } },
+    );
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: null,
+    });
+  });
+
+  it('honors the org override where the partner has NOT locked that field', async () => {
+    // Partner sets nothing; org sets manual. Org value applies (no partner lock).
+    seed({ defaults: { agentUpdatePolicy: 'manual' } }, { defaults: {} });
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: null,
+    });
+  });
+
+  it('merges per field: partner locks the policy, org keeps its own window', async () => {
+    // Partner locks the policy only; maintenanceWindow is left to the org. The
+    // two fields resolve independently (mirrors effectiveSettings.mergeCategory).
+    seed(
+      { defaults: { agentUpdatePolicy: 'auto', maintenanceWindow: 'Sun 02:00-04:00' } },
+      { defaults: { agentUpdatePolicy: 'staged' } },
+    );
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: 'Sun 02:00-04:00',
+    });
+  });
+
+  it('partner locks the window while the org keeps its own policy', async () => {
+    seed(
+      { defaults: { agentUpdatePolicy: 'manual' } },
+      { defaults: { maintenanceWindow: 'Mon 01:00-03:00' } },
+    );
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: 'Mon 01:00-03:00',
+    });
+  });
+
+  it('permissive default when neither partner nor org configured either field', async () => {
+    seed({ defaults: {} }, { defaults: {} });
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'staged', maintenanceWindow: null,
+    });
+  });
+
+  it('a partner with a non-object settings blob falls back to org-local values', async () => {
+    seed({ defaults: { agentUpdatePolicy: 'manual' } }, 'not-an-object');
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).resolves.toEqual({
+      policy: 'manual', maintenanceWindow: null,
+    });
+  });
+
+  it('propagates a DB error so the heartbeat gate can fail closed (#2125)', async () => {
+    // The lookup itself does not swallow errors — a thrown query rejects, and the
+    // heartbeat handler's catch is what withholds version-to-version upgrades
+    // (fail closed). This pins that getOrgAgentUpdatePolicy stays throw-through.
+    dbMock.select.mockImplementationOnce(() => {
+      throw new Error('db down');
+    });
+    await expect(getOrgAgentUpdatePolicy(ORG_ID)).rejects.toThrow('db down');
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -20,6 +20,7 @@ import {
   sensitiveDataFindings,
   sensitiveDataScans,
   organizations,
+  partners,
   deviceGroupMemberships,
   configPolicyAssignments,
   configurationPolicies,
@@ -2028,23 +2029,64 @@ export function __resetMalformedWindowWarnCache(): void {
   warnedMalformedWindowOrgs.clear();
 }
 
+/** Pull the `defaults` sub-object out of a settings JSONB blob (safe for null). */
+function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
+  const root = isObject(settings) ? settings : {};
+  return isObject(root.defaults) ? root.defaults : {};
+}
+
 /**
- * Read the org-level agent update policy from `organizations.settings.defaults`
- * (Org > General). Returns a normalized policy plus the raw maintenance-window
- * string; the gating decision lives in `shouldSendAgentUpgrade`. Unconfigured
- * orgs resolve to a permissive default (staged + no window = upgrade anytime).
+ * Resolve the EFFECTIVE agent update policy for an org (Org > General), applying
+ * partner defaults exactly as the settings UI and `getEffectiveOrgSettings`
+ * (`services/effectiveSettings.ts`) do: for each field a partner-set value wins
+ * and locks; the org-local value only applies where the partner has NOT set that
+ * field. Fields are merged independently — a partner may lock `agentUpdatePolicy`
+ * while leaving `maintenanceWindow` to the org, or vice versa.
+ *
+ * Returns a normalized policy plus the raw maintenance-window string; the gating
+ * decision lives in `shouldSendAgentUpgrade`. Orgs (and partners) that never
+ * configured the field resolve to a permissive default (staged + no window =
+ * upgrade anytime), preserving historical behaviour.
+ *
+ * Hot path: this runs once per device per heartbeat, so org + partner settings
+ * are fetched in a single joined round trip rather than two queries. A thrown
+ * error propagates to the heartbeat gate, which fails CLOSED (#2125); a missing
+ * org/partner row is NOT an error — it falls back to the permissive default like
+ * an unconfigured org, matching the pre-effective-settings behaviour.
+ *
+ * Issue #2123: before this, the gate read org-local `settings.defaults` only, so
+ * a partner-locked policy (e.g. Manual) had zero runtime effect and unconfigured
+ * child orgs fell back to the permissive default despite the partner lock.
+ * (#2124 will build version pins on top of this effective plumbing.)
  */
 export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
-  const [org] = await db
-    .select({ settings: organizations.settings })
+  // LEFT JOIN so a missing partner (shouldn't happen) still returns the org row
+  // and falls back to org-local settings rather than dropping the whole lookup.
+  const [row] = await db
+    .select({ orgSettings: organizations.settings, partnerSettings: partners.settings })
     .from(organizations)
+    .leftJoin(partners, eq(partners.id, organizations.partnerId))
     .where(eq(organizations.id, orgId))
     .limit(1);
-  const settings = isObject(org?.settings) ? org.settings : {};
-  const defaults = isObject(settings.defaults) ? settings.defaults : {};
-  const policy = normalizeAgentUpdatePolicy(defaults.agentUpdatePolicy);
-  const rawWindow =
-    typeof defaults.maintenanceWindow === 'string' ? defaults.maintenanceWindow.trim() : '';
+
+  const orgDefaults = extractSettingsDefaults(row?.orgSettings);
+  const partnerDefaults = extractSettingsDefaults(row?.partnerSettings);
+
+  // Effective merge, per field (mirrors effectiveSettings.mergeCategory): a
+  // partner-set field wins and locks; the org value fills the gap only where the
+  // partner has not set that field. `in` (not truthiness) matches mergeCategory,
+  // which locks any key the partner has present.
+  const effectivePolicy =
+    'agentUpdatePolicy' in partnerDefaults
+      ? partnerDefaults.agentUpdatePolicy
+      : orgDefaults.agentUpdatePolicy;
+  const effectiveWindow =
+    'maintenanceWindow' in partnerDefaults
+      ? partnerDefaults.maintenanceWindow
+      : orgDefaults.maintenanceWindow;
+
+  const policy = normalizeAgentUpdatePolicy(effectivePolicy);
+  const rawWindow = typeof effectiveWindow === 'string' ? effectiveWindow.trim() : '';
   // The explicit "24/7"/empty always-state means "no restriction" → null, same
   // as an absent window. Only a real window string is carried through to the gate.
   const maintenanceWindow = rawWindow && !isAlwaysMaintenanceWindow(rawWindow) ? rawWindow : null;

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2057,7 +2057,7 @@ function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
  * Issue #2123: before this, the gate read org-local `settings.defaults` only, so
  * a partner-locked policy (e.g. Manual) had zero runtime effect and unconfigured
  * child orgs fell back to the permissive default despite the partner lock.
- * (#2124 will build version pins on top of this effective plumbing.)
+ * (Future version-pin work is expected to build on this effective plumbing.)
  */
 export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
   // LEFT JOIN so a missing partner (shouldn't happen) still returns the org row

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -398,11 +398,12 @@ const partnerSettingsSchema = z.object({
     }).optional(),
     agentUpdatePolicy: z.string().optional(),
     // Reject malformed windows on the partner (/partners/me) write path at save
-    // time (issue #1963), for consistency with the org route. NOTE: the agent
-    // heartbeat gate reads ORG settings (see updateOrgHandler /
-    // getOrgAgentUpdatePolicy), so this partner-level check is UX parity — the
-    // org-route check is what actually protects the gate. Accepts the
-    // "24/7"/empty always-state or a "[Day ]HH:MM-HH:MM" window.
+    // time (issue #1963), for consistency with the org route. As of issue #2123
+    // the agent heartbeat gate reads the EFFECTIVE settings (partner defaults
+    // merged over org-local; see getOrgAgentUpdatePolicy), so a partner-locked
+    // window now reaches the gate directly — this save-time check protects it
+    // just as the org-route check does. Accepts the "24/7"/empty always-state or
+    // a "[Day ]HH:MM-HH:MM" window.
     maintenanceWindow: z.string().max(64).optional().refine(
       (v) => v === undefined || isValidMaintenanceWindow(v),
       { message: MAINTENANCE_WINDOW_ERROR_MESSAGE },


### PR DESCRIPTION
## Summary

Fixes issue #2123: partner-level Agent Update Policy / Maintenance Window defaults are locked in the settings UI but were **ignored by the runtime heartbeat update gate**. The gate read only org-local `organizations.settings.defaults`, so a partner-locked `Manual` policy had zero runtime effect and an unconfigured child org fell back to the permissive default (staged + no window) and still received automatic update targets during heartbeat.

## Root cause

`getOrgAgentUpdatePolicy` (`apps/api/src/routes/agents/helpers.ts`) selected only `organizations.settings` and normalized `settings.defaults.agentUpdatePolicy` / `maintenanceWindow` directly. It never loaded partner defaults and never used the effective-settings model (`getEffectiveOrgSettings` in `services/effectiveSettings.ts`).

## Change

- **`getOrgAgentUpdatePolicy` now resolves EFFECTIVE settings.** It joins the org to its partner in a single round trip and merges per field with the exact same lock semantics as `effectiveSettings.mergeCategory`: **a partner-set field wins and locks; the org-local value applies only where the partner has not set that field.** `agentUpdatePolicy` and `maintenanceWindow` merge independently. Unconfigured on both sides → the historical permissive default (staged + no window).
- **The heartbeat resolves the gate in a short-lived SYSTEM context, before the org-scoped block opens.** The heartbeat's org-scoped RLS context (`accessiblePartnerIds: []`) *cannot* read the parent `partners` row, so a naive join inside that block would silently return null partner settings (bug would appear "fixed" in mocked tests but no-op in prod). Running the lookup under `withSystemDbAccessContext` **before** the org transaction opens is both RLS-safe (system context reads the partner row) and #1105-safe (the system context closes before the org connection is acquired — no two pooled connections held at once, same pattern as the existing policy-probe / trust-keyset reads).
- **Preserves #2125 fail-closed.** `updateGateAllows` starts denied; only a successful policy evaluation opens it. A lookup failure withholds version-to-version upgrades and reports to Sentry. Missing-component **bootstrap** installs remain ungated. The malformed-maintenance-window per-org warn dedup is intact.
- Refreshed the now-stale doc comments in `agentUpdatePolicy.ts` and `orgs.ts` that claimed partner settings never reach the gate.

No schema/migration change — this only changes how existing columns are read.

## Tests

- `helpers.agentUpdatePolicy.test.ts` — new effective-merge suite: partner default applies when org unset (the reported bug); partner-locked field wins over an org-local value; org override honored where partner not locked; per-field merge (partner locks policy, org keeps window, and vice versa); both unconfigured → permissive default; partner non-object settings → org fallback; DB error propagates so the gate can fail closed.
- `heartbeat.test.ts` — added `withSystemDbAccessContext` pass-through to the db mock; existing gating + #2125 fail-closed tests still green.
- All 418 `apps/api/src/routes/agents/` tests pass single-fork; `tsc --noEmit` clean.

## Follow-up

#2124 (agent version pins) will build on this effective-settings plumbing.

Refs #2123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)