### PR TITLE
feat(auth): partner-scope SSO for MSP technicians + login-page branding

### DIFF
--- a/apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql
+++ b/apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql
@@ -1,0 +1,106 @@
+-- Partner-axis SSO providers + partner login branding (#2183, epic #2135 playbook).
+--
+-- sso_providers becomes dual-ownership: org-axis (org_id set, partner_id NULL —
+-- the existing customer-org SSO shape) OR partner-axis (partner_id set, org_id
+-- NULL — the MSP's own technician login). Exactly one axis per row (CHECK).
+-- user_sso_identities is unchanged: it keys off provider_id, and the provider
+-- row carries ownership. sso_sessions gains a nullable link_user_id: when set,
+-- the session is a LINK-mode round-trip (an already-authenticated user
+-- connecting their SSO identity) rather than a login. sso_verified_domains
+-- stays org-only (it gates JIT, which partner-axis providers do not do in v1).
+--
+-- partner_login_branding is deliberately partner-ONLY (not dual-axis): org-level
+-- login branding already exists as portal_branding.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. No inner BEGIN/COMMIT (autoMigrate wraps each file).
+
+-- ============================================
+-- Step 1: sso_providers — add partner_id, relax org_id, exactly-one-axis
+-- ============================================
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE sso_providers
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sso_providers_one_owner_chk'
+      AND conrelid = 'sso_providers'::regclass
+  ) THEN
+    ALTER TABLE sso_providers
+      ADD CONSTRAINT sso_providers_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sso_providers_partner_id_idx
+  ON sso_providers(partner_id);
+
+-- Link-mode marker for the self-service Connect SSO flow: when set, the
+-- callback links the verified identity to THIS user instead of logging in.
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS link_user_id uuid REFERENCES users(id);
+
+-- ============================================
+-- Step 2: sso_providers RLS — dual-axis (org OR partner) + FORCE
+-- ============================================
+
+ALTER TABLE sso_providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_providers FORCE ROW LEVEL SECURITY;
+
+-- Pre-existing policies on this table are per-command
+-- (breeze_org_isolation_{select,insert,update,delete}), not the single-name
+-- shape assumed elsewhere in this playbook. Drop all of them plus the
+-- conventionally-named single policy, whichever exist, before creating the
+-- combined dual-axis policy below.
+DROP POLICY IF EXISTS breeze_org_isolation_select ON sso_providers;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON sso_providers;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON sso_providers;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON sso_providers;
+DROP POLICY IF EXISTS sso_providers_org_isolation ON sso_providers;
+
+CREATE POLICY sso_providers_org_isolation
+  ON sso_providers
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: partner_login_branding — table + partner-axis RLS + FORCE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS partner_login_branding (
+  partner_id uuid PRIMARY KEY REFERENCES partners(id) ON DELETE CASCADE,
+  logo_url text,
+  accent_color varchar(7),
+  headline varchar(120),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+ALTER TABLE partner_login_branding ENABLE ROW LEVEL SECURITY;
+ALTER TABLE partner_login_branding FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS partner_login_branding_partner_isolation ON partner_login_branding;
+CREATE POLICY partner_login_branding_partner_isolation
+  ON partner_login_branding
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR public.breeze_has_partner_access(partner_id)
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR public.breeze_has_partner_access(partner_id)
+  );

--- a/apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql
+++ b/apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql
@@ -46,6 +46,20 @@ CREATE INDEX IF NOT EXISTS sso_providers_partner_id_idx
 ALTER TABLE sso_sessions
   ADD COLUMN IF NOT EXISTS link_user_id uuid REFERENCES users(id);
 
+-- ON DELETE CASCADE for link_user_id: an abandoned link session (user starts
+-- Connect SSO, never completes it) is never cleaned up -- the callback only
+-- deletes CLAIMED sessions -- so a lingering row pins the user row. Without
+-- CASCADE, a hard user delete (account deletion, tenant-cascade canary
+-- purges) hits FK 23503 and aborts; sso_sessions has no partner_id/org_id so
+-- the tenant-cascade sweep never reaches it either. Guarded constraint-swap
+-- (not relying on ADD COLUMN IF NOT EXISTS re-run semantics, since the
+-- column above already exists pre-fix on dev DBs): drop the constraint if
+-- present, then re-add it with CASCADE. Idempotent on repeated runs.
+ALTER TABLE sso_sessions DROP CONSTRAINT IF EXISTS sso_sessions_link_user_id_fkey;
+ALTER TABLE sso_sessions
+  ADD CONSTRAINT sso_sessions_link_user_id_fkey
+  FOREIGN KEY (link_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
 -- ============================================
 -- Step 2: sso_providers RLS — dual-axis (org OR partner) + FORCE
 -- ============================================

--- a/apps/api/src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * partner_login_branding RLS — partner-axis (Shape 3) enforcement (#2183).
+ *
+ * Migration under test: 2026-07-03-sso-partner-axis-login-branding.sql.
+ *
+ * partner_login_branding is deliberately partner-ONLY (no org axis): one row
+ * per partner, PK = partner_id, FK ON DELETE CASCADE to partners. Policy
+ * (USING + WITH CHECK):
+ *   breeze_current_scope() = 'system' OR breeze_has_partner_access(partner_id)
+ *
+ * Runs through the REAL postgres.js driver (breeze_app role, rolbypassrls=f
+ * — see setup.ts), so RLS is genuinely enforced and these assertions are not
+ * vacuous. See memory: worktree_env_test_rls_vacuous.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { partnerLoginBranding, partners } from '../../db/schema';
+import { createPartner } from './db-utils';
+
+function partnerContext(partnerId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+const systemContext: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+describe('partner_login_branding RLS — partner-axis (2026-07-03 migration)', () => {
+  it('partner A can upsert its own login-branding row', async () => {
+    const partnerA = await createPartner();
+
+    const inserted = await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db
+        .insert(partnerLoginBranding)
+        .values({ partnerId: partnerA.id, headline: 'Welcome to Acme MSP', accentColor: '#336699' })
+        .returning(),
+    );
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.partnerId).toBe(partnerA.id);
+
+    const upserted = await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db
+        .insert(partnerLoginBranding)
+        .values({ partnerId: partnerA.id, headline: 'Welcome back', accentColor: '#336699' })
+        .onConflictDoUpdate({
+          target: partnerLoginBranding.partnerId,
+          set: { headline: 'Welcome back' },
+        })
+        .returning(),
+    );
+    expect(upserted).toHaveLength(1);
+    expect(upserted[0]?.headline).toBe('Welcome back');
+  });
+
+  it('partner B forging partner A\'s partner_id is rejected (42501)', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id), () =>
+        db
+          .insert(partnerLoginBranding)
+          .values({ partnerId: partnerA.id, headline: 'Forged branding' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('partner B sees nothing when selecting partner A\'s branding row', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db.insert(partnerLoginBranding).values({ partnerId: partnerA.id, headline: 'Acme MSP' }).returning(),
+    );
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id), () =>
+      db
+        .select({ partnerId: partnerLoginBranding.partnerId })
+        .from(partnerLoginBranding)
+        .where(eq(partnerLoginBranding.partnerId, partnerA.id)),
+    );
+    expect(visibleToB).toEqual([]);
+  });
+
+  it('DELETE FROM partners cascades to remove the branding row (ON DELETE CASCADE)', async () => {
+    const partnerA = await createPartner();
+
+    await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db.insert(partnerLoginBranding).values({ partnerId: partnerA.id, headline: 'Acme MSP' }).returning(),
+    );
+
+    await withDbAccessContext(systemContext, () => db.delete(partners).where(eq(partners.id, partnerA.id)));
+
+    const remaining = await withDbAccessContext(systemContext, () =>
+      db
+        .select({ partnerId: partnerLoginBranding.partnerId })
+        .from(partnerLoginBranding)
+        .where(eq(partnerLoginBranding.partnerId, partnerA.id)),
+    );
+    expect(remaining).toEqual([]);
+
+    // Belt-and-suspenders: confirm the row is genuinely gone at the storage
+    // level, not just filtered out by RLS on a system-scope read.
+    const count = await withDbAccessContext(systemContext, () =>
+      db.execute(sql`SELECT count(*)::int AS n FROM partner_login_branding WHERE partner_id = ${partnerA.id}`),
+    );
+    expect((count as unknown as { n: number }[])[0]?.n).toBe(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -196,6 +196,10 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // are direct org_id (Shape 1) and are auto-discovered — not listed here.
   ['unifi_integrations', 'partner_id'],
   ['unifi_sync_runs', 'partner_id'],
+  // partner_login_branding (#2183): login-page branding for the MSP's own
+  // technician login. Deliberately partner-ONLY (no org axis) — see
+  // 2026-07-03-sso-partner-axis-login-branding.sql. partner_id is the PK.
+  ['partner_login_branding', 'partner_id'],
 ]);
 
 // Tables whose policies reference both helpers (org OR partner). `users`
@@ -314,6 +318,14 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   'notification_channels',
   'notification_routing_rules',
   'escalation_policies',
+  // sso_providers (#2183): org-axis (org_id set — customer-org SSO, the
+  // original shape) OR partner-axis (partner_id set, org_id NULL — MSP
+  // technician login). Converted in 2026-07-03-sso-partner-axis-login-branding.
+  // Org auto-discovery asserts the org branch; this entry asserts the
+  // breeze_has_partner_access branch. CHECK sso_providers_one_owner_chk
+  // enforces exactly one axis. Functional forge proof:
+  // ssoProvidersPartnerRls.integration.test.ts.
+  'sso_providers',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -11,6 +11,15 @@
  * limiting) is real, the same pattern used by routes/sso.test.ts's mocked-db
  * unit suite but here against the genuine `breeze_app` RLS-enforced pool.
  *
+ * Also includes ONE org-axis callback case (see "org-axis callback" test
+ * below) to regression-lock the shared `withSystemDbAccessContext` fix to
+ * the callback's provider read — that fix is shared plumbing hit by BOTH
+ * axes, so a partner-only suite wouldn't catch a regression on the org side.
+ * That case seeds `sso_sessions` directly rather than going through
+ * `GET /sso/login/:orgId`, because that route's own provider read is a
+ * SEPARATE, pre-existing, unfixed bare-db bug (see PR description) that
+ * always 404s regardless of this fix.
+ *
  * Prerequisites:
  *   docker compose -f docker-compose.test.yml up -d
  *
@@ -23,9 +32,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { decodeJwt } from 'jose';
 import { eq } from 'drizzle-orm';
+import { createHmac } from 'crypto';
 import { getTestDb } from './setup';
 import { ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
-import { createPartner, createOrganization, createRole, assignUserToPartner } from './db-utils';
+import {
+  createPartner,
+  createOrganization,
+  createRole,
+  assignUserToPartner,
+  assignUserToOrganization,
+} from './db-utils';
 import { encryptSecret } from '../../services/secretCrypto';
 import { createAccessToken } from '../../services/jwt';
 
@@ -39,7 +55,7 @@ vi.mock('../../services/sso', async (importOriginal) => {
   };
 });
 
-import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature } from '../../services/sso';
+import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature, generateState, generateNonce } from '../../services/sso';
 import { ssoRoutes } from '../../routes/sso';
 
 // buildSsoStateCookieValue (routes/sso.ts) requires one of these to be set —
@@ -114,6 +130,18 @@ function extractSsoCodeFromLocation(location: string): string {
   const match = location.match(/#ssoCode=([^&]+)/);
   if (!match || !match[1]) throw new Error(`no #ssoCode fragment in redirect location: ${location}`);
   return decodeURIComponent(match[1]);
+}
+
+/** Reproduces routes/sso.ts's buildSsoStateCookieValue (not exported) so a
+ * directly-seeded session (see the org-axis test) can present a
+ * browser-binding cookie the callback will accept without going through the
+ * real /login/:orgId route — whose OWN provider read is a separate,
+ * pre-existing, unfixed bare-db bug that always 404s regardless of this
+ * suite's fix (see PR description). */
+function buildTestSsoStateCookie(state: string): string {
+  const secret = process.env.APP_ENCRYPTION_KEY!;
+  const value = createHmac('sha256', secret).update(`sso-login-state:${state}`).digest('hex');
+  return `breeze_sso_state=${encodeURIComponent(value)}`;
 }
 
 describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', () => {
@@ -394,6 +422,93 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     expect(secondPayload.sub).toBe(passwordUser.id);
     expect(secondPayload.partnerId).toBe(partner.id);
     expect(secondPayload.orgId).toBeNull();
+  });
+
+  it('org-axis callback: the shared provider-read fix resolves an org provider too (regression lock for both axes)', async () => {
+    // This is the ORG-axis sibling of the "Get provider" fix's regression
+    // coverage. The fix (routes/sso.ts, wrapping the callback's provider
+    // read in withSystemDbAccessContext) is shared plumbing hit identically
+    // by both axes — if it regressed back to a bare `db` read, an org-axis
+    // provider would 0-row exactly like a partner-axis one, and this test
+    // would see `provider_not_found`/`session_expired` instead of the
+    // asserted `no_org_access`.
+    //
+    // We can't reach this via GET /sso/login/:orgId — that route's OWN
+    // provider read is a separate, pre-existing, unfixed bare-db bug (see
+    // PR description) that always 404s. So the sso_sessions row is seeded
+    // directly instead (that table carries no RLS policy at all — confirmed
+    // empirically and via migration grep — so a direct insert is a faithful
+    // stand-in for what a working initiation route would have written).
+    //
+    // The org-axis callback has its OWN separate, pre-existing, unfixed
+    // bare-db bug too — the final organizationUsers membership check
+    // (routes/sso.ts, org branch of the token-payload switch) — which always
+    // 0-rows and yields `no_org_access` regardless of real membership. That
+    // is NOT what this test is regression-locking (org-axis behavior is out
+    // of scope for this fix); it's simply the accurate, currently-true
+    // outcome once the provider resolves correctly. The important signal is
+    // that the callback gets THIS far at all — proving the shared fix works
+    // for the org axis, not just partner.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await createPasswordlessUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `org-user-${Date.now()}@example.com`,
+    });
+    await assignUserToOrganization(user.id, org.id, role.id);
+
+    const db = getTestDb();
+    const [orgProvider] = await db
+      .insert(ssoProviders)
+      .values({
+        orgId: org.id,
+        partnerId: null,
+        name: 'Org IdP',
+        type: 'oidc',
+        status: 'active',
+        issuer: ISSUER,
+        clientId: 'test-client-id',
+        clientSecret: encryptSecret('test-client-secret'),
+        authorizationUrl: `${ISSUER}/authorize`,
+        tokenUrl: `${ISSUER}/token`,
+        userInfoUrl: `${ISSUER}/userinfo`,
+        jwksUrl: `${ISSUER}/jwks`,
+        autoProvision: false,
+      })
+      .returning();
+    if (!orgProvider) throw new Error('failed to create org-axis provider fixture');
+
+    const state = generateState();
+    const nonce = generateNonce();
+    await db.insert(ssoSessions).values({
+      providerId: orgProvider.id,
+      state,
+      nonce,
+      codeVerifier: null,
+      redirectUrl: '/',
+      linkUserId: null,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-org', user.email, nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-org', email: user.email, name: 'Org User' });
+
+    const callbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${state}`, {
+      headers: { cookie: buildTestSsoStateCookie(state) },
+    });
+    expect(callbackRes.status).toBe(302);
+    // Exact match (not `.toContain`): a regression back to the bare provider
+    // read would land on a DIFFERENT error (provider_not_found), so this
+    // assertion fails loudly rather than passing on the wrong redirect.
+    expect(callbackRes.headers.get('location')).toBe('/login?error=no_org_access');
+
+    // The session row was still atomically claimed (deleted) — proves the
+    // callback reached past the session-claim step and into provider
+    // resolution, not an early bail before ever touching the DB.
+    const [claimedSession] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
+    expect(claimedSession).toBeUndefined();
   });
 });
 

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -525,6 +525,50 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     expect(identity?.userId).toBe(user.id);
     expect(identity?.externalId).toBe('external-sub-org');
   });
+
+  it('sso_sessions.link_user_id ON DELETE CASCADE: an abandoned link session never blocks a hard user delete', async () => {
+    // An abandoned Connect SSO link attempt (user starts POST /sso/link/start
+    // but never completes the callback) leaves an sso_sessions row with
+    // link_user_id set — the callback only deletes CLAIMED sessions, so this
+    // row is never cleaned up on its own. sso_sessions has no partner_id/
+    // org_id, so the tenant-cascade sweep never reaches it either. Without
+    // ON DELETE CASCADE on link_user_id, a hard user delete (account
+    // deletion, tenant-cascade canary purges) would hit FK 23503 and abort.
+    const partner = await createPartner();
+    const provider = await createPartnerAxisProvider(partner.id);
+    const user = await createPasswordlessUser({
+      partnerId: partner.id,
+      email: `abandoned-link-${Date.now()}@example.com`,
+    });
+
+    const db = getTestDb();
+    await db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state: generateState(),
+      nonce: generateNonce(),
+      codeVerifier: null,
+      redirectUrl: '/settings/profile',
+      linkUserId: user.id,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+
+    const [pendingSession] = await db
+      .select()
+      .from(ssoSessions)
+      .where(eq(ssoSessions.linkUserId, user.id))
+      .limit(1);
+    expect(pendingSession).toBeDefined();
+
+    // The hard delete must succeed without an FK violation.
+    await expect(db.delete(users).where(eq(users.id, user.id))).resolves.not.toThrow();
+
+    const [afterDelete] = await db
+      .select()
+      .from(ssoSessions)
+      .where(eq(ssoSessions.linkUserId, user.id))
+      .limit(1);
+    expect(afterDelete).toBeUndefined();
+  });
 });
 
 // ── shared helpers ──────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -12,13 +12,14 @@
  * unit suite but here against the genuine `breeze_app` RLS-enforced pool.
  *
  * Also includes ONE org-axis callback case (see "org-axis callback" test
- * below) to regression-lock the shared `withSystemDbAccessContext` fix to
- * the callback's provider read — that fix is shared plumbing hit by BOTH
- * axes, so a partner-only suite wouldn't catch a regression on the org side.
- * That case seeds `sso_sessions` directly rather than going through
+ * below) to regression-lock the TWO `withSystemDbAccessContext` fixes to
+ * the callback's shared plumbing (the provider read, and the org-membership
+ * read in the org branch of the token-payload switch) — both are shared by
+ * BOTH axes, so a partner-only suite wouldn't catch a regression on the org
+ * side. That case seeds `sso_sessions` directly rather than going through
  * `GET /sso/login/:orgId`, because that route's own provider read is a
- * SEPARATE, pre-existing, unfixed bare-db bug (see PR description) that
- * always 404s regardless of this fix.
+ * SEPARATE, still-pre-existing, unfixed bare-db bug (see PR description)
+ * that always 404s independent of the callback fixes.
  *
  * Prerequisites:
  *   docker compose -f docker-compose.test.yml up -d
@@ -424,31 +425,26 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     expect(secondPayload.orgId).toBeNull();
   });
 
-  it('org-axis callback: the shared provider-read fix resolves an org provider too (regression lock for both axes)', async () => {
-    // This is the ORG-axis sibling of the "Get provider" fix's regression
-    // coverage. The fix (routes/sso.ts, wrapping the callback's provider
-    // read in withSystemDbAccessContext) is shared plumbing hit identically
-    // by both axes — if it regressed back to a bare `db` read, an org-axis
-    // provider would 0-row exactly like a partner-axis one, and this test
-    // would see `provider_not_found`/`session_expired` instead of the
-    // asserted `no_org_access`.
+  it('org-axis callback: full login succeeds and mints a scope:organization token (regression lock for both axes)', async () => {
+    // This is the ORG-axis sibling of the callback's shared-plumbing fixes:
+    // both the "Get provider" read AND the org-membership read (org branch
+    // of the token-payload switch) were bare `db` reads that 0-rowed under
+    // real RLS — the first blocked EVERY axis at provider resolution, the
+    // second specifically blocked org-axis at the final membership check.
+    // Both are now wrapped in withSystemDbAccessContext, matching every
+    // other pre-auth read in this handler. This test drives a full org-axis
+    // login to a successfully minted token, so a regression in EITHER fix
+    // fails loudly here: reverting the provider-read fix yields
+    // `provider_not_found`; reverting the membership-read fix yields
+    // `no_org_access` — neither matches the asserted `#ssoCode=` success path.
     //
     // We can't reach this via GET /sso/login/:orgId — that route's OWN
-    // provider read is a separate, pre-existing, unfixed bare-db bug (see
-    // PR description) that always 404s. So the sso_sessions row is seeded
-    // directly instead (that table carries no RLS policy at all — confirmed
-    // empirically and via migration grep — so a direct insert is a faithful
-    // stand-in for what a working initiation route would have written).
-    //
-    // The org-axis callback has its OWN separate, pre-existing, unfixed
-    // bare-db bug too — the final organizationUsers membership check
-    // (routes/sso.ts, org branch of the token-payload switch) — which always
-    // 0-rows and yields `no_org_access` regardless of real membership. That
-    // is NOT what this test is regression-locking (org-axis behavior is out
-    // of scope for this fix); it's simply the accurate, currently-true
-    // outcome once the provider resolves correctly. The important signal is
-    // that the callback gets THIS far at all — proving the shared fix works
-    // for the org axis, not just partner.
+    // provider read is a separate, still-pre-existing, unfixed bare-db bug
+    // (see PR description) that always 404s. So the sso_sessions row is
+    // seeded directly instead (that table carries no RLS policy at all —
+    // confirmed empirically and via migration grep — so a direct insert is a
+    // faithful stand-in for what a working initiation route would have
+    // written).
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
     const role = await createRole({ scope: 'organization', orgId: org.id });
@@ -499,16 +495,35 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
       headers: { cookie: buildTestSsoStateCookie(state) },
     });
     expect(callbackRes.status).toBe(302);
-    // Exact match (not `.toContain`): a regression back to the bare provider
-    // read would land on a DIFFERENT error (provider_not_found), so this
-    // assertion fails loudly rather than passing on the wrong redirect.
-    expect(callbackRes.headers.get('location')).toBe('/login?error=no_org_access');
+    const location = callbackRes.headers.get('location');
+    expect(location).toContain('#ssoCode=');
 
-    // The session row was still atomically claimed (deleted) — proves the
-    // callback reached past the session-claim step and into provider
-    // resolution, not an early bail before ever touching the DB.
+    // The session row was atomically claimed (deleted).
     const [claimedSession] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
     expect(claimedSession).toBeUndefined();
