### PR TITLE
feat(devices): linked device profiles for multi-boot systems (#2138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -984,8 +984,9 @@ jobs:
     # The suite (138 files / ~690 tests) runs ~29 min and was tipping over the
     # old 30-min ceiling at the boundary (passed/cancelled non-deterministically
     # on the same commit). Raised to 40 for headroom — the tests pass, this is
-    # runtime growth, not a hang.
-    timeout-minutes: 40
+    # runtime growth, not a hang. By 2026-07 the baseline hit ~36 min and PRs
+    # adding integration suites tipped over 40 the same way; raised to 55.
+    timeout-minutes: 55
 
     steps:
       - name: Checkout

--- a/apps/api/migrations/2026-07-09-device-link-groups.sql
+++ b/apps/api/migrations/2026-07-09-device-link-groups.sql
@@ -1,0 +1,93 @@
+-- 2026-07-09: Linked device profiles for multi-boot systems (#2138).
+--
+-- A physical machine that dual/multi-boots runs one Breeze agent per OS, so it
+-- surfaces as several device records — only one can be online at a time. This
+-- adds a NON-destructive link: two or more device records grouped as boot
+-- profiles of one physical machine. Each device record stays fully separate
+-- (inventory, software, scripts, command history, audit, telemetry all
+-- preserved); the group is a UI/monitoring overlay, not a merge.
+--
+-- Model: a `device_link_groups` parent row (Shape 1, direct org_id) plus a
+-- nullable `devices.link_group_id` FK. Membership IS the column on devices —
+-- one group per device — so there is no membership child table to cascade and
+-- no denormalized org_id to keep in sync on move-org. All members of a group
+-- share the group's org, enforced STRUCTURALLY by the composite FK
+-- devices(link_group_id, org_id) -> device_link_groups(id, org_id): a device's
+-- org must equal its group's org, so every member of a group is same-org. This
+-- is the CRITICAL tenant-isolation invariant for the feature.
+--
+-- Tenancy: device_link_groups carries a direct org_id with the four standard
+-- breeze_has_org_access policies, so the rls-coverage contract test
+-- auto-discovers it — no allowlist entry needed. tenantCascade adds it to the
+-- org-erasure sweep (the topo-sort deletes `devices` first since devices
+-- references the group).
+--
+-- Idempotent: CREATE TABLE/INDEX/COLUMN IF NOT EXISTS, DO-guarded constraint,
+-- DROP POLICY IF EXISTS before each CREATE. autoMigrate wraps the file in one
+-- transaction — no inner BEGIN/COMMIT.
+
+CREATE TABLE IF NOT EXISTS device_link_groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  -- Optional operator label for the physical machine (e.g. "Todd's ThinkPad").
+  -- NULL is fine; the UI falls back to the members' hostnames.
+  name varchar(255),
+  created_by uuid REFERENCES users(id),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS device_link_groups_org_id_idx ON device_link_groups(org_id);
+
+-- Composite unique so `devices` can carry a (link_group_id, org_id) FK that pins
+-- every member to the group's org. `id` is already unique (PK); this just
+-- exposes (id, org_id) as a valid FK target.
+CREATE UNIQUE INDEX IF NOT EXISTS device_link_groups_id_org_id_uniq
+  ON device_link_groups(id, org_id);
+
+-- Membership column on devices. NULL => unlinked (the default for every device).
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS link_group_id uuid;
+
+CREATE INDEX IF NOT EXISTS devices_link_group_id_idx ON devices(link_group_id);
+
+-- Composite FK: a linked device's org must equal its group's org (same-org
+-- invariant). MATCH SIMPLE (the default) means the FK is NOT enforced while
+-- link_group_id is NULL, so unlinked devices are entirely unaffected. No
+-- ON DELETE action: group deletion nulls its members in application code before
+-- deleting the row, keeping this portable across Postgres versions (no reliance
+-- on column-list ON DELETE SET NULL, which is PG15+).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'devices_link_group_id_org_id_fkey'
+  ) THEN
+    ALTER TABLE devices
+      ADD CONSTRAINT devices_link_group_id_org_id_fkey
+      FOREIGN KEY (link_group_id, org_id)
+      REFERENCES device_link_groups(id, org_id);
+  END IF;
+END $$;
+
+-- RLS: direct org_id (Shape 1) — standard org isolation.
+ALTER TABLE device_link_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE device_link_groups FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON device_link_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON device_link_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON device_link_groups;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON device_link_groups;
+
+CREATE POLICY breeze_org_isolation_select ON device_link_groups FOR SELECT USING (
+  public.breeze_has_org_access(org_id)
+);
+CREATE POLICY breeze_org_isolation_insert ON device_link_groups FOR INSERT WITH CHECK (
+  public.breeze_has_org_access(org_id)
+);
+CREATE POLICY breeze_org_isolation_update ON device_link_groups FOR UPDATE USING (
+  public.breeze_has_org_access(org_id)
+) WITH CHECK (
+  public.breeze_has_org_access(org_id)
+);
+CREATE POLICY breeze_org_isolation_delete ON device_link_groups FOR DELETE USING (
+  public.breeze_has_org_access(org_id)
+);

--- a/apps/api/src/__tests__/integration/deviceLinkGroupsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceLinkGroupsRls.integration.test.ts
@@ -189,6 +189,50 @@ describe('device link-group dissolution', () => {
     expect(survivor[0]?.linkGroupId).toBeNull();
   });
 
+  runDb('org flip on a linked device requires unlinking first, then dissolves the orphan (move-org contract)', async () => {
+    const { orgA, orgB, deviceA1, deviceA2 } = await seed();
+
+    const groupId = await withSystemDbAccessContext(async () => {
+      const [group] = await db
+        .insert(deviceLinkGroups)
+        .values({ orgId: orgA.id, name: 'move-org-test' })
+        .returning({ id: deviceLinkGroups.id });
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA1.id));
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA2.id));
+      return group!.id;
+    });
+
+    // Flipping org_id while still linked violates the composite FK — this is
+    // exactly why moveOrg nulls link_group_id in the same UPDATE.
+    let caught: unknown;
+    try {
+      await withSystemDbAccessContext(() =>
+        db.update(devices).set({ orgId: orgB.id }).where(eq(devices.id, deviceA1.id)),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { cause?: { code?: string } } | undefined)?.cause?.code).toBe('23503');
+
+    // Unlink + flip in one shot (as moveOrg does), then dissolve the orphan.
+    await withSystemDbAccessContext(async () => {
+      await db
+        .update(devices)
+        .set({ orgId: orgB.id, linkGroupId: null })
+        .where(eq(devices.id, deviceA1.id));
+      await dissolveLinkGroupIfBelowMinimum(db, groupId);
+    });
+
+    const group = await withSystemDbAccessContext(() =>
+      db.select({ id: deviceLinkGroups.id }).from(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId)),
+    );
+    expect(group).toHaveLength(0);
+    const survivor = await withSystemDbAccessContext(() =>
+      db.select({ linkGroupId: devices.linkGroupId }).from(devices).where(eq(devices.id, deviceA2.id)),
+    );
+    expect(survivor[0]?.linkGroupId).toBeNull();
+  });
+
   runDb('deleteLinkGroup unlinks every member and removes the group row', async () => {
     const { orgA, deviceA1, deviceA2 } = await seed();
 

--- a/apps/api/src/__tests__/integration/deviceLinkGroupsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceLinkGroupsRls.integration.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Real-driver cross-tenant forge test for device_link_groups (#2138).
+ *
+ * device_link_groups is a direct org-axis table (Shape 1: org_id + the four
+ * breeze_has_org_access policies). Membership lives on devices.link_group_id,
+ * pinned to the group's org by the composite FK
+ * devices(link_group_id, org_id) -> device_link_groups(id, org_id).
+ *
+ * This proves, as the unprivileged breeze_app role:
+ *   1. same-org create + link is allowed,
+ *   2. a forged cross-org group insert is rejected by RLS (42501),
+ *   3. an org cannot read another org's link groups, and
+ *   4. the composite FK forbids linking a device to a group in a DIFFERENT org
+ *      (23503) — the same-org invariant, enforced structurally.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { deviceLinkGroups, devices, sites } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+import {
+  deleteLinkGroup,
+  dissolveLinkGroupIfBelowMinimum,
+} from '../../services/deviceLinkGroups';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function orgCtx(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+async function seedDevice(orgId: string, siteId: string, tag: string) {
+  const [device] = await db
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `link-rls-agent-${tag}`,
+      hostname: `link-rls-host-${tag}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+  if (!device) throw new Error(`failed to seed device ${tag}`);
+  return device;
+}
+
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+
+    const [siteA] = await db
+      .insert(sites)
+      .values({ orgId: orgA.id, name: `Link RLS Site A ${unique}` })
+      .returning({ id: sites.id });
+    const [siteB] = await db
+      .insert(sites)
+      .values({ orgId: orgB.id, name: `Link RLS Site B ${unique}` })
+      .returning({ id: sites.id });
+    if (!siteA || !siteB) throw new Error('failed to seed sites');
+
+    const deviceA1 = await seedDevice(orgA.id, siteA.id, `${unique}-a1`);
+    const deviceA2 = await seedDevice(orgA.id, siteA.id, `${unique}-a2`);
+    const deviceB = await seedDevice(orgB.id, siteB.id, `${unique}-b`);
+
+    return { orgA, orgB, deviceA1, deviceA2, deviceB };
+  });
+}
+
+describe('device_link_groups RLS (breeze_app)', () => {
+  runDb('allows same-org create + link and rejects forged cross-org insert', async () => {
+    const { orgA, orgB, deviceA1, deviceA2 } = await seed();
+
+    // Same-org: create a group and link both org-A profiles.
+    const groupId = await withDbAccessContext(orgCtx(orgA.id), async () => {
+      const [group] = await db
+        .insert(deviceLinkGroups)
+        .values({ orgId: orgA.id, name: 'multi-boot A' })
+        .returning({ id: deviceLinkGroups.id });
+      expect(group?.id).toBeDefined();
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA1.id));
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA2.id));
+      return group!.id;
+    });
+
+    const membersProbe = await withSystemDbAccessContext(() =>
+      db.select({ id: devices.id }).from(devices).where(eq(devices.linkGroupId, groupId)),
+    );
+    expect(membersProbe).toHaveLength(2);
+
+    // Forge: org B inserts a group claiming org A — RLS WITH CHECK rejects it.
+    let caught: unknown;
+    try {
+      await withDbAccessContext(orgCtx(orgB.id), () =>
+        db.insert(deviceLinkGroups).values({ orgId: orgA.id, name: 'forged' }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught, 'cross-org insert must be rejected by RLS').toBeDefined();
+    const cause = (caught as { cause?: { message?: string; code?: string } } | undefined)?.cause;
+    expect(cause?.code).toBe('42501');
+    expect(cause?.message).toMatch(
+      /new row violates row-level security policy for table "device_link_groups"/,
+    );
+
+    // Read isolation: org B cannot see org A's group.
+    const orgBView = await withDbAccessContext(orgCtx(orgB.id), () =>
+      db.select({ id: deviceLinkGroups.id }).from(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId)),
+    );
+    expect(orgBView).toHaveLength(0);
+  });
+
+  runDb('composite FK forbids linking a device to a group in another org', async () => {
+    const { orgA, orgB, deviceB } = await seed();
+
+    // A real group in org A.
+    const groupA = await withDbAccessContext(orgCtx(orgA.id), async () => {
+      const [group] = await db
+        .insert(deviceLinkGroups)
+        .values({ orgId: orgA.id, name: 'org A group' })
+        .returning({ id: deviceLinkGroups.id });
+      return group!.id;
+    });
+
+    // Under SYSTEM context (RLS bypassed) so the FK is the sole guard: try to
+    // point an org-B device at org-A's group. (link_group_id=groupA, org_id=B)
+    // has no matching (id, org_id) in device_link_groups -> FK violation.
+    let caught: unknown;
+    try {
+      await withSystemDbAccessContext(() =>
+        db.update(devices).set({ linkGroupId: groupA }).where(eq(devices.id, deviceB.id)),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught, 'cross-org link must be rejected by the composite FK').toBeDefined();
+    const cause = (caught as { cause?: { code?: string } } | undefined)?.cause;
+    expect(cause?.code).toBe('23503'); // foreign_key_violation
+  });
+});
+
+describe('device link-group dissolution', () => {
+  runDb('dissolveLinkGroupIfBelowMinimum keeps a full group but dissolves a lone survivor', async () => {
+    const { orgA, deviceA1, deviceA2 } = await seed();
+
+    const groupId = await withSystemDbAccessContext(async () => {
+      const [group] = await db
+        .insert(deviceLinkGroups)
+        .values({ orgId: orgA.id, name: 'dissolve-test' })
+        .returning({ id: deviceLinkGroups.id });
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA1.id));
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA2.id));
+      return group!.id;
+    });
+
+    // Two members: no dissolution.
+    const keptOpen = await withSystemDbAccessContext(() => dissolveLinkGroupIfBelowMinimum(db, groupId));
+    expect(keptOpen).toBe(false);
+
+    // Drop to one member, then dissolve: the survivor is unlinked and the group deleted.
+    await withSystemDbAccessContext(() =>
+      db.update(devices).set({ linkGroupId: null }).where(eq(devices.id, deviceA2.id)),
+    );
+    const dissolved = await withSystemDbAccessContext(() => dissolveLinkGroupIfBelowMinimum(db, groupId));
+    expect(dissolved).toBe(true);
+
+    const remaining = await withSystemDbAccessContext(() =>
+      db.select({ id: deviceLinkGroups.id }).from(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId)),
+    );
+    expect(remaining).toHaveLength(0);
+
+    const survivor = await withSystemDbAccessContext(() =>
+      db.select({ linkGroupId: devices.linkGroupId }).from(devices).where(eq(devices.id, deviceA1.id)),
+    );
+    expect(survivor[0]?.linkGroupId).toBeNull();
+  });
+
+  runDb('deleteLinkGroup unlinks every member and removes the group row', async () => {
+    const { orgA, deviceA1, deviceA2 } = await seed();
+
+    const groupId = await withSystemDbAccessContext(async () => {
+      const [group] = await db
+        .insert(deviceLinkGroups)
+        .values({ orgId: orgA.id, name: 'delete-test' })
+        .returning({ id: deviceLinkGroups.id });
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA1.id));
+      await db.update(devices).set({ linkGroupId: group!.id }).where(eq(devices.id, deviceA2.id));
+      return group!.id;
+    });
+
+    await withSystemDbAccessContext(() => deleteLinkGroup(db, groupId));
+
+    const remaining = await withSystemDbAccessContext(() =>
+      db.select({ id: deviceLinkGroups.id }).from(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId)),
+    );
+    expect(remaining).toHaveLength(0);
+
+    const stillLinked = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(eq(devices.linkGroupId, groupId)),
+    );
+    expect(stillLinked).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/setup.ts
+++ b/apps/api/src/__tests__/integration/setup.ts
@@ -286,6 +286,10 @@ export async function cleanupDatabase() {
     'device_network',
     'device_hardware',
     'device_software',
+    // #2138 — devices carries a composite FK to device_link_groups; truncate
+    // the groups first (CASCADE clears the referencing devices) so cleanup is
+    // FK-safe and deterministic.
+    'device_link_groups',
     'devices',
     'automation_executions',
     'automations',

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -66,6 +66,13 @@ export const devices = pgTable('devices', {
   lastSeenAt: timestamp('last_seen_at'),
   enrolledAt: timestamp('enrolled_at').defaultNow().notNull(),
   enrolledBy: uuid('enrolled_by').references(() => users.id),
+  // Linked device profiles for multi-boot systems (#2138). NULL => unlinked.
+  // When set, the device is one boot profile of a physical machine grouped in
+  // `device_link_groups`. A composite FK (link_group_id, org_id) ->
+  // device_link_groups(id, org_id) — declared in the migration, not here,
+  // matching the users(org_id, partner_id) composite-FK convention — pins every
+  // member of a group to the group's org (same-org invariant).
+  linkGroupId: uuid('link_group_id'),
   tags: text('tags').array().default([]),
   customFields: jsonb('custom_fields').default({}),
   managementPosture: jsonb('management_posture'),
@@ -99,6 +106,24 @@ export const devices = pgTable('devices', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });
+
+// Linked device profiles for multi-boot systems (#2138). One row per physical
+// machine whose OS boot profiles are surfaced as separate device records. This
+// is a NON-destructive UI/monitoring overlay — the linked device rows keep all
+// of their own inventory/software/scripts/history/audit. Shape 1 (direct
+// org_id): auto-discovered by the rls-coverage contract test. Membership lives
+// on `devices.link_group_id` (one group per device), not a child table.
+export const deviceLinkGroups = pgTable('device_link_groups', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  name: varchar('name', { length: 255 }),
+  createdBy: uuid('created_by').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  orgIdIdx: index('device_link_groups_org_id_idx').on(table.orgId),
+  idOrgUnique: unique('device_link_groups_id_org_id_uniq').on(table.id, table.orgId),
+}));
 
 export const deviceHardware = pgTable('device_hardware', {
   deviceId: uuid('device_id').primaryKey().references(() => devices.id),

--- a/apps/api/src/db/schema/devices.ts
+++ b/apps/api/src/db/schema/devices.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, real, bigint, date, primaryKey, index, unique } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, real, bigint, date, primaryKey, index, unique, uniqueIndex } from 'drizzle-orm/pg-core';
 import { organizations, sites } from './orgs';
 import { users } from './users';
 import type { BatteryStatus, DesktopAccessState, InterfaceBandwidth, TCCPermissions } from '@breeze/shared';
@@ -122,7 +122,11 @@ export const deviceLinkGroups = pgTable('device_link_groups', {
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 }, (table) => ({
   orgIdIdx: index('device_link_groups_org_id_idx').on(table.orgId),
-  idOrgUnique: unique('device_link_groups_id_org_id_uniq').on(table.id, table.orgId),
+  // UNIQUE INDEX (not a constraint) to match the migration's
+  // `CREATE UNIQUE INDEX` and satisfy db:check-drift — same convention as the
+  // pax8/ticketMailbox composite-(id, axis) FK targets. Backs the composite FK
+  // devices(link_group_id, org_id) -> device_link_groups(id, org_id).
+  idOrgUnique: uniqueIndex('device_link_groups_id_org_id_uniq').on(table.id, table.orgId),
 }));
 
 export const deviceHardware = pgTable('device_hardware', {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -39,6 +39,7 @@ import {
   type DevicesSortKey,
 } from './cursor';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { dissolveLinkGroupIfBelowMinimum } from '../../services/deviceLinkGroups';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import {
   resolveRemoteAccessLaunch,
@@ -1340,6 +1341,13 @@ coreRoutes.delete(
           await tx.execute(sql`DELETE FROM ${sql.identifier(table)} WHERE device_id = ${deviceId}`);
         }
         await tx.delete(devices).where(eq(devices.id, deviceId));
+
+        // #2138 — the deleted device's link_group_id went with its row. If it
+        // was a boot profile and the group now has a single lone survivor,
+        // dissolve the (meaningless) group.
+        if (device.linkGroupId) {
+          await dissolveLinkGroupIfBelowMinimum(tx, device.linkGroupId);
+        }
       });
     } catch (err: unknown) {
       const pgCode = (err as { code?: string })?.code;

--- a/apps/api/src/routes/devices/index.ts
+++ b/apps/api/src/routes/devices/index.ts
@@ -25,6 +25,7 @@ import { actuateElevationRoutes } from './actuateElevation';
 import { softwareActionsRoutes } from './softwareActions';
 import { networkRoutes } from './network';
 import { customFieldValuesRoutes } from './customFieldValues';
+import { linksRoutes } from './links';
 
 export const deviceRoutes = new Hono();
 
@@ -57,6 +58,10 @@ deviceRoutes.route('/', moveOrgRoutes);
 // routes — `GET /network` is a static path that must not be eaten by the
 // `/:id` matcher in coreRoutes.
 deviceRoutes.route('/', networkRoutes);
+
+// Mount linked-device-profile routes (#2138) BEFORE core — the static
+// `/link-groups` paths must not be eaten by the `/:id` matcher in coreRoutes.
+deviceRoutes.route('/', linksRoutes);
 
 // Mount core routes (/, /:id, PATCH /:id, DELETE /:id)
 deviceRoutes.route('/', coreRoutes);

--- a/apps/api/src/routes/devices/links.test.ts
+++ b/apps/api/src/routes/devices/links.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { siteDenied } = vi.hoisted(() => ({
+  siteDenied: Symbol('SITE_ACCESS_DENIED'),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123' },
+      scope: 'organization',
+      orgId: 'org-123',
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+      canAccessSite: () => true,
+      orgCondition: () => undefined,
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('./helpers', () => ({
+  getDeviceWithOrgAndSiteCheck: vi.fn(),
+  SITE_ACCESS_DENIED: siteDenied,
+  ensureOrgAccess: vi.fn(async () => true),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../services/deviceLinkGroups', () => ({
+  MAX_LINK_GROUP_SIZE: 10,
+  deleteLinkGroup: vi.fn(),
+  dissolveLinkGroupIfBelowMinimum: vi.fn(async () => false),
+}));
+
+import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
+import { linksRoutes } from './links';
+
+const mockDevice = (over: Record<string, unknown> = {}) => ({
+  id: 'dev-1',
+  orgId: 'org-123',
+  siteId: 'site-1',
+  hostname: 'host-1',
+  displayName: null,
+  osType: 'windows',
+  osVersion: '11',
+  agentVersion: '1.0.0',
+  status: 'offline',
+  lastSeenAt: null,
+  linkGroupId: null,
+  ...over,
+});
+
+const UUID_A = '11111111-1111-1111-1111-111111111111';
+const UUID_B = '22222222-2222-2222-2222-222222222222';
+
+function jsonReq(path: string, method: string, body: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('device link-group routes (guard branches)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', linksRoutes);
+  });
+
+  it('rejects a create with fewer than two distinct devices', async () => {
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_A] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when a device to link is not found', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A }) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(null);
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_B] }));
+    expect(res.status).toBe(404);
+  });
+
+  it('403s when a device site is denied', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(SITE_ACCESS_DENIED as any);
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_B] }));
+    expect(res.status).toBe(403);
+  });
+
+  it('409s when a device is already part of a link group', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A }) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(
+      mockDevice({ id: UUID_B, linkGroupId: 'existing-group' }) as any,
+    );
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_B] }));
+    expect(res.status).toBe(409);
+  });
+
+  it('400s when devices belong to different organizations', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A, orgId: 'org-123' }) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_B, orgId: 'org-999' }) as any);
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_B] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns group:null for an unlinked device', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A, linkGroupId: null }) as any);
+    const res = await app.request(new Request(`http://localhost/devices/${UUID_A}/link-group`));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { group: unknown };
+    expect(body.group).toBeNull();
+  });
+});

--- a/apps/api/src/routes/devices/links.test.ts
+++ b/apps/api/src/routes/devices/links.test.ts
@@ -46,7 +46,23 @@ vi.mock('../../services/deviceLinkGroups', () => ({
 }));
 
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
+import { db } from '../../db';
 import { linksRoutes } from './links';
+
+const dbSelectMock = vi.mocked(db.select);
+const dbTransactionMock = vi.mocked(db.transaction);
+
+/** A drizzle-select chain (.from().where().limit()) that resolves to `rows`. */
+function selectChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => Promise.resolve(rows);
+  // Awaitable without .limit() (the currentMembers query has no limit).
+  chain.then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(res, rej);
+  return chain;
+}
 
 const mockDevice = (over: Record<string, unknown> = {}) => ({
   id: 'dev-1',
@@ -123,5 +139,66 @@ describe('device link-group routes (guard branches)', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { group: unknown };
     expect(body.group).toBeNull();
+  });
+});
+
+describe('device link-group routes (create success + PATCH branches)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', linksRoutes);
+  });
+
+  it('creates a group and returns 201 with members', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck)
+      .mockResolvedValueOnce(mockDevice({ id: UUID_A }) as any)
+      .mockResolvedValueOnce(mockDevice({ id: UUID_B }) as any);
+    dbTransactionMock.mockImplementation((async (cb: any) =>
+      cb({
+        insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 'grp-1' }]) }) }),
+        update: () => ({ set: () => ({ where: () => Promise.resolve(undefined) }) }),
+      })) as any);
+    dbSelectMock.mockReturnValueOnce(
+      selectChain([
+        { deviceId: UUID_A, linkGroupId: 'grp-1', siteId: 's', hostname: 'a', displayName: null, osType: 'windows', osVersion: '11', agentVersion: '1', status: 'online', lastSeenAt: null },
+        { deviceId: UUID_B, linkGroupId: 'grp-1', siteId: 's', hostname: 'b', displayName: null, osType: 'linux', osVersion: '22', agentVersion: '1', status: 'offline', lastSeenAt: null },
+      ]) as any,
+    );
+
+    const res = await app.request(jsonReq('/devices/link-groups', 'POST', { deviceIds: [UUID_A, UUID_B], name: 'box' }));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; members: unknown[] };
+    expect(body.id).toBe('grp-1');
+    expect(body.members).toHaveLength(2);
+  });
+
+  it('404s a PATCH on an unknown group', async () => {
+    dbSelectMock.mockReturnValueOnce(selectChain([]) as any);
+    const res = await app.request(jsonReq(`/devices/link-groups/${UUID_A}`, 'PATCH', { name: 'x' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('403s a PATCH remove for a site-denied device', async () => {
+    dbSelectMock.mockReturnValueOnce(selectChain([{ id: 'grp-1', orgId: 'org-123', name: null }]) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(SITE_ACCESS_DENIED as any);
+    const res = await app.request(jsonReq('/devices/link-groups/grp-1', 'PATCH', { removeDeviceIds: [UUID_A] }));
+    expect(res.status).toBe(403);
+  });
+
+  it('409s a PATCH add for a device already in another group', async () => {
+    dbSelectMock.mockReturnValueOnce(selectChain([{ id: 'grp-1', orgId: 'org-123', name: null }]) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A, linkGroupId: 'other' }) as any);
+    const res = await app.request(jsonReq('/devices/link-groups/grp-1', 'PATCH', { addDeviceIds: [UUID_A] }));
+    expect(res.status).toBe(409);
+  });
+
+  it('400s a PATCH that would exceed the size ceiling', async () => {
+    dbSelectMock.mockReturnValueOnce(selectChain([{ id: 'grp-1', orgId: 'org-123', name: null }]) as any);
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValueOnce(mockDevice({ id: UUID_A }) as any);
+    dbSelectMock.mockReturnValueOnce(selectChain(Array.from({ length: 10 }, (_, i) => ({ id: `d${i}` }))) as any);
+    const res = await app.request(jsonReq('/devices/link-groups/grp-1', 'PATCH', { addDeviceIds: [UUID_A] }));
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/api/src/routes/devices/links.ts
+++ b/apps/api/src/routes/devices/links.ts
@@ -1,0 +1,408 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../../db';
+import { deviceLinkGroups, devices } from '../../db/schema';
+import { authMiddleware, requireMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { PERMISSIONS } from '../../services/permissions';
+import { writeRouteAudit } from '../../services/auditEvents';
+import {
+  ensureOrgAccess,
+  getDeviceWithOrgAndSiteCheck,
+  SITE_ACCESS_DENIED,
+} from './helpers';
+import { createLinkGroupSchema, updateLinkGroupSchema } from './schemas';
+import {
+  MAX_LINK_GROUP_SIZE,
+  deleteLinkGroup,
+  dissolveLinkGroupIfBelowMinimum,
+} from '../../services/deviceLinkGroups';
+import type { AuthContext } from '../../middleware/auth';
+
+/**
+ * Linked device profiles for multi-boot systems (#2138).
+ *
+ * Manual link/unlink of 2+ device records as boot profiles of one physical
+ * machine. NON-destructive: each device keeps its own inventory/history. The
+ * device-list and device-detail UI use these to collapse a linked group into a
+ * single primary row (active OS surfaced, siblings de-emphasized) and to flag a
+ * link as conflicting when more than one profile reports online at once.
+ *
+ * Mounted BEFORE coreRoutes so the static `/link-groups` paths are not eaten by
+ * the core `/:id` matcher.
+ */
+export const linksRoutes = new Hono();
+
+linksRoutes.use('*', authMiddleware);
+
+/** Client-facing shape of one boot profile in a link group. */
+interface LinkGroupMember {
+  deviceId: string;
+  hostname: string;
+  displayName: string | null;
+  osType: string;
+  osVersion: string;
+  agentVersion: string;
+  status: string;
+  lastSeenAt: Date | null;
+}
+
+/**
+ * Fetch the boot-profile members of one or more groups, honoring the caller's
+ * site-scope restriction. A site-restricted caller only sees members in sites
+ * they can access — so a group can render with a subset of its profiles, never
+ * with devices from a forbidden site.
+ */
+async function loadMembers(
+  groupIds: string[],
+  auth: Pick<AuthContext, 'canAccessSite'>,
+): Promise<Map<string, LinkGroupMember[]>> {
+  const byGroup = new Map<string, LinkGroupMember[]>();
+  if (groupIds.length === 0) return byGroup;
+
+  const rows = await db
+    .select({
+      deviceId: devices.id,
+      linkGroupId: devices.linkGroupId,
+      siteId: devices.siteId,
+      hostname: devices.hostname,
+      displayName: devices.displayName,
+      osType: devices.osType,
+      osVersion: devices.osVersion,
+      agentVersion: devices.agentVersion,
+      status: devices.status,
+      lastSeenAt: devices.lastSeenAt,
+    })
+    .from(devices)
+    .where(inArray(devices.linkGroupId, groupIds));
+
+  for (const r of rows) {
+    if (!r.linkGroupId) continue;
+    if (auth.canAccessSite && !auth.canAccessSite(r.siteId)) continue;
+    const list = byGroup.get(r.linkGroupId) ?? [];
+    list.push({
+      deviceId: r.deviceId,
+      hostname: r.hostname,
+      displayName: r.displayName,
+      osType: r.osType,
+      osVersion: r.osVersion,
+      agentVersion: r.agentVersion,
+      status: r.status,
+      lastSeenAt: r.lastSeenAt,
+    });
+    byGroup.set(r.linkGroupId, list);
+  }
+  return byGroup;
+}
+
+// GET /devices/link-groups — every link group in the caller's accessible orgs,
+// each with its (site-scoped) members. Powers the device list's grouping.
+linksRoutes.get(
+  '/link-groups',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  async (c) => {
+    const auth = c.get('auth');
+
+    const orgFilter = auth.orgCondition(deviceLinkGroups.orgId);
+    const groups = await db
+      .select()
+      .from(deviceLinkGroups)
+      .where(orgFilter ?? undefined);
+
+    const members = await loadMembers(groups.map((g) => g.id), auth);
+
+    return c.json({
+      data: groups.map((g) => ({
+        id: g.id,
+        orgId: g.orgId,
+        name: g.name,
+        createdBy: g.createdBy,
+        createdAt: g.createdAt,
+        updatedAt: g.updatedAt,
+        members: members.get(g.id) ?? [],
+      })),
+    });
+  },
+);
+
+// POST /devices/link-groups — link 2+ devices as boot profiles of one machine.
+linksRoutes.post(
+  '/link-groups',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action),
+  requireMfa(),
+  zValidator('json', createLinkGroupSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { name, deviceIds } = c.req.valid('json');
+
+    const uniqueIds = [...new Set(deviceIds)];
+    if (uniqueIds.length < 2) {
+      return c.json({ error: 'A link group needs at least two distinct devices' }, 400);
+    }
+
+    // Validate every device: org + site access, existence, not already linked,
+    // and collect the rows so we can enforce the same-org invariant.
+    const resolved: (typeof devices.$inferSelect)[] = [];
+    for (const id of uniqueIds) {
+      const device = await getDeviceWithOrgAndSiteCheck(c, id, auth);
+      if (device === SITE_ACCESS_DENIED) {
+        return c.json({ error: 'Access to a device site denied' }, 403);
+      }
+      if (!device) {
+        return c.json({ error: `Device ${id} not found` }, 404);
+      }
+      if (device.linkGroupId) {
+        return c.json({ error: `Device ${id} is already part of a link group` }, 409);
+      }
+      resolved.push(device);
+    }
+
+    // Same-org invariant — the DB composite FK enforces it too, but a clean 400
+    // beats a raw constraint error. All boot profiles are one physical machine
+    // in one org.
+    const orgId = resolved[0]!.orgId;
+    if (resolved.some((d) => d.orgId !== orgId)) {
+      return c.json({ error: 'All linked devices must belong to the same organization' }, 400);
+    }
+
+    let groupId: string;
+    await db.transaction(async (tx) => {
+      const [group] = await tx
+        .insert(deviceLinkGroups)
+        .values({ orgId, name: name ?? null, createdBy: auth.user.id })
+        .returning({ id: deviceLinkGroups.id });
+      groupId = group!.id;
+      await tx
+        .update(devices)
+        .set({ linkGroupId: groupId, updatedAt: new Date() })
+        .where(inArray(devices.id, uniqueIds));
+    });
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'device_link_group.create',
+      resourceType: 'device_link_group',
+      resourceId: groupId!,
+      resourceName: name ?? null,
+      details: { deviceIds: uniqueIds },
+    });
+
+    const members = await loadMembers([groupId!], auth);
+    return c.json(
+      { id: groupId!, orgId, name: name ?? null, members: members.get(groupId!) ?? [] },
+      201,
+    );
+  },
+);
+
+/** Load a group and enforce org access. Returns null (→ 404) when hidden. */
+async function getGroupWithOrgCheck(groupId: string, auth: AuthContext) {
+  const [group] = await db
+    .select()
+    .from(deviceLinkGroups)
+    .where(eq(deviceLinkGroups.id, groupId))
+    .limit(1);
+  if (!group) return null;
+  if (!(await ensureOrgAccess(group.orgId, auth))) return null;
+  return group;
+}
+
+// GET /devices/link-groups/:groupId — one group with its members.
+linksRoutes.get(
+  '/link-groups/:groupId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  async (c) => {
+    const auth = c.get('auth');
+    const groupId = c.req.param('groupId')!;
+
+    const group = await getGroupWithOrgCheck(groupId, auth);
+    if (!group) return c.json({ error: 'Link group not found' }, 404);
+
+    const members = await loadMembers([groupId], auth);
+    return c.json({
+      id: group.id,
+      orgId: group.orgId,
+      name: group.name,
+      createdBy: group.createdBy,
+      createdAt: group.createdAt,
+      updatedAt: group.updatedAt,
+      members: members.get(groupId) ?? [],
+    });
+  },
+);
+
+// PATCH /devices/link-groups/:groupId — rename and/or add/remove profiles.
+linksRoutes.patch(
+  '/link-groups/:groupId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_WRITE.resource, PERMISSIONS.DEVICES_WRITE.action),
+  requireMfa(),
+  zValidator('json', updateLinkGroupSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const groupId = c.req.param('groupId')!;
+    const { name, addDeviceIds, removeDeviceIds } = c.req.valid('json');
+
+    const group = await getGroupWithOrgCheck(groupId, auth);
+    if (!group) return c.json({ error: 'Link group not found' }, 404);
+
+    // Validate additions up front (org + site + not-already-linked-elsewhere)
+    // before mutating anything.
+    const toAdd = [...new Set(addDeviceIds ?? [])];
+    for (const id of toAdd) {
+      const device = await getDeviceWithOrgAndSiteCheck(c, id, auth);
+      if (device === SITE_ACCESS_DENIED) {
+        return c.json({ error: 'Access to a device site denied' }, 403);
+      }
+      if (!device) {
+        return c.json({ error: `Device ${id} not found` }, 404);
+      }
+      if (device.orgId !== group.orgId) {
+        return c.json({ error: 'All linked devices must belong to the same organization' }, 400);
+      }
+      if (device.linkGroupId && device.linkGroupId !== groupId) {
+        return c.json({ error: `Device ${id} is already part of another link group` }, 409);
+      }
+    }
+
+    const toRemove = [...new Set(removeDeviceIds ?? [])];
+
+    // Enforce the size ceiling on the resulting membership.
+    const currentMembers = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .where(eq(devices.linkGroupId, groupId));
+    const currentIds = new Set(currentMembers.map((m) => m.id));
+    for (const id of toRemove) currentIds.delete(id);
+    for (const id of toAdd) currentIds.add(id);
+    if (currentIds.size > MAX_LINK_GROUP_SIZE) {
+      return c.json({ error: `A link group may contain at most ${MAX_LINK_GROUP_SIZE} devices` }, 400);
+    }
+
+    let dissolved = false;
+    await db.transaction(async (tx) => {
+      if (name !== undefined || toAdd.length > 0) {
+        await tx
+          .update(deviceLinkGroups)
+          .set({ ...(name !== undefined ? { name } : {}), updatedAt: new Date() })
+          .where(eq(deviceLinkGroups.id, groupId));
+      }
+      if (toRemove.length > 0) {
+        // Only unlink devices actually in THIS group.
+        await tx
+          .update(devices)
+          .set({ linkGroupId: null, updatedAt: new Date() })
+          .where(and(inArray(devices.id, toRemove), eq(devices.linkGroupId, groupId)));
+      }
+      if (toAdd.length > 0) {
+        await tx
+          .update(devices)
+          .set({ linkGroupId: groupId, updatedAt: new Date() })
+          .where(inArray(devices.id, toAdd));
+      }
+      // A group that fell below the minimum after removals is meaningless —
+      // dissolve it (unlink the lone survivor, delete the row).
+      dissolved = await dissolveLinkGroupIfBelowMinimum(tx, groupId);
+    });
+
+    writeRouteAudit(c, {
+      orgId: group.orgId,
+      action: dissolved ? 'device_link_group.dissolve' : 'device_link_group.update',
+      resourceType: 'device_link_group',
+      resourceId: groupId,
+      resourceName: name ?? group.name,
+      details: { addDeviceIds: toAdd, removeDeviceIds: toRemove, dissolved },
+    });
+
+    if (dissolved) {
+      return c.json({ id: groupId, dissolved: true, members: [] });
+    }
+
+    const members = await loadMembers([groupId], auth);
+    return c.json({
+      id: group.id,
+      orgId: group.orgId,
+      name: name !== undefined ? name : group.name,
+      members: members.get(groupId) ?? [],
+    });
+  },
+);
+
+// DELETE /devices/link-groups/:groupId — unlink every profile and remove the group.
+linksRoutes.delete(
+  '/link-groups/:groupId',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_DELETE.resource, PERMISSIONS.DEVICES_DELETE.action),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth');
+    const groupId = c.req.param('groupId')!;
+
+    const group = await getGroupWithOrgCheck(groupId, auth);
+    if (!group) return c.json({ error: 'Link group not found' }, 404);
+
+    await db.transaction(async (tx) => {
+      await deleteLinkGroup(tx, groupId);
+    });
+
+    writeRouteAudit(c, {
+      orgId: group.orgId,
+      action: 'device_link_group.delete',
+      resourceType: 'device_link_group',
+      resourceId: groupId,
+      resourceName: group.name,
+    });
+
+    return c.json({ success: true });
+  },
+);
+
+// GET /devices/:id/link-group — the boot-profile group a device belongs to,
+// with its sibling profiles (agent version + last seen). Powers the device
+// detail "Linked Profiles" panel. Returns { group: null } when unlinked.
+linksRoutes.get(
+  '/:id/link-group',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action),
+  async (c) => {
+    const auth = c.get('auth');
+    const deviceId = c.req.param('id')!;
+
+    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    if (device === SITE_ACCESS_DENIED) {
+      return c.json({ error: 'Access to this site denied' }, 403);
+    }
+    if (!device) {
+      return c.json({ error: 'Device not found' }, 404);
+    }
+
+    if (!device.linkGroupId) {
+      return c.json({ group: null, members: [] });
+    }
+
+    const [group] = await db
+      .select()
+      .from(deviceLinkGroups)
+      .where(eq(deviceLinkGroups.id, device.linkGroupId))
+      .limit(1);
+    if (!group) {
+      // Defensive: dangling reference (should be impossible under the FK).
+      return c.json({ group: null, members: [] });
+    }
+
+    const members = await loadMembers([group.id], auth);
+    return c.json({
+      group: {
+        id: group.id,
+        orgId: group.orgId,
+        name: group.name,
+        createdAt: group.createdAt,
+        updatedAt: group.updatedAt,
+      },
+      members: members.get(group.id) ?? [],
+    });
+  },
+);

