### PR TITLE
feat(agents): partner + org agent/watchdog version pins (#2124)

### DIFF
--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -209,6 +209,31 @@ describe("agentVersions routes", () => {
     });
   });
 
+  describe("GET /agent-versions/pinnable (#2124)", () => {
+    it("returns distinct agent + watchdog versions and the promoted set, excluding non-pinnable components", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          // newest-first order (createdAt desc) drives dedupe
+          { version: "0.88.0", component: "agent", isLatest: true },
+          { version: "0.88.0", component: "agent", isLatest: true }, // dupe (other arch)
+          { version: "0.87.0", component: "agent", isLatest: false },
+          { version: "0.88.0", component: "watchdog", isLatest: true },
+          { version: "0.50.0", component: "helper", isLatest: true }, // NOT pinnable
+        ]) as any,
+      );
+
+      const res = await app.request("/agent-versions/pinnable");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.components.agent.versions).toEqual(["0.88.0", "0.87.0"]);
+      expect(body.components.agent.promoted).toEqual(["0.88.0"]);
+      expect(body.components.watchdog.versions).toEqual(["0.88.0"]);
+      expect(body.components.watchdog.promoted).toEqual(["0.88.0"]);
+      // helper is not a pinnable component → absent from the response entirely.
+      expect(body.components).not.toHaveProperty("helper");
+    });
+  });
+
   describe("POST /agent-versions/promote", () => {
     // Build a fake transaction whose tx.select/tx.update record calls so we can
     // assert demote-then-promote happened. `priorByTuple` controls what the

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -661,6 +661,68 @@ agentVersionRoutes.post(
 // This is the operator view used to decide what to promote after a release is
 // registered (with AGENT_AUTO_PROMOTE=false). Returns every registered row,
 // newest-first, with an isLatest flag marking the current upgrade target.
+// GET /agent-versions/pinnable — the registered agent + watchdog versions an
+// org/partner admin may pin as their update target (issue #2124). Distinct from
+// the platform-admin `GET /` (which exposes every component + upload metadata):
+// this is a narrow, read-only picker feed available to any authenticated
+// org/partner/system user configuring settings. agent_versions is a GLOBAL,
+// non-tenant table, so exposing the version STRINGS carries no tenant data.
+agentVersionRoutes.get(
+  "/pinnable",
+  authMiddleware,
+  requireScope("organization", "partner", "system"),
+  async (c) => {
+    const rows = await db
+      .select({
+        version: agentVersions.version,
+        component: agentVersions.component,
+        isLatest: agentVersions.isLatest,
+      })
+      .from(agentVersions)
+      .orderBy(desc(agentVersions.createdAt)); // newest-first drives the dedupe order
+
+    // Only the two operator-facing binaries are pinnable (agent, watchdog).
+    type Bucket = {
+      versions: string[];
+      promoted: string[];
+      seen: Set<string>;
+      promotedSeen: Set<string>;
+    };
+    const newBucket = (): Bucket => ({
+      versions: [],
+      promoted: [],
+      seen: new Set(),
+      promotedSeen: new Set(),
+    });
+    const buckets = { agent: newBucket(), watchdog: newBucket() };
+
+    for (const row of rows) {
+      const bucket =
+        row.component === 'agent'
+          ? buckets.agent
+          : row.component === 'watchdog'
+            ? buckets.watchdog
+            : null; // skip helper/viewer/user-helper — not pinnable
+      if (!bucket) continue;
+      if (!bucket.seen.has(row.version)) {
+        bucket.seen.add(row.version);
+        bucket.versions.push(row.version);
+      }
+      if (row.isLatest && !bucket.promotedSeen.has(row.version)) {
+        bucket.promotedSeen.add(row.version);
+        bucket.promoted.push(row.version);
+      }
+    }
+
+    return c.json({
+      components: {
+        agent: { versions: buckets.agent.versions, promoted: buckets.agent.promoted },
+        watchdog: { versions: buckets.watchdog.versions, promoted: buckets.watchdog.promoted },
+      },
+    });
+  },
+);
+
 agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
   const rows = await db
     .select({

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -109,9 +109,17 @@ vi.mock('./helpers', () => ({
   buildHelperConfigUpdate: vi.fn(() => undefined),
   buildPamConfigUpdate: vi.fn(async () => ({ uacInterceptionEnabled: false })),
   buildPatchSourceConfigUpdate: vi.fn(async () => ({ exclusiveWindowsUpdate: false })),
-  // Permissive default (staged + no window = upgrade anytime) so the upgrade
-  // gating is transparent to tests that don't care about the org policy.
-  getOrgAgentUpdatePolicy: vi.fn(async () => ({ policy: 'staged', maintenanceWindow: null })),
+  // Permissive default (staged + no window = upgrade anytime) and no version
+  // pins (issue #2124), so the upgrade gating is transparent to tests that don't
+  // care about the org policy. The heartbeat resolves BOTH from this one call.
+  getOrgAgentUpdateConfig: vi.fn(async () => ({
+    settings: { policy: 'staged', maintenanceWindow: null },
+    pins: { agent: null, watchdog: null },
+  })),
+  // Default target mirrors the `selectMock` '0.66.0' convention used across the
+  // upgrade tests: the resolver returns the candidate target version, and the
+  // gate + compareAgentVersions (default 0 = no newer) decide whether to send it.
+  resolvePinnedUpgradeTarget: vi.fn(async () => '0.66.0'),
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -764,6 +772,67 @@ describe('POST /agents/:id/heartbeat — watchdog-branch agent recovery upgradeT
     const body = await resp.json() as { upgradeTo?: string };
     expect(body.upgradeTo).toBeUndefined();
   });
+
+  // #2124 — this recovery path is UNGATED by the update policy, so it carries the
+  // same `pinsResolved` fail-closed guard as the watchdog bootstrap: if the pin
+  // lookup failed we must NOT recover a wedged agent to global latest and thereby
+  // defeat a holdback pin on exactly the devices most likely to hit it.
+  it('resolver failure (pins unresolved) → withholds agent recovery upgradeTo (fail closed)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // would upgrade if it got that far
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValueOnce(new Error('db down'));
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.20',
+        lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+      },
+      [{ version: '0.66.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBeUndefined();
+  });
+
+  // #2124 — the recovery resolve threads the AGENT pin (versionPins.agent), never
+  // the watchdog pin. A mis-wiring here would recover the agent to the watchdog's
+  // pinned version. Uses component-keyed impl because the watchdog branch resolves
+  // first in this same beat; restored at the end so it does not leak.
+  it('recovery resolve threads the AGENT pin with this device’s platform/arch (no cross-wiring)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValueOnce({
+      settings: { policy: 'auto', maintenanceWindow: null },
+      pins: { agent: '0.90.0', watchdog: '0.91.0' },
+    });
+    vi.mocked(resolvePinnedUpgradeTarget).mockImplementation(
+      async ({ component }: { component: string }) => (component === 'agent' ? '0.90.0' : '0.91.0'),
+    );
+    primeSelects(
+      {
+        id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+        architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.20',
+        lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+      },
+      [{ version: '0.90.0' }],
+    );
+
+    const resp = await post();
+    expect(resp.status).toBe(200);
+
+    const agentCall = vi.mocked(resolvePinnedUpgradeTarget).mock.calls
+      .map((c) => c[0] as any)
+      .find((a) => a.component === 'agent');
+    expect(agentCall).toMatchObject({ component: 'agent', pin: '0.90.0', platform: 'windows', architecture: 'amd64' });
+    expect(agentCall?.pin).not.toBe('0.91.0'); // watchdog pin must not leak in
+    const body = await resp.json() as { upgradeTo?: string };
+    expect(body.upgradeTo).toBe('0.90.0');
+
+    // Restore the suite's default resolver impl (clearAllMocks does not).
+    vi.mocked(resolvePinnedUpgradeTarget).mockResolvedValue('0.66.0');
+  });
 });
 
 
@@ -821,9 +890,12 @@ describe('POST /agents/:id/heartbeat — controlled fleet rollout (promotion gat
   }
 
   it('offers upgradeTo for the explicitly-promoted (isLatest=true) version', async () => {
-    const { compareAgentVersions } = await import('./helpers');
+    const { compareAgentVersions, resolvePinnedUpgradeTarget } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1); // promoted > reported
-    prime([{ version: '0.71.0' }]); // a promoted row exists
+    // The resolver returns the promoted version as the candidate target (its
+    // isLatest-query behaviour is unit-tested in helpers.agentUpdatePolicy.test).
+    vi.mocked(resolvePinnedUpgradeTarget).mockResolvedValueOnce('0.71.0');
+    prime([{ version: '0.71.0' }]);
 
     const resp = await beat();
     expect(resp.status).toBe(200);
@@ -832,11 +904,12 @@ describe('POST /agents/:id/heartbeat — controlled fleet rollout (promotion gat
   });
 
   it('does NOT offer upgradeTo when the newer version is merely registered but un-promoted (no isLatest=true row)', async () => {
-    const { compareAgentVersions } = await import('./helpers');
-    // Even if a comparison WOULD say newer, the isLatest=true query returns no
-    // row, so the handler never reaches the comparison for a target.
+    const { compareAgentVersions, resolvePinnedUpgradeTarget } = await import('./helpers');
+    // Even if a comparison WOULD say newer, the resolver returns null (no
+    // isLatest=true row and no pin), so the handler never reaches a target.
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    prime([]); // no promoted row — 0.71.0 is registered with isLatest=false
+    vi.mocked(resolvePinnedUpgradeTarget).mockResolvedValueOnce(null);
+    prime([]);
 
     const resp = await beat();
     expect(resp.status).toBe(200);
@@ -1232,9 +1305,9 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   }
 
   it('manual policy → withholds agent upgradeTo even when a newer version exists', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1); // latest > reported
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'manual', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1245,9 +1318,9 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   });
 
   it('auto policy with no maintenance window → offers agent upgradeTo when newer exists', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1258,12 +1331,12 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   });
 
   it('staged policy outside the maintenance window → withholds agent upgradeTo', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
     // A window on a different UTC day than "now" guarantees we're outside it.
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     const otherDay = days[(new Date().getUTCDay() + 3) % 7];
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'staged', maintenanceWindow: `${otherDay} 02:00-04:00` });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'staged', maintenanceWindow: `${otherDay} 02:00-04:00` }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1278,10 +1351,10 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   // CLOSED and withhold the version-to-version agent upgradeTo (a fail-open here
   // would silently bypass Manual mode / a maintenance window on a DB hiccup).
   it('fails closed (withholds upgrade) when the policy lookup throws', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     const { captureException } = await import('../../services/sentry');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValueOnce(new Error('db down'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1302,8 +1375,8 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   // org block — reintroducing both the RLS bug and the #1105 hazard — would
   // pass every other test in this file.
   it('resolves the update policy in a system context that closes before the org context opens', async () => {
-    const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    const { getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
     callOrder.length = 0;
@@ -1327,9 +1400,9 @@ describe('POST /agents/:id/heartbeat — org agent update policy gating', () => 
   // regardless of policy. This pins the precedence of the dev-build short
   // circuit relative to the `updateGateAllows` branch (heartbeat.ts:508-511).
   it('dev- agent build is never upgraded even under auto policy', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1401,8 +1474,8 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   }
 
   it('manual policy → withholds helper and watchdog version-to-version upgrades', async () => {
-    const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    const { getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'manual', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
 
     const resp = await postWithInstalledComponents(deviceWithWatchdog);
     expect(resp.status).toBe(200);
@@ -1412,8 +1485,8 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   });
 
   it('auto policy → offers helper and watchdog version-to-version upgrades', async () => {
-    const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    const { getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
 
     const resp = await postWithInstalledComponents(deviceWithWatchdog);
     expect(resp.status).toBe(200);
@@ -1423,9 +1496,9 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   });
 
   it('manual policy → STILL bootstraps a missing helper and watchdog (bootstrap is ungated)', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'manual', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'manual', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1448,8 +1521,8 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
   // #2125 — a policy lookup failure must fail closed on the helper and watchdog
   // version-to-version channels too, not just the main agent channel.
   it('policy lookup failure → withholds helper and watchdog version-to-version upgrades (fail closed)', async () => {
-    const { getOrgAgentUpdatePolicy } = await import('./helpers');
-    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+    const { getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValueOnce(new Error('db down'));
 
     const resp = await postWithInstalledComponents(deviceWithWatchdog);
     expect(resp.status).toBe(200);
@@ -1458,12 +1531,14 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     expect(body.watchdogUpgradeTo).toBeFalsy();
   });
 
-  // Fail-closed must not strand fresh devices: a missing helper/watchdog still
-  // bootstraps even when the policy lookup itself throws (bootstrap is ungated).
-  it('policy lookup failure → STILL bootstraps a missing helper and watchdog', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+  // Fail-closed must not strand fresh devices on the UNPINNABLE helper channel:
+  // a missing helper still bootstraps even when the policy lookup throws. The
+  // WATCHDOG channel is pinnable (#2124), so its bootstrap is withheld until the
+  // pins resolve — see the next test for why.
+  it('policy lookup failure → STILL bootstraps a missing helper (unpinnable channel)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     vi.mocked(compareAgentVersions).mockReturnValue(1);
-    vi.mocked(getOrgAgentUpdatePolicy).mockRejectedValueOnce(new Error('db down'));
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValueOnce(new Error('db down'));
     selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
     selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
 
@@ -1478,7 +1553,28 @@ describe('POST /agents/:id/heartbeat — helper/watchdog upgrade gating', () => 
     };
     expect(body.upgradeTo).toBeFalsy(); // agent version-to-version gated → withheld
     expect(body.helperUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite lookup failure
-    expect(body.watchdogUpgradeTo).toBe('0.66.0'); // bootstrap → offered despite lookup failure
+  });
+
+  // #2124 — the WATCHDOG bootstrap IS withheld when the version-pin lookup fails.
+  // The upgrade channel is upgrade-only (`cmp > 0`), so it can never walk back a
+  // wrong-version bootstrap: if the org pinned an OLDER known-good watchdog and
+  // we bootstrap global latest because we couldn't read the pin, the device is
+  // permanently stranded above the pin. Fail closed and self-heal next heartbeat.
+  it('policy lookup failure → WITHHOLDS the missing-watchdog bootstrap (pin unresolved, fail closed)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
+    vi.mocked(compareAgentVersions).mockReturnValue(1);
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValueOnce(new Error('db down'));
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceNeedingBootstrap]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', agentVersion: '0.65.10', metrics: minimalHeartbeatBody.metrics }),
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { watchdogUpgradeTo?: string | null };
+    expect(body.watchdogUpgradeTo).toBeFalsy(); // withheld: pin could not be confirmed
   });
 });
 
@@ -1541,10 +1637,10 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
   });
 
   it('uses the reported version (not the stale column) to suppress redundant re-sends', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
     arrange(setSpy);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
 
     // Stale column is '0.65.0' (would trigger an upgrade); the agent now reports
@@ -1557,10 +1653,10 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
   });
 
   it('still upgrades when the reported watchdogVersion is genuinely behind latest', async () => {
-    const { compareAgentVersions, getOrgAgentUpdatePolicy } = await import('./helpers');
+    const { compareAgentVersions, getOrgAgentUpdateConfig } = await import('./helpers');
     const setSpy = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
     arrange(setSpy);
-    vi.mocked(getOrgAgentUpdatePolicy).mockResolvedValue({ policy: 'auto', maintenanceWindow: null });
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({ settings: { policy: 'auto', maintenanceWindow: null }, pins: { agent: null, watchdog: null } });
     vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
 
     const resp = await post({ agentVersion: '0.66.0', watchdogVersion: '0.65.0' });
@@ -1667,4 +1763,88 @@ describe('POST /agents/:id/heartbeat — virtualization attribute (#1387)', () =
   // dropped to undefined by .catch) is asserted against the real schema in
   // schemas.test.ts — this route test mocks zValidator out, so the handler
   // here only ever sees already-validated `data`.
+});
+
+// ---------------------------------------------------------------------
+// #2124 — version-pin threading: the AGENT branch must receive the agent
+// pin and the WATCHDOG branch the watchdog pin. Kept at the end of the file
+// because these tests set resolvePinnedUpgradeTarget's implementation, which
+// vi.clearAllMocks() does NOT restore — a swap-guard regression that would
+// otherwise pass the whole suite (both branches call the same resolver).
+// ---------------------------------------------------------------------
+
+describe('POST /agents/:id/heartbeat — version-pin threading (#2124)', () => {
+  const deviceRow = {
+    id: 'device-1', orgId: 'org-1', siteId: 'site-1', hostname: 'host',
+    osType: 'windows', architecture: 'amd64', agentVersion: '0.66.0',
+    watchdogVersion: '0.65.0', deviceRoleSource: 'auto',
+    lastSeenAt: new Date(), mainAgentSilentSince: null,
+  };
+  const realishCompare = (a: string, b: string) => (a === b ? 0 : a > b ? 1 : -1);
+
+  function arrange() {
+    vi.clearAllMocks();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+    updateMock.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  }
+
+  async function post(body: Record<string, unknown>) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', metrics: minimalHeartbeatBody.metrics, ...body }),
+    });
+  }
+
+  it('threads the agent pin to the agent resolve and the watchdog pin to the watchdog resolve (no cross-wiring)', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget } = await import('./helpers');
+    arrange();
+    vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'auto', maintenanceWindow: null },
+      pins: { agent: '0.90.0', watchdog: '0.91.0' },
+    });
+    vi.mocked(resolvePinnedUpgradeTarget).mockImplementation(
+      async ({ component }: { component: string }) => (component === 'agent' ? '0.90.0' : '0.91.0'),
+    );
+
+    const resp = await post({ agentVersion: '0.66.0', watchdogVersion: '0.65.0' });
+    expect(resp.status).toBe(200);
+
+    const calls = vi.mocked(resolvePinnedUpgradeTarget).mock.calls.map((c) => c[0] as any);
+    const agentCall = calls.find((a) => a.component === 'agent');
+    const watchdogCall = calls.find((a) => a.component === 'watchdog');
+
+    // Each branch gets ITS OWN pin + the device's real platform/arch.
+    expect(agentCall).toMatchObject({ component: 'agent', pin: '0.90.0', platform: 'windows', architecture: 'amd64' });
+    expect(watchdogCall).toMatchObject({ component: 'watchdog', pin: '0.91.0', platform: 'windows', architecture: 'amd64' });
+    // Regression guard: a swapped wiring would pass the version comparisons but
+    // hand the agent branch the watchdog pin (and vice-versa).
+    expect(agentCall?.pin).not.toBe('0.91.0');
+    expect(watchdogCall?.pin).not.toBe('0.90.0');
+  });
+
+  it('fails closed: a null pinned target on the watchdog branch withholds watchdogUpgradeTo', async () => {
+    const { compareAgentVersions, getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget } = await import('./helpers');
+    arrange();
+    vi.mocked(compareAgentVersions).mockImplementation(realishCompare);
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'auto', maintenanceWindow: null },
+      pins: { agent: null, watchdog: '0.91.0' },
+    });
+    // The pinned watchdog version has no build for this platform/arch → the
+    // resolver fails closed to null, so no watchdog upgrade is offered even
+    // though the reported 0.65.0 is behind.
+    vi.mocked(resolvePinnedUpgradeTarget).mockImplementation(
+      async ({ component }: { component: string }) => (component === 'watchdog' ? null : '0.66.0'),
+    );
+
+    const resp = await post({ agentVersion: '0.66.0', watchdogVersion: '0.65.0' });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { watchdogUpgradeTo?: string | null };
+    expect(body.watchdogUpgradeTo).toBeFalsy();
+  });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -25,7 +25,9 @@ import {
   buildPamConfigUpdate,
   buildOnedriveHelperConfigUpdate,
   buildPatchSourceConfigUpdate,
-  getOrgAgentUpdatePolicy,
+  getOrgAgentUpdateConfig,
+  resolvePinnedUpgradeTarget,
+  type AgentVersionPins,
   type OnedriveConfigUpdate,
 } from './helpers';
 import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