+
+    const ssoCode = extractSsoCodeFromLocation(location!);
+    const exchangeRes = await app.request('/sso/exchange', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: ssoCode }),
+    });
+    expect(exchangeRes.status).toBe(200);
+    const exchangeBody = await exchangeRes.json();
+    const payload = decodeJwt(exchangeBody.accessToken);
+    expect(payload.scope).toBe('organization');
+    expect(payload.orgId).toBe(org.id);
+    expect(payload.partnerId).toBeNull();
+    expect(payload.roleId).toBe(role.id);
+    expect(payload.sub).toBe(user.id);
+
+    const [identity] = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(eq(userSsoIdentities.providerId, orgProvider.id))
+      .limit(1);
+    expect(identity?.userId).toBe(user.id);
+    expect(identity?.externalId).toBe('external-sub-org');
   });
 });
 

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Real-DB end-to-end partner-axis SSO login + Connect SSO link flow (#2183).
+ *
+ * Exercises the actual route handlers (`ssoRoutes`) against real Postgres +
+ * Redis, through the full HTTP surface: GET /sso/login/partner/:partnerId →
+ * GET /sso/callback → POST /sso/exchange, plus the authenticated Connect SSO
+ * link round-trip (POST /sso/link/start/:providerId → GET /sso/callback).
+ * Only the IdP network calls are stubbed (exchangeCodeForTokens,
+ * getUserInfo, verifyIdTokenSignature) — everything else (state/nonce/PKCE
+ * generation, cookie binding, DB reads/writes, RLS, JWT minting, rate
+ * limiting) is real, the same pattern used by routes/sso.test.ts's mocked-db
+ * unit suite but here against the genuine `breeze_app` RLS-enforced pool.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { decodeJwt } from 'jose';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
+import { createPartner, createOrganization, createRole, assignUserToPartner } from './db-utils';
+import { encryptSecret } from '../../services/secretCrypto';
+import { createAccessToken } from '../../services/jwt';
+
+vi.mock('../../services/sso', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/sso')>();
+  return {
+    ...actual,
+    exchangeCodeForTokens: vi.fn(),
+    getUserInfo: vi.fn(),
+    verifyIdTokenSignature: vi.fn(),
+  };
+});
+
+import { exchangeCodeForTokens, getUserInfo, verifyIdTokenSignature } from '../../services/sso';
+import { ssoRoutes } from '../../routes/sso';
+
+// buildSsoStateCookieValue (routes/sso.ts) requires one of these to be set —
+// .env.test doesn't provide either, so the login-initiation route 500s
+// ("SSO login binding secret is not configured") without it.
+process.env.APP_ENCRYPTION_KEY = 'integration-test-app-encryption-key-32-bytes!';
+
+const ISSUER = 'https://idp.example.test';
+
+async function createPartnerAxisProvider(partnerId: string, opts: { trustsIdpMfa?: boolean } = {}) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId: null,
+      partnerId,
+      name: 'Partner IdP',
+      type: 'oidc',
+      status: 'active',
+      issuer: ISSUER,
+      clientId: 'test-client-id',
+      clientSecret: encryptSecret('test-client-secret'),
+      authorizationUrl: `${ISSUER}/authorize`,
+      tokenUrl: `${ISSUER}/token`,
+      userInfoUrl: `${ISSUER}/userinfo`,
+      jwksUrl: `${ISSUER}/jwks`,
+      trustsIdpMfa: opts.trustsIdpMfa ?? false,
+      autoProvision: false,
+    })
+    .returning();
+  if (!row) throw new Error('failed to create partner-axis provider fixture');
+  return row;
+}
+
+/** Insert a user row directly (bypassing db-utils' createUser, which always
+ * hashes a password) so passwordHash can be left null for SSO-only staff. */
+async function createPasswordlessUser(opts: { partnerId: string; orgId?: string | null; email: string; name?: string }) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(users)
+    .values({
+      partnerId: opts.partnerId,
+      orgId: opts.orgId ?? null,
+      email: opts.email,
+      name: opts.name ?? 'Test User',
+      passwordHash: null,
+      status: 'active',
+    })
+    .returning();
+  if (!row) throw new Error('failed to create passwordless user fixture');
+  return row;
+}
+
+function extractStateFromLocation(location: string): string {
+  const url = new URL(location);
+  const state = url.searchParams.get('state');
+  if (!state) throw new Error(`no state param in redirect location: ${location}`);
+  return state;
+}
+
+/** Pull just the `name=value` pair out of a Set-Cookie header, discarding
+ * attributes (Path/HttpOnly/SameSite/Max-Age), for use as a Cookie header
+ * on the follow-up callback request. */
+function extractCookiePair(setCookieHeader: string): string {
+  const first = setCookieHeader.split(',')[0] ?? setCookieHeader;
+  const pair = first.split(';')[0]?.trim();
+  if (!pair) throw new Error(`could not parse Set-Cookie header: ${setCookieHeader}`);
+  return pair;
+}
+
+function extractSsoCodeFromLocation(location: string): string {
+  const match = location.match(/#ssoCode=([^&]+)/);
+  if (!match || !match[1]) throw new Error(`no #ssoCode fragment in redirect location: ${location}`);
+  return decodeURIComponent(match[1]);
+}
+
+describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.route('/sso', ssoRoutes);
+    vi.mocked(exchangeCodeForTokens).mockReset().mockResolvedValue({
+      access_token: 'idp-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'idp-refresh-token',
+      id_token: 'header.payload.signature',
+    });
+  });
+
+  afterEach(() => {
+    vi.mocked(exchangeCodeForTokens).mockClear();
+    vi.mocked(getUserInfo).mockClear();
+    vi.mocked(verifyIdTokenSignature).mockClear();
+  });
+
+  it('full partner-axis login mints a scope:partner token for the linked user', async () => {
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const user = await createPasswordlessUser({
+      partnerId: partner.id,
+      email: `tech-${Date.now()}@example.com`,
+    });
+    await assignUserToPartner(user.id, partner.id, role.id, 'all');
+    const provider = await createPartnerAxisProvider(partner.id);
+
+    // Step 1: GET /sso/login/partner/:partnerId → 302 to IdP, session row
+    // created, state cookie set.
+    const loginRes = await app.request(`/sso/login/partner/${partner.id}`);
+    expect(loginRes.status).toBe(302);
+    const location = loginRes.headers.get('location');
+    expect(location).toBeTruthy();
+    expect(location).toContain(ISSUER);
+
+    const setCookie = loginRes.headers.get('set-cookie');
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toContain('breeze_sso_state=');
+
+    const state = extractStateFromLocation(location!);
+    const db = getTestDb();
+    const [sessionRow] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
+    expect(sessionRow).toBeDefined();
+    expect(sessionRow?.providerId).toBe(provider.id);
+    expect(sessionRow?.linkUserId).toBeNull();
+
+    // Step 2: GET /sso/callback with matching state/cookie + stubbed IdP
+    // responses asserting the user's email → 302 with #ssoCode=.
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue({
+      iss: ISSUER,
+      sub: 'external-sub-tech-1',
+      aud: 'test-client-id',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+      nonce: sessionRow!.nonce,
+      email: user.email,
+      email_verified: true,
+    });
+    vi.mocked(getUserInfo).mockResolvedValue({
+      sub: 'external-sub-tech-1',
+      email: user.email,
+      name: user.name ?? 'Tech',
+    });
+
+    const callbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${state}`, {
+      headers: { cookie: extractCookiePair(setCookie!) },
+    });
+    expect(callbackRes.status).toBe(302);
+    const callbackLocation = callbackRes.headers.get('location');
+    expect(callbackLocation).toBeTruthy();
+    expect(callbackLocation).toContain('#ssoCode=');
+
+    // The session row was atomically claimed (deleted) by the callback.
+    const [claimedSession] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
+    expect(claimedSession).toBeUndefined();
+
+    // Step 3: POST /sso/exchange { code } → accessToken with the expected
+    // scope:'partner' claims.
+    const ssoCode = extractSsoCodeFromLocation(callbackLocation!);
+    const exchangeRes = await app.request('/sso/exchange', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: ssoCode }),
+    });
+    expect(exchangeRes.status).toBe(200);
+    const exchangeBody = await exchangeRes.json();
+    expect(exchangeBody.accessToken).toBeDefined();
+
+    const payload = decodeJwt(exchangeBody.accessToken);
+    expect(payload.scope).toBe('partner');
+    expect(payload.partnerId).toBe(partner.id);
+    expect(payload.orgId).toBeNull();
+    expect(payload.roleId).toBe(role.id);
+    expect(payload.mfa).toBe(false);
+    expect(payload.sub).toBe(user.id);
+
+    // The identity link + last-login stamp were persisted under system
+    // context (bare reads would silently 0-row under RLS — see PR sweep notes).
+    const [identity] = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(eq(userSsoIdentities.providerId, provider.id))
+      .limit(1);
+    expect(identity?.userId).toBe(user.id);
+    expect(identity?.externalId).toBe('external-sub-tech-1');
+  });
+
+  it('an org-bound user with the same email domain never resolves through the partner provider (email-match exclusion)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await createPartnerAxisProvider(partner.id);
+
+    // orgId set → excluded by the partner-axis email condition
+    // (partnerId match AND orgId IS NULL), even though the email matches
+    // exactly and the partner is the same as the provider's.
+    const orgBoundUser = await createPasswordlessUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `org-bound-${Date.now()}@example.com`,
+    });
+
+    const state = await initiatePartnerLogin(app, partner.id);
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-org-bound', orgBoundUser.email, state.nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-org-bound', email: orgBoundUser.email, name: 'Org Bound' });
+
+    const callbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${state.state}`, {
+      headers: { cookie: state.cookiePair },
+    });
+    expect(callbackRes.status).toBe(302);
+    const location = callbackRes.headers.get('location');
+    expect(location).toContain('/login?error=invite_required');
+  });
+
+  it('mint gate: a pre-linked org-bound user with partner membership is still rejected at token mint (no_partner_access)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const provider = await createPartnerAxisProvider(partner.id);
+
+    const orgBoundUser = await createPasswordlessUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `mint-gate-${Date.now()}@example.com`,
+    });
+    // Give the org-bound user a partner_users membership too, so membership
+    // is NOT what blocks this — the mint-gate's `user.orgId != null` check
+    // must fire first, independent of membership.
+    await assignUserToPartner(orgBoundUser.id, partner.id, role.id, 'all');
+
+    const db = getTestDb();
+    await db.insert(userSsoIdentities).values({
+      userId: orgBoundUser.id,
+      providerId: provider.id,
+      externalId: 'external-sub-mint-gate',
+      email: orgBoundUser.email,
+    });
+
+    const state = await initiatePartnerLogin(app, partner.id);
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-mint-gate', orgBoundUser.email, state.nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-mint-gate', email: orgBoundUser.email, name: 'Mint Gate' });
+
+    const callbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${state.state}`, {
+      headers: { cookie: state.cookiePair },
+    });
+    expect(callbackRes.status).toBe(302);
+    expect(callbackRes.headers.get('location')).toContain('/login?error=no_partner_access');
+  });
+
+  it('Connect SSO: password-holding partner tech gets sso_link_required at login, then links, then SSO login succeeds', async () => {
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const provider = await createPartnerAxisProvider(partner.id);
+
+    // V holds a password already — never auto-linked at login.
+    const db = getTestDb();
+    const [passwordUser] = await db
+      .insert(users)
+      .values({
+        partnerId: partner.id,
+        orgId: null,
+        email: `v-${Date.now()}@example.com`,
+        name: 'V Tech',
+        passwordHash: '$2b$10$abcdefghijklmnopqrstuuC0zQx1Y0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0Z0', // bcrypt-shaped, never verified in this flow
+        status: 'active',
+      })
+      .returning();
+    if (!passwordUser) throw new Error('failed to create password-holding user fixture');
+    await assignUserToPartner(passwordUser.id, partner.id, role.id, 'all');
+
+    // (a) Login-path callback asserting V's email → sso_link_required.
+    const firstLogin = await initiatePartnerLogin(app, partner.id);
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-v', passwordUser.email, firstLogin.nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-v', email: passwordUser.email, name: 'V Tech' });
+
+    const firstCallback = await app.request(`/sso/callback?code=idp-auth-code&state=${firstLogin.state}`, {
+      headers: { cookie: firstLogin.cookiePair },
+    });
+    expect(firstCallback.status).toBe(302);
+    expect(firstCallback.headers.get('location')).toContain('/login?error=sso_link_required');
+
+    // (b) Authenticated POST /sso/link/start/:providerId as V (mfa:true in
+    // the test token, since requireMfa() gates the link-start route).
+    const vToken = await createAccessToken({
+      sub: passwordUser.id,
+      email: passwordUser.email,
+      roleId: role.id,
+      orgId: null,
+      partnerId: partner.id,
+      scope: 'partner',
+      mfa: true,
+    });
+
+    const linkStartRes = await app.request(`/sso/link/start/${provider.id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${vToken}` },
+    });
+    expect(linkStartRes.status).toBe(200);
+    const linkStartBody = await linkStartRes.json();
+    expect(linkStartBody.authUrl).toBeDefined();
+    expect(String(linkStartBody.authUrl)).toContain(ISSUER);
+
+    const linkSetCookie = linkStartRes.headers.get('set-cookie');
+    expect(linkSetCookie).toBeTruthy();
+    const linkState = extractStateFromLocation(String(linkStartBody.authUrl));
+
+    const [linkSessionRow] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, linkState)).limit(1);
+    expect(linkSessionRow).toBeDefined();
+    expect(linkSessionRow?.linkUserId).toBe(passwordUser.id);
+
+    // (c) Callback with that state + stubbed IdP asserting V's email →
+    // redirect /settings/profile?ssoLinked=1, identity row created.
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-v', passwordUser.email, linkSessionRow!.nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-v', email: passwordUser.email, name: 'V Tech' });
+
+    const linkCallbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${linkState}`, {
+      headers: { cookie: extractCookiePair(linkSetCookie!) },
+    });
+    expect(linkCallbackRes.status).toBe(302);
+    expect(linkCallbackRes.headers.get('location')).toContain('/settings/profile?ssoLinked=1');
+
+    const [identity] = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(eq(userSsoIdentities.providerId, provider.id))
+      .limit(1);
+    expect(identity?.userId).toBe(passwordUser.id);
+    expect(identity?.externalId).toBe('external-sub-v');
+
+    // (d) Login-path round-trip again for V → NOW succeeds via the linked
+    // identity; scope:'partner', sub === V.id.
+    const secondLogin = await initiatePartnerLogin(app, partner.id);
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-v', passwordUser.email, secondLogin.nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-v', email: passwordUser.email, name: 'V Tech' });
+
+    const secondCallback = await app.request(`/sso/callback?code=idp-auth-code&state=${secondLogin.state}`, {
+      headers: { cookie: secondLogin.cookiePair },
+    });
+    expect(secondCallback.status).toBe(302);
+    const secondLocation = secondCallback.headers.get('location');
+    expect(secondLocation).toContain('#ssoCode=');
+
+    const secondSsoCode = extractSsoCodeFromLocation(secondLocation!);
+    const secondExchangeRes = await app.request('/sso/exchange', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: secondSsoCode }),
+    });
+    expect(secondExchangeRes.status).toBe(200);
+    const secondExchangeBody = await secondExchangeRes.json();
+    const secondPayload = decodeJwt(secondExchangeBody.accessToken);
+    expect(secondPayload.scope).toBe('partner');
+    expect(secondPayload.sub).toBe(passwordUser.id);
+    expect(secondPayload.partnerId).toBe(partner.id);
+    expect(secondPayload.orgId).toBeNull();
+  });
+});
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+function idClaimsFor(sub: string, email: string, nonce: string) {
+  return {
+    iss: ISSUER,
+    sub,
+    aud: 'test-client-id',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+    nonce,
+    email,
+    email_verified: true,
+  };
+}
+
+async function initiatePartnerLogin(app: Hono, partnerId: string): Promise<{ state: string; nonce: string; cookiePair: string }> {
+  const loginRes = await app.request(`/sso/login/partner/${partnerId}`);
+  if (loginRes.status !== 302) {
+    throw new Error(`expected 302 from /sso/login/partner/${partnerId}, got ${loginRes.status}: ${await loginRes.text()}`);
+  }
+  const location = loginRes.headers.get('location');
+  const setCookie = loginRes.headers.get('set-cookie');
+  if (!location || !setCookie) throw new Error('login response missing location/set-cookie');
+
+  const state = extractStateFromLocation(location);
+  const db = getTestDb();
+  const [sessionRow] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
+  if (!sessionRow) throw new Error(`no sso_sessions row for state ${state}`);
+
+  return { state, nonce: sessionRow.nonce, cookiePair: extractCookiePair(setCookie) };
+}

--- a/apps/api/src/__tests__/integration/ssoProvidersPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoProvidersPartnerRls.integration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * sso_providers RLS — dual-axis (org OR partner) enforcement (#2183).
+ *
+ * Migration under test: 2026-07-03-sso-partner-axis-login-branding.sql.
+ *
+ * An sso_providers row is owned by EITHER an org (org_id set, partner_id
+ * NULL — the original customer-org SSO shape) OR a partner (partner_id set,
+ * org_id NULL — the MSP's own technician login, "partner-axis"). The
+ * dual-axis policy is:
+ *   system OR (org_id IS NOT NULL AND breeze_has_org_access(org_id))
+ *          OR (partner_id IS NOT NULL AND breeze_has_partner_access(partner_id))
+ *
+ * Same blindspot as configuration_policies / software_policies: the
+ * rls-coverage contract test's org-tenant auto-discovery already asserts the
+ * breeze_has_org_access branch (sso_providers has an org_id column), but it
+ * does NOT prove the partner branch — that requires a functional test
+ * through the REAL postgres.js driver (breeze_app role), which is what this
+ * suite is. See memory: rls_dual_axis_contract_test_blindspot.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { ssoProviders } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(
+    { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null },
+    async () => {
+      for (const id of created) {
+        await db.delete(ssoProviders).where(eq(ssoProviders.id, id));
+      }
+    },
+  );
+  created.length = 0;
+});
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+describe('sso_providers RLS — dual-axis (2026-07-03 migration)', () => {
+  it('partner A can INSERT a partner-axis provider (org_id NULL, partner_id set)', async () => {
+    const partnerA = await createPartner();
+
+    const rows = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      db
+        .insert(ssoProviders)
+        .values({ partnerId: partnerA.id, orgId: null, name: 'Partner IdP', type: 'oidc', status: 'inactive' })
+        .returning(),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.orgId).toBeNull();
+    expect(rows[0]?.partnerId).toBe(partnerA.id);
+    if (rows[0]) created.push(rows[0].id);
+  });
+
+  it('partner B forging partner A\'s partner_id is rejected (42501)', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(ssoProviders)
+          .values({ partnerId: partnerA.id, orgId: null, name: 'Forged partner IdP', type: 'oidc', status: 'inactive' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('the one-owner CHECK rejects a row that sets BOTH axes and one that sets NEITHER (23514)', async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const systemContext: DbAccessContext = {
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null,
+      accessiblePartnerIds: null,
+      userId: null,
+    };
+
+    // Both axes set → CHECK violation.
+    await expect(
+      withDbAccessContext(systemContext, () =>
+        db
+          .insert(ssoProviders)
+          .values({ orgId: orgA.id, partnerId: partnerA.id, name: 'Both axes', type: 'oidc', status: 'inactive' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    // Neither axis set → CHECK violation.
+    await expect(
+      withDbAccessContext(systemContext, () =>
+        db
+          .insert(ssoProviders)
+          .values({ orgId: null, partnerId: null, name: 'No axis', type: 'oidc', status: 'inactive' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+
+  it('partner B cannot SELECT partner A\'s partner-axis provider (visibility isolation)', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    const inserted = await withDbAccessContext(partnerContext(partnerA.id, []), () =>
+      db
+        .insert(ssoProviders)
+        .values({ partnerId: partnerA.id, orgId: null, name: 'Partner IdP', type: 'oidc', status: 'inactive' })
+        .returning(),
+    );
+    const id = inserted[0]!.id;
+    created.push(id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: ssoProviders.id }).from(ssoProviders).where(eq(ssoProviders.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+  });
+
+  it('an org-scope caller under partner A cannot see partner A\'s partner-axis provider (org tokens never pass breeze_has_partner_access)', async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+
+    const inserted = await withDbAccessContext(partnerContext(partnerA.id, [orgA.id]), () =>
+      db
+        .insert(ssoProviders)
+        .values({ partnerId: partnerA.id, orgId: null, name: 'Partner IdP', type: 'oidc', status: 'inactive' })
+        .returning(),
+    );
+    const id = inserted[0]!.id;
+    created.push(id);
+
+    const visibleToOrg = await withDbAccessContext(orgContext(orgA.id), () =>
+      db.select({ id: ssoProviders.id }).from(ssoProviders).where(eq(ssoProviders.id, id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+  });
+});

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -99,3 +99,4 @@ export * from './pax8';
 export * from './accounting';
 export * from './onedriveHelper';
 export * from './vulnerabilityManagement';
+export * from './partnerLoginBranding';

--- a/apps/api/src/db/schema/partnerLoginBranding.ts
+++ b/apps/api/src/db/schema/partnerLoginBranding.ts
@@ -1,0 +1,16 @@
+import { pgTable, uuid, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+
+// Login-page branding for the MSP's OWN technician login (#2183). Deliberately
+// partner-only (no org axis): org/customer login branding already exists as
+// portal_branding. One row per partner (PK = partner_id). RLS shape 3:
+// breeze_has_partner_access(partner_id), FORCE — see the 2026-07-03 migration.
+// NOT the same feature as the "Partner Branding" inheritable org-defaults tab.
+export const partnerLoginBranding = pgTable('partner_login_branding', {
+  partnerId: uuid('partner_id').primaryKey().references(() => partners.id, { onDelete: 'cascade' }),
+  logoUrl: text('logo_url'),
+  accentColor: varchar('accent_color', { length: 7 }),
+  headline: varchar('headline', { length: 120 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -96,7 +96,10 @@ export const ssoSessions = pgTable('sso_sessions', {
 
   // Link-mode marker (#2183 Connect SSO): when set, the callback links the
   // verified identity to this user instead of minting login tokens.
-  linkUserId: uuid('link_user_id').references(() => users.id),
+  // ON DELETE CASCADE: an abandoned link session (never completed, so never
+  // deleted by the callback) must not block a hard user delete — sso_sessions
+  // has no partner_id/org_id, so the tenant-cascade sweep never reaches it.
+  linkUserId: uuid('link_user_id').references(() => users.id, { onDelete: 'cascade' }),
 
   expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull()

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -1,14 +1,17 @@
 import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, uniqueIndex } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 
 export const ssoProviderTypeEnum = pgEnum('sso_provider_type', ['oidc', 'saml']);
 export const ssoProviderStatusEnum = pgEnum('sso_provider_status', ['active', 'inactive', 'testing']);
 
-// SSO Provider Configuration per Organization
+// SSO Provider Configuration — dual ownership (#2183): org-axis (orgId set,
+// partnerId NULL — customer-org SSO) XOR partner-axis (partnerId set, orgId
+// NULL — the MSP's own technician login). Enforced by sso_providers_one_owner_chk.
 export const ssoProviders = pgTable('sso_providers', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
 
   // Provider identification
   name: varchar('name', { length: 255 }).notNull(),
@@ -90,6 +93,10 @@ export const ssoSessions = pgTable('sso_sessions', {
   nonce: varchar('nonce', { length: 64 }).notNull(),
   codeVerifier: varchar('code_verifier', { length: 128 }), // for PKCE
   redirectUrl: varchar('redirect_url', { length: 500 }),
+
+  // Link-mode marker (#2183 Connect SSO): when set, the callback links the
+  // verified identity to this user instead of minting login tokens.
+  linkUserId: uuid('link_user_id').references(() => users.id),
 
   expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull()

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -64,6 +64,7 @@ import { apiKeyRoutes } from './routes/apiKeys';
 import { enrollmentKeyRoutes, publicEnrollmentRoutes, publicShortLinkRoutes } from './routes/enrollmentKeys';
 import { installerRoutes } from './routes/installer';
 import { ssoRoutes } from './routes/sso';
+import { partnerLoginBrandingRoutes } from './routes/partnerLoginBranding';
 import { docsRoutes } from './routes/docs';
 import { accessReviewRoutes } from './routes/accessReviews';
 import { webhookRoutes } from './routes/webhooks';
@@ -823,6 +824,10 @@ api.route('/enrollment-keys', publicEnrollmentRoutes); // Public download (no au
 api.route('/enrollment-keys', enrollmentKeyRoutes);
 api.route('/installer', installerRoutes);
 api.route('/sso', ssoRoutes);
+// Mounted directly at /partners (not nested under /orgs' /partners/me or the
+// legacy singular /partner router) — final URL /api/v1/partners/me/login-branding
+// per Task 11's consumed contract (#2183).
+api.route('/partners', partnerLoginBrandingRoutes);
 api.route('/docs', docsRoutes);
 api.route('/access-reviews', accessReviewRoutes);
 api.route('/webhooks', webhookRoutes);

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -703,7 +703,7 @@ export async function auditUserLoginFailure(
 
 export function auditLogin(
   c: RequestLike,
-  opts: { orgId: string | null; userId: string; email: string; name: string; mfa: boolean; scope: string; ip: string }
+  opts: { orgId: string | null; userId: string; email: string; name: string; mfa: boolean; scope: string; ip: string; method?: string }
 ): void {
   createAuditLogAsync({
     orgId: opts.orgId ?? undefined,
@@ -713,7 +713,7 @@ export function auditLogin(
     resourceType: 'user',
     resourceId: opts.userId,
     resourceName: opts.name,
-    details: { method: 'password', mfa: opts.mfa, scope: opts.scope },
+    details: { method: opts.method ?? 'password', mfa: opts.mfa, scope: opts.scope },
     ipAddress: opts.ip,
     userAgent: c.req.header('user-agent'),
     result: 'success'

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -10,6 +10,7 @@ import { accountDeletionRoutes } from './accountDeletion';
 import { testApprovalRoutes } from './testApproval';
 import { cfAccessRedirectLoginRoutes } from './cfAccessRedirectLogin';
 import { passkeyRoutes } from './passkeys';
+import { loginContextRoutes } from './loginContext';
 
 export const authRoutes = new Hono();
 
@@ -27,3 +28,4 @@ authRoutes.route('/', verifyEmailRoutes);
 authRoutes.route('/', accountDeletionRoutes);
 authRoutes.route('/', testApprovalRoutes);
 authRoutes.route('/', cfAccessRedirectLoginRoutes);
+authRoutes.route('/', loginContextRoutes);

--- a/apps/api/src/routes/auth/loginContext.test.ts
+++ b/apps/api/src/routes/auth/loginContext.test.ts
@@ -26,9 +26,14 @@ vi.mock('../../services', () => ({
   getRedis: vi.fn(() => ({})),
 }));
 
+vi.mock('../../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
 import { loginContextRoutes } from './loginContext';
-import { db } from '../../db';
+import { db, withSystemDbAccessContext } from '../../db';
 import { rateLimiter, getRedis } from '../../services';
+import { captureException } from '../../services/sentry';
 
 const PARTNER_UUID = '00000000-0000-4000-8000-000000000030';
 const PARTNER_UUID_2 = '00000000-0000-4000-8000-000000000031';
@@ -140,5 +145,33 @@ describe('GET /auth/login-context (#2183)', () => {
     const res = await getContext();
     expect(res.status).toBe(429);
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('calls rateLimiter unconditionally when Redis is unavailable (fail-closed, no skip-the-check guard)', async () => {
+    vi.mocked(getRedis).mockReturnValue(null as any);
+    // rateLimiter itself fails closed on a null redis client in production;
+    // here we assert the route still invokes it (with the null client) and
+    // honors whatever it returns, rather than short-circuiting past it.
+    vi.mocked(rateLimiter).mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date() } as any);
+
+    const res = await getContext();
+    expect(rateLimiter).toHaveBeenCalledWith(null, expect.stringContaining('login-context:'), 30, 60);
+    expect(res.status).toBe(429);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('degrades to the stock page (200, null shape, no-store) when the DB read throws', async () => {
+    vi.mocked(withSystemDbAccessContext).mockRejectedValueOnce(new Error('connection reset'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ branding: null, partnerSso: null });
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error), expect.anything());
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/api/src/routes/auth/loginContext.test.ts
+++ b/apps/api/src/routes/auth/loginContext.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  db: { select: vi.fn() },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  partners: { id: 'partners.id' },
+  ssoProviders: {
+    id: 'ssoProviders.id',
+    partnerId: 'ssoProviders.partnerId',
+    name: 'ssoProviders.name',
+    status: 'ssoProviders.status',
+  },
+  partnerLoginBranding: {
+    partnerId: 'partnerLoginBranding.partnerId',
+    logoUrl: 'partnerLoginBranding.logoUrl',
+    accentColor: 'partnerLoginBranding.accentColor',
+    headline: 'partnerLoginBranding.headline',
+  },
+}));
+
+vi.mock('../../services', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 29, resetAt: new Date() })),
+  getRedis: vi.fn(() => ({})),
+}));
+
+import { loginContextRoutes } from './loginContext';
+import { db } from '../../db';
+import { rateLimiter, getRedis } from '../../services';
+
+const PARTNER_UUID = '00000000-0000-4000-8000-000000000030';
+const PARTNER_UUID_2 = '00000000-0000-4000-8000-000000000031';
+
+// Builds a select() return value that supports both call shapes used by the
+// route: `.from(t).limit(n)` (the partner-count probe, no filter) and
+// `.from(t).where(cond).limit(n)` (the branding/provider lookups).
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(rows),
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+async function getContext() {
+  return loginContextRoutes.request('/login-context');
+}
+
+describe('GET /auth/login-context (#2183)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRedis).mockReturnValue({} as any);
+    vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 29, resetAt: new Date() } as any);
+    vi.mocked(db.select).mockReset().mockReturnValue(selectChain([]) as any);
+  });
+
+  it('returns branding + partnerSso on a single-partner instance with both configured', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any)
+      .mockReturnValueOnce(selectChain([{
+        logoUrl: 'https://cdn.example.com/logo.png',
+        accentColor: '#112233',
+        headline: 'Welcome back'
+      }]) as any)
+      .mockReturnValueOnce(selectChain([{ name: 'Okta' }]) as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      branding: {
+        logoUrl: 'https://cdn.example.com/logo.png',
+        accentColor: '#112233',
+        headline: 'Welcome back'
+      },
+      partnerSso: {
+        available: true,
+        providerName: 'Okta',
+        loginUrl: `/api/v1/sso/login/partner/${PARTNER_UUID}`
+      }
+    });
+  });
+
+  it('returns branding null / partnerSso null when neither is configured (single partner)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any)
+      .mockReturnValueOnce(selectChain([]) as any)
+      .mockReturnValueOnce(selectChain([]) as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ branding: null, partnerSso: null });
+  });
+
+  it('returns all-null on a multi-partner instance (no tenant leakage)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([{ id: PARTNER_UUID }, { id: PARTNER_UUID_2 }]) as any
+    );
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ branding: null, partnerSso: null });
+    // Only the partner-count probe should run — no branding/provider lookup,
+    // no partner id/name ever touches the response.
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(body)).not.toContain(PARTNER_UUID);
+  });
+
+  it('returns all-null on a zero-partner instance', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([]) as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ branding: null, partnerSso: null });
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits provider config beyond name + loginUrl', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any)
+      .mockReturnValueOnce(selectChain([]) as any)
+      .mockReturnValueOnce(selectChain([{ name: 'Okta' }]) as any);
+
+    const res = await getContext();
+    const body = await res.json();
+    expect(Object.keys(body.partnerSso).sort()).toEqual(['available', 'loginUrl', 'providerName']);
+  });
+
+  it('429s past the rate limit', async () => {
+    vi.mocked(rateLimiter).mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: new Date() } as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(429);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/auth/loginContext.ts
+++ b/apps/api/src/routes/auth/loginContext.ts
@@ -1,0 +1,63 @@
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, ssoProviders, partnerLoginBranding } from '../../db/schema';
+import { getTrustedClientIp } from '../../services/clientIp';
+import { getRedis, rateLimiter } from '../../services';
+
+export const loginContextRoutes = new Hono();
+
+// Public, unauthenticated. Single-partner (self-hosted) fast-path only: on a
+// multi-partner instance this endpoint deliberately reveals NOTHING (#2183
+// tenant-leakage constraint). The future /login/:partnerSlug variant returns
+// the same shape resolved by slug.
+loginContextRoutes.get('/login-context', async (c) => {
+  const redis = getRedis();
+  if (redis) {
+    const check = await rateLimiter(redis, `login-context:${getTrustedClientIp(c)}`, 30, 60);
+    if (!check.allowed) {
+      return c.json({ error: 'Too many requests' }, 429);
+    }
+  }
+
+  const context = await withSystemDbAccessContext(async () => {
+    const partnerRows = await db.select({ id: partners.id }).from(partners).limit(2);
+    if (partnerRows.length !== 1 || !partnerRows[0]) {
+      return { branding: null, partnerSso: null };
+    }
+    const partnerId = partnerRows[0].id;
+
+    const [brandingRow] = await db
+      .select({
+        logoUrl: partnerLoginBranding.logoUrl,
+        accentColor: partnerLoginBranding.accentColor,
+        headline: partnerLoginBranding.headline
+      })
+      .from(partnerLoginBranding)
+      .where(eq(partnerLoginBranding.partnerId, partnerId))
+      .limit(1);
+
+    const [provider] = await db
+      .select({ name: ssoProviders.name })
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.partnerId, partnerId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .limit(1);
+
+    return {
+      branding: brandingRow ?? null,
+      partnerSso: provider
+        ? {
+            available: true as const,
+            providerName: provider.name,
+            loginUrl: `/api/v1/sso/login/partner/${partnerId}`
+          }
+        : null
+    };
+  });
+
+  c.header('Cache-Control', 'public, max-age=60');
+  return c.json(context);
+});

--- a/apps/api/src/routes/auth/loginContext.ts
+++ b/apps/api/src/routes/auth/loginContext.ts
@@ -4,6 +4,7 @@ import { db, withSystemDbAccessContext } from '../../db';
 import { partners, ssoProviders, partnerLoginBranding } from '../../db/schema';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { getRedis, rateLimiter } from '../../services';
+import { captureException } from '../../services/sentry';
 
 export const loginContextRoutes = new Hono();
 
@@ -13,50 +14,63 @@ export const loginContextRoutes = new Hono();
 // the same shape resolved by slug.
 loginContextRoutes.get('/login-context', async (c) => {
   const redis = getRedis();
-  if (redis) {
-    const check = await rateLimiter(redis, `login-context:${getTrustedClientIp(c)}`, 30, 60);
-    if (!check.allowed) {
-      return c.json({ error: 'Too many requests' }, 429);
-    }
+  // Call unconditionally (no `if (redis)` guard) — mirrors the partner SSO
+  // entry route (GET /sso/login/partner/:partnerId): rateLimiter fails
+  // CLOSED (allowed: false) when redis is null, so a missing Redis denies
+  // the request rather than silently skipping the limit.
+  const check = await rateLimiter(redis, `login-context:${getTrustedClientIp(c)}`, 30, 60);
+  if (!check.allowed) {
+    return c.json({ error: 'Too many requests' }, 429);
   }
 
-  const context = await withSystemDbAccessContext(async () => {
-    const partnerRows = await db.select({ id: partners.id }).from(partners).limit(2);
-    if (partnerRows.length !== 1 || !partnerRows[0]) {
-      return { branding: null, partnerSso: null };
-    }
-    const partnerId = partnerRows[0].id;
+  let context: { branding: unknown; partnerSso: unknown };
+  try {
+    context = await withSystemDbAccessContext(async () => {
+      const partnerRows = await db.select({ id: partners.id }).from(partners).limit(2);
+      if (partnerRows.length !== 1 || !partnerRows[0]) {
+        return { branding: null, partnerSso: null };
+      }
+      const partnerId = partnerRows[0].id;
 
-    const [brandingRow] = await db
-      .select({
-        logoUrl: partnerLoginBranding.logoUrl,
-        accentColor: partnerLoginBranding.accentColor,
-        headline: partnerLoginBranding.headline
-      })
-      .from(partnerLoginBranding)
-      .where(eq(partnerLoginBranding.partnerId, partnerId))
-      .limit(1);
+      const [brandingRow] = await db
+        .select({
+          logoUrl: partnerLoginBranding.logoUrl,
+          accentColor: partnerLoginBranding.accentColor,
+          headline: partnerLoginBranding.headline
+        })
+        .from(partnerLoginBranding)
+        .where(eq(partnerLoginBranding.partnerId, partnerId))
+        .limit(1);
 
-    const [provider] = await db
-      .select({ name: ssoProviders.name })
-      .from(ssoProviders)
-      .where(and(
-        eq(ssoProviders.partnerId, partnerId),
-        eq(ssoProviders.status, 'active')
-      ))
-      .limit(1);
+      const [provider] = await db
+        .select({ name: ssoProviders.name })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.partnerId, partnerId),
+          eq(ssoProviders.status, 'active')
+        ))
+        .limit(1);
 
-    return {
-      branding: brandingRow ?? null,
-      partnerSso: provider
-        ? {
-            available: true as const,
-            providerName: provider.name,
-            loginUrl: `/api/v1/sso/login/partner/${partnerId}`
-          }
-        : null
-    };
-  });
+      return {
+        branding: brandingRow ?? null,
+        partnerSso: provider
+          ? {
+              available: true as const,
+              providerName: provider.name,
+              loginUrl: `/api/v1/sso/login/partner/${partnerId}`
+            }
+          : null
+      };
+    });
+  } catch (err) {
+    // This endpoint gates login-page RENDERING on a public, unauthenticated
+    // route — a DB blip must degrade to the stock login page, never surface
+    // a 500. Never cache the degraded response as if it were a real result.
+    console.error('[auth] login-context DB read failed, degrading to stock page:', err);
+    captureException(err, c);
+    c.header('Cache-Control', 'no-store');
+    return c.json({ branding: null, partnerSso: null });
+  }
 
   c.header('Cache-Control', 'public, max-age=60');
   return c.json(context);

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -269,7 +269,8 @@ passwordRoutes.post('/change-password', authMiddleware, zValidator('json', chang
   try {
     await assertPasswordAuthAllowedBySso({
       scope: auth.scope,
-      orgId: auth.orgId
+      orgId: auth.orgId,
+      partnerId: auth.partnerId
     });
   } catch (error) {
     if (!(error instanceof SsoPasswordAuthRequiredError)) throw error;

--- a/apps/api/src/routes/auth/ssoPolicy.test.ts
+++ b/apps/api/src/routes/auth/ssoPolicy.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../db/schema', () => ({
   ssoProviders: {
     id: 'ssoProviders.id',
     orgId: 'ssoProviders.orgId',
+    partnerId: 'ssoProviders.partnerId',
     status: 'ssoProviders.status',
     enforceSSO: 'ssoProviders.enforceSSO',
   },
@@ -44,25 +45,74 @@ describe('SSO password auth policy', () => {
   it('disables password auth for organization contexts with an active enforcing provider', async () => {
     mockProviderRows([{ id: 'provider-1' }]);
 
-    await expect(isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1' })).resolves.toBe(true);
+    await expect(isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1', partnerId: null })).resolves.toBe(true);
   });
 
   it('allows password auth when no active enforcing provider exists', async () => {
     mockProviderRows([]);
 
-    await expect(isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1' })).resolves.toBe(false);
+    await expect(isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1', partnerId: null })).resolves.toBe(false);
   });
 
   it('does not apply customer-org SSO policy to partner or system contexts', async () => {
-    await expect(isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null })).resolves.toBe(false);
-    await expect(isPasswordAuthDisabledBySso({ scope: 'system', orgId: null })).resolves.toBe(false);
+    await expect(isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: null })).resolves.toBe(false);
+    await expect(isPasswordAuthDisabledBySso({ scope: 'system', orgId: null, partnerId: null })).resolves.toBe(false);
     expect(db.select).not.toHaveBeenCalled();
   });
 
   it('throws a typed error when password auth is disabled by SSO', async () => {
     mockProviderRows([{ id: 'provider-1' }]);
 
-    await expect(assertPasswordAuthAllowedBySso({ scope: 'organization', orgId: 'org-1' }))
+    await expect(assertPasswordAuthAllowedBySso({ scope: 'organization', orgId: 'org-1', partnerId: null }))
       .rejects.toBeInstanceOf(SsoPasswordAuthRequiredError);
+  });
+});
+
+describe('isPasswordAuthDisabledBySso — partner scope (#2183)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('true for partner-scope context when an active enforceSSO partner provider exists', async () => {
+    mockProviderRows([{ id: 'provider-1' }]);
+
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: 'partner-1' })
+    ).resolves.toBe(true);
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('false when the partner provider is testing (break-glass preserved)', async () => {
+    // The query only matches status='active' rows, so a 'testing' provider
+    // never surfaces here — this is what enforces the break-glass invariant.
+    mockProviderRows([]);
+
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: 'partner-1' })
+    ).resolves.toBe(false);
+  });
+
+  it('false for partner scope with no partner provider', async () => {
+    mockProviderRows([]);
+
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: 'partner-1' })
+    ).resolves.toBe(false);
+  });
+
+  it('org behavior unchanged', async () => {
+    mockProviderRows([{ id: 'provider-1' }]);
+
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1', partnerId: null })
+    ).resolves.toBe(true);
+
+    vi.clearAllMocks();
+    mockProviderRows([]);
+
+    // Org-scope users are never affected by a partner provider's enforceSSO.
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'organization', orgId: 'org-1', partnerId: 'partner-1' })
+    ).resolves.toBe(false);
   });
 });

