### PR TITLE
ci: raise Integration Tests timeout 40 -> 55 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -984,8 +984,9 @@ jobs:
     # The suite (138 files / ~690 tests) runs ~29 min and was tipping over the
     # old 30-min ceiling at the boundary (passed/cancelled non-deterministically
     # on the same commit). Raised to 40 for headroom — the tests pass, this is
-    # runtime growth, not a hang.
-    timeout-minutes: 40
+    # runtime growth, not a hang. By 2026-07 the baseline hit ~36 min and PRs
+    # adding integration suites tipped over 40 the same way; raised to 55.
+    timeout-minutes: 55
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What & why

The Integration Tests job baseline now runs ~36 min on PR runners (see the ~36m passes on #2184/#2185/#2187), and branches that add their own integration suites tip over the 40-minute ceiling and get cancelled mid-pass — the exact boundary failure that prompted the previous 30 → 40 raise (comment at the job definition). PR #2186 hit this: all tests passing, job cancelled at 40m20s.

One-line change: `timeout-minutes: 40 -> 55` with the job comment updated. Tests pass; this is runtime growth, not a hang.

Extracted from the now-closed #2186 branch so main gets the headroom before the other open PRs' integration suites land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)