@@ -128,12 +130,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // successful policy evaluation; a lookup failure withholds version-to-version
   // targets rather than bypass Manual mode / a maintenance window. Bootstrap
   // installs (a component not yet present) are NOT gated inside the block below.
+  //
+  // The SAME resolver also returns the effective per-component version pins
+  // (issue #2124), so this one system-context round trip yields both the gate
+  // decision and the pins. `versionPins` defaults to no-pin (track global
+  // latest). `pinsResolved` gates the UNGATED pin-dependent paths (watchdog
+  // bootstrap install + the watchdog-role recovery branch): on a resolver
+  // failure we cannot prove the tenant isn't holding a version back, so those
+  // paths must withhold rather than fall back to global latest — otherwise a
+  // brand-new device would silently install the very build the pin holds back.
+  // (The gated version-to-version paths are already withheld via updateGateAllows.)
   let updateGateAllows = false;
+  let pinsResolved = false;
+  let versionPins: AgentVersionPins = { agent: null, watchdog: null };
   try {
-    const updateSettings = await withSystemDbAccessContext(() =>
-      getOrgAgentUpdatePolicy(agent.orgId),
+    const updateConfig = await withSystemDbAccessContext(() =>
+      getOrgAgentUpdateConfig(agent.orgId),
     );
-    const gate = shouldSendAgentUpgrade(updateSettings, new Date());
+    versionPins = updateConfig.pins;
+    pinsResolved = true;
+    const gate = shouldSendAgentUpgrade(updateConfig.settings, new Date());
     updateGateAllows = gate.allow;
     if (!gate.allow) {
       console.log(
@@ -276,30 +292,29 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // Claim watchdog-targeted commands (marks as sent to prevent duplicate delivery)
     const watchdogCommands = await claimPendingCommandsForDevice(device.id, 10, 'watchdog');
 
-    // Check for watchdog upgrade
+    // Check for watchdog upgrade. Honors the tenant's watchdog pin (issue
+    // #2124) via the same resolver as the main path; fail-closed to no upgrade
+    // when the pinned version has no build for this platform/arch.
     let watchdogUpgradeTo: string | undefined;
     const normalizedArch = normalizeAgentArchitecture(device.architecture);
-    if (normalizedArch) {
+    // `pinsResolved` guard: this recovery path is NOT gated by the update policy,
+    // so on a pin-resolution failure it must withhold rather than fall back to
+    // global latest (which would defeat a holdback pin). Self-heals next heartbeat.
+    if (normalizedArch && pinsResolved) {
       try {
-        const [latestWatchdog] = await db
-          .select({ version: agentVersions.version })
-          .from(agentVersions)
-          .where(
-            and(
-              eq(agentVersions.platform, device.osType),
-              eq(agentVersions.architecture, normalizedArch),
-              eq(agentVersions.component, 'watchdog'),
-              eq(agentVersions.isLatest, true)
-            )
-          )
-          .orderBy(desc(agentVersions.createdAt)) // newest first if multiple isLatest rows exist
-          .limit(1);
+        const targetWatchdog = await resolvePinnedUpgradeTarget({
+          component: 'watchdog',
+          platform: device.osType,
+          architecture: normalizedArch,
+          pin: versionPins.watchdog,
+          agentId,
+        });
 
-        if (latestWatchdog) {
+        if (targetWatchdog) {
           if (!data.agentVersion.startsWith('dev-')) {
-            const cmp = compareAgentVersions(latestWatchdog.version, data.agentVersion);
+            const cmp = compareAgentVersions(targetWatchdog, data.agentVersion);
             if (cmp > 0) {
-              watchdogUpgradeTo = latestWatchdog.version;
+              watchdogUpgradeTo = targetWatchdog;
             }
           }
         }
@@ -321,26 +336,24 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     if (
       mainAgentSilent &&
       normalizedArch &&
+      pinsResolved &&
       device.agentVersion &&
       !device.agentVersion.startsWith('dev-')
     ) {
       try {
-        const [latestAgent] = await db
-          .select({ version: agentVersions.version })
-          .from(agentVersions)
-          .where(
-            and(
-              eq(agentVersions.platform, device.osType),
-              eq(agentVersions.architecture, normalizedArch),
-              eq(agentVersions.component, 'agent'),
-              eq(agentVersions.isLatest, true)
-            )
-          )
-          .orderBy(desc(agentVersions.createdAt))
-          .limit(1);
+        // Recovery honors the tenant's agent pin (issue #2124): a wedged agent
+        // is recovered TO the pinned version, not blindly to latest. Fail-closed
+        // to no recovery if the pin has no build for this platform/arch.
+        const targetAgent = await resolvePinnedUpgradeTarget({
+          component: 'agent',
+          platform: device.osType,
+          architecture: normalizedArch,
+          pin: versionPins.agent,
+          agentId,
+        });
 
-        if (latestAgent && compareAgentVersions(latestAgent.version, device.agentVersion) > 0) {
-          agentUpgradeTo = latestAgent.version;
+        if (targetAgent && compareAgentVersions(targetAgent, device.agentVersion) > 0) {
+          agentUpgradeTo = targetAgent;
         }
       } catch (err) {
         console.error(`[agents] failed to evaluate watchdog-branch agent recovery target for ${agentId}:`, err);
@@ -594,30 +607,30 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   const normalizedArch = normalizeAgentArchitecture(device.architecture);
   if (normalizedArch) {
     try {
-      const [latestVersion] = await db
-        .select({ version: agentVersions.version })
-        .from(agentVersions)
-        .where(
-          and(
-            eq(agentVersions.platform, device.osType),
-            eq(agentVersions.architecture, normalizedArch),
-            eq(agentVersions.component, 'agent'),
-            eq(agentVersions.isLatest, true)
-          )
-        )
-        .orderBy(desc(agentVersions.createdAt))
-        .limit(1);
+      // Resolve the effective target: the tenant's agent pin (issue #2124) when
+      // set, else the globally promoted latest. Fails closed if the pinned
+      // version has no build for this platform/arch (returns null → no upgrade).
+      const targetVersion = await resolvePinnedUpgradeTarget({
+        component: 'agent',
+        platform: device.osType,
+        architecture: normalizedArch,
+        pin: versionPins.agent,
+        agentId,
+      });
 
-      if (latestVersion) {
+      if (targetVersion) {
         // Dev builds (dev-*) are local dev-push binaries — never auto-upgrade
         // them back to a release version. The dev-push flow disables auto_update
         // on the agent side; the server also refrains from sending upgradeTo.
         if (data.agentVersion.startsWith('dev-')) {
           // no-op: leave upgradeTo null so agent stays on the dev build
         } else if (updateGateAllows) {
-          const cmp = compareAgentVersions(latestVersion.version, data.agentVersion);
+          // Upgrade-only: a pin names the target but never triggers an auto
+          // DOWNGRADE through this channel (cmp > 0). Holdback works by keeping
+          // devices already on/below the pin from jumping to a newer latest.
+          const cmp = compareAgentVersions(targetVersion, data.agentVersion);
           if (cmp > 0) {
-            upgradeTo = latestVersion.version;
+            upgradeTo = targetVersion;
           }
         }
       }
@@ -663,19 +676,15 @@ if (latestHelper) {
   let watchdogUpgradeTo: string | null = null;
   if (normalizedArch) {
     try {
-      const [latestWatchdog] = await db
-        .select({ version: agentVersions.version })
-        .from(agentVersions)
-        .where(
-          and(
-            eq(agentVersions.platform, device.osType),
-            eq(agentVersions.architecture, normalizedArch),
-            eq(agentVersions.component, 'watchdog'),
-            eq(agentVersions.isLatest, true)
-          )
-        )
-        .orderBy(desc(agentVersions.createdAt))
-        .limit(1);
+      // Effective watchdog target: the tenant's watchdog pin (issue #2124) when
+      // set, else the globally promoted latest. Independent of the agent pin.
+      const targetWatchdog = await resolvePinnedUpgradeTarget({
+        component: 'watchdog',
+        platform: device.osType,
+        architecture: normalizedArch,
+        pin: versionPins.watchdog,
+        agentId,
+      });
 
       // Prefer the version the agent just reported over the stored column so a
       // successful swap stops the re-send on the VERY NEXT heartbeat (#1802),
@@ -683,18 +692,29 @@ if (latestHelper) {
       // so fall back to the stored value to preserve existing behavior.
       const installedWatchdogVersion = data.watchdogVersion ?? device.watchdogVersion;
 
-      if (latestWatchdog && installedWatchdogVersion) {
+      if (targetWatchdog && installedWatchdogVersion) {
         // Version-to-version upgrade is subject to the org update policy.
         if (updateGateAllows && !installedWatchdogVersion.startsWith('dev-')) {
-          const cmp = compareAgentVersions(latestWatchdog.version, installedWatchdogVersion);
+          const cmp = compareAgentVersions(targetWatchdog, installedWatchdogVersion);
           if (cmp > 0) {
-            watchdogUpgradeTo = latestWatchdog.version;
+            watchdogUpgradeTo = targetWatchdog;
           }
         }
-      } else if (latestWatchdog && !installedWatchdogVersion) {
+      } else if (targetWatchdog && !installedWatchdogVersion && pinsResolved) {
         // Watchdog not yet installed — signal to agent to install it. Bootstrap
-        // installs are NOT gated by the org update policy.
-        watchdogUpgradeTo = latestWatchdog.version;
+        // installs are NOT gated by the org update policy. When a pin is set,
+        // targetWatchdog is that pinned build (fail-closed to null if it has no
+        // build for this platform/arch), so a first install still honors the pin
+        // rather than jumping straight to latest. `pinsResolved` guards the case
+        // where the pin lookup FAILED: without it we'd install global latest and
+        // silently defeat a holdback pin on exactly the new devices most likely
+        // to hit it. Withheld installs self-heal on the next successful heartbeat.
+        watchdogUpgradeTo = targetWatchdog;
+      } else if (targetWatchdog && !installedWatchdogVersion && !pinsResolved) {
+        console.warn(
+          `[agents] watchdog bootstrap withheld for ${agentId}: version pins unresolved ` +
+            `this heartbeat (fail closed; retries next heartbeat)`,
+        );
       }
     } catch (err) {
       console.error(`[agents] failed to evaluate watchdog upgrade target for ${agentId}:`, err);

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -33,6 +33,7 @@ const { dbMock } = vi.hoisted(() => {
       from: vi.fn(() => chain),
       leftJoin: vi.fn(() => chain),
       where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
       limit: vi.fn(() => Promise.resolve(nextResult)),
     };
     chain.then = (resolve: any, reject: any) => Promise.resolve(nextResult).then(resolve, reject);
@@ -88,6 +89,18 @@ vi.mock('../../db/schema', () => ({
   configPolicyMonitoringSettings: {},
   configPolicyMonitoringWatches: {},
   configPolicyEventLogSettings: {},
+  configPolicyOnedriveSettings: {},
+  configPolicyOnedriveLibraries: {},
+  pamOrgConfig: {},
+  agentVersions: {
+    id: 'av.id',
+    version: 'av.version',
+    platform: 'av.platform',
+    architecture: 'av.architecture',
+    component: 'av.component',
+    isLatest: 'av.is_latest',
+    createdAt: 'av.created_at',
+  },
 }));
 
 vi.mock('../../services/redis', () => ({ getRedis: vi.fn() }));
@@ -119,7 +132,12 @@ vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => 
 // ---------------------------------------------------------------------------
 // Import under test — AFTER all mocks are installed.
 // ---------------------------------------------------------------------------
-import { getOrgAgentUpdatePolicy, __resetMalformedWindowWarnCache } from './helpers';
+import {
+  getOrgAgentUpdatePolicy,
+  getOrgAgentUpdateConfig,
+  resolvePinnedUpgradeTarget,
+  __resetMalformedWindowWarnCache,
+} from './helpers';
 
 const ORG_ID = '00000000-0000-4000-8000-000000000001';
 
@@ -313,5 +331,136 @@ describe('getOrgAgentUpdatePolicy — effective partner→org merge (issue #2123
       throw new Error('db down');
     });
     await expect(getOrgAgentUpdatePolicy(ORG_ID)).rejects.toThrow('db down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOrgAgentUpdateConfig — effective version pins (issue #2124). Same org⋈
+// partner join and partner-locks precedence as the policy, resolved in ONE
+// round trip. `agentVersionPins` is an atomic unit: a partner that sets it locks
+// the whole object for the org; agent and watchdog stay independent knobs.
+// ---------------------------------------------------------------------------
+describe('getOrgAgentUpdateConfig — version pins', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetMalformedWindowWarnCache();
+  });
+
+  it('no pin anywhere → both components track global latest (null)', async () => {
+    seed({ defaults: {} }, null);
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    expect(pins).toEqual({ agent: null, watchdog: null });
+  });
+
+  it('org pin only → uses the org pin (no partner pin to inherit)', async () => {
+    seed({ defaults: { agentVersionPins: { agent: '0.88.0' } } }, { defaults: {} });
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    expect(pins).toEqual({ agent: '0.88.0', watchdog: null });
+  });
+
+  it('partner pin only → org inherits the partner pin', async () => {
+    seed({ defaults: {} }, { defaults: { agentVersionPins: { watchdog: '0.87.0' } } });
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    expect(pins).toEqual({ agent: null, watchdog: '0.87.0' });
+  });
+
+  it('org pin OVERRIDES the partner pin (inherit-with-override, not locks)', async () => {
+    seed(
+      { defaults: { agentVersionPins: { agent: '0.80.0', watchdog: '0.80.0' } } },
+      { defaults: { agentVersionPins: { agent: '0.88.0' } } },
+    );
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    // agent: org 0.80.0 overrides partner 0.88.0. watchdog: org 0.80.0 (partner
+    // unset). The partner pin is a default, not a lock — the org wins.
+    expect(pins).toEqual({ agent: '0.80.0', watchdog: '0.80.0' });
+  });
+
+  it('org inherits the partner pin per component where the org has not set it', async () => {
+    seed(
+      { defaults: { agentVersionPins: { watchdog: '0.70.0' } } },
+      { defaults: { agentVersionPins: { agent: '0.88.0' } } },
+    );
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    // agent: inherited partner 0.88.0 (org unset); watchdog: org 0.70.0. Agent
+    // and watchdog resolve independently across the two levels.
+    expect(pins).toEqual({ agent: '0.88.0', watchdog: '0.70.0' });
+  });
+
+  it("an org 'latest' deliberately overrides a partner pin back to global latest", async () => {
+    seed(
+      { defaults: { agentVersionPins: { agent: 'latest' } } },
+      { defaults: { agentVersionPins: { agent: '0.88.0' } } },
+    );
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    // Presence-keyed merge: the org SET agent ('latest'), so it wins and
+    // normalizes to null (track global latest) despite the partner pin.
+    expect(pins).toEqual({ agent: null, watchdog: null });
+  });
+
+  it("the 'latest' sentinel normalizes to null (no pin)", async () => {
+    seed({ defaults: { agentVersionPins: { agent: 'latest', watchdog: '0.88.0' } } }, null);
+    const { pins } = await getOrgAgentUpdateConfig(ORG_ID);
+    expect(pins).toEqual({ agent: null, watchdog: '0.88.0' });
+  });
+
+  it('resolves settings and pins together from one lookup', async () => {
+    seed(
+      { defaults: { agentUpdatePolicy: 'manual', agentVersionPins: { agent: '0.88.0' } } },
+      null,
+    );
+    const cfg = await getOrgAgentUpdateConfig(ORG_ID);
+    expect(cfg.settings).toEqual({ policy: 'manual', maintenanceWindow: null });
+    expect(cfg.pins).toEqual({ agent: '0.88.0', watchdog: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePinnedUpgradeTarget — turns a pin (or its absence) into a concrete
+// target version, fail-closed when a pinned build is missing for the device's
+// platform/arch (issue #2124).
+// ---------------------------------------------------------------------------
+describe('resolvePinnedUpgradeTarget', () => {
+  const base = { component: 'agent', platform: 'windows', architecture: 'amd64' as const };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear the per-(component/platform/arch/version) capture dedup so the
+    // fail-closed Sentry assertion isn't suppressed by a prior test.
+    __resetMalformedWindowWarnCache();
+  });
+
+  it('no pin → returns the globally promoted latest version', async () => {
+    dbMock._setResult([{ version: '0.88.0' }]);
+    await expect(resolvePinnedUpgradeTarget({ ...base, pin: null })).resolves.toBe('0.88.0');
+  });
+
+  it('no pin and no promoted build → null (unchanged legacy behaviour)', async () => {
+    dbMock._setResult([]);
+    await expect(resolvePinnedUpgradeTarget({ ...base, pin: null })).resolves.toBeNull();
+  });
+
+  it('pin with a registered build for this platform/arch → returns the pinned version', async () => {
+    dbMock._setResult([{ version: '0.85.0' }]);
+    await expect(resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0' })).resolves.toBe('0.85.0');
+  });
+
+  it('pin with NO build for this platform/arch → null (fail closed, no fallback to latest)', async () => {
+    dbMock._setResult([]);
+    await expect(
+      resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0', agentId: 'device-1' }),
+    ).resolves.toBeNull();
+  });
+
+  it('routes the fail-closed pin-miss to Sentry (observability parity with the #2125 gate)', async () => {
+    const { captureException } = await import('../../services/sentry');
+    dbMock._setResult([]);
+    await resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0', agentId: 'device-1' });
+    expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
+
+    // Deduped: a second identical miss must NOT re-capture (avoids per-heartbeat
+    // Sentry spam for a persistent misconfig).
+    dbMock._setResult([]);
+    await resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0', agentId: 'device-2' });
+    expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -31,6 +31,7 @@ import {
   configPolicyOnedriveSettings,
   configPolicyOnedriveLibraries,
   pamOrgConfig,
+  agentVersions,
 } from '../../db/schema';
 import { getRedis } from '../../services/redis';
 import { publishEvent } from '../../services/eventBus';
@@ -61,7 +62,7 @@ import {
   normalizeAgentUpdatePolicy,
   type AgentUpdateSettings,
 } from './agentUpdatePolicy';
-import { isAlwaysMaintenanceWindow, parseMaintenanceWindow } from '@breeze/shared';
+import { isAlwaysMaintenanceWindow, parseMaintenanceWindow, normalizeVersionPin } from '@breeze/shared';
 import {
   type SecurityProviderValue,
   type SecurityStatusPayload,
@@ -2024,9 +2025,16 @@ export function generateApiKey(): string {
 // org would emit one warn per device per heartbeat. Cleared by tests.
 const warnedMalformedWindowOrgs = new Set<string>();
 
-/** Test-only: reset the malformed-window warn dedup so cases stay isolated. */
+// Same rationale for the "pinned build missing for platform/arch" fail-closed
+// path (issue #2124): a persistent misconfig would otherwise fire per device per
+// heartbeat. Deduped per (component, platform, arch, version) so Sentry sees the
+// freeze ONCE per process rather than a flood. Cleared by tests.
+const warnedMissingPinBuilds = new Set<string>();
+
+/** Test-only: reset the malformed-window + missing-pin warn dedup between cases. */
 export function __resetMalformedWindowWarnCache(): void {
   warnedMalformedWindowOrgs.clear();
+  warnedMissingPinBuilds.clear();
 }
 
 /** Pull the `defaults` sub-object out of a settings JSONB blob (safe for null). */
@@ -2036,17 +2044,46 @@ function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
 }
 
 /**
- * Resolve the EFFECTIVE agent update policy for an org (Org > General), applying
- * partner defaults exactly as the settings UI and `getEffectiveOrgSettings`
- * (`services/effectiveSettings.ts`) do: for each field a partner-set value wins
- * and locks; the org-local value only applies where the partner has NOT set that
- * field. Fields are merged independently — a partner may lock `agentUpdatePolicy`
- * while leaving `maintenanceWindow` to the org, or vice versa.
+ * Effective per-component update version pins (issue #2124). `null` means "no
+ * pin" → track the globally promoted latest version (historical behaviour).
+ */
+export interface AgentVersionPins {
+  agent: string | null;
+  watchdog: string | null;
+}
+
+/**
+ * The full effective agent-update config for an org: the update-policy gate
+ * inputs PLUS the version pins. Both are resolved from the SAME single org⋈
+ * partner join (see getOrgAgentUpdateConfig) so the heartbeat hot path pays one
+ * round trip for everything it needs.
+ */
+export interface AgentUpdateConfig {
+  settings: AgentUpdateSettings;
+  pins: AgentVersionPins;
+}
+
+/**
+ * Resolve the EFFECTIVE agent update config for an org (Org > General). The
+ * update-POLICY fields (`agentUpdatePolicy`, `maintenanceWindow`) use the same
+ * partner-locks precedence as the settings UI / `getEffectiveOrgSettings`: a
+ * partner-set field wins and locks; the org value applies only where the partner
+ * has not set it (merged independently per field).
  *
- * Returns a normalized policy plus the raw maintenance-window string; the gating
- * decision lives in `shouldSendAgentUpgrade`. Orgs (and partners) that never
- * configured the field resolve to a permissive default (staged + no window =
- * upgrade anytime), preserving historical behaviour.
+ * `agentVersionPins` deliberately uses DIFFERENT, weaker precedence —
+ * INHERIT-WITH-OVERRIDE (issue #2124, per maintainer): a partner pin is an
+ * inherited DEFAULT, but an org-set pin WINS for that org, per component and by
+ * presence (so an org may pin 'latest' to override a partner pin back to global
+ * latest). Pins are intentionally exempt from the partner lock model in v1 — this
+ * is what lets a partner pilot a new version on one org without unsetting the
+ * fleet-wide default. See the assertNotLocked exemption in routes/orgs.ts.
+ *
+ * Returns a normalized policy + raw maintenance-window string (the gating
+ * decision lives in `shouldSendAgentUpgrade`) AND the normalized version pins
+ * (the heartbeat turns these into concrete upgrade targets, fail-closed when a
+ * pinned version has no build for the device's platform/arch). Orgs (and
+ * partners) that never configured a field resolve to permissive/no-pin defaults,
+ * preserving historical behaviour.
  *
  * Hot path: this runs once per device per heartbeat, so org + partner settings
  * are fetched in a single joined round trip rather than two queries. A thrown
@@ -2057,9 +2094,10 @@ function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
  * Issue #2123: before this, the gate read org-local `settings.defaults` only, so
  * a partner-locked policy (e.g. Manual) had zero runtime effect and unconfigured
  * child orgs fell back to the permissive default despite the partner lock.
- * (Future version-pin work is expected to build on this effective plumbing.)
+ * Issue #2124 rides version pins on top of the exact same join and precedence so
+ * there is one resolver, not two.
  */
-export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
+export async function getOrgAgentUpdateConfig(orgId: string): Promise<AgentUpdateConfig> {
   // LEFT JOIN so a missing partner (shouldn't happen) still returns the org row
   // and falls back to org-local settings rather than dropping the whole lookup.
   const [row] = await db
@@ -2084,6 +2122,20 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
     'maintenanceWindow' in partnerDefaults
       ? partnerDefaults.maintenanceWindow
       : orgDefaults.maintenanceWindow;
+  // Version pins: inherit-with-override, per component (issue #2124). An org-set
+  // component wins for that org; where the org has NOT set a component the partner
+  // default is inherited; unset at both levels → global promoted latest. Keyed by
+  // PRESENCE ('agent' in orgPins), NOT truthiness, so an org can store 'latest' to
+  // deliberately override a partner pin back to the global latest. Agent and
+  // watchdog are independent.
+  const orgPins = isObject(orgDefaults.agentVersionPins) ? orgDefaults.agentVersionPins : {};
+  const partnerPins = isObject(partnerDefaults.agentVersionPins)
+    ? partnerDefaults.agentVersionPins
+    : {};
+  const pins: AgentVersionPins = {
+    agent: normalizeVersionPin('agent' in orgPins ? orgPins.agent : partnerPins.agent),
+    watchdog: normalizeVersionPin('watchdog' in orgPins ? orgPins.watchdog : partnerPins.watchdog),
+  };
 
   const policy = normalizeAgentUpdatePolicy(effectivePolicy);
   const rawWindow = typeof effectiveWindow === 'string' ? effectiveWindow.trim() : '';
@@ -2107,7 +2159,101 @@ export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdat
       `agent updates are NOT time-restricted (failing open). value=${JSON.stringify(maintenanceWindow)}`,
     );
   }
-  return { policy, maintenanceWindow };
+  return { settings: { policy, maintenanceWindow }, pins };
+}
+
+/**
+ * Back-compat thin wrapper: resolve only the update-policy gate settings.
+ * Retained so existing callers/tests that only need the gate keep their surface;
+ * the heartbeat resolves the full config (settings + pins) via
+ * getOrgAgentUpdateConfig in a single round trip.
+ */
+export async function getOrgAgentUpdatePolicy(orgId: string): Promise<AgentUpdateSettings> {
+  return (await getOrgAgentUpdateConfig(orgId)).settings;
+}
+
+/**
+ * Resolve the candidate upgrade-target version for a component on a device's
+ * platform/arch, honoring an effective version pin (issue #2124).
+ *
+ *  - `pin === null` → the globally promoted latest build (`is_latest = true`),
+ *    or `null` if none is registered. This is byte-for-byte the pre-#2124
+ *    behaviour, so unpinned tenants are unaffected.
+ *  - `pin === '<version>'` → that EXACT version, but only if a build is
+ *    registered for (component, platform, arch). If not, returns `null` and
+ *    logs — a pin whose build is missing for this platform/arch **fails closed**
+ *    (withholds the upgrade) rather than silently falling back to latest, which
+ *    would defeat the holdback/rollback intent of the pin.
+ *
+ * Returns only the candidate version string. The caller keeps the existing
+ * decision to actually send it (dev-build guard, update-policy gate, version
+ * comparison) so heartbeat semantics are otherwise unchanged. `agentVersions`
+ * is a global (non-tenant) table, so this is safe to call in any DB context.
+ */
+export async function resolvePinnedUpgradeTarget(args: {
+  component: string;
+  platform: string;
+  architecture: string;
+  pin: string | null;
+  agentId?: string;
+}): Promise<string | null> {
+  const { component, platform, architecture, pin, agentId } = args;
+
+  if (pin === null) {
+    const [latest] = await db
+      .select({ version: agentVersions.version })
+      .from(agentVersions)
+      .where(
+        and(
+          eq(agentVersions.platform, platform),
+          eq(agentVersions.architecture, architecture),
+          eq(agentVersions.component, component),
+          eq(agentVersions.isLatest, true),
+        ),
+      )
+      .orderBy(desc(agentVersions.createdAt)) // newest first if multiple isLatest rows exist
+      .limit(1);
+    return latest?.version ?? null;
+  }
+
+  const [pinned] = await db
+    .select({ version: agentVersions.version })
+    .from(agentVersions)
+    .where(
+      and(
+        eq(agentVersions.platform, platform),
+        eq(agentVersions.architecture, architecture),
+        eq(agentVersions.component, component),
+        eq(agentVersions.version, pin),
+      ),
+    )
+    .limit(1);
+
+  if (!pinned) {
+    // Fail-closed, but loudly: an operator pinned a version with no build for
+    // this platform/arch (typo, or a build that was never published). Withhold
+    // the upgrade AND surface it. Per-heartbeat stdout alone is not enough — this
+    // is the same class of invisible, fleet-wide freeze the #2125 gate catch
+    // routes to Sentry, so match that bar. Deduped per (component/platform/arch/
+    // version) so a persistent misconfig captures ONCE per process, not per beat.
+    console.warn(
+      `[agents] update withheld for ${agentId ?? 'device'}: pinned ${component} version ` +
+        `"${pin}" has no registered build for ${platform}/${architecture} (fail closed)`,
+    );
+    const key = `${component}:${platform}:${architecture}:${pin}`;
+    if (!warnedMissingPinBuilds.has(key)) {
+      warnedMissingPinBuilds.add(key);
+      captureException(
+        new Error(
+          `Agent update withheld (#2124): pinned ${component} version "${pin}" has no ` +
+            `registered build for ${platform}/${architecture}; fleet freeze until a build ` +
+            `is published or the pin is corrected.`,
+        ),
+      );
+    }
+    return null;
+  }
+  return pinned.version;
 }
 
 export async function getOrgHelperSettings(orgId: string): Promise<{ enabled: boolean }> {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -94,7 +94,9 @@ vi.mock('../db/schema', () => ({
   // inArray was called against the sites.id column specifically.
   sites: { id: { __column: 'sites.id' }, orgId: { __column: 'sites.orgId' } },
   // GET /orgs/sites enriches each site with a grouped device count (#1790).
-  devices: { siteId: { __column: 'devices.siteId' } }
+  devices: { siteId: { __column: 'devices.siteId' } },
+  // Agent version pins (issue #2124) validate against this table at save time.
+  agentVersions: { id: {}, component: {}, version: {} }
 }));
 
 // Spy on inArray so the site-allowlist test can assert the GET /orgs/sites
@@ -1393,6 +1395,137 @@ describe('org routes', () => {
       expect(db.update).toHaveBeenCalled();
     });
 
+    // issue #2124: an agent/watchdog version pin must reference a registered
+    // agent_versions row. The default db.select mock resolves [] (no matching
+    // version), so an unknown pin is rejected before any DB write.
+    it('rejects an unknown agent version pin with 400', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      // A clean select chain resolving [] (no matching registered version). Set
+      // explicitly so a prior test's leaked db.select mock can't perturb this.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: { agent: '9.9.9' } } } })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('9.9.9');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-object agentVersionPins with 400 (z.any() settings blob has no structural guard)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      // A string reaches the handler because org `settings` is z.any(); the
+      // explicit validator must reject it rather than iterate a non-object.
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: 'latest' } } })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/agentVersionPins must be an object/i);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the SECOND component is unknown even though the first is valid', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      // agent '0.88.0' resolves (row found), watchdog '9.9.9' does not ([]) — the
+      // loop must reject the second, not stop at the first valid one.
+      const limit = vi.fn().mockResolvedValueOnce([{ id: 'ver-1' }]).mockResolvedValue([]);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit }) })
+      } as any);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: { agent: '0.88.0', watchdog: '9.9.9' } } } })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('9.9.9');
+      expect(body.error).toMatch(/watchdog/i);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // A single select mock that serves BOTH seams the accept path hits:
+    //  - validateAgentVersionPins uses `.where().limit()` → `pinRows`
+    //  - assertNotLocked uses `.where().then(rows => rows[0])` → an org row that
+    //    carries partnerId + settings (one row satisfies its org & partner reads)
+    function primeAcceptSelect(pinRows: unknown[], partnerSettings: Record<string, unknown> = {}) {
+      const whereRet: any = Promise.resolve([{ partnerId: 'partner-123', settings: partnerSettings }]);
+      whereRet.limit = vi.fn().mockResolvedValue(pinRows);
+      whereRet.orderBy = vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue(whereRet) })
+      } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O' }])
+          })
+        })
+      } as any);
+    }
+
+    it('accepts a registered agent version pin (200)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      primeAcceptSelect([{ id: 'ver-1' }]); // agentVersions lookup finds the pin
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: { agent: '0.88.0' } } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('accepts the "latest" sentinel pin without a registry lookup (200)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      // pinRows is irrelevant: 'latest' normalizes to null so no lookup happens.
+      primeAcceptSelect([]);
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: { agent: 'latest', watchdog: 'latest' } } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('lets an org override a partner-set pin — agentVersionPins is exempt from assertNotLocked (200)', async () => {
+      // Partner has pinned agent for all its orgs. Under a lock model this org
+      // PATCH would 403; under inherit-with-override the org may still pin its
+      // OWN version, so assertNotLocked must NOT block agentVersionPins.
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      primeAcceptSelect([{ id: 'ver-1' }], { defaults: { agentVersionPins: { agent: '0.87.0' } } });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { agentVersionPins: { agent: '0.88.0' } } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
     it('should allow system scope updates without partnerId context', async () => {
       setAuthContext({ scope: 'system', partnerId: null });
       vi.mocked(db.update).mockReturnValue({
@@ -2265,6 +2398,25 @@ describe('org routes', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    // issue #2124: a partner-locked pin can freeze every child org's fleet, so an
+    // unknown version is rejected at save time (before the partner row is even
+    // fetched). Default db.select resolves [] → no matching agent_versions row.
+    it('rejects an unknown watchdog version pin on the partner defaults with 400', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: { defaults: { agentVersionPins: { watchdog: '9.9.9' } } }
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('9.9.9');
+      expect(db.update).not.toHaveBeenCalled();
     });
 
     it('accepts a valid branding update within size limits', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -5,7 +5,7 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { partners, organizations, sites, devices } from '../db/schema';
+import { partners, organizations, sites, devices, agentVersions } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, requirePartner, type AuthContext } from '../middleware/auth';
 import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getEffectiveOrgSettings, assertNotLocked } from '../services/effectiveSettings';
@@ -20,7 +20,7 @@ import {
 import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
-import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema } from '@breeze/shared';
 import type { IpAllowlistStatus } from '@breeze/shared';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
@@ -48,6 +48,39 @@ const paginationSchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional()
 });
+
+/**
+ * Save-time validation for agent/watchdog version pins on a `settings.defaults`
+ * object (issue #2124). A pin of 'latest' / unset is always valid. A concrete
+ * version must reference a registered `agent_versions` row for that component;
+ * an unknown version is rejected so operators get immediate feedback rather than
+ * a silent heartbeat freeze. Per-platform/arch existence is enforced later at
+ * heartbeat resolution (fail-closed) — a version is legitimately registered for
+ * only some platforms, so we don't reject on a per-arch basis here. Returns an
+ * error message to reject with (HTTP 400), or null when the pins are clean.
+ */
+async function validateAgentVersionPins(defaults: unknown): Promise<string | null> {
+  if (!defaults || typeof defaults !== 'object' || Array.isArray(defaults)) return null;
+  const pinsRaw = (defaults as Record<string, unknown>).agentVersionPins;
+  if (pinsRaw === undefined || pinsRaw === null) return null;
+  if (typeof pinsRaw !== 'object' || Array.isArray(pinsRaw)) {
+    return 'agentVersionPins must be an object with optional agent/watchdog version strings.';
+  }
+  const pins = pinsRaw as Record<string, unknown>;
+  for (const component of PINNABLE_COMPONENTS) {
+    const version = normalizeVersionPin(pins[component]);
+    if (version === null) continue; // unset / 'latest' → tracks global latest
+    const [row] = await db
+      .select({ id: agentVersions.id })
+      .from(agentVersions)
+      .where(and(eq(agentVersions.component, component), eq(agentVersions.version, version)))
+      .limit(1);
+    if (!row) {
+      return `Unknown ${component} version "${version}" — pin a registered version or choose Latest.`;
+    }
+  }
+  return null;
+}
 
 const createPartnerSchema = z.object({
   name: z.string().min(1),
@@ -408,6 +441,10 @@ const partnerSettingsSchema = z.object({
       (v) => v === undefined || isValidMaintenanceWindow(v),
       { message: MAINTENANCE_WINDOW_ERROR_MESSAGE },
     ),
+    // Per-component update version pins (issue #2124). Structural check only;
+    // the "version must be registered" check needs a DB lookup and is done in
+    // the handler via validateAgentVersionPins (same as the org PATCH path).
+    agentVersionPins: agentVersionPinsSchema.optional(),
   }).optional(),
   branding: z.object({
     logoUrl: z.string().max(400_000, 'Logo data exceeds maximum size (400 KB)').optional(),
@@ -548,6 +585,14 @@ orgRoutes.patch(
   async (c) => {
   const auth = c.get('auth');
   const body = c.req.valid('json');
+
+  // Agent/watchdog version pins (issue #2124) — reject unknown versions at save
+  // time so a partner-locked pin can't silently freeze every child org's fleet.
+  // Mirrors the org PATCH path; the zod schema already checked the shape.
+  const pinError = await validateAgentVersionPins(body.settings?.defaults);
+  if (pinError) {
+    return c.json({ error: pinError }, 400);
+  }
 
   // Get current partner to merge settings
   const [current] = await db
@@ -1202,12 +1247,30 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
       if (mw !== undefined && mw !== null && (typeof mw !== 'string' || !isValidMaintenanceWindow(mw))) {
         return c.json({ error: MAINTENANCE_WINDOW_ERROR_MESSAGE }, 400);
       }
+
+      // Agent/watchdog version pins (issue #2124) — reject unknown versions at
+      // save time. Same rationale as the window check: the org `settings` blob
+      // is `z.any()`, so pins are validated explicitly here rather than in the
+      // schema, and this is the path getOrgAgentUpdateConfig reads at heartbeat.
+      const pinError = await validateAgentVersionPins(defaults);
+      if (pinError) {
+        return c.json({ error: pinError }, 400);
+      }
     }
 
-    // Enforce partner locks on settings categories (after auth check)
+    // Enforce partner locks on settings categories (after auth check).
     for (const category of ['security', 'notifications', 'eventLogs', 'defaults', 'branding']) {
       if (settingsObj[category] && typeof settingsObj[category] === 'object') {
-        const fields = Object.keys(settingsObj[category] as Record<string, unknown>);
+        let fields = Object.keys(settingsObj[category] as Record<string, unknown>);
+        // Issue #2124: `agentVersionPins` is INHERIT-WITH-OVERRIDE, not partner-
+        // locked — an org may override the partner's pinned version (that's what
+        // lets a partner pilot a new version on one org). So it is deliberately
+        // exempt from the lock model here; a partner pin is only a default, and
+        // getOrgAgentUpdateConfig resolves org-over-partner. Do NOT "fix" this
+        // back to a lock without a per-field enforcement flag.
+        if (category === 'defaults') {
+          fields = fields.filter((f) => f !== 'agentVersionPins');
+        }
         await assertNotLocked(id, category, fields);
       }
     }

--- a/apps/api/src/services/aiToolsAgentMgmt.test.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.test.ts
@@ -18,11 +18,30 @@ vi.mock('./commandQueue', () => ({
   CommandTypes: new Proxy({}, { get: (_t, prop) => String(prop) }),
 }));
 
+// The version-pin resolver (issue #2124) lives in the heartbeat helpers, a heavy
+// module; mock it so the tool's default-target path can be steered per test and
+// the real module's import graph is not pulled into this service test.
+vi.mock('../routes/agents/helpers', () => ({
+  getOrgAgentUpdateConfig: vi.fn(async () => ({
+    settings: { policy: 'staged', maintenanceWindow: null },
+    pins: { agent: null, watchdog: null },
+  })),
+  // The manual upgrade path resolves each device's target through the SAME
+  // fail-closed resolver the heartbeat uses. Default: echo the pin, else a
+  // stand-in global latest — so a pin dispatches verbatim and no-pin → latest.
+  resolvePinnedUpgradeTarget: vi.fn(async ({ pin }: { pin: string | null }) => pin ?? '0.88.0'),
+  // Real function is a pure arch-string normalizer; a faithful mini-impl keeps
+  // the tests honest without pulling in the heavy helpers module.
+  normalizeAgentArchitecture: (a: string | null | undefined) =>
+    a === 'amd64' || a === 'arm64' ? a : a === 'x86_64' ? 'amd64' : a == null ? null : null,
+}));
+
 import { db } from '../db';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { executeCommand } from './commandQueue';
 import { registerAgentMgmtTools } from './aiToolsAgentMgmt';
+import { getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget } from '../routes/agents/helpers';
 import { TOOL_PERMISSIONS } from './aiGuardrails';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
@@ -34,6 +53,8 @@ function createQueryChain(rows: any[] = []) {
   chain.from = vi.fn(() => chain);
   chain.where = vi.fn(() => chain);
   chain.limit = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
   chain.then = (resolve: (value: any[]) => unknown, reject?: (error: unknown) => unknown) =>
     Promise.resolve(rows).then(resolve, reject);
   return chain;
@@ -68,6 +89,51 @@ function buildToolMap(): Map<string, AiTool> {
 function offlineDeviceRow() {
   return { id: DEVICE_ID, orgId: ORG_ID, siteId: null, status: 'offline', hostname: 'wedged-pc' };
 }
+
+// issue #2124 — check_upgrades must measure "outdated" against the fleet's
+// EFFECTIVE target (the org's pin when set), not the global promoted latest, or
+// a holdback-pinned org is reported as N-behind when it will never move.
+describe('query_agent_versions check_upgrades — pin-aware target (#2124)', () => {
+  let tool: AiTool;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: null, watchdog: null },
+    });
+    tool = buildToolMap().get('query_agent_versions')!;
+  });
+
+  it('counts against the org pin (not global latest) when the org is pinned', async () => {
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: '0.80.0', watchdog: null },
+    });
+    // #1 global latest, #2 outdated groupBy (devices not on the effective target).
+    mockSelectSequence([[{ version: '0.90.0' }], [{ currentVersion: '0.90.0', count: 3 }]]);
+
+    const result = JSON.parse(await tool.handler({ action: 'check_upgrades' }, makeAuth()));
+
+    expect(result.pinned).toBe(true);
+    expect(result.effectiveTarget).toBe('0.80.0'); // the pin, not 0.90.0
+    expect(result.latestVersion).toBe('0.90.0'); // global latest still reported for context
+    // Devices on global-latest 0.90.0 are "outdated" relative to the 0.80.0 holdback pin.
+    expect(result.totalOutdated).toBe(3);
+  });
+
+  it('a multi-org (non-org-scoped) caller is told pins are not reflected', async () => {
+    const partnerAuth = { ...makeAuth(), scope: 'partner', orgId: null } as any;
+    mockSelectSequence([[{ version: '0.90.0' }], [{ currentVersion: '0.70.0', count: 2 }]]);
+
+    const result = JSON.parse(await tool.handler({ action: 'check_upgrades' }, partnerAuth));
+
+    expect(result.pinned).toBe(false);
+    expect(result.effectiveTarget).toBe('0.90.0');
+    expect(result.note).toMatch(/multiple orgs/i);
+    // The org pin resolver is never consulted without a single owning org.
+    expect(getOrgAgentUpdateConfig).not.toHaveBeenCalled();
+  });
+});
 
 describe('trigger_agent_restart', () => {
   let tool: AiTool;
@@ -170,6 +236,185 @@ describe('trigger_agent_restart', () => {
     const raw = await tool.handler({ deviceIds: [] }, makeAuth());
     expect(JSON.parse(raw).error).toMatch(/deviceIds/);
     expect(db.select).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+});
+
+// issue #2124 — the manual upgrade path resolves the SAME tenant version pin the
+// heartbeat honors when no explicit targetVersion is given, so a manual "update"
+// respects a partner/org holdback instead of always jumping to global latest.
+describe('trigger_agent_upgrade — pin-aware default target (#2124)', () => {
+  let tool: AiTool;
+  const onlineDeviceRow = () => ({
+    id: DEVICE_ID, orgId: ORG_ID, siteId: null, status: 'online', hostname: 'pc',
+  });
+  // Device→org rows for the default-resolution select now also carry platform/arch,
+  // because the target is resolved per device (fail-closed on a missing build).
+  const deviceOrgRow = (id: string, orgId: string) => ({
+    id, orgId, osType: 'windows', architecture: 'amd64',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeCommand).mockResolvedValue({ status: 'completed', result: {} } as any);
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: null, watchdog: null },
+    });
+    // Default resolver: echo the pin, else stand-in global latest for the platform.
+    vi.mocked(resolvePinnedUpgradeTarget).mockImplementation(
+      async ({ pin }: { pin: string | null }) => pin ?? '0.88.0',
+    );
+    tool = buildToolMap().get('trigger_agent_upgrade')!;
+  });
+
+  it('with no explicit version and an org agent pin → dispatches the PINNED version', async () => {
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: '0.80.0', watchdog: null },
+    });
+    // #1 verifyDeviceAccess, #2 org-wide access check, #3 device→org+platform lookup.
+    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], [deviceOrgRow(DEVICE_ID, ORG_ID)]]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.queued).toBe(1);
+    expect(result.targetVersions).toEqual(['0.80.0']);
+    // The pin was resolved through the fail-closed resolver with THIS device's platform/arch.
+    expect(resolvePinnedUpgradeTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ component: 'agent', pin: '0.80.0', platform: 'windows', architecture: 'amd64' }),
+    );
+    expect(executeCommand).toHaveBeenCalledWith(
+      DEVICE_ID, 'update_agent', { version: '0.80.0' },
+      expect.objectContaining({ targetRole: 'watchdog' }),
+    );
+  });
+
+  it('with no explicit version and no pin → falls back to the globally promoted latest', async () => {
+    // #1 verifyDeviceAccess, #2 org-wide check, #3 device→org+platform lookup.
+    // (No separate global-latest select: the resolver returns latest for pin=null.)
+    mockSelectSequence([
+      [onlineDeviceRow()], [{ id: DEVICE_ID }], [deviceOrgRow(DEVICE_ID, ORG_ID)],
+    ]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.queued).toBe(1);
+    expect(result.targetVersions).toEqual(['0.88.0']);
+    expect(resolvePinnedUpgradeTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ component: 'agent', pin: null, platform: 'windows', architecture: 'amd64' }),
+    );
+    expect(executeCommand).toHaveBeenCalledWith(
+      DEVICE_ID, 'update_agent', { version: '0.88.0' },
+      expect.objectContaining({ targetRole: 'watchdog' }),
+    );
+  });
+
+  it('fails closed: a pinned version with no build for the device is recorded, not dispatched', async () => {
+    vi.mocked(getOrgAgentUpdateConfig).mockResolvedValue({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: '1.2.3', watchdog: null },
+    });
+    // The pinned 1.2.3 has no build for this device's platform/arch → resolver null.
+    vi.mocked(resolvePinnedUpgradeTarget).mockResolvedValue(null);
+    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], [deviceOrgRow(DEVICE_ID, ORG_ID)]]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    // No doomed dispatch; the operator is told, not silently timed out.
+    expect(result.error).toMatch(/No latest agent version found/i);
+    expect(result.errors[DEVICE_ID]).toMatch(/has no build for this device/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('an explicit targetVersion overrides any pin and is used verbatim', async () => {
+    // #1 verifyDeviceAccess, #2 org-wide check, #3 explicit-version existence.
+    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], [{ version: '0.90.0' }]]);
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID], targetVersion: '0.90.0' }, makeAuth()),
+    );
+
+    expect(result.queued).toBe(1);
+    expect(result.targetVersion).toBe('0.90.0');
+    // The pin resolver is never consulted when a version is explicitly given.
+    expect(getOrgAgentUpdateConfig).not.toHaveBeenCalled();
+    expect(executeCommand).toHaveBeenCalledWith(
+      DEVICE_ID, 'update_agent', { version: '0.90.0' },
+      expect.objectContaining({ targetRole: 'watchdog' }),
+    );
+  });
+
+  // --- Multi-org batch isolation (the load-bearing new behavior) -------------
+  const ORG_B = '22222222-2222-2222-2222-222222222222';
+  // The org-wide access check uses auth.orgCondition, which is mocked to undefined,
+  // so both devices pass access; each resolves its OWN org's pin independently.
+  const multiOrgAuth = () => ({ ...makeAuth(), accessibleOrgIds: [ORG_ID, ORG_B] }) as AuthContext;
+
+  it('isolates one org’s resolver failure: healthy device queues, failed org is recorded, batch does not throw', async () => {
+    // #1 verifyDeviceAccess (first device), #2 org-wide check (both allowed),
+    // #3 device→org+platform lookup spanning two orgs.
+    mockSelectSequence([
+      [onlineDeviceRow()],
+      [{ id: DEVICE_ID }, { id: OTHER_DEVICE_ID }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID), deviceOrgRow(OTHER_DEVICE_ID, ORG_B)],
+    ]);
+    // ORG_ID resolves to a pin; ORG_B's resolver throws (e.g. DB blip).
+    vi.mocked(getOrgAgentUpdateConfig).mockImplementation(async (orgId: string) => {
+      if (orgId === ORG_B) throw new Error('db down');
+      return { settings: { policy: 'staged', maintenanceWindow: null }, pins: { agent: '0.80.0', watchdog: null } } as any;
+    });
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID, OTHER_DEVICE_ID] }, multiOrgAuth()),
+    );
+
+    // Healthy device queued; failed org surfaced; the throw did NOT abort the batch.
+    expect(result.queued).toBe(1);
+    expect(result.errors[OTHER_DEVICE_ID]).toMatch(/Failed to resolve version pin/i);
+    expect(result.targetVersions).toEqual(['0.80.0']);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledWith(
+      DEVICE_ID, 'update_agent', { version: '0.80.0' },
+      expect.objectContaining({ targetRole: 'watchdog' }),
+    );
+  });
+
+  it('reports the distinct targets across a mixed batch (pinned org + unpinned org → global latest)', async () => {
+    // #1, #2, #3 as above. No global-latest select: the resolver returns latest
+    // for the unpinned org (pin=null → '0.88.0').
+    mockSelectSequence([
+      [onlineDeviceRow()],
+      [{ id: DEVICE_ID }, { id: OTHER_DEVICE_ID }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID), deviceOrgRow(OTHER_DEVICE_ID, ORG_B)],
+    ]);
+    vi.mocked(getOrgAgentUpdateConfig).mockImplementation(async (orgId: string) => ({
+      settings: { policy: 'staged', maintenanceWindow: null },
+      pins: { agent: orgId === ORG_ID ? '0.80.0' : null, watchdog: null },
+    }) as any);
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID, OTHER_DEVICE_ID] }, multiOrgAuth()),
+    );
+
+    expect(result.queued).toBe(2);
+    expect(result.errors).toBeUndefined();
+    // ORG_ID → pinned 0.80.0; ORG_B → global latest 0.88.0 (via the resolver).
+    expect([...result.targetVersions].sort()).toEqual(['0.80.0', '0.88.0']);
+  });
+
+  it('fails the whole call when EVERY org’s resolver fails (no target resolved)', async () => {
+    mockSelectSequence([
+      [onlineDeviceRow()],
+      [{ id: DEVICE_ID }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID)],
+    ]);
+    vi.mocked(getOrgAgentUpdateConfig).mockRejectedValue(new Error('db down'));
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.error).toMatch(/No latest agent version found/i);
+    expect(result.errors[DEVICE_ID]).toMatch(/Failed to resolve version pin/i);
     expect(executeCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -7,11 +7,12 @@
  * - trigger_agent_restart (Tier 3): Ask the watchdog to restart a wedged/silent agent
  */
 
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { devices, agentVersions } from '../db/schema';
 import { eq, ne, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget, normalizeAgentArchitecture } from '../routes/agents/helpers';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -102,19 +103,44 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
       }
 
       if (action === 'check_upgrades') {
-        // Get the latest agent version
+        // Get the globally promoted latest agent version.
         const [latest] = await db
           .select({ version: agentVersions.version })
           .from(agentVersions)
           .where(eq(agentVersions.isLatest, true))
           .limit(1);
 
-        if (!latest) {
+        // Issue #2124: "outdated" must be measured against the fleet's EFFECTIVE
+        // target, not the global latest — an org pinned to an older known-good
+        // version will never be pushed past its pin, so counting those devices as
+        // "behind global latest" contradicts what the fleet will actually do. For
+        // an org-scoped caller (the common case) resolve that org's effective pin
+        // and compare against it. A partner/system caller can span many orgs with
+        // different pins, which no single target can represent — keep the global
+        // latest but say so, so the count isn't misread as pin-aware.
+        let effectiveTarget: string | null = latest?.version ?? null;
+        let pinned = false;
+        let note: string | undefined;
+        if (auth.orgId) {
+          try {
+            const cfg = await withSystemDbAccessContext(() => getOrgAgentUpdateConfig(auth.orgId!));
+            if (cfg.pins.agent) {
+              effectiveTarget = cfg.pins.agent;
+              pinned = true;
+            }
+          } catch {
+            note = 'Could not resolve this org’s version pin; counting against global latest.';
+          }
+        } else {
+          note = 'Caller spans multiple orgs; per-org version pins are not reflected in this count.';
+        }
+
+        if (!effectiveTarget) {
           return JSON.stringify({ error: 'No latest agent version found' });
         }
 
-        // Find devices in org with a different agent version
-        const conditions: SQL[] = [ne(devices.agentVersion, latest.version)];
+        // Find devices whose agent version differs from the effective target.
+        const conditions: SQL[] = [ne(devices.agentVersion, effectiveTarget)];
         const orgCond = auth.orgCondition(devices.orgId);
         if (orgCond) conditions.push(orgCond);
 
@@ -131,9 +157,14 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         const totalOutdated = outdated.reduce((sum, row) => sum + row.count, 0);
 
         return JSON.stringify({
-          latestVersion: latest.version,
+          // `latestVersion` stays the global promoted latest (back-compat); the
+          // count is measured against `effectiveTarget` (the pin when set).
+          latestVersion: latest?.version ?? null,
+          effectiveTarget,
+          pinned,
           totalOutdated,
           byVersion: outdated,
+          ...(note ? { note } : {}),
         });
       }
 
@@ -193,38 +224,118 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: `Access denied for devices: ${deniedIds.join(', ')}` });
       }
 