--- a/apps/api/src/routes/auth/ssoPolicy.test.ts
+++ b/apps/api/src/routes/auth/ssoPolicy.test.ts
@@ -37,6 +37,25 @@ function mockProviderRows(rows: unknown[]) {
   } as unknown as ReturnType<typeof db.select>);
 }
 
+// Axis-aware mock: inspects the actual `and(eq(...), ...)` condition object
+// built by the (also-mocked) drizzle-orm helpers above and returns different
+// rows depending on whether the query filtered on `ssoProviders.orgId` or
+// `ssoProviders.partnerId`. This lets a single test prove one axis's rows
+// never leak into the other axis's query — a naive mock that returns the
+// same rows regardless of the `where` argument can't distinguish "queried
+// the wrong axis and got a false positive" from "queried the right axis and
+// correctly found nothing".
+function mockAxisAwareProviderRows(orgAxisRows: unknown[], partnerAxisRows: unknown[]) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn((condition: { conditions?: Array<{ left?: unknown }> }) => {
+        const isOrgAxis = condition?.conditions?.some((c) => c.left === 'ssoProviders.orgId');
+        return { limit: vi.fn().mockResolvedValue(isOrgAxis ? orgAxisRows : partnerAxisRows) };
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>);
+}
+
 describe('SSO password auth policy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,6 +113,17 @@ describe('isPasswordAuthDisabledBySso — partner scope (#2183)', () => {
 
   it('false for partner scope with no partner provider', async () => {
     mockProviderRows([]);
+
+    await expect(
+      isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: 'partner-1' })
+    ).resolves.toBe(false);
+  });
+
+  it('partner staff unaffected by an org provider\'s enforceSSO', async () => {
+    // Org axis has an active enforcing provider; partner axis has none.
+    // If the partner branch ever queried (or matched) the org-axis rows,
+    // this would incorrectly resolve to `true`.
+    mockAxisAwareProviderRows([{ id: 'org-provider' }], []);
 
     await expect(
       isPasswordAuthDisabledBySso({ scope: 'partner', orgId: null, partnerId: 'partner-1' })

--- a/apps/api/src/routes/auth/ssoPolicy.ts
+++ b/apps/api/src/routes/auth/ssoPolicy.ts
@@ -10,31 +10,46 @@ export class SsoPasswordAuthRequiredError extends Error {
   }
 }
 
-export async function isPasswordAuthDisabledBySso(context: Pick<UserTokenContext, 'scope' | 'orgId'>): Promise<boolean> {
-  if (context.scope !== 'organization' || !context.orgId) {
-    return false;
-  }
-
-  const orgId = context.orgId;
-  const [provider] = await withSystemDbAccessContext(async () =>
-    db
-      .select({ id: ssoProviders.id })
-      .from(ssoProviders)
-      .where(
-        and(
+export async function isPasswordAuthDisabledBySso(
+  context: Pick<UserTokenContext, 'scope' | 'orgId' | 'partnerId'>
+): Promise<boolean> {
+  if (context.scope === 'organization' && context.orgId) {
+    const orgId = context.orgId;
+    const [provider] = await withSystemDbAccessContext(async () =>
+      db
+        .select({ id: ssoProviders.id })
+        .from(ssoProviders)
+        .where(and(
           eq(ssoProviders.orgId, orgId),
           eq(ssoProviders.status, 'active'),
           eq(ssoProviders.enforceSSO, true)
-        )
-      )
-      .limit(1)
-  );
+        ))
+        .limit(1)
+    );
+    return Boolean(provider);
+  }
 
-  return Boolean(provider);
+  if (context.scope === 'partner' && context.partnerId) {
+    const partnerId = context.partnerId;
+    const [provider] = await withSystemDbAccessContext(async () =>
+      db
+        .select({ id: ssoProviders.id })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.partnerId, partnerId),
+          eq(ssoProviders.status, 'active'),
+          eq(ssoProviders.enforceSSO, true)
+        ))
+        .limit(1)
+    );
+    return Boolean(provider);
+  }
+
+  return false;
 }
 
 export async function assertPasswordAuthAllowedBySso(
-  context: Pick<UserTokenContext, 'scope' | 'orgId'>
+  context: Pick<UserTokenContext, 'scope' | 'orgId' | 'partnerId'>
 ): Promise<void> {
   if (await isPasswordAuthDisabledBySso(context)) {
     throw new SsoPasswordAuthRequiredError();

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -57,7 +57,6 @@ const createPartnerSchema = z.object({
   // They are intentionally excluded from the API schema to prevent self-service changes.
   maxOrganizations: z.number().int().nullable().optional(),
   settings: z.any().optional(),
-  ssoConfig: z.any().optional(),
   billingEmail: z.string().email().optional()
 });
 
@@ -117,7 +116,6 @@ const createOrganizationSchema = z.object({
   status: z.enum(['active', 'suspended', 'trial', 'churned']).optional(),
   // maxDevices is managed by the billing service — excluded from API schema
   settings: z.any().optional(),
-  ssoConfig: z.any().optional(),
   contractStart: z.string().nullable().optional(),
   contractEnd: z.string().nullable().optional(),
   billingContact: z.any().optional()
@@ -282,7 +280,6 @@ orgRoutes.post('/partners', requireScope('system'), requireOrgWrite, requireMfa(
         type: data.type,
         maxOrganizations: data.maxOrganizations,
         settings: data.settings,
-        ssoConfig: data.ssoConfig,
         billingEmail: data.billingEmail
       })
       .returning();
@@ -1103,7 +1100,6 @@ orgRoutes.post('/organizations', requireScope('partner', 'system'), requireOrgWr
     type: data.type,
     status: data.status,
     settings: data.settings,
-    ssoConfig: data.ssoConfig,
     contractStart: data.contractStart ? new Date(data.contractStart) : null,
     contractEnd: data.contractEnd ? new Date(data.contractEnd) : null,
     billingContact: data.billingContact
@@ -1226,7 +1222,6 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     // before writing organizations.settings. See encryptedColumnRegistry.
     updates.settings = encryptColumnValueForWrite('organizations', 'settings', data.settings);
   }
-  if (data.ssoConfig !== undefined) updates.ssoConfig = data.ssoConfig;
   if (data.billingContact !== undefined) updates.billingContact = data.billingContact;
   if (data.contractStart !== undefined) {
     updates.contractStart = data.contractStart ? new Date(data.contractStart) : null;

--- a/apps/api/src/routes/partnerLoginBranding.test.ts
+++ b/apps/api/src/routes/partnerLoginBranding.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, dbSelectResult, dbUpsertReturning, auditSpy } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as string,
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
+      partnerId: 'p-1' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      orgId: null as string | null,
+      accessibleOrgIds: null as string[] | null
+    }
+  },
+  dbSelectResult: vi.fn(),
+  dbUpsertReturning: vi.fn(),
+  auditSpy: vi.fn()
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    if (!authRef.current) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (c: any, next: any) => {
+    if (!c.get('auth')) {
+      return c.json({ error: 'Not authenticated' }, 401);
+    }
+    await next();
+  }
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => dbSelectResult())
+        }))
+      }))
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          returning: vi.fn(() => dbUpsertReturning())
+        }))
+      }))
+    }))
+  }
+}));
+
+vi.mock('../db/schema', () => ({
+  partnerLoginBranding: {
+    partnerId: 'partnerId',
+    logoUrl: 'logoUrl',
+    accentColor: 'accentColor',
+    headline: 'headline'
+  }
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: (...args: unknown[]) => auditSpy(...args)
+}));
+
+import { authMiddleware } from '../middleware/auth';
+import { partnerLoginBrandingRoutes } from './partnerLoginBranding';
+
+const DEFAULT_AUTH = {
+  scope: 'partner' as string,
+  user: { id: 'u-1', name: 'Tess Tech', email: 'tess@msp.example', isPlatformAdmin: false },
+  partnerId: 'p-1' as string | null,
+  partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+  orgId: null as string | null,
+  accessibleOrgIds: null as string[] | null
+};
+
+function resetAuth(overrides: Partial<typeof DEFAULT_AUTH> = {}) {
+  authRef.current = { ...DEFAULT_AUTH, ...overrides } as typeof authRef.current;
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/partners', partnerLoginBrandingRoutes);
+  return app;
+}
+
+describe('partner login branding routes (#2183)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authMiddleware);
+    resetAuth();
+  });
+
+  it('GET returns null data when unset', async () => {
+    dbSelectResult.mockResolvedValueOnce([]);
+    const res = await makeApp().request('/partners/me/login-branding');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toBeNull();
+  });
+
+  it('PUT upserts for a partner admin with orgAccess=all', async () => {
+    resetAuth({ partnerOrgAccess: 'all' });
+    const returned = { logoUrl: 'https://cdn.example.com/logo.png', accentColor: '#336699', headline: 'Welcome' };
+    dbUpsertReturning.mockResolvedValueOnce([returned]);
+
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(returned)
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual(returned);
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+    const event = auditSpy.mock.calls[0]?.[1];
+    expect(event.orgId).toBeNull();
+    expect(event.action).toBe('partner.login_branding.update');
+    expect(event.resourceId).toBe('p-1');
+    expect(event.details.partnerId).toBe('p-1');
+  });
+
+  it('PUT 403s without canManagePartnerWidePolicies', async () => {
+    resetAuth({ partnerOrgAccess: 'selected' });
+
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accentColor: '#336699' })
+    });
+
+    expect(res.status).toBe(403);
+    expect(auditSpy).not.toHaveBeenCalled();
+  });
+
+  it('PUT 400s a non-hex accentColor', async () => {
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accentColor: 'blue' })
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT 400s a logoUrl that is neither https:// nor data:image/', async () => {
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ logoUrl: 'http://insecure.example.com/logo.png' })
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT 400s a headline over 120 chars', async () => {
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ headline: 'x'.repeat(121) })
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/partnerLoginBranding.test.ts
+++ b/apps/api/src/routes/partnerLoginBranding.test.ts
@@ -122,6 +122,47 @@ describe('partner login branding routes (#2183)', () => {
     expect(event.action).toBe('partner.login_branding.update');
     expect(event.resourceId).toBe('p-1');
     expect(event.details.partnerId).toBe('p-1');
+    // Audit must reflect the effective applied row, not the raw request body —
+    // full-replace semantics mean omitted fields were coalesced to null.
+    expect(event.details.applied).toEqual(returned);
+  });
+
+  it('PUT audits the effective applied row (full-replace nulls omitted fields), not a changed-fields list', async () => {
+    resetAuth({ partnerOrgAccess: 'all' });
+    // Only accentColor is sent; logoUrl/headline are coalesced to null by the
+    // route and that's what actually lands in the DB row returned here.
+    const returned = { logoUrl: null, accentColor: '#abcdef', headline: null };
+    dbUpsertReturning.mockResolvedValueOnce([returned]);
+
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accentColor: '#abcdef' })
+    });
+
+    expect(res.status).toBe(200);
+    const event = auditSpy.mock.calls[0]?.[1];
+    expect(event.details).not.toHaveProperty('changedFields');
+    expect(event.details.applied).toEqual(returned);
+  });
+
+  it('PUT populated then GET returns the populated row (round-trip)', async () => {
+    resetAuth({ partnerOrgAccess: 'all' });
+    const applied = { logoUrl: 'https://cdn.example.com/logo.png', accentColor: '#336699', headline: 'Welcome' };
+    dbUpsertReturning.mockResolvedValueOnce([applied]);
+
+    const putRes = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(applied)
+    });
+    expect(putRes.status).toBe(200);
+    expect((await putRes.json()).data).toEqual(applied);
+
+    dbSelectResult.mockResolvedValueOnce([applied]);
+    const getRes = await makeApp().request('/partners/me/login-branding');
+    expect(getRes.status).toBe(200);
+    expect((await getRes.json()).data).toEqual(applied);
   });
 
   it('PUT 403s without canManagePartnerWidePolicies', async () => {

--- a/apps/api/src/routes/partnerLoginBranding.ts
+++ b/apps/api/src/routes/partnerLoginBranding.ts
@@ -1,0 +1,91 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { partnerLoginBranding } from '../db/schema';
+import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { writeRouteAudit } from '../services/auditEvents';
+
+// Partner admin read/write for the MSP's own technician-login branding
+// (#2183). Deliberately NOT under orgRoutes' /orgs/partners/me or the
+// legacy singular /partner router — mounted directly at /partners so the
+// final URL matches Task 11's contract: /api/v1/partners/me/login-branding.
+export const partnerLoginBrandingRoutes = new Hono();
+
+const brandingSchema = z.object({
+  logoUrl: z.string().max(400_000)
+    .refine((v) => v.startsWith('https://') || v.startsWith('data:image/'), {
+      message: 'logoUrl must be an https:// URL or a data:image/ URI'
+    })
+    .nullable().optional(),
+  accentColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'accentColor must be a #rrggbb hex color')
+    .nullable().optional(),
+  headline: z.string().max(120).nullable().optional()
+});
+
+partnerLoginBrandingRoutes.get('/me/login-branding', authMiddleware, requireScope('partner'), async (c) => {
+  const auth = c.get('auth') as AuthContext;
+  if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 400);
+
+  const [row] = await db
+    .select({
+      logoUrl: partnerLoginBranding.logoUrl,
+      accentColor: partnerLoginBranding.accentColor,
+      headline: partnerLoginBranding.headline
+    })
+    .from(partnerLoginBranding)
+    .where(eq(partnerLoginBranding.partnerId, auth.partnerId))
+    .limit(1);
+
+  return c.json({ data: row ?? null });
+});
+
+partnerLoginBrandingRoutes.put(
+  '/me/login-branding',
+  authMiddleware,
+  requireScope('partner'),
+  zValidator('json', brandingSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 400);
+    if (!canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
+    const body = c.req.valid('json');
+    const [row] = await db
+      .insert(partnerLoginBranding)
+      .values({
+        partnerId: auth.partnerId,
+        logoUrl: body.logoUrl ?? null,
+        accentColor: body.accentColor ?? null,
+        headline: body.headline ?? null
+      })
+      .onConflictDoUpdate({
+        target: partnerLoginBranding.partnerId,
+        set: {
+          logoUrl: body.logoUrl ?? null,
+          accentColor: body.accentColor ?? null,
+          headline: body.headline ?? null,
+          updatedAt: new Date()
+        }
+      })
+      .returning({
+        logoUrl: partnerLoginBranding.logoUrl,
+        accentColor: partnerLoginBranding.accentColor,
+        headline: partnerLoginBranding.headline
+      });
+
+    writeRouteAudit(c, {
+      orgId: null,
+      action: 'partner.login_branding.update',
+      resourceType: 'partner_login_branding',
+      resourceId: auth.partnerId,
+      details: { partnerId: auth.partnerId, changedFields: Object.keys(body) }
+    });
+
+    return c.json({ data: row });
+  }
+);

