### PR TITLE
fix(discovery): Asset Info save fails with "[object Object]" on empty Display Name

### DIFF
--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -1646,6 +1646,40 @@ describe('discovery routes', () => {
       expect(body.typeSource).toBe('manual');
     });
 
+    it('accepts label:null (empty Display Name) and clears the label (#2198)', async () => {
+      let capturedSetPayload: any;
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn((payload) => {
+          capturedSetPayload = payload;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{
+                id: ASSET_ID,
+                orgId: ORG,
+                assetType: 'camera',
+                typeSource: 'manual',
+                detectedAssetType: null,
+                hostname: null,
+                label: null,
+                ipAddress: '10.0.0.1',
+              }])
+            })
+          };
+        })
+      } as any);
+
+      // Exact body AssetDetailModal sends for an asset with an empty Display
+      // Name — label must be nullable, not just optional.
+      const res = await app.request(`/discovery/assets/${ASSET_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ label: null, notes: null, tags: [], assetType: 'camera' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedSetPayload).toMatchObject({ label: null, assetType: 'camera', typeSource: 'manual' });
+    });
+
     it('rejects an invalid assetType value', async () => {
       const res = await app.request(`/discovery/assets/${ASSET_ID}`, {
         method: 'PATCH',

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -334,7 +334,9 @@ const bulkDismissSchema = z.object({
 });
 
 const updateAssetSchema = z.object({
-  label: z.string().max(255).optional(),
+  // null clears the display name — the edit form sends `label: null` for an
+  // empty Display Name field, so this must be nullable, not just optional.
+  label: z.string().max(255).nullish(),
   notes: z.string().nullish(),
   tags: z.string().array().optional(),
   // NOTE: keep this list literal — do NOT derive it from `discoveredAssetTypeEnum.enumValues`.

--- a/apps/web/src/components/discovery/AssetDetailModal.test.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.test.tsx
@@ -416,6 +416,44 @@ describe('AssetDetailModal — server error surfaced on save/reset (#1424)', () 
     expect(await screen.findByText('Asset not found')).toBeInTheDocument();
   });
 
+  // @hono/zod-validator's default 400 hook emits the bare ZodError object as
+  // `error`. zod v4 hides `issues` from JSON.stringify, so the wire shape is
+  // {name:'ZodError', message:'<stringified issues>'} — the exact body behind
+  // the "[object Object]" report in #2198.
+  const zodErrorBody = {
+    success: false,
+    error: {
+      name: 'ZodError',
+      message: JSON.stringify([
+        { message: 'Invalid input: expected string, received null', path: ['label'] }
+      ])
+    }
+  };
+
+  it('renders readable validation text, not [object Object], when save returns a ZodError body (#2198)', async () => {
+    failPatchWith(zodErrorBody);
+    render(<AssetDetailModal open asset={asset} devices={devices} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText(/Invalid input: expected string, received null/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
+  it('renders readable validation text, not [object Object], when reset-type returns a ZodError body (#2198)', async () => {
+    failPatchWith(zodErrorBody);
+    render(<AssetDetailModal open asset={manualAsset} devices={devices} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByTestId('asset-modal-type-reset'));
+
+    expect(
+      await screen.findByText(/Invalid input: expected string, received null/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
   it('falls back to the generic message when the error body has no error field', async () => {
     failPatchWith({});
     render(<AssetDetailModal open asset={asset} devices={devices} onClose={() => {}} />);

--- a/apps/web/src/components/discovery/AssetDetailModal.tsx
+++ b/apps/web/src/components/discovery/AssetDetailModal.tsx
@@ -233,7 +233,7 @@ export default function AssetDetailModal({
       });
       if (!response.ok) {
         const body = await response.json().catch(() => null);
-        throw new Error(body?.error || 'Failed to save asset info');
+        throw new Error(extractApiError(body, 'Failed to save asset info'));
       }
       setSaveSuccess(true);
       onUpdated?.(asset.id);
@@ -256,7 +256,7 @@ export default function AssetDetailModal({
       });
       if (!response.ok) {
         const body = await response.json().catch(() => null);
-        throw new Error(body?.error || 'Failed to reset type');
+        throw new Error(extractApiError(body, 'Failed to reset type'));
       }
       setSaveSuccess(true);
       onUpdated?.(asset.id);


### PR DESCRIPTION
## Summary

Fixes the `[object Object]` error reported on Discord (v0.90.0) when saving the Asset Info card of a discovered asset — e.g. manually setting a UniFi camera's type to Camera. Refs #2198.

Two stacked bugs:

1. **Every save on an unlabeled asset failed with HTTP 400.** The form sends `label: null` for an empty Display Name, but `updateAssetSchema.label` was `z.string().max(255).optional()` — `.optional()` permits `undefined`, not `null`. Changed to `.nullish()` (matching `notes`); the handler already treated `null` as "clear the label".
2. **The 400 body rendered raw.** `handleSaveInfo`/`handleResetType` threw `new Error(body?.error || ...)`, and on a zValidator 400 `body.error` is the ZodError object → `"[object Object]"`. Both now go through `extractApiError`, like the sibling unlink handler already did.

The "Camera" type itself was never the problem — the reporter's underlying ask (auto-identifying UniFi Protect cameras) is planned separately in #2199.

## Tests

- API: new route test PATCHes the exact browser payload (`{label: null, notes: null, tags: [], assetType: 'camera'}`) — failed 400 before the schema fix, now 200 and asserts `label: null` reaches the DB set payload.
- Web: two new component tests feed the realistic zod-v4 ZodError wire shape into save and reset-type failures and assert readable validation text renders and `[object Object]` does not — both failed before the fix.
- Full files green: `discovery.test.ts` 53/53, `AssetDetailModal.test.tsx` 27/27. `tsc --noEmit` (api) and `astro check` (web) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)