-      // Resolve target version
-      let targetVersion = input.targetVersion as string | undefined;
-      if (!targetVersion) {
-        const [latest] = await db
-          .select({ version: agentVersions.version })
-          .from(agentVersions)
-          .where(eq(agentVersions.isLatest, true))
-          .limit(1);
+      // Resolve the target version PER DEVICE. An explicit targetVersion applies
+      // to all devices; otherwise each device resolves to its org's effective
+      // AGENT pin (issue #2124) — the SAME pin the heartbeat honors — falling
+      // back to the globally promoted latest when the tenant has no pin. This
+      // keeps manual and automatic updates on one resolution path.
+      const explicitVersion = input.targetVersion as string | undefined;
+      const errors: Record<string, string> = {};
+      const targetByDevice = new Map<string, string>();
 
-        if (!latest) {
-          return JSON.stringify({ error: 'No latest agent version found' });
-        }
-        targetVersion = latest.version;
-      } else {
-        // Verify the specified version exists
+      if (explicitVersion) {
         const [versionRow] = await db
           .select({ version: agentVersions.version })
           .from(agentVersions)
-          .where(eq(agentVersions.version, targetVersion))
+          .where(eq(agentVersions.version, explicitVersion))
           .limit(1);
-
         if (!versionRow) {
-          return JSON.stringify({ error: `Agent version "${targetVersion}" not found` });
+          return JSON.stringify({ error: `Agent version "${explicitVersion}" not found` });
+        }
+        for (const id of deviceIds) targetByDevice.set(id, explicitVersion);
+      } else {
+        // Need each device's org (to resolve its effective pin) AND its
+        // platform/arch (to fail closed when the pinned/latest version has no
+        // build for that device). Resolving through resolvePinnedUpgradeTarget
+        // per device — the SAME call the heartbeat uses — is what stops this
+        // manual channel from dispatching an update_agent for a binary that
+        // doesn't exist and reporting it as `queued` (a silent, on-device 60s
+        // timeout the operator never sees).
+        const deviceRows = await db
+          .select({
+            id: devices.id,
+            orgId: devices.orgId,
+            osType: devices.osType,
+            architecture: devices.architecture,
+          })
+          .from(devices)
+          .where(inArray(devices.id, deviceIds));
+
+        const pinByOrg = new Map<string, string | null>();
+        const failedOrgs = new Set<string>();
+
+        for (const d of deviceRows) {
+          if (failedOrgs.has(d.orgId)) {
+            errors[d.id] = 'Failed to resolve version pin for this organization';
+            continue;
+          }
+          if (!pinByOrg.has(d.orgId)) {
+            // Effective pin needs the parent partners row (partner-set defaults),
+            // which org-scoped RLS can't read — resolve in a system context, the
+            // same pattern the heartbeat and aiAgent use. Isolate per org so one
+            // org's resolver failure doesn't abort the whole batch.
+            try {
+              const cfg = await withSystemDbAccessContext(() => getOrgAgentUpdateConfig(d.orgId));
+              pinByOrg.set(d.orgId, cfg.pins.agent);
+            } catch {
+              failedOrgs.add(d.orgId);
+              errors[d.id] = 'Failed to resolve version pin for this organization';
+              continue;
+            }
+          }
+
+          const normalizedArch = normalizeAgentArchitecture(d.architecture);
+          if (!d.osType || !normalizedArch) {
+            errors[d.id] = 'Device platform/architecture unknown — cannot resolve an agent build';
+            continue;
+          }
+
+          const pin = pinByOrg.get(d.orgId) ?? null;
+          // pin set → that exact build for this platform/arch (null if missing);
+          // pin null → the globally promoted latest for this platform/arch.
+          // Either way, null means "no build" → fail closed, do not dispatch.
+          let target: string | null;
+          try {
+            target = await resolvePinnedUpgradeTarget({
+              component: 'agent',
+              platform: d.osType,
+              architecture: normalizedArch,
+              pin,
+              agentId: d.id,
+            });
+          } catch {
+            errors[d.id] = 'Failed to resolve an agent build for this device';
+            continue;
+          }
+
+          if (target) {
+            targetByDevice.set(d.id, target);
+          } else {
+            errors[d.id] = pin
+              ? `Pinned agent version "${pin}" has no build for this device (${d.osType}/${normalizedArch})`
+              : 'No agent build available for this device platform/architecture';
+          }
+        }
+
+        if (targetByDevice.size === 0) {
+          return JSON.stringify({
+            error: 'No latest agent version found',
+            ...(Object.keys(errors).length > 0 ? { errors } : {}),
+          });
         }
       }
 
       // Dispatch upgrade commands
       const { executeCommand } = await getCommandQueue();
       let queued = 0;
-      const errors: Record<string, string> = {};
 
       for (const deviceId of deviceIds) {
+        const targetVersion = targetByDevice.get(deviceId);
+        if (!targetVersion) {
+          // Already recorded (e.g. no pin + no global latest for this device).
+          if (!errors[deviceId]) errors[deviceId] = 'No target version resolved';
+          continue;
+        }
         try {
           // Agent upgrades are executed by the breeze-watchdog process, not
           // the agent. The watchdog handles type `update_agent` and reads
@@ -251,9 +362,13 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         }
       }
 
+      // Report the distinct target(s) queued so a pinned/mixed batch is legible.
+      const distinctTargets = [...new Set(targetByDevice.values())];
       return JSON.stringify({
         queued,
-        targetVersion,
+        ...(explicitVersion
+          ? { targetVersion: explicitVersion }
+          : { targetVersions: distinctTargets }),
         ...(Object.keys(errors).length > 0 ? { errors } : {}),
       });
     },