--- a/apps/api/src/routes/partnerLoginBranding.ts
+++ b/apps/api/src/routes/partnerLoginBranding.ts
@@ -78,12 +78,17 @@ partnerLoginBrandingRoutes.put(
         headline: partnerLoginBranding.headline
       });
 
+    // Full-replace semantics: an omitted field is coalesced to null above, so
+    // a "changed fields" list derived from the request body would misrepresent
+    // what happened (e.g. PUT {accentColor} also NULLs logoUrl/headline). Log
+    // the effective applied row instead — truthful regardless of which fields
+    // were present in the request.
     writeRouteAudit(c, {
       orgId: null,
       action: 'partner.login_branding.update',
       resourceType: 'partner_login_branding',
       resourceId: auth.partnerId,
-      details: { partnerId: auth.partnerId, changedFields: Object.keys(body) }
+      details: { partnerId: auth.partnerId, applied: row }
     });
 
     return c.json({ data: row });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -2074,4 +2074,173 @@ describe('sso routes', () => {
       expect(res.status).toBe(403);
     });
   });
+
+  // ============================================================
+  // Self-service "Connect SSO" identity linking (#2183, Task 6)
+  // ============================================================
+  describe('Connect SSO link flow (#2183)', () => {
+    const OTHER_PARTNER = '00000000-0000-4000-8000-0000000000ff';
+    const sel = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+    // /link/options uses a leftJoin then a where that resolves directly (no limit).
+    const selLeftJoin = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ leftJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+
+    const ORG_PROVIDER = {
+      id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, status: 'active', type: 'oidc',
+      name: 'Okta', issuer: 'https://issuer.example.com',
+      authorizationUrl: 'https://issuer.example.com/auth', tokenUrl: 'https://issuer.example.com/token',
+      userInfoUrl: 'https://issuer.example.com/userinfo', jwksUrl: 'https://issuer.example.com/jwks',
+      clientId: 'client-id', clientSecret: 'client-secret', scopes: 'openid profile email',
+      attributeMapping: { email: 'email', name: 'name' }, defaultRoleId: null
+    };
+    const PARTNER_PROVIDER = { ...ORG_PROVIDER, orgId: null, partnerId: PARTNER_UUID, name: 'MSP IdP' };
+
+    it('GET /sso/link/options lists org-axis providers with linked flags', async () => {
+      // org user (scope organization, orgId set) → org-axis providers.
+      vi.mocked(db.select).mockReturnValueOnce(selLeftJoin([
+        { id: 'p-1', name: 'Okta', type: 'oidc', linkedId: 'link-1' },
+        { id: 'p-2', name: 'Entra', type: 'oidc', linkedId: null }
+      ]));
+
+      const res = await app.request('/sso/link/options', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([
+        { id: 'p-1', name: 'Okta', type: 'oidc', linked: true },
+        { id: 'p-2', name: 'Entra', type: 'oidc', linked: false }
+      ]);
+    });
+
+    it('GET /sso/link/options lists partner-axis providers for partner staff', async () => {
+      setAuthContext({ scope: 'partner', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: [] });
+      vi.mocked(db.select).mockReturnValueOnce(selLeftJoin([
+        { id: 'pp-1', name: 'MSP IdP', type: 'oidc', linkedId: null }
+      ]));
+
+      const res = await app.request('/sso/link/options', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toEqual([{ id: 'pp-1', name: 'MSP IdP', type: 'oidc', linked: false }]);
+    });
+
+    it('POST /sso/link/start/:providerId returns authUrl, sets state cookie, and stamps linkUserId', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(sel([ORG_PROVIDER]));
+      const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+      vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+
+      const res = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.authUrl).toMatch(/^https:\/\/idp\.example\.com\/auth/);
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('breeze_sso_state');
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ linkUserId: USER_UUID }));
+    });
+
+    it('POST /sso/link/start 401s an unauthenticated caller', async () => {
+      vi.mocked(authMiddleware).mockImplementation((c: any) => c.json({ error: 'Unauthorized' }, 401));
+
+      const res = await app.request(`/sso/link/start/${PROVIDER_UUID}`, { method: 'POST' });
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /sso/link/start is blocked without MFA (requireMfa)', async () => {
+      mfaGate.deny = true;
+      const res = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('POST /sso/link/start 403s a provider outside the user axis pool', async () => {
+      // org user attempting to link a PARTNER-axis provider → 403.
+      vi.mocked(db.select).mockReturnValueOnce(sel([PARTNER_PROVIDER]));
+      const orgRes = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(orgRes.status).toBe(403);
+
+      // partner staff attempting to link ANOTHER partner's provider → 403.
+      setAuthContext({ scope: 'partner', orgId: null, partnerId: OTHER_PARTNER, accessibleOrgIds: [] });
+      vi.mocked(db.select).mockReturnValueOnce(sel([PARTNER_PROVIDER]));
+      const partnerRes = await app.request(`/sso/link/start/${PROVIDER_UUID}`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(partnerRes.status).toBe(403);
+    });
+
+    // ── Callback link-mode branch ──────────────────────────────────────────
+    const primeLinkCallback = (linkUserId: string) => {
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@example.com', name: 'Tech' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@example.com', name: 'Tech' } as any);
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-link', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/settings/profile', linkUserId }]) })
+      } as any);
+    };
+    const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
+
+    it('callback link mode creates the identity for the SESSION user after verification', async () => {
+      primeLinkCallback(USER_UUID);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))                                        // provider by id
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }])) // linking user
+        .mockReturnValueOnce(sel([]));                                                    // (provider, sub) not in use
+      const insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+      vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/settings/profile?ssoLinked=1');
+      expect(createTokenPair).not.toHaveBeenCalled();
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+        userId: USER_UUID, providerId: PROVIDER_UUID, externalId: 'external-user-1'
+      }));
+    });
+
+    it('callback link mode rejects an email mismatch (no insert)', async () => {
+      primeLinkCallback(USER_UUID);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'someone-else@corp.com', name: 'Other' }]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('ssoLinkError=email_mismatch');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('callback link mode rejects a (provider, sub) already linked to another user (no insert)', async () => {
+      primeLinkCallback(USER_UUID);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([ORG_PROVIDER]))
+        .mockReturnValueOnce(sel([{ id: USER_UUID, email: 'tech@example.com', name: 'Tech' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-x', userId: '00000000-0000-4000-8000-0000000000aa' }]));
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('ssoLinkError=identity_in_use');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -1960,6 +1960,22 @@ describe('sso routes', () => {
       expect(createTokenPair).not.toHaveBeenCalled();
     });
 
+    it('rejects a linked user whose row is org-bound even with a partner membership (mint-gate re-assert)', async () => {
+      prime();
+      // Pre-existing (provider, sub) link resolves an ORG-BOUND user (orgId set).
+      // The mint-gate orgId IS NULL re-assert must reject before minting, even
+      // though a partner membership could exist.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))           // link exists
+        .mockReturnValueOnce(sel([{ ...STAFF, orgId: ORG_UUID }]));  // resolved user is org-bound
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=no_partner_access');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
     it('redirects no_partner_access when the user has no partner_users membership', async () => {
       prime();
       vi.mocked(db.select)

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -95,12 +95,14 @@ vi.mock('../db/schema', () => ({
   ssoProviders: {
     id: 'id',
     orgId: 'orgId',
+    partnerId: 'partnerId',
     name: 'name',
     type: 'type',
     status: 'status',
     issuer: 'issuer',
     autoProvision: 'autoProvision',
     enforceSSO: 'enforceSSO',
+    trustsIdpMfa: 'trustsIdpMfa',
     createdAt: 'createdAt',
     authorizationUrl: 'authorizationUrl',
     tokenUrl: 'tokenUrl',
@@ -134,7 +136,9 @@ vi.mock('../db/schema', () => ({
   roles: {
     id: 'id',
     name: 'name',
-    scope: 'scope'
+    scope: 'scope',
+    orgId: 'orgId',
+    partnerId: 'partnerId'
   }
 }));
 
@@ -193,6 +197,7 @@ import {
   verifyIdTokenSignature,
 } from '../services/sso';
 import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
 const ORG_UUID = '00000000-0000-4000-8000-000000000010';
@@ -209,6 +214,7 @@ describe('sso routes', () => {
     partnerId: string | null;
     accessibleOrgIds: string[] | null;
     canAccessOrg: (orgId: string) => boolean;
+    partnerOrgAccess: 'all' | 'selected' | 'none' | null;
   }> = {}) => {
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', {
@@ -217,6 +223,7 @@ describe('sso routes', () => {
         partnerId: 'partnerId' in overrides ? overrides.partnerId : null,
         accessibleOrgIds: 'accessibleOrgIds' in overrides ? overrides.accessibleOrgIds : [ORG_UUID],
         canAccessOrg: overrides.canAccessOrg ?? (() => true),
+        partnerOrgAccess: 'partnerOrgAccess' in overrides ? overrides.partnerOrgAccess : null,
         user: { id: USER_UUID, email: 'test@example.com' }
       });
       return next();
@@ -1457,6 +1464,265 @@ describe('sso routes', () => {
       expect(body.data[0].verified).toBe(false);
       expect(body.data[0].recordName).toBeDefined();
       expect(body.data[0].recordValue).toBeDefined();
+    });
+  });
+
+  describe('partner-axis provider CRUD (#2183)', () => {
+    it('creates a partner-axis provider for ownerScope=partner with orgAccess=all', async () => {
+      setAuthContext({
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_UUID,
+        accessibleOrgIds: [],
+        partnerOrgAccess: 'all'
+      });
+
+      const valuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: PROVIDER_UUID,
+          name: 'Partner Okta',
+          orgId: null,
+          partnerId: PARTNER_UUID
+        }])
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as any);
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner Okta',
+          type: 'oidc'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: null,
+        partnerId: PARTNER_UUID
+      }));
+    });
+
+    it('403s ownerScope=partner when partnerOrgAccess is not all', async () => {
+      setAuthContext({
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_UUID,
+        accessibleOrgIds: [ORG_UUID],
+        partnerOrgAccess: 'selected'
+      });
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner Okta',
+          type: 'oidc'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('400s a partner-axis defaultRoleId that is not a partner-scoped role of the caller partner', async () => {
+      setAuthContext({
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_UUID,
+        accessibleOrgIds: [],
+        partnerOrgAccess: 'all'
+      });
+
+      // No matching partner-scoped role for this partner.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          name: 'Partner Okta',
+          type: 'oidc',
+          defaultRoleId: '00000000-0000-4000-8000-000000000099'
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/partner-scoped role/);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects ownerScope on update (schema omits it)', async () => {
+      // Existing provider is org-axis; a PATCH body carrying `ownerScope` must
+      // be stripped by the schema (createProviderSchema.omit({ownerScope:true}))
+      // so the axis is never touched by an update.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }])
+          })
+        })
+      } as any);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: PROVIDER_UUID,
+            orgId: ORG_UUID,
+            partnerId: null,
+            name: 'Okta Renamed'
+          }])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ownerScope: 'partner', name: 'Okta Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      const setArg = setMock.mock.calls[0]?.[0];
+      expect(setArg).not.toHaveProperty('ownerScope');
+      expect(setArg).not.toHaveProperty('orgId');
+    });
+
+    it('does not accept partnerId from the request body', async () => {
+      setAuthContext({
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_UUID,
+        accessibleOrgIds: [],
+        partnerOrgAccess: 'all'
+      });
+
+      const valuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: PROVIDER_UUID,
+          name: 'Partner Okta',
+          orgId: null,
+          partnerId: PARTNER_UUID
+        }])
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as any);
+
+      const res = await app.request('/sso/providers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          partnerId: 'p-EVIL',
+          name: 'Partner Okta',
+          type: 'oidc'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      // partnerId always comes from the caller's token, never the body — even
+      // though createProviderSchema doesn't define a `partnerId` input field,
+      // this locks in the invariant so it can't regress if one is ever added.
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgId: null,
+        partnerId: PARTNER_UUID
+      }));
+    });
+
+    it('allows a system-scope caller scoped to the same partner to read a partner-axis provider by id', async () => {
+      // canAccessProviderRow requires `auth.partnerId === row.partnerId` even
+      // for system scope (partner-axis rows are never globally world-readable
+      // by an unscoped system token) — this simulates a system caller acting
+      // with that partner context (e.g. support tooling), not the generic
+      // background-worker system scope (which carries partnerId: null).
+      setAuthContext({ scope: 'system', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: null });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PROVIDER_UUID,
+              orgId: null,
+              partnerId: PARTNER_UUID,
+              name: 'Partner Okta',
+              type: 'oidc',
+              issuer: 'https://issuer.example.com',
+              clientSecret: 'secret'
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('denies an org-scope caller from reading a partner-axis provider', async () => {
+      setAuthContext({ scope: 'organization', orgId: ORG_UUID, partnerId: null, accessibleOrgIds: [ORG_UUID] });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PROVIDER_UUID,
+              orgId: null,
+              partnerId: PARTNER_UUID,
+              name: 'Partner Okta',
+              type: 'oidc',
+              issuer: 'https://issuer.example.com',
+              clientSecret: 'secret'
+            }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('403s deleting a partner-axis provider when the caller lacks full partner org access', async () => {
+      setAuthContext({
+        scope: 'partner',
+        orgId: null,
+        partnerId: PARTNER_UUID,
+        accessibleOrgIds: [ORG_UUID],
+        partnerOrgAccess: 'selected'
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: PROVIDER_UUID, orgId: null, partnerId: PARTNER_UUID }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -131,12 +131,19 @@ vi.mock('../db/schema', () => ({
   },
   users: {
     id: 'id',
-    email: 'email'
+    email: 'email',
+    orgId: 'orgId',
+    partnerId: 'partnerId'
   },
   organizationUsers: {
     orgId: 'orgId',
     roleId: 'roleId',
     userId: 'userId'
+  },
+  partnerUsers: {
+    userId: 'userId',
+    partnerId: 'partnerId',
+    roleId: 'roleId'
   },
   roles: {
     id: 'id',
@@ -154,6 +161,14 @@ vi.mock('../services/ssoDomainVerification', () => ({
   recordValueFor: vi.fn((token: string) => `breeze-domain-verify=${token}`),
   isSsoProvisioningBlocked: vi.fn().mockResolvedValue(false),
 }));
+
+// Partial-mock auth/helpers: keep the real cookie helpers the callback uses,
+// but stub auditLogin so partner-axis login tests can assert the audit call
+// (method: 'sso-partner') without invoking the real async audit-log writer.
+vi.mock('./auth/helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./auth/helpers')>();
+  return { ...actual, auditLogin: vi.fn() };
+});
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
@@ -203,6 +218,7 @@ import {
 } from '../services/sso';
 import { createPendingDomain, verifyDomain, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { auditLogin } from './auth/helpers';
 
 const PROVIDER_UUID = '00000000-0000-4000-8000-000000000001';
 const ORG_UUID = '00000000-0000-4000-8000-000000000010';
@@ -522,6 +538,7 @@ describe('sso routes', () => {
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
             id: PROVIDER_UUID,
+            orgId: ORG_UUID,
             type: 'saml'
           }])
         })
@@ -542,6 +559,7 @@ describe('sso routes', () => {
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
             id: PROVIDER_UUID,
+            orgId: ORG_UUID,
             type: 'oidc',
             issuer: 'https://issuer.example.com'
           }])
@@ -1810,6 +1828,234 @@ describe('sso routes', () => {
       expect(body.retryAfter).toBeGreaterThan(0);
       expect(db.select).not.toHaveBeenCalled();
       expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SSO callback — partner axis (#2183)', () => {
+    // A partner-axis provider: partnerId set, orgId null (DB CHECK: org XOR partner).
+    const PARTNER_PROVIDER = {
+      id: PROVIDER_UUID,
+      orgId: null,
+      partnerId: PARTNER_UUID,
+      type: 'oidc',
+      issuer: 'https://issuer.example.com',
+      authorizationUrl: 'https://issuer.example.com/auth',
+      tokenUrl: 'https://issuer.example.com/token',
+      userInfoUrl: 'https://issuer.example.com/userinfo',
+      jwksUrl: 'https://issuer.example.com/jwks',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scopes: 'openid profile email',
+      attributeMapping: { email: 'email', name: 'name' },
+      autoProvision: false,
+      allowedDomains: null,
+      defaultRoleId: null,
+      trustsIdpMfa: false
+    };
+    const STAFF = {
+      id: USER_UUID,
+      email: 'tech@msp.example',
+      name: 'Tech',
+      orgId: null,
+      partnerId: PARTNER_UUID,
+      passwordHash: null
+    };
+    const sel = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) })
+    } as any);
+    const selJoin = (rows: unknown[]) => ({
+      from: vi.fn().mockReturnValue({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) }) })
+    } as any);
+    const prime = () => {
+      vi.mocked(exchangeCodeForTokens).mockResolvedValue({ access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s' } as any);
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-user-1', email: 'tech@msp.example', name: 'Tech' } as any);
+      vi.mocked(mapUserAttributes).mockReturnValue({ email: 'tech@msp.example', name: 'Tech' } as any);
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sso-session-p', providerId: PROVIDER_UUID, state: 'state', nonce: 'nonce', codeVerifier: 'verifier', redirectUrl: '/dashboard' }]) })
+      } as any);
+    };
+    const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', { method: 'GET', headers: { cookie: ssoStateCookieHeader('state') } });
+
+    it('logs in linked partner staff with scope partner and null orgId', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))                 // provider by id
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))           // (provider, sub) identity link
+        .mockReturnValueOnce(sel([STAFF]))                           // linked user by id
+        .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }])) // partner_users membership
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));           // existingIdentity → update
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: USER_UUID, roleId: 'prole-1', orgId: null, partnerId: PARTNER_UUID, scope: 'partner' }),
+        expect.any(Object)
+      );
+      expect(auditLogin).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ scope: 'partner', method: 'sso-partner', orgId: null, userId: USER_UUID })
+      );
+    });
+
+    it('auto-links by email ONLY for passwordless unlinked partner staff', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no (provider, sub) link
+        .mockReturnValueOnce(sel([STAFF]))                           // byEmail (partnerId match, orgId IS NULL)
+        .mockReturnValueOnce(sel([]))                                // no other-provider link → safe to link
+        .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }]))
+        .mockReturnValueOnce(sel([]));                               // existingIdentity none → insert
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'partner', partnerId: PARTNER_UUID, orgId: null }),
+        expect.any(Object)
+      );
+    });
+
+    it('redirects sso_link_required for a password-holding email match', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no link
+        .mockReturnValueOnce(sel([{ ...STAFF, passwordHash: '$argon2id$hash' }])) // byEmail w/ password
+        .mockReturnValueOnce(sel([]));                               // otherProviderLink — still denied (has password)
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=sso_link_required');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('never resolves an org-bound user through a partner provider', async () => {
+      prime();
+      // The email-match lookup is axis-restricted to `partnerId = provider.partnerId
+      // AND orgId IS NULL`, so an org-bound user sharing the email is filtered out
+      // at the DB layer → the mock returns [] → falls through to invite_required.
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no link
+        .mockReturnValueOnce(sel([]));                               // byEmail excludes org-bound user
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=invite_required');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('redirects invite_required for unknown identities (no JIT)', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no link
+        .mockReturnValueOnce(sel([]));                               // no email match
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=invite_required');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('redirects no_partner_access when the user has no partner_users membership', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))           // linked
+        .mockReturnValueOnce(sel([STAFF]))
+        .mockReturnValueOnce(selJoin([]));                           // NO partner_users membership
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=no_partner_access');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('rejects a partner provider whose defaultRoleId is not partner-scoped', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{ ...PARTNER_PROVIDER, defaultRoleId: 'bad-role' }]))
+        .mockReturnValueOnce(sel([]));                               // role not partner-scoped in this partner → not found
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=invalid_provider_configuration');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    const wireMfa = (opts: { trustsIdpMfa: boolean; amr?: string[] }) => {
+      prime();
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue({ sub: 'external-user-1', nonce: 'nonce', amr: opts.amr } as any);
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([{ ...PARTNER_PROVIDER, trustsIdpMfa: opts.trustsIdpMfa }]))
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]))
+        .mockReturnValueOnce(sel([STAFF]))
+        .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }]))
+        .mockReturnValueOnce(sel([{ id: 'identity-1' }]));
+    };
+
+    it('sets mfa true only with trustsIdpMfa AND amr mfa', async () => {
+      wireMfa({ trustsIdpMfa: true, amr: ['pwd', 'mfa'] });
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'partner', mfa: true }),
+        expect.any(Object)
+      );
+    });
+
+    it('sets mfa false when trustsIdpMfa is set but amr does not attest mfa', async () => {
+      wireMfa({ trustsIdpMfa: true, amr: ['pwd'] });
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'partner', mfa: false }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('POST /sso/providers/:id/test — partner axis (#2183)', () => {
+    const OTHER_PARTNER = '00000000-0000-4000-8000-0000000000ff';
+    // Partner-axis provider WITHOUT an issuer → skips discovery, returns the
+    // "appears valid" success path once access is granted.
+    const partnerProviderRow = {
+      id: PROVIDER_UUID, orgId: null, partnerId: PARTNER_UUID, type: 'oidc', name: 'MSP IdP', issuer: null
+    };
+
+    it('allows a partner-scope caller to test their own partner-axis provider', async () => {
+      setAuthContext({ scope: 'partner', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: [], partnerOrgAccess: 'all' });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([partnerProviderRow]) }) })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('denies a cross-partner caller (no canAccessOrg fall-through on the partner axis)', async () => {
+      // canAccessOrg defaults to () => true — the deny MUST come from the
+      // axis-aware provider check, not an org fall-through.
+      setAuthContext({ scope: 'partner', orgId: null, partnerId: OTHER_PARTNER, accessibleOrgIds: [], partnerOrgAccess: 'all' });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([partnerProviderRow]) }) })
+      } as any);
+
+      const res = await app.request(`/sso/providers/${PROVIDER_UUID}/test`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(403);
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -1725,4 +1725,63 @@ describe('sso routes', () => {
       expect(db.delete).not.toHaveBeenCalled();
     });
   });