--- a/apps/api/src/routes/devices/links.ts
+++ b/apps/api/src/routes/devices/links.ts
@@ -268,7 +268,19 @@ linksRoutes.patch(
       }
     }
 
+    // Validate removals through the SAME org+site chokepoint as additions and
+    // reads (loadMembers), so a site-restricted caller cannot unlink a boot
+    // profile in a site they can't access just by knowing its id.
     const toRemove = [...new Set(removeDeviceIds ?? [])];
+    for (const id of toRemove) {
+      const device = await getDeviceWithOrgAndSiteCheck(c, id, auth);
+      if (device === SITE_ACCESS_DENIED) {
+        return c.json({ error: 'Access to a device site denied' }, 403);
+      }
+      if (!device) {
+        return c.json({ error: `Device ${id} not found` }, 404);
+      }
+    }
 
     // Enforce the size ceiling on the resulting membership.
     const currentMembers = await db

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -18,6 +18,7 @@ import {
 import { moveOrgSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { DEVICE_ORG_DENORMALIZED_TABLES, DEVICE_SITE_DENORMALIZED_TABLES } from './core';
+import { dissolveLinkGroupIfBelowMinimum } from '../../services/deviceLinkGroups';
 import { disconnectAgent } from '../agentWs';
 import { captureException } from '../../services/sentry';
 
@@ -138,11 +139,23 @@ moveOrgRoutes.post(
           .set({
             orgId: targetOrgId,
             siteId: targetSiteId,
+            // #2138 — a device leaving its org can no longer be a boot profile
+            // of a machine in the OLD org. Unlink it here; the composite FK
+            // (link_group_id, org_id) -> device_link_groups(id, org_id) would
+            // otherwise fail the org flip. The source group is dissolved below
+            // if it drops below the two-profile minimum.
+            linkGroupId: null,
             updatedAt: new Date(),
           })
           .where(eq(devices.id, deviceId))
           .returning();
         updated = row;
+
+        // #2138 — if the moved device left a link group with a single lone
+        // profile behind, that group is no longer meaningful: dissolve it.
+        if (device.linkGroupId) {
+          await dissolveLinkGroupIfBelowMinimum(tx, device.linkGroupId);
+        }
 
         // Rewrite the denormalized org_id on every device-scoped table.
         // Skipping any of these strands pre-existing rows under RLS.

--- a/apps/api/src/routes/devices/schemas.ts
+++ b/apps/api/src/routes/devices/schemas.ts
@@ -183,3 +183,23 @@ export const createGroupSchema = z.object({
 });
 
 export const updateGroupSchema = createGroupSchema.partial().omit({ orgId: true });
+
+// Linked device profiles for multi-boot systems (#2138). A link group ties 2+
+// device records together as boot profiles of one physical machine. Sizes track
+// MIN_LINK_GROUP_SIZE / MAX_LINK_GROUP_SIZE in services/deviceLinkGroups.ts.
+export const createLinkGroupSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  deviceIds: z.array(z.string().guid()).min(2).max(10),
+});
+
+export const updateLinkGroupSchema = z
+  .object({
+    // Nullable so the label can be cleared back to the hostname fallback.
+    name: z.string().min(1).max(255).nullable().optional(),
+    addDeviceIds: z.array(z.string().guid()).min(1).max(10).optional(),
+    removeDeviceIds: z.array(z.string().guid()).min(1).max(10).optional(),
+  })
+  .refine(
+    (d) => d.name !== undefined || d.addDeviceIds !== undefined || d.removeDeviceIds !== undefined,
+    { message: 'Provide at least one of name, addDeviceIds, or removeDeviceIds' },
+  );

--- a/apps/api/src/services/deviceLinkGroups.ts
+++ b/apps/api/src/services/deviceLinkGroups.ts
@@ -1,0 +1,74 @@
+/**
+ * Linked device profiles for multi-boot systems (#2138).
+ *
+ * A physical machine that dual/multi-boots runs one Breeze agent per OS and so
+ * appears as several device records — only one online at a time. A
+ * `device_link_groups` row plus the `devices.link_group_id` column groups those
+ * records as boot profiles of one machine. This is a NON-destructive overlay:
+ * device records stay fully separate. Membership is the column on `devices`
+ * (one group per device), so there is no child membership table — a group is
+ * dissolved by nulling its members and deleting the group row.
+ *
+ * These helpers run through a `DbExecutor` (the request `db` OR a transaction
+ * handle) so callers — the link routes and the move-org path — can compose them
+ * inside their own transactions. The composite FK
+ * devices(link_group_id, org_id) -> device_link_groups(id, org_id) means a
+ * group row can only be deleted once every member's `link_group_id` is cleared,
+ * which is exactly the order these helpers use.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceLinkGroups, devices } from '../db/schema';
+
+/** db instance or an open transaction — both expose the query builders used here. */
+export type DbExecutor = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** A linked group only makes sense with two or more boot profiles. */
+export const MIN_LINK_GROUP_SIZE = 2;
+
+/** Upper bound on members in one physical-machine group (generous headroom). */
+export const MAX_LINK_GROUP_SIZE = 10;
+
+/** Clear `link_group_id` on the given devices (unlink), leaving the group row. */
+export async function unlinkDevices(exec: DbExecutor, deviceIds: string[]): Promise<void> {
+  if (deviceIds.length === 0) return;
+  for (const id of deviceIds) {
+    await exec
+      .update(devices)
+      .set({ linkGroupId: null, updatedAt: new Date() })
+      .where(eq(devices.id, id));
+  }
+}
+
+/**
+ * If a group has fallen below {@link MIN_LINK_GROUP_SIZE} members, unlink any
+ * survivor and delete the (now-meaningless) group row. Returns true when the
+ * group was dissolved. A group at or above the minimum is left untouched.
+ */
+export async function dissolveLinkGroupIfBelowMinimum(
+  exec: DbExecutor,
+  groupId: string,
+): Promise<boolean> {
+  const members = await exec
+    .select({ id: devices.id })
+    .from(devices)
+    .where(eq(devices.linkGroupId, groupId));
+
+  if (members.length >= MIN_LINK_GROUP_SIZE) return false;
+
+  // Null any lone survivor first — the composite FK forbids deleting the group
+  // while a device still references it.
+  await unlinkDevices(exec, members.map((m) => m.id));
+  await exec.delete(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId));
+  return true;
+}
+
+/** Delete a group outright: unlink all members, then remove the group row. */
+export async function deleteLinkGroup(exec: DbExecutor, groupId: string): Promise<void> {
+  const members = await exec
+    .select({ id: devices.id })
+    .from(devices)
+    .where(eq(devices.linkGroupId, groupId));
+  await unlinkDevices(exec, members.map((m) => m.id));
+  await exec.delete(deviceLinkGroups).where(eq(deviceLinkGroups.id, groupId));
+}

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -143,6 +143,10 @@ export const ORG_CASCADE_DELETE_ORDER: ReadonlyArray<string> = Object.freeze([
   'device_groups',
   'device_hardware',
   'device_ip_history',
+  // #2138 — linked multi-boot profiles. The topo-sort deletes `devices` before
+  // this (devices carries the FK to device_link_groups), so members are cleared
+  // first and the group rows delete cleanly.
+  'device_link_groups',
   'device_metrics',
   'device_network',
   'device_patches',

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -26,6 +26,7 @@ import {
   TrendingUp,
   HeartPulse,
   ShieldCheck,
+  Link2,
 } from 'lucide-react';
 import { formatUptime } from '../../lib/utils';
 import type { Device, DeviceStatus } from './DeviceList';
@@ -62,6 +63,7 @@ import DeviceAnomaliesPanel from './DeviceAnomaliesPanel';
 import DeviceReliabilityPanel from './DeviceReliabilityPanel';
 import DeviceMonitoringTab from './DeviceMonitoringTab';
 import DeviceComplianceTab from './DeviceComplianceTab';
+import DeviceLinkedProfilesTab from './DeviceLinkedProfilesTab';
 
 type Tab =
   | 'overview'
@@ -88,6 +90,7 @@ type Tab =
   | 'playbooks'
   | 'peripherals'
   | 'backup'
+  | 'linked-profiles'
   | 'tickets';
 
 type DeviceDetailsProps = {
@@ -138,7 +141,7 @@ const VALID_TABS: Tab[] = [
   'overview', 'details', 'hardware', 'software', 'patches', 'vulnerabilities', 'security',
   'management', 'effective-config', 'alerts', 'scripts', 'performance',
   'anomalies', 'eventlog', 'monitoring', 'compliance', 'activities', 'connections', 'filesystem', 'ip-history',
-  'boot-performance', 'playbooks', 'peripherals', 'backup', 'tickets',
+  'boot-performance', 'playbooks', 'peripherals', 'backup', 'linked-profiles', 'tickets',
 ];
 
 function getTabFromHash(): Tab {
@@ -184,6 +187,7 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
     // --- Summary ---
     { id: 'overview', label: 'Overview', icon: <Monitor className="h-4 w-4" /> },
     { id: 'details', label: 'Details', icon: <Info className="h-4 w-4" />, title: 'OS, network, and system details' },
+    { id: 'linked-profiles', label: 'Linked Profiles', icon: <Link2 className="h-4 w-4" />, title: 'Multi-boot OS profiles linked to this machine' },
     // --- Monitoring ---
     { id: 'performance', label: 'Performance', icon: <Activity className="h-4 w-4" />, separator: true, title: 'CPU, RAM, and disk usage over time' },
     { id: 'alerts', label: 'Alerts', icon: <AlertTriangle className="h-4 w-4" />, title: 'Alert history for this device' },
@@ -326,6 +330,10 @@ export default function DeviceDetails({ device, timezone, onBack, onAction }: De
 
       {activeTab === 'details' && (
         <DeviceInfoTab deviceId={device.id} />
+      )}
+
+      {activeTab === 'linked-profiles' && (
+        <DeviceLinkedProfilesTab deviceId={device.id} />
       )}
 
       {activeTab === 'hardware' && (

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceLinkedProfilesTab from './DeviceLinkedProfilesTab';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+}));
+
+vi.mock('../../lib/runAction', () => ({
+  runAction: vi.fn(async ({ request }: { request: () => Promise<Response> }) => {
+    await request();
+  }),
+  handleActionError: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('DeviceLinkedProfilesTab', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the empty state when the device is unlinked', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ group: null, members: [] }));
+    render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+    await waitFor(() => expect(screen.getByTestId('linked-profiles-empty')).toBeInTheDocument());
+  });
+
+  it('renders linked profiles with agent version and last seen', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        group: { id: 'g1', name: 'Todd ThinkPad' },
+        members: [
+          { deviceId: 'dev-1', hostname: 'tp-win', displayName: null, osType: 'windows', osVersion: '11', agentVersion: '1.2.3', status: 'online', lastSeenAt: '2026-06-01T00:00:00.000Z' },
+          { deviceId: 'dev-2', hostname: 'tp-lin', displayName: null, osType: 'linux', osVersion: '22.04', agentVersion: '1.2.4', status: 'offline', lastSeenAt: null },
+        ],
+      }),
+    );
+    render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('linked-profiles-tab')).toBeInTheDocument());
+    expect(screen.getByTestId('linked-profile-dev-1')).toBeInTheDocument();
+    expect(screen.getByTestId('linked-profile-dev-2')).toBeInTheDocument();
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+    // No conflict: only one profile online.
+    expect(screen.queryByTestId('linked-profiles-conflict')).not.toBeInTheDocument();
+  });
+
+  it('flags a conflict when more than one profile is online', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        group: { id: 'g1', name: null },
+        members: [
+          { deviceId: 'dev-1', hostname: 'a', displayName: null, osType: 'windows', osVersion: '11', agentVersion: '1', status: 'online', lastSeenAt: null },
+          { deviceId: 'dev-2', hostname: 'b', displayName: null, osType: 'linux', osVersion: '22', agentVersion: '1', status: 'online', lastSeenAt: null },
+        ],
+      }),
+    );
+    render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+    await waitFor(() => expect(screen.getByTestId('linked-profiles-conflict')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.test.tsx
@@ -50,6 +50,15 @@ describe('DeviceLinkedProfilesTab', () => {
     expect(screen.queryByTestId('linked-profiles-conflict')).not.toBeInTheDocument();
   });
 
+  it('shows an access-denied state (no Retry) on a 403', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      { ok: false, status: 403, json: vi.fn().mockResolvedValue({}) } as unknown as Response,
+    );
+    render(<DeviceLinkedProfilesTab deviceId="dev-1" />);
+    await waitFor(() => expect(screen.getByTestId('linked-profiles-denied')).toBeInTheDocument());
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
   it('flags a conflict when more than one profile is online', async () => {
     fetchWithAuthMock.mockResolvedValue(
       jsonResponse({

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link2, Link2Off, AlertTriangle, Circle } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, handleActionError } from '../../lib/runAction';
+
+/** One boot profile (device record) in a linked multi-boot group. */
+export interface LinkedProfile {
+  deviceId: string;
+  hostname: string;
+  displayName: string | null;
+  osType: string;
+  osVersion: string;
+  agentVersion: string;
+  status: string;
+  lastSeenAt: string | null;
+}
+
+interface LinkGroupResponse {
+  group: { id: string; name: string | null } | null;
+  members: LinkedProfile[];
+}
+
+function formatLastSeen(iso: string | null): string {
+  if (!iso) return 'Never';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'Unknown';
+  const mins = Math.floor((Date.now() - then) / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function DeviceLinkedProfilesTab({ deviceId }: { deviceId: string }) {
+  const [data, setData] = useState<LinkGroupResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetchWithAuth(`/devices/${deviceId}/link-group`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as LinkGroupResponse);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const group = data?.group ?? null;
+  const members = data?.members ?? [];
+  const onlineCount = members.filter((m) => m.status === 'online').length;
+  const hasConflict = onlineCount > 1;
+
+  const unlinkThisDevice = async () => {
+    if (!group) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/devices/link-groups/${group.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ removeDeviceIds: [deviceId] }),
+          }),
+        errorFallback: 'Could not unlink this device',
+        successMessage: 'Device unlinked',
+      });
+      await load();
+    } catch (err) {
+      handleActionError(err, 'Could not unlink this device');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const dissolveGroup = async () => {
+    if (!group) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/devices/link-groups/${group.id}`, { method: 'DELETE' }),
+        errorFallback: 'Could not remove the link',
+        successMessage: 'Link removed',
+      });
+      await load();
+    } catch (err) {
+      handleActionError(err, 'Could not remove the link');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading linked profiles…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border bg-card p-6" data-testid="linked-profiles-error">
+        <p className="text-sm text-destructive">Could not load linked profiles.</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="mt-3 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div className="rounded-lg border bg-card p-6" data-testid="linked-profiles-empty">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Link2 className="h-4 w-4 text-muted-foreground" />
+          Not part of a linked group
+        </div>
+        <p className="mt-2 max-w-prose text-sm text-muted-foreground">
+          Multi-boot machines run a separate Breeze agent per OS, so the same hardware shows up as several
+          devices. Select this device and its other boot profiles in the device list, then choose
+          <span className="font-medium"> Link as multi-boot</span> to group them. The offline profiles stop
+          adding noise to your online/offline counts while every device keeps its own history.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="linked-profiles-tab">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Link2 className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">{group.name || 'Linked boot profiles'}</h3>
+          <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+            {members.length} profiles
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void unlinkThisDevice()}
+            data-testid="linked-profiles-unlink-self"
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+          >
+            <Link2Off className="h-3.5 w-3.5" />
+            Unlink this device
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void dissolveGroup()}
+            data-testid="linked-profiles-dissolve"
+            className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-50"
+          >
+            Remove link
+          </button>
+        </div>
+      </div>
+
+      {hasConflict && (
+        <div
+          data-testid="linked-profiles-conflict"
+          className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-sm text-warning"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            More than one linked profile is reporting online at the same time. A multi-boot machine can only
+            run one OS at once — this usually means the devices were linked incorrectly or the hardware
+            identity changed.
+          </span>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 font-medium">Profile</th>
+              <th className="px-3 py-2 font-medium">OS</th>
+              <th className="px-3 py-2 font-medium">Status</th>
+              <th className="px-3 py-2 font-medium">Agent</th>
+              <th className="px-3 py-2 font-medium">Last seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((m) => {
+              const isOnline = m.status === 'online';
+              const isCurrent = m.deviceId === deviceId;
+              return (
+                <tr
+                  key={m.deviceId}
+                  data-testid={`linked-profile-${m.deviceId}`}
+                  className={`border-t ${isOnline ? '' : 'text-muted-foreground'} ${isCurrent ? 'bg-muted/30' : ''}`}
+                >
+                  <td className="px-3 py-2">
+                    <div className="font-medium">
+                      {m.displayName || m.hostname}
+                      {isCurrent && <span className="ml-2 text-xs text-muted-foreground">(this device)</span>}
+                    </div>
+                    <div className="text-xs text-muted-foreground">{m.hostname}</div>
+                  </td>
+                  <td className="px-3 py-2 capitalize">
+                    {m.osType} <span className="text-xs text-muted-foreground">{m.osVersion}</span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-flex items-center gap-1.5 ${isOnline ? 'text-success' : 'text-muted-foreground'}`}
+                      data-testid={`linked-profile-${m.deviceId}-status`}
+                    >
+                      <Circle className={`h-2 w-2 ${isOnline ? 'fill-success' : 'fill-muted-foreground'}`} />
+                      {isOnline ? 'Online (active)' : m.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">v{m.agentVersion}</td>
+                  <td className="px-3 py-2">{formatLastSeen(m.lastSeenAt)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
+++ b/apps/web/src/components/devices/DeviceLinkedProfilesTab.tsx
@@ -35,18 +35,31 @@ function formatLastSeen(iso: string | null): string {
 export default function DeviceLinkedProfilesTab({ deviceId }: { deviceId: string }) {
   const [data, setData] = useState<LinkGroupResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  // 'none' = ok, 'denied' = 403 (a Retry can never succeed), 'other' = a
+  // transient/5xx failure worth retrying.
+  const [errorKind, setErrorKind] = useState<'none' | 'denied' | 'other'>('none');
   const [busy, setBusy] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
-    setError(false);
+    setErrorKind('none');
     try {
       const res = await fetchWithAuth(`/devices/${deviceId}/link-group`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (res.status === 403) {
+        setErrorKind('denied');
+        return;
+      }
+      if (!res.ok) {
+        // Observability: a persistent 5xx on this panel should be visible in
+        // the console rather than collapsing into a silent boolean.
+        console.error(`Failed to load linked profiles for ${deviceId}: HTTP ${res.status}`);
+        setErrorKind('other');
+        return;
+      }
       setData((await res.json()) as LinkGroupResponse);
-    } catch {
-      setError(true);
+    } catch (err) {
+      console.error(`Failed to load linked profiles for ${deviceId}:`, err);
+      setErrorKind('other');
     } finally {
       setLoading(false);
     }
@@ -104,7 +117,17 @@ export default function DeviceLinkedProfilesTab({ deviceId }: { deviceId: string
     return <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading linked profiles…</div>;
   }
 
-  if (error) {
+  if (errorKind === 'denied') {
+    return (
+      <div className="rounded-lg border bg-card p-6" data-testid="linked-profiles-denied">
+        <p className="text-sm text-muted-foreground">
+          You don&apos;t have access to this device&apos;s linked profiles.
+        </p>
+      </div>
+    );
+  }
+
+  if (errorKind === 'other') {
     return (
       <div className="rounded-lg border bg-card p-6" data-testid="linked-profiles-error">
         <p className="text-sm text-destructive">Could not load linked profiles.</p>

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -123,6 +123,16 @@ export type Device = {
    * dash. { present: false } = a real no-battery desktop → also a dash.
    */
   batteryStatus?: BatteryStatus | null;
+  /**
+   * Linked multi-boot profiles (#2138). Present only on a group's collapsed
+   * PRIMARY row (set by collapseLinkedDevices). `linkedSiblings` are the other
+   * boot profiles of the same physical machine (suppressed as their own rows);
+   * `linkConflict` is true when more than one profile reports online at once.
+   */
+  linkGroupId?: string | null;
+  linkGroupName?: string | null;
+  linkedSiblings?: Device[];
+  linkConflict?: boolean;
 };
 
 // Columns that only make sense for the network arm (#1322); hidden unless
@@ -1326,6 +1336,16 @@ export default function DeviceList({
                 >
                   Wake Selected
                 </button>
+                {selectedIds.size >= 2 && (
+                  <button
+                    type="button"
+                    data-testid="bulk-link-multiboot"
+                    onClick={() => handleBulkAction('link-multiboot')}
+                    className="w-full px-4 py-2 text-left text-sm hover:bg-muted"
+                  >
+                    Link as multi-boot
+                  </button>
+                )}
                 <hr className="my-1" />
                 <button
                   type="button"
@@ -1400,6 +1420,26 @@ export default function DeviceList({
                       onChange={e => handleSelectOne(device.id, e.target.checked)}
                       className="h-4 w-4 rounded border-border"
                     />
+                    {device.linkedSiblings && device.linkedSiblings.length > 0 && (
+                      <div className="mt-1.5 flex flex-col items-start gap-1">
+                        <span
+                          data-testid={`device-${device.id}-multiboot-badge`}
+                          title={`Multi-boot machine — ${device.linkedSiblings.length + 1} linked OS profiles${device.status === 'online' ? ` (${device.os} active)` : ''}. Open the device to expand all profiles.`}
+                          className="inline-flex items-center whitespace-nowrap rounded-full border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                        >
+                          {device.linkedSiblings.length + 1} OS
+                        </span>
+                        {device.linkConflict && (
+                          <span
+                            data-testid={`device-${device.id}-link-conflict`}
+                            title="More than one linked profile is online at once — the devices may be linked incorrectly."
+                            className="inline-flex items-center whitespace-nowrap rounded-full border border-warning/40 bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning"
+                          >
+                            Conflict
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </td>
                   {renderedColumns.map(id => columnDefs[id].cell(device))}
                   <td className="px-3 py-3 text-sm" onClick={e => e.stopPropagation()}>

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -5,6 +5,7 @@ import { List, Grid, Plus, AlertCircle } from 'lucide-react';
 import { showToast } from '../shared/Toast';
 import type { FilterConditionGroup } from '@breeze/shared';
 import DeviceList, { type Device, type DeviceClass, type DeviceStatus, type OSType } from './DeviceList';
+import { collapseLinkedDevices, type LinkGroupSummary } from './linkedDevices';
 import type { DeviceRole } from '@/lib/deviceRoles';
 import DeviceCard from './DeviceCard';
 import ScriptPickerModal, { type Script, type ScriptRunAsSelection } from './ScriptPickerModal';
@@ -26,7 +27,7 @@ import {
 import { fetchWithAuth } from '../../stores/auth';
 import { fetchAllDevices, fetchAllNetworkDevices } from '../../lib/devicesFetch';
 import { useOrgStore } from '../../stores/orgStore';
-import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage } from '../../services/deviceActions';
+import { sendDeviceCommand, sendBulkCommand, executeScript, toggleMaintenanceMode, decommissionDevice, bulkDecommissionDevices, restoreDevice, permanentDeleteDevice, sendWakeCommand, sendBulkWakeCommand, summarizeBulkWakeFailures, summarizeBulkCommandFailures, watchWakeOutcome, WakeCommandError, wakeFriendlyErrorMessage, linkDevicesMultiboot } from '../../services/deviceActions';
 import { navigateTo } from '@/lib/navigation';
 import { getErrorMessage, getErrorTitle, isAccessDenied } from '@/lib/errorMessages';
 import AccessDenied from '../shared/AccessDenied';
@@ -76,6 +77,9 @@ export default function DevicesPage() {
   const [sites, setSites] = useState<Site[]>([]);
   const [deviceGroups, setDeviceGroups] = useState<DeviceGroup[]>([]);
   const [groupMembershipMap, setGroupMembershipMap] = useState<Map<string, Set<string>>>(new Map());
+  // Linked multi-boot profiles (#2138) — used to collapse each group into a
+  // single primary row in the list view.
+  const [linkGroups, setLinkGroups] = useState<LinkGroupSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('list');
@@ -221,6 +225,12 @@ export default function DevicesPage() {
     },
     [classFilteredDevices, advancedFilterIds, includeDecommissioned]
   );
+  // Collapse linked multi-boot groups into a single primary row for the list
+  // view (#2138). The grid view keeps individual cards.
+  const listDevices = useMemo(
+    () => collapseLinkedDevices(classFilteredDevices, linkGroups),
+    [classFilteredDevices, linkGroups]
+  );
 
   const fetchDevices = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -238,7 +248,7 @@ export default function DevicesPage() {
       // `signal` is wired by the mount useEffect's AbortController so a
       // navigate-away mid-walk stops the next page request and prevents
       // setState on an unmounted component (#778 review).
-      const [devicesResult, networkResult, orgsResponse, sitesResponse, groupsResponse] = await Promise.all([
+      const [devicesResult, networkResult, orgsResponse, sitesResponse, groupsResponse, linkGroupsResponse] = await Promise.all([
         fetchAllDevices({
           includeDecommissioned: true,
           signal,
@@ -281,6 +291,15 @@ export default function DevicesPage() {
           // catch can short-circuit cleanly; don't log it as a real failure.
           if (err instanceof Error && err.name === 'AbortError') throw err;
           console.warn('Failed to fetch device groups:', err);
+          return null;
+        }),
+        // Linked multi-boot profiles (#2138). Best-effort: a transient/absent
+        // failure must not blank the fleet — degrade to no grouping. A 401 is a
+        // real auth failure and re-thrown to the outer catch (as elsewhere).
+        fetchWithAuth('/devices/link-groups', { signal }).catch((err) => {
+          if (err instanceof Error && err.name === 'AbortError') throw err;
+          if (err instanceof Response && err.status === 401) throw err;
+          console.warn('Failed to fetch device link groups:', err);
           return null;
         })
       ]);
@@ -420,8 +439,25 @@ export default function DevicesPage() {
         }
       }
 
+      // Linked multi-boot profiles (#2138): map to LinkGroupSummary for collapse.
+      let linkGroupsList: LinkGroupSummary[] = [];
+      if (linkGroupsResponse && linkGroupsResponse.ok) {
+        const linkData = await linkGroupsResponse.json();
+        const raw = (linkData.data ?? []) as Array<Record<string, unknown>>;
+        linkGroupsList = raw.map((g) => ({
+          id: g.id as string,
+          name: (g.name as string | null) ?? null,
+          deviceIds: Array.isArray(g.members)
+            ? (g.members as Array<Record<string, unknown>>).map((m) => m.deviceId as string)
+            : [],
+        }));
+      } else if (linkGroupsResponse && !linkGroupsResponse.ok) {
+        console.warn('Failed to fetch device link groups:', linkGroupsResponse.status);
+      }
+
       setDeviceGroups(groupsList);
       setGroupMembershipMap(memberMap);
+      setLinkGroups(linkGroupsList);
       setDevices(devicesWithNames);
       setOrgs(orgsList);
       setSites(sitesList);
@@ -753,6 +789,20 @@ export default function DevicesPage() {
       setActionInProgress(true);
 
       switch (action) {
+        case 'link-multiboot': {
+          if (deviceIds.length < 2) {
+            showToast({ type: 'error', message: 'Select at least two devices to link as multi-boot profiles.' });
+            break;
+          }
+          await linkDevicesMultiboot(deviceIds);
+          showToast({
+            type: 'success',
+            message: `Linked ${deviceCount} devices as multi-boot profiles.`,
+          });
+          await fetchDevices();
+          break;
+        }
+
         case 'reboot':
         case 'reboot_safe_mode':
         case 'shutdown':
@@ -1034,7 +1084,7 @@ export default function DevicesPage() {
         </div>
       ) : viewMode === 'list' ? (
         <DeviceList
-          devices={classFilteredDevices}
+          devices={listDevices}
           orgs={orgs}
           sites={sites}
           groups={deviceGroups}

--- a/apps/web/src/components/devices/linkedDevices.test.ts
+++ b/apps/web/src/components/devices/linkedDevices.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { collapseLinkedDevices, type LinkGroupSummary } from './linkedDevices';
+import type { Device } from './DeviceList';
+
+function mk(id: string, over: Partial<Device> = {}): Device {
+  return {
+    id,
+    hostname: `host-${id}`,
+    os: 'windows',
+    osVersion: '11',
+    status: 'offline',
+    cpuPercent: 0,
+    ramPercent: 0,
+    lastSeen: '2026-01-01T00:00:00.000Z',
+    orgId: 'org-1',
+    orgName: 'Org',
+    siteId: 'site-1',
+    siteName: 'Site',
+    agentVersion: '1.0.0',
+    tags: [],
+    ...over,
+  };
+}
+
+const group = (id: string, deviceIds: string[], name: string | null = null): LinkGroupSummary => ({
+  id,
+  name,
+  deviceIds,
+});
+
+describe('collapseLinkedDevices', () => {
+  it('returns the input unchanged when there are no groups', () => {
+    const devices = [mk('a'), mk('b')];
+    expect(collapseLinkedDevices(devices, [])).toBe(devices);
+  });
+
+  it('collapses a group to the online (active) profile and de-emphasizes siblings', () => {
+    const win = mk('win', { os: 'windows', status: 'online' });
+    const linux = mk('lin', { os: 'linux', status: 'offline' });
+    const out = collapseLinkedDevices([win, linux], [group('g1', ['win', 'lin'], 'Bootbox')]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('win');
+    expect(out[0]!.linkGroupId).toBe('g1');
+    expect(out[0]!.linkGroupName).toBe('Bootbox');
+    expect(out[0]!.linkedSiblings?.map((s) => s.id)).toEqual(['lin']);
+    expect(out[0]!.linkConflict).toBe(false);
+  });
+
+  it('surfaces the most-recently-seen profile when all are offline', () => {
+    const older = mk('old', { status: 'offline', lastSeen: '2026-01-01T00:00:00.000Z' });
+    const newer = mk('new', { status: 'offline', lastSeen: '2026-06-01T00:00:00.000Z' });
+    const out = collapseLinkedDevices([older, newer], [group('g1', ['old', 'new'])]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('new');
+    expect(out[0]!.linkConflict).toBe(false);
+  });
+
+  it('flags a conflict when more than one profile is online', () => {
+    const a = mk('a', { status: 'online', lastSeen: '2026-06-02T00:00:00.000Z' });
+    const b = mk('b', { status: 'online', lastSeen: '2026-06-01T00:00:00.000Z' });
+    const out = collapseLinkedDevices([a, b], [group('g1', ['a', 'b'])]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('a'); // most-recently-seen online
+    expect(out[0]!.linkConflict).toBe(true);
+    expect(out[0]!.linkedSiblings?.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('does not collapse a group with only one present member', () => {
+    // Sibling 'b' filtered out of the current view → 'a' renders normally.
+    const a = mk('a');
+    const out = collapseLinkedDevices([a], [group('g1', ['a', 'b'])]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.linkedSiblings).toBeUndefined();
+    expect(out[0]!.linkGroupId).toBeUndefined();
+  });
+
+  it('keeps ungrouped devices and preserves first-encountered ordering', () => {
+    const solo1 = mk('s1');
+    const win = mk('win', { status: 'online' });
+    const lin = mk('lin', { status: 'offline' });
+    const solo2 = mk('s2');
+    const out = collapseLinkedDevices([solo1, win, lin, solo2], [group('g1', ['win', 'lin'])]);
+
+    expect(out.map((d) => d.id)).toEqual(['s1', 'win', 's2']);
+  });
+});

--- a/apps/web/src/components/devices/linkedDevices.ts
+++ b/apps/web/src/components/devices/linkedDevices.ts
@@ -1,0 +1,83 @@
+import type { Device } from './DeviceList';
+
+/**
+ * Linked device profiles for multi-boot systems (#2138).
+ *
+ * A physical machine that dual/multi-boots runs one Breeze agent per OS, so the
+ * same hardware appears as several device records — only one can be online at a
+ * time. `collapseLinkedDevices` folds each linked group into a SINGLE primary
+ * row for the device list so the offline boot profiles stop inflating
+ * online/offline counts and cluttering the list.
+ *
+ * Primary-row selection:
+ *   - If any profile is online, the primary is an online profile (the most
+ *     recently seen one) — the "active OS".
+ *   - If all profiles are offline, the primary is the most-recently-seen
+ *     profile (so the group still surfaces its last-known identity).
+ *
+ * The collapsed primary carries its siblings (`linkedSiblings`) plus a
+ * `linkConflict` flag set when MORE THAN ONE profile reports online at once —
+ * which, for a machine that can only boot one OS at a time, signals the devices
+ * were linked incorrectly or the hardware identity changed.
+ */
+export interface LinkGroupSummary {
+  id: string;
+  name: string | null;
+  deviceIds: string[];
+}
+
+function lastSeenMs(d: Device): number {
+  const t = d.lastSeen ? new Date(d.lastSeen).getTime() : NaN;
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** Most-recently-seen wins; ties keep the first (stable). */
+function mostRecent(devices: Device[]): Device {
+  return devices.reduce((best, d) => (lastSeenMs(d) > lastSeenMs(best) ? d : best), devices[0]!);
+}
+
+export function collapseLinkedDevices(devices: Device[], groups: LinkGroupSummary[]): Device[] {
+  if (groups.length === 0) return devices;
+
+  const byId = new Map(devices.map((d) => [d.id, d]));
+  const groupOf = new Map<string, LinkGroupSummary>();
+  for (const g of groups) {
+    for (const id of g.deviceIds) groupOf.set(id, g);
+  }
+
+  const processed = new Set<string>();
+  const out: Device[] = [];
+
+  for (const device of devices) {
+    if (processed.has(device.id)) continue;
+
+    const group = groupOf.get(device.id);
+    // Only present members count — a sibling may be filtered out or on another
+    // page's fetch. A group with a single present member renders as normal.
+    const members = group
+      ? group.deviceIds.map((id) => byId.get(id)).filter((d): d is Device => d !== undefined)
+      : [];
+
+    if (!group || members.length < 2) {
+      out.push(device);
+      processed.add(device.id);
+      continue;
+    }
+
+    for (const m of members) processed.add(m.id);
+
+    const online = members.filter((m) => m.status === 'online');
+    const primary = online.length > 0 ? mostRecent(online) : mostRecent(members);
+    const siblings = members.filter((m) => m.id !== primary.id);
+
+    out.push({
+      ...primary,
+      linkGroupId: group.id,
+      linkGroupName: group.name,
+      linkedSiblings: siblings,
+      linkConflict: online.length > 1,
+    });
+  }
+
+  return out;
+}

--- a/apps/web/src/services/deviceActions.ts
+++ b/apps/web/src/services/deviceActions.ts
@@ -394,6 +394,29 @@ export async function decommissionDevice(deviceId: string): Promise<{ success: b
   return data.data ?? data;
 }
 
+/**
+ * Link 2+ devices as boot profiles of one physical machine (#2138). All must
+ * belong to the same organization and be currently unlinked; the API enforces
+ * both.
+ */
+export async function linkDevicesMultiboot(
+  deviceIds: string[],
+  name?: string,
+): Promise<{ id: string }> {
+  const response = await fetchWithAuth('/devices/link-groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(name ? { deviceIds, name } : { deviceIds }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, 'Failed to link devices'));
+  }
+
+  const data = await response.json();
+  return data.data ?? data;
+}
+
 export async function restoreDevice(deviceId: string): Promise<{ success: boolean }> {
   const response = await fetchWithAuth(`/devices/${deviceId}/restore`, {
     method: 'POST'


### PR DESCRIPTION
## What & why

Closes the multi-boot noise problem from #2138 (reporter: @ramphex; maintainer accepted the spec in-thread). A dual/multi-boot machine runs one Breeze agent per OS, so the same hardware shows up as several device records — only one online at a time. Today the inactive OS looks like an offline device and pollutes lists, online/offline counts, and alerts.

This adds a **non-destructive link**: 2+ device records grouped as boot profiles of one physical machine. Every device record stays fully separate — inventory, software, scripts, command history, audit, telemetry all preserved. It's a UI/monitoring overlay, not a merge. Manual link/unlink only; no automatic hardware-identity merging in v1.

## Data model (Shape 1, direct `org_id`)

- New **`device_link_groups`** table + a nullable **`devices.link_group_id`** column. Membership *is* the column on `devices` (one group per device), so there's **no membership child table** to cascade and no denormalized `org_id` to keep in sync.
- **RLS** enabled + forced with the four `breeze_has_org_access` policies **in the same migration** — auto-discovered by the rls-coverage contract (no allowlist edit needed).
- **Same-org invariant enforced structurally** by the composite FK `devices(link_group_id, org_id) → device_link_groups(id, org_id)`: a device's org must equal its group's org, so every member of a group is same-org. (The `users(org_id, partner_id)` composite-FK convention — declared in the migration, not Drizzle.)
- `tenantCascade` sweeps the new table (topo-sort deletes `devices` first); **move-org** unlinks the moving device and dissolves an orphaned source group; **permanent-delete** dissolves an orphan too.

## API (tenant-scoped, mounted before core `/:id`)

`POST/GET/PATCH/DELETE /devices/link-groups` and `GET /devices/:id/link-group`. Create/patch validate every device through the org+site chokepoint and reject cross-org or already-linked devices; a group that falls below two members is dissolved. Reads honor site-scope (a restricted caller never sees a profile in a forbidden site).

## Web

- **Device list** collapses each linked group into a single primary row — the active OS when one profile is online, else the most-recently-seen profile — de-emphasizing offline siblings and showing a **conflict** badge when more than one profile reports online at once. New **"Link as multi-boot"** bulk action.
- **Device detail → "Linked Profiles" tab** lists every profile with **agent version + last seen**, flags conflicts, and offers unlink / remove-link (wrapped in `runAction`). This is the "expand to see all profiles" surface.

Follow-up (explicitly out of scope, per the issue): alerting/dashboard noise-suppression for linked inactive profiles.

## Testing

- **Real-DB RLS forge** (`deviceLinkGroupsRls.integration.test.ts`): same-org create+link OK; forged cross-org insert rejected `42501`; composite-FK cross-org link rejected `23503`; cross-org read isolation; plus dissolve/delete behavior.
- Route guard branches (`links.test.ts`), pure collapse util (`linkedDevices.test.ts`), Linked Profiles tab render.
- Green: rls-coverage, tenant-cascade, move-org/cascade drift detectors, autoMigrate ordering, existing device-list/page suites, `no-silent-mutations`. `tsc --noEmit` clean (API + web).

Refs #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)