### PR TITLE
feat(devices): active VPN client presence telemetry (#2139)

### DIFF
--- a/agent/internal/collectors/vpn.go
+++ b/agent/internal/collectors/vpn.go
@@ -64,9 +64,16 @@ func (c *VPNCollector) Collect() ([]VpnPresence, error) {
 	if err != nil {
 		return nil, err
 	}
+	return assembleVPNs(ifaces, runningVPNSignals(), tailscaleDNSName), nil
+}
 
-	signals := runningVPNSignals()
-
+// assembleVPNs is the pure detection assembly: given the interface list, the
+// provider->source signal map, and a lazy Tailscale-DNS resolver, it produces
+// the reported VPN set. Split out from Collect (which owns the impure OS calls)
+// so the branch logic — no-IP skip, generic promotion, source corroboration,
+// per-provider DNS attachment — is table-testable. dnsFn is invoked at most
+// once, only when a Tailscale tunnel is present.
+func assembleVPNs(ifaces []psnet.InterfaceStat, signals map[string]string, dnsFn func() string) []VpnPresence {
 	var (
 		vpns             []VpnPresence
 		tailscaleName    string
@@ -110,7 +117,7 @@ func (c *VPNCollector) Collect() ([]VpnPresence, error) {
 
 		if provider == vpnTailscale {
 			if !tailscaleFetched {
-				tailscaleName = tailscaleDNSName()
+				tailscaleName = dnsFn()
 				tailscaleFetched = true
 			}
 			vpn.DNSName = tailscaleName
@@ -119,7 +126,7 @@ func (c *VPNCollector) Collect() ([]VpnPresence, error) {
 		vpns = append(vpns, vpn)
 	}
 
-	return vpns, nil
+	return vpns
 }
 
 // classifyVPNInterface maps an interface/adapter name to a VPN provider. It

--- a/agent/internal/collectors/vpn.go
+++ b/agent/internal/collectors/vpn.go
@@ -1,0 +1,306 @@
+package collectors
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+
+	psnet "github.com/shirou/gopsutil/v3/net"
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// VPN-client presence telemetry (#2139). Read-only current state: detect which
+// VPN overlay clients have an active tunnel from local interface/adapter
+// heuristics plus per-OS service/process signals, then report normalized
+// metadata. NO secrets, peer lists, keys, or VPN management — this only
+// surfaces provider / active state / interface / overlay IPs / DNS name so
+// operators can see at a glance which devices are reachable over a VPN.
+
+// Normalized provider ids. Keep in sync with VpnProvider in packages/shared.
+const (
+	vpnWireGuard      = "wireguard"
+	vpnTailscale      = "tailscale"
+	vpnNetBird        = "netbird"
+	vpnZeroTier       = "zerotier"
+	vpnOpenVPN        = "openvpn"
+	vpnCloudflareWARP = "cloudflare-warp"
+	vpnGeneric        = "generic"
+)
+
+// Detection sources. Keep in sync with VpnDetectionSource in packages/shared.
+const (
+	vpnSourceInterface = "interface"
+	vpnSourceService   = "service"
+	vpnSourceProcess   = "process"
+	vpnSourceAdapter   = "adapter"
+)
+
+// VpnPresence is the agent-sent wire shape for one detected VPN. The API stamps
+// reportedAt on ingest, so it is intentionally absent here. Mirrors VpnPresence
+// in packages/shared minus reportedAt.
+type VpnPresence struct {
+	Provider        string `json:"provider"`
+	Active          bool   `json:"active"`
+	InterfaceName   string `json:"interfaceName"`
+	IPv4            string `json:"ipv4,omitempty"`
+	IPv6            string `json:"ipv6,omitempty"`
+	DNSName         string `json:"dnsName,omitempty"`
+	DetectionSource string `json:"detectionSource"`
+}
+
+type VPNCollector struct{}
+
+func NewVPNCollector() *VPNCollector {
+	return &VPNCollector{}
+}
+
+// Collect returns the set of VPN overlay clients with an active tunnel. It is
+// interface-driven (the reliable cross-platform signal that a tunnel is truly
+// up with an overlay IP), with per-OS service/process signals used only to
+// disambiguate a generic tunnel adapter to a specific provider and to record
+// the detection source.
+func (c *VPNCollector) Collect() ([]VpnPresence, error) {
+	ifaces, err := psnet.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	signals := runningVPNSignals()
+
+	var (
+		vpns             []VpnPresence
+		tailscaleName    string
+		tailscaleFetched bool
+	)
+
+	for _, iface := range ifaces {
+		provider, isTunnel := classifyVPNInterface(iface.Name)
+		if !isTunnel || !interfaceIsUp(iface.Flags) {
+			continue
+		}
+
+		ipv4, ipv6 := extractVPNIPs(iface.Addrs)
+		if ipv4 == "" && ipv6 == "" {
+			// An up tunnel adapter with no overlay IP is not actually
+			// connected — skip it so we don't report phantom VPNs.
+			continue
+		}
+
+		source := vpnSourceInterface
+		if provider == vpnGeneric {
+			// Generic tunnel (e.g. utun3 on macOS, tun0): promote to a
+			// specific provider only when exactly one known VPN
+			// service/process is running, so we never guess wrong.
+			if p, src, ok := soleVPNSignal(signals); ok {
+				provider, source = p, src
+			}
+		} else if src, ok := signals[provider]; ok {
+			// A matching service/process corroborates the interface guess.
+			source = src
+		}
+
+		vpn := VpnPresence{
+			Provider:        provider,
+			Active:          true,
+			InterfaceName:   iface.Name,
+			IPv4:            ipv4,
+			IPv6:            ipv6,
+			DetectionSource: source,
+		}
+
+		if provider == vpnTailscale {
+			if !tailscaleFetched {
+				tailscaleName = tailscaleDNSName()
+				tailscaleFetched = true
+			}
+			vpn.DNSName = tailscaleName
+		}
+
+		vpns = append(vpns, vpn)
+	}
+
+	return vpns, nil
+}
+
+// classifyVPNInterface maps an interface/adapter name to a VPN provider. It
+// returns (provider, true) for anything that looks like a tunnel adapter —
+// specific provider when the name is distinctive, else "generic". On Windows,
+// gopsutil returns the friendly adapter name (e.g. "Tailscale", "OpenVPN
+// TAP-Windows Adapter V9") so the same name-based rules classify those too.
+func classifyVPNInterface(name string) (string, bool) {
+	n := strings.ToLower(name)
+	switch {
+	case strings.Contains(n, "tailscale"):
+		return vpnTailscale, true
+	case strings.Contains(n, "netbird"):
+		return vpnNetBird, true
+	case strings.Contains(n, "zerotier") || strings.HasPrefix(n, "zt"):
+		return vpnZeroTier, true
+	case strings.Contains(n, "wireguard") || strings.HasPrefix(n, "wg"):
+		return vpnWireGuard, true
+	case strings.Contains(n, "warp") || strings.Contains(n, "cloudflare"):
+		return vpnCloudflareWARP, true
+	case strings.Contains(n, "openvpn") || strings.Contains(n, "tap-windows") || strings.Contains(n, "tap-win"):
+		return vpnOpenVPN, true
+	case strings.HasPrefix(n, "utun") ||
+		strings.HasPrefix(n, "tun") ||
+		strings.HasPrefix(n, "tap") ||
+		strings.HasPrefix(n, "ppp") ||
+		strings.HasPrefix(n, "wt"):
+		return vpnGeneric, true
+	default:
+		return "", false
+	}
+}
+
+func interfaceIsUp(flags []string) bool {
+	for _, f := range flags {
+		if strings.EqualFold(f, "up") {
+			return true
+		}
+	}
+	return false
+}
+
+// extractVPNIPs returns the first IPv4 and first non-link-local IPv6 on the
+// interface. Link-local IPv6 (fe80::) is skipped — it's not an overlay address.
+func extractVPNIPs(addrs []psnet.InterfaceAddr) (string, string) {
+	var ipv4, ipv6 string
+	for _, addr := range addrs {
+		ip := parseAddrIP(addr.Addr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			if ipv4 == "" {
+				ipv4 = ip.String()
+			}
+		} else if ipv6 == "" && !ip.IsLinkLocalUnicast() {
+			ipv6 = ip.String()
+		}
+	}
+	return ipv4, ipv6
+}
+
+func parseAddrIP(addr string) net.IP {
+	if ip, _, err := net.ParseCIDR(addr); err == nil {
+		return ip
+	}
+	return net.ParseIP(addr)
+}
+
+// soleVPNSignal returns the single specific (non-generic) provider that has a
+// running service/process, if exactly one exists. When zero or many are
+// running we can't safely map a generic tunnel to a provider, so it stays
+// generic.
+func soleVPNSignal(signals map[string]string) (string, string, bool) {
+	var provider, source string
+	count := 0
+	for p, s := range signals {
+		if p == vpnGeneric {
+			continue
+		}
+		provider, source = p, s
+		count++
+	}
+	if count == 1 {
+		return provider, source, true
+	}
+	return "", "", false
+}
+
+// runningVPNSignals merges cross-platform process signals with per-OS service
+// signals into provider -> detection-source. Service signals take precedence
+// for the source label when both fire.
+func runningVPNSignals() map[string]string {
+	signals := make(map[string]string)
+	for provider := range runningVPNProcesses() {
+		signals[provider] = vpnSourceProcess
+	}
+	for provider := range vpnServiceSignals() {
+		signals[provider] = vpnSourceService
+	}
+	return signals
+}
+
+// vpnProcessSignatures maps a provider to lowercase process-name tokens. Match
+// is exact or substring against the process base name (.exe stripped).
+var vpnProcessSignatures = map[string][]string{
+	vpnWireGuard:      {"wireguard", "wg-quick"},
+	vpnTailscale:      {"tailscaled", "tailscale"},
+	vpnNetBird:        {"netbird"},
+	vpnZeroTier:       {"zerotier-one", "zerotier_one", "zerotier"},
+	vpnOpenVPN:        {"openvpn"},
+	vpnCloudflareWARP: {"warp-svc", "cloudflarewarp"},
+}
+
+func runningVPNProcesses() map[string]bool {
+	found := make(map[string]bool)
+	procs, err := process.Processes()
+	if err != nil {
+		return found
+	}
+	for _, p := range procs {
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+		ln := strings.TrimSuffix(strings.ToLower(name), ".exe")
+		for provider, sigs := range vpnProcessSignatures {
+			for _, sig := range sigs {
+				if strings.Contains(ln, sig) {
+					found[provider] = true
+					break
+				}
+			}
+		}
+	}
+	return found
+}
+
+// vpnServiceSignatures maps a provider to lowercase tokens matched against a
+// running-services listing (per-OS command output). Kept broad because service
+// names vary (e.g. "WireGuardTunnel$home", "OpenVPNServiceInteractive").
+var vpnServiceSignatures = map[string][]string{
+	vpnWireGuard:      {"wireguard", "wg-quick"},
+	vpnTailscale:      {"tailscale"},
+	vpnNetBird:        {"netbird"},
+	vpnZeroTier:       {"zerotier"},
+	vpnOpenVPN:        {"openvpn"},
+	vpnCloudflareWARP: {"warp", "cloudflare"},
+}
+
+// matchVPNServiceTokens scans a running-services listing for provider tokens.
+// Pure and OS-agnostic so it can be unit-tested with canned command output.
+func matchVPNServiceTokens(servicesText string) map[string]bool {
+	lower := strings.ToLower(servicesText)
+	found := make(map[string]bool)
+	for provider, sigs := range vpnServiceSignatures {
+		for _, sig := range sigs {
+			if strings.Contains(lower, sig) {
+				found[provider] = true
+				break
+			}
+		}
+	}
+	return found
+}
+
+// tailscaleDNSName best-effort fetches the device's Tailscale MagicDNS name.
+// Returns "" if the CLI is absent, times out, or errors — never blocks or
+// fails collection. Only the device's own DNS name is read; no peer data.
+func tailscaleDNSName() string {
+	out, err := runCollectorOutput(collectorShortCommandTimeout, "tailscale", "status", "--json")
+	if err != nil {
+		return ""
+	}
+	var status struct {
+		Self struct {
+			DNSName string `json:"DNSName"`
+		} `json:"Self"`
+	}
+	if err := json.Unmarshal(out, &status); err != nil {
+		return ""
+	}
+	return strings.TrimSuffix(status.Self.DNSName, ".")
+}

--- a/agent/internal/collectors/vpn_darwin.go
+++ b/agent/internal/collectors/vpn_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package collectors
+
+// vpnServiceSignals reports which VPN providers have a loaded launchd job.
+// Best-effort: a failed launchctl just yields no service signals — the
+// interface + process detection in vpn.go still works.
+func vpnServiceSignals() map[string]bool {
+	out, err := runCollectorOutput(collectorShortCommandTimeout, "launchctl", "list")
+	if err != nil {
+		return nil
+	}
+	return matchVPNServiceTokens(string(out))
+}

--- a/agent/internal/collectors/vpn_linux.go
+++ b/agent/internal/collectors/vpn_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package collectors
+
+// vpnServiceSignals reports which VPN providers have a running systemd service.
+// Best-effort: a failed/absent systemctl just yields no service signals — the
+// interface + process detection in vpn.go still works.
+func vpnServiceSignals() map[string]bool {
+	out, err := runCollectorOutput(collectorShortCommandTimeout,
+		"systemctl", "list-units", "--type=service", "--state=running", "--no-legend", "--plain")
+	if err != nil {
+		return nil
+	}
+	return matchVPNServiceTokens(string(out))
+}

--- a/agent/internal/collectors/vpn_other.go
+++ b/agent/internal/collectors/vpn_other.go
@@ -1,0 +1,9 @@
+//go:build !windows && !linux && !darwin
+
+package collectors
+
+// vpnServiceSignals has no per-OS service enumeration on unsupported platforms;
+// interface + process detection in vpn.go still works.
+func vpnServiceSignals() map[string]bool {
+	return nil
+}

--- a/agent/internal/collectors/vpn_test.go
+++ b/agent/internal/collectors/vpn_test.go
@@ -1,0 +1,200 @@
+package collectors
+
+import (
+	"testing"
+
+	psnet "github.com/shirou/gopsutil/v3/net"
+)
+
+func TestClassifyVPNInterface(t *testing.T) {
+	tests := []struct {
+		name         string
+		iface        string
+		wantProvider string
+		wantTunnel   bool
+	}{
+		{"tailscale linux", "tailscale0", vpnTailscale, true},
+		{"tailscale windows adapter", "Tailscale", vpnTailscale, true},
+		{"netbird", "netbird0", vpnNetBird, true},
+		{"zerotier prefix", "ztabcd1234", vpnZeroTier, true},
+		{"zerotier name", "ZeroTier One [abcd]", vpnZeroTier, true},
+		{"wireguard prefix", "wg0", vpnWireGuard, true},
+		{"wireguard name", "WireGuard Tunnel", vpnWireGuard, true},
+		{"warp", "CloudflareWARP", vpnCloudflareWARP, true},
+		{"openvpn name", "OpenVPN TAP-Windows Adapter V9", vpnOpenVPN, true},
+		{"tap-windows", "TAP-Windows Adapter V9", vpnOpenVPN, true},
+		{"generic utun", "utun3", vpnGeneric, true},
+		{"generic tun", "tun0", vpnGeneric, true},
+		{"generic tap", "tap0", vpnGeneric, true},
+		{"generic ppp", "ppp0", vpnGeneric, true},
+		{"generic wt (netbird linux)", "wt0", vpnGeneric, true},
+		{"ethernet not tunnel", "eth0", "", false},
+		{"wifi not tunnel", "wlan0", "", false},
+		{"loopback not tunnel", "lo", "", false},
+		{"windows ethernet", "Ethernet", "", false},
+		{"empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, isTunnel := classifyVPNInterface(tt.iface)
+			if isTunnel != tt.wantTunnel {
+				t.Fatalf("classifyVPNInterface(%q) tunnel = %v, want %v", tt.iface, isTunnel, tt.wantTunnel)
+			}
+			if provider != tt.wantProvider {
+				t.Errorf("classifyVPNInterface(%q) provider = %q, want %q", tt.iface, provider, tt.wantProvider)
+			}
+		})
+	}
+}
+
+func TestInterfaceIsUp(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags []string
+		want  bool
+	}{
+		{"up lowercase", []string{"up", "broadcast"}, true},
+		{"up mixed case", []string{"UP", "RUNNING"}, true},
+		{"down", []string{"broadcast", "multicast"}, false},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := interfaceIsUp(tt.flags); got != tt.want {
+				t.Errorf("interfaceIsUp(%v) = %v, want %v", tt.flags, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractVPNIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		addrs    []psnet.InterfaceAddr
+		wantIPv4 string
+		wantIPv6 string
+	}{
+		{
+			name:     "cidr ipv4",
+			addrs:    []psnet.InterfaceAddr{{Addr: "100.101.102.103/32"}},
+			wantIPv4: "100.101.102.103",
+		},
+		{
+			name:     "bare ipv4",
+			addrs:    []psnet.InterfaceAddr{{Addr: "10.8.0.2"}},
+			wantIPv4: "10.8.0.2",
+		},
+		{
+			name:     "ipv4 and global ipv6",
+			addrs:    []psnet.InterfaceAddr{{Addr: "100.64.0.1/32"}, {Addr: "fd7a:115c:a1e0::1/128"}},
+			wantIPv4: "100.64.0.1",
+			wantIPv6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:     "link-local ipv6 skipped",
+			addrs:    []psnet.InterfaceAddr{{Addr: "fe80::1/64"}},
+			wantIPv4: "",
+			wantIPv6: "",
+		},
+		{
+			name:     "first ipv4 wins",
+			addrs:    []psnet.InterfaceAddr{{Addr: "10.0.0.1/24"}, {Addr: "10.0.0.2/24"}},
+			wantIPv4: "10.0.0.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4, ipv6 := extractVPNIPs(tt.addrs)
+			if ipv4 != tt.wantIPv4 {
+				t.Errorf("ipv4 = %q, want %q", ipv4, tt.wantIPv4)
+			}
+			if ipv6 != tt.wantIPv6 {
+				t.Errorf("ipv6 = %q, want %q", ipv6, tt.wantIPv6)
+			}
+		})
+	}
+}
+
+func TestSoleVPNSignal(t *testing.T) {
+	tests := []struct {
+		name         string
+		signals      map[string]string
+		wantProvider string
+		wantSource   string
+		wantOK       bool
+	}{
+		{
+			name:         "single specific",
+			signals:      map[string]string{vpnTailscale: vpnSourceProcess},
+			wantProvider: vpnTailscale,
+			wantSource:   vpnSourceProcess,
+			wantOK:       true,
+		},
+		{
+			name:    "two specific -> ambiguous",
+			signals: map[string]string{vpnTailscale: vpnSourceProcess, vpnWireGuard: vpnSourceService},
+			wantOK:  false,
+		},
+		{
+			name:    "empty",
+			signals: map[string]string{},
+			wantOK:  false,
+		},
+		{
+			name:         "generic ignored, one specific",
+			signals:      map[string]string{vpnGeneric: vpnSourceProcess, vpnOpenVPN: vpnSourceService},
+			wantProvider: vpnOpenVPN,
+			wantSource:   vpnSourceService,
+			wantOK:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, source, ok := soleVPNSignal(tt.signals)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && (provider != tt.wantProvider || source != tt.wantSource) {
+				t.Errorf("got (%q,%q), want (%q,%q)", provider, source, tt.wantProvider, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestMatchVPNServiceTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "windows service names",
+			text: "WireGuardTunnel$home\nTailscale\nZeroTierOneService\nOpenVPNServiceInteractive\nCloudflareWARP",
+			want: []string{vpnWireGuard, vpnTailscale, vpnZeroTier, vpnOpenVPN, vpnCloudflareWARP},
+		},
+		{
+			name: "darwin launchd labels",
+			text: "com.tailscale.tailscaled\ncom.zerotier.one\ncom.cloudflare.1dot1dot1dot1.macos.warp.daemon",
+			want: []string{vpnTailscale, vpnZeroTier, vpnCloudflareWARP},
+		},
+		{
+			name: "none",
+			text: "sshd\ncron\nnginx",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchVPNServiceTokens(tt.text)
+			for _, provider := range tt.want {
+				if !got[provider] {
+					t.Errorf("expected provider %q in %v", provider, got)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d providers %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+		})
+	}
+}

--- a/agent/internal/collectors/vpn_test.go
+++ b/agent/internal/collectors/vpn_test.go
@@ -162,6 +162,110 @@ func TestSoleVPNSignal(t *testing.T) {
 	}
 }
 
+func TestAssembleVPNs(t *testing.T) {
+	noDNS := func() string { return "" }
+
+	t.Run("skips down interfaces and non-tunnels", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "eth0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.0.0.5/24"}}},
+			{Name: "wg0", Flags: []string{"broadcast"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.8.0.2/32"}}}, // down
+		}
+		if got := assembleVPNs(ifaces, map[string]string{}, noDNS); len(got) != 0 {
+			t.Fatalf("expected no VPNs, got %+v", got)
+		}
+	})
+
+	t.Run("skips up tunnel with no overlay IP (phantom guard)", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "utun4", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "fe80::1/64"}}}, // link-local only
+		}
+		if got := assembleVPNs(ifaces, map[string]string{}, noDNS); len(got) != 0 {
+			t.Fatalf("expected phantom tunnel skipped, got %+v", got)
+		}
+	})
+
+	t.Run("classified provider keeps interface source with no signals", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "wg0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.8.0.2/32"}}},
+		}
+		got := assembleVPNs(ifaces, map[string]string{}, noDNS)
+		if len(got) != 1 || got[0].Provider != vpnWireGuard || got[0].DetectionSource != vpnSourceInterface {
+			t.Fatalf("got %+v", got)
+		}
+		if got[0].IPv4 != "10.8.0.2" || !got[0].Active {
+			t.Errorf("unexpected fields %+v", got[0])
+		}
+	})
+
+	t.Run("classified provider source upgraded by corroborating signal", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "wg0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.8.0.2/32"}}},
+		}
+		got := assembleVPNs(ifaces, map[string]string{vpnWireGuard: vpnSourceService}, noDNS)
+		if len(got) != 1 || got[0].DetectionSource != vpnSourceService {
+			t.Fatalf("expected source upgraded to service, got %+v", got)
+		}
+	})
+
+	t.Run("generic tunnel promoted to sole signal provider", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "utun3", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "100.64.0.1/32"}}},
+		}
+		got := assembleVPNs(ifaces, map[string]string{vpnOpenVPN: vpnSourceProcess}, noDNS)
+		if len(got) != 1 || got[0].Provider != vpnOpenVPN || got[0].DetectionSource != vpnSourceProcess {
+			t.Fatalf("expected generic promoted to openvpn/process, got %+v", got)
+		}
+	})
+
+	t.Run("generic tunnel stays generic when signals ambiguous", func(t *testing.T) {
+		ifaces := []psnet.InterfaceStat{
+			{Name: "utun3", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "100.64.0.1/32"}}},
+		}
+		signals := map[string]string{vpnOpenVPN: vpnSourceProcess, vpnWireGuard: vpnSourceService}
+		got := assembleVPNs(ifaces, signals, noDNS)
+		if len(got) != 1 || got[0].Provider != vpnGeneric || got[0].DetectionSource != vpnSourceInterface {
+			t.Fatalf("expected generic/interface when ambiguous, got %+v", got)
+		}
+	})
+
+	t.Run("tailscale DNS fetched once and attached only to tailscale", func(t *testing.T) {
+		calls := 0
+		dnsFn := func() string { calls++; return "host.tailnet.ts.net" }
+		ifaces := []psnet.InterfaceStat{
+			{Name: "tailscale0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "100.64.0.1/32"}}},
+			{Name: "tailscale1", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "100.64.0.2/32"}}},
+			{Name: "wg0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.8.0.2/32"}}},
+		}
+		got := assembleVPNs(ifaces, map[string]string{}, dnsFn)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 VPNs, got %d", len(got))
+		}
+		if calls != 1 {
+			t.Errorf("expected dnsFn called once, got %d", calls)
+		}
+		for _, v := range got {
+			if v.Provider == vpnTailscale && v.DNSName != "host.tailnet.ts.net" {
+				t.Errorf("tailscale entry missing DNS name: %+v", v)
+			}
+			if v.Provider == vpnWireGuard && v.DNSName != "" {
+				t.Errorf("non-tailscale entry should not carry DNS name: %+v", v)
+			}
+		}
+	})
+
+	t.Run("dnsFn not called when no tailscale present", func(t *testing.T) {
+		calls := 0
+		dnsFn := func() string { calls++; return "x" }
+		ifaces := []psnet.InterfaceStat{
+			{Name: "wg0", Flags: []string{"up"}, Addrs: []psnet.InterfaceAddr{{Addr: "10.8.0.2/32"}}},
+		}
+		assembleVPNs(ifaces, map[string]string{}, dnsFn)
+		if calls != 0 {
+			t.Errorf("expected dnsFn not called, got %d", calls)
+		}
+	})
+}
+
 func TestMatchVPNServiceTokens(t *testing.T) {
 	tests := []struct {
 		name string

--- a/agent/internal/collectors/vpn_windows.go
+++ b/agent/internal/collectors/vpn_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package collectors
+
+// vpnServiceSignals reports which VPN providers have a running Windows service.
+// Best-effort: a failed PowerShell call just yields no service signals — the
+// interface + process detection in vpn.go still works.
+func vpnServiceSignals() map[string]bool {
+	out, err := runCollectorOutput(collectorShortCommandTimeout,
+		"powershell", "-NoProfile", "-NonInteractive", "-Command",
+		utf8PowerShellCommand("Get-Service | Where-Object {$_.Status -eq 'Running'} | Select-Object -ExpandProperty Name"))
+	if err != nil {
+		return nil
+	}
+	return matchVPNServiceTokens(string(out))
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1411,23 +1411,29 @@ func (h *Heartbeat) sendNetworkInventory() {
 
 	// Active-VPN-client presence (#2139) rides along with the network payload
 	// on the same cached-inventory cadence. Non-fatal: if VPN detection fails
-	// we still ship the adapter list, just without VPN telemetry.
-	var vpns []collectors.VpnPresence
+	// we still ship the adapter list. Crucially we OMIT the `vpns` key on
+	// failure rather than sending `[]` — an empty array means "collected, no
+	// active VPN", and the API only overwrites the stored snapshot when the key
+	// is present, so a transient failure preserves last-known state instead of
+	// clobbering a live tunnel to "no VPN".
+	payload := map[string]any{"adapters": adapters}
+	vpnLabel := "vpns skipped"
 	if h.vpnCol != nil {
 		if detected, vErr := h.vpnCol.Collect(); vErr != nil {
 			log.Warn("failed to collect VPN presence", "error", vErr.Error())
 		} else {
-			vpns = detected
+			if detected == nil {
+				detected = []collectors.VpnPresence{}
+			}
+			payload["vpns"] = detected
+			vpnLabel = fmt.Sprintf("%d vpns", len(detected))
 		}
-	}
-	if vpns == nil {
-		vpns = []collectors.VpnPresence{}
 	}
 
 	h.sendInventoryData(
 		"network",
-		map[string]any{"adapters": adapters, "vpns": vpns},
-		fmt.Sprintf("network (%d adapters, %d vpns)", len(adapters), len(vpns)),
+		payload,
+		fmt.Sprintf("network (%d adapters, %s)", len(adapters), vpnLabel),
 	)
 }
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -139,6 +139,7 @@ type Heartbeat struct {
 	hardwareCol           *collectors.HardwareCollector
 	softwareCol           *collectors.SoftwareCollector
 	inventoryCol          *collectors.InventoryCollector
+	vpnCol                *collectors.VPNCollector
 	changeTrackerCol      *collectors.ChangeTrackerCollector
 	sessionCol            *collectors.SessionCollector
 	policyStateCol        *collectors.PolicyStateCollector
@@ -387,6 +388,7 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 		hardwareCol:  collectors.NewHardwareCollector(),
 		softwareCol:  collectors.NewSoftwareCollector(),
 		inventoryCol: collectors.NewInventoryCollector(),
+		vpnCol:       collectors.NewVPNCollector(),
 		changeTrackerCol: collectors.NewChangeTrackerCollector(
 			filepath.Join(config.GetDataDir(), "change_tracker_snapshot.json"),
 		),
@@ -1407,7 +1409,26 @@ func (h *Heartbeat) sendNetworkInventory() {
 		return
 	}
 
-	h.sendInventoryData("network", map[string]any{"adapters": adapters}, fmt.Sprintf("network (%d adapters)", len(adapters)))
+	// Active-VPN-client presence (#2139) rides along with the network payload
+	// on the same cached-inventory cadence. Non-fatal: if VPN detection fails
+	// we still ship the adapter list, just without VPN telemetry.
+	var vpns []collectors.VpnPresence
+	if h.vpnCol != nil {
+		if detected, vErr := h.vpnCol.Collect(); vErr != nil {
+			log.Warn("failed to collect VPN presence", "error", vErr.Error())
+		} else {
+			vpns = detected
+		}
+	}
+	if vpns == nil {
+		vpns = []collectors.VpnPresence{}
+	}
+
+	h.sendInventoryData(
+		"network",
+		map[string]any{"adapters": adapters, "vpns": vpns},
+		fmt.Sprintf("network (%d adapters, %d vpns)", len(adapters), len(vpns)),
+	)
 }
 
 func (h *Heartbeat) sendConfigurationChanges() {

--- a/apps/api/migrations/2026-07-09-device-active-vpns.sql
+++ b/apps/api/migrations/2026-07-09-device-active-vpns.sql
@@ -1,0 +1,19 @@
+-- Active-VPN-client presence telemetry for devices (#2139).
+--
+-- Stores the latest set of active VPN overlay clients reported by the agent's
+-- periodic network inventory as a jsonb array on the devices row, alongside
+-- other per-report current state (battery_status, uptime_seconds,
+-- pending_reboot). Not a new tenant-scoped table — the devices table already
+-- carries org_id + forced RLS — so no policy changes are needed here.
+--
+-- Shape (see VpnPresence in packages/shared):
+--   [{ provider, active, interfaceName, ipv4?, ipv6?, dnsName?,
+--      detectionSource, reportedAt }, ...]
+-- null column = agent has never reported (old agent)
+-- []          = reported, no active VPN detected
+--
+-- Read-only telemetry: no secrets, peer lists, keys, or VPN management.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS makes re-application a no-op.
+
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS active_vpns jsonb;

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -1,7 +1,7 @@
 import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, real, bigint, date, primaryKey, index, unique } from 'drizzle-orm/pg-core';
 import { organizations, sites } from './orgs';
 import { users } from './users';
-import type { BatteryStatus, DesktopAccessState, InterfaceBandwidth, TCCPermissions } from '@breeze/shared';
+import type { BatteryStatus, DesktopAccessState, InterfaceBandwidth, TCCPermissions, VpnPresence } from '@breeze/shared';
 
 export const osTypeEnum = pgEnum('os_type', ['windows', 'macos', 'linux']);
 export const deviceStatusEnum = pgEnum('device_status', ['online', 'offline', 'maintenance', 'decommissioned', 'quarantined', 'updating', 'pending']);
@@ -86,6 +86,13 @@ export const devices = pgTable('devices', {
   // no-battery desktop. Backs the optional "Power" list column and the
   // device-detail Power section.
   batteryStatus: jsonb('battery_status').$type<BatteryStatus | null>(),
+  // Active-VPN-client presence snapshot from the agent's periodic network
+  // inventory (#2139). Latest value only — fully replaced each network report,
+  // stored next to batteryStatus rather than in a time-series/child table.
+  // null when the agent has never reported (old agent); [] when reported with
+  // no active VPN. Backs the optional "VPN" list column and the device-detail
+  // VPN section. Read-only telemetry — no secrets/peers/keys.
+  activeVpns: jsonb('active_vpns').$type<VpnPresence[] | null>(),
   watchdogStatus: watchdogStatusEnum('watchdog_status'),
   watchdogLastSeen: timestamp('watchdog_last_seen'),
   watchdogVersion: varchar('watchdog_version', { length: 50 }),

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -190,20 +190,25 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
 
   const now = new Date();
 
-  // Active-VPN-client presence snapshot (#2139). Stamp reportedAt server-side
-  // per entry (agents don't send it) and store the latest snapshot on the
-  // devices row. `[]` = reported with no active VPN (distinct from a null
-  // column = never reported). Written in the same txn as the adapter replace.
-  const activeVpns = (data.vpns ?? []).map((vpn) => ({
-    provider: vpn.provider,
-    active: vpn.active,
-    interfaceName: vpn.interfaceName,
-    ipv4: vpn.ipv4,
-    ipv6: vpn.ipv6,
-    dnsName: vpn.dnsName,
-    detectionSource: vpn.detectionSource,
-    reportedAt: now.toISOString()
-  }));
+  // Active-VPN-client presence snapshot (#2139). Only present when the agent
+  // successfully collected VPN state — a failed collection OMITS the key (see
+  // sendNetworkInventory) so we DON'T overwrite the stored snapshot and clobber
+  // a live tunnel to "no VPN". We stamp reportedAt server-side per entry.
+  // Semantics of the stored column: null = never successfully reported (old
+  // agent or every collection failed); [] = reported with no active VPN.
+  const vpnProvided = data.vpns !== undefined;
+  const activeVpns = vpnProvided
+    ? data.vpns!.map((vpn) => ({
+        provider: vpn.provider,
+        active: vpn.active,
+        interfaceName: vpn.interfaceName,
+        ipv4: vpn.ipv4,
+        ipv6: vpn.ipv6,
+        dnsName: vpn.dnsName,
+        detectionSource: vpn.detectionSource,
+        reportedAt: now.toISOString()
+      }))
+    : null;
 
   await db.transaction(async (tx) => {
     await tx
@@ -225,13 +230,22 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
       );
     }
 
-    await tx
-      .update(devices)
-      .set({ activeVpns, updatedAt: now })
-      .where(eq(devices.id, device.id));
+    // Leave devices.activeVpns untouched when the agent didn't report VPN
+    // state, so an old agent (or a transient collection failure) never
+    // overwrites last-known-good.
+    if (vpnProvided) {
+      await tx
+        .update(devices)
+        .set({ activeVpns, updatedAt: now })
+        .where(eq(devices.id, device.id));
+    }
   });
 
-  return c.json({ success: true, count: data.adapters.length, vpnCount: activeVpns.length });
+  return c.json({
+    success: true,
+    count: data.adapters.length,
+    vpnCount: vpnProvided ? activeVpns!.length : null
+  });
 });
 
 // PUT /:id/warranty-info — agent reports locally-collected warranty data (e.g. Apple plist)

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -188,13 +188,29 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
     return c.json({ error: 'Device not found' }, 404);
   }
 
+  const now = new Date();
+
+  // Active-VPN-client presence snapshot (#2139). Stamp reportedAt server-side
+  // per entry (agents don't send it) and store the latest snapshot on the
+  // devices row. `[]` = reported with no active VPN (distinct from a null
+  // column = never reported). Written in the same txn as the adapter replace.
+  const activeVpns = (data.vpns ?? []).map((vpn) => ({
+    provider: vpn.provider,
+    active: vpn.active,
+    interfaceName: vpn.interfaceName,
+    ipv4: vpn.ipv4,
+    ipv6: vpn.ipv6,
+    dnsName: vpn.dnsName,
+    detectionSource: vpn.detectionSource,
+    reportedAt: now.toISOString()
+  }));
+
   await db.transaction(async (tx) => {
     await tx
       .delete(deviceNetwork)
       .where(eq(deviceNetwork.deviceId, device.id));
 
     if (data.adapters.length > 0) {
-      const now = new Date();
       await tx.insert(deviceNetwork).values(
         data.adapters.map((adapter) => ({
           deviceId: device.id,
@@ -208,9 +224,14 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
         }))
       );
     }
+
+    await tx
+      .update(devices)
+      .set({ activeVpns, updatedAt: now })
+      .where(eq(devices.id, device.id));
   });
 
-  return c.json({ success: true, count: data.adapters.length });
+  return c.json({ success: true, count: data.adapters.length, vpnCount: activeVpns.length });
 });
 
 // PUT /:id/warranty-info — agent reports locally-collected warranty data (e.g. Apple plist)