+
+  describe('GET /sso/login/partner/:partnerId (#2183)', () => {
+    it('404s when the partner has no active partner-axis provider', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/sso/login/partner/${PARTNER_UUID}`);
+
+      expect(res.status).toBe(404);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the IdP authorization URL and sets the state cookie for an active provider', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: PROVIDER_UUID,
+              orgId: null,
+              partnerId: PARTNER_UUID,
+              type: 'oidc',
+              status: 'active',
+              issuer: 'https://issuer.example.com',
+              authorizationUrl: 'https://issuer.example.com/auth',
+              tokenUrl: 'https://issuer.example.com/token',
+              userInfoUrl: 'https://issuer.example.com/userinfo',
+              jwksUrl: 'https://issuer.example.com/jwks',
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              scopes: 'openid profile email',
+              attributeMapping: { email: 'email', name: 'name' },
+              autoProvision: false,
+              allowedDomains: null,
+              defaultRoleId: null
+            }])
+          })
+        })
+      } as any);
+
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as any);
+
+      const res = await app.request(`/sso/login/partner/${PARTNER_UUID}?redirect=/dashboard`);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://idp.example.com/auth');
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+        providerId: PROVIDER_UUID,
+        redirectUrl: '/dashboard'
+      }));
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('breeze_sso_state=');
+    });
+  });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -57,7 +57,12 @@ vi.mock('../services', () => ({
   // Task 7 follow-up: SSO callback now mints a refresh-token family for
   // every completed sign-in so reuse-detection covers SSO sessions.
   mintRefreshTokenFamily: vi.fn().mockResolvedValue('sso-family-id-mock'),
-  bindRefreshJtiToFamily: vi.fn().mockResolvedValue(undefined)
+  bindRefreshJtiToFamily: vi.fn().mockResolvedValue(undefined),
+  // Partner-axis login rate limiting (#2183 spec §5) — default allowed so
+  // existing tests exercising the route body are unaffected; the dedicated
+  // 429 test overrides this per-call.
+  rateLimiter: vi.fn().mockResolvedValue({ allowed: true, remaining: 9, resetAt: new Date(Date.now() + 60_000) }),
+  getRedis: vi.fn().mockReturnValue({})
 }));
 
 vi.mock('../db', () => ({
@@ -187,7 +192,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db } from '../db';
-import { createTokenPair } from '../services';
+import { createTokenPair, rateLimiter } from '../services';
 import { authMiddleware } from '../middleware/auth';
 import {
   discoverOIDCConfig,
@@ -247,6 +252,11 @@ describe('sso routes', () => {
     } as any);
     vi.mocked(db.update).mockReset().mockReturnValue({
       set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })) }))
+    } as any);
+    vi.mocked(rateLimiter).mockReset().mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      resetAt: new Date(Date.now() + 60_000)
     } as any);
     delete process.env.SSO_EXCHANGE_RETURN_REFRESH_TOKEN;
     process.env.APP_ENCRYPTION_KEY = SSO_STATE_COOKIE_SECRET;
@@ -1782,6 +1792,24 @@ describe('sso routes', () => {
       }));
       const setCookie = res.headers.get('set-cookie') ?? '';
       expect(setCookie).toContain('breeze_sso_state=');
+    });
+
+    it('429s when the per-IP+partner rate limit is exceeded, without touching the DB', async () => {
+      const resetAt = new Date(Date.now() + 45_000);
+      vi.mocked(rateLimiter).mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt
+      } as any);
+
+      const res = await app.request(`/sso/login/partner/${PARTNER_UUID}`);
+
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.error).toBe('Too many login attempts. Please try again later.');
+      expect(body.retryAfter).toBeGreaterThan(0);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -32,7 +32,7 @@ import {
   PROVIDER_PRESETS,
   type OIDCConfig
 } from '../services/sso';
-import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily } from '../services';
+import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, rateLimiter, getRedis } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { getTrustedClientIp } from '../services/clientIp';
@@ -991,6 +991,13 @@ ssoRoutes.delete(
 
 const partnerIdParamSchema = z.object({ partnerId: z.string().guid() });
 
+// Design spec (#2183, "Security & error handling"): "login rate limits
+// (per-IP and per-IP+identity) apply to the new entry point." There's no
+// user identity at this pre-auth entry point, so the partnerId being
+// targeted stands in for "identity" — same shape as the password-login
+// per-(IP,email) bucket in routes/auth/login.ts.
+const PARTNER_SSO_LOGIN_RATE_LIMIT = { limit: 10, windowSeconds: 5 * 60 };
+
 // Initiate partner-axis SSO login (#2183) — the MSP's own technician login.
 // Public route: all DB access MUST run under system context (no request scope
 // exists yet; bare `db` silently returns 0 rows under RLS). Mounted ABOVE
@@ -1000,6 +1007,21 @@ const partnerIdParamSchema = z.object({ partnerId: z.string().guid() });
 ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSchema), async (c) => {
   const { partnerId } = c.req.valid('param');
   const redirectUrl = normalizeRedirectPath(c.req.query('redirect'));
+
+  const ip = getClientIP(c);
+  const redis = getRedis();
+  const rateCheck = await rateLimiter(
+    redis,
+    `sso:login:partner:${ip}:${partnerId}`,
+    PARTNER_SSO_LOGIN_RATE_LIMIT.limit,
+    PARTNER_SSO_LOGIN_RATE_LIMIT.windowSeconds
+  );
+  if (!rateCheck.allowed) {
+    return c.json({
+      error: 'Too many login attempts. Please try again later.',
+      retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
 
   const [provider] = await withSystemDbAccessContext(async () =>
     db

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -987,6 +987,139 @@ ssoRoutes.delete(
 );
 
 // ============================================
+// Self-service "Connect SSO" — authenticated identity linking (#2183)
+// ============================================
+//
+// Password-holding users are NEVER auto-linked at login (Task 5 refuses to
+// JIT-link an assertion to an account that has a password or another provider
+// link). This is the sanctioned path for those users to adopt SSO: an
+// already-authenticated user connects their own IdP identity, from their own
+// security settings. It works on BOTH axes — an org member links an org-axis
+// provider, partner staff link a partner-axis provider.
+//
+// Axis determinant: the caller's TOKEN scope, not the provider. An
+// organization-scope token means an org member (auth.orgId = their org); a
+// partner-scope token means partner staff (auth.partnerId = their partner).
+// `AuthContext.user` carries no orgId/partnerId, so we key off the token's
+// scope/orgId/partnerId. This is exactly what keeps an org-bound user from ever
+// linking a partner-axis provider (an org-bound user can only ever hold an
+// organization-scope token), preserving the Task-5 mint-gate invariant.
+
+// Providers the current user may link, each with its linked status.
+ssoRoutes.get('/link/options', authMiddleware, async (c) => {
+  const auth = c.get('auth') as AuthContext;
+
+  const axisCondition =
+    auth.scope === 'organization' && auth.orgId
+      ? eq(ssoProviders.orgId, auth.orgId)
+      : auth.scope === 'partner' && auth.partnerId
+        ? eq(ssoProviders.partnerId, auth.partnerId)
+        : null;
+  if (!axisCondition) {
+    return c.json({ data: [] });
+  }
+
+  const providers = await db
+    .select({
+      id: ssoProviders.id,
+      name: ssoProviders.name,
+      type: ssoProviders.type,
+      linkedId: userSsoIdentities.id
+    })
+    .from(ssoProviders)
+    .leftJoin(userSsoIdentities, and(
+      eq(userSsoIdentities.providerId, ssoProviders.id),
+      eq(userSsoIdentities.userId, auth.user.id)
+    ))
+    .where(and(axisCondition, ne(ssoProviders.status, 'inactive')));
+
+  return c.json({
+    data: providers.map((p) => ({ id: p.id, name: p.name, type: p.type, linked: !!p.linkedId }))
+  });
+});
+
+// Start a link-mode IdP round-trip. requireMfa(): connecting an SSO identity
+// adds a login credential, so it is a security-sensitive account change and an
+// unMFA'd session must not be able to bind a new login method.
+ssoRoutes.post(
+  '/link/start/:providerId',
+  authMiddleware,
+  requireMfa(),
+  zValidator('param', z.object({ providerId: z.string().guid() })),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { providerId } = c.req.valid('param');
+
+    const [provider] = await db
+      .select()
+      .from(ssoProviders)
+      .where(eq(ssoProviders.id, providerId))
+      .limit(1);
+
+    if (!provider || provider.status === 'inactive') {
+      return c.json({ error: 'Provider not found' }, 404);
+    }
+
+    // Axis-pool check: the provider must be plausible for the linking user.
+    // Org-axis → the caller must be a member of that org (organization-scope
+    // token, matching orgId). Partner-axis → the caller must be staff of that
+    // partner (partner-scope token, matching partnerId). An org-bound user
+    // (organization scope) can therefore NEVER pass the partner branch, so a
+    // link Task-5's resolution would later reject can never be created.
+    const inPool = provider.orgId
+      ? auth.scope === 'organization' && auth.orgId === provider.orgId
+      : auth.scope === 'partner' && auth.partnerId === provider.partnerId;
+    if (!inPool) {
+      return c.json({ error: 'You cannot link this SSO provider' }, 403);
+    }
+
+    if (provider.type !== 'oidc') {
+      return c.json({ error: 'Only OIDC linking is currently supported' }, 400);
+    }
+
+    const config = getOIDCConfig(provider);
+    const pkce = generatePKCEChallenge();
+    const state = generateState();
+    const nonce = generateNonce();
+
+    await db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl: '/settings/profile',
+      linkUserId: auth.user.id,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+    });
+
+    const authUrl = buildAuthorizationUrl({
+      config,
+      state,
+      nonce,
+      redirectUri: buildSsoCallbackUri(),
+      pkce
+    });
+
+    const stateCookie = buildSsoStateCookie(state);
+    if (!stateCookie) {
+      return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+    }
+    c.header('Set-Cookie', stateCookie, { append: true });
+
+    writeRouteAudit(c, {
+      orgId: provider.orgId,
+      action: 'sso.identity.link_started',
+      resourceType: 'sso_provider',
+      resourceId: provider.id,
+      resourceName: provider.name,
+      details: { partnerId: provider.partnerId, userId: auth.user.id }
+    });
+
+    return c.json({ authUrl });
+  }
+);
+
+// ============================================
 // SSO Login Flow (Public)
 // ============================================
 
@@ -1332,6 +1465,75 @@ ssoRoutes.get('/callback', async (c) => {
     if (typeof externalSub !== 'string' || externalSub.length === 0) {
       clearStateCookie();
       return c.redirect('/login?error=sso_no_subject');
+    }
+
+    // ── Link mode (#2183 Connect SSO): this round-trip belongs to an
+    // already-authenticated user connecting their identity — never a login.
+    // Placed AFTER the full id_token signature/nonce verification, the atomic
+    // session claim, the userinfo `sub` binding, and the allowedDomains check,
+    // and BEFORE the login-path user resolution. Link mode NEVER mints tokens,
+    // NEVER creates users, and NEVER touches login's identity resolution.
+    if (session.linkUserId) {
+      const outcome = await withSystemDbAccessContext(async () => {
+        const [linkingUser] = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, session.linkUserId!))
+          .limit(1);
+        if (!linkingUser) return { error: 'user_gone' as const };
+
+        // The verified assertion must be for the SAME person: the asserted
+        // email must equal the linking user's email. Without this a user could
+        // bind an arbitrary IdP account (or a phished consent) to their session.
+        if (attrs.email.toLowerCase() !== linkingUser.email.toLowerCase()) {
+          return { error: 'email_mismatch' as const };
+        }
+
+        // (provider, sub) must not already belong to someone else — a link must
+        // never overwrite or hijack another user's identity.
+        const [existing] = await db
+          .select({ id: userSsoIdentities.id, userId: userSsoIdentities.userId })
+          .from(userSsoIdentities)
+          .where(and(
+            eq(userSsoIdentities.providerId, provider.id),
+            eq(userSsoIdentities.externalId, externalSub)
+          ))
+          .limit(1);
+        if (existing && existing.userId !== linkingUser.id) {
+          return { error: 'identity_in_use' as const };
+        }
+
+        if (!existing) {
+          await db.insert(userSsoIdentities).values({
+            userId: linkingUser.id,
+            providerId: provider.id,
+            externalId: externalSub,
+            email: attrs.email,
+            profile: userInfo,
+            accessToken: encryptSecret(tokens.access_token),
+            refreshToken: encryptSecret(tokens.refresh_token),
+            tokenExpiresAt: tokens.expires_in
+              ? new Date(Date.now() + tokens.expires_in * 1000)
+              : null,
+            lastLoginAt: null
+          });
+        }
+        return { ok: true as const };
+      });
+
+      clearStateCookie();
+      if ('error' in outcome) {
+        return c.redirect(`/settings/profile?ssoLinkError=${outcome.error}`);
+      }
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.identity.linked',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        details: { partnerId: provider.partnerId, userId: session.linkUserId }
+      });
+      return c.redirect('/settings/profile?ssoLinked=1');
     }
 
     let user = await withSystemDbAccessContext(async () => {

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1503,6 +1503,17 @@ ssoRoutes.get('/callback', async (c) => {
     // Membership resolution + token payload, keyed on the provider's axis.
     let tokenPayload: Parameters<typeof createTokenPair>[0];
     if (provider.partnerId) {
+      // Defense-in-depth: a partner token is ONLY for partner STAFF
+      // (users.orgId IS NULL). Re-assert the invariant at the MINT gate, not
+      // just at link/email-resolution time — so even a resolved user reached
+      // via a pre-existing (provider, sub) link cannot mint a scope:'partner'
+      // / orgId:null token if their row is org-bound. Org-bound users never
+      // authenticate through a partner provider.
+      if (user.orgId != null) {
+        clearStateCookie();
+        return c.redirect('/login?error=no_partner_access');
+      }
+
       // Partner axis (#2183): the tech's role membership lives in partner_users
       // and MUST be partner-scoped. A user with NO partner_users membership is
       // REJECTED (no_partner_access) — it never falls back to the provider

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1760,22 +1760,32 @@ ssoRoutes.get('/callback', async (c) => {
         mfa: ssoMfa
       };
     } else {
-      const [orgUser] = await db
-        .select({
-          orgId: organizationUsers.orgId,
-          roleId: organizationUsers.roleId,
-          roleName: roles.name,
-          roleScope: roles.scope
-        })
-        .from(organizationUsers)
-        .innerJoin(roles, eq(roles.id, organizationUsers.roleId))
-        .where(
-          and(
-            eq(organizationUsers.userId, user.id),
-            eq(organizationUsers.orgId, provider.orgId!)
+      // System context required: same class of bug as the "Get provider"
+      // fix above — the callback is unauthenticated (no request scope), so a
+      // bare `db` read here silently 0-rows under RLS and every org-axis
+      // login would fail with no_org_access regardless of real membership.
+      // Pre-existing (predates #2183, confirmed via git blame); fixed here
+      // alongside the provider-read fix since both are shared callback
+      // plumbing and the org-axis e2e regression case now exercises this
+      // exact path (see ssoPartnerLogin.integration.test.ts).
+      const [orgUser] = await withSystemDbAccessContext(async () =>
+        db
+          .select({
+            orgId: organizationUsers.orgId,
+            roleId: organizationUsers.roleId,
+            roleName: roles.name,
+            roleScope: roles.scope
+          })
+          .from(organizationUsers)
+          .innerJoin(roles, eq(roles.id, organizationUsers.roleId))
+          .where(
+            and(
+              eq(organizationUsers.userId, user.id),
+              eq(organizationUsers.orgId, provider.orgId!)
+            )
           )
-        )
-        .limit(1);
+          .limit(1)
+      );
 
       if (!orgUser) {
         clearStateCookie();

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -34,6 +34,7 @@ import {
 } from '../services/sso';
 import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { getTrustedClientIp } from '../services/clientIp';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
@@ -123,6 +124,7 @@ function isValidSsoStateCookie(state: string, cookieHeader: string | undefined):
 // ============================================
 
 const createProviderSchema = z.object({
+  ownerScope: z.enum(['organization', 'partner']).default('organization'),
   orgId: z.string().guid().optional(),
   name: z.string().min(1).max(255),
   type: z.enum(['oidc', 'saml']),
@@ -145,7 +147,7 @@ const createProviderSchema = z.object({
   trustsIdpMfa: z.boolean().optional()
 });
 
-const updateProviderSchema = createProviderSchema.omit({ orgId: true }).partial();
+const updateProviderSchema = createProviderSchema.omit({ orgId: true, ownerScope: true }).partial();
 const tokenExchangeSchema = z.object({
   code: z.string().min(1)
 });
@@ -355,6 +357,21 @@ function resolveOrgIdForProviderRoute(
   return { error: 'Organization ID required', status: 400 };
 }
 
+type ProviderOwnerRow = { orgId: string | null; partnerId: string | null };
+
+// Read access: org rows by org access; partner rows only for the same partner's
+// partner/system-scope callers (org tokens never see partner-axis providers).
+function canAccessProviderRow(auth: AuthContext, row: ProviderOwnerRow): boolean {
+  if (row.orgId) return auth.canAccessOrg(row.orgId);
+  return (auth.scope === 'system' || auth.scope === 'partner') && auth.partnerId === row.partnerId;
+}
+
+// Write access: partner-axis rows additionally require full partner org access.
+function canWriteProviderRow(auth: AuthContext, row: ProviderOwnerRow): boolean {
+  if (row.orgId) return auth.canAccessOrg(row.orgId);
+  return auth.partnerId === row.partnerId && canManagePartnerWidePolicies(auth);
+}
+
 const providerIdParamSchema = z.object({ id: z.string().guid() });
 const orgIdParamSchema = z.object({ orgId: z.string().guid() });
 
@@ -375,6 +392,31 @@ ssoRoutes.get('/presets', authMiddleware, requireScope('organization', 'partner'
 // List SSO providers for organization
 ssoRoutes.get('/providers', authMiddleware, requireScope('organization', 'partner', 'system'), async (c) => {
   const auth = c.get('auth') as AuthContext;
+
+  if (c.req.query('scope') === 'partner') {
+    if (!(auth.scope === 'partner' || auth.scope === 'system') || !auth.partnerId) {
+      return c.json({ error: 'Partner scope required' }, 400);
+    }
+
+    const partnerProviders = await db
+      .select({
+        id: ssoProviders.id,
+        name: ssoProviders.name,
+        type: ssoProviders.type,
+        status: ssoProviders.status,
+        issuer: ssoProviders.issuer,
+        autoProvision: ssoProviders.autoProvision,
+        enforceSSO: ssoProviders.enforceSSO,
+        trustsIdpMfa: ssoProviders.trustsIdpMfa,
+        createdAt: ssoProviders.createdAt,
+        partnerId: ssoProviders.partnerId
+      })
+      .from(ssoProviders)
+      .where(eq(ssoProviders.partnerId, auth.partnerId));
+
+    return c.json({ data: partnerProviders });
+  }
+
   const orgResult = resolveOrgIdForProviderRoute(auth, c.req.query('orgId'));
   if ('error' in orgResult) {
     return c.json({ error: orgResult.error }, orgResult.status);
@@ -413,7 +455,7 @@ ssoRoutes.get('/providers/:id', authMiddleware, requireScope('organization', 'pa
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  if (!auth.canAccessOrg(provider.orgId)) {
+  if (!canAccessProviderRow(auth, provider)) {
     return c.json({ error: 'Access denied' }, 403);
   }
 
@@ -434,9 +476,36 @@ ssoRoutes.post(
   async (c) => {
   const auth = c.get('auth') as AuthContext;
   const body = c.req.valid('json');
-  const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
-  if ('error' in orgResult) {
-    return c.json({ error: orgResult.error }, orgResult.status);
+
+  let ownerColumns: { orgId: string | null; partnerId: string | null };
+  if (body.ownerScope === 'partner') {
+    if (auth.scope !== 'partner' || !auth.partnerId) {
+      return c.json({ error: 'Partner scope required for a partner-axis SSO provider' }, 400);
+    }
+    if (!canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+    if (body.defaultRoleId) {
+      const [role] = await db
+        .select({ id: roles.id })
+        .from(roles)
+        .where(and(
+          eq(roles.id, body.defaultRoleId),
+          eq(roles.scope, 'partner'),
+          eq(roles.partnerId, auth.partnerId)
+        ))
+        .limit(1);
+      if (!role) {
+        return c.json({ error: 'defaultRoleId must be a partner-scoped role belonging to your partner' }, 400);
+      }
+    }
+    ownerColumns = { orgId: null, partnerId: auth.partnerId };
+  } else {
+    const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
+    if ('error' in orgResult) {
+      return c.json({ error: orgResult.error }, orgResult.status);
+    }
+    ownerColumns = { orgId: orgResult.orgId, partnerId: null };
   }
 
   // Apply preset if specified
@@ -468,7 +537,7 @@ ssoRoutes.post(
   const [provider] = await db
     .insert(ssoProviders)
     .values({
-      orgId: orgResult.orgId,
+      ...ownerColumns,
       name: body.name,
       type: body.type,
       issuer: body.issuer,
@@ -500,7 +569,7 @@ ssoRoutes.post(
     resourceType: 'sso_provider',
     resourceId: provider.id,
     resourceName: provider.name,
-    details: { type: provider.type, status: provider.status }
+    details: { type: provider.type, status: provider.status, partnerId: provider.partnerId }
   });
 
     const { clientSecret, ...safeProvider } = provider;
@@ -523,7 +592,7 @@ ssoRoutes.patch(
   const body = c.req.valid('json');
 
   const [existing] = await db
-    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId })
+    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
     .from(ssoProviders)
     .where(eq(ssoProviders.id, providerId))
     .limit(1);
@@ -532,8 +601,23 @@ ssoRoutes.patch(
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  if (!auth.canAccessOrg(existing.orgId)) {
+  if (!canWriteProviderRow(auth, existing)) {
     return c.json({ error: 'Access denied' }, 403);
+  }
+
+  if (existing.partnerId && body.defaultRoleId) {
+    const [role] = await db
+      .select({ id: roles.id })
+      .from(roles)
+      .where(and(
+        eq(roles.id, body.defaultRoleId),
+        eq(roles.scope, 'partner'),
+        eq(roles.partnerId, existing.partnerId)
+      ))
+      .limit(1);
+    if (!role) {
+      return c.json({ error: 'defaultRoleId must be a partner-scoped role belonging to your partner' }, 400);
+    }
   }
 
   const updates: Partial<typeof ssoProviders.$inferInsert> = {
@@ -548,7 +632,7 @@ ssoRoutes.patch(
   const [updated] = await db
     .update(ssoProviders)
     .set(updates)
-    .where(and(eq(ssoProviders.id, providerId), eq(ssoProviders.orgId, existing.orgId)))
+    .where(eq(ssoProviders.id, providerId))
     .returning();
 
   if (!updated) {
@@ -561,7 +645,7 @@ ssoRoutes.patch(
     resourceType: 'sso_provider',
     resourceId: updated.id,
     resourceName: updated.name,
-    details: { changedFields: Object.keys(body) }
+    details: { changedFields: Object.keys(body), partnerId: updated.partnerId }
   });
 
     const { clientSecret, ...safeProvider } = updated;
@@ -582,7 +666,7 @@ ssoRoutes.delete(
   const { id: providerId } = c.req.valid('param');
 
   const [existing] = await db
-    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId })
+    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
     .from(ssoProviders)
     .where(eq(ssoProviders.id, providerId))
     .limit(1);
@@ -591,7 +675,7 @@ ssoRoutes.delete(
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  if (!auth.canAccessOrg(existing.orgId)) {
+  if (!canWriteProviderRow(auth, existing)) {
     return c.json({ error: 'Access denied' }, 403);
   }
 
@@ -601,7 +685,7 @@ ssoRoutes.delete(
 
   const [deleted] = await db
     .delete(ssoProviders)
-    .where(and(eq(ssoProviders.id, providerId), eq(ssoProviders.orgId, existing.orgId)))
+    .where(eq(ssoProviders.id, providerId))
     .returning();
 
   if (!deleted) {
@@ -613,7 +697,8 @@ ssoRoutes.delete(
     action: 'sso.provider.delete',
     resourceType: 'sso_provider',
     resourceId: deleted.id,
-    resourceName: deleted.name
+    resourceName: deleted.name,
+    details: { partnerId: deleted.partnerId }
   });
 
     return c.json({ success: true });
@@ -635,7 +720,7 @@ ssoRoutes.post(
   const { status } = c.req.valid('json');
 
   const [existing] = await db
-    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId })
+    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
     .from(ssoProviders)
     .where(eq(ssoProviders.id, providerId))
     .limit(1);
@@ -644,14 +729,14 @@ ssoRoutes.post(
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  if (!auth.canAccessOrg(existing.orgId)) {
+  if (!canWriteProviderRow(auth, existing)) {
     return c.json({ error: 'Access denied' }, 403);
   }
 
   const [updated] = await db
     .update(ssoProviders)
     .set({ status, updatedAt: new Date() })
-    .where(and(eq(ssoProviders.id, providerId), eq(ssoProviders.orgId, existing.orgId)))
+    .where(eq(ssoProviders.id, providerId))
     .returning();
 
   if (!updated) {
@@ -664,7 +749,7 @@ ssoRoutes.post(
     resourceType: 'sso_provider',
     resourceId: updated.id,
     resourceName: updated.name,
-    details: { status }
+    details: { status, partnerId: updated.partnerId }
   });
 
     return c.json({ data: updated });
@@ -693,7 +778,11 @@ ssoRoutes.post(
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  if (!auth.canAccessOrg(provider.orgId)) {
+  // Test-configuration is org-axis only for now (partner-axis provider testing
+  // is deferred to a later #2183 task); a null orgId here fails closed for
+  // org/partner-scope callers via canAccessOrg's `.includes(null)` and is
+  // allowed for system scope, matching the pre-#2183 behavior for org rows.
+  if (!auth.canAccessOrg(provider.orgId as string)) {
     return c.json({ error: 'Access denied' }, 403);
   }
 
@@ -1031,6 +1120,17 @@ ssoRoutes.get('/callback', async (c) => {
     return c.redirect('/login?error=provider_not_found');
   }
 
+  // This callback only ever completes an org-axis login today — sessions are
+  // only ever created by the org-scoped /login/:orgId lookup (partner-axis
+  // login is a later #2183 task), so orgId is expected to be set here. Narrow
+  // explicitly (rather than assert) so the type flows into the closures below,
+  // and fail closed defensively if that invariant is ever violated.
+  const providerOrgId = provider.orgId;
+  if (!providerOrgId) {
+    clearStateCookie();
+    return c.redirect('/login?error=provider_not_found');
+  }
+
   let validatedDefaultRoleId: string | null = null;
   if (provider.defaultRoleId) {
     const [defaultRole] = await db
@@ -1040,7 +1140,7 @@ ssoRoutes.get('/callback', async (c) => {
         and(
           eq(roles.id, provider.defaultRoleId),
           eq(roles.scope, 'organization'),
-          eq(roles.orgId, provider.orgId)
+          eq(roles.orgId, providerOrgId)
         )
       )
       .limit(1);
@@ -1162,11 +1262,11 @@ ssoRoutes.get('/callback', async (c) => {
     if (!user) {
       const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
       const domainBlocked = await withSystemDbAccessContext(() =>
-        isSsoProvisioningBlocked(provider.orgId, assertedEmailDomain)
+        isSsoProvisioningBlocked(providerOrgId, assertedEmailDomain)
       );
       if (domainBlocked) {
         console.warn(
-          `[sso/callback] domain verification blocked link/provision: org=${provider.orgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
+          `[sso/callback] domain verification blocked link/provision: org=${providerOrgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
         );
         clearStateCookie();
         return c.redirect('/login?error=sso_domain_unverified');
@@ -1225,7 +1325,7 @@ ssoRoutes.get('/callback', async (c) => {
         const [providerOrg] = await db
           .select({ partnerId: organizations.partnerId })
           .from(organizations)
-          .where(eq(organizations.id, provider.orgId))
+          .where(eq(organizations.id, providerOrgId))
           .limit(1);
         if (!providerOrg) {
           return null;
@@ -1235,7 +1335,7 @@ ssoRoutes.get('/callback', async (c) => {
           .insert(users)
           .values({
             partnerId: providerOrg.partnerId,
-            orgId: provider.orgId,
+            orgId: providerOrgId,
             email: attrs.email.toLowerCase(),
             name: attrs.name,
             status: 'active',
@@ -1248,7 +1348,7 @@ ssoRoutes.get('/callback', async (c) => {
         }
 
         await db.insert(organizationUsers).values({
-          orgId: provider.orgId,
+          orgId: providerOrgId,
           userId: created.id,
           roleId: validatedDefaultRoleId
         });
@@ -1276,7 +1376,7 @@ ssoRoutes.get('/callback', async (c) => {
       .where(
         and(
           eq(organizationUsers.userId, user.id),
-          eq(organizationUsers.orgId, provider.orgId)
+          eq(organizationUsers.orgId, providerOrgId)
         )
       )
       .limit(1);
@@ -1363,7 +1463,7 @@ ssoRoutes.get('/callback', async (c) => {
       sub: user.id,
       email: user.email,
       roleId: orgUser.roleId,
-      orgId: provider.orgId,
+      orgId: providerOrgId,
       partnerId: null,
       scope: 'organization' as const,
       mfa: ssoMfa

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, and, gt, ne } from 'drizzle-orm';
+import { eq, and, gt, ne, isNull } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { db, withSystemDbAccessContext } from '../db';
@@ -13,6 +13,7 @@ import {
   users,
   organizations,
   organizationUsers,
+  partnerUsers,
   roles
 } from '../db/schema';
 import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked } from '../services/ssoDomainVerification';
@@ -39,7 +40,7 @@ import { getTrustedClientIp } from '../services/clientIp';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
 import { envFlag } from '../utils/envFlag';
-import { setRefreshTokenCookie, getCookieValue } from './auth/helpers';
+import { setRefreshTokenCookie, getCookieValue, auditLogin } from './auth/helpers';
 
 export const ssoRoutes = new Hono();
 
@@ -778,11 +779,11 @@ ssoRoutes.post(
     return c.json({ error: 'Provider not found' }, 404);
   }
 
-  // Test-configuration is org-axis only for now (partner-axis provider testing
-  // is deferred to a later #2183 task); a null orgId here fails closed for
-  // org/partner-scope callers via canAccessOrg's `.includes(null)` and is
-  // allowed for system scope, matching the pre-#2183 behavior for org rows.
-  if (!auth.canAccessOrg(provider.orgId as string)) {
+  // Axis-aware access (#2183): org rows resolve via org access; partner-axis
+  // rows (orgId NULL) are decided on the provider's OWN partner — a system- or
+  // partner-scope caller must match provider.partnerId and never falls through
+  // a canAccessOrg(null) org check.
+  if (!canAccessProviderRow(auth, provider)) {
     return c.json({ error: 'Access denied' }, 403);
   }
 
@@ -1207,30 +1208,39 @@ ssoRoutes.get('/callback', async (c) => {
     return c.redirect('/login?error=provider_not_found');
   }
 
-  // This callback only ever completes an org-axis login today — sessions are
-  // only ever created by the org-scoped /login/:orgId lookup (partner-axis
-  // login is a later #2183 task), so orgId is expected to be set here. Narrow
-  // explicitly (rather than assert) so the type flows into the closures below,
-  // and fail closed defensively if that invariant is ever violated.
+  // A provider is bound to exactly one axis (DB CHECK: org_id XOR partner_id):
+  // org-axis sessions come from /login/:orgId, partner-axis from
+  // /login/partner/:partnerId (#2183). Fail closed only if NEITHER axis is set
+  // (should be impossible). `providerOrgId` stays the org-axis handle; the
+  // partner branch below keys off `provider.partnerId` instead.
   const providerOrgId = provider.orgId;
-  if (!providerOrgId) {
+  if (!providerOrgId && !provider.partnerId) {
     clearStateCookie();
     return c.redirect('/login?error=provider_not_found');
   }
 
+  // Default-role validation is axis-aware: partner-axis providers require a
+  // partner-scoped role in the provider's OWN partner; org-axis providers an
+  // organization-scoped role in the provider's org. NOTE: on the partner axis
+  // this is config validation ONLY — v1 never APPLIES a default role at login
+  // (identity-first, membership-required), so a defaultRoleId can never grant
+  // access to a membershipless user.
   let validatedDefaultRoleId: string | null = null;
   if (provider.defaultRoleId) {
-    const [defaultRole] = await db
-      .select({ id: roles.id })
-      .from(roles)
-      .where(
-        and(
+    const roleCondition = provider.partnerId
+      ? and(
+          eq(roles.id, provider.defaultRoleId),
+          eq(roles.scope, 'partner'),
+          eq(roles.partnerId, provider.partnerId)
+        )
+      : and(
           eq(roles.id, provider.defaultRoleId),
           eq(roles.scope, 'organization'),
-          eq(roles.orgId, providerOrgId)
-        )
-      )
-      .limit(1);
+          eq(roles.orgId, provider.orgId!)
+        );
+    const [defaultRole] = await withSystemDbAccessContext(async () =>
+      db.select({ id: roles.id }).from(roles).where(roleCondition).limit(1)
+    );
 
     if (!defaultRole) {
       clearStateCookie();
@@ -1346,14 +1356,18 @@ ssoRoutes.get('/callback', async (c) => {
     // identities (resolved above by provider+sub) are intentionally exempt, so
     // turning enforcement on never locks out existing SSO users. System scope:
     // the public callback is unauthenticated.
-    if (!user) {
+    // Org-axis only: the DNS domain-ownership gate protects JIT link/provision
+    // into an ORG. The partner axis has no JIT and its email-match is already
+    // restricted to the partner's own staff pool (partnerId + orgId IS NULL)
+    // below, so it doesn't consult verified org domains.
+    if (!user && provider.orgId) {
       const assertedEmailDomain = attrs.email.split('@')[1]?.toLowerCase() ?? null;
       const domainBlocked = await withSystemDbAccessContext(() =>
-        isSsoProvisioningBlocked(providerOrgId, assertedEmailDomain)
+        isSsoProvisioningBlocked(provider.orgId!, assertedEmailDomain)
       );
       if (domainBlocked) {
         console.warn(
-          `[sso/callback] domain verification blocked link/provision: org=${providerOrgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
+          `[sso/callback] domain verification blocked link/provision: org=${provider.orgId} provider=${provider.id} emailDomain=${assertedEmailDomain ?? 'none'}`
         );
         clearStateCookie();
         return c.redirect('/login?error=sso_domain_unverified');
@@ -1367,8 +1381,19 @@ ssoRoutes.get('/callback', async (c) => {
       // can assert a victim's email). Only auto-link when it is SAFE: the
       // account has no password AND no link to a DIFFERENT provider. Otherwise
       // the user must opt into SSO linking from an authenticated session.
+      // Partner axis restricts the email-match to the provider's OWN staff pool
+      // (partnerId match AND orgId IS NULL). This is what guarantees an
+      // org-bound user (orgId set) can NEVER be resolved through a partner
+      // provider — the row is filtered out at the DB layer, never matched.
+      const emailCondition = provider.partnerId
+        ? and(
+            eq(users.email, attrs.email.toLowerCase()),
+            eq(users.partnerId, provider.partnerId),
+            isNull(users.orgId)
+          )
+        : eq(users.email, attrs.email.toLowerCase());
       const [byEmail] = await withSystemDbAccessContext(async () =>
-        db.select().from(users).where(eq(users.email, attrs.email.toLowerCase())).limit(1)
+        db.select().from(users).where(emailCondition).limit(1)
       );
 
       if (byEmail) {
@@ -1392,6 +1417,15 @@ ssoRoutes.get('/callback', async (c) => {
       }
     }
 
+    // Partner axis: identity-first, NO JIT. A user was neither linked by
+    // (provider, sub) nor matched to an existing passwordless staff account, so
+    // there is no account to log in — the tech must be invited/provisioned out
+    // of band. Never auto-provision on the partner axis.
+    if (!user && provider.partnerId) {
+      clearStateCookie();
+      return c.redirect('/login?error=invite_required');
+    }
+
     if (!user) {
       if (!provider.autoProvision) {
         clearStateCookie();
@@ -1403,6 +1437,11 @@ ssoRoutes.get('/callback', async (c) => {
         return c.redirect('/login?error=default_role_required');
       }
 
+      // Reachable on the ORG axis ONLY — the partner axis returned
+      // invite_required above. The org XOR partner invariant guarantees
+      // org_id is set here.
+      const provisionOrgId = provider.orgId!;
+
       // SSO callback runs without authMiddleware; wrap the provisioning
       // in system scope so users + organization_users writes pass RLS.
       // SSO-provisioned users are customer-org members: partner_id is
@@ -1412,7 +1451,7 @@ ssoRoutes.get('/callback', async (c) => {
         const [providerOrg] = await db
           .select({ partnerId: organizations.partnerId })
           .from(organizations)
-          .where(eq(organizations.id, providerOrgId))
+          .where(eq(organizations.id, provisionOrgId))
           .limit(1);
         if (!providerOrg) {
           return null;
@@ -1422,7 +1461,7 @@ ssoRoutes.get('/callback', async (c) => {
           .insert(users)
           .values({
             partnerId: providerOrg.partnerId,
-            orgId: providerOrgId,
+            orgId: provisionOrgId,
             email: attrs.email.toLowerCase(),
             name: attrs.name,
             status: 'active',
@@ -1435,7 +1474,7 @@ ssoRoutes.get('/callback', async (c) => {
         }
 
         await db.insert(organizationUsers).values({
-          orgId: providerOrgId,
+          orgId: provisionOrgId,
           userId: created.id,
           roleId: validatedDefaultRoleId
         });
@@ -1451,34 +1490,94 @@ ssoRoutes.get('/callback', async (c) => {
       user = newUser;
     }
 
-    const [orgUser] = await db
-      .select({
-        orgId: organizationUsers.orgId,
-        roleId: organizationUsers.roleId,
-        roleName: roles.name,
-        roleScope: roles.scope
-      })
-      .from(organizationUsers)
-      .innerJoin(roles, eq(roles.id, organizationUsers.roleId))
-      .where(
-        and(
-          eq(organizationUsers.userId, user.id),
-          eq(organizationUsers.orgId, providerOrgId)
+    // IdP-asserted MFA (security review #2 H-1) — axis-independent, so it is
+    // computed here (above the membership branch) and shared by both the org
+    // and partner token payloads. When the provider opts in via `trustsIdpMfa`
+    // AND the verified id_token's `amr` attests multi-factor, propagate
+    // mfa:true so the tenant can satisfy Breeze's MFA-gated routes via their
+    // IdP. Fail-safe: any provider that hasn't opted in, or an assertion
+    // without the `mfa` amr, yields mfa:false. This claim never satisfies the
+    // L4 step-up (requireFreshMfaStepUp re-verifies a Breeze-held TOTP).
+    const ssoMfa = provider.trustsIdpMfa === true && idpAssertedMfa(idClaims);
+
+    // Membership resolution + token payload, keyed on the provider's axis.
+    let tokenPayload: Parameters<typeof createTokenPair>[0];
+    if (provider.partnerId) {
+      // Partner axis (#2183): the tech's role membership lives in partner_users
+      // and MUST be partner-scoped. A user with NO partner_users membership is
+      // REJECTED (no_partner_access) — it never falls back to the provider
+      // defaultRoleId, which would recreate the membershipless-user
+      // system-scope-token bug class. defaultRoleId is NEVER applied at login in
+      // v1. orgId is always null on a partner token.
+      const providerPartnerId = provider.partnerId;
+      const [partnerMembership] = await withSystemDbAccessContext(async () =>
+        db
+          .select({ roleId: partnerUsers.roleId, roleScope: roles.scope })
+          .from(partnerUsers)
+          .innerJoin(roles, eq(roles.id, partnerUsers.roleId))
+          .where(and(
+            eq(partnerUsers.userId, user.id),
+            eq(partnerUsers.partnerId, providerPartnerId)
+          ))
+          .limit(1)
+      );
+      if (!partnerMembership) {
+        clearStateCookie();
+        return c.redirect('/login?error=no_partner_access');
+      }
+      if (partnerMembership.roleScope !== 'partner') {
+        clearStateCookie();
+        return c.redirect('/login?error=invalid_role_scope');
+      }
+      tokenPayload = {
+        sub: user.id,
+        email: user.email,
+        roleId: partnerMembership.roleId,
+        orgId: null,
+        partnerId: providerPartnerId,
+        scope: 'partner' as const,
+        mfa: ssoMfa
+      };
+    } else {
+      const [orgUser] = await db
+        .select({
+          orgId: organizationUsers.orgId,
+          roleId: organizationUsers.roleId,
+          roleName: roles.name,
+          roleScope: roles.scope
+        })
+        .from(organizationUsers)
+        .innerJoin(roles, eq(roles.id, organizationUsers.roleId))
+        .where(
+          and(
+            eq(organizationUsers.userId, user.id),
+            eq(organizationUsers.orgId, provider.orgId!)
+          )
         )
-      )
-      .limit(1);
+        .limit(1);
 
-    if (!orgUser) {
-      clearStateCookie();
-      return c.redirect('/login?error=no_org_access');
+      if (!orgUser) {
+        clearStateCookie();
+        return c.redirect('/login?error=no_org_access');
+      }
+
+      if (orgUser.roleScope !== 'organization') {
+        clearStateCookie();
+        return c.redirect('/login?error=invalid_role_scope');
+      }
+
+      tokenPayload = {
+        sub: user.id,
+        email: user.email,
+        roleId: orgUser.roleId,
+        orgId: provider.orgId!,
+        partnerId: null,
+        scope: 'organization' as const,
+        mfa: ssoMfa
+      };
     }
 
-    if (orgUser.roleScope !== 'organization') {
-      clearStateCookie();
-      return c.redirect('/login?error=invalid_role_scope');
-    }
-
-    // Update or create SSO identity link
+    // Update or create SSO identity link (shared across both axes)
     const [existingIdentity] = await db
       .select()
       .from(userSsoIdentities)
@@ -1534,27 +1633,10 @@ ssoRoutes.get('/callback', async (c) => {
     // The SSO session row was already consumed atomically up-front
     // (delete().returning()), so there is nothing left to clean up here.
 
-    // Create session and tokens
+    // Create session and tokens. `tokenPayload` (and its mfa claim) was already
+    // built by the axis branch above.
     const ip = getClientIP(c);
     const userAgent = c.req.header('user-agent') || 'unknown';
-
-    // IdP-asserted MFA (security review #2 H-1): when the org opts in via
-    // `trustsIdpMfa` AND the verified id_token's `amr` attests multi-factor,
-    // propagate mfa:true so the org can satisfy Breeze's MFA-gated routes via
-    // their IdP. Fail-safe: any provider that hasn't opted in, or an assertion
-    // without the `mfa` amr, yields mfa:false. This claim never satisfies the
-    // L4 step-up (requireFreshMfaStepUp re-verifies a Breeze-held TOTP).
-    const ssoMfa = provider.trustsIdpMfa === true && idpAssertedMfa(idClaims);
-
-    const tokenPayload = {
-      sub: user.id,
-      email: user.email,
-      roleId: orgUser.roleId,
-      orgId: providerOrgId,
-      partnerId: null,
-      scope: 'organization' as const,
-      mfa: ssoMfa
-    };
 
     // Mint a fresh refresh-token family for the SSO-completed session so
     // SSO logins get the same reuse-detection coverage as password/MFA
@@ -1572,6 +1654,22 @@ ssoRoutes.get('/callback', async (c) => {
       ipAddress: ip,
       userAgent
     });
+
+    // Partner-axis logins are audited as user.login with method 'sso-partner'
+    // (org-axis SSO keeps its existing audit path). orgId is null on a partner
+    // token, matching the audit row's tenancy.
+    if (provider.partnerId) {
+      auditLogin(c, {
+        orgId: null,
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        mfa: ssoMfa,
+        scope: 'partner',
+        ip,
+        method: 'sso-partner'
+      });
+    }
 
     const tokenExchangeCode = createSsoTokenExchangeGrant(accessToken, refreshToken, expiresInSeconds);
     const redirectPath = normalizeRedirectPath(session.redirectUrl ?? '/');

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1329,12 +1329,20 @@ ssoRoutes.get('/callback', async (c) => {
     return c.redirect('/login?error=session_expired');
   }
 
-  // Get provider
-  const [provider] = await db
-    .select()
-    .from(ssoProviders)
-    .where(eq(ssoProviders.id, session.providerId))
-    .limit(1);
+  // Get provider. System context required: the callback is unauthenticated
+  // (no request scope exists yet), so a bare `db` read here silently 0-rows
+  // under RLS — the same class of bug as the other pre-auth reads in this
+  // handler (session claim, membership resolution, etc), all of which are
+  // already wrapped. Without this wrap the callback 404s to
+  // provider_not_found for EVERY SSO login, org-axis or partner-axis alike
+  // (#2183 real-DB e2e test caught this — see ssoPartnerLogin.integration.test.ts).
+  const [provider] = await withSystemDbAccessContext(async () =>
+    db
+      .select()
+      .from(ssoProviders)
+      .where(eq(ssoProviders.id, session.providerId))
+      .limit(1)
+  );
 
   if (!provider) {
     clearStateCookie();

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -989,6 +989,71 @@ ssoRoutes.delete(
 // SSO Login Flow (Public)
 // ============================================
 
+const partnerIdParamSchema = z.object({ partnerId: z.string().guid() });
+
+// Initiate partner-axis SSO login (#2183) — the MSP's own technician login.
+// Public route: all DB access MUST run under system context (no request scope
+// exists yet; bare `db` silently returns 0 rows under RLS). Mounted ABOVE
+// `/login/:orgId` so the literal `partner` path segment is never parsed as
+// an orgId (Hono would also disambiguate correctly by segment count, but
+// ordering here documents the intent).
+ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSchema), async (c) => {
+  const { partnerId } = c.req.valid('param');
+  const redirectUrl = normalizeRedirectPath(c.req.query('redirect'));
+
+  const [provider] = await withSystemDbAccessContext(async () =>
+    db
+      .select()
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.partnerId, partnerId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .limit(1)
+  );
+
+  if (!provider) {
+    return c.json({ error: 'No active SSO provider for this partner' }, 404);
+  }
+
+  if (provider.type !== 'oidc') {
+    return c.json({ error: 'Only OIDC login is currently supported' }, 400);
+  }
+
+  const config = getOIDCConfig(provider);
+  const pkce = generatePKCEChallenge();
+  const state = generateState();
+  const nonce = generateNonce();
+
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+  await withSystemDbAccessContext(async () =>
+    db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl,
+      expiresAt
+    })
+  );
+
+  const authUrl = buildAuthorizationUrl({
+    config,
+    state,
+    nonce,
+    redirectUri: buildSsoCallbackUri(),
+    pkce
+  });
+
+  const stateCookie = buildSsoStateCookie(state);
+  if (!stateCookie) {
+    return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+  }
+  c.header('Set-Cookie', stateCookie, { append: true });
+
+  return c.redirect(authUrl);
+});
+
 // Initiate SSO login
 ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) => {
   const { orgId } = c.req.valid('param');

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -617,7 +617,7 @@ userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
       // ordering; additionally allow MFA step-up for passwordless users
       // (change-password rejects them with 400), BEFORE any write.
       // (a) SSO-enforced org: email is managed at the IdP.
-      if (await isPasswordAuthDisabledBySso({ scope: auth.scope, orgId: auth.orgId })) {
+      if (await isPasswordAuthDisabledBySso({ scope: auth.scope, orgId: auth.orgId, partnerId: auth.partnerId })) {
         return c.json({ error: 'Email changes for this organization are managed through your SSO provider.' }, 403);
       }
 

--- a/apps/api/src/services/passwordResetEligibility.ts
+++ b/apps/api/src/services/passwordResetEligibility.ts
@@ -166,6 +166,7 @@ async function evaluateEligibility(user: UserLookupRow): Promise<ResetEligibilit
     const ssoBlocked = await isPasswordAuthDisabledBySso({
       scope: 'organization',
       orgId: user.orgId,
+      partnerId: null,
     });
     if (ssoBlocked) {
       return { allowed: false, reason: 'sso_required', userId: user.id, email: user.email };

--- a/apps/web/src/components/auth/AuthPanelBranding.test.tsx
+++ b/apps/web/src/components/auth/AuthPanelBranding.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLoginContext } from '../../lib/loginContext';
+import type { LoginContext } from '../../lib/loginContext';
+
+vi.mock('../../lib/loginContext', () => ({
+  getLoginContext: vi.fn(),
+}));
+
+import AuthPanelBranding from './AuthPanelBranding';
+
+const mockedGetLoginContext = vi.mocked(getLoginContext);
+
+function resolveWith(ctx: LoginContext) {
+  mockedGetLoginContext.mockResolvedValue(ctx);
+}
+
+describe('AuthPanelBranding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders stock Breeze content when branding is null', async () => {
+    resolveWith({ branding: null, partnerSso: null });
+
+    render(<AuthPanelBranding tagline="The modern RMM platform." />);
+
+    // Stock wordmark + marketing copy present.
+    expect(screen.getByText('Breeze')).toBeInTheDocument();
+    expect(screen.getByText(/Effortless endpoint/i)).toBeInTheDocument();
+    expect(screen.getByText('10,000+ endpoints')).toBeInTheDocument();
+
+    // Give the (null) effect a chance to run; content must stay stock.
+    await Promise.resolve();
+    expect(screen.getByText('10,000+ endpoints')).toBeInTheDocument();
+    expect(screen.queryByTestId('partner-logo')).not.toBeInTheDocument();
+  });
+
+  it('renders partner branding and drops marketing copy when branding is present', async () => {
+    resolveWith({
+      branding: { logoUrl: 'https://x/logo.png', accentColor: '#112233', headline: 'Acme IT' },
+      partnerSso: null,
+    });
+
+    const { container } = render(<AuthPanelBranding tagline="The modern RMM platform." />);
+
+    await screen.findByText('Acme IT');
+
+    // Marketing copy is gone.
+    expect(screen.queryByText('10,000+ endpoints')).not.toBeInTheDocument();
+    expect(screen.queryByText('Breeze')).not.toBeInTheDocument();
+
+    // Partner logo present.
+    const logo = screen.getByTestId('partner-logo') as HTMLImageElement;
+    expect(logo).toBeInTheDocument();
+    expect(logo.getAttribute('src')).toBe('https://x/logo.png');
+
+    // Accent color applied to the panel background.
+    const panel = container.firstElementChild as HTMLElement;
+    expect(panel.style.backgroundColor).toBe('rgb(17, 34, 51)');
+  });
+});

--- a/apps/web/src/components/auth/AuthPanelBranding.tsx
+++ b/apps/web/src/components/auth/AuthPanelBranding.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { getLoginContext, type LoginContextBranding } from '../../lib/loginContext';
+import { sanitizeImageSrc } from '../../lib/safeImageSrc';
+
+/**
+ * The entire left branded panel of the auth shell, as a React island.
+ *
+ * Initial render is byte-for-byte the stock Breeze marketing panel (copied from
+ * AuthShellBranded.astro), so hosted/multi-partner deployments see no visual
+ * regression. On mount it fetches the (memoized) login context; when a partner
+ * branding payload is present it swaps in the partner logo/accent/headline and
+ * DROPS the Breeze marketing copy.
+ */
+export default function AuthPanelBranding({ tagline }: { tagline: string }) {
+  const [branding, setBranding] = useState<LoginContextBranding | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getLoginContext().then((ctx) => {
+      if (!cancelled && ctx.branding) setBranding(ctx.branding);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const panelStyle = branding?.accentColor ? { backgroundColor: branding.accentColor } : undefined;
+  const safeLogo = branding?.logoUrl ? sanitizeImageSrc(branding.logoUrl) : null;
+
+  return (
+    <div
+      className="hidden u-w-pct-42 flex-col justify-between bg-[hsl(225,62%,48%)] p-10 text-white md:flex lg:p-14"
+      style={panelStyle}
+    >
+      <div>
+        <div className="flex items-center gap-3">
+          {safeLogo ? (
+            <img
+              src={safeLogo}
+              alt=""
+              data-testid="partner-logo"
+              className="h-8 max-w-[180px] object-contain"
+            />
+          ) : (
+            <>
+              <svg className="h-8 w-8" viewBox="0 0 64 64" fill="none">
+                <path d="M12 22C12 22 20 22 28 22C36 22 40 16 48 16C52 16 54 18 54 20C54 22 52 24 48 24C44 24 42 22 42 22" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" opacity="0.9" />
+                <path d="M8 34C8 34 18 34 30 34C42 34 46 28 52 28C55 28 57 30 57 32C57 34 55 36 52 36C48 36 46 34 46 34" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" opacity="0.9" />
+                <path d="M14 46C14 46 22 46 32 46C40 46 44 40 50 40C53 40 55 42 55 44C55 46 53 48 50 48C46 48 44 46 44 46" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" opacity="0.9" />
+              </svg>
+              <span className="text-xl font-bold tracking-tight">Breeze</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-10">
+        <div>
+          <h2 className="text-2xl font-bold leading-snug tracking-tight lg:text-3xl">
+            {branding?.headline ?? (
+              <>
+                Effortless endpoint
+                <br />
+                management
+              </>
+            )}
+          </h2>
+          {!branding && (
+            <p className="mt-3 text-sm leading-relaxed text-white/70">{tagline}</p>
+          )}
+        </div>
+
+        {!branding && (
+          <div className="space-y-5">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
+                <svg className="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="1.5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 6.878V6a2.25 2.25 0 0 1 2.25-2.25h7.5A2.25 2.25 0 0 1 18 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 0 0 4.5 9v.878m13.5-3A2.25 2.25 0 0 1 19.5 9v.878m0 0a2.246 2.246 0 0 0-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0 1 21 12v6a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18v-6c0-1.007.66-1.86 1.573-2.147" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white/95">10,000+ endpoints</p>
+                <p className="text-xs leading-relaxed text-white/55">Built to handle fleets of any size without breaking a sweat.</p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
+                <svg className="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="1.5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white/95">Real-time monitoring</p>
+                <p className="text-xs leading-relaxed text-white/55">Live telemetry, instant alerts, zero guesswork.</p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
+                <svg className="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="1.5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white/95">AI-powered insights</p>
+                <p className="text-xs leading-relaxed text-white/55">Smart diagnostics and automated remediation at your fingertips.</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-white/40">&copy; {new Date().getFullYear()} {branding ? '' : 'Breeze RMM'}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -21,6 +21,13 @@ vi.mock('../../lib/navigation', () => ({
   navigateTo: vi.fn(),
 }));
 
+// Partner SSO button (#2183): LoginPage reads the memoized login context to
+// decide whether to surface a "Sign in with {provider}" button. Default to the
+// empty shape so existing password-form tests are unaffected.
+vi.mock('../../lib/loginContext', () => ({
+  getLoginContext: vi.fn(async () => ({ branding: null, partnerSso: null })),
+}));
+
 // LoginPage now fetches /api/v1/config at mount to decide whether to redirect
 // the browser to the Cloudflare Access login endpoint. The default mock here
 // answers "feature disabled" so the existing happy-path tests render the
@@ -40,6 +47,7 @@ beforeEach(() => {
 import LoginPage from './LoginPage';
 import { apiLogin, apiVerifyMFA } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
+import { getLoginContext } from '../../lib/loginContext';
 
 const baseLoginSuccess = {
   success: true,
@@ -127,6 +135,65 @@ describe('LoginPage navigation after login', () => {
 
     await waitFor(() => expect(navigateTo).toHaveBeenCalled());
     expect(navigateTo).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('LoginPage partner SSO button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore the default empty-context resolution cleared above.
+    vi.mocked(getLoginContext).mockResolvedValue({ branding: null, partnerSso: null });
+  });
+
+  it('renders a "Sign in with {provider}" button when partner SSO is available', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { available: true, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
+    });
+
+    render(<LoginPage />);
+
+    const btn = await screen.findByTestId('partner-sso-button');
+    expect(btn).toHaveTextContent('Sign in with Okta');
+    // safeNext defaults to '/', so the redirect param is always appended.
+    expect(btn.getAttribute('href')).toBe('/api/v1/sso/login/partner/p1?redirect=%2F');
+    // Password form remains visible.
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+
+  it('appends the safe next as a redirect param on the SSO button href', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { available: true, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
+    });
+
+    render(<LoginPage next="/devices" />);
+
+    const btn = await screen.findByTestId('partner-sso-button');
+    expect(btn.getAttribute('href')).toBe(
+      '/api/v1/sso/login/partner/p1?redirect=%2Fdevices'
+    );
+  });
+
+  it('omits the SSO button when partner SSO is unavailable', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { available: false, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => screen.getByLabelText(/email/i));
+    expect(screen.queryByTestId('partner-sso-button')).not.toBeInTheDocument();
+  });
+
+  it('omits the SSO button when the login-context fetch degrades to null', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({ branding: null, partnerSso: null });
+
+    render(<LoginPage />);
+
+    await waitFor(() => screen.getByLabelText(/email/i));
+    expect(screen.queryByTestId('partner-sso-button')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -22,6 +22,22 @@ function getRegistrationDisabledNotice(): string | undefined {
   }
 }
 
+// Copy for SSO callback `?error=<reason>` bounces that land back on /login.
+// `sso_link_required` (#2183): a password-holding user tried to sign in via SSO
+// and was refused auto-linking — they must connect SSO from an authenticated
+// session instead (Profile → Security → Connect SSO).
+const SSO_LOGIN_ERROR_COPY: Record<string, string> = {
+  sso_link_required:
+    'This account already has a password. Sign in with your password, then connect SSO under Profile → Security.'
+};
+
+function getSsoLoginNotice(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get('error');
+  return error ? SSO_LOGIN_ERROR_COPY[error] : undefined;
+}
+
 function shouldSkipCfAccessRedirect(): boolean {
   if (typeof window === 'undefined') return true;
   const params = new URLSearchParams(window.location.search);
@@ -65,6 +81,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   const safeNext = getSafeNext(next);
   const [error, setError] = useState<string>();
   const registrationNotice = getRegistrationDisabledNotice();
+  const ssoLoginNotice = getSsoLoginNotice();
   const [loading, setLoading] = useState(false);
   const [mfaRequired, setMfaRequired] = useState(false);
   const [tempToken, setTempToken] = useState<string>();
@@ -250,6 +267,14 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
       {registrationNotice && (
         <div className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200">
           {registrationNotice}
+        </div>
+      )}
+      {ssoLoginNotice && (
+        <div
+          role="alert"
+          className="mb-6 rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200"
+        >
+          {ssoLoginNotice}
         </div>
       )}
       <LoginForm

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -13,6 +13,7 @@ import {
 import type { MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
 import { getSafeNext } from '../../lib/authNext';
+import { getLoginContext } from '../../lib/loginContext';
 
 function getRegistrationDisabledNotice(): string | undefined {
   if (typeof window === 'undefined') return undefined;
@@ -98,8 +99,24 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   // entirely in the effect (client-only), keeping SSR and CSR initial output
   // identical (both render the placeholder).
   const [cfAccessRedirectChecked, setCfAccessRedirectChecked] = useState(false);
+  const [partnerSso, setPartnerSso] = useState<{ providerName: string; loginUrl: string } | null>(null);
 
   const login = useAuthStore((state) => state.login);
+
+  // Partner SSO: the (memoized) login context tells us whether this deployment
+  // resolves to a single partner with an enforced/available SSO provider. If so,
+  // surface a "Sign in with {provider}" button above the password form. Fetch
+  // failure / null response leaves the button absent (password-only login).
+  useEffect(() => {
+    let cancelled = false;
+    getLoginContext().then((ctx) => {
+      if (cancelled) return;
+      if (ctx.partnerSso?.available) {
+        setPartnerSso({ providerName: ctx.partnerSso.providerName, loginUrl: ctx.partnerSso.loginUrl });
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // CF Access trust mode: if the deployment has it on AND we're not already
   // in the post-redirect bounce (which AuthOverlay handles), top-level
@@ -276,6 +293,15 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
         >
           {ssoLoginNotice}
         </div>
+      )}
+      {partnerSso && (
+        <a
+          href={`${partnerSso.loginUrl}${safeNext ? `?redirect=${encodeURIComponent(safeNext)}` : ''}`}
+          data-testid="partner-sso-button"
+          className="mb-4 flex w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          Sign in with {partnerSso.providerName}
+        </a>
       )}
       <LoginForm
         onSubmit={handleLogin}

--- a/apps/web/src/components/settings/ConnectSsoCard.test.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ConnectSsoCard from './ConnectSsoCard';
+import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+// runAction (used for the mutation) toasts through this module; mock it so the
+// real runAction path runs without touching the DOM toast host.
+vi.mock('../shared/Toast', () => ({
+  showToast: vi.fn()
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const assignMock = vi.fn();
+function setLocation(search: string) {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { search, assign: assignMock, href: 'http://localhost/settings/profile', pathname: '/settings/profile' }
+  });
+}
+
+describe('ConnectSsoCard (#2183)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocation('');
+  });
+
+  it('renders one row per provider with a Connect button or Connected badge', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'p-1', name: 'Okta', type: 'oidc', linked: false },
+        { id: 'p-2', name: 'Entra', type: 'oidc', linked: true }
+      ]
+    }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText('Okta')).toBeInTheDocument();
+    expect(screen.getByTestId('connect-sso-p-1')).toBeInTheDocument();
+    // Linked provider shows a "Connected" badge, not a button.
+    expect(screen.getByText('Entra')).toBeInTheDocument();
+    expect(screen.queryByTestId('connect-sso-p-2')).not.toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('clicking Connect starts linking and navigates to the returned authUrl', async () => {
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      if (url === '/sso/link/options') {
+        return Promise.resolve(jsonResponse({ data: [{ id: 'p-1', name: 'Okta', type: 'oidc', linked: false }] }));
+      }
+      if (url === '/sso/link/start/p-1') {
+        return Promise.resolve(jsonResponse({ authUrl: 'https://idp.example.com/authorize?x=1' }));
+      }
+      return Promise.resolve(jsonResponse({ data: [] }));
+    });
+
+    render(<ConnectSsoCard />);
+
+    fireEvent.click(await screen.findByTestId('connect-sso-p-1'));
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledWith('https://idp.example.com/authorize?x=1');
+    });
+    // The POST went through the /sso/link/start endpoint.
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/sso/link/start/p-1', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('shows a success banner when the page loads with ?ssoLinked=1', async () => {
+    setLocation('?ssoLinked=1');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/connected/i)).toBeInTheDocument();
+  });
+
+  it('shows an error banner for ?ssoLinkError=email_mismatch', async () => {
+    setLocation('?ssoLinkError=email_mismatch');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/different email/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/ConnectSsoCard.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { runAction } from '../../lib/runAction';
+import { fetchWithAuth } from '../../stores/auth';
+
+type LinkOption = { id: string; name: string; type: string; linked: boolean };
+
+// User-facing copy for the callback's typed reason codes
+// (`/settings/profile?ssoLinkError=<reason>`).
+const LINK_ERROR_COPY: Record<string, string> = {
+  email_mismatch:
+    'That identity provider account uses a different email than your Breeze account. Sign in to your provider with the email on your Breeze account and try again.',
+  identity_in_use: 'That identity provider account is already linked to a different Breeze user.',
+  user_gone: 'Your account could not be found. Please sign in again.'
+};
+
+export default function ConnectSsoCard() {
+  const [options, setOptions] = useState<LinkOption[]>([]);
+  const [notice, setNotice] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth('/sso/link/options')
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((body) => {
+        if (!cancelled) setOptions(Array.isArray(body?.data) ? body.data : []);
+      })
+      .catch(() => {
+        if (!cancelled) setOptions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Surface the callback's result banner (redirects back with ?ssoLinked=1 on
+  // success or ?ssoLinkError=<reason> on failure).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('ssoLinked') === '1') {
+      setNotice({ type: 'success', message: 'Single sign-on connected.' });
+      return;
+    }
+    const err = params.get('ssoLinkError');
+    if (err) {
+      setNotice({ type: 'error', message: LINK_ERROR_COPY[err] ?? 'Could not connect single sign-on.' });
+    }
+  }, []);
+
+  async function connect(providerId: string) {
+    setConnectingId(providerId);
+    try {
+      const body = await runAction<{ authUrl: string }>({
+        request: () => fetchWithAuth(`/sso/link/start/${providerId}`, { method: 'POST' }),
+        errorFallback: 'Could not start SSO linking',
+        successMessage: 'Redirecting to your identity provider…'
+      });
+      if (body?.authUrl) {
+        // External IdP URL — a full-page navigation, not the SPA router (which
+        // would reject an off-origin path as an open-redirect).
+        window.location.assign(body.authUrl);
+      }
+    } catch {
+      // runAction already surfaced the failure via toast.
+      setConnectingId(null);
+    }
+  }
+
+  if (options.length === 0 && !notice) return null;
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-6 shadow-xs" data-testid="connect-sso-card">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">Single sign-on</h2>
+        <p className="text-sm text-muted-foreground">
+          Connect your identity provider account so you can sign in with SSO.
+        </p>
+      </div>
+
+      {notice && (
+        <div
+          role={notice.type === 'error' ? 'alert' : 'status'}
+          className={
+            notice.type === 'error'
+              ? 'rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive'
+              : 'rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600'
+          }
+        >
+          {notice.message}
+        </div>
+      )}
+
+      {options.length > 0 && (
+        <ul className="space-y-2">
+          {options.map((o) => (
+            <li key={o.id} className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm">
+              <span className="font-medium">{o.name}</span>
+              {o.linked ? (
+                <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">Connected</span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => connect(o.id)}
+                  disabled={connectingId === o.id}
+                  data-testid={`connect-sso-${o.id}`}
+                  className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {connectingId === o.id ? 'Connecting…' : 'Connect'}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/LoginBrandingCard.test.tsx
+++ b/apps/web/src/components/settings/LoginBrandingCard.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+// Pass-through runAction so the request fn (and thus the PUT via fetchWithAuth)
+// actually runs — lets us assert the mutation fired (no silent mutation).
+const runAction = vi.fn(async (o: { request: () => Promise<Response> }) => {
+  const r = await o.request();
+  return r.json().catch(() => null);
+});
+vi.mock('../../lib/runAction', () => ({
+  runAction: (o: { request: () => Promise<Response> }) => runAction(o),
+  ActionError: class ActionError extends Error {
+    status: number;
+    constructor(m: string, s: number) { super(m); this.status = s; }
+  },
+  handleActionError: vi.fn(),
+}));
+
+import LoginBrandingCard from './LoginBrandingCard';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+type Branding = { logoUrl: string | null; accentColor: string | null; headline: string | null };
+
+function routeFetch(data: Branding | null) {
+  fetchWithAuth.mockImplementation((url: string, opts?: { method?: string }) => {
+    if (url === '/partners/me/login-branding' && (!opts || !opts.method || opts.method === 'GET')) {
+      return Promise.resolve(jsonRes({ data }));
+    }
+    if (url === '/partners/me/login-branding' && opts?.method === 'PUT') {
+      return Promise.resolve(jsonRes({ data }));
+    }
+    return Promise.resolve(jsonRes({ data: null }));
+  });
+}
+
+function lastPut() {
+  const call = [...fetchWithAuth.mock.calls].reverse().find(
+    (c) => c[0] === '/partners/me/login-branding' && (c[1] as { method?: string })?.method === 'PUT'
+  );
+  if (!call) throw new Error('no PUT call recorded');
+  return JSON.parse((call[1] as { body: string }).body);
+}
+
+describe('LoginBrandingCard', () => {
+  beforeEach(() => {
+    fetchWithAuth.mockReset();
+    runAction.mockClear();
+  });
+
+  it('loads current branding values from GET', async () => {
+    routeFetch({ logoUrl: 'https://cdn.example.com/logo.png', accentColor: '#112233', headline: 'Welcome back' });
+    render(<LoginBrandingCard />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('login-branding-logo-url') as HTMLInputElement).value).toBe(
+        'https://cdn.example.com/logo.png'
+      );
+    });
+    expect((screen.getByTestId('login-branding-headline') as HTMLInputElement).value).toBe('Welcome back');
+    expect((screen.getByTestId('login-branding-accent-hex') as HTMLInputElement).value).toBe('#112233');
+  });
+
+  it('renders three inputs and a headline capped at 120 chars', async () => {
+    routeFetch(null);
+    render(<LoginBrandingCard />);
+    await waitFor(() => expect(screen.getByTestId('login-branding-logo-url')).toBeTruthy());
+    expect(screen.getByTestId('login-branding-accent-color')).toBeTruthy();
+    expect(screen.getByTestId('login-branding-headline').getAttribute('maxLength')).toBe('120');
+  });
+
+  it('preview background reflects the entered accent color', async () => {
+    routeFetch(null);
+    render(<LoginBrandingCard />);
+    await waitFor(() => expect(screen.getByTestId('login-branding-accent-hex')).toBeTruthy());
+
+    fireEvent.change(screen.getByTestId('login-branding-accent-hex'), { target: { value: '#ff0000' } });
+    const preview = screen.getByTestId('login-branding-preview') as HTMLElement;
+    expect(preview.style.backgroundColor).toBe('rgb(255, 0, 0)');
+  });
+
+  it('saves via runAction sending ALL THREE fields (full-replace)', async () => {
+    routeFetch({ logoUrl: 'https://cdn.example.com/logo.png', accentColor: '#112233', headline: 'Old headline' });
+    render(<LoginBrandingCard />);
+    await waitFor(() =>
+      expect((screen.getByTestId('login-branding-headline') as HTMLInputElement).value).toBe('Old headline')
+    );
+
+    // Clear the headline; logo + accent stay set.
+    fireEvent.change(screen.getByTestId('login-branding-headline'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('login-branding-save'));
+
+    await waitFor(() => expect(runAction).toHaveBeenCalled());
+    const body = lastPut();
+    // Full-replace: every field present, cleared one sent as null (not omitted).
+    expect(Object.keys(body).sort()).toEqual(['accentColor', 'headline', 'logoUrl']);
+    expect(body.logoUrl).toBe('https://cdn.example.com/logo.png');
+    expect(body.accentColor).toBe('#112233');
+    expect(body.headline).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/LoginBrandingCard.tsx
+++ b/apps/web/src/components/settings/LoginBrandingCard.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react';
+import { Loader2, Palette, Save } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { sanitizeImageSrc } from '../../lib/safeImageSrc';
+import { navigateTo } from '@/lib/navigation';
+
+type LoginBranding = {
+  logoUrl: string | null;
+  accentColor: string | null;
+  headline: string | null;
+};
+
+// Fallback swatch when no accent has been set yet, so the color picker and the
+// preview have something sensible to render. Not persisted unless the user saves.
+const DEFAULT_ACCENT = '#2563eb';
+const HEADLINE_MAX = 120;
+
+const inputClass = 'h-10 w-full rounded-md border bg-background px-3 text-sm';
+
+/**
+ * Partner "Login Branding" settings card (#2183). Lets a partner admin brand the
+ * technician login screen (logo, accent color, headline) shown at
+ * `/login?partner=<slug>`. Reads/writes GET/PUT /api/v1/partners/me/login-branding.
+ *
+ * PUT is FULL-REPLACE: we always send all three fields on every save, so an
+ * omitted field is not treated as "unchanged" — it is nulled server-side. That
+ * matches the server contract (Task 9) and keeps the UI the single source of truth.
+ */
+export default function LoginBrandingCard() {
+  const [logoUrl, setLogoUrl] = useState('');
+  const [accentColor, setAccentColor] = useState('');
+  const [headline, setHeadline] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth('/partners/me/login-branding');
+        if (res.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        if (res.ok) {
+          const body = (await res.json().catch(() => null)) as { data?: LoginBranding | null } | null;
+          const data = body?.data ?? null;
+          if (!cancelled && data) {
+            setLogoUrl(data.logoUrl ?? '');
+            setAccentColor(data.accentColor ?? '');
+            setHeadline(data.headline ?? '');
+          }
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await runAction<{ data: LoginBranding }>({
+        // Full-replace: always send all three fields. A blank field goes as null
+        // (cleared), never omitted — omitting would NULL it server-side anyway,
+        // but sending explicit null keeps request intent unambiguous.
+        request: () =>
+          fetchWithAuth('/partners/me/login-branding', {
+            method: 'PUT',
+            body: JSON.stringify({
+              logoUrl: logoUrl.trim() || null,
+              accentColor: accentColor.trim() || null,
+              headline: headline.trim() || null,
+            }),
+          }),
+        successMessage: 'Login branding saved',
+        errorFallback: 'Failed to save login branding',
+        onUnauthorized: () => {
+          void navigateTo('/login', { replace: true });
+        },
+      });
+    } catch (err) {
+      // 401 → the auth redirect is the feedback; non-401 ActionError was already
+      // toasted by runAction; anything else is unexpected → surface it.
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({ message: 'Failed to save login branding', type: 'error' });
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const previewAccent = accentColor.trim() || DEFAULT_ACCENT;
+  const previewLogo = sanitizeImageSrc(logoUrl.trim() || null);
+
+  if (loading) {
+    return (
+      <section className="rounded-lg border bg-card p-6 shadow-xs" data-testid="login-branding-card">
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border bg-card p-6 shadow-xs" data-testid="login-branding-card">
+      <div className="mb-6">
+        <div className="flex items-center gap-2">
+          <Palette className="h-5 w-5 text-muted-foreground" />
+          <h2 className="text-lg font-semibold">Login Branding</h2>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Brand the technician login screen your team sees at <code>/login?partner=…</code>. Applies to
+          all of your organizations.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Fields */}
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="login-branding-logo-url" className="text-sm font-medium">
+              Logo URL
+            </label>
+            <input
+              id="login-branding-logo-url"
+              data-testid="login-branding-logo-url"
+              type="url"
+              value={logoUrl}
+              onChange={(e) => setLogoUrl(e.target.value)}
+              placeholder="https://cdn.example.com/logo.png"
+              className={inputClass}
+            />
+            <p className="text-xs text-muted-foreground">
+              An <code>https://</code> URL to your logo. Leave blank for no logo.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="login-branding-accent-hex" className="text-sm font-medium">
+              Accent color
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                aria-label="Accent color picker"
+                data-testid="login-branding-accent-color"
+                type="color"
+                value={/^#[0-9a-fA-F]{6}$/.test(accentColor) ? accentColor : DEFAULT_ACCENT}
+                onChange={(e) => setAccentColor(e.target.value)}
+                className="h-10 w-14 shrink-0 cursor-pointer rounded-md border bg-background"
+              />
+              <input
+                id="login-branding-accent-hex"
+                data-testid="login-branding-accent-hex"
+                type="text"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+                placeholder="#2563eb"
+                maxLength={7}
+                className={inputClass}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">A <code>#rrggbb</code> hex color.</p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="login-branding-headline" className="text-sm font-medium">
+              Headline
+            </label>
+            <input
+              id="login-branding-headline"
+              data-testid="login-branding-headline"
+              type="text"
+              value={headline}
+              onChange={(e) => setHeadline(e.target.value)}
+              placeholder="Sign in to Acme IT"
+              maxLength={HEADLINE_MAX}
+              className={inputClass}
+            />
+            <p className="text-xs text-muted-foreground">
+              {headline.length}/{HEADLINE_MAX} characters.
+            </p>
+          </div>
+        </div>
+
+        {/* Live preview */}
+        <div className="space-y-2">
+          <span className="text-sm font-medium">Preview</span>
+          <div
+            data-testid="login-branding-preview"
+            className="flex min-h-40 flex-col items-center justify-center gap-4 rounded-lg border p-6 text-center"
+            style={{ backgroundColor: previewAccent }}
+          >
+            {previewLogo && (
+              <img
+                src={previewLogo}
+                alt="Login logo preview"
+                className="max-h-16 max-w-[70%] object-contain"
+              />
+            )}
+            <div className="rounded-md bg-white/90 px-4 py-3 shadow-sm">
+              <p className="text-base font-semibold text-gray-900">
+                {headline.trim() || 'Sign in to your account'}
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Approximate preview of the technician login screen.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          data-testid="login-branding-save"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          {saving ? 'Saving...' : 'Save branding'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -20,6 +20,7 @@ import PartnerBrandingTab from './PartnerBrandingTab';
 import PartnerAiBudgetsTab from './PartnerAiBudgetsTab';
 import PartnerRemoteAccessTab from './PartnerRemoteAccessTab';
 import PartnerCompanyTab from './PartnerCompanyTab';
+import LoginBrandingCard from './LoginBrandingCard';
 import type {
   PartnerSettings,
   BusinessHoursPreset,
@@ -39,7 +40,7 @@ import { isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE } from '@bre
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 
-type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'aiBudgets' | 'remoteAccess' | 'ticketing';
+type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'loginBranding' | 'aiBudgets' | 'remoteAccess' | 'ticketing';
 
 type Partner = {
   id: string;
@@ -61,6 +62,7 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'eventLogs', label: 'Event Logs' },
   { key: 'defaults', label: 'Defaults' },
   { key: 'branding', label: 'Branding' },
+  { key: 'loginBranding', label: 'Login Branding' },
   { key: 'aiBudgets', label: 'AI Budgets' },
   { key: 'remoteAccess', label: 'Remote' },
   { key: 'ticketing', label: 'Ticketing' },
@@ -442,7 +444,7 @@ export default function PartnerSettingsPage() {
         ))}
       </div>
 
-      {activeTab !== 'regional' && activeTab !== 'company' && activeTab !== 'ticketing' && (
+      {activeTab !== 'regional' && activeTab !== 'company' && activeTab !== 'ticketing' && activeTab !== 'loginBranding' && (
         <div className="rounded-md border bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-700 dark:text-blue-300">
           Values you set here are enforced across all organizations. Leave fields empty to let each organization configure individually.
         </div>
@@ -613,6 +615,10 @@ export default function PartnerSettingsPage() {
           <PartnerBrandingTab data={brandingData} onChange={setBrandingData} />
         </section>
       )}
+
+      {/* Login Branding: self-contained card with its own load/save (the
+          top-level "Save Settings" button does not apply here). */}
+      {activeTab === 'loginBranding' && <LoginBrandingCard />}
 
       {activeTab === 'aiBudgets' && (
         <section className="rounded-lg border bg-card p-6 shadow-xs">

--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -27,6 +27,13 @@ vi.mock('./ApproverDevicesSection', () => ({
   default: () => null,
 }));
 
+// ConnectSsoCard (#2183) fetches /sso/link/options on mount; stub it so it
+// doesn't consume from this file's ordered fetchWithAuth mock sequence. Its own
+// behavior is covered by ConnectSsoCard.test.tsx.
+vi.mock('./ConnectSsoCard', () => ({
+  default: () => null,
+}));
+
 import ProfilePage from './ProfilePage';
 
 const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import ChangePasswordForm from './ChangePasswordForm';
+import ConnectSsoCard from './ConnectSsoCard';
 import MFASettings from './MFASettings';
 import ApproverDevicesSection from './ApproverDevicesSection';
 import ThemingSettings from './ThemingSettings';
@@ -764,6 +765,9 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         successMessage={mfaSuccess}
         loading={mfaLoading}
       />
+
+      {/* Connect SSO (self-service identity linking, #2183) */}
+      <ConnectSsoCard />
 
       {/* Passkeys */}
       <div className="space-y-6 rounded-lg border bg-card p-6 shadow-xs">

--- a/apps/web/src/components/settings/SsoProviderForm.test.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SsoProviderForm, { type Role } from './SsoProviderForm';
+
+const ROLES: Role[] = [
+  { id: 'org-role', name: 'Org Technician', scope: 'organization' },
+  { id: 'partner-role', name: 'Partner Technician', scope: 'partner' },
+];
+
+describe('SsoProviderForm ownership selector', () => {
+  it('shows the ownership selector on create for partner-scope users', () => {
+    render(<SsoProviderForm showOwnerScope roles={ROLES} />);
+    expect(screen.getByTestId('sso-provider-owner')).toBeTruthy();
+    expect(screen.getByTestId('sso-provider-owner-org')).toBeTruthy();
+    expect(screen.getByTestId('sso-provider-owner-partner')).toBeTruthy();
+  });
+
+  it('hides the selector when not partner-scope', () => {
+    render(<SsoProviderForm showOwnerScope={false} roles={ROLES} />);
+    expect(screen.queryByTestId('sso-provider-owner')).toBeNull();
+  });
+
+  it('hides the selector on edit (create-only)', () => {
+    render(<SsoProviderForm showOwnerScope isEditing roles={ROLES} />);
+    expect(screen.queryByTestId('sso-provider-owner')).toBeNull();
+  });
+
+  it('defaults to organization scope and shows org roles', () => {
+    render(<SsoProviderForm showOwnerScope roles={ROLES} />);
+    const orgRadio = screen.getByTestId('sso-provider-owner-org') as HTMLInputElement;
+    expect(orgRadio.checked).toBe(true);
+    expect(screen.getByRole('option', { name: 'Org Technician' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Partner Technician' })).toBeNull();
+  });
+
+  it('filters the default-role dropdown to partner roles when partner scope is selected', () => {
+    render(<SsoProviderForm showOwnerScope roles={ROLES} />);
+    fireEvent.click(screen.getByTestId('sso-provider-owner-partner'));
+    expect(screen.getByRole('option', { name: 'Partner Technician' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Org Technician' })).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/SsoProviderForm.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.tsx
@@ -6,6 +6,11 @@ import { zodResolver } from '@hookform/resolvers/zod';
 const ssoProviderSchema = z.object({
   name: z.string().min(1, 'Provider name is required'),
   type: z.enum(['oidc', 'saml']),
+  // Ownership axis (#2183, mirrors software policies #2126): 'partner' = a
+  // partner-wide provider used for technician login. Surfaced on create only,
+  // for partner-scope users (showOwnerScope); the server derives the partner
+  // from the caller's own token. Update schema omits it (create-only).
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   preset: z.string().optional(),
   issuer: z.string().url('Must be a valid URL').optional().or(z.literal('')),
   clientId: z.string().optional(),
@@ -42,6 +47,9 @@ export type ProviderPreset = {
 export type Role = {
   id: string;
   name: string;
+  // Present on roles fetched from /roles. Used to filter the default-role
+  // dropdown by the selected ownership scope (partner vs organization).
+  scope?: 'partner' | 'organization';
 };
 
 type SsoProviderFormProps = {
@@ -56,6 +64,8 @@ type SsoProviderFormProps = {
   testingConnection?: boolean;
   isEditing?: boolean;
   hasClientSecret?: boolean;
+  /** Show the ownership-scope selector (create-only, partner-scope users). */
+  showOwnerScope?: boolean;
 };
 
 const presetOptions = [
@@ -77,7 +87,8 @@ export default function SsoProviderForm({
   loading,
   testingConnection,
   isEditing,
-  hasClientSecret
+  hasClientSecret,
+  showOwnerScope = false
 }: SsoProviderFormProps) {
   const [showSecret, setShowSecret] = useState(false);
 
@@ -108,12 +119,23 @@ export default function SsoProviderForm({
       defaultRoleId: '',
       allowedDomains: '',
       enforceSSO: false,
+      ownerScope: 'organization',
       ...defaultValues
     }
   });
 
   const selectedPreset = useWatch({ control, name: 'preset' });
   const enforceSSO = useWatch({ control, name: 'enforceSSO' });
+  const ownerScope = useWatch({ control, name: 'ownerScope' });
+
+  // The default-role dropdown must offer roles that match the chosen ownership
+  // scope: partner-wide providers auto-provision into PARTNER roles, org
+  // providers into ORG roles. Roles carry `scope`; when it's absent (older
+  // payloads) fall back to showing them under the organization scope.
+  const visibleRoles = useMemo(() => {
+    if (ownerScope === 'partner') return roles.filter(r => r.scope === 'partner');
+    return roles.filter(r => r.scope !== 'partner');
+  }, [roles, ownerScope]);
 
   // Apply preset configuration when preset changes
   useEffect(() => {
@@ -135,6 +157,32 @@ export default function SsoProviderForm({
       })}
       className="space-y-6 rounded-lg border bg-card p-6 shadow-xs"
     >
+      {/* Ownership scope — partner-scope creators only, create-only (#2183) */}
+      {showOwnerScope && !isEditing && (
+        <fieldset className="space-y-2 rounded-md border p-4" data-testid="sso-provider-owner">
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">Applies to</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="organization"
+              {...register('ownerScope')}
+              data-testid="sso-provider-owner-org"
+            />
+            This organization
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="partner"
+              {...register('ownerScope')}
+              data-testid="sso-provider-owner-partner"
+            />
+            Partner (technician login){' '}
+            <span className="text-muted-foreground">(your own team signs in with this)</span>
+          </label>
+        </fieldset>
+      )}
+
       {/* Basic Information */}
       <div className="space-y-4">
         <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
@@ -374,7 +422,7 @@ export default function SsoProviderForm({
               {...register('defaultRoleId')}
             >
               <option value="">Select a role...</option>
-              {roles.map(role => (
+              {visibleRoles.map(role => (
                 <option key={role.id} value={role.id}>
                   {role.name}
                 </option>

--- a/apps/web/src/components/settings/SsoProviderList.test.tsx
+++ b/apps/web/src/components/settings/SsoProviderList.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SsoProviderList, { type SsoProvider } from './SsoProviderList';
+
+function provider(overrides: Partial<SsoProvider>): SsoProvider {
+  return {
+    id: 'p-1',
+    name: 'Okta',
+    type: 'oidc',
+    status: 'active',
+    autoProvision: true,
+    enforceSSO: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SsoProviderList partner badge', () => {
+  it('renders a Partner badge for partner-wide providers', () => {
+    render(<SsoProviderList providers={[provider({ id: 'a', name: 'Team Login', partnerId: 'pt-1' })]} />);
+    expect(screen.getByTestId('sso-provider-partner-badge')).toBeTruthy();
+  });
+
+  it('does not render the badge for org-scoped providers', () => {
+    render(<SsoProviderList providers={[provider({ id: 'b', name: 'Org Login', partnerId: null })]} />);
+    expect(screen.queryByTestId('sso-provider-partner-badge')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/SsoProviderList.tsx
+++ b/apps/web/src/components/settings/SsoProviderList.tsx
@@ -9,6 +9,9 @@ export type SsoProvider = {
   autoProvision: boolean;
   enforceSSO: boolean;
   createdAt: string;
+  // Set for partner-wide providers used for technician login (#2183). When
+  // present, the row shows a "Partner" badge.
+  partnerId?: string | null;
 };
 
 type SsoProviderListProps = {
@@ -156,7 +159,20 @@ export default function SsoProviderList({
                     key={provider.id}
                     className="transition hover:bg-muted/40"
                   >
-                    <td className="px-4 py-3 text-sm font-medium">{provider.name}</td>
+                    <td className="px-4 py-3 text-sm font-medium">
+                      <div className="flex items-center gap-2">
+                        <span>{provider.name}</span>
+                        {provider.partnerId && (
+                          <span
+                            className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                            title="Partner-wide provider — used for technician login across all organizations"
+                            data-testid="sso-provider-partner-badge"
+                          >
+                            Partner
+                          </span>
+                        )}
+                      </div>
+                    </td>
                     <td className="px-4 py-3 text-sm">
                       <span className="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium">
                         {typeLabels[provider.type]}

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+const getJwtClaims = vi.fn(() => ({ scope: 'partner', partnerId: 'p-1', orgId: null }));
+vi.mock('../../lib/authScope', () => ({ getJwtClaims: () => getJwtClaims() }));
+
+import SsoProvidersPage from './SsoProvidersPage';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+type Provider = {
+  id: string;
+  name: string;
+  type: 'oidc' | 'saml';
+  status: 'active' | 'inactive' | 'testing';
+  autoProvision: boolean;
+  enforceSSO: boolean;
+  createdAt: string;
+  partnerId?: string | null;
+};
+
+const PARTNER_PROVIDER: Provider = {
+  id: 'pp-1',
+  name: 'Team Login',
+  type: 'oidc',
+  status: 'active',
+  autoProvision: true,
+  enforceSSO: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  partnerId: 'p-1',
+};
+
+/**
+ * Route the 4 fetches the page makes on mount. Callers override the two
+ * providers responses; presets + roles default to sensible values.
+ */
+function routes(opts: {
+  org?: Response;
+  partner?: Response;
+  roles?: Response;
+}) {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url === '/sso/providers') return Promise.resolve(opts.org ?? jsonRes({ data: [] }));
+    if (url === '/sso/providers?scope=partner')
+      return Promise.resolve(opts.partner ?? jsonRes({ data: [] }));
+    if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+    if (url === '/roles')
+      return Promise.resolve(
+        opts.roles ?? jsonRes({ data: [{ id: 'pr-1', name: 'Partner Technician', scope: 'partner' }] })
+      );
+    return Promise.resolve(jsonRes({ data: [] }));
+  });
+}
+
+describe('SsoProvidersPage partner-axis behavior', () => {
+  beforeEach(() => {
+    fetchWithAuth.mockReset();
+    getJwtClaims.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+  });
+
+  it('tolerates the expected org-fetch 400 (no org context) and still shows partner rows', async () => {
+    routes({
+      org: jsonRes({ error: 'Organization ID required' }, false, 400),
+      partner: jsonRes({ data: [PARTNER_PROVIDER] }),
+    });
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    // Expected 400 is not a real error — no error banner.
+    expect(screen.queryByText(/Failed to fetch SSO providers/)).toBeNull();
+  });
+
+  it('surfaces a real org-fetch 500 while still rendering partner rows', async () => {
+    routes({
+      org: jsonRes({ error: 'boom' }, false, 500),
+      partner: jsonRes({ data: [PARTNER_PROVIDER] }),
+    });
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText(/Failed to fetch SSO providers/)).toBeTruthy());
+    // Rows that DID load are still rendered.
+    expect(screen.getByText('Team Login')).toBeTruthy();
+  });
+
+  it('surfaces a partner-fetch 500', async () => {
+    routes({
+      org: jsonRes({ data: [] }),
+      partner: jsonRes({ error: 'boom' }, false, 500),
+    });
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText(/Failed to fetch SSO providers/)).toBeTruthy());
+  });
+
+  it('hands partner-scoped roles through so the Partner default-role dropdown is non-empty', async () => {
+    routes({
+      org: jsonRes({ data: [] }),
+      partner: jsonRes({ data: [] }),
+      roles: jsonRes({ data: [{ id: 'pr-1', name: 'Partner Technician', scope: 'partner' }] }),
+    });
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Add provider')).toBeTruthy());
+    fireEvent.click(screen.getByText('Add provider'));
+
+    // Owner selector is shown (partner scope); pick partner ownership.
+    const partnerRadio = await screen.findByTestId('sso-provider-owner-partner');
+    fireEvent.click(partnerRadio);
+
+    // The partner-scoped role loads into the default-role dropdown.
+    expect(screen.getByRole('option', { name: 'Partner Technician' })).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -42,16 +42,30 @@ export default function SsoProvidersPage() {
       setLoading(true);
       setError(undefined);
 
+      // Track fetch failures separately from rows: a partial failure must still
+      // render whatever loaded AND surface the error — never silently swallow it.
+      let hadError = false;
+
       const response = await fetchWithAuth('/sso/providers');
       if (response.status === 401) {
         void navigateTo('/login', { replace: true });
         return;
       }
-      const orgProviders: SsoProvider[] = response.ok ? (await response.json()).data ?? [] : [];
+      let orgProviders: SsoProvider[] = [];
+      if (response.ok) {
+        orgProviders = (await response.json()).data ?? [];
+      } else if (isPartnerScope && response.status === 400) {
+        // Expected: a partner viewer with no single-org context can't resolve an
+        // org for the org-scoped list (API returns 400 "Organization ID
+        // required"). Their partner-wide providers still load below — not an
+        // error worth surfacing. Any OTHER non-ok status is a real failure.
+      } else {
+        hadError = true;
+      }
 
       // Also pull partner-wide providers for partner-scope viewers and merge
       // them in (deduped by id). Additive: a failure here must not wipe the
-      // org list, and vice-versa.
+      // org list, and vice-versa — but it MUST surface, not vanish.
       let partnerProviders: SsoProvider[] = [];
       if (isPartnerScope) {
         const partnerRes = await fetchWithAuth('/sso/providers?scope=partner');
@@ -61,16 +75,18 @@ export default function SsoProvidersPage() {
         }
         if (partnerRes.ok) {
           partnerProviders = (await partnerRes.json()).data ?? [];
+        } else {
+          hadError = true;
         }
-      }
-
-      if (!response.ok && partnerProviders.length === 0) {
-        throw new Error('Failed to fetch SSO providers');
       }
 
       const byId = new Map<string, SsoProvider>();
       for (const p of [...orgProviders, ...partnerProviders]) byId.set(p.id, p);
       setProviders(Array.from(byId.values()));
+
+      if (hadError) {
+        setError('Failed to fetch SSO providers');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import SsoProviderList, { type SsoProvider } from './SsoProviderList';
 import SsoProviderForm, { type SsoProviderFormValues, type ProviderPreset, type Role } from './SsoProviderForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { getJwtClaims } from '../../lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete' | 'test';
@@ -31,26 +32,51 @@ export default function SsoProvidersPage() {
   const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
 
+  // Partner-scope viewers additionally own partner-wide (technician-login)
+  // providers. Gate on the JWT scope, never partners.length (known-broken).
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const isPartnerScope = jwtScope === 'partner' && !!jwtPartnerId;
+
   const fetchProviders = useCallback(async () => {
     try {
       setLoading(true);
       setError(undefined);
+
       const response = await fetchWithAuth('/sso/providers');
-      if (!response.ok) {
-        if (response.status === 401) {
+      if (response.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return;
+      }
+      const orgProviders: SsoProvider[] = response.ok ? (await response.json()).data ?? [] : [];
+
+      // Also pull partner-wide providers for partner-scope viewers and merge
+      // them in (deduped by id). Additive: a failure here must not wipe the
+      // org list, and vice-versa.
+      let partnerProviders: SsoProvider[] = [];
+      if (isPartnerScope) {
+        const partnerRes = await fetchWithAuth('/sso/providers?scope=partner');
+        if (partnerRes.status === 401) {
           void navigateTo('/login', { replace: true });
           return;
         }
+        if (partnerRes.ok) {
+          partnerProviders = (await partnerRes.json()).data ?? [];
+        }
+      }
+
+      if (!response.ok && partnerProviders.length === 0) {
         throw new Error('Failed to fetch SSO providers');
       }
-      const data = await response.json();
-      setProviders(data.data ?? []);
+
+      const byId = new Map<string, SsoProvider>();
+      for (const p of [...orgProviders, ...partnerProviders]) byId.set(p.id, p);
+      setProviders(Array.from(byId.values()));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isPartnerScope]);
 
   const fetchPresets = useCallback(async () => {
     try {
@@ -191,8 +217,10 @@ export default function SsoProvidersPage() {
 
       // Don't send empty client secret on edit
       const payload = { ...values };
-      if (modalMode === 'edit' && !payload.clientSecret) {
-        delete payload.clientSecret;
+      if (modalMode === 'edit') {
+        if (!payload.clientSecret) delete payload.clientSecret;
+        // ownerScope is create-only (the update schema omits it); never PATCH it.
+        delete payload.ownerScope;
       }
 
       const response = await fetchWithAuth(url, {
@@ -343,6 +371,7 @@ export default function SsoProvidersPage() {
               testingConnection={testingConnection}
               isEditing={modalMode === 'edit'}
               hasClientSecret={selectedProviderDetails?.hasClientSecret}
+              showOwnerScope={isPartnerScope}
             />
           </div>
         </div>

--- a/apps/web/src/components/settings/index.ts
+++ b/apps/web/src/components/settings/index.ts
@@ -6,6 +6,7 @@ export { default as ApiKeyList } from './ApiKeyList';
 export { default as ApiKeysPage } from './ApiKeysPage';
 export { default as BrandingEditor } from './BrandingEditor';
 export { default as ChangePasswordForm } from './ChangePasswordForm';
+export { default as ConnectSsoCard } from './ConnectSsoCard';
 export { default as MFASettings } from './MFASettings';
 export { default as OrgBrandingEditor } from './OrgBrandingEditor';
 export { default as OrgDefaultsEditor } from './OrgDefaultsEditor';

--- a/apps/web/src/layouts/AuthShellBranded.astro
+++ b/apps/web/src/layouts/AuthShellBranded.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
+import AuthPanelBranding from '../components/auth/AuthPanelBranding';
 
 interface Props {
   title: string;
@@ -34,70 +35,8 @@ const {
   <body class="min-h-screen bg-background antialiased">
     <div class="flex min-h-screen">
 
-      <!-- Left branded panel -->
-      <div class="hidden u-w-pct-42 flex-col justify-between bg-[hsl(225,62%,48%)] p-10 text-white md:flex lg:p-14">
-        <div>
-          <div class="flex items-center gap-3">
-            <svg class="h-8 w-8" viewBox="0 0 64 64" fill="none">
-              <path d="M12 22C12 22 20 22 28 22C36 22 40 16 48 16C52 16 54 18 54 20C54 22 52 24 48 24C44 24 42 22 42 22" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>
-              <path d="M8 34C8 34 18 34 30 34C42 34 46 28 52 28C55 28 57 30 57 32C57 34 55 36 52 36C48 36 46 34 46 34" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>
-              <path d="M14 46C14 46 22 46 32 46C40 46 44 40 50 40C53 40 55 42 55 44C55 46 53 48 50 48C46 48 44 46 44 46" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>
-            </svg>
-            <span class="text-xl font-bold tracking-tight">Breeze</span>
-          </div>
-        </div>
-
-        <div class="space-y-10">
-          <div>
-            <h2 class="text-2xl font-bold leading-snug tracking-tight lg:text-3xl">
-              Effortless endpoint<br />management
-            </h2>
-            <p class="mt-3 text-sm leading-relaxed text-white/70">
-              {tagline}
-            </p>
-          </div>
-
-          <div class="space-y-5">
-            <div class="flex items-start gap-3">
-              <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
-                <svg class="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 0 1 2.25-2.25h7.5A2.25 2.25 0 0 1 18 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 0 0 4.5 9v.878m13.5-3A2.25 2.25 0 0 1 19.5 9v.878m0 0a2.246 2.246 0 0 0-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0 1 21 12v6a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18v-6c0-1.007.66-1.86 1.573-2.147" />
-                </svg>
-              </div>
-              <div>
-                <p class="text-sm font-semibold text-white/95">10,000+ endpoints</p>
-                <p class="text-xs leading-relaxed text-white/55">Built to handle fleets of any size without breaking a sweat.</p>
-              </div>
-            </div>
-
-            <div class="flex items-start gap-3">
-              <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
-                <svg class="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
-                </svg>
-              </div>
-              <div>
-                <p class="text-sm font-semibold text-white/95">Real-time monitoring</p>
-                <p class="text-xs leading-relaxed text-white/55">Live telemetry, instant alerts, zero guesswork.</p>
-              </div>
-            </div>
-
-            <div class="flex items-start gap-3">
-              <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
-                <svg class="h-4 w-4 text-white/80" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
-                </svg>
-              </div>
-              <div>
-                <p class="text-sm font-semibold text-white/95">AI-powered insights</p>
-                <p class="text-xs leading-relaxed text-white/55">Smart diagnostics and automated remediation at your fingertips.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <p class="text-xs text-white/40">&copy; {new Date().getFullYear()} Breeze RMM</p>
-      </div>
+      <!-- Left branded panel (partner-aware island) -->
+      <AuthPanelBranding tagline={tagline} client:load />
 
       <!-- Right form panel -->
       <div class="flex flex-1 items-center justify-center px-6 py-12 sm:px-12">

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -32,6 +32,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/AlertsPage.tsx',
   'src/components/alerts/AlertDetailPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
+  'src/components/settings/LoginBrandingCard.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
   'src/components/devices/DeviceInfoTab.tsx',
@@ -274,7 +275,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(55);
+    expect(absoluteFiles.length).toBe(56);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/loginContext.ts
+++ b/apps/web/src/lib/loginContext.ts
@@ -1,0 +1,36 @@
+export type LoginContextBranding = {
+  logoUrl: string | null;
+  accentColor: string | null;
+  headline: string | null;
+};
+
+export type LoginContext = {
+  branding: LoginContextBranding | null;
+  partnerSso: { available: boolean; providerName: string; loginUrl: string } | null;
+};
+
+const EMPTY: LoginContext = { branding: null, partnerSso: null };
+
+let cached: Promise<LoginContext> | null = null;
+
+/** Memoized: the branded panel island and LoginPage share one request. */
+export function getLoginContext(): Promise<LoginContext> {
+  if (!cached) cached = fetchLoginContext();
+  return cached;
+}
+
+async function fetchLoginContext(): Promise<LoginContext> {
+  try {
+    const apiHost = import.meta.env.PUBLIC_API_URL || '';
+    // Same timeout rationale as the CF Access check (LoginPage.tsx:38-58):
+    // a hung request must not stall the login page.
+    const res = await fetch(`${apiHost}/api/v1/auth/login-context`, {
+      signal: AbortSignal.timeout(4000)
+    });
+    if (!res.ok) return EMPTY;
+    const body = (await res.json()) as Partial<LoginContext>;
+    return { branding: body.branding ?? null, partnerSso: body.partnerSso ?? null };
+  } catch {
+    return EMPTY; // fail open to stock Breeze branding
+  }
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -24,7 +24,6 @@ export interface Partner {
   /** First-class partner timezone (#1318); canonical tz default. */
   timezone?: string;
   settings: Record<string, unknown>;
-  ssoConfig: Record<string, unknown> | null;
   billingEmail: string;
   createdAt: Date;
   updatedAt: Date;
@@ -40,7 +39,6 @@ export interface Organization {
   status: OrgStatus;
   maxDevices: number | null;
   settings: Record<string, unknown>;
-  ssoConfig: Record<string, unknown> | null;
   contractStart: Date | null;
   contractEnd: Date | null;
   billingContact: Record<string, unknown> | null;


### PR DESCRIPTION
## What & why

Partner-scope SSO for MSP technician logins + partner login-page branding, for self-hosted deployments (reporter: @win-wxx, spec accepted in-thread). An MSP's own techs can now SSO into the partner dashboard through a **partner-axis SSO provider**, and single-partner instances show partner branding + a partner SSO button on the login page instead of hardcoded Breeze marketing copy.

Design docs (committed on the triage branch): spec `docs/superpowers/specs/2026-07-03-partner-sso-login-branding-design.md`, plan `docs/superpowers/plans/2026-07-03-partner-sso-login-branding.md`.

## Architecture (epic #2135 dual-axis playbook)

- **`sso_providers` goes dual-axis**: `org_id XOR partner_id` (CHECK-enforced), one dual-axis RLS policy (FORCE kept), partner index — the existing `jose`-based OIDC engine, presets, testing→active gate, and `#ssoCode` token-exchange flow are reused unchanged. No MSAL, no new libraries.
- **Provider CRUD**: create-only `ownerScope: 'organization' | 'partner'`; partner id always derived from the caller's token (never the body); partner writes gated on `canManagePartnerWidePolicies`; `defaultRoleId` must be a partner-scoped role on partner-axis providers — and is **validated but never applied at login in v1** (identity-first).
- **Login flow**: `GET /sso/login/partner/:partnerId` (public, per-IP+partner rate-limited, system-context DB) → shared `/sso/callback` branches on the provider's axis. Identity-first, **no JIT**: linked identity → safe-email-match (partner staff only: `partnerId` match + `orgId IS NULL`, no password, no other-provider link) → typed error (`invite_required` / `sso_link_required`). The mint gate re-asserts `orgId IS NULL` for every partner mint — org-bound users can never obtain a `scope:'partner'` token, by three independent layers.
- **Connect SSO (self-service linking)**: password-holding users are never auto-linked; an authenticated, `requireMfa()`-gated flow (`/sso/link/options`, `/sso/link/start/:providerId`, link-mode callback via `sso_sessions.link_user_id`) lets a tech link their identity from their own security settings. Never mints tokens, never creates users.
- **enforceSSO for partner staff**: active partner provider with `enforceSSO` suppresses password login for that partner's staff only; `status='testing'` never suppresses (break-glass preserved by construction).
- **MFA**: mirrors org SSO — per-provider `trustsIdpMfa` + `amr` claim sets the JWT `mfa` claim; role-level `forceMfa` still backstops.
- **Branding**: new `partner_login_branding` table (partner-only, shape-3 RLS) + `GET/PUT /partners/me/login-branding` (strict Zod, full-replace PUT, audited with the effective applied row) + public `GET /auth/login-context` (single-partner fast-path; multi-partner instances return nulls and leak nothing; fail-closed rate limit; degrades gracefully to the stock page on DB errors) + prop-driven `AuthShellBranded` with a "Sign in with {provider}" button. Admin UI: ownership selector on provider create + Login Branding settings card (runAction, no-silent-mutations covered).

## Fixes two pre-existing production bugs (found by this branch's real-DB e2e)

The new `ssoPartnerLogin.integration.test.ts` immediately exposed that **org SSO callbacks were broken in any deployment running the API as `breeze_app`**: the callback's provider read, org-membership read, and default-role validation read were bare `db` calls that return 0 rows under FORCED RLS with no pre-auth context → every SSO callback failed with `provider_not_found` (and org providers with a defaultRoleId had a second, independent breaker). This branch wraps those three reads in `withSystemDbAccessContext` (matching the neighboring reads) and regression-locks BOTH axes with full-success e2e cases (org-axis: callback → `#ssoCode` → exchange → `scope:'organization'` JWT).

**Still broken, deliberately left for a follow-up issue** (enumerate-only here): bare reads in `GET /sso/login/:orgId` (initiation), `GET /sso/check/:orgId` (always returns `ssoEnabled:false`), and the callback `existingIdentity` select (dup-insert risk); plus a missing unique index on `user_sso_identities (provider_id, external_id)` and SSO tables missing from tenant-cascade sweeps. Follow-up issue incoming.

## Self-hoster notes

- One idempotent migration: `2026-07-03-sso-partner-axis-login-branding.sql` (dual-axis columns + policies, `partner_login_branding`, `sso_sessions.link_user_id` with ON DELETE CASCADE). Auto-applies via autoMigrate. No env changes.
- Existing org SSO configs are untouched (`org_id` rows keep working; org admin surface unchanged). `partners.ssoConfig` / `organizations.ssoConfig` jsonb are now write-disabled (they were storage-only placeholders — #2183 discussion); columns remain, cleanup drop later.

## Testing

- Real-DB integration: `ssoPartnerLogin.integration.test.ts` (6 cases: partner happy path to decoded `scope:'partner'` JWT; org-bound email-match exclusion; mint-gate rejection; full `sso_link_required` → Connect SSO → login arc; org-axis full-success regression) + `ssoProvidersPartnerRls` / `partnerLoginBrandingRls` forge suites (42501/23514/visibility, non-vacuous under `breeze_app`).
- Unit: sso routes 99, ssoPolicy 9 (axis-aware mock proves cross-axis isolation), loginContext 8, login-branding 8; web: branded shell, SSO button, providers page error-surfacing, LoginBrandingCard full-replace payload, no-silent-mutations 56.
- `tsc --noEmit` + `astro check` + `db:check-drift` clean. Every task passed an independent spec+quality review with fix loops; final whole-branch review verdict: ready (findings triaged into this PR + the follow-up issue).

## Deliberate v1 scope calls (owner-approved)

Self-hosted first (multi-partner/hosted instances get the stock login page — `/login/:partnerSlug` discovery deferred); identity-first with no JIT; stock→branded flash on first paint accepted; `defaultRoleId` inert until JIT ships; minimal branding fields (no custom CSS).

Refs #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
