### PR TITLE
fix(api): duplicate-key 409s no longer clobbered into 500s; distributor import enrichment runs outside the held transaction

### DIFF
--- a/apps/api/src/__tests__/integration/catalogService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/catalogService.integration.test.ts
@@ -587,6 +587,102 @@ describe('catalogService (breeze_app, real DB)', () => {
     expect(econ.marginPct).toBe(25);
   });
 
+  // ---------------------------------------------------------------------------
+  // (h) REGRESSION — duplicate SKU must 409 WITHOUT poisoning the RLS transaction
+  //
+  // The request path runs inside withDbAccessContext's postgres.js transaction.
+  // postgres.js begin() records ANY query error as uncaughtError and re-throws
+  // it when the callback resolves — even if the app caught it and mapped it to a
+  // 409. So a raised unique violation used to surface as a raw PostgresError 500
+  // (TD SYNNEX "Import & add" on an already-imported SKU). createCatalogItem now
+  // uses ON CONFLICT DO NOTHING (no error raised); updateCatalogItem pre-checks.
+  // These tests run the duplicate attempt INSIDE one context and then keep using
+  // the same transaction — both fail if the conflict is allowed to raise.
+  // ---------------------------------------------------------------------------
+  const dupInput = (name: string, sku: string) => ({
+    itemType: 'hardware' as const,
+    name,
+    sku,
+    billingType: 'one_time' as const,
+    unitPrice: 100,
+    unitOfMeasure: 'each',
+    taxable: true,
+    isBundle: false,
+    attributes: {},
+  });
+
+  runDb('createCatalogItem: duplicate partner+sku throws 409 DUPLICATE_SKU and the transaction stays usable', async () => {
+    const fx = await seedFixture();
+
+    const outcome = await withDbAccessContext(fx.ctxA, async () => {
+      await createCatalogItem(dupInput('First import', 'DUP-SKU-1'), fx.actorA);
+
+      let caught: unknown;
+      try {
+        await createCatalogItem(dupInput('Second import', 'DUP-SKU-1'), fx.actorA);
+      } catch (err) {
+        caught = err;
+      }
+
+      // The conflict must not abort the surrounding transaction: this follow-up
+      // query would fail with 25P02 (and the context itself would reject at
+      // commit) if the unique violation had been raised and merely caught.
+      const rows = await db.select({ id: catalogItems.id }).from(catalogItems)
+        .where(and(eq(catalogItems.partnerId, fx.partnerA.id), eq(catalogItems.sku, 'DUP-SKU-1')));
+      return { caught, rowCount: rows.length };
+    });
+
+    expect(outcome.caught).toBeInstanceOf(CatalogServiceError);
+    expect(outcome.caught).toMatchObject({ status: 409, code: 'DUPLICATE_SKU' });
+    expect(outcome.rowCount).toBe(1); // only the first import persisted
+  });
+
+  runDb('createCatalogItem: same sku under a DIFFERENT partner is not a conflict', async () => {
+    const fx = await seedFixture();
+    await withDbAccessContext(fx.ctxA, () =>
+      createCatalogItem(dupInput('Partner A item', 'SHARED-SKU'), fx.actorA));
+
+    const actorB: CatalogActor = { userId: null as unknown as string, partnerId: fx.partnerB.id, accessibleOrgIds: null };
+    const ctxB: DbAccessContext = { scope: 'partner', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: [fx.partnerB.id], userId: null };
+    const itemB = await withDbAccessContext(ctxB, () =>
+      createCatalogItem(dupInput('Partner B item', 'SHARED-SKU'), actorB));
+    expect(itemB.sku).toBe('SHARED-SKU');
+  });
+
+  runDb('updateCatalogItem: changing sku to another item\'s sku throws 409 without poisoning the transaction', async () => {
+    const fx = await seedFixture();
+    const [, itemB] = await withDbAccessContext(fx.ctxA, () => Promise.all([
+      createCatalogItem(dupInput('Item A', 'SKU-A'), fx.actorA),
+      createCatalogItem(dupInput('Item B', 'SKU-B'), fx.actorA),
+    ]));
+
+    const outcome = await withDbAccessContext(fx.ctxA, async () => {
+      let caught: unknown;
+      try {
+        await updateCatalogItem(itemB!.id, { sku: 'SKU-A' }, fx.actorA);
+      } catch (err) {
+        caught = err;
+      }
+      const rows = await db.select({ sku: catalogItems.sku }).from(catalogItems)
+        .where(eq(catalogItems.id, itemB!.id)).limit(1);
+      return { caught, skuAfter: rows[0]?.sku };
+    });
+
+    expect(outcome.caught).toMatchObject({ status: 409, code: 'DUPLICATE_SKU' });
+    expect(outcome.skuAfter).toBe('SKU-B'); // pre-check ran before the write
+  });
+
+  runDb('updateCatalogItem: re-submitting an item\'s own sku is not a conflict', async () => {
+    const fx = await seedFixture();
+    const item = await withDbAccessContext(fx.ctxA, () =>
+      createCatalogItem(dupInput('Keep my sku', 'SKU-KEEP'), fx.actorA));
+
+    const updated = await withDbAccessContext(fx.ctxA, () =>
+      updateCatalogItem(item.id, { sku: 'SKU-KEEP', name: 'Renamed' }, fx.actorA));
+    expect(updated.sku).toBe('SKU-KEEP');
+    expect(updated.name).toBe('Renamed');
+  });
+
   runDb('updateCatalogItem: flipping a bundle to a plain item clears its components (no orphans)', async () => {
     const fx = await seedFixture();
     const { bundle, comp1 } = await seedBundleAndComponents(fx);

--- a/apps/api/src/__tests__/integration/dbSavepointErrorIsolation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbSavepointErrorIsolation.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Savepoint error-isolation regression test (issue #2189, spike).
+ *
+ * QUESTION: inside the withDbAccessContext request transaction (postgres.js
+ * `sql.begin`), does wrapping a statement that is EXPECTED to fail in a nested
+ * Drizzle transaction (`db.transaction` → postgres.js `sql.savepoint`) isolate
+ * the error so that (a) the outer transaction stays healthy (no 25P02 on
+ * follow-up queries) and (b) the outer begin() does NOT re-throw the handled
+ * error when the callback resolves?
+ *
+ * SOURCE ANALYSIS (postgres@3.4.9, src/index.js):
+ *   - begin() → scope(connection, fn) [~line 251]. EACH scope() call creates
+ *     its own `Sql(handler)` instance with a CLOSURE-SCOPED `uncaughtError`,
+ *     and its handler records errors only for queries issued through that
+ *     scope's sql instance: `q.catch(e => uncaughtError || (uncaughtError = e))`
+ *     [~292].
+ *   - `sql.savepoint(fn)` → scope(c, fn, 's<N>') [~283-288]: emits
+ *     `savepoint sN`, and on error runs `rollback to sN` [~266-271] — restoring
+ *     the OUTER transaction to health — then rethrows to the caller. The outer
+ *     scope's `uncaughtError` stays unset, so the outer commit path
+ *     (`if (uncaughtError) throw uncaughtError`) stays clean.
+ *   - drizzle-orm@0.45.2 postgres-js/session.js [~130-131]: a nested
+ *     `transaction()` on a PostgresJsTransaction calls
+ *     `this.session.client.savepoint(...)` — exactly the API above.
+ *
+ * CRITICAL USAGE CAVEAT: the failing statement MUST be issued on the nested
+ * callback's `tx` object. The ambient `db` proxy still resolves (via
+ * AsyncLocalStorage) to the OUTER transaction's sql instance, whose handler
+ * would record the error in the OUTER scope — reintroducing the clobber.
+ *
+ * The CONTROL test documents the bug mechanism itself: without the savepoint,
+ * a caught-and-handled unique violation aborts the transaction (follow-up
+ * queries fail with 25P02) and the raw error is re-thrown at commit even
+ * though the callback resolved.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { catalogItems } from '../../db/schema';
+import { createPartner } from './db-utils';
+import { isPgUniqueViolation, pgErrorCode } from '../../utils/pgErrors';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function partnerCtx(partnerId: string): DbAccessContext {
+  return { scope: 'partner', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: [partnerId], userId: null };
+}
+
+// Minimal catalog row; catalog_items_partner_sku_uq (partner_id, sku) is the
+// unique index we deliberately violate.
+const item = (partnerId: string, name: string, sku: string) => ({
+  partnerId,
+  itemType: 'service' as const,
+  name,
+  sku,
+  unitPrice: '1.00',
+});
+
+describe('postgres.js savepoint error isolation (real DB, breeze_app)', () => {
+  runDb('a unique violation inside a nested db.transaction (SAVEPOINT) does not poison the outer request transaction', async () => {
+    const partner = await withSystemDbAccessContext(() => createPartner());
+    const SKU = 'SAVEPOINT-SPIKE-1';
+
+    const outcome = await withDbAccessContext(partnerCtx(partner.id), async () => {
+      await db.insert(catalogItems).values(item(partner.id, 'first', SKU));
+
+      let caught: unknown;
+      try {
+        // Nested Drizzle transaction → postgres.js sql.savepoint → its OWN
+        // scope with its own uncaughtError. The duplicate insert MUST go
+        // through `tx` (see file header caveat).
+        await db.transaction(async (tx) => {
+          await tx.insert(catalogItems).values(item(partner.id, 'dup', SKU));
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      // (a) The savepoint rollback restored the outer transaction: this
+      // follow-up query would fail with 25P02 if the abort had escaped.
+      const rows = await db
+        .select({ id: catalogItems.id })
+        .from(catalogItems)
+        .where(and(eq(catalogItems.partnerId, partner.id), eq(catalogItems.sku, SKU)));
+      return { caught, rowCount: rows.length };
+    });
+
+    // (b) Reaching here at all proves the outer begin() resolved instead of
+    // re-throwing the inner error at commit (each scope tracks its own
+    // uncaughtError).
+    expect(isPgUniqueViolation(outcome.caught)).toBe(true);
+    expect(outcome.rowCount).toBe(1);
+
+    // And the outer transaction genuinely COMMITTED (not rolled back): the
+    // first insert is visible from a fresh context.
+    const persisted = await withSystemDbAccessContext(() =>
+      db.select({ id: catalogItems.id }).from(catalogItems)
+        .where(and(eq(catalogItems.partnerId, partner.id), eq(catalogItems.sku, SKU)))
+    );
+    expect(persisted).toHaveLength(1);
+  });
+
+  runDb('CONTROL (bug mechanism, #2189): without a savepoint the handled violation aborts the transaction and is re-thrown at commit', async () => {
+    const partner = await withSystemDbAccessContext(() => createPartner());
+    const SKU = 'SAVEPOINT-SPIKE-CONTROL';
+
+    let followUpError: unknown;
+    await expect(
+      withDbAccessContext(partnerCtx(partner.id), async () => {
+        await db.insert(catalogItems).values(item(partner.id, 'first', SKU));
+
+        // "Handle" the violation the way the pre-#2189 call sites did…
+        try {
+          await db.insert(catalogItems).values(item(partner.id, 'dup', SKU));
+        } catch {
+          // mapped to a friendly 4xx and swallowed — callback will RESOLVE
+        }
+
+        // …but the transaction is already aborted: any follow-up statement
+        // fails with 25P02.
+        try {
+          await db.select({ id: catalogItems.id }).from(catalogItems)
+            .where(eq(catalogItems.partnerId, partner.id));
+        } catch (err) {
+          followUpError = err;
+        }
+        return 'resolved';
+      })
+      // …and postgres.js re-throws the ORIGINAL raw error at commit even
+      // though the callback resolved — this is what clobbered mapped 409s
+      // into raw 500s.
+    ).rejects.toSatisfy((err: unknown) => isPgUniqueViolation(err));
+
+    expect(pgErrorCode(followUpError)).toBe('25P02');
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerStripe.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerStripe.integration.test.ts
@@ -27,6 +27,7 @@ import {
   getPartnerStripe,
   getPartnerStripeStatus,
   disconnectPartnerStripe,
+  PartnerStripeError,
 } from '../../services/partnerStripe';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -125,6 +126,69 @@ describe('partner Stripe API-key credentials (breeze_app, real DB)', () => {
       .rejects.toMatchObject({ code: 'INVALID_STRIPE_KEY' });
     const rows = await withSystemDbAccessContext(() => db.select().from(stripeConnectAccounts).where(eq(stripeConnectAccounts.partnerId, b.id)));
     expect(rows).toHaveLength(0); // acct_uq violation rolled back — nothing persisted for B
+  });
+
+  // REGRESSION #2189 — the cross-partner claim must surface as a typed error
+  // WITHOUT poisoning the partner-scoped request transaction. The old code let
+  // acct_uq raise a 23505 inside withDbAccessContext; postgres.js records the
+  // raw error and re-throws it at commit even after the service mapped it, so
+  // the route's friendly 400 was deterministically clobbered into a raw 500.
+  // The fix pre-checks the claim under a SYSTEM context on its own connection
+  // (partner-axis RLS hides the other partner's row from the request context,
+  // so an in-context pre-check would be silently vacuous). This test runs the
+  // duplicate attempt INSIDE one partner-scoped context — the route's exact
+  // shape — then keeps using the same transaction; both assertions fail
+  // against the old code (25P02 on the follow-up, raw re-throw at commit).
+  runDb('duplicate account claim inside a partner-scoped request context: typed error caught inline, transaction stays usable', async () => {
+    const [a, b] = await withSystemDbAccessContext(async () => [await createPartner(), await createPartner()]);
+    accountsRetrieveMock.mockResolvedValue({ id: 'acct_claimed2189', charges_enabled: true });
+    await withSystemDbAccessContext(() =>
+      savePartnerStripeKey({ partnerId: a.id, apiKey: ['sk', 'test', '51CLAIMEDaaaa1111'].join('_'), userId: null }));
+
+    const outcome = await withDbAccessContext(partnerCtx(b!.id), async () => {
+      let caught: unknown;
+      try {
+        await savePartnerStripeKey({ partnerId: b!.id, apiKey: ['sk', 'test', '51CLAIMEDbbbb2222'].join('_'), userId: null });
+      } catch (err) {
+        caught = err;
+      }
+      // Follow-up query in the SAME transaction — dies with 25P02 under the
+      // old code because the acct_uq violation aborted the transaction.
+      const rows = await db
+        .select({ id: stripeConnectAccounts.id })
+        .from(stripeConnectAccounts)
+        .where(eq(stripeConnectAccounts.partnerId, b!.id));
+      return { caught, rowCount: rows.length };
+    });
+
+    // Reaching here proves the context resolved (no raw re-throw at commit).
+    expect(outcome.caught).toBeInstanceOf(PartnerStripeError);
+    expect(outcome.caught).toMatchObject({
+      code: 'INVALID_STRIPE_KEY',
+      status: 400,
+      message: 'That Stripe account is already connected to another partner. Use a key for a different Stripe account.',
+    });
+    expect(outcome.rowCount).toBe(0); // nothing persisted for B
+  });
+
+  // The pre-check must not false-positive on the partner's OWN claim: rotating
+  // a key for the same Stripe account, inside the partner's own request
+  // context, still upserts in place.
+  runDb('re-saving the SAME account under the partner\'s own request context passes the pre-check (rotation)', async () => {
+    const partner = await withSystemDbAccessContext(() => createPartner());
+    accountsRetrieveMock.mockResolvedValue({ id: 'acct_rotate2189', charges_enabled: true });
+    const keyA = ['sk', 'test', '51ROTATEaaaa1111'].join('_');
+    const keyB = ['sk', 'test', '51ROTATEbbbb2222'].join('_');
+    await withDbAccessContext(partnerCtx(partner.id), () =>
+      savePartnerStripeKey({ partnerId: partner.id, apiKey: keyA, userId: null }));
+    const res = await withDbAccessContext(partnerCtx(partner.id), () =>
+      savePartnerStripeKey({ partnerId: partner.id, apiKey: keyB, userId: null }));
+    expect(res.last4).toBe('2222');
+
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(stripeConnectAccounts).where(eq(stripeConnectAccounts.partnerId, partner.id)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.keyLast4).toBe('2222');
   });
 
   // A live key (rk_live/sk_live) flips livemode — drives the test/live badge in the UI.

--- a/apps/api/src/__tests__/integration/time-entries-rls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/time-entries-rls.integration.test.ts
@@ -307,15 +307,14 @@ describe('timer semantics (D3) — real driver', () => {
 
     // Each startTimer runs in its own withDbAccessContext (its own transaction)
     // to simulate two concurrent HTTP requests racing — exactly how it happens
-    // in production. withDbAccessContext wraps everything in a single postgres.js
-    // transaction, so if a unique-constraint violation occurs inside a context,
-    // that transaction is aborted and the retry (which happens inside the same
-    // aborted transaction) will also fail. This is expected: in production, one
-    // concurrent request wins and the other surfaces a transient error to the
-    // client, who can retry. What the DB-level unique index GUARANTEES is that
-    // you can NEVER end up with two running entries simultaneously — at most one
-    // survives. Promise.allSettled lets us accept that one call may throw while
-    // proving the invariant: exactly one running entry in the DB.
+    // in production. Since #2189, startTimer suppresses the one-running-timer
+    // conflict with ON CONFLICT DO NOTHING (a raised 23505 used to abort the
+    // request transaction, kill the in-transaction retry with 25P02, and get
+    // re-thrown raw at commit by postgres.js). The loser's insert now blocks on
+    // the winner's uncommitted row, returns zero rows once it commits, and the
+    // retry auto-stops the winner's entry and starts its own — so BOTH requests
+    // succeed, and the DB-level partial unique index still guarantees at most
+    // one running entry survives.
     const results = await Promise.allSettled([
       withDbAccessContext(partnerAContext, () =>
         startTimer({ description: 'race-1' }, techAActor)
@@ -325,9 +324,10 @@ describe('timer semantics (D3) — real driver', () => {
       ),
     ]);
 
-    // At least one call must have succeeded.
+    // Both calls succeed (the loser retries after the conflict instead of
+    // dying inside an aborted transaction).
     const succeeded = results.filter((r) => r.status === 'fulfilled');
-    expect(succeeded.length).toBeGreaterThanOrEqual(1);
+    expect(succeeded).toHaveLength(2);
 
     // The DB-level partial unique index enforces the invariant: exactly one
     // running entry per user — regardless of which request(s) succeeded.
@@ -341,6 +341,59 @@ describe('timer semantics (D3) — real driver', () => {
           isNull(timeEntries.endedAt)
         )
       );
+    expect(running).toHaveLength(1);
+  });
+
+  // REGRESSION #2189 — a running-timer conflict that startTimer can NEVER
+  // resolve (the conflicting row is hidden from the request context by
+  // partner-axis RLS, so the D3 auto-stop can't see or stop it, while the
+  // GLOBAL partial unique index still fires) must surface as the typed 409
+  // WITHOUT poisoning the request transaction. Under the old catch-and-retry
+  // code this was the doubly-broken path: the 23505 aborted the transaction,
+  // the retry died with 25P02 (not a unique violation), the intended 409 was
+  // unreachable, and postgres.js re-threw the raw error at commit.
+  it('an unresolvable running-timer conflict maps to a typed 409 inside one context and the transaction stays usable', async () => {
+    const { partnerB, techA, partnerAContext, techAActor } = await seedFixture();
+    const adminDb = getTestDb() as any;
+
+    // A RUNNING entry for techA under partner B, seeded via the privileged
+    // pool. Partner A's context cannot see it (partner-axis RLS), so
+    // stopRunningEntry never stops it — but time_entries_one_running_per_user_uq
+    // is a global index on user_id and still rejects a second running row.
+    await adminDb.insert(timeEntries).values({
+      partnerId: partnerB.id,
+      userId: techA.id,
+      startedAt: new Date(Date.now() - 60_000),
+      endedAt: null,
+      durationMinutes: null,
+    });
+
+    const outcome = await withDbAccessContext(partnerAContext, async () => {
+      let caught: unknown;
+      try {
+        await startTimer({ description: 'blocked by hidden running entry' }, techAActor);
+      } catch (err) {
+        caught = err;
+      }
+      // Follow-up query in the SAME transaction — fails with 25P02 under the
+      // old code because the raised 23505 aborted the transaction.
+      const rows = await db
+        .select({ id: timeEntries.id })
+        .from(timeEntries)
+        .where(eq(timeEntries.userId, techAActor.userId));
+      return { caught, followUpOk: Array.isArray(rows) };
+    });
+
+    // Reaching here proves the context resolved (no raw re-throw at commit).
+    expect(outcome.caught).toBeInstanceOf(TimeEntryServiceError);
+    expect(outcome.caught).toMatchObject({ status: 409, code: 'ENTRY_RUNNING' });
+    expect(outcome.followUpOk).toBe(true);
+
+    // No second running entry was created for the user.
+    const running = await adminDb
+      .select({ id: timeEntries.id })
+      .from(timeEntries)
+      .where(and(eq(timeEntries.userId, techA.id), isNull(timeEntries.endedAt)));
     expect(running).toHaveLength(1);
   });
 

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -18,6 +18,15 @@ describe('isSelfManagedDbContextRoute', () => {
     ['GET', '/api/v1/accounting/quickbooks/customers/'],
     ['POST', '/api/v1/accounting/quickbooks/customers/import'],
     ['POST', '/api/v1/accounting/quickbooks/customers/import/'],
+    // #2190 — distributor catalog imports run a best-effort AI enrichment call
+    // inside the handler.
+    ['POST', '/api/v1/catalog/distributors/td-synnex/import'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex/import/'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex-ec/import'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex-ec/import/'],
+    ['POST', '/api/v1/catalog/distributors/pax8/import'],
+    ['POST', '/api/v1/catalog/distributors/pax8/import/'],
+    ['post', '/api/v1/catalog/distributors/pax8/import'], // method is case-insensitive
   ];
 
   const NO_MATCH: ReadonlyArray<[string, string, string]> = [
@@ -34,6 +43,21 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/accounting/quickbooks/customers', 'POST to the list route (only GET + /customers/import opt out)'],
     ['GET', '/api/v1/accounting/quickbooks/customers/import', 'import is POST-only'],
     ['POST', '/api/v1/accounting/quickbooks/customers/import/extra', 'extra segment must not match'],
+    // #2190 — the other distributor routes (status/config/test/search/lookup/pricing)
+    // do only DB work — keep the ambient tx.
+    ['GET', '/api/v1/catalog/distributors/td-synnex/status', 'status route is DB-only'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex/test', 'connection test is DB-only'],
+    ['GET', '/api/v1/catalog/distributors/td-synnex/search', 'search is DB-only'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex/import/extra', 'extra segment must not match'],
+    ['GET', '/api/v1/catalog/distributors/td-synnex/import', 'import is POST-only'],
+    ['GET', '/api/v1/catalog/distributors/td-synnex-ec/status', 'status route is DB-only'],
+    ['GET', '/api/v1/catalog/distributors/td-synnex-ec/lookup', 'lookup is DB-only'],
+    ['POST', '/api/v1/catalog/distributors/td-synnex-ec/import/extra', 'extra segment must not match'],
+    ['GET', '/api/v1/catalog/distributors/pax8/status', 'status route is DB-only'],
+    ['GET', '/api/v1/catalog/distributors/pax8/search', 'search is DB-only'],
+    ['GET', '/api/v1/catalog/distributors/pax8/pricing', 'pricing is DB-only'],
+    ['POST', '/api/v1/catalog/distributors/pax8/import/extra', 'extra segment must not match'],
+    ['GET', '/api/v1/catalog/distributors/pax8/import', 'import is POST-only'],
   ];
 
   it.each(MATCH)('opts out: %s %s', (method, path) => {

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -38,6 +38,15 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   // around each DB op, so we must NOT pin a request transaction across the call.
   { method: 'GET', pattern: /^\/api\/v1\/accounting\/[^/]+\/customers\/?$/ },
   { method: 'POST', pattern: /^\/api\/v1\/accounting\/[^/]+\/customers\/import\/?$/ },
+  // #2190 — the three distributor catalog import routes run a best-effort AI
+  // enrichment (enrichDistributorListing, up to a 12s outbound Anthropic call)
+  // before persisting. The import services manage their own short
+  // withDbAccessContext blocks around each DB op (the request-scoped context
+  // built by the route from `auth`), so the enrichment call runs with NO
+  // ambient transaction held across it.
+  { method: 'POST', pattern: /^\/api\/v1\/catalog\/distributors\/td-synnex\/import\/?$/ },
+  { method: 'POST', pattern: /^\/api\/v1\/catalog\/distributors\/td-synnex-ec\/import\/?$/ },
+  { method: 'POST', pattern: /^\/api\/v1\/catalog\/distributors\/pax8\/import\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/catalog/catalog.test.ts
+++ b/apps/api/src/routes/catalog/catalog.test.ts
@@ -71,7 +71,15 @@ vi.mock('../../middleware/auth', () => ({
   },
   requireScope: () => async (_c: any, next: any) => next(),
   requirePermission: () => async (_c: any, next: any) => next(),
-  requireMfa: () => async (_c: any, next: any) => next()
+  requireMfa: () => async (_c: any, next: any) => next(),
+  // #2190 — the import routes rebuild the request DbAccessContext from `auth`
+  // and pass it into the (mocked) import services; the value only needs to exist.
+  dbAccessContextFromAuth: (auth: any) => ({
+    scope: auth?.scope ?? 'partner',
+    currentPartnerId: auth?.partnerId ?? null,
+    accessibleOrgIds: auth?.accessibleOrgIds ?? null,
+    userId: auth?.user?.id ?? null
+  })
 }));
 
 import { catalogRoutes } from './index';

--- a/apps/api/src/routes/catalog/distributors.test.ts
+++ b/apps/api/src/routes/catalog/distributors.test.ts
@@ -33,6 +33,17 @@ vi.mock('../../middleware/auth', () => ({
     if (mfaGate.block) return c.json({ error: 'MFA required' }, 403);
     return next();
   },
+  // #2190 — the import routes rebuild a DbAccessContext from `auth` since they
+  // opt out of the ambient request transaction; a trivial pass-through is
+  // enough here since the underlying import services are themselves mocked.
+  dbAccessContextFromAuth: (auth: any) => ({
+    scope: auth.scope,
+    orgId: auth.orgId,
+    accessibleOrgIds: auth.accessibleOrgIds,
+    accessiblePartnerIds: auth.scope === 'partner' && auth.partnerId ? [auth.partnerId] : null,
+    userId: auth.user?.id ?? null,
+    currentPartnerId: auth.partnerId ?? null,
+  }),
 }));
 
 vi.mock('../../services/permissions', () => ({
@@ -210,6 +221,11 @@ describe('POST /distributors/pax8/import', () => {
     const body = await res.json();
     expect(body.data.id).toBe('ci-1');
     expect(pax8Svc.importPax8CatalogItem).toHaveBeenCalledOnce();
+    // #2190 — a third arg (the rebuilt DbAccessContext) is passed alongside actor,
+    // since the route opts out of the ambient request transaction.
+    const call = pax8Svc.importPax8CatalogItem.mock.calls[0]!;
+    expect(call).toHaveLength(3);
+    expect(call[2]).toMatchObject({ scope: 'partner', currentPartnerId: 'p1' });
   });
 
   it('requires MFA — returns 403 without it', async () => {

--- a/apps/api/src/routes/catalog/distributors.ts
+++ b/apps/api/src/routes/catalog/distributors.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
+import { requireMfa, requirePermission, requireScope, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { checkSsrfSafe } from '../../services/ssrfGuard';
 import { CatalogServiceError } from '../../services/catalogService';
@@ -37,6 +37,17 @@ export const catalogDistributorRoutes = new Hono();
 const scopes = requireScope('partner', 'system');
 const readPerm = requirePermission(PERMISSIONS.CATALOG_READ.resource, PERMISSIONS.CATALOG_READ.action);
 const writePerm = requirePermission(PERMISSIONS.CATALOG_WRITE.resource, PERMISSIONS.CATALOG_WRITE.action);
+
+// #2190 — the three import routes below opt out of the auth middleware's
+// ambient request transaction (SELF_MANAGED_DB_CONTEXT_ROUTES) so the best-effort
+// AI enrichment call the import services make doesn't hold a pooled connection
+// idle-in-transaction across it. Rebuild the request's RLS DbAccessContext here
+// (mirroring `dbAccessContextFromAuth`'s single-source-of-truth mapping from
+// `auth`) and pass it into the import service, which wraps its own short DB ops
+// in it AFTER enrichment completes.
+function catalogDbContextFrom(c: { get: (k: string) => unknown }) {
+  return dbAccessContextFromAuth(c.get('auth') as AuthContext);
+}
 
 const baseUrlSchema = z.string().url().max(2000).superRefine((value, ctx) => {
   let parsed: URL;
@@ -205,6 +216,7 @@ catalogDistributorRoutes.post(
       const data = await importTdSynnexCatalogItem(
         { product: body.product, item: body.item, aiCleanup: body.aiCleanup },
         catalogActorFrom(c),
+        catalogDbContextFrom(c),
       );
       return c.json({ data });
     } catch (err) {
@@ -304,7 +316,7 @@ catalogDistributorRoutes.get('/distributors/td-synnex-ec/lookup', scopes, readPe
 catalogDistributorRoutes.post('/distributors/td-synnex-ec/import', scopes, writePerm, requireMfa(), zValidator('json', ecImportSchema), async (c) => {
   try {
     const body = c.req.valid('json');
-    const data = await importEcExpressCatalogItem({ product: body.product, item: body.item, aiCleanup: body.aiCleanup }, catalogActorFrom(c));
+    const data = await importEcExpressCatalogItem({ product: body.product, item: body.item, aiCleanup: body.aiCleanup }, catalogActorFrom(c), catalogDbContextFrom(c));
     return c.json({ data });
   } catch (err) { return handleEcError(c, err); }
 });
@@ -373,6 +385,7 @@ catalogDistributorRoutes.post('/distributors/pax8/import', scopes, writePerm, re
     const data = await importPax8CatalogItem(
       { product: body.product, item: body.item, aiCleanup: body.aiCleanup },
       catalogActorFrom(c),
+      catalogDbContextFrom(c),
     );
     return c.json({ data });
   } catch (err) { return handlePax8Error(c, err); }

--- a/apps/api/src/routes/configurationPolicies/assignments.test.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.test.ts
@@ -125,6 +125,29 @@ describe('configurationPolicies assignment routes', () => {
     );
   });
 
+  it('returns 409 (not 500) when the policy is already assigned to this target at this level', async () => {
+    // assignPolicy uses .onConflictDoNothing().returning() rather than raising
+    // a 23505: withDbAccessContext wraps the request in a postgres.js
+    // transaction that re-throws the original error at commit time even after
+    // it's caught, turning a mapped 409 back into a raw 500 (see
+    // createCatalogItem in catalogService.ts). A null return from the mocked
+    // service is how the route detects the duplicate assignment.
+    getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue(null);
+
+    const res = await app.request(`/${POLICY_ID}/assignments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level: 'device', targetId: DEVICE_ID }),
+    });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: 'This policy is already assigned to this target at this level',
+    });
+  });
+
   it('denies cross-org assignment targets before inserting the assignment', async () => {
     getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' });
     validateAssignmentTargetMock.mockResolvedValue({

--- a/apps/api/src/routes/configurationPolicies/assignments.ts
+++ b/apps/api/src/routes/configurationPolicies/assignments.ts
@@ -4,7 +4,6 @@ import type { AuthContext } from '../../middleware/auth';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
-import { isPgUniqueViolation } from '../../utils/pgErrors';
 import {
   getConfigPolicy,
   assignPolicy,
@@ -100,36 +99,37 @@ assignmentRoutes.post(
       return c.json({ error: targetValidation.error ?? 'Assignment target is not valid for this policy organization' }, 403);
     }
 
-    try {
-      const assignment = await assignPolicy(
-        id,
-        data.level,
-        targetId,
-        data.priority ?? 0,
-        auth.user.id,
-        data.roleFilter,
-        data.osFilter
-      );
+    // assignPolicy returns null (instead of throwing) on a duplicate — see the
+    // comment on its onConflictDoNothing insert in configurationPolicy.ts for
+    // why the raised-violation catch pattern doesn't work inside this route's
+    // withDbAccessContext transaction.
+    const assignment = await assignPolicy(
+      id,
+      data.level,
+      targetId,
+      data.priority ?? 0,
+      auth.user.id,
+      data.roleFilter,
+      data.osFilter
+    );
 
-      // Invalidate remote access policy cache — assignment may affect access decisions
-      invalidateRemoteAccessCache();
-
-      writeRouteAudit(c, {
-        orgId: policy.orgId,
-        action: 'config_policy.assign',
-        resourceType: 'configuration_policy',
-        resourceId: id,
-        resourceName: policy.name,
-        details: { level: data.level, targetId, priority: data.priority },
-      });
-
-      return c.json(assignment, 201);
-    } catch (err: unknown) {
-      if (isPgUniqueViolation(err)) {
-        return c.json({ error: 'This policy is already assigned to this target at this level' }, 409);
-      }
-      throw err;
+    if (!assignment) {
+      return c.json({ error: 'This policy is already assigned to this target at this level' }, 409);
     }
+
+    // Invalidate remote access policy cache — assignment may affect access decisions
+    invalidateRemoteAccessCache();
+
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'config_policy.assign',
+      resourceType: 'configuration_policy',
+      resourceId: id,
+      resourceName: policy.name,
+      details: { level: data.level, targetId, priority: data.priority },
+    });
+
+    return c.json(assignment, 201);
   }
 );
 

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -186,6 +186,29 @@ describe('featureLinks routes', () => {
       expect(addFeatureLinkMock).toHaveBeenCalled();
     });
 
+    it('returns 409 (not 500) when the feature type is already linked to this policy', async () => {
+      // addFeatureLink uses .onConflictDoNothing().returning() rather than
+      // raising a 23505: withDbAccessContext wraps the request in a postgres.js
+      // transaction that re-throws the original error at commit time even
+      // after it's caught, turning a mapped 409 back into a raw 500 (see
+      // createCatalogItem in catalogService.ts). A null return from the
+      // mocked service is how the route detects the duplicate feature link.
+      addFeatureLinkMock.mockResolvedValue(null);
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'pam',
+          inlineSettings: {},
+        }),
+      });
+
+      expect(res.status).toBe(409);
+      await expect(res.json()).resolves.toEqual({
+        error: 'Feature type "pam" already linked to this policy',
+      });
+    });
+
     it('rejects pam inlineSettings with unknown extra key (strict passthrough behavior)', async () => {
       const res = await app.request(`/${POLICY_ID}/features`, {
         method: 'POST',

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -6,7 +6,6 @@ import { backupInlineSettingsSchema, patchInlineSettingsSchema } from '@breeze/s
 import { ORG_SCOPED_ONLY_FEATURE_TYPES } from '@breeze/shared/constants';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
-import { isPgUniqueViolation } from '../../utils/pgErrors';
 import { findOfflineDurationViolation } from '../../services/alertConditions/offlineDuration';
 import {
   getConfigPolicy,
@@ -170,30 +169,31 @@ featureLinkRoutes.post(
       if (violation) return c.json({ error: violation }, 400);
     }
 
-    try {
-      const link = await addFeatureLink(
-        id,
-        data.featureType,
-        data.featurePolicyId,
-        data.inlineSettings
-      );
+    // addFeatureLink returns null (instead of throwing) on a duplicate — see the
+    // comment on its onConflictDoNothing insert in configurationPolicy.ts for
+    // why the raised-violation catch pattern doesn't work inside this route's
+    // withDbAccessContext transaction.
+    const link = await addFeatureLink(
+      id,
+      data.featureType,
+      data.featurePolicyId,
+      data.inlineSettings
+    );
 
-      writeRouteAudit(c, {
-        orgId: policy.orgId,
-        action: 'config_policy.feature_link.add',
-        resourceType: 'configuration_policy',
-        resourceId: id,
-        resourceName: policy.name,
-        details: { featureType: data.featureType, featurePolicyId: data.featurePolicyId },
-      });
-
-      return c.json(link, 201);
-    } catch (err: unknown) {
-      if (isPgUniqueViolation(err)) {
-        return c.json({ error: `Feature type "${data.featureType}" already linked to this policy` }, 409);
-      }
-      throw err;
+    if (!link) {
+      return c.json({ error: `Feature type "${data.featureType}" already linked to this policy` }, 409);
     }
+
+    writeRouteAudit(c, {
+      orgId: policy.orgId,
+      action: 'config_policy.feature_link.add',
+      resourceType: 'configuration_policy',
+      resourceId: id,
+      resourceName: policy.name,
+      details: { featureType: data.featureType, featurePolicyId: data.featurePolicyId },
+    });
+
+    return c.json(link, 201);
   }
 );
 

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -177,18 +177,20 @@ describe('incidentRoutes', () => {
   it('creates an incident from POST /incidents', async () => {
     vi.mocked(db.insert).mockReturnValueOnce({
       values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: '33333333-3333-4333-8333-333333333333',
-            orgId: '22222222-2222-4222-8222-222222222222',
-            title: 'Ransomware behavior detected',
-            classification: 'malware',
-            severity: 'p1',
-            status: 'detected',
-            relatedAlerts: [],
-            affectedDevices: [],
-          },
-        ]),
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: '33333333-3333-4333-8333-333333333333',
+              orgId: '22222222-2222-4222-8222-222222222222',
+              title: 'Ransomware behavior detected',
+              classification: 'malware',
+              severity: 'p1',
+              status: 'detected',
+              relatedAlerts: [],
+              affectedDevices: [],
+            },
+          ]),
+        }),
       }),
     } as any);
 
@@ -219,20 +221,22 @@ describe('incidentRoutes', () => {
 
   it('persists sourceType/sourceRef when promoting an EDR finding', async () => {
     const valuesMock = vi.fn().mockReturnValue({
-      returning: vi.fn().mockResolvedValue([
-        {
-          id: '33333333-3333-4333-8333-333333333333',
-          orgId: '22222222-2222-4222-8222-222222222222',
-          title: 'Huntress: Suspicious login',
-          classification: 'huntress-incident',
-          severity: 'p1',
-          status: 'detected',
-          relatedAlerts: [],
-          affectedDevices: [],
-          sourceType: 'huntress_incident',
-          sourceRef: 'hunt-abc-123',
-        },
-      ]),
+      onConflictDoNothing: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: '33333333-3333-4333-8333-333333333333',
+            orgId: '22222222-2222-4222-8222-222222222222',
+            title: 'Huntress: Suspicious login',
+            classification: 'huntress-incident',
+            severity: 'p1',
+            status: 'detected',
+            relatedAlerts: [],
+            affectedDevices: [],
+            sourceType: 'huntress_incident',
+            sourceRef: 'hunt-abc-123',
+          },
+        ]),
+      }),
     });
     vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
 
@@ -261,20 +265,17 @@ describe('incidentRoutes', () => {
   });
 
   it('returns 409 (not 500) when the same EDR finding is promoted twice', async () => {
-    // postgres.js raises a 23505 PostgresError carrying the constraint name;
-    // Drizzle wraps it in a query error whose real fields live on `.cause`.
-    // isPgUniqueViolation walks that chain, so reproduce both layers here. The
-    // promote handler matches `incidents_source_ref_unique` specifically.
-    const pgError = Object.assign(
-      new Error('duplicate key value violates unique constraint "incidents_source_ref_unique"'),
-      { code: '23505', constraint: 'incidents_source_ref_unique' },
-    );
-    const drizzleError = Object.assign(new Error('Failed query: insert into "incidents"'), {
-      cause: pgError,
-    });
+    // The route uses .onConflictDoNothing().returning() rather than catching a
+    // raised 23505: withDbAccessContext wraps the request in a postgres.js
+    // transaction that re-throws the original error at commit time even after
+    // it's caught, turning a mapped 409 back into a raw 500 (see
+    // createCatalogItem in catalogService.ts). Zero returned rows is how the
+    // route detects the duplicate `incidents_source_ref_unique` collision.
     vi.mocked(db.insert).mockReturnValueOnce({
       values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockRejectedValue(drizzleError),
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
       }),
     } as any);
 

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -32,7 +32,6 @@ import {
   getIncidentWithOrgCheck,
 } from './incidents.helpers';
 import { incidentActionRoutes } from './incidentActions';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 
 export const incidentRoutes = new Hono();
 const requireIncidentRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
@@ -100,39 +99,35 @@ incidentRoutes.post(
       },
     }];
 
-    let incident;
-    try {
-      [incident] = await db
-        .insert(incidents)
-        .values({
-          orgId: orgId!,
-          title: data.title,
-          classification: data.classification,
-          severity: data.severity,
-          status: data.status ?? 'detected',
-          summary: data.summary,
-          relatedAlerts: data.relatedAlerts ?? [],
-          affectedDevices: data.affectedDevices ?? [],
-          timeline: initialTimeline,
-          assignedTo: data.assignedTo,
-          detectedAt,
-          sourceType: data.sourceType,
-          sourceRef: data.sourceRef,
-        })
-        .returning();
-    } catch (err) {
-      // Promoting the same EDR finding twice collides on the partial unique
-      // index `incidents_source_ref_unique` (org_id, source_type, source_ref).
-      // Surface a clean 409 instead of leaking the raw Postgres 23505 as a 500.
-      // Match the specific constraint so an unrelated 23505 still throws.
-      if (isPgUniqueViolation(err, 'incidents_source_ref_unique')) {
-        return c.json({ error: 'This finding has already been promoted to an incident' }, 409);
-      }
-      throw err;
-    }
+    // ON CONFLICT DO NOTHING instead of catch-and-map: the request runs inside
+    // the withDbAccessContext transaction, and postgres.js re-throws a raised
+    // unique violation at commit time even after it's caught here, turning the
+    // mapped 409 back into a raw 500 (see createCatalogItem in catalogService.ts).
+    // Promoting the same EDR finding twice collides on the partial unique index
+    // `incidents_source_ref_unique` (org_id, source_type, source_ref); zero
+    // returned rows means it's already been promoted.
+    const [incident] = await db
+      .insert(incidents)
+      .values({
+        orgId: orgId!,
+        title: data.title,
+        classification: data.classification,
+        severity: data.severity,
+        status: data.status ?? 'detected',
+        summary: data.summary,
+        relatedAlerts: data.relatedAlerts ?? [],
+        affectedDevices: data.affectedDevices ?? [],
+        timeline: initialTimeline,
+        assignedTo: data.assignedTo,
+        detectedAt,
+        sourceType: data.sourceType,
+        sourceRef: data.sourceRef,
+      })
+      .onConflictDoNothing()
+      .returning();
 
     if (!incident) {
-      return c.json({ error: 'Failed to create incident' }, 500);
+      return c.json({ error: 'This finding has already been promoted to an incident' }, 409);
     }
 
     try {

--- a/apps/api/src/routes/networkBaselines.test.ts
+++ b/apps/api/src/routes/networkBaselines.test.ts
@@ -126,10 +126,11 @@ function rigSiteLookup(site: unknown) {
   vi.mocked(db.select).mockReturnValueOnce({ from } as never);
 }
 
-/** Rigs the insert chain: db.insert(...).values(...).returning(). */
+/** Rigs the insert chain: db.insert(...).values(...).onConflictDoNothing().returning(). */
 function rigInsert(row: unknown) {
   const returning = vi.fn().mockResolvedValue([row]);
-  const values = vi.fn().mockReturnValue({ returning });
+  const onConflictDoNothing = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn().mockReturnValue({ onConflictDoNothing });
   vi.mocked(db.insert).mockReturnValueOnce({ values } as never);
 }
 

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -11,7 +11,6 @@ import {
 } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { enqueueBaselineScan } from '../jobs/networkBaselineWorker';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 import {
   normalizeBaselineAlertSettings,
   normalizeBaselineScanSchedule
@@ -288,47 +287,46 @@ networkBaselineRoutes.post(
     const schedule = normalizeBaselineScanSchedule(body.scanSchedule);
     const alertSettings = normalizeBaselineAlertSettings(body.alertSettings);
 
-    try {
-      const [created] = await db
-        .insert(networkBaselines)
-        .values({
-          orgId,
-          siteId: body.siteId,
-          subnet: body.subnet,
-          knownDevices: [],
-          scanSchedule: schedule,
-          alertSettings,
-          lastScanAt: null,
-          lastScanJobId: null,
-          updatedAt: new Date()
-        })
-        .returning();
-
-      if (!created) {
-        return c.json({ error: 'Failed to create baseline' }, 500);
-      }
-
-      writeRouteAudit(c, {
+    // ON CONFLICT DO NOTHING instead of catch-and-map: the request runs inside
+    // the withDbAccessContext transaction, and postgres.js re-throws a raised
+    // unique violation at commit time even after it's caught here, turning the
+    // mapped 409 back into a raw 500 (see createCatalogItem in catalogService.ts).
+    // Zero returned rows means a baseline already exists for this org/site/subnet.
+    const [created] = await db
+      .insert(networkBaselines)
+      .values({
         orgId,
-        action: 'network.baseline.create',
-        resourceType: 'network_baseline',
-        resourceId: created.id,
-        resourceName: created.subnet,
-        details: {
-          siteId: created.siteId,
-          profileId: body.profileId ?? null,
-          scanSchedule: created.scanSchedule,
-          alertSettings: created.alertSettings
-        }
-      });
+        siteId: body.siteId,
+        subnet: body.subnet,
+        knownDevices: [],
+        scanSchedule: schedule,
+        alertSettings,
+        lastScanAt: null,
+        lastScanJobId: null,
+        updatedAt: new Date()
+      })
+      .onConflictDoNothing()
+      .returning();
 
-      return c.json(mapBaselineRow(created), 201);
-    } catch (error) {
-      if (isPgUniqueViolation(error)) {
-        return c.json({ error: 'Baseline already exists for this org/site/subnet' }, 409);
-      }
-      throw error;
+    if (!created) {
+      return c.json({ error: 'Baseline already exists for this org/site/subnet' }, 409);
     }
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'network.baseline.create',
+      resourceType: 'network_baseline',
+      resourceId: created.id,
+      resourceName: created.subnet,
+      details: {
+        siteId: created.siteId,
+        profileId: body.profileId ?? null,
+        scanSchedule: created.scanSchedule,
+        alertSettings: created.alertSettings
+      }
+    });
+
+    return c.json(mapBaselineRow(created), 201);
   }
 );
 

--- a/apps/api/src/routes/networkBaselines_list_create.test.ts
+++ b/apps/api/src/routes/networkBaselines_list_create.test.ts
@@ -288,7 +288,9 @@ describe('networkBaseline routes', () => {
       const created = makeBaseline();
       vi.mocked(db.insert).mockReturnValueOnce({
         values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([created]),
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([created]),
+          }),
         }),
       } as any);
 
@@ -364,11 +366,17 @@ describe('networkBaseline routes', () => {
         }),
       } as any);
 
+      // The route uses .onConflictDoNothing().returning() rather than catching
+      // a raised 23505: withDbAccessContext wraps the request in a postgres.js
+      // transaction that re-throws the original error at commit time even
+      // after it's caught, turning a mapped 409 back into a raw 500 (see
+      // createCatalogItem in catalogService.ts). Zero returned rows is how the
+      // route detects the duplicate org/site/subnet collision.
       vi.mocked(db.insert).mockReturnValueOnce({
         values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockRejectedValue(
-            Object.assign(new Error('unique constraint'), { code: '23505' })
-          ),
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
         }),
       } as any);
 

--- a/apps/api/src/routes/networkKnownGuests.test.ts
+++ b/apps/api/src/routes/networkKnownGuests.test.ts
@@ -177,7 +177,8 @@ describe('networkKnownGuests routes', () => {
       };
 
       const mockReturning = vi.fn().mockResolvedValue([insertedGuest]);
-      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockOnConflictDoNothing = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
       vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
 
       const res = await app.request('/partner/known-guests', {
@@ -212,7 +213,8 @@ describe('networkKnownGuests routes', () => {
       };
 
       const mockReturning = vi.fn().mockResolvedValue([insertedGuest]);
-      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockOnConflictDoNothing = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
       vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
 
       const res = await app.request('/partner/known-guests', {
@@ -231,10 +233,15 @@ describe('networkKnownGuests routes', () => {
     });
 
     it('returns 409 on duplicate MAC for same partner', async () => {
-      const mockReturning = vi.fn().mockRejectedValue(
-        Object.assign(new Error('unique constraint'), { code: '23505' })
-      );
-      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      // The route uses .onConflictDoNothing().returning() rather than catching
+      // a raised 23505: withDbAccessContext wraps the request in a postgres.js
+      // transaction that re-throws the original error at commit time even
+      // after it's caught, turning a mapped 409 back into a raw 500 (see
+      // createCatalogItem in catalogService.ts). Zero returned rows is how the
+      // route detects the duplicate partner/MAC collision.
+      const mockReturning = vi.fn().mockResolvedValue([]);
+      const mockOnConflictDoNothing = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
       vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
 
       const res = await app.request('/partner/known-guests', {

--- a/apps/api/src/routes/networkKnownGuests.ts
+++ b/apps/api/src/routes/networkKnownGuests.ts
@@ -6,7 +6,6 @@ import { db } from '../db';
 import { networkKnownGuests } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 
 export const networkKnownGuestsRoutes = new Hono();
 const requireKnownGuestRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
@@ -51,25 +50,28 @@ networkKnownGuestsRoutes.post(
     const body = c.req.valid('json');
     const normalizedMac = body.macAddress.toLowerCase();
 
-    try {
-      const [guest] = await db
-        .insert(networkKnownGuests)
-        .values({
-          partnerId: auth.partnerId,
-          macAddress: normalizedMac,
-          label: body.label,
-          notes: body.notes ?? null,
-          addedBy: auth.user?.id ?? null
-        })
-        .returning();
+    // ON CONFLICT DO NOTHING instead of catch-and-map: the request runs inside
+    // the withDbAccessContext transaction, and postgres.js re-throws a raised
+    // unique violation at commit time even after it's caught here, turning the
+    // mapped 409 back into a raw 500 (see createCatalogItem in catalogService.ts).
+    // Zero returned rows means this partner/MAC pair already exists.
+    const [guest] = await db
+      .insert(networkKnownGuests)
+      .values({
+        partnerId: auth.partnerId,
+        macAddress: normalizedMac,
+        label: body.label,
+        notes: body.notes ?? null,
+        addedBy: auth.user?.id ?? null
+      })
+      .onConflictDoNothing()
+      .returning();
 
-      return c.json({ data: guest }, 201);
-    } catch (err: unknown) {
-      if (isPgUniqueViolation(err)) {
-        return c.json({ error: 'This MAC address is already in your known guests list' }, 409);
-      }
-      throw err;
+    if (!guest) {
+      return c.json({ error: 'This MAC address is already in your known guests list' }, 409);
     }
+
+    return c.json({ data: guest }, 201);
   }
 );
 

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { calculateCostCents, recordUsage, recordUsageFromSdkResult } from './aiCostTracker';
-import { db } from '../db';
+import { calculateCostCents, checkAiRateLimit, checkBudget, recordUsage, recordUsageFromSdkResult } from './aiCostTracker';
+import { db, withSystemDbAccessContext } from '../db';
+import { getEffectiveAiBudget } from './effectiveSettings';
+import { rateLimiter } from './rate-limit';
 
 // ============================================
 // Mocks
@@ -345,5 +347,82 @@ describe('recordUsage', () => {
     await expect(
       recordUsage(null, 'org-1', 'claude-sonnet-4-6', 100, 50, true),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ============================================
+// #2190 — self-contexted DB ops (no ambient request transaction)
+// ============================================
+//
+// The distributor catalog import routes opt out of the auth middleware's auto
+// request-transaction, so checkBudget / checkAiRateLimit / recordUsage now run
+// with NO ambient DB context on that path. Each DB op in this module must open
+// its own short withSystemDbAccessContext (which reuses an ambient context when
+// one is active, so all other callers are unchanged). These tests run with the
+// '../db' mock's pass-through withSystemDbAccessContext and assert the wrapper
+// actually guards the DB work — a regression back to bare `db` calls would drop
+// the wrapper calls and silently skip budget enforcement / usage recording
+// under RLS.
+
+describe('#2190 self-contexted DB ops', () => {
+  const effectiveBudget = (over: Record<string, unknown> = {}) => ({
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode: 'per_step',
+    ...over,
+  }) as Awaited<ReturnType<typeof getEffectiveAiBudget>>;
+
+  it('checkBudget wraps the effective-budget read and the usage read, and still enforces the budget', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({ dailyBudgetCents: 1000 }));
+    // Daily usage row at the budget → must be blocked.
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ totalCostCents: 1000 }]) })),
+      })),
+    }));
+
+    const res = await checkBudget('org-1');
+
+    expect(res).toContain('Daily AI budget exceeded');
+    // getEffectiveAiBudget + the daily usage read each ran inside the wrapper.
+    expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('checkBudget still allows when under budget (wrapper is a pass-through, not a filter)', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({ dailyBudgetCents: 1000, monthlyBudgetCents: 5000 }));
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ totalCostCents: 1 }]) })),
+      })),
+    }));
+
+    await expect(checkBudget('org-1')).resolves.toBeNull();
+    // budget read + daily read + monthly read all self-contexted.
+    expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('checkAiRateLimit wraps its getEffectiveAiBudget read (it is NOT Redis-only)', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget());
+    vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, resetAt: new Date() } as Awaited<ReturnType<typeof rateLimiter>>);
+
+    await expect(checkAiRateLimit('u1', 'org-1')).resolves.toBeNull();
+    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getEffectiveAiBudget)).toHaveBeenCalledWith('org-1');
+  });
+
+  it('recordUsage (sessionless) wraps each aggregate upsert and still writes both periods', async () => {
+    const captured = setupDbMocks(null);
+
+    await recordUsage(null, 'org-1', 'claude-sonnet-4-6', 100, 50, false);
+
+    // Both aggregates written, each inside its own short context (a third call
+    // may come from the fire-and-forget anomaly check — assert at least the two
+    // awaited upserts).
+    expect(captured.aggregateValues.length).toBe(2);
+    expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -5,7 +5,7 @@
  * and provides usage summaries.
  */
 
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { aiSessions, aiCostUsage, aiBudgets, organizations } from '../db/schema';
 import { eq, and, sql, desc, isNotNull } from 'drizzle-orm';
 import { getRedis } from './redis';
@@ -48,11 +48,21 @@ export async function checkBillingCredits(orgId: string): Promise<string | null>
   const billingKey = process.env.BILLING_SERVICE_API_KEY;
   if (!billingUrl || !billingKey) return null;
 
-  const [org] = await db
+  // #2190 — self-context this read (and every other DB op in this module's
+  // budget/usage path): the distributor import routes now run WITHOUT an ambient
+  // request transaction (SELF_MANAGED_DB_CONTEXT_ROUTES), and a contextless read
+  // under forced RLS silently returns 0 rows. withSystemDbAccessContext reuses an
+  // already-active ambient context (withDbAccessContext short-circuits), so every
+  // existing AI caller behaves identically; only the contextless path escalates.
+  // Spend/budget accounting is an internal-metering question keyed by the explicit
+  // orgId, not a tenant-visibility one — same rationale as the identity-read
+  // escalation in getUserPermissions (services/permissions.ts). The outbound
+  // billing fetch below stays OUTSIDE the context.
+  const [org] = await withSystemDbAccessContext(() => db
     .select({ partnerId: organizations.partnerId })
     .from(organizations)
     .where(eq(organizations.id, orgId))
-    .limit(1);
+    .limit(1));
 
   if (!org?.partnerId) return null;
 
@@ -163,7 +173,12 @@ export async function checkBudget(orgId: string): Promise<string | null> {
   const creditError = await checkBillingCredits(orgId);
   if (creditError) return creditError;
 
-  const budget = await getEffectiveAiBudget(orgId);
+  // #2190 — getEffectiveAiBudget reads organizations/partners/aiBudgets; run
+  // contextless (the exempted distributor import routes) the org read is
+  // RLS-filtered to 0 rows and throws a 404, silently disabling enrichment.
+  // Self-context it; the wrapper reuses any active ambient context (see the
+  // rationale on checkBillingCredits above).
+  const budget = await withSystemDbAccessContext(() => getEffectiveAiBudget(orgId));
   if (!budget.enabled) return 'AI features are disabled for this organization';
 
   const now = new Date();
@@ -172,7 +187,9 @@ export async function checkBudget(orgId: string): Promise<string | null> {
 
   // Check daily budget
   if (budget.dailyBudgetCents) {
-    const [dailyUsage] = await db
+    // #2190 — self-contexted: contextless this read returned 0 rows, silently
+    // skipping budget enforcement.
+    const [dailyUsage] = await withSystemDbAccessContext(() => db
       .select({ totalCostCents: aiCostUsage.totalCostCents })
       .from(aiCostUsage)
       .where(
@@ -182,7 +199,7 @@ export async function checkBudget(orgId: string): Promise<string | null> {
           eq(aiCostUsage.periodKey, dailyKey)
         )
       )
-      .limit(1);
+      .limit(1));
 
     if (dailyUsage && dailyUsage.totalCostCents >= budget.dailyBudgetCents) {
       return `Daily AI budget exceeded ($${(budget.dailyBudgetCents / 100).toFixed(2)})`;
@@ -191,7 +208,8 @@ export async function checkBudget(orgId: string): Promise<string | null> {
 
   // Check monthly budget
   if (budget.monthlyBudgetCents) {
-    const [monthlyUsage] = await db
+    // #2190 — self-contexted (same as the daily read above).
+    const [monthlyUsage] = await withSystemDbAccessContext(() => db
       .select({ totalCostCents: aiCostUsage.totalCostCents })
       .from(aiCostUsage)
       .where(
@@ -201,7 +219,7 @@ export async function checkBudget(orgId: string): Promise<string | null> {
           eq(aiCostUsage.periodKey, monthlyKey)
         )
       )
-      .limit(1);
+      .limit(1));
 
     if (monthlyUsage && monthlyUsage.totalCostCents >= budget.monthlyBudgetCents) {
       return `Monthly AI budget exceeded ($${(budget.monthlyBudgetCents / 100).toFixed(2)})`;
@@ -221,8 +239,12 @@ export async function checkAiRateLimit(
 ): Promise<string | null> {
   const redis = getRedis();
 
-  // Load effective rate limits (partner overrides org)
-  const budget = await getEffectiveAiBudget(orgId);
+  // Load effective rate limits (partner overrides org).
+  // #2190 — despite this function being otherwise Redis-only, this call reads
+  // organizations/partners/aiBudgets; contextless (exempted import routes) the
+  // org read is RLS-filtered to 0 rows and throws a 404. Self-context it; the
+  // wrapper reuses any active ambient context (see checkBillingCredits).
+  const budget = await withSystemDbAccessContext(() => getEffectiveAiBudget(orgId));
   const msgsPerMin = budget?.messagesPerMinutePerUser ?? 20;
   const msgsPerHour = budget?.messagesPerHourPerOrg ?? 200;
 
@@ -286,7 +308,13 @@ export async function recordUsage(
   // These are additive counters so partial failure is acceptable.
   if (sessionId !== null) {
     try {
-      await db
+      // #2190 — self-contexted: a contextless write under forced RLS silently
+      // matches 0 rows AND trips the contextless-write guard (#1375). The
+      // wrapper reuses any active ambient context (see checkBillingCredits), so
+      // existing in-request callers are unchanged; the fire-and-forget
+      // invocation from the sessionless enrichment path (which may run after
+      // its caller's context closed) now opens its own short system context.
+      await withSystemDbAccessContext(() => db
         .update(aiSessions)
         .set({
           totalInputTokens: sql`${aiSessions.totalInputTokens} + ${inputTokens}`,
@@ -296,7 +324,7 @@ export async function recordUsage(
           lastActivityAt: new Date(),
           updatedAt: new Date()
         })
-        .where(eq(aiSessions.id, sessionId));
+        .where(eq(aiSessions.id, sessionId)));
     } catch (err) {
       console.error(`[AI] Failed to update session totals for session=${sessionId}, cost=${costCents}:`, err);
       throw err;
@@ -306,7 +334,10 @@ export async function recordUsage(
   // Update daily/monthly aggregates
   for (const [period, periodKey] of [['daily', dailyKey], ['monthly', monthlyKey]] as const) {
     try {
-      await db
+      // #2190 — self-contexted per upsert (keeps the "partial failure is
+      // acceptable" independence of the two periods; see the session update
+      // above for the escalation rationale).
+      await withSystemDbAccessContext(() => db
         .insert(aiCostUsage)
         .values({
           orgId,
@@ -331,7 +362,7 @@ export async function recordUsage(
               : aiCostUsage.toolExecutionCount,
             updatedAt: new Date()
           }
-        });
+        }));
     } catch (err) {
       console.error(`[AI] Failed to update ${period} aggregate for org=${orgId}, key=${periodKey}, cost=${costCents}:`, err);
       // Continue to attempt the other period
@@ -596,51 +627,58 @@ async function checkCostAnomalies(
   costCents: number,
   dailyKey: string
 ): Promise<void> {
-  const [budget] = await db
-    .select()
-    .from(aiBudgets)
-    .where(eq(aiBudgets.orgId, orgId))
-    .limit(1);
+  // #2190 — self-contexted: reached fire-and-forget from recordUsage on the
+  // (contextless) enrichment path; without a context these reads RLS-filter to
+  // 0 rows and the anomaly warnings silently never fire. The whole body is
+  // DB reads + console.warn, so one short context covers it; the wrapper
+  // reuses any active ambient context (see checkBillingCredits).
+  return withSystemDbAccessContext(async () => {
+    const [budget] = await db
+      .select()
+      .from(aiBudgets)
+      .where(eq(aiBudgets.orgId, orgId))
+      .limit(1);
 
-  if (!budget || !budget.dailyBudgetCents) return;
+    if (!budget || !budget.dailyBudgetCents) return;
 
-  // Check if single session exceeds 10% of daily budget. Sessionless flows
-  // (sessionId === null, e.g. catalog enrichment) have no per-session row, so
-  // skip straight to the org-level daily check.
-  const [session] = sessionId === null
-    ? [undefined]
-    : await db
-        .select({ totalCostCents: aiSessions.totalCostCents })
-        .from(aiSessions)
-        .where(eq(aiSessions.id, sessionId))
-        .limit(1);
+    // Check if single session exceeds 10% of daily budget. Sessionless flows
+    // (sessionId === null, e.g. catalog enrichment) have no per-session row, so
+    // skip straight to the org-level daily check.
+    const [session] = sessionId === null
+      ? [undefined]
+      : await db
+          .select({ totalCostCents: aiSessions.totalCostCents })
+          .from(aiSessions)
+          .where(eq(aiSessions.id, sessionId))
+          .limit(1);
 
-  if (session && session.totalCostCents > budget.dailyBudgetCents * 0.1) {
-    console.warn(
-      `[AI] Cost anomaly: session ${sessionId} has used ${session.totalCostCents} cents ` +
-      `(>${Math.round(budget.dailyBudgetCents * 0.1)} cents = 10% of daily budget)`
-    );
-  }
+    if (session && session.totalCostCents > budget.dailyBudgetCents * 0.1) {
+      console.warn(
+        `[AI] Cost anomaly: session ${sessionId} has used ${session.totalCostCents} cents ` +
+        `(>${Math.round(budget.dailyBudgetCents * 0.1)} cents = 10% of daily budget)`
+      );
+    }
 
-  // Check if daily spend > 80% of budget
-  const [dailyUsage] = await db
-    .select({ totalCostCents: aiCostUsage.totalCostCents })
-    .from(aiCostUsage)
-    .where(
-      and(
-        eq(aiCostUsage.orgId, orgId),
-        eq(aiCostUsage.period, 'daily'),
-        eq(aiCostUsage.periodKey, dailyKey)
+    // Check if daily spend > 80% of budget
+    const [dailyUsage] = await db
+      .select({ totalCostCents: aiCostUsage.totalCostCents })
+      .from(aiCostUsage)
+      .where(
+        and(
+          eq(aiCostUsage.orgId, orgId),
+          eq(aiCostUsage.period, 'daily'),
+          eq(aiCostUsage.periodKey, dailyKey)
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
 
-  if (dailyUsage && dailyUsage.totalCostCents > budget.dailyBudgetCents * 0.8) {
-    console.warn(
-      `[AI] Cost warning: org ${orgId} daily spend at ${dailyUsage.totalCostCents} cents ` +
-      `(>${Math.round(budget.dailyBudgetCents * 0.8)} cents = 80% of daily budget)`
-    );
-  }
+    if (dailyUsage && dailyUsage.totalCostCents > budget.dailyBudgetCents * 0.8) {
+      console.warn(
+        `[AI] Cost warning: org ${orgId} daily spend at ${dailyUsage.totalCostCents} cents ` +
+        `(>${Math.round(budget.dailyBudgetCents * 0.8)} cents = 80% of daily budget)`
+      );
+    }
+  });
 }
 
 /**

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -111,6 +111,63 @@ describe('configuration policy AI tools', () => {
     expect(assignPolicyMock).not.toHaveBeenCalled();
   });
 
+  it('assigns a configuration policy when no conflicting assignment exists', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' }]),
+        }),
+      }),
+    } as any);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue({ id: 'assignment-1' });
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('apply_configuration_policy')!.handler({
+      configPolicyId: POLICY_ID,
+      level: 'device',
+      targetId: DEVICE_ID,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      success: true,
+      message: `Policy "Policy 1" assigned to device ${DEVICE_ID}`,
+      assignmentId: 'assignment-1',
+    });
+  });
+
+  // assignPolicy's insert (configurationPolicy.ts) uses onConflictDoNothing and
+  // returns null instead of throwing on a duplicate — see the comment there.
+  // Before the fix, this scenario surfaced as a raw PostgresError because the
+  // withDbAccessContext transaction re-throws a caught unique violation at
+  // commit time; the tool handler must instead branch on a null return.
+  it('returns a friendly error, not a throw, when apply_configuration_policy hits a duplicate assignment', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Policy 1' }]),
+        }),
+      }),
+    } as any);
+    validateAssignmentTargetMock.mockResolvedValue({ valid: true });
+    assignPolicyMock.mockResolvedValue(null);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('apply_configuration_policy')!.handler({
+      configPolicyId: POLICY_ID,
+      level: 'device',
+      targetId: DEVICE_ID,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      error: 'This policy is already assigned to this target at this level',
+    });
+  });
+
   // The HTTP route (featureLinks.ts) rejects org-scoped-only features on
   // partner-wide policies with a 400; the AI path must mirror that rule from
   // the same shared constant (ORG_SCOPED_ONLY_FEATURE_TYPES, #2101) since
@@ -167,5 +224,35 @@ describe('configuration policy AI tools', () => {
       null,
       { sources: ['os'] }
     );
+  });
+
+  // addFeatureLink's insert (configurationPolicy.ts) uses onConflictDoNothing
+  // and returns null instead of throwing on a duplicate — see the comment
+  // there. Before the fix, this scenario surfaced as a raw PostgresError
+  // because the withDbAccessContext transaction re-throws a caught unique
+  // violation at commit time; the tool handler must instead branch on a null
+  // return.
+  it('returns a friendly error, not a throw, when manage_policy_feature_link hits a duplicate feature link', async () => {
+    vi.mocked(getConfigPolicy).mockResolvedValue({
+      id: POLICY_ID,
+      orgId: ORG_ID,
+      partnerId: null,
+      name: 'Org policy',
+    } as any);
+    vi.mocked(addFeatureLink).mockResolvedValue(null as any);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('manage_policy_feature_link')!.handler({
+      action: 'add',
+      configPolicyId: POLICY_ID,
+      featureType: 'patch',
+      inlineSettings: { sources: ['os'] },
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      error: 'Feature type "patch" already exists on this policy. Use update action instead.',
+    });
   });
 });

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -1,5 +1,4 @@
 import { db } from '../db';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 import { ORG_SCOPED_ONLY_FEATURE_TYPES, type ConfigFeatureType } from '@breeze/shared/constants';
 import { configurationPolicies, configPolicyFeatureLinks, configPolicyAssignments, automationPolicyCompliance } from '../db/schema';
 import { eq, and, desc, isNull, isNotNull, inArray, SQL } from 'drizzle-orm';
@@ -221,28 +220,29 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: targetValidation.error ?? 'Assignment target is not valid for this policy organization' });
       }
 
-      try {
-        const assignment = await assignPolicy(
-          input.configPolicyId as string,
-          input.level as any,
-          input.targetId as string,
-          Number(input.priority) || 0,
-          auth.user.id,
-          (input.roleFilter as string[] | undefined),
-          (input.osFilter as string[] | undefined)
-        );
+      // assignPolicy returns null (instead of throwing) on a duplicate — see
+      // the comment on its onConflictDoNothing insert in configurationPolicy.ts
+      // for why the raised-violation catch pattern doesn't work inside this
+      // tool call's withDbAccessContext transaction.
+      const assignment = await assignPolicy(
+        input.configPolicyId as string,
+        input.level as any,
+        input.targetId as string,
+        Number(input.priority) || 0,
+        auth.user.id,
+        (input.roleFilter as string[] | undefined),
+        (input.osFilter as string[] | undefined)
+      );
 
-        return JSON.stringify({
-          success: true,
-          message: `Policy "${policy.name}" assigned to ${input.level} ${input.targetId}`,
-          assignmentId: assignment.id,
-        });
-      } catch (err: unknown) {
-        if (isPgUniqueViolation(err)) {
-          return JSON.stringify({ error: 'This policy is already assigned to this target at this level' });
-        }
-        throw err;
+      if (!assignment) {
+        return JSON.stringify({ error: 'This policy is already assigned to this target at this level' });
       }
+
+      return JSON.stringify({
+        success: true,
+        message: `Policy "${policy.name}" assigned to ${input.level} ${input.targetId}`,
+        assignmentId: assignment.id,
+      });
     }),
   });
 
@@ -617,20 +617,20 @@ For link-only types, set featurePolicyId instead of inlineSettings:
           });
         }
 
-        try {
-          const link = await addFeatureLink(
-            configPolicyId,
-            featureType as any,
-            (input.featurePolicyId as string) ?? null,
-            input.inlineSettings ?? null
-          );
-          return JSON.stringify({ success: true, featureLink: link });
-        } catch (err: unknown) {
-          if (isPgUniqueViolation(err)) {
-            return JSON.stringify({ error: `Feature type "${featureType}" already exists on this policy. Use update action instead.` });
-          }
-          throw err;
+        // addFeatureLink returns null (instead of throwing) on a duplicate —
+        // see the comment on its onConflictDoNothing insert in
+        // configurationPolicy.ts for why the raised-violation catch pattern
+        // doesn't work inside this tool call's withDbAccessContext transaction.
+        const link = await addFeatureLink(
+          configPolicyId,
+          featureType as any,
+          (input.featurePolicyId as string) ?? null,
+          input.inlineSettings ?? null
+        );
+        if (!link) {
+          return JSON.stringify({ error: `Feature type "${featureType}" already exists on this policy. Use update action instead.` });
         }
+        return JSON.stringify({ success: true, featureLink: link });
       }
 
       if (action === 'update') {

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -664,8 +664,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
             });
           }
 
-          // Add new patch feature link
+          // Add new patch feature link. addFeatureLink returns null (instead of
+          // throwing) on a duplicate; existingLinks was just checked above so
+          // this is effectively unreachable outside a race, but guard anyway.
           const link = await addFeatureLink(configPolicyId, 'patch', null, patchSettings);
+          if (!link) return JSON.stringify({ error: 'Patch feature link already exists on this policy' });
           return JSON.stringify({
             success: true,
             message: `Patch auto-approval configured on policy "${policy.name}"`,
@@ -686,7 +689,10 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
         if (!newPolicy) return JSON.stringify({ error: 'Failed to create configuration policy' });
 
+        // newPolicy.id is freshly generated above, so a duplicate feature-link
+        // conflict is not realistically reachable; guard for type-safety only.
         const link = await addFeatureLink(newPolicy.id, 'patch', null, patchSettings);
+        if (!link) return JSON.stringify({ error: 'Failed to configure patch auto-approval on the new policy' });
         return JSON.stringify({
           success: true,
           message: `Created new policy "${newPolicy.name}" with patch auto-approval`,

--- a/apps/api/src/services/aiToolsNetwork.test.ts
+++ b/apps/api/src/services/aiToolsNetwork.test.ts
@@ -1,0 +1,169 @@
+/**
+ * aiToolsNetwork — configure_network_baseline creation-path tests.
+ *
+ * Covers the duplicate-baseline case for `configure_network_baseline`. The
+ * insert used to catch the unique violation on (org_id, site_id, subnet) and
+ * map it to a friendly error, but this handler runs inside the AI tool's
+ * withDbAccessContext transaction, which re-throws a caught unique violation
+ * as a raw PostgresError at commit time (see createCatalogItem in
+ * catalogService.ts). The fix suppresses the conflict at the statement level
+ * via onConflictDoNothing(); these tests assert the friendly JSON result is
+ * returned instead of a throw.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  deviceIpHistory: {},
+  networkBaselines: {
+    id: 'nb.id',
+    orgId: 'nb.orgId',
+    siteId: 'nb.siteId',
+    subnet: 'nb.subnet',
+  },
+  networkChangeEvents: {
+    id: 'nce.id',
+    orgId: 'nce.orgId',
+    siteId: 'nce.siteId',
+    baselineId: 'nce.baselineId',
+    eventType: { enumValues: ['new_device', 'device_disappeared', 'device_changed', 'rogue_device'] },
+    acknowledged: 'nce.acknowledged',
+    detectedAt: 'nce.detectedAt',
+  },
+  sites: { id: 'sites.id', orgId: 'sites.orgId' },
+  discoveredAssetTypeEnum: {
+    enumValues: [
+      'workstation', 'server', 'printer', 'router', 'switch', 'firewall',
+      'access_point', 'phone', 'iot', 'camera', 'nas', 'unknown',
+    ],
+  },
+}));
+
+import { db } from '../db';
+import { registerNetworkTools } from './aiToolsNetwork';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SITE_ID = '22222222-2222-2222-2222-222222222222';
+const BASELINE_ID = '33333333-3333-3333-3333-333333333333';
+const SUBNET = '192.168.1.0/24';
+
+function createSelectChain(rows: any[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+function createInsertChain(rows: any[]) {
+  const chain: any = {};
+  chain.values = vi.fn(() => chain);
+  chain.onConflictDoNothing = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+function makeAuth() {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    scope: 'organization',
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    orgCondition: () => undefined,
+  } as any;
+}
+
+describe('configure_network_baseline (create path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function registerAndGetTool() {
+    const tools = new Map<string, any>();
+    registerNetworkTools(tools);
+    return tools.get('configure_network_baseline')!;
+  }
+
+  it('creates a baseline when no conflicting org/site/subnet exists', async () => {
+    // 1st select: site lookup. Insert: succeeds with a returned row.
+    vi.mocked(db.select).mockReturnValueOnce(createSelectChain([{ id: SITE_ID }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(createInsertChain([{ id: BASELINE_ID }]) as any);
+
+    const tool = registerAndGetTool();
+    const output = await tool.handler({
+      org_id: ORG_ID,
+      site_id: SITE_ID,
+      subnet: SUBNET,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      success: true,
+      baselineId: BASELINE_ID,
+      action: 'created',
+    });
+  });
+
+  it('returns a friendly error, not a throw, when a baseline already exists for this org/site/subnet', async () => {
+    // Site lookup succeeds; the onConflictDoNothing insert returns zero rows
+    // because a baseline for this (org_id, site_id, subnet) already exists.
+    vi.mocked(db.select).mockReturnValueOnce(createSelectChain([{ id: SITE_ID }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(createInsertChain([]) as any);
+
+    const tool = registerAndGetTool();
+    const output = await tool.handler({
+      org_id: ORG_ID,
+      site_id: SITE_ID,
+      subnet: SUBNET,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      error: 'Baseline already exists for this org/site/subnet',
+    });
+  });
+
+  it('denies access to an organization the caller cannot access', async () => {
+    const tool = registerAndGetTool();
+    const output = await tool.handler({
+      org_id: 'other-org',
+      site_id: SITE_ID,
+      subnet: SUBNET,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({ error: 'Access to this organization denied' });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('requires org_id, site_id, and subnet when creating a baseline', async () => {
+    const tool = registerAndGetTool();
+    const output = await tool.handler({ org_id: ORG_ID, site_id: SITE_ID }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({
+      error: 'org_id, site_id, and subnet are required when creating a baseline',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the site is not found for the organization', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(createSelectChain([]) as any);
+
+    const tool = registerAndGetTool();
+    const output = await tool.handler({
+      org_id: ORG_ID,
+      site_id: SITE_ID,
+      subnet: SUBNET,
+    }, makeAuth());
+
+    expect(JSON.parse(output)).toEqual({ error: 'Site not found for this organization' });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsNetwork.ts
+++ b/apps/api/src/services/aiToolsNetwork.ts
@@ -11,7 +11,6 @@
 
 import { isIP } from 'node:net';
 import { db } from '../db';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 import {
   devices,
   deviceIpHistory,
@@ -321,31 +320,31 @@ export function registerNetworkTools(aiTools: Map<string, AiTool>): void {
         ...(alertOverrides.rogueDevice !== undefined ? { rogueDevice: alertOverrides.rogueDevice } : {})
       });
 
-      try {
-        const [created] = await db
-          .insert(networkBaselines)
-          .values({
-            orgId,
-            siteId,
-            subnet,
-            knownDevices: [],
-            scanSchedule: nextSchedule,
-            alertSettings: nextAlertSettings,
-            updatedAt: new Date()
-          })
-          .returning({ id: networkBaselines.id });
+      // ON CONFLICT DO NOTHING instead of catch-and-map: this handler runs inside
+      // the AI tool's withDbAccessContext transaction, which re-throws a caught
+      // unique violation as a raw PostgresError at commit time (see
+      // createCatalogItem in catalogService.ts). Suppressing the conflict at the
+      // statement level keeps the transaction healthy; zero returned rows means
+      // a baseline already exists for this org/site/subnet.
+      const [created] = await db
+        .insert(networkBaselines)
+        .values({
+          orgId,
+          siteId,
+          subnet,
+          knownDevices: [],
+          scanSchedule: nextSchedule,
+          alertSettings: nextAlertSettings,
+          updatedAt: new Date()
+        })
+        .onConflictDoNothing()
+        .returning({ id: networkBaselines.id });
 
-        if (!created) {
-          return JSON.stringify({ error: 'Failed to create baseline' });
-        }
-
-        return JSON.stringify({ success: true, baselineId: created.id, action: 'created' });
-      } catch (error) {
-        if (isPgUniqueViolation(error)) {
-          return JSON.stringify({ error: 'Baseline already exists for this org/site/subnet' });
-        }
-        throw error;
+      if (!created) {
+        return JSON.stringify({ error: 'Baseline already exists for this org/site/subnet' });
       }
+
+      return JSON.stringify({ success: true, baselineId: created.id, action: 'created' });
     }
   });
 

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -3,6 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { resolveDefaultModel } from './aiAgent';
 import { checkBudget, checkAiRateLimit, checkUserAiRateLimit, recordUsage } from './aiCostTracker';
 import { captureException } from './sentry';
+import { assertOutsideHeldDbContext } from '../db';
 import {
   enrichDraftSchema,
   type CatalogItemType,
@@ -329,6 +330,13 @@ export async function enrichDistributorListing(
   actor: { userId: string | null; orgId: string | null },
   timeoutMs: number = DISTRIBUTOR_ENRICH_TIMEOUT_MS,
 ): Promise<DistributorEnrichment | null> {
+  // #2190 tripwire: this call can block up to `timeoutMs` (default 12s) on an
+  // outbound Anthropic request. Its only callers are the three distributor
+  // import services (tdSynnexEcExpress, tdSynnexDigitalBridge, pax8CatalogService),
+  // all three of which now opt out of the auth middleware's ambient request
+  // transaction (SELF_MANAGED_DB_CONTEXT_ROUTES) and call this with NO context
+  // held — so this should never fire. It's here to catch a future reintroduction.
+  assertOutsideHeldDbContext('enrichDistributorListing');
   const q = query.trim();
   if (!q) return null;
   try {

--- a/apps/api/src/services/catalogService.ts
+++ b/apps/api/src/services/catalogService.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, ilike, inArray } from 'drizzle-orm';
+import { and, asc, eq, gt, ilike, inArray, ne } from 'drizzle-orm';
 import { db } from '../db';
 import { catalogItems, catalogItemOrgPricing, catalogBundleComponents } from '../db/schema';
 import { emitCatalogEvent } from './catalogEvents';
@@ -92,35 +92,37 @@ export async function createCatalogItem(input: CreateCatalogItemInput, actor: Ca
     markupPercent: input.markupPercent != null ? input.markupPercent.toFixed(2) : null
   });
   assertPriceInRange(unitPrice);
-  try {
-    const rows = await db.insert(catalogItems).values({
-      partnerId,
-      itemType: input.itemType,
-      name: input.name,
-      sku: input.sku ?? null,
-      description: input.description ?? null,
-      billingType: input.billingType,
-      billingFrequency: input.billingFrequency ?? null,
-      commitmentTermMonths: input.commitmentTermMonths ?? null,
-      unitPrice,
-      costBasis: input.costBasis != null ? input.costBasis.toFixed(2) : null,
-      markupPercent: input.markupPercent != null ? input.markupPercent.toFixed(2) : null,
-      unitOfMeasure: input.unitOfMeasure,
-      taxable: input.taxable,
-      taxCategory: input.taxCategory ?? null,
-      isBundle: input.isBundle,
-      attributes: input.attributes,
-      createdBy: actor.userId
-    }).returning();
-    const item = rows[0]!;
-    await emitCatalogEvent({ type: 'catalog.item.created', catalogItemId: item.id, partnerId, actorUserId: actor.userId });
-    return item;
-  } catch (err) {
-    if (isPgUniqueViolation(err)) {
-      throw new CatalogServiceError('An item with this SKU already exists', 409, 'DUPLICATE_SKU');
-    }
-    throw err;
+  // ON CONFLICT DO NOTHING instead of catch-and-map: the request runs inside the
+  // withDbAccessContext transaction, and postgres.js re-throws any query error at
+  // commit time even after it was caught here (begin() records it as
+  // uncaughtError), so a raised unique violation turns the mapped 409 back into a
+  // raw 500. Suppressing the conflict at the statement level keeps the
+  // transaction healthy; zero returned rows means the SKU already exists.
+  const rows = await db.insert(catalogItems).values({
+    partnerId,
+    itemType: input.itemType,
+    name: input.name,
+    sku: input.sku ?? null,
+    description: input.description ?? null,
+    billingType: input.billingType,
+    billingFrequency: input.billingFrequency ?? null,
+    commitmentTermMonths: input.commitmentTermMonths ?? null,
+    unitPrice,
+    costBasis: input.costBasis != null ? input.costBasis.toFixed(2) : null,
+    markupPercent: input.markupPercent != null ? input.markupPercent.toFixed(2) : null,
+    unitOfMeasure: input.unitOfMeasure,
+    taxable: input.taxable,
+    taxCategory: input.taxCategory ?? null,
+    isBundle: input.isBundle,
+    attributes: input.attributes,
+    createdBy: actor.userId
+  }).onConflictDoNothing().returning();
+  const item = rows[0];
+  if (!item) {
+    throw new CatalogServiceError('An item with this SKU already exists', 409, 'DUPLICATE_SKU');
   }
+  await emitCatalogEvent({ type: 'catalog.item.created', catalogItemId: item.id, partnerId, actorUserId: actor.userId });
+  return item;
 }
 
 async function getOwnedItemOr404(id: string, partnerId: string) {
@@ -134,6 +136,20 @@ async function getOwnedItemOr404(id: string, partnerId: string) {
 export async function updateCatalogItem(id: string, input: UpdateCatalogItemInput, actor: CatalogActor) {
   const partnerId = requirePartner(actor);
   const existing = await getOwnedItemOr404(id, partnerId);
+
+  // Pre-check a SKU change instead of relying on the unique index raising: a
+  // raised violation aborts the surrounding withDbAccessContext transaction and
+  // postgres.js re-throws it at commit even when caught, clobbering the mapped
+  // 409 with a raw 500 (same reasoning as createCatalogItem's onConflictDoNothing).
+  // The isPgUniqueViolation catch below stays as a concurrent-writer backstop.
+  if (input.sku != null && input.sku !== existing.sku) {
+    const dup = await db.select({ one: catalogItems.id }).from(catalogItems)
+      .where(and(eq(catalogItems.partnerId, partnerId), eq(catalogItems.sku, input.sku), ne(catalogItems.id, id)))
+      .limit(1);
+    if (dup.length > 0) {
+      throw new CatalogServiceError('An item with this SKU already exists', 409, 'DUPLICATE_SKU');
+    }
+  }
 
   // Recompute derived price if markup/cost changed and no explicit price supplied.
   // unit_price is authoritative — a manually entered unit_price always wins, and a

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -15,6 +15,7 @@ vi.mock('../db', () => ({
 
 import {
   addFeatureLink,
+  assignPolicy,
   updateFeatureLink,
   listFeatureLinks,
   pamInlineSettingsSchema,
@@ -78,17 +79,19 @@ describe('patch feature link round-trip (apps + autoApproveDeferralDays)', () =>
             // feature link insert — captures what lands in the inline_settings JSONB
             storedJsonb = v.inlineSettings;
             return {
-              returning: vi.fn(() =>
-                Promise.resolve([
-                  {
-                    id: 'link-1',
-                    configPolicyId: 'policy-1',
-                    featureType: 'patch',
-                    featurePolicyId: null,
-                    inlineSettings: v.inlineSettings,
-                  },
-                ])
-              ),
+              onConflictDoNothing: vi.fn(() => ({
+                returning: vi.fn(() =>
+                  Promise.resolve([
+                    {
+                      id: 'link-1',
+                      configPolicyId: 'policy-1',
+                      featureType: 'patch',
+                      featurePolicyId: null,
+                      inlineSettings: v.inlineSettings,
+                    },
+                  ])
+                ),
+              })),
             };
           }
           // config_policy_patch_settings insert (decomposeInlineSettings)
@@ -404,11 +407,13 @@ describe('addFeatureLink — pam inlineSettings service-layer validation', () =>
     const tx = {
       insert: vi.fn(() => ({
         values: vi.fn(() => ({
-          returning: vi.fn(() =>
-            Promise.resolve([
-              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: { uacInterceptionEnabled: false } },
-            ])
-          ),
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() =>
+              Promise.resolve([
+                { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: { uacInterceptionEnabled: false } },
+              ])
+            ),
+          })),
         })),
       })),
     };
@@ -423,11 +428,13 @@ describe('addFeatureLink — pam inlineSettings service-layer validation', () =>
     const tx = {
       insert: vi.fn(() => ({
         values: vi.fn(() => ({
-          returning: vi.fn(() =>
-            Promise.resolve([
-              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: {} },
-            ])
-          ),
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() =>
+              Promise.resolve([
+                { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: {} },
+              ])
+            ),
+          })),
         })),
       })),
     };
@@ -441,11 +448,13 @@ describe('addFeatureLink — pam inlineSettings service-layer validation', () =>
     const tx = {
       insert: vi.fn(() => ({
         values: vi.fn(() => ({
-          returning: vi.fn(() =>
-            Promise.resolve([
-              { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: null },
-            ])
-          ),
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() =>
+              Promise.resolve([
+                { id: 'link-pam', configPolicyId: 'policy-1', featureType: 'pam', featurePolicyId: null, inlineSettings: null },
+              ])
+            ),
+          })),
         })),
       })),
     };
@@ -526,11 +535,13 @@ describe('addFeatureLink — vulnerability inlineSettings service-layer validati
     const tx = {
       insert: vi.fn(() => ({
         values: vi.fn(() => ({
-          returning: vi.fn(() =>
-            Promise.resolve([
-              { id: 'link-vuln', configPolicyId: 'policy-1', featureType: 'vulnerability', featurePolicyId: null, inlineSettings },
-            ])
-          ),
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() =>
+              Promise.resolve([
+                { id: 'link-vuln', configPolicyId: 'policy-1', featureType: 'vulnerability', featurePolicyId: null, inlineSettings },
+              ])
+            ),
+          })),
         })),
       })),
     };
@@ -769,5 +780,54 @@ describe('validateFeaturePolicyExists — software_policy dual-axis linking (#21
     const result = await validateFeaturePolicyExists('security', 'missing', { orgId: 'org-1', partnerId: null });
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/Security policy .* not found/i);
+  });
+});
+
+// ============================================================
+// onConflictDoNothing duplicate handling (issue #2189) — a raised unique
+// violation gets re-thrown by postgres.js at withDbAccessContext commit time
+// even after a caller catches it, turning a mapped 409 back into a raw 500
+// (see createCatalogItem in catalogService.ts). Both inserts below suppress
+// the conflict at the statement level and return null instead.
+// ============================================================
+
+describe('addFeatureLink — duplicate feature link returns null instead of throwing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when onConflictDoNothing suppresses a duplicate (config_feature_links_unique)', async () => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([])),
+          })),
+        })),
+      })),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const link = await addFeatureLink('policy-1', 'patch', null, null);
+    expect(link).toBeNull();
+  });
+});
+
+describe('assignPolicy — duplicate assignment returns null instead of throwing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when onConflictDoNothing suppresses a duplicate (config_assignments_unique)', async () => {
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    } as any);
+
+    const assignment = await assignPolicy('policy-1', 'device', 'device-1', 0, 'user-1');
+    expect(assignment).toBeNull();
   });
 });

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -982,6 +982,14 @@ export async function addFeatureLink(
         ? normalizePatchInlineSettings(inlineSettings)
         : inlineSettings;
 
+    // ON CONFLICT DO NOTHING instead of catch-and-map: callers run inside the
+    // withDbAccessContext transaction, and postgres.js re-throws a raised
+    // unique violation at commit time even after it's caught by the caller,
+    // turning a mapped 409 back into a raw 500 (see createCatalogItem in
+    // catalogService.ts). `config_feature_links_unique` (config_policy_id,
+    // feature_type) is the only non-PK unique constraint on this table, so a
+    // bare onConflictDoNothing only ever suppresses that duplicate-link case.
+    // Callers must treat a null return as "already linked".
     const [link] = await tx
       .insert(configPolicyFeatureLinks)
       .values({
@@ -991,9 +999,10 @@ export async function addFeatureLink(
         // Keep JSONB as a compatibility/UI mirror; runtime must read normalized settings.
         inlineSettings: effectiveInlineSettings ?? null,
       })
+      .onConflictDoNothing()
       .returning();
 
-    if (!link) throw new Error('Failed to create feature link');
+    if (!link) return null;
 
     // Decompose inlineSettings into normalized per-feature table
     if (featureType === 'patch' || effectiveInlineSettings) {
@@ -1131,6 +1140,14 @@ export async function assignPolicy(
   roleFilter?: string[],
   osFilter?: string[]
 ) {
+  // ON CONFLICT DO NOTHING instead of catch-and-map: callers run inside the
+  // withDbAccessContext transaction, and postgres.js re-throws a raised unique
+  // violation at commit time even after it's caught by the caller, turning a
+  // mapped 409 back into a raw 500 (see createCatalogItem in catalogService.ts).
+  // `config_assignments_unique` (config_policy_id, level, target_id) is the
+  // only non-PK unique constraint on this table, so a bare onConflictDoNothing
+  // only ever suppresses that duplicate-assignment case. Callers must treat a
+  // null return as "already assigned".
   const [assignment] = await db
     .insert(configPolicyAssignments)
     .values({
@@ -1142,9 +1159,9 @@ export async function assignPolicy(
       osFilter: osFilter?.length ? osFilter : null,
       assignedBy: userId,
     })
+    .onConflictDoNothing()
     .returning();
-  if (!assignment) throw new Error('Failed to create policy assignment');
-  return assignment;
+  return assignment ?? null;
 }
 
 export async function validateAssignmentTarget(

--- a/apps/api/src/services/partnerStripe.test.ts
+++ b/apps/api/src/services/partnerStripe.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for savePartnerStripeKey (issue #2189 fix).
+ *
+ * The cross-partner "Stripe account already claimed" case must be detected by
+ * the SYSTEM-context pre-check SELECT (partner-axis RLS hides the other
+ * partner's row from the request context) and surface as a typed
+ * PartnerStripeError — never by letting the acct_uq 23505 raise inside the
+ * request transaction, where postgres.js re-throws the raw error at commit and
+ * clobbers the mapped response into a 500.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const PARTNER_A = '11111111-1111-4111-8111-111111111111';
+const PARTNER_B = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+const { dbMocks, accountsRetrieveMock, systemContextCalls } = vi.hoisted(() => ({
+  dbMocks: {
+    // queue of results for successive db.select()...limit() terminals
+    selectResults: [] as unknown[][],
+    insertedValues: [] as Record<string, unknown>[],
+    upsertConfigs: [] as Record<string, unknown>[],
+    upsertErrors: [] as unknown[],
+  },
+  accountsRetrieveMock: vi.fn(),
+  systemContextCalls: { count: 0 },
+}));
+
+vi.mock('stripe', () => ({
+  default: class MockStripe {
+    accounts = { retrieve: accountsRetrieveMock };
+    constructor(_key: string, _opts?: unknown) {}
+  },
+}));
+
+vi.mock('./secretCrypto', () => ({
+  encryptSecret: (x: string) => `enc(${x})`,
+  decryptSecret: (x: string) => x.replace(/^enc\((.*)\)$/, '$1'),
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => {
+    systemContextCalls.count += 1;
+    return fn();
+  },
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(dbMocks.selectResults.shift() ?? [])),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((vals: Record<string, unknown>) => {
+        dbMocks.insertedValues.push(vals);
+        return {
+          onConflictDoUpdate: vi.fn((cfg: Record<string, unknown>) => {
+            dbMocks.upsertConfigs.push(cfg);
+            const err = dbMocks.upsertErrors.shift();
+            return err ? Promise.reject(err) : Promise.resolve();
+          }),
+        };
+      }),
+    })),
+  },
+}));
+
+import { savePartnerStripeKey, PartnerStripeError } from './partnerStripe';
+
+const TEST_KEY = ['sk', 'test', '51UNITtestKEY9999'].join('_');
+const CLAIM_MESSAGE =
+  'That Stripe account is already connected to another partner. Use a key for a different Stripe account.';
+
+beforeEach(() => {
+  dbMocks.selectResults.length = 0;
+  dbMocks.insertedValues.length = 0;
+  dbMocks.upsertConfigs.length = 0;
+  dbMocks.upsertErrors.length = 0;
+  systemContextCalls.count = 0;
+  accountsRetrieveMock.mockReset();
+  accountsRetrieveMock.mockResolvedValue({ id: 'acct_unit' });
+});
+
+describe('savePartnerStripeKey', () => {
+  it('happy path: validates the key, pre-checks under a system context, then upserts encrypted', async () => {
+    dbMocks.selectResults.push([]); // account not claimed by anyone
+
+    const res = await savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID });
+
+    expect(res).toEqual({ stripeAccountId: 'acct_unit', last4: '9999', livemode: false });
+    // Pre-check ran inside the system context (partner-axis RLS would hide a
+    // cross-partner claim from the request context).
+    expect(systemContextCalls.count).toBe(1);
+    const vals = dbMocks.insertedValues[0]!;
+    expect(vals.partnerId).toBe(PARTNER_A);
+    expect(vals.apiKey).toBe(`enc(${TEST_KEY})`); // never plaintext
+    expect(vals.stripeAccountId).toBe('acct_unit');
+    expect(dbMocks.upsertConfigs).toHaveLength(1); // partner_id upsert reached
+  });
+
+  it('account claimed by ANOTHER partner: throws the typed error BEFORE any write', async () => {
+    dbMocks.selectResults.push([{ partnerId: PARTNER_B }]);
+
+    await expect(savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID }))
+      .rejects.toMatchObject({
+        name: 'PartnerStripeError',
+        code: 'INVALID_STRIPE_KEY',
+        status: 400,
+        message: CLAIM_MESSAGE,
+      });
+
+    // The write never runs, so no statement can raise inside the request
+    // transaction — the mapped error survives to the route (#2189).
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('account claimed by the SAME partner (key rotation / reconnect): proceeds with the upsert', async () => {
+    dbMocks.selectResults.push([{ partnerId: PARTNER_A }]);
+
+    const res = await savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID });
+
+    expect(res.stripeAccountId).toBe('acct_unit');
+    expect(dbMocks.insertedValues).toHaveLength(1);
+  });
+
+  it('concurrent-race backstop: an acct_uq 23505 from the upsert still maps to the typed error', async () => {
+    dbMocks.selectResults.push([]); // pre-check saw nothing (claim landed after it)
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint "stripe_connect_accounts_acct_uq"'), {
+      code: '23505',
+      constraint_name: 'stripe_connect_accounts_acct_uq',
+    });
+    dbMocks.upsertErrors.push(Object.assign(new Error('Failed query: insert ...'), { cause: pgError }));
+
+    await expect(savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID }))
+      .rejects.toMatchObject({ name: 'PartnerStripeError', code: 'INVALID_STRIPE_KEY', message: CLAIM_MESSAGE });
+  });
+
+  it('a non-unique-violation upsert error is rethrown unchanged', async () => {
+    dbMocks.selectResults.push([]);
+    const dbDown = new Error('connection terminated');
+    dbMocks.upsertErrors.push(dbDown);
+
+    await expect(savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID }))
+      .rejects.toBe(dbDown);
+  });
+
+  it('a key Stripe rejects maps to INVALID_STRIPE_KEY without touching the DB', async () => {
+    accountsRetrieveMock.mockRejectedValue(
+      Object.assign(new Error('Invalid API Key provided'), { type: 'StripeAuthenticationError' })
+    );
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: TEST_KEY, userId: USER_ID }))
+        .rejects.toMatchObject({ name: 'PartnerStripeError', code: 'INVALID_STRIPE_KEY' });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+    expect(systemContextCalls.count).toBe(0);
+    expect(dbMocks.insertedValues).toHaveLength(0);
+  });
+
+  it('a live-mode key sets livemode=true', async () => {
+    dbMocks.selectResults.push([]);
+    const liveKey = ['rk', 'live', '51LIVEkey8888'].join('_');
+    const res = await savePartnerStripeKey({ partnerId: PARTNER_A, apiKey: liveKey, userId: USER_ID });
+    expect(res.livemode).toBe(true);
+    expect(dbMocks.insertedValues[0]!.livemode).toBe(true);
+  });
+});

--- a/apps/api/src/services/partnerStripe.ts
+++ b/apps/api/src/services/partnerStripe.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { stripeConnectAccounts } from '../db/schema/stripePayments';
 import { encryptSecret, decryptSecret } from './secretCrypto';
 import { isPgUniqueViolation } from '../utils/pgErrors';
@@ -81,6 +81,40 @@ export async function savePartnerStripeKey(input: {
   const encrypted = encryptSecret(apiKey);
   const now = new Date();
 
+  // stripe_connect_accounts_acct_uq is a GLOBAL unique index on
+  // stripe_account_id (one Breeze partner per Stripe account, cross-partner),
+  // while the table's RLS policy is partner-axis — from THIS partner's request
+  // context another partner's claim on the account is invisible. Two
+  // consequences (issue #2189):
+  //   1. an in-context pre-check SELECT would silently return zero rows and
+  //      the upsert would still trip the constraint, and
+  //   2. letting the constraint raise doesn't work either: the request runs
+  //      inside the withDbAccessContext transaction, and postgres.js records
+  //      the raw 23505 and re-throws it at commit even after the catch below
+  //      maps it — the route's mapped 400 was deterministically clobbered
+  //      into a raw 500.
+  // So pre-check under a system context on its own short-lived transaction.
+  // runOutsideDbContext is required: a nested withSystemDbAccessContext alone
+  // short-circuits into the SAME partner-scoped request transaction. Only the
+  // claiming partner_id is read — nothing crosses the tenant boundary back to
+  // the caller.
+  const claimedByOtherPartner = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const rows = await db
+        .select({ partnerId: stripeConnectAccounts.partnerId })
+        .from(stripeConnectAccounts)
+        .where(eq(stripeConnectAccounts.stripeAccountId, accountId))
+        .limit(1);
+      return rows[0] !== undefined && rows[0].partnerId !== input.partnerId;
+    })
+  );
+  if (claimedByOtherPartner) {
+    throw new PartnerStripeError(
+      'That Stripe account is already connected to another partner. Use a key for a different Stripe account.',
+      'INVALID_STRIPE_KEY',
+    );
+  }
+
   try {
     await db
       .insert(stripeConnectAccounts)
@@ -111,12 +145,16 @@ export async function savePartnerStripeKey(input: {
         },
       });
   } catch (err) {
-    // The upsert resolves conflicts on partner_id, but a second unique index
-    // (stripe_connect_accounts_acct_uq) guards stripe_account_id. If this key
-    // belongs to a Stripe account already claimed by ANOTHER partner, the row is
-    // a fresh INSERT that trips acct_uq (23505). Surface it as a key problem the
-    // partner can act on, not a raw 500. Drizzle wraps the postgres.js error, so
-    // the pg code/constraint live on `.cause` — isPgUniqueViolation walks the chain.
+    // Concurrent-writer backstop only: the system-context pre-check above
+    // catches the deterministic case, so acct_uq (23505) can now fire solely
+    // when another partner claims the same Stripe account BETWEEN the
+    // pre-check and this upsert. On this path the surrounding
+    // withDbAccessContext transaction is already aborted and postgres.js will
+    // re-throw the raw error at commit (the mapped error below does NOT reach
+    // the caller — they see a 500), but the window is a vanishing-probability
+    // race instead of the previously deterministic path. Kept for the log/
+    // intent trail; Drizzle wraps the postgres.js error, so the pg code/
+    // constraint live on `.cause` — isPgUniqueViolation walks the chain.
     if (isPgUniqueViolation(err, 'stripe_connect_accounts_acct_uq')) {
       throw new PartnerStripeError(
         'That Stripe account is already connected to another partner. Use a key for a different Stripe account.',

--- a/apps/api/src/services/pax8CatalogService.test.ts
+++ b/apps/api/src/services/pax8CatalogService.test.ts
@@ -6,9 +6,12 @@ const mocks = vi.hoisted(() => ({
   createCatalogItem: vi.fn(),
   getRedis: vi.fn(() => null),
   enrichDistributorListing: vi.fn(),
+  // #2190 — pass-through wrapper; kept as a vi.fn (not an inline arrow) so
+  // tests can assert call ORDER relative to enrichDistributorListing.
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
 }));
 
-vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('../db', () => ({ db: mocks.db, withDbAccessContext: mocks.withDbAccessContext }));
 vi.mock('./pax8SyncService', () => ({ createPax8ClientForIntegration: mocks.createPax8ClientForIntegration }));
 vi.mock('./catalogService', async (orig) => ({ ...(await orig<typeof import('./catalogService')>()), createCatalogItem: mocks.createCatalogItem }));
 vi.mock('./redis', () => ({ getRedis: mocks.getRedis }));
@@ -18,6 +21,9 @@ import { searchPax8Products, importPax8CatalogItem, getPax8CatalogStatus, getPax
 import { CatalogServiceError } from './catalogService';
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+// #2190 — the request-scoped DbAccessContext the route rebuilds from `auth` and
+// passes into the import function alongside `actor`.
+const dbCtx = { scope: 'partner' as const, orgId: null, accessibleOrgIds: null, accessiblePartnerIds: ['p1'], userId: 'u1', currentPartnerId: 'p1' };
 const integration = { id: 'int-1', partnerId: 'p1', isActive: true };
 
 function selectChain(rows: unknown[]) {
@@ -32,6 +38,9 @@ beforeEach(() => {
   mocks.createPax8ClientForIntegration.mockReset(); mocks.createCatalogItem.mockReset();
   mocks.getRedis.mockReturnValue(null);
   mocks.enrichDistributorListing.mockReset();
+  // mockClear (not mockReset) preserves the pass-through implementation while
+  // resetting call history/order between tests.
+  mocks.withDbAccessContext.mockClear();
 });
 
 describe('searchPax8Products', () => {
@@ -63,7 +72,7 @@ describe('importPax8CatalogItem', () => {
     mocks.createCatalogItem.mockRejectedValueOnce(new CatalogServiceError('dup', 409, 'DUPLICATE_SKU'));
     mocks.db.insert.mockReturnValueOnce(insertChain());
     const product = { source: 'pax8' as const, pax8ProductId: 'p1', name: 'Microsoft 365 Business Premium', vendorName: 'Microsoft', vendorSku: 'CFQ7', commitmentTerm: 'Annual', billingTerm: 'Monthly', partnerBuyRate: '18.50', currency: 'USD', raw: {} };
-    const item = await importPax8CatalogItem({ product, item: { name: product.name, sku: 'CFQ7', unitPrice: 22 } }, actor);
+    const item = await importPax8CatalogItem({ product, item: { name: product.name, sku: 'CFQ7', unitPrice: 22 } }, actor, dbCtx);
     expect(item.id).toBe('existing-1');
     expect(mocks.db.insert).toHaveBeenCalled();
   });
@@ -73,7 +82,7 @@ describe('importPax8CatalogItem', () => {
     mocks.createCatalogItem.mockResolvedValue({ id: 'item-1', name: 'Microsoft 365 Business Premium' });
     mocks.db.insert.mockReturnValueOnce(insertChain());
     const product = { source: 'pax8' as const, pax8ProductId: 'p1', name: 'Microsoft 365 Business Premium', vendorName: 'Microsoft', vendorSku: 'CFQ7', commitmentTerm: 'Annual', billingTerm: 'Monthly', partnerBuyRate: '18.50', currency: 'USD', raw: {} };
-    const item = await importPax8CatalogItem({ product, item: { name: product.name, sku: 'CFQ7', unitPrice: 22, costBasis: 18.5, taxable: true } }, actor);
+    const item = await importPax8CatalogItem({ product, item: { name: product.name, sku: 'CFQ7', unitPrice: 22, costBasis: 18.5, taxable: true } }, actor, dbCtx);
     expect(item.id).toBe('item-1');
     const arg = mocks.createCatalogItem.mock.calls[0]![0];
     expect(arg).toMatchObject({ itemType: 'software', billingType: 'recurring', billingFrequency: 'monthly', unitPrice: 22, costBasis: 18.5 });
@@ -94,7 +103,7 @@ describe('importPax8CatalogItem', () => {
       provenance: { source: 'ai_enrich', model: 'm', query: 'q', suggestion: {}, enrichedAt: 't', enrichedBy: 'u1' },
     });
     const product = { source: 'pax8' as const, pax8ProductId: 'p1', name: 'M365 BP', vendorName: 'Microsoft', vendorSku: 'CFQ7', commitmentTerm: 'Annual', billingTerm: 'Monthly', partnerBuyRate: '18.50', currency: 'USD', raw: {} };
-    await importPax8CatalogItem({ product, item: { name: 'M365 BP', sku: 'CFQ7', unitPrice: 22 }, aiCleanup: true }, actor);
+    await importPax8CatalogItem({ product, item: { name: 'M365 BP', sku: 'CFQ7', unitPrice: 22 }, aiCleanup: true }, actor, dbCtx);
     const [query, hint] = mocks.enrichDistributorListing.mock.calls[0]!;
     expect(query).toContain('Microsoft');
     expect(hint).toBe('software');
@@ -103,6 +112,16 @@ describe('importPax8CatalogItem', () => {
     expect(arg.description).toMatch(/Defender/);
     expect((arg.attributes as any).pax8.aiEnriched).toBe(true);
     expect((arg.attributes as any).pax8.rawName).toBe('M365 BP');
+
+    // #2190 — enrichDistributorListing must run BEFORE the short DB context that
+    // wraps createCatalogItem + the pax8ProductMappings upsert, so the
+    // (potentially 12s) call never runs inside a held transaction. The
+    // getActiveIntegration read (first withDbAccessContext call) legitimately
+    // happens before enrichment; the write context (second call) must come after.
+    const enrichOrder = mocks.enrichDistributorListing.mock.invocationCallOrder[0]!;
+    const ctxOrders = mocks.withDbAccessContext.mock.invocationCallOrder;
+    expect(ctxOrders).toHaveLength(2);
+    expect(ctxOrders[1]).toBeGreaterThan(enrichOrder);
   });
 
   it('keeps raw values and marks aiEnriched=false when enrichment is unavailable', async () => {
@@ -111,7 +130,7 @@ describe('importPax8CatalogItem', () => {
     mocks.db.insert.mockReturnValueOnce(insertChain());
     mocks.enrichDistributorListing.mockResolvedValueOnce(null); // budget/rate/timeout
     const product = { source: 'pax8' as const, pax8ProductId: 'p1', name: 'M365 BP', vendorName: 'Microsoft', vendorSku: 'CFQ7', commitmentTerm: 'Annual', billingTerm: 'Monthly', partnerBuyRate: '18.50', currency: 'USD', raw: {} };
-    await importPax8CatalogItem({ product, item: { name: 'M365 BP', sku: 'CFQ7', unitPrice: 22, description: 'raw desc' }, aiCleanup: true }, actor);
+    await importPax8CatalogItem({ product, item: { name: 'M365 BP', sku: 'CFQ7', unitPrice: 22, description: 'raw desc' }, aiCleanup: true }, actor, dbCtx);
     const arg = mocks.createCatalogItem.mock.calls[0]![0];
     expect(arg.name).toBe('M365 BP'); // unchanged
     expect(arg.description).toBe('raw desc');

--- a/apps/api/src/services/pax8CatalogService.ts
+++ b/apps/api/src/services/pax8CatalogService.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withDbAccessContext, type DbAccessContext } from '../db';
 import { pax8Integrations, pax8ProductMappings } from '../db/schema/pax8';
 import { catalogItems } from '../db/schema/catalog';
 import { createPax8ClientForIntegration } from './pax8SyncService';
@@ -118,8 +118,17 @@ function mapBillingFrequency(billingTerm: string | null): 'monthly' | 'annual' {
   return 'monthly';
 }
 
-export async function importPax8CatalogItem(input: Pax8ImportInput, actor: CatalogActor): Promise<typeof catalogItems.$inferSelect> {
-  const integration = await getActiveIntegration(actor);
+// #2190 — this route (POST /distributors/pax8/import) opts out of the auth
+// middleware's ambient request transaction (SELF_MANAGED_DB_CONTEXT_ROUTES) so
+// the up-to-12s enrichDistributorListing call below never runs inside a held DB
+// transaction. `dbCtx` is the request's RLS DbAccessContext, rebuilt by the route
+// from `auth` (dbAccessContextFromAuth) since it can no longer rely on an ambient
+// one; the getActiveIntegration read runs in its own short context, then — after
+// enrichment, under NO ambient context — the catalog-item write and the product-
+// mapping upsert run together in a second short context (same atomicity as
+// before, when both lived in the single ambient request transaction).
+export async function importPax8CatalogItem(input: Pax8ImportInput, actor: CatalogActor, dbCtx: DbAccessContext): Promise<typeof catalogItems.$inferSelect> {
+  const integration = await withDbAccessContext(dbCtx, () => getActiveIntegration(actor));
   if (!integration) throw new Pax8CatalogError('Pax8 is not connected', 400, 'PAX8_NOT_CONFIGURED');
   const { product, item } = input;
 
@@ -171,37 +180,39 @@ export async function importPax8CatalogItem(input: Pax8ImportInput, actor: Catal
     },
   };
 
-  let created: typeof catalogItems.$inferSelect;
-  try {
-    created = await createCatalogItem(payload, actor);
-  } catch (err) {
-    const sku = payload.sku;
-    if (err instanceof CatalogServiceError && err.code === 'DUPLICATE_SKU' && sku) {
-      const [existing] = await db.select().from(catalogItems)
-        .where(and(eq(catalogItems.partnerId, integration.partnerId), eq(catalogItems.sku, sku)))
-        .limit(1);
-      if (!existing) throw err;
-      created = existing;
-    } else {
-      throw err;
+  return withDbAccessContext(dbCtx, async () => {
+    let created: typeof catalogItems.$inferSelect;
+    try {
+      created = await createCatalogItem(payload, actor);
+    } catch (err) {
+      const sku = payload.sku;
+      if (err instanceof CatalogServiceError && err.code === 'DUPLICATE_SKU' && sku) {
+        const [existing] = await db.select().from(catalogItems)
+          .where(and(eq(catalogItems.partnerId, integration.partnerId), eq(catalogItems.sku, sku)))
+          .limit(1);
+        if (!existing) throw err;
+        created = existing;
+      } else {
+        throw err;
+      }
     }
-  }
 
-  // Dedup + linkage so subscription pricing-sync can later reconcile this product.
-  await db
-    .insert(pax8ProductMappings)
-    .values({
-      integrationId: integration.id,
-      partnerId: integration.partnerId,
-      pax8ProductId: product.pax8ProductId,
-      vendorSkuId: product.vendorSku,
-      productName: product.name,
-      catalogItemId: created.id,
-    })
-    .onConflictDoUpdate({
-      target: [pax8ProductMappings.integrationId, pax8ProductMappings.pax8ProductId],
-      set: { catalogItemId: created.id, productName: product.name, vendorSkuId: product.vendorSku, updatedAt: new Date() },
-    });
+    // Dedup + linkage so subscription pricing-sync can later reconcile this product.
+    await db
+      .insert(pax8ProductMappings)
+      .values({
+        integrationId: integration.id,
+        partnerId: integration.partnerId,
+        pax8ProductId: product.pax8ProductId,
+        vendorSkuId: product.vendorSku,
+        productName: product.name,
+        catalogItemId: created.id,
+      })
+      .onConflictDoUpdate({
+        target: [pax8ProductMappings.integrationId, pax8ProductMappings.pax8ProductId],
+        set: { catalogItemId: created.id, productName: product.name, vendorSkuId: product.vendorSku, updatedAt: new Date() },
+      });
 
-  return created;
+    return created;
+  });
 }

--- a/apps/api/src/services/tdSynnexDigitalBridge.test.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.test.ts
@@ -14,10 +14,13 @@ const mocks = vi.hoisted(() => {
     safeFetch: vi.fn(),
     SsrfBlockedError,
     enrichDistributorListing: vi.fn(),
+    // #2190 — pass-through wrapper; kept as a vi.fn (not an inline arrow) so
+    // tests can assert call ORDER relative to enrichDistributorListing.
+    withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
   };
 });
 
-vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('../db', () => ({ db: mocks.db, withDbAccessContext: mocks.withDbAccessContext }));
 vi.mock('./secretCrypto', () => ({
   encryptSecret: mocks.encryptSecret,
   decryptForColumn: mocks.decryptForColumn,
@@ -44,6 +47,9 @@ import {
 } from './tdSynnexDigitalBridge';
 
 const actor = { userId: 'user-1', partnerId: 'partner-1', accessibleOrgIds: null };
+// #2190 — the request-scoped DbAccessContext the route rebuilds from `auth` and
+// passes into the import function alongside `actor`.
+const dbCtx = { scope: 'partner' as const, orgId: null, accessibleOrgIds: null, accessiblePartnerIds: ['partner-1'], userId: 'user-1', currentPartnerId: 'partner-1' };
 
 function selectChain(rows: unknown[]) {
   return {
@@ -217,7 +223,7 @@ describe('tdSynnexDigitalBridge service', () => {
         unitPrice: 125,
         taxable: true,
       },
-    }, actor)).rejects.toThrow(TdSynnexDigitalBridgeError);
+    }, actor, dbCtx)).rejects.toThrow(TdSynnexDigitalBridgeError);
     expect(mocks.createCatalogItem).not.toHaveBeenCalled();
   });
 
@@ -431,7 +437,7 @@ describe('tdSynnexDigitalBridge service', () => {
         raw: { anything: true }, lastRefreshedAt: new Date().toISOString(),
       },
       item: { name: 'Dock', sku: 'SKU-1', unitPrice: 125, taxable: true },
-    }, actor);
+    }, actor, dbCtx);
     const input = mocks.createCatalogItem.mock.calls[0]![0];
     expect(input.attributes.distributor).toMatchObject({
       provider: 'td_synnex_digital_bridge', sourceProductId: 'td-1', vendor: 'Lenovo',
@@ -460,7 +466,7 @@ describe('tdSynnexDigitalBridge service', () => {
       },
       item: { name: 'SPL Dock DISTI', sku: 'SKU-1', unitPrice: 125, taxable: true },
       aiCleanup: true,
-    }, actor);
+    }, actor, dbCtx);
     const [query, hint] = mocks.enrichDistributorListing.mock.calls[0]!;
     expect(query).toContain('MPN-1');
     expect(hint).toBe('hardware');
@@ -469,6 +475,16 @@ describe('tdSynnexDigitalBridge service', () => {
     expect(input.description).toMatch(/4K/);
     expect(input.attributes.distributor.aiEnriched).toBe(true);
     expect(input.attributes.distributor.rawName).toBe('SPL Dock DISTI');
+
+    // #2190 — enrichDistributorListing must run BEFORE the short DB context that
+    // wraps createCatalogItem, so the (potentially 12s) call never runs inside a
+    // held transaction. The getActiveIntegration read (first withDbAccessContext
+    // call) legitimately happens before enrichment; the createCatalogItem write
+    // (second call) must come after.
+    const enrichOrder = mocks.enrichDistributorListing.mock.invocationCallOrder[0]!;
+    const ctxOrders = mocks.withDbAccessContext.mock.invocationCallOrder;
+    expect(ctxOrders).toHaveLength(2);
+    expect(ctxOrders[1]).toBeGreaterThan(enrichOrder);
   });
 
   it('keeps raw values and marks aiEnriched=false when enrichment is unavailable', async () => {
@@ -484,7 +500,7 @@ describe('tdSynnexDigitalBridge service', () => {
       },
       item: { name: 'SPL Dock DISTI', sku: 'SKU-1', unitPrice: 125, taxable: true },
       aiCleanup: true,
-    }, actor);
+    }, actor, dbCtx);
     const input = mocks.createCatalogItem.mock.calls[0]![0];
     expect(input.name).toBe('SPL Dock DISTI'); // unchanged
     expect(input.description).toBe('raw desc');

--- a/apps/api/src/services/tdSynnexDigitalBridge.ts
+++ b/apps/api/src/services/tdSynnexDigitalBridge.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { db } from '../db';
+import { db, withDbAccessContext, type DbAccessContext } from '../db';
 import { tdSynnexDigitalBridgeIntegrations } from '../db/schema';
 import { encryptSecret, decryptForColumn } from './secretCrypto';
 import { createCatalogItem, type CatalogActor } from './catalogService';
@@ -530,8 +530,16 @@ export interface ImportTdSynnexCatalogItemInput {
   aiCleanup?: boolean;
 }
 
-export async function importTdSynnexCatalogItem(input: ImportTdSynnexCatalogItemInput, actor: CatalogActor) {
-  await getActiveIntegration(actor);
+// #2190 — this route (POST /distributors/td-synnex/import) opts out of the auth
+// middleware's ambient request transaction (SELF_MANAGED_DB_CONTEXT_ROUTES) so
+// the up-to-12s enrichDistributorListing call below never runs inside a held DB
+// transaction. `dbCtx` is the request's RLS DbAccessContext, rebuilt by the route
+// from `auth` (dbAccessContextFromAuth) since it can no longer rely on an ambient
+// one; each DB op (the getActiveIntegration read, then createCatalogItem) runs in
+// its own short-lived withDbAccessContext, with enrichment running between them
+// under NO ambient context.
+export async function importTdSynnexCatalogItem(input: ImportTdSynnexCatalogItemInput, actor: CatalogActor, dbCtx: DbAccessContext) {
+  await withDbAccessContext(dbCtx, () => getActiveIntegration(actor));
   const existingSku = input.item.sku?.trim();
 
   // Optional web-search enrichment: turn the raw distributor listing into a clean
@@ -586,5 +594,5 @@ export async function importTdSynnexCatalogItem(input: ImportTdSynnexCatalogItem
       }
     }
   };
-  return createCatalogItem(catalogInput, actor);
+  return withDbAccessContext(dbCtx, () => createCatalogItem(catalogInput, actor));
 }

--- a/apps/api/src/services/tdSynnexEcExpress.test.ts
+++ b/apps/api/src/services/tdSynnexEcExpress.test.ts
@@ -14,12 +14,18 @@ const mocks = vi.hoisted(() => {
       value?.startsWith('enc(') ? value.slice(4, -1) : (value ?? null)
     ),
     safeFetch: vi.fn(),
+    // #2190 — pass-through wrapper; kept as a vi.fn (not an inline arrow) so
+    // tests can assert call ORDER relative to enrichDistributorListing below.
+    withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
   };
 });
 
 const enrichMocks = vi.hoisted(() => ({ enrichDistributorListing: vi.fn() }));
 
-vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('../db', () => ({
+  db: mocks.db,
+  withDbAccessContext: mocks.withDbAccessContext,
+}));
 vi.mock('./secretCrypto', () => ({
   encryptSecret: mocks.encryptSecret,
   decryptForColumn: mocks.decryptForColumn,
@@ -48,6 +54,9 @@ vi.mock('./catalogService', () => ({
 }));
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+// #2190 — the request-scoped DbAccessContext the route rebuilds from `auth` and
+// passes into the import function alongside `actor`.
+const dbCtx = { scope: 'partner' as const, orgId: null, accessibleOrgIds: null, accessiblePartnerIds: ['p1'], userId: 'u1', currentPartnerId: 'p1' };
 
 function selectChain(rows: unknown[]) {
   return {
@@ -408,7 +417,7 @@ it('maps msrp === "0" to null', () => {
 it('imports a product into the catalog with a distributor snapshot', async () => {
   const createSpy = vi.mocked(createCatalogItem).mockResolvedValue({ id: 'item1' } as any);
   const product = { source: 'td_synnex_ec_express' as const, synnexSku: '8938995', mfgPartNo: 'DELL-U2724D', status: 'ACTIVE', name: 'Dell U2724D', description: 'Dell U2724D', currency: 'USD', cost: 381.35, msrp: 549.99, discount: null, totalQty: 1437, warehouses: [], weight: 20.50, parcelShippable: 'Y', raw: {} };
-  await importEcExpressCatalogItem({ product, item: { name: 'Dell U2724D', sku: '8938995', unitPrice: 549.99, costBasis: 381.35, taxable: true } }, actor);
+  await importEcExpressCatalogItem({ product, item: { name: 'Dell U2724D', sku: '8938995', unitPrice: 549.99, costBasis: 381.35, taxable: true } }, actor, dbCtx);
   const arg = createSpy.mock.calls[0]![0];
   expect(arg).toMatchObject({ itemType: 'hardware', name: 'Dell U2724D', sku: '8938995', unitPrice: 549.99, costBasis: 381.35 });
   expect((arg.attributes as any).distributor.source).toBe('td_synnex_ec_express');
@@ -426,7 +435,7 @@ it('web-enriches the listing when aiCleanup is set (clean name + technical descr
     provenance: { source: 'ai_enrich', model: 'm', query: 'q', suggestion: {}, enrichedAt: 't', enrichedBy: 'u1' },
   });
   const product = { source: 'td_synnex_ec_express' as const, synnexSku: '8938995', mfgPartNo: 'DELL-U2724D', status: 'ACTIVE', name: 'SPL Dell U2724D DISTI', description: null, currency: 'USD', cost: 381.35, msrp: 549.99, discount: null, totalQty: 1, warehouses: [], weight: null, parcelShippable: 'Y', raw: {} };
-  await importEcExpressCatalogItem({ product, item: { name: 'SPL Dell U2724D DISTI', sku: '8938995', unitPrice: 549.99, taxable: true }, aiCleanup: true }, actor);
+  await importEcExpressCatalogItem({ product, item: { name: 'SPL Dell U2724D DISTI', sku: '8938995', unitPrice: 549.99, taxable: true }, aiCleanup: true }, actor, dbCtx);
 
   // Query is anchored on the manufacturer part number for an accurate web lookup.
   const [query, hint] = enrichMocks.enrichDistributorListing.mock.calls.at(-1)!;
@@ -441,13 +450,20 @@ it('web-enriches the listing when aiCleanup is set (clean name + technical descr
   expect((arg.attributes as any).distributor.aiEnriched).toBe(true);
   expect((arg.attributes as any).distributor.aiProvenance.source).toBe('ai_enrich');
   expect((arg.attributes as any).distributor.rawName).toBe('SPL Dell U2724D DISTI');
+
+  // #2190 — enrichDistributorListing must run BEFORE the short DB context that
+  // wraps createCatalogItem, so the (potentially 12s) call never runs inside a
+  // held transaction.
+  const enrichOrder = enrichMocks.enrichDistributorListing.mock.invocationCallOrder.at(-1)!;
+  const ctxOrder = mocks.withDbAccessContext.mock.invocationCallOrder.at(-1)!;
+  expect(enrichOrder).toBeLessThan(ctxOrder);
 });
 
 it('falls back to the raw values when aiCleanup is set but enrichment is unavailable', async () => {
   const createSpy = vi.mocked(createCatalogItem).mockResolvedValue({ id: 'item3' } as any);
   enrichMocks.enrichDistributorListing.mockResolvedValueOnce(null); // rate-limited / down
   const product = { source: 'td_synnex_ec_express' as const, synnexSku: '8938995', mfgPartNo: 'DELL-U2724D', status: 'ACTIVE', name: 'SPL Dell U2724D DISTI', description: 'raw desc', currency: 'USD', cost: 381.35, msrp: 549.99, discount: null, totalQty: 1, warehouses: [], weight: null, parcelShippable: 'Y', raw: {} };
-  await importEcExpressCatalogItem({ product, item: { name: 'SPL Dell U2724D DISTI', sku: '8938995', unitPrice: 549.99, taxable: true }, aiCleanup: true }, actor);
+  await importEcExpressCatalogItem({ product, item: { name: 'SPL Dell U2724D DISTI', sku: '8938995', unitPrice: 549.99, taxable: true }, aiCleanup: true }, actor, dbCtx);
   const arg = createSpy.mock.calls.at(-1)![0];
   expect(arg.name).toBe('SPL Dell U2724D DISTI'); // unchanged raw name
   expect((arg.attributes as any).distributor.aiEnriched).toBe(false);

--- a/apps/api/src/services/tdSynnexEcExpress.ts
+++ b/apps/api/src/services/tdSynnexEcExpress.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { XMLParser } from 'fast-xml-parser';
-import { db } from '../db';
+import { db, withDbAccessContext, type DbAccessContext } from '../db';
 import { tdSynnexEcExpressIntegrations } from '../db/schema';
 import { encryptSecret, decryptForColumn } from './secretCrypto';
 import { safeFetch } from './urlSafety';
@@ -499,7 +499,14 @@ export interface EcImportInput {
   aiCleanup?: boolean;
 }
 
-export async function importEcExpressCatalogItem(input: EcImportInput, actor: CatalogActor) {
+// #2190 — this route (POST /distributors/td-synnex-ec/import) opts out of the
+// auth middleware's ambient request transaction (SELF_MANAGED_DB_CONTEXT_ROUTES)
+// so the up-to-12s enrichDistributorListing call below never runs inside a held
+// DB transaction. `dbCtx` is the request's RLS DbAccessContext, rebuilt by the
+// route from `auth` (dbAccessContextFromAuth) since it can no longer rely on an
+// ambient one; the only DB op this function performs (createCatalogItem) is
+// wrapped in a fresh short-lived withDbAccessContext AFTER enrichment completes.
+export async function importEcExpressCatalogItem(input: EcImportInput, actor: CatalogActor, dbCtx: DbAccessContext) {
   const { product, item } = input;
 
   // The quote/catalog lookup flows pass the raw distributor title as item.name,
@@ -563,5 +570,5 @@ export async function importEcExpressCatalogItem(input: EcImportInput, actor: Ca
       },
     },
   };
-  return createCatalogItem(payload, actor);
+  return withDbAccessContext(dbCtx, () => createCatalogItem(payload, actor));
 }

--- a/apps/api/src/services/ticketConfigService.test.ts
+++ b/apps/api/src/services/ticketConfigService.test.ts
@@ -56,6 +56,7 @@ vi.mock('../db', () => ({
         };
         return {
           returning: vi.fn(returning),
+          onConflictDoNothing: vi.fn(() => ({ returning: vi.fn(returning) })),
           onConflictDoUpdate: vi.fn((arg: Record<string, unknown>) => {
             dbMocks.conflictArgs.push(arg);
             // priority upsert has no .returning(); make the chain awaitable AND
@@ -103,6 +104,7 @@ vi.mock('drizzle-orm', async (importActual) => {
     ...actual,
     and: vi.fn((...conds: unknown[]) => ({ __op: 'and', conds })),
     eq: vi.fn((column: unknown, value: unknown) => ({ __op: 'eq', column, value })),
+    ne: vi.fn((column: unknown, value: unknown) => ({ __op: 'ne', column, value })),
     inArray: vi.fn((column: unknown, values: unknown) => ({ __op: 'inArray', column, values })),
   };
 });
@@ -134,6 +136,11 @@ vi.mock('../db/schema', () => ({
   organizations: {
     id: 'id', partnerId: 'partnerId',
   },
+  customerEmailDomains: {
+    id: 'id', partnerId: 'partnerId', orgId: 'orgId', domain: 'domain',
+    autoCreateContact: 'autoCreateContact', isActive: 'isActive', createdBy: 'createdBy',
+    createdAt: 'createdAt', updatedAt: 'updatedAt',
+  },
 }));
 
 // ticketStatusEnum is read at module load for CoreTicketStatus type/values.
@@ -159,6 +166,7 @@ import {
   upsertPrioritySettings, upsertOrgTicketSettings, getOrgTicketSettings,
   TicketConfigServiceError, findStatusByName, listActiveStatusNames,
   listEmailInboundQueue, convertEmailInbound, dismissEmailInbound,
+  createCustomerEmailDomain,
 } from './ticketConfigService';
 
 const PARTNER = 'p-1';
@@ -300,30 +308,13 @@ describe('createTicketStatus', () => {
     expect(vals).toMatchObject({ partnerId: PARTNER, name: 'Triage', coreStatus: 'open', sortOrder: 0, isSystem: false, isActive: true, color: null });
   });
 
-  it('maps a 23505 unique violation to STATUS_NAME_TAKEN 409', async () => {
-    dbMocks.insertErrors.push(Object.assign(new Error('dup'), { code: '23505', constraint: 'ticket_statuses_partner_name_uq' }));
+  it('maps a suppressed conflict (onConflictDoNothing returns zero rows) to STATUS_NAME_TAKEN 409', async () => {
+    // The insert uses .onConflictDoNothing().returning() so a name collision never
+    // raises at the statement level (see the comment on createTicketStatus) — it
+    // surfaces as an empty .returning() result instead of a thrown 23505.
+    dbMocks.insertResult = [];
     await expect(createTicketStatus(PARTNER, { name: 'New', coreStatus: 'new' }))
       .rejects.toMatchObject({ status: 409, code: 'STATUS_NAME_TAKEN' });
-  });
-
-  it('maps a constraint-name violation surfaced only in the message to STATUS_NAME_TAKEN', async () => {
-    // postgres.js sets code 23505 but some wrappers drop the discrete .constraint
-    // field — the helper then falls back to scanning the message.
-    dbMocks.insertErrors.push(Object.assign(new Error('violates unique constraint "ticket_statuses_partner_name_uq"'), { code: '23505' }));
-    await expect(createTicketStatus(PARTNER, { name: 'New', coreStatus: 'new' }))
-      .rejects.toMatchObject({ code: 'STATUS_NAME_TAKEN' });
-  });
-
-  it('does NOT map a 23505 on a different constraint to STATUS_NAME_TAKEN', async () => {
-    // A 23505 on ticket_statuses_partner_core_status_system_uq is unrelated to name
-    // uniqueness and must be rethrown as-is (not mapped to STATUS_NAME_TAKEN).
-    const err = Object.assign(new Error('dup key'), {
-      code: '23505',
-      constraint: 'ticket_statuses_partner_core_status_system_uq',
-    });
-    dbMocks.insertErrors.push(err);
-    await expect(createTicketStatus(PARTNER, { name: 'New', coreStatus: 'new' }))
-      .rejects.toSatisfy((e: unknown) => !(e instanceof TicketConfigServiceError));
   });
 });
 
@@ -347,7 +338,8 @@ describe('updateTicketStatus', () => {
   });
 
   it('allows renaming + recoloring a system row (same coreStatus is fine)', async () => {
-    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'new', isSystem: true }]);
+    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'new', isSystem: true }]); // load
+    dbMocks.selectResults.push([]); // name pre-check: no duplicate
     dbMocks.updateResult = [{ id: STATUS_ID, name: 'Brand New' }];
     const row = await updateTicketStatus(PARTNER, STATUS_ID, { name: 'Brand New', color: '#112233', coreStatus: 'new' });
     expect(row).toEqual({ id: STATUS_ID, name: 'Brand New' });
@@ -364,8 +356,25 @@ describe('updateTicketStatus', () => {
     expect(dbMocks.updateSetArgs[0]!).toMatchObject({ isActive: false });
   });
 
-  it('maps a name unique violation on update to STATUS_NAME_TAKEN', async () => {
-    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'open', isSystem: false }]);
+  it('throws STATUS_NAME_TAKEN 409 from the pre-check when another status already has that name', async () => {
+    // The pre-check SELECT finds a conflicting row before the UPDATE ever runs —
+    // this is the fix for the 23505-clobbers-409 bug (see the comment on
+    // updateTicketStatus): no statement-level unique violation is raised.
+    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'open', isSystem: false }]); // load
+    dbMocks.selectResults.push([{ one: 'other-status-id' }]); // pre-check: conflicting row found
+    await expect(updateTicketStatus(PARTNER, STATUS_ID, { name: 'New' }))
+      .rejects.toMatchObject({ status: 409, code: 'STATUS_NAME_TAKEN' });
+    // The pre-check excludes the row being updated and scopes to the partner.
+    const dupWhere = dbMocks.whereArgs[dbMocks.whereArgs.length - 1];
+    expect(whereHasColumn(dupWhere, 'partnerId')).toBe(true);
+  });
+
+  it('maps a name unique violation on update to STATUS_NAME_TAKEN (concurrent-writer backstop)', async () => {
+    // The pre-check SELECT finds no duplicate, but a concurrent writer inserts the
+    // same name between the pre-check and the UPDATE — the isUniqueNameViolation
+    // catch is the backstop for that race.
+    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'open', isSystem: false }]); // load
+    dbMocks.selectResults.push([]); // pre-check: no duplicate at check time
     dbMocks.updateResult = []; // unused; error path
     // force the update returning to reject
     const { db } = await import('../db');
@@ -382,7 +391,8 @@ describe('updateTicketStatus', () => {
 
   it('throws STATUS_NOT_FOUND 404 when the UPDATE affects no rows (TOCTOU guard)', async () => {
     // Row exists at load time but is deleted before the UPDATE executes.
-    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'open', isSystem: false }]);
+    dbMocks.selectResults.push([{ id: STATUS_ID, coreStatus: 'open', isSystem: false }]); // load
+    dbMocks.selectResults.push([]); // pre-check: no duplicate
     dbMocks.updateResult = []; // UPDATE returns empty — row was deleted between SELECT and UPDATE
     await expect(updateTicketStatus(PARTNER, STATUS_ID, { name: 'X' }))
       .rejects.toMatchObject({ status: 404, code: 'STATUS_NOT_FOUND' });
@@ -664,5 +674,40 @@ describe('dismissEmailInbound', () => {
   it('throws INBOUND_ROW_ALREADY_RESOLVED for an already-ignored row', async () => {
     dbMocks.selectResults.push([{ id: 'r-1', partnerId: 'p-1', parseStatus: 'ignored' }]);
     await expect(dismissEmailInbound('p-1', 'r-1')).rejects.toMatchObject({ code: 'INBOUND_ROW_ALREADY_RESOLVED' });
+  });
+});
+
+// ── createCustomerEmailDomain ─────────────────────────────────────────────
+
+describe('createCustomerEmailDomain', () => {
+  const DOMAIN_ACTOR = { userId: 'u-1' };
+
+  it('creates a domain mapping for an org under the partner', async () => {
+    dbMocks.selectResults.push([{ id: 'o-1' }]); // org guard
+    dbMocks.insertResult = [{ id: 'd-1', domain: 'acme.com', orgId: 'o-1' }];
+    const row = await createCustomerEmailDomain(
+      PARTNER,
+      { orgId: 'o-1', domain: 'acme.com', autoCreateContact: true },
+      DOMAIN_ACTOR,
+    );
+    expect(row).toEqual({ id: 'd-1', domain: 'acme.com', orgId: 'o-1' });
+  });
+
+  it('throws ORG_NOT_ACCESSIBLE when the org is not under the partner', async () => {
+    dbMocks.selectResults.push([]); // org guard fails
+    await expect(
+      createCustomerEmailDomain(PARTNER, { orgId: 'o-x', domain: 'acme.com', autoCreateContact: true }, DOMAIN_ACTOR),
+    ).rejects.toMatchObject({ status: 400, code: 'ORG_NOT_ACCESSIBLE' });
+  });
+
+  it('maps a suppressed conflict (onConflictDoNothing returns zero rows) to DOMAIN_ALREADY_MAPPED 409', async () => {
+    // The insert uses .onConflictDoNothing().returning() so a domain collision
+    // never raises at the statement level (see the comment on
+    // createCustomerEmailDomain) — it surfaces as an empty .returning() result.
+    dbMocks.selectResults.push([{ id: 'o-1' }]); // org guard
+    dbMocks.insertResult = [];
+    await expect(
+      createCustomerEmailDomain(PARTNER, { orgId: 'o-1', domain: 'acme.com', autoCreateContact: true }, DOMAIN_ACTOR),
+    ).rejects.toMatchObject({ status: 409, code: 'DOMAIN_ALREADY_MAPPED' });
   });
 });

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -1,6 +1,6 @@
 // Owns ticketing configuration: custom statuses, priority SLA settings, and org-level overrides — per 2026-06-12 spec.
 
-import { eq, and, asc, desc, inArray, count } from 'drizzle-orm';
+import { eq, and, asc, desc, inArray, count, ne, sql } from 'drizzle-orm';
 import { ticketStatuses, ticketPrioritySettings, orgTicketSettings, partners, ticketEmailInbound, organizations, customerEmailDomains } from '../db/schema';
 import { ticketStatusEnum } from '../db/schema/portal';
 import { getConfig } from '../config/validate';
@@ -408,26 +408,31 @@ export async function getTicketConfig(partnerId: string) {
 }
 
 export async function createTicketStatus(partnerId: string, input: CreateTicketStatusInput) {
-  try {
-    const [row] = await db
-      .insert(ticketStatuses)
-      .values({
-        partnerId,
-        name: input.name,
-        coreStatus: input.coreStatus,
-        color: input.color ?? null,
-        sortOrder: input.sortOrder ?? 0,
-        isSystem: false,
-        isActive: true,
-      })
-      .returning();
-    return row;
-  } catch (err) {
-    if (isUniqueNameViolation(err)) {
-      throw new TicketConfigServiceError('A status with this name already exists', 409, 'STATUS_NAME_TAKEN');
-    }
-    throw err;
+  // ON CONFLICT DO NOTHING instead of catch-and-map: see createCatalogItem in
+  // catalogService.ts — postgres.js re-throws a raised unique violation at
+  // transaction-commit time even after it's caught here, clobbering the mapped
+  // 409 into a raw 500. A bare .onConflictDoNothing() is fine: this insert
+  // always sets isSystem: false, so ticket_statuses_partner_core_status_system_uq
+  // (partial, isSystem-only) can never be the conflicting index, and the id PK
+  // is a generated uuid — the only realistic conflict is the name index.
+  const rows = await db
+    .insert(ticketStatuses)
+    .values({
+      partnerId,
+      name: input.name,
+      coreStatus: input.coreStatus,
+      color: input.color ?? null,
+      sortOrder: input.sortOrder ?? 0,
+      isSystem: false,
+      isActive: true,
+    })
+    .onConflictDoNothing()
+    .returning();
+  const row = rows[0];
+  if (!row) {
+    throw new TicketConfigServiceError('A status with this name already exists', 409, 'STATUS_NAME_TAKEN');
   }
+  return row;
 }
 
 export async function updateTicketStatus(partnerId: string, id: string, input: UpdateTicketStatusInput) {
@@ -452,6 +457,30 @@ export async function updateTicketStatus(partnerId: string, id: string, input: U
     }
     if (input.isActive === false) {
       throw new TicketConfigServiceError('System statuses cannot be deactivated', 400, 'SYSTEM_STATUS_REQUIRED');
+    }
+  }
+
+  // Pre-check a name change instead of relying on the unique index raising: see
+  // createCatalogItem/updateCatalogItem in catalogService.ts — a raised violation
+  // aborts the surrounding withDbAccessContext transaction and postgres.js
+  // re-throws it at commit even when caught, clobbering the mapped 409 with a raw
+  // 500. Match ticket_statuses_partner_name_uq's case-insensitivity (it's a
+  // lower(name) functional index) via sql`lower(...)`. The isUniqueNameViolation
+  // catch below stays as a concurrent-writer backstop.
+  if (input.name !== undefined) {
+    const dup = await db
+      .select({ one: ticketStatuses.id })
+      .from(ticketStatuses)
+      .where(
+        and(
+          eq(ticketStatuses.partnerId, partnerId),
+          sql`lower(${ticketStatuses.name}) = lower(${input.name})`,
+          ne(ticketStatuses.id, id),
+        ),
+      )
+      .limit(1);
+    if (dup.length > 0) {
+      throw new TicketConfigServiceError('A status with this name already exists', 409, 'STATUS_NAME_TAKEN');
     }
   }
 
@@ -848,26 +877,28 @@ export async function createCustomerEmailDomain(
     .limit(1);
   if (!orgOk) throw new TicketConfigServiceError('That organization is not in your partner', 400, 'ORG_NOT_ACCESSIBLE');
 
-  try {
-    const [row] = await db
-      .insert(customerEmailDomains)
-      .values({
-        partnerId,
-        orgId: input.orgId,
-        domain: input.domain,
-        autoCreateContact: input.autoCreateContact,
-        createdBy: actor.userId,
-      })
-      .returning();
-    return row!;
-  } catch (err) {
-    // Pin the constraint name (matches the isUniqueNameViolation pattern above):
-    // a future second unique index must not be mislabeled as a domain collision.
-    if (isPgUniqueViolation(err, 'customer_email_domains_partner_domain_uq')) {
-      throw new TicketConfigServiceError('That domain is already mapped', 409, 'DOMAIN_ALREADY_MAPPED');
-    }
-    throw err;
+  // ON CONFLICT DO NOTHING instead of catch-and-map: see createCatalogItem in
+  // catalogService.ts — postgres.js re-throws a raised unique violation at
+  // transaction-commit time even after it's caught here, clobbering the mapped
+  // 409 into a raw 500. A bare .onConflictDoNothing() is fine: the id PK is a
+  // generated uuid, so the only realistic conflict is
+  // customer_email_domains_partner_domain_uq.
+  const rows = await db
+    .insert(customerEmailDomains)
+    .values({
+      partnerId,
+      orgId: input.orgId,
+      domain: input.domain,
+      autoCreateContact: input.autoCreateContact,
+      createdBy: actor.userId,
+    })
+    .onConflictDoNothing()
+    .returning();
+  const row = rows[0];
+  if (!row) {
+    throw new TicketConfigServiceError('That domain is already mapped', 409, 'DOMAIN_ALREADY_MAPPED');
   }
+  return row;
 }
 
 export async function updateCustomerEmailDomain(

--- a/apps/api/src/services/timeEntryService.test.ts
+++ b/apps/api/src/services/timeEntryService.test.ts
@@ -6,11 +6,16 @@ const { dbMocks, emitMock, configMocks } = vi.hoisted(() => {
     // queue of results for successive db.select()...where()/limit() terminals
     selectResults: [] as unknown[][],
     insertResult: [] as unknown[],
+    // Per-call insert results (shifted before falling back to insertResult) —
+    // lets a test give the first timeEntries insert a conflict (empty array via
+    // onConflictDoNothing) and the retry a success row.
+    insertResultsQueue: [] as unknown[][],
     insertErrors: [] as unknown[],
     updateResult: [] as unknown[],
     insertedValues: [] as Record<string, unknown>[],
     updateSetArgs: [] as Record<string, unknown>[],
-    whereArgs: [] as unknown[]
+    whereArgs: [] as unknown[],
+    onConflictDoNothingCalls: 0
   };
   const configMocks = {
     getOrgBillingDefaults: vi.fn().mockResolvedValue(null),
@@ -54,11 +59,19 @@ vi.mock('../db', () => ({
     insert: vi.fn(() => ({
       values: vi.fn((vals: Record<string, unknown>) => {
         dbMocks.insertedValues.push(vals);
+        const returning = vi.fn(() => {
+          const err = dbMocks.insertErrors.shift();
+          if (err) return Promise.reject(err);
+          const queued = dbMocks.insertResultsQueue.shift();
+          return Promise.resolve(queued ?? dbMocks.insertResult);
+        });
         return {
-          returning: vi.fn(() => {
-            const err = dbMocks.insertErrors.shift();
-            if (err) return Promise.reject(err);
-            return Promise.resolve(dbMocks.insertResult);
+          returning,
+          // startTimer suppresses the one-running-timer conflict at the
+          // statement level (#2189): zero returned rows = lost the race.
+          onConflictDoNothing: vi.fn(() => {
+            dbMocks.onConflictDoNothingCalls += 1;
+            return { returning };
           })
         };
       })
@@ -138,9 +151,11 @@ beforeEach(() => {
   dbMocks.insertedValues.length = 0;
   dbMocks.updateSetArgs.length = 0;
   dbMocks.insertErrors.length = 0;
+  dbMocks.insertResultsQueue.length = 0;
   dbMocks.whereArgs.length = 0;
   dbMocks.insertResult = [];
   dbMocks.updateResult = [];
+  dbMocks.onConflictDoNothingCalls = 0;
   emitMock.mockClear();
   configMocks.getOrgBillingDefaults.mockResolvedValue(null);
 });
@@ -388,51 +403,47 @@ describe('startTimer / stopTimer', () => {
     await expect(stopTimer({}, ACTOR)).rejects.toMatchObject({ code: 'NO_RUNNING_TIMER', status: 404 });
   });
 
-  it('converts a second running-timer unique violation into a 409 service error', async () => {
-    const uniqueViolation = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
-    dbMocks.insertErrors.push(uniqueViolation, uniqueViolation);
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      await expect(startTimer({ description: 'race' }, ACTOR))
-        .rejects.toMatchObject({ code: 'ENTRY_RUNNING', status: 409 });
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[timeEntryService.startTimer] unique violation, retrying once',
-        uniqueViolation.message
-      );
-    } finally {
-      consoleSpy.mockRestore();
-    }
-  });
-
-  // Regression: real postgres.js/Drizzle errors nest the PG code under `.cause`
-  // (the top-level DrizzleQueryError has no `.code`). A flat `{ code: '23505' }`
-  // mock hid this — in production the unique-violation guard never matched and a
-  // raw 500 leaked instead of the retry/409 path. isUniqueViolation must unwrap.
-  it('detects a unique violation wrapped in a DrizzleQueryError cause (no top-level code)', async () => {
-    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
-    const wrapped = Object.assign(new Error('Failed query: insert into "time_entries" ...'), { cause: pgError }); // no .code on the wrapper
-    dbMocks.insertErrors.push(wrapped, wrapped);
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      await expect(startTimer({ description: 'race' }, ACTOR))
-        .rejects.toMatchObject({ code: 'ENTRY_RUNNING', status: 409 });
-    } finally {
-      consoleSpy.mockRestore();
-    }
-  });
-
-  it('retries once and succeeds when only the first start hits a wrapped unique violation', async () => {
-    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
-    const wrapped = Object.assign(new Error('Failed query: insert ...'), { cause: pgError });
+  // #2189 regression block: the one-running-timer conflict must NEVER raise a
+  // statement error. The old catch-and-retry design let the 23505 abort the
+  // surrounding withDbAccessContext transaction — the in-transaction retry then
+  // died with 25P02 (not a unique violation), so the intended 409 at the end of
+  // startTimer was unreachable, and postgres.js re-threw the raw error at
+  // commit anyway. startTimer now suppresses the conflict with ON CONFLICT DO
+  // NOTHING: zero returned rows = lost the race, no error object ever exists.
+  it('startTimer routes the running-timer insert through onConflictDoNothing', async () => {
     dbMocks.updateResult = []; // no running timer to stop
-    dbMocks.insertErrors.push(wrapped); // first attempt fails, retry uses insertResult
-    dbMocks.insertResult = [{ id: 'te-retry', endedAt: null }];
+    dbMocks.insertResult = [{ id: 'te-new', endedAt: null }];
+    await startTimer({ description: 'plain start' }, ACTOR);
+    expect(dbMocks.onConflictDoNothingCalls).toBe(1);
+  });
+
+  it('converts a persistent running-timer conflict into the typed 409 (no statement ever raises)', async () => {
+    dbMocks.updateResult = []; // nothing visible to auto-stop (e.g. an RLS-hidden running entry)
+    dbMocks.insertResultsQueue.push([], []); // both attempts lose the race → zero rows
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(startTimer({ description: 'race' }, ACTOR))
+        .rejects.toMatchObject({ name: 'TimeEntryServiceError', code: 'ENTRY_RUNNING', status: 409 });
+      expect(consoleSpy).toHaveBeenCalledWith('[timeEntryService.startTimer] running-timer conflict, retrying once');
+    } finally {
+      consoleSpy.mockRestore();
+    }
+    // Exactly two attempts: the initial insert plus one retry (each preceded by
+    // an auto-stop CAS update).
+    expect(dbMocks.insertedValues).toHaveLength(2);
+    expect(dbMocks.updateSetArgs).toHaveLength(2);
+  });
+
+  it('retries once and succeeds when only the first insert loses the running-timer race', async () => {
+    dbMocks.updateResult = []; // no running timer to stop
+    dbMocks.insertResultsQueue.push([], [{ id: 'te-retry', endedAt: null }]);
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
       await expect(startTimer({ description: 'race' }, ACTOR)).resolves.toMatchObject({ id: 'te-retry' });
     } finally {
       consoleSpy.mockRestore();
     }
+    expect(emitMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'time_entry.created', timeEntryId: 'te-retry' }));
   });
 });
 

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -3,7 +3,6 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { timeEntries, ticketParts, tickets, ticketCategories, organizations, users, ticketComments } from '../db/schema';
 import { emitTimeEntryEvent } from './timeEntryEvents';
 import { getOrgBillingDefaults } from './ticketConfigService';
-import { isPgUniqueViolation } from '../utils/pgErrors';
 import type { CreateTimeEntryInput, UpdateTimeEntryInput, TicketPartInput, BillingStatus } from '@breeze/shared';
 
 export type TimeEntryServiceErrorCode =
@@ -268,10 +267,6 @@ async function stopRunningEntry(
   return rows[0] ?? null;
 }
 
-// Unwraps the DrizzleQueryError `.cause` so the retry/409 path actually fires
-// (a bare `err.code` check missed every wrapped insert). See utils/pgErrors.
-const isUniqueViolation = (err: unknown): boolean => isPgUniqueViolation(err);
-
 export async function startTimer(input: { ticketId?: string; description?: string }, actor: TimeEntryActor) {
   let partnerId = actor.partnerId;
   let orgId: string | null = null;
@@ -300,6 +295,17 @@ export async function startTimer(input: { ticketId?: string; description?: strin
         `${actor.name ?? 'Technician'} logged ${fmtMinutes(autoStopped.durationMinutes)}${autoStopped.isBillable ? ' (billable)' : ''}`
       );
     }
+    // ON CONFLICT DO NOTHING instead of catch-and-retry (issue #2189): the
+    // request runs inside the withDbAccessContext transaction, so a raised
+    // 23505 on time_entries_one_running_per_user_uq ABORTED that transaction —
+    // the old catch-then-retry re-ran attempt() inside the aborted transaction,
+    // the retry failed with 25P02 (not a unique violation), and postgres.js
+    // substituted the original raw error back in at commit, so the intended
+    // 409 below was unreachable and callers always got a raw 500. Suppressing
+    // the conflict at the statement level keeps the transaction healthy: zero
+    // rows back means we lost the one-running-timer-per-user race (including
+    // to a running entry that partner-axis RLS hides from this context, which
+    // stopRunningEntry can never see or stop).
     const rows = await db
       .insert(timeEntries)
       .values({
@@ -315,25 +321,20 @@ export async function startTimer(input: { ticketId?: string; description?: strin
         hourlyRate: defaultRate,
         billingStatus: 'not_billed'
       })
+      .onConflictDoNothing()
       .returning();
-    return rows[0]!;
+    return rows[0] ?? null;
   };
 
-  let entry: typeof timeEntries.$inferSelect;
-  try {
+  let entry = await attempt();
+  if (!entry) {
+    // Lost the race: another start slipped in between the auto-stop and our
+    // insert — stop that one too and retry once.
+    console.error('[timeEntryService.startTimer] running-timer conflict, retrying once');
     entry = await attempt();
-  } catch (err) {
-    if (!isUniqueViolation(err)) throw err;
-    // Lost the race: another start slipped in — stop it and retry once.
-    console.error('[timeEntryService.startTimer] unique violation, retrying once', err instanceof Error ? err.message : err);
-    try {
-      entry = await attempt();
-    } catch (retryErr) {
-      if (isUniqueViolation(retryErr)) {
-        throw new TimeEntryServiceError('Timer start conflicted with a concurrent request — try again', 409, 'ENTRY_RUNNING');
-      }
-      throw retryErr;
-    }
+  }
+  if (!entry) {
+    throw new TimeEntryServiceError('Timer start conflicted with a concurrent request — try again', 409, 'ENTRY_RUNNING');
   }
 
   await emitTimeEntryEvent({


### PR DESCRIPTION
## Summary

Three related fixes rooted in one production bug (TD SYNNEX catalog import returning `Internal Server Error` when re-importing an existing SKU):

**1. Catalog import duplicate-SKU 500 → 409** (`46f0ac65f`). `createCatalogItem` mapped the unique violation to a 409 at every layer, but the request runs inside the `withDbAccessContext` transaction and postgres.js `begin()` re-throws the recorded raw query error at commit even after the app handled it — so the client always saw a raw 500. Fixed with `onConflictDoNothing().returning()` + zero-rows → 409 (create) and a pre-check SELECT (update), so the expected conflict never raises and the transaction stays healthy.

**2. Sweep of the same pattern across the API** (`33d1f31a2`). Every other request-path site that caught a unique violation and mapped it to a 4xx/friendly result had the same deterministic clobber — ten sites: incidents, network known-guests, network baselines, config-policy assignments + feature links (fixed in `configurationPolicy.assignPolicy`/`addFeatureLink`, all four callers updated to a null-on-conflict contract), the AI config/network tools, `ticketConfigService` (creates + rename pre-check), `partnerStripe` (cross-partner `stripe_account_id` claim pre-checked under a short system context, since partner-axis RLS makes an in-context pre-check silently vacuous), and `timeEntryService.startTimer`, whose catch-and-retry re-ran inside the aborted transaction making its intended 409 unreachable. Also adds a real-DB spike test proving nested Drizzle transactions (SAVEPOINT) isolate errors from the outer `begin()` scope, for future sites where statement-level suppression doesn't fit.

**3. Distributor import AI enrichment conn-hold** (`dc24fa77c`). All three distributor importers (TD SYNNEX Digital Bridge, EC Express, Pax8) awaited the up-to-12s `enrichDistributorListing` call inside the ambient request transaction, pinning a pooled connection idle-in-transaction (#1105 class — the held-context tripwire fired in production). The import routes now join the #1448 `SELF_MANAGED_DB_CONTEXT_ROUTES` opt-out and the importers open short request-scoped contexts around just their DB ops; `enrichDistributorListing` gained an `assertOutsideHeldDbContext` tripwire. `aiCostTracker`'s budget/usage path self-contexts its DB ops via `withSystemDbAccessContext` (ambient-context callers are unchanged; contextless, `checkAiRateLimit`'s org read would otherwise 404 and silently disable enrichment entirely).

## Test plan

- 11,449 API unit tests green (the 2 remaining failures are known parallel-run flakes — `mcpServer.effectiveTier` / `encryptedColumnRegistry` — which pass in isolation and vary run-to-run).
- 47/47 integration tests against real Postgres, including new poisoned-transaction regressions that perform the duplicate attempt inside one `withDbAccessContext` and keep using the transaction (these fail with the `25P02` abort signature against the old code), partnerStripe cross-partner claim, time-entry RLS-hidden-running-entry, and the savepoint isolation spike.
- `tsc --noEmit` clean.

Closes #2189
Closes #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)