--- a/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
+++ b/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
@@ -41,14 +41,16 @@ function mockDeviceLookup(device: { id: string; orgId: string } | null) {
 }
 
 // Capture what the handler writes to devices.activeVpns inside the txn.
+// `updateCalled` distinguishes "wrote []" from "never touched the column".
 function mockTransactionCapture() {
-  const captured: { activeVpns?: unknown } = {};
+  const captured: { activeVpns?: unknown; updateCalled: boolean } = { updateCalled: false };
   vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
     const tx = {
       delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
       insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
       update: vi.fn().mockReturnValue({
         set: vi.fn().mockImplementation((row: { activeVpns?: unknown }) => {
+          captured.updateCalled = true;
           captured.activeVpns = row.activeVpns;
           return { where: vi.fn().mockResolvedValue(undefined) };
         }),
@@ -106,7 +108,8 @@ describe('agent network inventory — VPN presence ingest (#2139)', () => {
 
     const stored = captured.activeVpns as Array<Record<string, unknown>>;
     expect(stored).toHaveLength(1);
-    expect(stored[0]).toMatchObject({
+    const [entry] = stored;
+    expect(entry).toMatchObject({
       provider: 'tailscale',
       active: true,
       interfaceName: 'utun3',
@@ -115,11 +118,11 @@ describe('agent network inventory — VPN presence ingest (#2139)', () => {
       detectionSource: 'interface',
     });
     // reportedAt is stamped by the API, not sent by the agent.
-    expect(typeof stored[0].reportedAt).toBe('string');
-    expect(Number.isNaN(Date.parse(stored[0].reportedAt as string))).toBe(false);
+    expect(typeof entry!.reportedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(entry!.reportedAt as string))).toBe(false);
   });
 
-  it('stores an empty array when an older agent omits vpns', async () => {
+  it('leaves activeVpns untouched (preserving last-known) when an older agent omits vpns', async () => {
     mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
     const captured = mockTransactionCapture();
 
@@ -128,7 +131,24 @@ describe('agent network inventory — VPN presence ingest (#2139)', () => {
     });
 
     expect(res.status).toBe(200);
+    // Omitted key -> no clobber, and no devices update at all.
+    expect((await res.json()).vpnCount).toBeNull();
+    expect(captured.updateCalled).toBe(false);
+  });
+
+  it('stores an empty array when the agent reports zero active VPNs', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const captured = mockTransactionCapture();
+
+    const res = await putNetwork(makeApp(), {
+      adapters: [{ interfaceName: 'eth0', ipAddress: '10.0.0.5', ipType: 'ipv4' }],
+      vpns: [],
+    });
+
+    expect(res.status).toBe(200);
+    // Explicit [] -> "collected, no active VPN": the column IS written to [].
     expect((await res.json()).vpnCount).toBe(0);
+    expect(captured.updateCalled).toBe(true);
     expect(captured.activeVpns).toEqual([]);
   });
 

--- a/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
+++ b/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Active-VPN-client presence ingest via PUT /:id/network (#2139). Verifies the
+// handler stamps reportedAt server-side and persists the snapshot to
+// devices.activeVpns, that old agents (no `vpns`) store an empty array, and
+// that the payload validator rejects unknown providers.
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    transaction: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+vi.mock('../../services/warrantySync', () => ({ upsertAgentWarranty: vi.fn() }));
+vi.mock('../../services/warrantyWorker', () => ({
+  queueWarrantySyncForDevice: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from '../../db';
+import { inventoryRoutes } from './inventory';
+
+function mockDeviceLookup(device: { id: string; orgId: string } | null) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(device ? [device] : []),
+      }),
+    }),
+  } as any);
+}
+
+// Capture what the handler writes to devices.activeVpns inside the txn.
+function mockTransactionCapture() {
+  const captured: { activeVpns?: unknown } = {};
+  vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
+    const tx = {
+      delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((row: { activeVpns?: unknown }) => {
+          captured.activeVpns = row.activeVpns;
+          return { where: vi.fn().mockResolvedValue(undefined) };
+        }),
+      }),
+    };
+    return fn(tx);
+  });
+  return captured;
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.use('*', async (c: any, next: any) => {
+    c.set('agent', { orgId: 'org-1', agentId: 'agent-1', role: 'agent' });
+    await next();
+  });
+  app.route('/agents', inventoryRoutes);
+  return app;
+}
+
+function putNetwork(app: Hono, body: Record<string, unknown>) {
+  return app.request('/agents/agent-1/network', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('agent network inventory — VPN presence ingest (#2139)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists reported VPNs to devices.activeVpns and stamps reportedAt', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const captured = mockTransactionCapture();
+
+    const res = await putNetwork(makeApp(), {
+      adapters: [{ interfaceName: 'en0', ipAddress: '192.168.1.10', ipType: 'ipv4', isPrimary: true }],
+      vpns: [
+        {
+          provider: 'tailscale',
+          active: true,
+          interfaceName: 'utun3',
+          ipv4: '100.101.102.103',
+          dnsName: 'host.tailnet.ts.net',
+          detectionSource: 'interface',
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vpnCount).toBe(1);
+
+    const stored = captured.activeVpns as Array<Record<string, unknown>>;
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      provider: 'tailscale',
+      active: true,
+      interfaceName: 'utun3',
+      ipv4: '100.101.102.103',
+      dnsName: 'host.tailnet.ts.net',
+      detectionSource: 'interface',
+    });
+    // reportedAt is stamped by the API, not sent by the agent.
+    expect(typeof stored[0].reportedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(stored[0].reportedAt as string))).toBe(false);
+  });
+
+  it('stores an empty array when an older agent omits vpns', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const captured = mockTransactionCapture();
+
+    const res = await putNetwork(makeApp(), {
+      adapters: [{ interfaceName: 'eth0', ipAddress: '10.0.0.5', ipType: 'ipv4' }],
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).vpnCount).toBe(0);
+    expect(captured.activeVpns).toEqual([]);
+  });
+
+  it('rejects an unknown VPN provider (validator)', async () => {
+    // zValidator rejects before the handler runs — no db mocks needed, and
+    // queuing a device lookup here would leak into the next test.
+    const res = await putNetwork(makeApp(), {
+      adapters: [],
+      vpns: [{ provider: 'nordvpn', active: true, interfaceName: 'utun9', detectionSource: 'interface' }],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 and does not open a txn when the device is unknown', async () => {
+    mockDeviceLookup(null);
+
+    const res = await putNetwork(makeApp(), { adapters: [], vpns: [] });
+
+    expect(res.status).toBe(404);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { isIP } from 'node:net';
+import { vpnPresenceIngestSchema } from '@breeze/shared';
 
 // ============================================
 // Enrollment
@@ -448,7 +449,10 @@ export const updateNetworkSchema = z.object({
     ipAddress: z.string().optional(),
     ipType: z.enum(['ipv4', 'ipv6']).optional(),
     isPrimary: z.boolean().optional()
-  })).max(100)
+  })).max(100),
+  // Active-VPN-client presence (#2139). Optional so older agents that don't
+  // report VPNs still validate. The API stamps reportedAt per entry on ingest.
+  vpns: z.array(vpnPresenceIngestSchema).max(50).optional()
 });
 
 // ============================================

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -539,6 +539,7 @@ coreRoutes.get(
         isHeadless: devices.isHeadless,
         pendingReboot: devices.pendingReboot,
         batteryStatus: devices.batteryStatus,
+        activeVpns: devices.activeVpns,
         createdAt: devices.createdAt,
         updatedAt: devices.updatedAt,
         // Hardware summary
@@ -656,6 +657,7 @@ coreRoutes.get(
         uptimeSeconds: d.uptimeSeconds,
         isHeadless: d.isHeadless,
         batteryStatus: d.batteryStatus ?? null,
+        activeVpns: d.activeVpns ?? null,
         createdAt: d.createdAt,
         updatedAt: d.updatedAt,
         cpuPercent: latestMetrics?.cpuPercent ?? 0,

--- a/apps/web/src/components/devices/DeviceInfoTab.tsx
+++ b/apps/web/src/components/devices/DeviceInfoTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Monitor, Cpu, Shield, Tag, Info, ListChecks, Pencil, Check, X, AlertTriangle, BatteryCharging } from 'lucide-react';
-import type { BatteryStatus, DesktopAccessState, TCCPermissions } from '@breeze/shared';
+import { Monitor, Cpu, Shield, Tag, Info, ListChecks, Pencil, Check, X, AlertTriangle, BatteryCharging, Lock } from 'lucide-react';
+import type { BatteryStatus, DesktopAccessState, TCCPermissions, VpnPresence } from '@breeze/shared';
+import { activeVpnList, getVpnProviderLabel, getVpnProviderIcon } from '@/lib/vpnProviders';
 import MacOSPermissionsCard from './MacOSPermissionsCard';
 import { fetchWithAuth } from '../../stores/auth';
 import { formatUptime } from '../../lib/utils';
@@ -51,6 +52,7 @@ type DeviceInfo = {
   tccPermissions?: TCCPermissions | null;
   desktopAccess?: DesktopAccessState | null;
   batteryStatus?: BatteryStatus | null;
+  activeVpns?: VpnPresence[] | null;
   hardware?: {
     serialNumber?: string | null;
     manufacturer?: string | null;
@@ -744,6 +746,42 @@ export default function DeviceInfoTab({ deviceId }: DeviceInfoTabProps) {
           <InfoRow label="Last Reported" value={formatDate(info.batteryStatus.reportedAt)} />
         </Section>
       )}
+
+      {/* Active VPN clients (#2139) — full list from cached network inventory.
+          Only rendered when at least one active VPN was reported. */}
+      {(() => {
+        const vpns = activeVpnList(info?.activeVpns);
+        if (vpns.length === 0) return null;
+        return (
+          <Section title="VPN" icon={<Lock className="h-4 w-4 text-muted-foreground" />}>
+            <div className="space-y-4" data-testid="device-vpn-section">
+              {vpns.map((vpn) => {
+                const Icon = getVpnProviderIcon(vpn.provider);
+                return (
+                  <div
+                    key={`${vpn.provider}:${vpn.interfaceName}`}
+                    className="rounded-md border p-3"
+                    data-testid={`device-vpn-row-${vpn.provider}`}
+                  >
+                    <div className="mb-2 flex items-center gap-2">
+                      <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                      <span className="text-sm font-semibold">{getVpnProviderLabel(vpn.provider)}</span>
+                    </div>
+                    <dl className="divide-y">
+                      <InfoRow label="Interface" value={vpn.interfaceName} />
+                      {vpn.ipv4 && <InfoRow label="VPN IPv4" value={vpn.ipv4} />}
+                      {vpn.ipv6 && <InfoRow label="VPN IPv6" value={vpn.ipv6} />}
+                      {vpn.dnsName && <InfoRow label="VPN DNS Name" value={vpn.dnsName} />}
+                      <InfoRow label="Detection Source" value={vpn.detectionSource} />
+                      <InfoRow label="Last Reported" value={formatDate(vpn.reportedAt)} />
+                    </dl>
+                  </div>
+                );
+              })}
+            </div>
+          </Section>
+        );
+      })()}
 
       <Section title="Agent" icon={<Shield className="h-4 w-4 text-muted-foreground" />}>
         <InfoRow label="Agent Version" value={info?.agentVersion ?? '—'} />

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -1,11 +1,18 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, ArrowUpDown, MoreHorizontal, MoreVertical, Filter, Terminal, FileCode, RotateCcw, Settings, Trash2, Zap, Columns3, Network, Cpu, Battery, BatteryCharging, BatteryWarning, Plug } from 'lucide-react';
-import type { BatteryStatus, DesktopAccessState, RemoteAccessPolicy } from '@breeze/shared';
+import type { BatteryStatus, DesktopAccessState, RemoteAccessPolicy, VpnPresence } from '@breeze/shared';
 import ConnectDesktopButton from '../remote/ConnectDesktopButton';
 import { widthPercentClass, formatUptime } from '@/lib/utils';
 import { formatLastSeen } from '@/lib/formatTime';
 import { getDeviceRoleLabel, getDeviceRoleIcon, type DeviceRole } from '@/lib/deviceRoles';
+import {
+  activeVpnList,
+  getVpnProviderIcon,
+  getVpnProviderLabel,
+  getVpnProviderBadgeClass,
+  formatVpnTooltip,
+} from '@/lib/vpnProviders';
 import {
   PAGE_SIZE_OPTIONS,
   readPageSizePreference,
@@ -123,6 +130,13 @@ export type Device = {
    * dash. { present: false } = a real no-battery desktop → also a dash.
    */
   batteryStatus?: BatteryStatus | null;
+  /**
+   * Active-VPN-client presence snapshot (#2139). null/undefined = no data
+   * reported yet (old agent or network device) → the VPN column renders a
+   * dash. [] = reported with no active VPN → also a dash. Rendered purely
+   * from cached inventory — the list never fans out live commands.
+   */
+  activeVpns?: VpnPresence[] | null;
 };
 
 // Columns that only make sense for the network arm (#1322); hidden unless
@@ -311,6 +325,12 @@ const sortValue: Record<ColumnId, (d: Device) => string | number | null> = {
   // No computed score yet (newly enrolled / pre-worker, or a network device)
   // sorts as a blank-last null to match the dash the cell renders (#1284).
   reliability: d => (typeof d.reliabilityScore === 'number' ? d.reliabilityScore : null),
+  // Sort by the first active VPN's provider label; devices with no active VPN
+  // sort blanks-last (null) to match the dash the cell renders (#1284).
+  vpn: d => {
+    const active = activeVpnList(d.activeVpns);
+    return active.length > 0 ? getVpnProviderLabel(active[0].provider) : null;
+  },
 };
 
 export default function DeviceList({
@@ -342,6 +362,10 @@ export default function DeviceList({
   // Unified-list class facet (#1322): All / Agent-managed / Network. Kept
   // local to DeviceList (it lives next to the count, not in the toolbar).
   const [classFilter, setClassFilter] = useState<'all' | 'agent' | 'network'>('all');
+  // Client-side VPN facet (#2139): 'all' | 'any' (any active VPN) | a provider
+  // id. Operates on already-loaded cached inventory, mirroring the class facet
+  // — no server round-trip, no live command fan-out.
+  const [vpnFilter, setVpnFilter] = useState<'all' | 'any' | string>('all');
   const [currentPage, setCurrentPage] = useState(1);
   // Live, user-controllable page size. Initialized from localStorage; the
   // pageSize prop is just the fallback when no preference is stored.
@@ -464,7 +488,7 @@ export default function DeviceList({
   // lived on each filter input before the toolbar was extracted.
   useEffect(() => {
     setCurrentPage(1);
-  }, [query, classFilter, serverFilterIds]);
+  }, [query, classFilter, vpnFilter, serverFilterIds]);
 
   const filteredDevices = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -486,14 +510,43 @@ export default function DeviceList({
       const deviceClass = device.deviceClass ?? 'agent';
       const matchesClass = classFilter === 'all' ? true : deviceClass === classFilter;
 
+      // VPN facet (#2139): 'all' passes everything; 'any' requires ≥1 active
+      // VPN; a provider id requires that provider to be active on the device.
+      let matchesVpn = true;
+      if (vpnFilter !== 'all') {
+        const active = activeVpnList(device.activeVpns);
+        matchesVpn = vpnFilter === 'any'
+          ? active.length > 0
+          : active.some(v => v.provider === vpnFilter);
+      }
+
       const matchesQuery = normalizedQuery.length === 0
         ? true
         : device.hostname.toLowerCase().includes(normalizedQuery) ||
           (device.displayName?.toLowerCase().includes(normalizedQuery) ?? false);
 
-      return matchesClass && matchesQuery;
+      return matchesClass && matchesVpn && matchesQuery;
     });
-  }, [devices, query, classFilter, serverFilterIds, includeDecommissioned]);
+  }, [devices, query, classFilter, vpnFilter, serverFilterIds, includeDecommissioned]);
+
+  // Providers present across the loaded set — drives the VPN facet options so
+  // techs only see providers that actually exist in their fleet.
+  const availableVpnProviders = useMemo(() => {
+    const set = new Set<string>();
+    for (const device of devices) {
+      for (const vpn of activeVpnList(device.activeVpns)) set.add(vpn.provider);
+    }
+    return Array.from(set).sort((a, b) => getVpnProviderLabel(a).localeCompare(getVpnProviderLabel(b)));
+  }, [devices]);
+
+  // Reset a by-provider VPN filter back to 'all' if that provider drops out of
+  // the loaded set (e.g. the device went offline) so the facet never gets stuck
+  // on an option that matches nothing.
+  useEffect(() => {
+    if (vpnFilter !== 'all' && vpnFilter !== 'any' && !availableVpnProviders.includes(vpnFilter)) {
+      setVpnFilter('all');
+    }
+  }, [vpnFilter, availableVpnProviders]);
 
   const handleSort = (field: ColumnId) => {
     if (sortField === field) {
@@ -1129,6 +1182,54 @@ export default function DeviceList({
         );
       },
     },
+    vpn: {
+      header: () => sortHeader('vpn', 'VPN', 'Sort by VPN provider'),
+      cell: (device) => {
+        // Rendered ONLY from cached inventory (device.activeVpns) — never a
+        // live command fan-out from the table (#2139).
+        const active = activeVpnList(device.activeVpns);
+        if (active.length === 0) {
+          return (
+            <td key="vpn" className="px-3 py-3 text-sm text-muted-foreground" data-testid={`device-${device.id}-vpn`}>
+              {dash}
+            </td>
+          );
+        }
+        const VPN_CHIP_CAP = 2;
+        const shown = active.slice(0, VPN_CHIP_CAP);
+        const overflow = active.length - shown.length;
+        // Full list on the cell title so hover reveals every provider/IP/DNS.
+        const fullTitle = active.map(formatVpnTooltip).join('\n');
+        return (
+          <td key="vpn" className="px-3 py-3 text-sm whitespace-nowrap" data-testid={`device-${device.id}-vpn`}>
+            <span className="inline-flex items-center gap-1" title={fullTitle}>
+              {shown.map((vpn) => {
+                const Icon = getVpnProviderIcon(vpn.provider);
+                return (
+                  <span
+                    key={`${vpn.provider}:${vpn.interfaceName}`}
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${getVpnProviderBadgeClass(vpn.provider)}`}
+                    title={formatVpnTooltip(vpn)}
+                    data-testid={`device-${device.id}-vpn-badge-${vpn.provider}`}
+                  >
+                    <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+                    {getVpnProviderLabel(vpn.provider)}
+                  </span>
+                );
+              })}
+              {overflow > 0 && (
+                <span
+                  className="inline-flex items-center rounded-full border border-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
+                  data-testid={`device-${device.id}-vpn-overflow`}
+                >
+                  +{overflow}
+                </span>
+              )}
+            </span>
+          </td>
+        );
+      },
+    },
   };
 
   return (
@@ -1176,6 +1277,23 @@ export default function DeviceList({
                   </button>
                 ))}
               </div>
+            )}
+            {visibleColumns.has('vpn') && (
+              <select
+                aria-label="Filter by VPN"
+                data-testid="device-vpn-filter"
+                value={vpnFilter}
+                onChange={(e) => setVpnFilter(e.target.value)}
+                className="h-10 rounded-md border bg-background px-2 text-sm text-muted-foreground"
+              >
+                <option value="all">All VPN</option>
+                <option value="any">Any active VPN</option>
+                {availableVpnProviders.map((provider) => (
+                  <option key={provider} value={provider}>
+                    {getVpnProviderLabel(provider)}
+                  </option>
+                ))}
+              </select>
             )}
             {/* Interface density is now an account-wide control in the
                 top-bar theme/display menu (Header.tsx). The table still

--- a/apps/web/src/components/devices/DeviceList.vpn.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.vpn.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import DeviceList, { type Device } from './DeviceList';
+import { DEFAULT_VISIBLE_COLUMNS, writeColumnVisibility } from './columnVisibility';
+import type { VpnPresence } from '@breeze/shared';
+
+// Optional VPN column + client-side facet (#2139). Rendered purely from the
+// cached inventory carried on each Device row — no live command fan-out.
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../remote/ConnectDesktopButton', () => ({ default: () => null }));
+vi.mock('@/lib/formatTime', () => ({ formatLastSeen: () => 'just now' }));
+
+function vpn(overrides: Partial<VpnPresence>): VpnPresence {
+  return {
+    provider: 'generic',
+    active: true,
+    interfaceName: 'utun0',
+    detectionSource: 'interface',
+    reportedAt: '2026-07-09T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function device(id: string, hostname: string, activeVpns: VpnPresence[] | null): Device {
+  return {
+    id,
+    deviceClass: 'agent',
+    hostname,
+    os: 'linux',
+    osVersion: '22.04',
+    status: 'online',
+    cpuPercent: 1,
+    ramPercent: 1,
+    lastSeen: new Date().toISOString(),
+    orgId: 'org-1',
+    orgName: 'Acme',
+    siteId: 'site-1',
+    siteName: 'HQ',
+    agentVersion: '0.70.0',
+    tags: [],
+    activeVpns,
+  };
+}
+
+const tailscaleBox = device('11111111-1111-1111-1111-111111111111', 'ts-box', [
+  vpn({ provider: 'tailscale', interfaceName: 'tailscale0', ipv4: '100.64.0.1', dnsName: 'ts-box.tailnet.ts.net' }),
+]);
+const multiVpnBox = device('22222222-2222-2222-2222-222222222222', 'multi-box', [
+  vpn({ provider: 'wireguard', interfaceName: 'wg0', ipv4: '10.8.0.2' }),
+  vpn({ provider: 'openvpn', interfaceName: 'tun0', ipv4: '10.9.0.2' }),
+  vpn({ provider: 'zerotier', interfaceName: 'zt0', ipv4: '10.147.0.2' }),
+]);
+const noVpnBox = device('33333333-3333-3333-3333-333333333333', 'plain-box', []);
+
+describe('DeviceList — VPN column + facet (#2139)', () => {
+  beforeEach(() => {
+    writeColumnVisibility([...DEFAULT_VISIBLE_COLUMNS, 'vpn']);
+  });
+  afterEach(() => window.localStorage.clear());
+
+  it('renders a provider badge for an active VPN and a dash for none', () => {
+    render(<DeviceList devices={[tailscaleBox, noVpnBox]} pageSize={50} />);
+
+    const tsCell = screen.getByTestId(`device-${tailscaleBox.id}-vpn`);
+    expect(within(tsCell).getByTestId(`device-${tailscaleBox.id}-vpn-badge-tailscale`).textContent).toMatch(/Tailscale/);
+    // Tooltip carries interface + IP + DNS.
+    expect(tsCell.querySelector('[title]')?.getAttribute('title')).toContain('ts-box.tailnet.ts.net');
+
+    const noneCell = screen.getByTestId(`device-${noVpnBox.id}-vpn`);
+    expect(within(noneCell).queryByTestId(`device-${noVpnBox.id}-vpn-badge-tailscale`)).toBeNull();
+    expect(noneCell.textContent).toContain('—');
+  });
+
+  it('caps badges at 2 and shows a +N overflow indicator', () => {
+    render(<DeviceList devices={[multiVpnBox]} pageSize={50} />);
+
+    const cell = screen.getByTestId(`device-${multiVpnBox.id}-vpn`);
+    // Sorted by label: OpenVPN, WireGuard shown; ZeroTier overflows.
+    expect(within(cell).getByTestId(`device-${multiVpnBox.id}-vpn-badge-openvpn`)).toBeTruthy();
+    expect(within(cell).getByTestId(`device-${multiVpnBox.id}-vpn-badge-wireguard`)).toBeTruthy();
+    expect(within(cell).queryByTestId(`device-${multiVpnBox.id}-vpn-badge-zerotier`)).toBeNull();
+    expect(within(cell).getByTestId(`device-${multiVpnBox.id}-vpn-overflow`).textContent).toBe('+1');
+  });
+
+  it('facet "any active VPN" hides devices without a VPN', () => {
+    render(<DeviceList devices={[tailscaleBox, noVpnBox]} pageSize={50} />);
+
+    expect(screen.getByText('ts-box')).toBeTruthy();
+    expect(screen.getByText('plain-box')).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId('device-vpn-filter'), { target: { value: 'any' } });
+
+    expect(screen.getByText('ts-box')).toBeTruthy();
+    expect(screen.queryByText('plain-box')).toBeNull();
+  });
+
+  it('facet by-provider shows only devices running that provider', () => {
+    render(<DeviceList devices={[tailscaleBox, multiVpnBox, noVpnBox]} pageSize={50} />);
+
+    fireEvent.change(screen.getByTestId('device-vpn-filter'), { target: { value: 'wireguard' } });
+
+    expect(screen.getByText('multi-box')).toBeTruthy();
+    expect(screen.queryByText('ts-box')).toBeNull();
+    expect(screen.queryByText('plain-box')).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -320,6 +320,7 @@ export default function DevicesPage() {
           isHeadless: typeof d.isHeadless === 'boolean' ? d.isHeadless : undefined,
           pendingReboot: d.pendingReboot === true,
           batteryStatus: (d.batteryStatus as Device['batteryStatus']) ?? null,
+          activeVpns: (d.activeVpns as Device['activeVpns']) ?? null,
           enrolledAt: d.enrolledAt as string | undefined,
           desktopAccess: (d.desktopAccess as Device['desktopAccess']) ?? null,
           hardware: hardware ? {

--- a/apps/web/src/components/devices/columnVisibility.ts
+++ b/apps/web/src/components/devices/columnVisibility.ts
@@ -36,6 +36,7 @@ export const COLUMN_IDS = [
   'enrolled',
   'desktopAccess',
   'reliability',
+  'vpn',
 ] as const;
 
 export type ColumnId = (typeof COLUMN_IDS)[number];
@@ -70,6 +71,7 @@ export const COLUMN_LABELS: Record<ColumnId, string> = {
   enrolled: 'Enrolled',
   desktopAccess: 'Desktop Access',
   reliability: 'Reliability',
+  vpn: 'VPN',
 };
 
 export const DEFAULT_VISIBLE_COLUMNS: ReadonlyArray<ColumnId> = [

--- a/apps/web/src/lib/vpnProviders.test.ts
+++ b/apps/web/src/lib/vpnProviders.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { VpnPresence } from '@breeze/shared';
+import {
+  getVpnProviderLabel,
+  getVpnProviderBadgeClass,
+  activeVpnList,
+  activeVpnProviders,
+  formatVpnTooltip,
+} from './vpnProviders';
+
+function vpn(overrides: Partial<VpnPresence>): VpnPresence {
+  return {
+    provider: 'generic',
+    active: true,
+    interfaceName: 'utun0',
+    detectionSource: 'interface',
+    reportedAt: '2026-07-09T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('getVpnProviderLabel', () => {
+  it('maps known providers to display labels', () => {
+    expect(getVpnProviderLabel('wireguard')).toBe('WireGuard');
+    expect(getVpnProviderLabel('cloudflare-warp')).toBe('Cloudflare WARP');
+    expect(getVpnProviderLabel('generic')).toBe('VPN');
+  });
+
+  it('falls back to the generic label for unknown providers', () => {
+    expect(getVpnProviderLabel('nordvpn')).toBe('VPN');
+  });
+});
+
+describe('getVpnProviderBadgeClass', () => {
+  it('returns a class string for known and unknown providers', () => {
+    expect(getVpnProviderBadgeClass('tailscale')).toContain('indigo');
+    // unknown -> generic fallback, still a non-empty class string
+    expect(getVpnProviderBadgeClass('mystery')).toBe(getVpnProviderBadgeClass('generic'));
+  });
+});
+
+describe('activeVpnList', () => {
+  it('returns [] for null/undefined/empty', () => {
+    expect(activeVpnList(null)).toEqual([]);
+    expect(activeVpnList(undefined)).toEqual([]);
+    expect(activeVpnList([])).toEqual([]);
+  });
+
+  it('drops inactive VPNs', () => {
+    const list = activeVpnList([
+      vpn({ provider: 'wireguard', active: false }),
+      vpn({ provider: 'tailscale', active: true }),
+    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0].provider).toBe('tailscale');
+  });
+
+  it('dedupes by provider+interface', () => {
+    const list = activeVpnList([
+      vpn({ provider: 'zerotier', interfaceName: 'zt0' }),
+      vpn({ provider: 'zerotier', interfaceName: 'zt0' }),
+      vpn({ provider: 'zerotier', interfaceName: 'zt1' }),
+    ]);
+    expect(list).toHaveLength(2);
+  });
+
+  it('sorts by provider label', () => {
+    const list = activeVpnList([
+      vpn({ provider: 'wireguard', interfaceName: 'wg0' }),
+      vpn({ provider: 'openvpn', interfaceName: 'tun0' }),
+    ]);
+    expect(list.map((v) => v.provider)).toEqual(['openvpn', 'wireguard']);
+  });
+});
+
+describe('activeVpnProviders', () => {
+  it('returns distinct active provider ids', () => {
+    const providers = activeVpnProviders([
+      vpn({ provider: 'tailscale', interfaceName: 'utun3' }),
+      vpn({ provider: 'tailscale', interfaceName: 'utun4' }),
+      vpn({ provider: 'wireguard', interfaceName: 'wg0' }),
+      vpn({ provider: 'openvpn', active: false }),
+    ]);
+    expect(providers.sort()).toEqual(['tailscale', 'wireguard']);
+  });
+});
+
+describe('formatVpnTooltip', () => {
+  it('joins provider, interface and available addresses/dns', () => {
+    expect(
+      formatVpnTooltip(
+        vpn({ provider: 'tailscale', interfaceName: 'utun3', ipv4: '100.64.0.1', dnsName: 'host.ts.net' }),
+      ),
+    ).toBe('Tailscale · utun3 · 100.64.0.1 · host.ts.net');
+  });
+
+  it('omits missing optional fields', () => {
+    expect(formatVpnTooltip(vpn({ provider: 'wireguard', interfaceName: 'wg0' }))).toBe('WireGuard · wg0');
+  });
+});

--- a/apps/web/src/lib/vpnProviders.ts
+++ b/apps/web/src/lib/vpnProviders.ts
@@ -1,0 +1,76 @@
+import type { ComponentType } from 'react';
+import { Shield, ShieldCheck, Network, Globe, Cloud, Lock } from 'lucide-react';
+import type { VpnPresence, VpnProvider } from '@breeze/shared';
+
+// Presentation metadata for VPN providers surfaced on the Devices list column
+// and the device-detail VPN section (#2139). Mirrors the ROLE_META pattern in
+// deviceRoles.ts: a Record keyed by the normalized provider id with graceful
+// fallback for unknown ids. lucide icons are used (no vendor logos in v1) —
+// each provider gets a distinct glyph + badge color so multiple active VPNs
+// read apart at a glance.
+
+type VpnProviderMeta = {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  /** Tailwind classes for the compact badge (light/dark aware via /20 alpha). */
+  badgeClass: string;
+};
+
+const PROVIDER_META: Record<VpnProvider, VpnProviderMeta> = {
+  wireguard:         { label: 'WireGuard',      icon: ShieldCheck, badgeClass: 'bg-rose-500/15 text-rose-700 border-rose-500/40 dark:text-rose-300' },
+  tailscale:         { label: 'Tailscale',      icon: Network,     badgeClass: 'bg-indigo-500/15 text-indigo-700 border-indigo-500/40 dark:text-indigo-300' },
+  netbird:           { label: 'NetBird',        icon: Globe,       badgeClass: 'bg-sky-500/15 text-sky-700 border-sky-500/40 dark:text-sky-300' },
+  zerotier:          { label: 'ZeroTier',       icon: Network,     badgeClass: 'bg-amber-500/15 text-amber-700 border-amber-500/40 dark:text-amber-300' },
+  openvpn:           { label: 'OpenVPN',        icon: Shield,      badgeClass: 'bg-orange-500/15 text-orange-700 border-orange-500/40 dark:text-orange-300' },
+  'cloudflare-warp': { label: 'Cloudflare WARP', icon: Cloud,      badgeClass: 'bg-yellow-500/15 text-yellow-800 border-yellow-500/40 dark:text-yellow-300' },
+  generic:           { label: 'VPN',            icon: Lock,        badgeClass: 'bg-slate-500/15 text-slate-700 border-slate-500/40 dark:text-slate-300' },
+};
+
+const FALLBACK_META: VpnProviderMeta = PROVIDER_META.generic;
+
+function metaFor(provider: string): VpnProviderMeta {
+  return PROVIDER_META[provider as VpnProvider] ?? FALLBACK_META;
+}
+
+export function getVpnProviderLabel(provider: string): string {
+  return metaFor(provider).label;
+}
+
+export function getVpnProviderIcon(provider: string): ComponentType<{ className?: string }> {
+  return metaFor(provider).icon;
+}
+
+export function getVpnProviderBadgeClass(provider: string): string {
+  return metaFor(provider).badgeClass;
+}
+
+/** Active VPNs only, deduped by provider+interface, sorted by provider label. */
+export function activeVpnList(vpns: VpnPresence[] | null | undefined): VpnPresence[] {
+  if (!vpns || vpns.length === 0) return [];
+  const seen = new Set<string>();
+  const result: VpnPresence[] = [];
+  for (const vpn of vpns) {
+    if (!vpn.active) continue;
+    const key = `${vpn.provider}:${vpn.interfaceName}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(vpn);
+  }
+  return result.sort((a, b) => getVpnProviderLabel(a.provider).localeCompare(getVpnProviderLabel(b.provider)));
+}
+
+/** Distinct provider ids among active VPNs (for the list facet options). */
+export function activeVpnProviders(vpns: VpnPresence[] | null | undefined): VpnProvider[] {
+  const set = new Set<VpnProvider>();
+  for (const vpn of activeVpnList(vpns)) set.add(vpn.provider);
+  return Array.from(set);
+}
+
+/** One-line tooltip for a single VPN: "WireGuard · wg0 · 10.8.0.2 · host.tailnet.ts.net". */
+export function formatVpnTooltip(vpn: VpnPresence): string {
+  const parts: string[] = [getVpnProviderLabel(vpn.provider), vpn.interfaceName];
+  if (vpn.ipv4) parts.push(vpn.ipv4);
+  if (vpn.ipv6) parts.push(vpn.ipv6);
+  if (vpn.dnsName) parts.push(vpn.dnsName);
+  return parts.join(' · ');
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -154,6 +154,7 @@ export interface Device {
   isHeadless: boolean;
   pendingReboot: boolean;
   batteryStatus: BatteryStatus | null;
+  activeVpns: VpnPresence[] | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -179,6 +180,46 @@ export interface BatteryStatus {
   timeRemainingMinutes?: number;
   /** Estimated time to full charge, in minutes, when the OS reports it. */
   timeToFullMinutes?: number;
+  /** ISO timestamp the API stamped when it ingested this snapshot. */
+  reportedAt: string;
+}
+
+// Active-VPN-client presence telemetry (#2139). Read-only current state: the
+// agent detects which VPN overlay clients have an active tunnel from local
+// interface / adapter-description heuristics plus per-OS service/process
+// signals, and the API stores the latest snapshot as a jsonb array on the
+// `devices` row (next to batteryStatus / pendingReboot). Fully replaced every
+// network-inventory report — a null column means the agent has never reported
+// (old agent); an empty array means "reported, no active VPN". No secrets, peer
+// lists, keys, or VPN management are ever collected — provider/state/interface/
+// IPs/DNS name only.
+export type VpnProvider =
+  | 'wireguard'
+  | 'tailscale'
+  | 'netbird'
+  | 'zerotier'
+  | 'openvpn'
+  | 'cloudflare-warp'
+  | 'generic';
+
+/** How the agent recognized the VPN — a raw signal, not a trust ranking. */
+export type VpnDetectionSource = 'interface' | 'service' | 'process' | 'adapter';
+
+export interface VpnPresence {
+  /** Normalized provider id; 'generic' = unknown tunnel adapter fallback. */
+  provider: VpnProvider;
+  /** Whether the tunnel interface is currently up / connected. */
+  active: boolean;
+  /** OS interface/adapter name backing the tunnel (e.g. utun3, wg0, ztabc123). */
+  interfaceName: string;
+  /** Overlay IPv4 assigned on the tunnel, when present. */
+  ipv4?: string;
+  /** Overlay IPv6 assigned on the tunnel, when present. */
+  ipv6?: string;
+  /** VPN DNS / device name when safely available (e.g. Tailscale MagicDNS). */
+  dnsName?: string;
+  /** Which local signal surfaced this VPN. */
+  detectionSource: VpnDetectionSource;
   /** ISO timestamp the API stamped when it ingested this snapshot. */
   reportedAt: string;
 }

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -447,6 +447,31 @@ export const commandResultSchema = z.object({
   durationMs: z.number()
 });
 
+// Active-VPN-client presence (#2139). This is the AGENT-sent wire shape for one
+// detected VPN — the API stamps `reportedAt` on ingest, so it is intentionally
+// absent here. Mirrors the VpnPresence type in ../types minus reportedAt.
+export const vpnProviderSchema = z.enum([
+  'wireguard',
+  'tailscale',
+  'netbird',
+  'zerotier',
+  'openvpn',
+  'cloudflare-warp',
+  'generic'
+]);
+
+export const vpnDetectionSourceSchema = z.enum(['interface', 'service', 'process', 'adapter']);
+
+export const vpnPresenceIngestSchema = z.object({
+  provider: vpnProviderSchema,
+  active: z.boolean(),
+  interfaceName: z.string().min(1).max(128),
+  ipv4: z.string().max(45).optional(),
+  ipv6: z.string().max(45).optional(),
+  dnsName: z.string().max(255).optional(),
+  detectionSource: vpnDetectionSourceSchema
+});
+
 // ============================================
 // Filter Validators
 // ============================================


### PR DESCRIPTION
## What & why

Adds first-class **active-VPN-client presence** telemetry so operators can see at a glance which endpoints have a live VPN overlay tunnel — and the overlay IP/DNS name to reach them — without opening each device or fanning out remote tools. Implements the accepted scope in #2139 (read-only v1; no VPN management, peers, or secrets).

## Approach

**Storage — no new table.** VPN presence is latest-snapshot current state that must appear on the Devices *list* (which selects from `devices` directly), so it's an `active_vpns` jsonb column on `devices`, mirroring the `battery_status` snapshot pattern (#2142). It inherits the devices table's forced RLS — no new tenant-scoped table, no allowlist ceremony. `null` = agent never reported; `[]` = reported with no active VPN.

**Agent** (`agent/internal/collectors/vpn.go` + per-OS files): interface-driven detection (the reliable cross-platform "tunnel is up with an overlay IP" signal), provider classification from interface/adapter name, disambiguated by per-OS service signals (systemd/launchd/Windows services) + cross-platform process signals when the adapter is generic (`utun`/`tun`/`tap`). Providers: WireGuard, Tailscale, NetBird, ZeroTier, OpenVPN, Cloudflare WARP, generic fallback. Best-effort Tailscale MagicDNS name (own device only, never blocks/fails collection). Rides the existing 15-min network-inventory cadence — no hot loop.

**API/shared:** `VpnPresence` type + validator in `packages/shared`; ingest stamps `reportedAt` server-side and writes the snapshot in the same txn as the adapter replace; list + detail responses carry `activeVpns`.

**Web:** optional (default-off) "VPN" Devices column — compact provider badges, dash when none, `+N` overflow, hover tooltip (provider/interface/IP/DNS), sortable; a client-side VPN facet (any / by-provider) mirroring the existing class facet; device-detail VPN section with the full list. Rendered **only** from cached inventory — never a live command fan-out from the table. `data-testid` on all new elements.

## Verification

- **Go**: `go test -race ./internal/collectors/` green; builds for windows/linux/darwin.
- **API**: new `inventoryNetworkVpn.test.ts` (reportedAt stamping, empty-array for old agents, unknown-provider reject, 404) + existing inventory/schemas/autoMigrate suites green; `tsc --noEmit` clean.
- **Web**: new `vpnProviders.test.ts` + all 380 devices component tests green; `astro-check` 0 errors.

## Notes

`Refs #2139` (community reporter verifies — not auto-closing). The maintainer committed to linking the PR on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)