--- a/apps/web/src/components/settings/AgentVersionPinSelectors.test.tsx
+++ b/apps/web/src/components/settings/AgentVersionPinSelectors.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AgentVersionPinSelectors, { type PinnableVersions } from './AgentVersionPinSelectors';
+
+const pinnable: PinnableVersions = {
+  components: {
+    agent: { versions: ['0.88.0', '0.87.0'], promoted: ['0.88.0'] },
+    watchdog: { versions: ['0.88.0'], promoted: ['0.88.0'] },
+  },
+};
+
+describe('AgentVersionPinSelectors', () => {
+  it('offers Latest promoted plus each registered version', () => {
+    render(
+      <AgentVersionPinSelectors context="organization" value={{}} onChange={vi.fn()} pinnable={pinnable} />,
+    );
+    const agent = screen.getByTestId('agent-pin-organization-agent') as HTMLSelectElement;
+    const values = Array.from(agent.options).map((o) => o.value);
+    expect(values).toEqual(['', '0.88.0', '0.87.0']);
+    // Empty option surfaces the promoted version for context.
+    expect(agent.options[0].textContent).toContain('0.88.0');
+  });
+
+  it('emits the "latest" sentinel when the empty option is chosen', () => {
+    const onChange = vi.fn();
+    render(
+      <AgentVersionPinSelectors
+        context="organization"
+        value={{ agent: '0.87.0' }}
+        onChange={onChange}
+        pinnable={pinnable}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('agent-pin-organization-agent'), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith({ agent: 'latest' });
+  });
+
+  it('shows the org-pin provenance when a version is pinned', () => {
+    render(
+      <AgentVersionPinSelectors
+        context="organization"
+        value={{ agent: '0.87.0' }}
+        onChange={vi.fn()}
+        pinnable={pinnable}
+      />,
+    );
+    expect(screen.getByTestId('agent-pin-source-organization-agent').textContent).toMatch(
+      /Pinned for this organization/i,
+    );
+  });
+
+  it('shows the inherited partner default (editable) when the org has not set its own pin', () => {
+    render(
+      <AgentVersionPinSelectors
+        context="organization"
+        value={{}}
+        onChange={vi.fn()}
+        pinnable={pinnable}
+        inheritedPins={{ agent: '0.87.0' }}
+      />,
+    );
+    const agent = screen.getByTestId('agent-pin-organization-agent') as HTMLSelectElement;
+    // Inherit-with-override: never disabled — the org can override.
+    expect(agent.disabled).toBe(false);
+    // The org's OWN value is empty (inheriting), and the empty option surfaces
+    // the inherited partner value.
+    expect(agent.value).toBe('');
+    expect(agent.options[0].textContent).toMatch(/Inherit partner default \(0\.87\.0\)/i);
+    expect(screen.getByTestId('agent-pin-source-organization-agent').textContent).toMatch(
+      /Inherited from partner: 0\.87\.0/i,
+    );
+  });
+
+  it('marks an org pin that overrides the partner default', () => {
+    render(
+      <AgentVersionPinSelectors
+        context="organization"
+        value={{ agent: '0.88.0' }}
+        onChange={vi.fn()}
+        pinnable={pinnable}
+        inheritedPins={{ agent: '0.87.0' }}
+      />,
+    );
+    const agent = screen.getByTestId('agent-pin-organization-agent') as HTMLSelectElement;
+    expect(agent.value).toBe('0.88.0');
+    expect(screen.getByTestId('agent-pin-source-organization-agent').textContent).toMatch(
+      /Overrides partner default \(0\.87\.0\)/i,
+    );
+  });
+
+  it('preserves a stored pin whose build is no longer registered', () => {
+    render(
+      <AgentVersionPinSelectors
+        context="partner"
+        value={{ agent: '0.50.0' }}
+        onChange={vi.fn()}
+        pinnable={pinnable}
+      />,
+    );
+    const agent = screen.getByTestId('agent-pin-partner-agent') as HTMLSelectElement;
+    expect(agent.value).toBe('0.50.0');
+    expect(Array.from(agent.options).some((o) => o.textContent?.includes('unregistered'))).toBe(true);
+  });
+});

--- a/apps/web/src/components/settings/AgentVersionPinSelectors.tsx
+++ b/apps/web/src/components/settings/AgentVersionPinSelectors.tsx
@@ -1,0 +1,144 @@
+import { RefreshCcw } from 'lucide-react';
+
+/**
+ * Agent + watchdog version-pin selectors (issue #2124). Shared by the partner
+ * defaults tab and the org defaults editor so both render identical controls.
+ *
+ * A pin value is a registered version string or the 'latest' sentinel (= no pin
+ * → track the globally promoted latest). The empty select option maps to
+ * 'latest'.
+ *
+ * Semantics: INHERIT-WITH-OVERRIDE. A partner pin is an inherited default; an
+ * org may set its own pin (including 'latest') to override it. The selector
+ * always edits the CURRENT level's own value; the caption + empty-option label
+ * explain the effective source (global latest / partner default / this level).
+ */
+
+export type PinnableVersions = {
+  components: {
+    agent: { versions: string[]; promoted: string[] };
+    watchdog: { versions: string[]; promoted: string[] };
+  };
+};
+
+export type AgentVersionPinsValue = {
+  agent?: string;
+  watchdog?: string;
+};
+
+type Props = {
+  value: AgentVersionPinsValue;
+  onChange: (value: AgentVersionPinsValue) => void;
+  pinnable: PinnableVersions | null;
+  context: 'partner' | 'organization';
+  /** Org view only: the partner's pins, shown as the inherited default. */
+  inheritedPins?: AgentVersionPinsValue;
+};
+
+const COMPONENTS: Array<{ key: 'agent' | 'watchdog'; label: string }> = [
+  { key: 'agent', label: 'Agent target' },
+  { key: 'watchdog', label: 'Watchdog target' },
+];
+
+/** '' | 'latest' | undefined → no pin. Otherwise the concrete version. */
+function normalize(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const t = raw.trim();
+  if (t === '' || t.toLowerCase() === 'latest') return null;
+  return t;
+}
+
+export default function AgentVersionPinSelectors({
+  value,
+  onChange,
+  pinnable,
+  context,
+  inheritedPins,
+}: Props) {
+  const setPin = (key: 'agent' | 'watchdog', raw: string) => {
+    // Empty select → 'latest' sentinel so the saved object is explicit (and, for
+    // an org, deliberately overrides an inherited partner pin back to latest).
+    onChange({ ...value, [key]: raw === '' ? 'latest' : raw });
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-muted/40 p-4" data-testid="agent-version-pins">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <RefreshCcw className="h-4 w-4" />
+        Update version targets
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Pin the agent and watchdog to a specific registered version, or leave on{' '}
+        <strong>Latest promoted</strong> to track the globally promoted release. Agent and watchdog
+        are independent.
+        {context === 'partner'
+          ? ' A pin here is the default for all your organizations; an organization can override it.'
+          : ' An organization pin overrides the partner default.'}
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {COMPONENTS.map(({ key, label }) => {
+          const options = pinnable?.components?.[key]?.versions ?? [];
+          const promoted = pinnable?.components?.[key]?.promoted?.[0];
+          const ownVal = normalize(value[key]);
+          const inheritedVal = context === 'organization' ? normalize(inheritedPins?.[key]) : null;
+          const selectValue = value[key] ?? '';
+
+          // Empty-option label: for an org that hasn't set its own pin, the empty
+          // state means "inherit the partner default", so surface that value.
+          const emptyLabel =
+            inheritedVal != null
+              ? `Inherit partner default (${inheritedVal})`
+              : promoted
+                ? `Latest promoted (${promoted})`
+                : 'Latest promoted';
+
+          let caption: string;
+          if (ownVal) {
+            if (context === 'partner') {
+              caption = 'Pinned for all organizations';
+            } else {
+              caption = inheritedVal
+                ? `Overrides partner default (${inheritedVal})`
+                : 'Pinned for this organization';
+            }
+          } else if (inheritedVal != null) {
+            caption = `Inherited from partner: ${inheritedVal}`;
+          } else {
+            caption = promoted ? `Global latest promoted (${promoted})` : 'Global latest promoted';
+          }
+
+          return (
+            <label key={key} className="space-y-1 text-sm">
+              <span className="font-medium">{label}</span>
+              <select
+                value={selectValue}
+                onChange={(e) => setPin(key, e.target.value)}
+                data-testid={`agent-pin-${context}-${key}`}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="">{emptyLabel}</option>
+                {options.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+                {/* Preserve a stored pin whose build is no longer registered so a
+                    save doesn't silently drop it. */}
+                {selectValue && !options.includes(selectValue) && (
+                  <option value={selectValue}>{selectValue} (unregistered)</option>
+                )}
+              </select>
+              <span
+                className="block text-xs text-muted-foreground"
+                data-testid={`agent-pin-source-${context}-${key}`}
+              >
+                {caption}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
+import AgentVersionPinSelectors, {
+  type PinnableVersions,
+  type AgentVersionPinsValue,
+} from './AgentVersionPinSelectors';
 import {
   MAINTENANCE_WINDOW_ALWAYS,
   MAINTENANCE_DAYS,
@@ -45,6 +49,7 @@ type DefaultsData = {
   };
   agentUpdatePolicy?: string;
   maintenanceWindow?: string;
+  agentVersionPins?: { agent?: string; watchdog?: string };
 };
 
 type OrgDefaultsEditorProps = {
@@ -52,6 +57,11 @@ type OrgDefaultsEditorProps = {
   defaults?: DefaultsData;
   onDirty?: () => void;
   onSave?: (data: DefaultsData) => void;
+  // Issue #2124: the registered versions to offer plus the partner's effective
+  // pins to show as the inherited default. Pins are inherit-with-override, so
+  // there is no lock — an org pin always overrides the partner default.
+  pinnableVersions?: PinnableVersions | null;
+  partnerPins?: AgentVersionPinsValue;
 };
 
 const defaultValues: DefaultsData = {
@@ -93,8 +103,20 @@ const alertThresholds = [
   { value: 'medium', label: 'Medium and above' }
 ];
 
-export default function OrgDefaultsEditor({ organizationName, defaults, onDirty, onSave }: OrgDefaultsEditorProps) {
+export default function OrgDefaultsEditor({
+  organizationName,
+  defaults,
+  onDirty,
+  onSave,
+  pinnableVersions,
+  partnerPins,
+}: OrgDefaultsEditorProps) {
   const initialData = { ...defaultValues, ...defaults };
+  // Version pins are inherit-with-override (issue #2124): the org can always set
+  // its own, which overrides the partner default. No lock.
+  const [agentVersionPins, setAgentVersionPins] = useState<AgentVersionPinsValue>(
+    initialData.agentVersionPins ?? {},
+  );
   const [policyDefaults, setPolicyDefaults] = useState(initialData.policyDefaults || defaultValues.policyDefaults!);
   const [deviceGroup, setDeviceGroup] = useState(initialData.deviceGroup || defaultValues.deviceGroup!);
   const [alertThreshold, setAlertThreshold] = useState(initialData.alertThreshold || defaultValues.alertThreshold!);
@@ -150,7 +172,8 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
       alertThreshold,
       autoEnrollment,
       agentUpdatePolicy,
-      maintenanceWindow: builtWindow
+      maintenanceWindow: builtWindow,
+      agentVersionPins,
     };
     onSave?.(data);
   };
@@ -434,6 +457,17 @@ export default function OrgDefaultsEditor({ organizationName, defaults, onDirty,
           </div>
         </div>
       </div>
+
+      <AgentVersionPinSelectors
+        context="organization"
+        value={agentVersionPins}
+        onChange={(next) => {
+          setAgentVersionPins(next);
+          markDirty();
+        }}
+        pinnable={pinnableVersions ?? null}
+        inheritedPins={partnerPins}
+      />
     </section>
   );
 }

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -20,6 +20,7 @@ import OrgBrandingEditor from './OrgBrandingEditor';
 import OrgPortalSettingsEditor from './OrgPortalSettingsEditor';
 import OrgTicketSettingsEditor from './OrgTicketSettingsEditor';
 import OrgDefaultsEditor from './OrgDefaultsEditor';
+import type { PinnableVersions, AgentVersionPinsValue } from './AgentVersionPinSelectors';
 import OrgNotificationSettings from './OrgNotificationSettings';
 import OrgSecuritySettings from './OrgSecuritySettings';
 import { OrgApprovalSecurityTab } from './OrgApprovalSecurityTab';
@@ -233,6 +234,10 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
   });
   const [orgDetails, setOrgDetails] = useState<OrgDetails | null>(null);
   const [locked, setLocked] = useState<string[]>([]);
+  // Issue #2124: registered versions for the pin selectors + the partner's
+  // effective pins (shown when `defaults.agentVersionPins` is partner-locked).
+  const [pinnableVersions, setPinnableVersions] = useState<PinnableVersions | null>(null);
+  const [partnerPins, setPartnerPins] = useState<AgentVersionPinsValue | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [copiedOrgId, setCopiedOrgId] = useState(false);
@@ -270,10 +275,34 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
       const effRes = await fetchWithAuth(`/orgs/organizations/${effectiveOrgId}/effective-settings`);
       if (effRes.ok) {
         const effData = await effRes.json();
-        setLocked(effData.locked || []);
+        const lockedList: string[] = effData.locked || [];
+        setLocked(lockedList);
+        // Issue #2124: pins are inherit-with-override, NOT enforced-locked (see the
+        // assertNotLocked exemption in the org PATCH). But `locked` still carries
+        // `defaults.agentVersionPins` when the PARTNER set one — we use that purely
+        // as a "partner has a pin" signal so the effective value is the partner's
+        // (not the org's own, which mergeCategory would surface when the partner
+        // hasn't pinned). The org selector is never disabled by this.
+        setPartnerPins(
+          lockedList.includes('defaults.agentVersionPins')
+            ? effData.effective?.defaults?.agentVersionPins
+            : undefined,
+        );
       } else {
         console.warn('[OrgSettingsPage] Failed to fetch effective settings:', effRes.status);
       }
+
+      // Registered agent/watchdog versions for the pin selectors (#2124).
+      // Isolated (own promise chain, not awaited in this try) so a network throw
+      // or JSON-parse failure on this NON-critical picker feed can't blank the
+      // whole settings page — it just leaves the dropdowns with "Latest promoted".
+      fetchWithAuth('/agent-versions/pinnable')
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`status ${r.status}`))))
+        .then((p: PinnableVersions) => setPinnableVersions(p))
+        .catch((e) => {
+          console.warn('[OrgSettingsPage] Failed to fetch pinnable versions:', e);
+          setPinnableVersions(null);
+        });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -619,6 +648,8 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
               defaults={orgDetails?.settings?.defaults}
               onDirty={handleDirty}
               onSave={(data) => handleSave('defaults', data)}
+              pinnableVersions={pinnableVersions}
+              partnerPins={partnerPins}
             />
           </div>
         );

--- a/apps/web/src/components/settings/PartnerDefaultsTab.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.tsx
@@ -1,14 +1,16 @@
 import type { InheritableDefaultSettings } from '@breeze/shared';
 import { isValidMaintenanceWindow } from '@breeze/shared';
+import AgentVersionPinSelectors, { type PinnableVersions } from './AgentVersionPinSelectors';
 
 type Props = {
   data: InheritableDefaultSettings;
   onChange: (data: InheritableDefaultSettings) => void;
+  pinnableVersions?: PinnableVersions | null;
 };
 
 const PLACEHOLDER = 'Not set — orgs configure individually';
 
-export default function PartnerDefaultsTab({ data, onChange }: Props) {
+export default function PartnerDefaultsTab({ data, onChange, pinnableVersions }: Props) {
   const set = (patch: Partial<InheritableDefaultSettings>) =>
     onChange({ ...data, ...patch });
 
@@ -60,6 +62,15 @@ export default function PartnerDefaultsTab({ data, onChange }: Props) {
               always-on, or leave empty so orgs configure it individually.
             </p>
           )}
+        </div>
+
+        <div className="space-y-2 sm:col-span-2">
+          <AgentVersionPinSelectors
+            context="partner"
+            value={data.agentVersionPins ?? {}}
+            onChange={(agentVersionPins) => set({ agentVersionPins })}
+            pinnable={pinnableVersions ?? null}
+          />
         </div>
 
         <div className="space-y-2">

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -16,6 +16,7 @@ import PartnerSecurityTab, { currentIpCovered } from './PartnerSecurityTab';
 import PartnerNotificationsTab from './PartnerNotificationsTab';
 import PartnerEventLogsTab from './PartnerEventLogsTab';
 import PartnerDefaultsTab from './PartnerDefaultsTab';
+import type { PinnableVersions } from './AgentVersionPinSelectors';
 import PartnerBrandingTab from './PartnerBrandingTab';
 import PartnerAiBudgetsTab from './PartnerAiBudgetsTab';
 import PartnerRemoteAccessTab from './PartnerRemoteAccessTab';
@@ -167,6 +168,8 @@ export default function PartnerSettingsPage() {
   const [brandingData, setBrandingData] = useState<InheritableBrandingSettings>({});
   const [aiBudgetsData, setAiBudgetsData] = useState<InheritableAiBudgetSettings>({});
   const [remoteAccessData, setRemoteAccessData] = useState<InheritableRemoteAccessSettings>({});
+  // Registered agent/watchdog versions for the pin selectors (#2124).
+  const [pinnableVersions, setPinnableVersions] = useState<PinnableVersions | null>(null);
 
   const fetchPartner = useCallback(async () => {
     try {
@@ -214,6 +217,13 @@ export default function PartnerSettingsPage() {
         .then(r => (r.ok ? r.json() : Promise.reject(new Error('status fetch failed'))))
         .then((s: IpAllowlistStatus) => { setIpStatus(s); setIpStatusUnavailable(false); })
         .catch(() => { setIpStatus(null); setIpStatusUnavailable(true); });
+
+      // Best-effort: registered versions for the pin selectors (#2124). On
+      // failure the dropdowns simply offer "Latest promoted" only.
+      fetchWithAuth('/agent-versions/pinnable')
+        .then(r => (r.ok ? r.json() : Promise.reject(new Error('pinnable fetch failed'))))
+        .then((p: PinnableVersions) => setPinnableVersions(p))
+        .catch(() => setPinnableVersions(null));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -604,7 +614,7 @@ export default function PartnerSettingsPage() {
 
       {activeTab === 'defaults' && (
         <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerDefaultsTab data={defaultsData} onChange={setDefaultsData} />
+          <PartnerDefaultsTab data={defaultsData} onChange={setDefaultsData} pinnableVersions={pinnableVersions} />
         </section>
       )}
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -624,6 +624,18 @@ export interface InheritableDefaultSettings {
   };
   agentUpdatePolicy?: string;
   maintenanceWindow?: string;
+  // Per-component update version pins (issue #2124). Each value is a registered
+  // version string or the 'latest' sentinel (= no pin → global promoted latest).
+  // INHERIT-WITH-OVERRIDE (NOT partner-locked, unlike the other fields here): a
+  // partner-set pin is an inherited default; an org may override it (including
+  // back to 'latest'). getOrgAgentUpdateConfig resolves org-over-partner, and
+  // agentVersionPins is deliberately exempt from assertNotLocked — see the note
+  // in apps/api/src/routes/orgs.ts. Do NOT "fix" this into a lock. Agent and
+  // watchdog are independent knobs.
+  agentVersionPins?: {
+    agent?: string;
+    watchdog?: string;
+  };
 }
 
 export interface InheritableBrandingSettings {

--- a/packages/shared/src/validators/agentVersionPins.test.ts
+++ b/packages/shared/src/validators/agentVersionPins.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  agentVersionPinsSchema,
+  normalizeVersionPin,
+  extractAgentVersionPins,
+  PINNABLE_COMPONENTS,
+} from './agentVersionPins';
+
+describe('normalizeVersionPin', () => {
+  it('maps the "latest" sentinel (any case), empty, whitespace, and non-strings to null', () => {
+    expect(normalizeVersionPin('latest')).toBeNull();
+    expect(normalizeVersionPin('LATEST')).toBeNull();
+    expect(normalizeVersionPin('  Latest ')).toBeNull();
+    expect(normalizeVersionPin('')).toBeNull();
+    expect(normalizeVersionPin('   ')).toBeNull();
+    expect(normalizeVersionPin(undefined)).toBeNull();
+    expect(normalizeVersionPin(null)).toBeNull();
+    expect(normalizeVersionPin(123)).toBeNull();
+  });
+
+  it('returns a trimmed concrete version string', () => {
+    expect(normalizeVersionPin('0.88.0')).toBe('0.88.0');
+    expect(normalizeVersionPin('  0.88.0 ')).toBe('0.88.0');
+  });
+});
+
+describe('agentVersionPinsSchema', () => {
+  it('accepts optional agent/watchdog strings', () => {
+    expect(agentVersionPinsSchema.parse({})).toEqual({});
+    expect(agentVersionPinsSchema.parse({ agent: '0.88.0' })).toEqual({ agent: '0.88.0' });
+    expect(agentVersionPinsSchema.parse({ agent: 'latest', watchdog: '0.87.0' })).toEqual({
+      agent: 'latest',
+      watchdog: '0.87.0',
+    });
+  });
+
+  it('rejects unknown keys and over-long values', () => {
+    expect(() => agentVersionPinsSchema.parse({ helper: '0.1.0' })).toThrow();
+    expect(() => agentVersionPinsSchema.parse({ agent: 'x'.repeat(21) })).toThrow();
+    expect(() => agentVersionPinsSchema.parse({ agent: '' })).toThrow();
+  });
+
+  it('exposes exactly agent and watchdog as the pinnable components', () => {
+    expect([...PINNABLE_COMPONENTS]).toEqual(['agent', 'watchdog']);
+  });
+});
+
+describe('extractAgentVersionPins', () => {
+  it('pulls normalized pins from a settings.defaults object', () => {
+    expect(
+      extractAgentVersionPins({ agentVersionPins: { agent: '0.88.0', watchdog: 'latest' } }),
+    ).toEqual({ agent: '0.88.0', watchdog: null });
+  });
+
+  it('is null-safe for missing / malformed input', () => {
+    expect(extractAgentVersionPins(undefined)).toEqual({ agent: null, watchdog: null });
+    expect(extractAgentVersionPins(null)).toEqual({ agent: null, watchdog: null });
+    expect(extractAgentVersionPins({})).toEqual({ agent: null, watchdog: null });
+    expect(extractAgentVersionPins({ agentVersionPins: 'nope' })).toEqual({
+      agent: null,
+      watchdog: null,
+    });
+  });
+});

--- a/packages/shared/src/validators/agentVersionPins.ts
+++ b/packages/shared/src/validators/agentVersionPins.ts
@@ -1,0 +1,95 @@
+/**
+ * Agent / watchdog version pins — shared grammar + validation (issue #2124).
+ *
+ * Partner and org settings may pin the update target for the `agent` and
+ * `watchdog` components independently:
+ *
+ *   settings.defaults.agentVersionPins = { agent?: <version|'latest'>, watchdog?: <version|'latest'> }
+ *
+ * A pin either names a specific registered version string OR the sentinel
+ * `'latest'` (equivalent to leaving the field unset) meaning "track the globally
+ * promoted latest version". This module is the ONE source of truth for the shape
+ * so the web editor, the save-time validators, and the heartbeat resolver never
+ * drift — mirroring the maintenanceWindow validator's role.
+ *
+ * The heartbeat gate is authoritative for turning a pin into an actual upgrade
+ * target (see getOrgAgentUpdateConfig / heartbeat.ts): a pin merely names WHICH
+ * version to aim for, replacing the global isLatest target. Per-component /
+ * platform / arch existence is confirmed at save time (against agent_versions)
+ * and again at resolution time (fail-closed if the pinned version has no build
+ * for the device's platform+arch).
+ */
+
+import { z } from 'zod';
+
+/** Sentinel meaning "no pin — track the globally promoted latest version". */
+export const AGENT_VERSION_PIN_LATEST = 'latest';
+
+/**
+ * Components that can be pinned. The full agent_versions component set also
+ * includes helper / viewer / user-helper, but issue #2124 scopes pins to the
+ * two operator-facing binaries: the main agent and its watchdog.
+ */
+export const PINNABLE_COMPONENTS = ['agent', 'watchdog'] as const;
+export type PinnableComponent = (typeof PINNABLE_COMPONENTS)[number];
+
+/** Single source of the rejection message shared by every save path + the UI. */
+export const AGENT_VERSION_PIN_ERROR_MESSAGE =
+  'Agent version pin must be "latest" or a registered agent/watchdog version.';
+
+// A pin value is either the 'latest' sentinel or a version string. The stored
+// agent_versions.version column is varchar(20), so bound the length to match;
+// existence against the registry is checked separately at save time.
+const pinValueSchema = z.string().trim().min(1).max(20);
+
+/**
+ * Zod shape for `settings.defaults.agentVersionPins`. Both sub-fields are
+ * optional and independent. Structural only — it does NOT prove the version is
+ * registered (that needs a DB lookup, done in the PATCH handlers).
+ */
+export const agentVersionPinsSchema = z
+  .object({
+    agent: pinValueSchema.optional(),
+    watchdog: pinValueSchema.optional(),
+  })
+  .strict();
+
+export type AgentVersionPinsInput = z.infer<typeof agentVersionPinsSchema>;
+
+/**
+ * Normalize a raw pin value to either a concrete version string or `null`
+ * (no pin → global latest). The `'latest'` sentinel, empty string, whitespace,
+ * and non-strings all collapse to `null`. Case-insensitive on the sentinel.
+ */
+export function normalizeVersionPin(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  if (trimmed.toLowerCase() === AGENT_VERSION_PIN_LATEST) return null;
+  return trimmed;
+}
+
+/**
+ * Extract the normalized { agent, watchdog } pins from a `settings.defaults`
+ * object (or anything shaped like it). Unset / 'latest' → null. Safe for any
+ * input; never throws.
+ */
+export function extractAgentVersionPins(defaults: unknown): {
+  agent: string | null;
+  watchdog: string | null;
+} {
+  const root =
+    defaults && typeof defaults === 'object' && !Array.isArray(defaults)
+      ? (defaults as Record<string, unknown>)
+      : {};
+  const pins =
+    root.agentVersionPins &&
+    typeof root.agentVersionPins === 'object' &&
+    !Array.isArray(root.agentVersionPins)
+      ? (root.agentVersionPins as Record<string, unknown>)
+      : {};
+  return {
+    agent: normalizeVersionPin(pins.agent),
+    watchdog: normalizeVersionPin(pins.watchdog),
+  };
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -23,6 +23,7 @@ export * from './contracts';
 export * from './mlFeedback';
 export * from './quotes';
 export * from './maintenanceWindow';
+export * from './agentVersionPins';
 export * from './softwareDetection';
 
 // ============================================


### PR DESCRIPTION
> ⚠️ **Stacked on #2184 — merge that first.** This branch is based on `fix/2123-heartbeat-effective-update-policy` and its diff against `main` currently includes #2184's commits. After #2184 squash-merges, this branch will be rebased `--onto main` (owner handles stacked squash-merges bottom-up). Review the **[#2184-excluded diff](https://github.com/LanternOps/breeze/compare/fix/2123-heartbeat-effective-update-policy...feat/2124-agent-version-pins)** to see only this PR's changes.

## What

Per-component **agent** and **watchdog** update *version pins* at partner and org settings (issue #2124). MSPs can hold an org — or all orgs under a partner — on a known-good version, stage a rollout to a subset, or hold back after a regression, all without moving the globally promoted latest.

`settings.defaults.agentVersionPins = { agent?: <version|'latest'>, watchdog?: <version|'latest'> }` at **both** partner and org level.

## Semantics — inherit-with-override

Per the maintainer's acceptance comment on #2124 ("org inherits the partner pin unless it overrides it") and the headline use case (pilot a risky update on **one** org):

- **Partner pin** = an inherited **default** for every org under the partner.
- **Org pin**, when set, **wins** for that org — it may differ from (override) the partner default. That is what lets a partner stage a rollout to a subset.
- **Both unset** → global promoted latest (current behavior).
- Agent and watchdog are independent knobs.

### Deliberate `assertNotLocked` exemption (please don't "fix" it back to a lock)
Because pins are inherit-with-override, an org **must** be able to override a partner-set pin. `agentVersionPins` is therefore **exempt** from the defaults partner-lock check (`assertNotLocked`) in v1 — a partner pin is a *default*, not a lock. The UI's effective-source caption (**global / partner default / org override**) does the explanatory work instead of a read-only lock. There is a test asserting an org PATCH that overrides a partner-set pin returns 200. Reverting this to a lock would break the pilot-one-org use case.

## Design — reuses #2184's effective-resolution plumbing (one resolver, not two)

- **Resolver:** `getOrgAgentUpdateConfig` → `{ settings, pins }` from the **same** single org⋈partner join, in the same short-lived system context. `settings` keep partner-lock semantics (unchanged from #2184); `pins` resolve **org-over-partner** per component.
- **Target selection:** `resolvePinnedUpgradeTarget` — a pin names the target version (replacing the global `isLatest` lookup); **fails closed** (no upgrade, logged + deduped Sentry capture) when the pinned build is missing for the device's platform/arch. Upgrade-only semantics preserved (a pin never triggers an auto *downgrade* through this channel). Applied in **both** heartbeat resolution sites (main path **and** the watchdog-role branch) and the **manual path** (`trigger_agent_upgrade` default target resolves the tenant pin per device org instead of global latest).
- **Fail-closed bootstrap (`pinsResolved` gate):** when the pin lookup itself *fails*, the (otherwise ungated) watchdog **bootstrap** is withheld — the upgrade channel is upgrade-only (`cmp > 0`), so it could never walk back a wrong-version first install if we bootstrapped global latest over an operator's holdback pin. The **unpinnable helper** bootstrap still fires. Self-heals on the next successful heartbeat.
- **Save-time validation:** org + partner PATCH reject an unknown version with a clear error (`latest`/unset always valid). Per-platform/arch existence is enforced at heartbeat resolution (fail-closed).
- **New endpoint:** `GET /agent-versions/pinnable` (org/partner/system scope) feeds the settings dropdowns — the existing list endpoint is platform-admin only. Fetched in an isolated promise so a failure never blanks the settings page.

## UI

Agent / Watchdog target selectors on the partner **Defaults** tab and org **General** tab. Options = "Latest promoted" + registered compatible versions. Selectors are **never disabled** (an org can always override); the empty option surfaces the inherited partner default, and a caption shows the effective source (**global latest / partner default / org override**). Mutations go through the existing `runAction` save path; new controls carry `data-testid`.

## Tests

Resolution matrix (no pin / org override / partner inherited / `latest` sentinel / missing-build fail-closed), `resolvePinnedUpgradeTarget` + deduped Sentry capture, **heartbeat pin-threading** (agent branch receives the agent pin, watchdog branch the watchdog pin — anti-swap regression guard), **watchdog-bootstrap fail-closed** on unresolved pins, save-time validation (org + partner, accept + reject + the org-overrides-partner exemption), the pinnable endpoint, the manual-path pin default, the shared validator, and the web selector component. Extends the #2184 test files rather than duplicating fixtures. Affected suites green single-fork; `tsc --noEmit` clean across api/web/shared.

Refs #2124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
