### PR TITLE
fix(sso): post-merge review follow-ups for partner SSO + login branding (#2194)

### DIFF
--- a/apps/api/migrations/2026-07-04-partner-login-branding-accent-check.sql
+++ b/apps/api/migrations/2026-07-04-partner-login-branding-accent-check.sql
@@ -1,0 +1,40 @@
+-- Enforce the #rrggbb hex-color shape on partner_login_branding.accent_color
+-- at the DB layer (#2194 review follow-up). The web/API validators already
+-- reject non-hex values on write (partnerLoginBranding.ts's brandingSchema),
+-- but that's app-layer-only -- a direct DB write (script, future admin tool,
+-- manual fix) could still leave a malformed value for the login page to
+-- render verbatim into CSS. Belt-and-suspenders: same shape as the Zod check.
+--
+-- Idempotent: guarded CHECK add (mirrors sso_providers_one_owner_chk in
+-- 2026-07-03-sso-partner-axis-login-branding.sql). No inner BEGIN/COMMIT
+-- (autoMigrate wraps each file).
+
+-- Clean up any pre-existing non-conforming rows before adding the CHECK, so
+-- the ALTER TABLE below doesn't fail on data written before this constraint
+-- existed. Report the count so a non-zero cleanup leaves a forensic trail.
+DO $$
+DECLARE
+  n int;
+BEGIN
+  UPDATE partner_login_branding
+  SET accent_color = NULL
+  WHERE accent_color IS NOT NULL
+    AND accent_color !~ '^#[0-9a-fA-F]{6}$';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'cleaned % partner_login_branding row(s) with malformed accent_color', n;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'partner_login_branding_accent_hex_chk'
+      AND conrelid = 'partner_login_branding'::regclass
+  ) THEN
+    ALTER TABLE partner_login_branding
+      ADD CONSTRAINT partner_login_branding_accent_hex_chk
+      CHECK (accent_color IS NULL OR accent_color ~ '^#[0-9a-fA-F]{6}$');
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/loginContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/loginContext.integration.test.ts
@@ -28,10 +28,11 @@
  * meaning `partners`/`organizations` rows actually accumulate across every
  * integration test that has ever run against this container. No existing
  * suite notices because they all scope assertions to a specific ID; this is
- * the first that counts rows globally. Reset both tables ourselves below,
- * using the same `breeze.allow_audit_retention` bypass setup.ts's own
- * ml_feedback_events cleanup uses (audit_logs DOES allow a real DELETE under
- * that GUC — only TRUNCATE is blocked unconditionally).
+ * the first that counts rows globally. Reset both tables ourselves below with
+ * TRUNCATE ... CASCADE, temporarily disabling the audit_logs trigger (the
+ * test-DB user owns the table) — plain DELETEs are not order-independent:
+ * whatever FK-child rows earlier suites left behind (backup_configs, etc.)
+ * make them fail with 23503.
  *
  * Run:
  *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
@@ -42,18 +43,25 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { Hono } from 'hono';
 import { sql } from 'drizzle-orm';
 import { getTestDb } from './setup';
-import { ssoProviders, partnerLoginBranding, organizations, partners } from '../../db/schema';
+import { ssoProviders, partnerLoginBranding } from '../../db/schema';
 import { createPartner } from './db-utils';
 import { loginContextRoutes } from '../../routes/auth/loginContext';
 
 beforeEach(async () => {
   const testDb = getTestDb();
-  await testDb.transaction(async (tx) => {
-    await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-    await tx.execute(sql`DELETE FROM audit_logs`);
-  });
-  await testDb.delete(organizations);
-  await testDb.delete(partners);
+  // Bare `DELETE FROM organizations/partners` is not enough here: earlier
+  // suites in the same run leave rows in FK-child tables without ON DELETE
+  // CASCADE (backup_configs bit us in CI, 23503). TRUNCATE ... CASCADE is the
+  // only order-independent reset, and the audit_logs BEFORE TRUNCATE trigger
+  // (append-only enforcement) is the one thing blocking it — the test-DB user
+  // owns the table, so disable it just for this statement and re-enable in a
+  // finally so a failed truncate can't leave the guard off.
+  await testDb.execute(sql`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_truncate`);
+  try {
+    await testDb.execute(sql`TRUNCATE TABLE partners, organizations CASCADE`);
+  } finally {
+    await testDb.execute(sql`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_truncate`);
+  }
 });
 
 async function createPartnerAxisProvider(

--- a/apps/api/src/__tests__/integration/loginContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/loginContext.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Real-DB integration coverage for the public GET /auth/login-context
+ * endpoint (#2183 / #2194 review follow-up).
+ *
+ * This is the PR's only fully-public, unauthenticated route — it runs on
+ * every render of the login page, before any tenant is known, and had zero
+ * integration coverage. It's also the platform's one deliberate
+ * tenant-leakage gate: on a multi-partner instance it must reveal NOTHING
+ * (no branding, no SSO hint) rather than guess which partner the visitor
+ * belongs to. These cases exercise the real handler (routes/auth/loginContext.ts)
+ * against genuine Postgres (RLS via withSystemDbAccessContext) and genuine
+ * Redis (the route rate-limits 30/min per IP and fails CLOSED without Redis;
+ * cleanupDatabase()'s per-test `flushdb` in setup.ts keeps that bucket fresh
+ * for every test).
+ *
+ * Wire contract under test: packages/shared/src/types/loginContext.ts.
+ * `partnerSso` is `{ providerName, loginUrl, enforceSSO } | null` — presence
+ * of `partnerSso` IS the availability signal, there is no separate
+ * `available` field.
+ *
+ * IMPORTANT — "which partners exist" is GLOBAL state, and cleanupDatabase()'s
+ * per-test TRUNCATE of `partners` (setup.ts) is NOT actually effective:
+ * `TRUNCATE partners CASCADE` cascades transitively into `organizations` and
+ * from there into `audit_logs`, whose `audit_log_block_truncate` trigger
+ * unconditionally rejects any TRUNCATE reaching it (append-only enforcement,
+ * no bypass GUC for TRUNCATE — only DELETE has one) — so that whole TRUNCATE
+ * statement fails and is silently swallowed by cleanupDatabase()'s try/catch,
+ * meaning `partners`/`organizations` rows actually accumulate across every
+ * integration test that has ever run against this container. No existing
+ * suite notices because they all scope assertions to a specific ID; this is
+ * the first that counts rows globally. Reset both tables ourselves below,
+ * using the same `breeze.allow_audit_retention` bypass setup.ts's own
+ * ml_feedback_events cleanup uses (audit_logs DOES allow a real DELETE under
+ * that GUC — only TRUNCATE is blocked unconditionally).
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/loginContext.integration.test.ts
+ */
+import './setup';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { ssoProviders, partnerLoginBranding, organizations, partners } from '../../db/schema';
+import { createPartner } from './db-utils';
+import { loginContextRoutes } from '../../routes/auth/loginContext';
+
+beforeEach(async () => {
+  const testDb = getTestDb();
+  await testDb.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
+    await tx.execute(sql`DELETE FROM audit_logs`);
+  });
+  await testDb.delete(organizations);
+  await testDb.delete(partners);
+});
+
+async function createPartnerAxisProvider(
+  partnerId: string,
+  opts: { status?: 'active' | 'inactive' | 'testing'; enforceSSO?: boolean; name?: string } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId: null,
+      partnerId,
+      name: opts.name ?? 'Acme MSP SSO',
+      type: 'oidc',
+      status: opts.status ?? 'active',
+      enforceSSO: opts.enforceSSO ?? false,
+    })
+    .returning();
+  if (!row) throw new Error('failed to create partner-axis provider fixture');
+  return row;
+}
+
+async function createBranding(
+  partnerId: string,
+  opts: { logoUrl?: string | null; accentColor?: string | null; headline?: string | null } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(partnerLoginBranding)
+    .values({
+      partnerId,
+      logoUrl: opts.logoUrl ?? 'https://cdn.example.test/acme-logo.png',
+      // Valid #rrggbb hex — the 2026-07-04 migration adds a DB-level CHECK
+      // constraint enforcing this shape.
+      accentColor: opts.accentColor ?? '#123abc',
+      headline: opts.headline ?? 'Welcome to Acme MSP',
+    })
+    .returning();
+  if (!row) throw new Error('failed to create partner_login_branding fixture');
+  return row;
+}
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/auth', loginContextRoutes);
+  return app;
+}
+
+describe('GET /auth/login-context — real-DB e2e (#2183)', () => {
+  it('single partner + active provider + branding row: returns branding and the new partnerSso contract (providerName, loginUrl, enforceSSO — no `available` field)', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    await createBranding(partner.id, { logoUrl: 'https://cdn.example.test/logo.png', accentColor: '#123abc', headline: 'Welcome' });
+    await createPartnerAxisProvider(partner.id, { status: 'active', enforceSSO: true, name: 'Acme Okta' });
+
+    const res = await app.request('/auth/login-context');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.branding).toEqual({
+      logoUrl: 'https://cdn.example.test/logo.png',
+      accentColor: '#123abc',
+      headline: 'Welcome',
+    });
+    expect(body.partnerSso).toEqual({
+      providerName: 'Acme Okta',
+      loginUrl: `/api/v1/sso/login/partner/${partner.id}`,
+      enforceSSO: true,
+    });
+    expect(body.partnerSso.available).toBeUndefined();
+  });
+
+  it('a status=testing provider is never advertised publicly: partnerSso is null while branding still returns', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    await createBranding(partner.id, { headline: 'Testing Partner' });
+    await createPartnerAxisProvider(partner.id, { status: 'testing', enforceSSO: true });
+
+    const res = await app.request('/auth/login-context');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.partnerSso).toBeNull();
+    expect(body.branding).toEqual({
+      logoUrl: 'https://cdn.example.test/acme-logo.png',
+      accentColor: '#123abc',
+      headline: 'Testing Partner',
+    });
+  });
+
+  it('more than one partner: leak-nothing gate returns { branding: null, partnerSso: null } even though both have branding/providers', async () => {
+    const app = buildApp();
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    await createBranding(partnerA.id, { headline: 'Partner A' });
+    await createBranding(partnerB.id, { headline: 'Partner B' });
+    await createPartnerAxisProvider(partnerA.id, { status: 'active' });
+    await createPartnerAxisProvider(partnerB.id, { status: 'active' });
+
+    const res = await app.request('/auth/login-context');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toEqual({ branding: null, partnerSso: null });
+  });
+
+  it('single partner with no branding row: branding is null (partnerSso still resolves normally)', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    await createPartnerAxisProvider(partner.id, { status: 'active', enforceSSO: false, name: 'No Branding IdP' });
+
+    const res = await app.request('/auth/login-context');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.branding).toBeNull();
+    expect(body.partnerSso).toEqual({
+      providerName: 'No Branding IdP',
+      loginUrl: `/api/v1/sso/login/partner/${partner.id}`,
+      enforceSSO: false,
+    });
+  });
+
+  it('zero partners: returns { branding: null, partnerSso: null } (partnerRows.length !== 1 branch)', async () => {
+    const app = buildApp();
+    const res = await app.request('/auth/login-context');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ branding: null, partnerSso: null });
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts
@@ -14,10 +14,13 @@
  */
 import './setup';
 import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
 import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { partnerLoginBranding, partners } from '../../db/schema';
-import { createPartner } from './db-utils';
+import { createOrganization, createPartner, createRole, createUser, assignUserToPartner } from './db-utils';
+import { createAccessToken } from '../../services/jwt';
+import { partnerLoginBrandingRoutes } from '../../routes/partnerLoginBranding';
 
 function partnerContext(partnerId: string): DbAccessContext {
   return {
@@ -25,6 +28,16 @@ function partnerContext(partnerId: string): DbAccessContext {
     orgId: null,
     accessibleOrgIds: [],
     accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
     userId: null,
   };
 }
@@ -118,5 +131,104 @@ describe('partner_login_branding RLS — partner-axis (2026-07-03 migration)', (
       db.execute(sql`SELECT count(*)::int AS n FROM partner_login_branding WHERE partner_id = ${partnerA.id}`),
     );
     expect((count as unknown as { n: number }[])[0]?.n).toBe(0);
+  });
+
+  it('an org-scope caller under partner A can neither SELECT nor UPDATE partner A\'s login-branding row (org tokens never pass breeze_has_partner_access)', async () => {
+    // Mirrors ssoProvidersPartnerRls.integration.test.ts's "org-scope caller
+    // cannot see partner-axis rows" case (~lines 144-161) for this table's
+    // own (also partner-ONLY, no org axis) policy.
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+
+    await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db.insert(partnerLoginBranding).values({ partnerId: partnerA.id, headline: 'Acme MSP' }).returning(),
+    );
+
+    const visibleToOrg = await withDbAccessContext(orgContext(orgA.id), () =>
+      db
+        .select({ partnerId: partnerLoginBranding.partnerId })
+        .from(partnerLoginBranding)
+        .where(eq(partnerLoginBranding.partnerId, partnerA.id)),
+    );
+    expect(visibleToOrg).toEqual([]);
+
+    // The USING clause filters the UPDATE's target row set to zero rows —
+    // this is a silent no-op, not a thrown error, since the row is simply
+    // invisible to the org-scope context (no error path to assert on).
+    const updatedByOrg = await withDbAccessContext(orgContext(orgA.id), () =>
+      db
+        .update(partnerLoginBranding)
+        .set({ headline: 'Hijacked by org scope' })
+        .where(eq(partnerLoginBranding.partnerId, partnerA.id))
+        .returning(),
+    );
+    expect(updatedByOrg).toEqual([]);
+
+    // Confirm the row is untouched at the storage level (not just filtered
+    // out of THIS read — a genuinely unauthorized write would have changed it).
+    const [stillIntact] = await withDbAccessContext(systemContext, () =>
+      db
+        .select({ headline: partnerLoginBranding.headline })
+        .from(partnerLoginBranding)
+        .where(eq(partnerLoginBranding.partnerId, partnerA.id)),
+    );
+    expect(stillIntact?.headline).toBe('Acme MSP');
+  });
+
+  it('PUT /partners/me/login-branding is full-replace: a partial PUT null-clears fields omitted from the request body (real route + real DB)', async () => {
+    const app = new Hono();
+    app.route('/partners', partnerLoginBrandingRoutes);
+
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, withMembership: false });
+    // 'all' org_access is required by canManagePartnerWidePolicies for the
+    // PUT to be authorized at all (services/partnerWideAccess.ts).
+    await assignUserToPartner(user.id, partner.id, role.id, 'all');
+    const token = await createAccessToken({
+      sub: user.id,
+      email: user.email,
+      roleId: role.id,
+      orgId: null,
+      partnerId: partner.id,
+      scope: 'partner',
+      mfa: false,
+    });
+    const authHeaders = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+    // (1) Full object.
+    const putFullRes = await app.request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: authHeaders,
+      body: JSON.stringify({ logoUrl: 'https://cdn.example.test/logo.png', accentColor: '#123abc', headline: 'Welcome' }),
+    });
+    expect(putFullRes.status).toBe(200);
+    const putFullBody = await putFullRes.json();
+    expect(putFullBody.data).toEqual({
+      logoUrl: 'https://cdn.example.test/logo.png',
+      accentColor: '#123abc',
+      headline: 'Welcome',
+    });
+
+    // (2) Partial PUT — only headline. logoUrl/accentColor are OMITTED, not
+    // explicitly nulled, so this proves the route's own null-coalescing
+    // (`body.logoUrl ?? null`), not just a client sending explicit nulls.
+    const putPartialRes = await app.request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: authHeaders,
+      body: JSON.stringify({ headline: 'Only headline now' }),
+    });
+    expect(putPartialRes.status).toBe(200);
+    const putPartialBody = await putPartialRes.json();
+    expect(putPartialBody.data).toEqual({ logoUrl: null, accentColor: null, headline: 'Only headline now' });
+
+    // (3) GET confirms the REAL database reflects the null-clear, not just
+    // the PUT handler's echoed response.
+    const getRes = await app.request('/partners/me/login-branding', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.data).toEqual({ logoUrl: null, accentColor: null, headline: 'Only headline now' });
   });
 });

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -40,11 +40,13 @@ import {
   createPartner,
   createOrganization,
   createRole,
+  createUser,
   assignUserToPartner,
   assignUserToOrganization,
 } from './db-utils';
 import { encryptSecret } from '../../services/secretCrypto';
 import { createAccessToken } from '../../services/jwt';
+import { loginRoutes } from '../../routes/auth/login';
 
 vi.mock('../../services/sso', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/sso')>();
@@ -66,7 +68,10 @@ process.env.APP_ENCRYPTION_KEY = 'integration-test-app-encryption-key-32-bytes!'
 
 const ISSUER = 'https://idp.example.test';
 
-async function createPartnerAxisProvider(partnerId: string, opts: { trustsIdpMfa?: boolean } = {}) {
+async function createPartnerAxisProvider(
+  partnerId: string,
+  opts: { trustsIdpMfa?: boolean; status?: 'active' | 'inactive' | 'testing'; enforceSSO?: boolean } = {},
+) {
   const db = getTestDb();
   const [row] = await db
     .insert(ssoProviders)
@@ -75,7 +80,7 @@ async function createPartnerAxisProvider(partnerId: string, opts: { trustsIdpMfa
       partnerId,
       name: 'Partner IdP',
       type: 'oidc',
-      status: 'active',
+      status: opts.status ?? 'active',
       issuer: ISSUER,
       clientId: 'test-client-id',
       clientSecret: encryptSecret('test-client-secret'),
@@ -84,6 +89,7 @@ async function createPartnerAxisProvider(partnerId: string, opts: { trustsIdpMfa
       userInfoUrl: `${ISSUER}/userinfo`,
       jwksUrl: `${ISSUER}/jwks`,
       trustsIdpMfa: opts.trustsIdpMfa ?? false,
+      enforceSSO: opts.enforceSSO ?? false,
       autoProvision: false,
     })
     .returning();
@@ -151,6 +157,10 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
   beforeEach(() => {
     app = new Hono();
     app.route('/sso', ssoRoutes);
+    // Mounted for the enforceSSO-non-suppression case below, which drives a
+    // real POST /auth/login to prove a status='testing' provider never gates
+    // password auth (only status='active' + enforceSSO does, via ssoPolicy.ts).
+    app.route('/auth', loginRoutes);
     vi.mocked(exchangeCodeForTokens).mockReset().mockResolvedValue({
       access_token: 'idp-access-token',
       token_type: 'Bearer',
@@ -568,6 +578,46 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
       .where(eq(ssoSessions.linkUserId, user.id))
       .limit(1);
     expect(afterDelete).toBeUndefined();
+  });
+
+  // ── review follow-up: status='active' provider-selection gate (real-DB) ──
+  // The WHERE eq(ssoProviders.status, 'active') filter that both the login-
+  // initiation route and ssoPolicy.ts's enforcement check rely on was, until
+  // now, verified only against a mocked db. These two cases exercise the real
+  // Postgres row so a status='testing' provider genuinely behaves like "not
+  // there yet" on both surfaces.
+
+  it('GET /sso/login/partner/:partnerId 404s when the partner\'s only provider is status=testing', async () => {
+    const partner = await createPartner();
+    await createPartnerAxisProvider(partner.id, { status: 'testing' });
+
+    const res = await app.request(`/sso/login/partner/${partner.id}`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain('No active SSO provider');
+  });
+
+  it('enforceSSO on a status=testing provider does NOT suppress password login for the partner\'s staff', async () => {
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const password = 'TestPass123!';
+    const user = await createUser({ partnerId: partner.id, password, withMembership: false });
+    await assignUserToPartner(user.id, partner.id, role.id, 'all');
+    // enforceSSO:true would suppress password login IF this provider were
+    // status='active' (see ssoPolicy.ts's isPasswordAuthDisabledBySso, which
+    // filters on both status='active' AND enforceSSO=true) — status='testing'
+    // must leave password login untouched even with enforceSSO set.
+    await createPartnerAxisProvider(partner.id, { status: 'testing', enforceSSO: true });
+
+    const res = await app.request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: user.email, password }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tokens?.accessToken).toBeDefined();
+    expect(body.mfaRequired).toBe(false);
   });
 });
 

--- a/apps/api/src/routes/auth/loginContext.test.ts
+++ b/apps/api/src/routes/auth/loginContext.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../db/schema', () => ({
     partnerId: 'ssoProviders.partnerId',
     name: 'ssoProviders.name',
     status: 'ssoProviders.status',
+    enforceSSO: 'ssoProviders.enforceSSO',
   },
   partnerLoginBranding: {
     partnerId: 'partnerLoginBranding.partnerId',
@@ -72,7 +73,7 @@ describe('GET /auth/login-context (#2183)', () => {
         accentColor: '#112233',
         headline: 'Welcome back'
       }]) as any)
-      .mockReturnValueOnce(selectChain([{ name: 'Okta' }]) as any);
+      .mockReturnValueOnce(selectChain([{ name: 'Okta', enforceSSO: true }]) as any);
 
     const res = await getContext();
     expect(res.status).toBe(200);
@@ -84,9 +85,28 @@ describe('GET /auth/login-context (#2183)', () => {
         headline: 'Welcome back'
       },
       partnerSso: {
-        available: true,
         providerName: 'Okta',
-        loginUrl: `/api/v1/sso/login/partner/${PARTNER_UUID}`
+        loginUrl: `/api/v1/sso/login/partner/${PARTNER_UUID}`,
+        enforceSSO: true
+      }
+    });
+  });
+
+  it('passes through enforceSSO: false when the provider does not enforce SSO', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any)
+      .mockReturnValueOnce(selectChain([]) as any)
+      .mockReturnValueOnce(selectChain([{ name: 'Okta', enforceSSO: false }]) as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      branding: null,
+      partnerSso: {
+        providerName: 'Okta',
+        loginUrl: `/api/v1/sso/login/partner/${PARTNER_UUID}`,
+        enforceSSO: false
       }
     });
   });
@@ -128,15 +148,15 @@ describe('GET /auth/login-context (#2183)', () => {
     expect(db.select).toHaveBeenCalledTimes(1);
   });
 
-  it('omits provider config beyond name + loginUrl', async () => {
+  it('omits provider config beyond name + loginUrl + enforceSSO', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any)
       .mockReturnValueOnce(selectChain([]) as any)
-      .mockReturnValueOnce(selectChain([{ name: 'Okta' }]) as any);
+      .mockReturnValueOnce(selectChain([{ name: 'Okta', enforceSSO: true }]) as any);
 
     const res = await getContext();
     const body = await res.json();
-    expect(Object.keys(body.partnerSso).sort()).toEqual(['available', 'loginUrl', 'providerName']);
+    expect(Object.keys(body.partnerSso).sort()).toEqual(['enforceSSO', 'loginUrl', 'providerName']);
   });
 
   it('429s past the rate limit', async () => {

--- a/apps/api/src/routes/auth/loginContext.ts
+++ b/apps/api/src/routes/auth/loginContext.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { and, eq } from 'drizzle-orm';
+import type { LoginContext } from '@breeze/shared';
 import { db, withSystemDbAccessContext } from '../../db';
 import { partners, ssoProviders, partnerLoginBranding } from '../../db/schema';
 import { getTrustedClientIp } from '../../services/clientIp';
@@ -23,7 +24,7 @@ loginContextRoutes.get('/login-context', async (c) => {
     return c.json({ error: 'Too many requests' }, 429);
   }
 
-  let context: { branding: unknown; partnerSso: unknown };
+  let context: LoginContext;
   try {
     context = await withSystemDbAccessContext(async () => {
       const partnerRows = await db.select({ id: partners.id }).from(partners).limit(2);
@@ -43,7 +44,7 @@ loginContextRoutes.get('/login-context', async (c) => {
         .limit(1);
 
       const [provider] = await db
-        .select({ name: ssoProviders.name })
+        .select({ name: ssoProviders.name, enforceSSO: ssoProviders.enforceSSO })
         .from(ssoProviders)
         .where(and(
           eq(ssoProviders.partnerId, partnerId),
@@ -55,9 +56,9 @@ loginContextRoutes.get('/login-context', async (c) => {
         branding: brandingRow ?? null,
         partnerSso: provider
           ? {
-              available: true as const,
               providerName: provider.name,
-              loginUrl: `/api/v1/sso/login/partner/${partnerId}`
+              loginUrl: `/api/v1/sso/login/partner/${partnerId}`,
+              enforceSSO: Boolean(provider.enforceSSO)
             }
           : null
       };

--- a/apps/api/src/routes/partnerLoginBranding.ts
+++ b/apps/api/src/routes/partnerLoginBranding.ts
@@ -11,7 +11,7 @@ import { writeRouteAudit } from '../services/auditEvents';
 // Partner admin read/write for the MSP's own technician-login branding
 // (#2183). Deliberately NOT under orgRoutes' /orgs/partners/me or the
 // legacy singular /partner router — mounted directly at /partners so the
-// final URL matches Task 11's contract: /api/v1/partners/me/login-branding.
+// final URL is /api/v1/partners/me/login-branding.
 export const partnerLoginBrandingRoutes = new Hono();
 
 const brandingSchema = z.object({

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -990,12 +990,13 @@ ssoRoutes.delete(
 // Self-service "Connect SSO" — authenticated identity linking (#2183)
 // ============================================
 //
-// Password-holding users are NEVER auto-linked at login (Task 5 refuses to
-// JIT-link an assertion to an account that has a password or another provider
-// link). This is the sanctioned path for those users to adopt SSO: an
-// already-authenticated user connects their own IdP identity, from their own
-// security settings. It works on BOTH axes — an org member links an org-axis
-// provider, partner staff link a partner-axis provider.
+// Password-holding users are NEVER auto-linked at login (the identity-
+// resolution step below refuses to JIT-link an assertion to an account that
+// has a password or another provider link). This is the sanctioned path for
+// those users to adopt SSO: an already-authenticated user connects their own
+// IdP identity, from their own security settings. It works on BOTH axes — an
+// org member links an org-axis provider, partner staff link a partner-axis
+// provider.
 //
 // Axis determinant: the caller's TOKEN scope, not the provider. An
 // organization-scope token means an org member (auth.orgId = their org); a
@@ -1003,7 +1004,8 @@ ssoRoutes.delete(
 // `AuthContext.user` carries no orgId/partnerId, so we key off the token's
 // scope/orgId/partnerId. This is exactly what keeps an org-bound user from ever
 // linking a partner-axis provider (an org-bound user can only ever hold an
-// organization-scope token), preserving the Task-5 mint-gate invariant.
+// organization-scope token), preserving the invariant that no link can be
+// created here that the login-path identity resolution would later reject.
 
 // Providers the current user may link, each with its linked status.
 ssoRoutes.get('/link/options', authMiddleware, async (c) => {
@@ -1065,7 +1067,8 @@ ssoRoutes.post(
     // token, matching orgId). Partner-axis → the caller must be staff of that
     // partner (partner-scope token, matching partnerId). An org-bound user
     // (organization scope) can therefore NEVER pass the partner branch, so a
-    // link Task-5's resolution would later reject can never be created.
+    // link the login-path identity resolution would later reject can never be
+    // created here.
     const inPool = provider.orgId
       ? auth.scope === 'organization' && auth.orgId === provider.orgId
       : auth.scope === 'partner' && auth.partnerId === provider.partnerId;
@@ -1406,7 +1409,7 @@ ssoRoutes.get('/callback', async (c) => {
     // SSO is an account-takeover-critical entry point, so the id_token MUST be
     // cryptographically verified and the identity used for account linking must
     // be bound to that verified token — never the old unsigned claim-decode
-    // path. (security review #2: C-1/C-2)
+    // path.
     //
     // 1) An id_token is required, and a JWKS URL is required to verify it. The
     //    previous code fell back to decode-only (NO signature check) when
@@ -1462,7 +1465,7 @@ ssoRoutes.get('/callback', async (c) => {
       }
     }
 
-    // ── Identity resolution (security review #2: identity-first + safe JIT link)
+    // ── Identity resolution (identity-first + safe JIT link) ──────────────────
     // The authoritative key is the (provider, external subject) pair recorded in
     // user_sso_identities — NOT the global-unique email. Once a user is linked to
     // a provider, only that provider asserting that exact `sub` can authenticate
@@ -1558,7 +1561,7 @@ ssoRoutes.get('/callback', async (c) => {
       return linkedUser ?? null;
     });
 
-    // ── SSO domain-verification gate (security review #2, H-2 / Plan B) ──────
+    // ── SSO domain-verification gate ──────────────────────────────────────────
     // Before JIT-linking-by-email or provisioning a NEW account, require the
     // asserted email's domain to be one the org proved it owns (DNS TXT). Blocks
     // a malicious/compromised org-admin from pointing the org at an attacker IdP
@@ -1700,7 +1703,7 @@ ssoRoutes.get('/callback', async (c) => {
       user = newUser;
     }
 
-    // IdP-asserted MFA (security review #2 H-1) — axis-independent, so it is
+    // IdP-asserted MFA — axis-independent, so it is
     // computed here (above the membership branch) and shared by both the org
     // and partner token payloads. When the provider opts in via `trustsIdpMfa`
     // AND the verified id_token's `amr` attests multi-factor, propagate
@@ -1809,6 +1812,13 @@ ssoRoutes.get('/callback', async (c) => {
     }
 
     // Update or create SSO identity link (shared across both axes)
+    // KNOWN BUG (#2195): this read is not wrapped in withSystemDbAccessContext,
+    // so on this unauthenticated callback route (no request context has been
+    // established) FORCED RLS silently matches 0 rows here — existingIdentity
+    // is always undefined regardless of whether a link already exists. That
+    // makes the UPDATE branch below unreachable and every returning SSO login
+    // INSERTs a duplicate identity row instead of updating the existing one.
+    // Fix tracked in the #2195 follow-up — do not copy this pattern elsewhere.
     const [existingIdentity] = await db
       .select()
       .from(userSsoIdentities)

--- a/apps/api/src/services/passwordResetEligibility.test.ts
+++ b/apps/api/src/services/passwordResetEligibility.test.ts
@@ -194,6 +194,60 @@ describe('getPasswordResetEligibility', () => {
     const result = await getPasswordResetEligibility('   ');
     expect(result).toEqual({ allowed: false, reason: 'unknown_user' });
   });
+
+  it('blocks reset for partner-axis-only users when the partner enforces SSO', async () => {
+    setupSelects(
+      [{ id: 'u-1', email: 'staff@acme.com', status: 'active', partnerId: 'p-1', orgId: null }],
+      [{ status: 'active', deletedAt: null }],
+    );
+    isSsoDisabledMock.mockResolvedValue(true);
+
+    const result = await getPasswordResetEligibility('staff@acme.com');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('sso_required');
+    expect(isSsoDisabledMock).toHaveBeenCalledWith({
+      scope: 'partner',
+      orgId: null,
+      partnerId: 'p-1',
+    });
+  });
+
+  it('allows reset for partner-axis-only users when the partner does not enforce SSO', async () => {
+    setupSelects(
+      [{ id: 'u-1', email: 'staff2@acme.com', status: 'active', partnerId: 'p-1', orgId: null }],
+      [{ status: 'active', deletedAt: null }],
+    );
+    isSsoDisabledMock.mockResolvedValue(false);
+
+    const result = await getPasswordResetEligibility('staff2@acme.com');
+
+    expect(result.allowed).toBe(true);
+    expect(isSsoDisabledMock).toHaveBeenCalledWith({
+      scope: 'partner',
+      orgId: null,
+      partnerId: 'p-1',
+    });
+  });
+
+  it('does not consult the partner SSO branch for org-scoped users (org branch unchanged)', async () => {
+    setupSelects(
+      [{ id: 'u-1', email: 'orguser@acme.com', status: 'active', partnerId: 'p-1', orgId: 'o-1' }],
+      [{ status: 'active', deletedAt: null }],
+      [{ status: 'active', deletedAt: null }],
+    );
+    isSsoDisabledMock.mockResolvedValue(false);
+
+    const result = await getPasswordResetEligibility('orguser@acme.com');
+
+    expect(result.allowed).toBe(true);
+    expect(isSsoDisabledMock).toHaveBeenCalledTimes(1);
+    expect(isSsoDisabledMock).toHaveBeenCalledWith({
+      scope: 'organization',
+      orgId: 'o-1',
+      partnerId: null,
+    });
+  });
 });
 
 describe('getPasswordResetEligibilityForUser', () => {

--- a/apps/api/src/services/passwordResetEligibility.ts
+++ b/apps/api/src/services/passwordResetEligibility.ts
@@ -159,14 +159,27 @@ async function evaluateEligibility(user: UserLookupRow): Promise<ResetEligibilit
   }
 
   // SSO check: defer to the existing helper so password reset and login share
-  // one definition of "SSO is mandatory for this org". `isPasswordAuthDisabledBySso`
-  // only flags `scope='organization'` users whose org has an active enforced
-  // provider — partner-scope users are never SSO-gated here.
+  // one definition of "SSO is mandatory for this org/partner". Org-axis users
+  // (orgId set) are gated against their org's active enforced provider;
+  // partner-axis-only users (orgId null, partnerId set) are gated against
+  // their partner's active enforced provider via the same helper's
+  // `scope: 'partner'` branch — both axes must be checked, or a partner-only
+  // account keeps a live password-reset path even after its partner turns on
+  // enforced SSO.
   if (user.orgId) {
     const ssoBlocked = await isPasswordAuthDisabledBySso({
       scope: 'organization',
       orgId: user.orgId,
       partnerId: null,
+    });
+    if (ssoBlocked) {
+      return { allowed: false, reason: 'sso_required', userId: user.id, email: user.email };
+    }
+  } else if (user.partnerId) {
+    const ssoBlocked = await isPasswordAuthDisabledBySso({
+      scope: 'partner',
+      orgId: null,
+      partnerId: user.partnerId,
     });
     if (ssoBlocked) {
       return { allowed: false, reason: 'sso_required', userId: user.id, email: user.email };

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -148,7 +148,7 @@ describe('LoginPage partner SSO button', () => {
   it('renders a "Sign in with {provider}" button when partner SSO is available', async () => {
     vi.mocked(getLoginContext).mockResolvedValue({
       branding: null,
-      partnerSso: { available: true, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: false },
     });
 
     render(<LoginPage />);
@@ -164,7 +164,7 @@ describe('LoginPage partner SSO button', () => {
   it('appends the safe next as a redirect param on the SSO button href', async () => {
     vi.mocked(getLoginContext).mockResolvedValue({
       branding: null,
-      partnerSso: { available: true, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: false },
     });
 
     render(<LoginPage next="/devices" />);
@@ -175,18 +175,6 @@ describe('LoginPage partner SSO button', () => {
     );
   });
 
-  it('omits the SSO button when partner SSO is unavailable', async () => {
-    vi.mocked(getLoginContext).mockResolvedValue({
-      branding: null,
-      partnerSso: { available: false, providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1' },
-    });
-
-    render(<LoginPage />);
-
-    await waitFor(() => screen.getByLabelText(/email/i));
-    expect(screen.queryByTestId('partner-sso-button')).not.toBeInTheDocument();
-  });
-
   it('omits the SSO button when the login-context fetch degrades to null', async () => {
     vi.mocked(getLoginContext).mockResolvedValue({ branding: null, partnerSso: null });
 
@@ -194,6 +182,62 @@ describe('LoginPage partner SSO button', () => {
 
     await waitFor(() => screen.getByLabelText(/email/i));
     expect(screen.queryByTestId('partner-sso-button')).not.toBeInTheDocument();
+  });
+
+  it('renders the SSO link banner from ?error=sso_link_required', async () => {
+    const realWindow = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...realWindow, search: '?error=sso_link_required' },
+    });
+
+    render(<LoginPage />);
+
+    const notice = await screen.findByRole('alert');
+    expect(notice).toHaveTextContent(/This account already has a password/i);
+
+    Object.defineProperty(window, 'location', { configurable: true, value: realWindow });
+  });
+
+  it('enforceSSO=true hides the password form initially and shows the SSO button', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: true },
+    });
+
+    render(<LoginPage />);
+
+    await screen.findByTestId('partner-sso-button');
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('show-password-form')).toBeInTheDocument();
+  });
+
+  it('clicking "Sign in with password instead" reveals the password form', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: true },
+    });
+
+    render(<LoginPage />);
+
+    const toggle = await screen.findByTestId('show-password-form');
+    fireEvent.click(toggle);
+
+    expect(await screen.findByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('show-password-form')).not.toBeInTheDocument();
+  });
+
+  it('enforceSSO=false leaves the password form visible as before', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: false },
+    });
+
+    render(<LoginPage />);
+
+    await screen.findByTestId('partner-sso-button');
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('show-password-form')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -99,20 +99,29 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   // entirely in the effect (client-only), keeping SSR and CSR initial output
   // identical (both render the placeholder).
   const [cfAccessRedirectChecked, setCfAccessRedirectChecked] = useState(false);
-  const [partnerSso, setPartnerSso] = useState<{ providerName: string; loginUrl: string } | null>(null);
+  const [partnerSso, setPartnerSso] = useState<{ providerName: string; loginUrl: string; enforceSSO: boolean } | null>(null);
+  // Only meaningful once enforceSSO is true: lets the user reveal the password
+  // form that's collapsed behind it (see the enforceSSO comment below).
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
 
   const login = useAuthStore((state) => state.login);
 
   // Partner SSO: the (memoized) login context tells us whether this deployment
-  // resolves to a single partner with an enforced/available SSO provider. If so,
-  // surface a "Sign in with {provider}" button above the password form. Fetch
-  // failure / null response leaves the button absent (password-only login).
+  // resolves to a single partner with an active SSO provider. Presence of
+  // partnerSso IS the availability signal (no separate `available` flag). If
+  // present, surface a "Sign in with {provider}" button above the password
+  // form. Fetch failure / null response leaves the button absent
+  // (password-only login).
   useEffect(() => {
     let cancelled = false;
     getLoginContext().then((ctx) => {
       if (cancelled) return;
-      if (ctx.partnerSso?.available) {
-        setPartnerSso({ providerName: ctx.partnerSso.providerName, loginUrl: ctx.partnerSso.loginUrl });
+      if (ctx.partnerSso) {
+        setPartnerSso({
+          providerName: ctx.partnerSso.providerName,
+          loginUrl: ctx.partnerSso.loginUrl,
+          enforceSSO: ctx.partnerSso.enforceSSO,
+        });
       }
     });
     return () => { cancelled = true; };
@@ -303,11 +312,30 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
           Sign in with {partnerSso.providerName}
         </a>
       )}
-      <LoginForm
-        onSubmit={handleLogin}
-        errorMessage={error}
-        loading={loading}
-      />
+      {/*
+        enforceSSO only de-emphasizes the UI here — it collapses the password
+        form behind a reveal toggle so the SSO button reads as the primary
+        path. The password form must stay reachable: org-axis users (customer
+        techs) on this same single-partner instance are NOT SSO-gated —
+        `enforceSSO` is a partner-provider setting enforced per-user at login
+        time server-side (ssoPolicy), never by hiding the form client-side.
+      */}
+      {partnerSso?.enforceSSO && !showPasswordForm ? (
+        <button
+          type="button"
+          data-testid="show-password-form"
+          onClick={() => setShowPasswordForm(true)}
+          className="w-full text-center text-sm text-muted-foreground hover:text-foreground hover:underline"
+        >
+          Sign in with password instead
+        </button>
+      ) : (
+        <LoginForm
+          onSubmit={handleLogin}
+          errorMessage={error}
+          loading={loading}
+        />
+      )}
       <McpUrlCard variant="compact" requireOAuth className="mt-8" />
     </div>
   );

--- a/apps/web/src/components/settings/ConnectSsoCard.test.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.test.tsx
@@ -96,4 +96,38 @@ describe('ConnectSsoCard (#2183)', () => {
 
     expect(await screen.findByText(/different email/i)).toBeInTheDocument();
   });
+
+  it('shows an error banner for ?ssoLinkError=identity_in_use', async () => {
+    setLocation('?ssoLinkError=identity_in_use');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/already linked to a different Breeze user/i)).toBeInTheDocument();
+  });
+
+  it('shows an error banner for ?ssoLinkError=user_gone', async () => {
+    setLocation('?ssoLinkError=user_gone');
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByText(/could not be found/i)).toBeInTheDocument();
+  });
+
+  it('renders an inline error line (not null) when the options fetch returns a server error', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, false, 500));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByTestId('connect-sso-load-error')).toBeInTheDocument();
+  });
+
+  it('renders an inline error line (not null) when the options fetch throws', async () => {
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('network down'));
+
+    render(<ConnectSsoCard />);
+
+    expect(await screen.findByTestId('connect-sso-load-error')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/settings/ConnectSsoCard.tsx
+++ b/apps/web/src/components/settings/ConnectSsoCard.tsx
@@ -17,16 +17,29 @@ export default function ConnectSsoCard() {
   const [options, setOptions] = useState<LinkOption[]>([]);
   const [notice, setNotice] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
+  // Track fetch failures separately from "genuinely no SSO to link" so a
+  // backend outage doesn't read as an empty state — mirrors how
+  // SsoProvidersPage separates `hadError` from a legitimately-empty list.
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     fetchWithAuth('/sso/link/options')
-      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((r) => {
+        if (r.ok) return r.json();
+        console.error('[connect-sso] failed to load link options', r.status);
+        if (!cancelled) setLoadError(true);
+        return { data: [] };
+      })
       .then((body) => {
         if (!cancelled) setOptions(Array.isArray(body?.data) ? body.data : []);
       })
-      .catch(() => {
-        if (!cancelled) setOptions([]);
+      .catch((err) => {
+        console.error('[connect-sso] failed to load link options', err);
+        if (!cancelled) {
+          setLoadError(true);
+          setOptions([]);
+        }
       });
     return () => {
       cancelled = true;
@@ -67,7 +80,9 @@ export default function ConnectSsoCard() {
     }
   }
 
-  if (options.length === 0 && !notice) return null;
+  // Genuinely empty (no error) — nothing to show. A load failure with an
+  // empty list still renders below so the failure isn't invisible.
+  if (options.length === 0 && !notice && !loadError) return null;
 
   return (
     <section className="space-y-4 rounded-lg border bg-card p-6 shadow-xs" data-testid="connect-sso-card">
@@ -77,6 +92,12 @@ export default function ConnectSsoCard() {
           Connect your identity provider account so you can sign in with SSO.
         </p>
       </div>
+
+      {loadError && options.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="connect-sso-load-error">
+          Couldn't check for available SSO providers.
+        </p>
+      )}
 
       {notice && (
         <div

--- a/apps/web/src/components/settings/LoginBrandingCard.test.tsx
+++ b/apps/web/src/components/settings/LoginBrandingCard.test.tsx
@@ -104,4 +104,40 @@ describe('LoginBrandingCard', () => {
     expect(body.accentColor).toBe('#112233');
     expect(body.headline).toBeNull();
   });
+
+  it('shows a warning banner and disables Save when the GET returns a server error', async () => {
+    fetchWithAuth.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (url === '/partners/me/login-branding' && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.resolve(jsonRes({ error: 'boom' }, false, 500));
+      }
+      return Promise.resolve(jsonRes({ data: null }));
+    });
+    render(<LoginBrandingCard />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent(/Couldn't load your current branding/i);
+    expect(screen.getByTestId('login-branding-save')).toBeDisabled();
+  });
+
+  it('shows a warning banner and disables Save when the GET throws', async () => {
+    fetchWithAuth.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (url === '/partners/me/login-branding' && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve(jsonRes({ data: null }));
+    });
+    render(<LoginBrandingCard />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByTestId('login-branding-save')).toBeDisabled();
+  });
+
+  it('enables Save and shows no banner on a successful load', async () => {
+    routeFetch({ logoUrl: null, accentColor: null, headline: null });
+    render(<LoginBrandingCard />);
+
+    await waitFor(() => expect(screen.getByTestId('login-branding-logo-url')).toBeTruthy());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByTestId('login-branding-save')).not.toBeDisabled();
+  });
 });

--- a/apps/web/src/components/settings/LoginBrandingCard.tsx
+++ b/apps/web/src/components/settings/LoginBrandingCard.tsx
@@ -1,16 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Loader2, Palette, Save } from 'lucide-react';
+import type { LoginContextBranding } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { sanitizeImageSrc } from '../../lib/safeImageSrc';
 import { navigateTo } from '@/lib/navigation';
-
-type LoginBranding = {
-  logoUrl: string | null;
-  accentColor: string | null;
-  headline: string | null;
-};
 
 // Fallback swatch when no accent has been set yet, so the color picker and the
 // preview have something sensible to render. Not persisted unless the user saves.
@@ -20,13 +15,15 @@ const HEADLINE_MAX = 120;
 const inputClass = 'h-10 w-full rounded-md border bg-background px-3 text-sm';
 
 /**
- * Partner "Login Branding" settings card (#2183). Lets a partner admin brand the
- * technician login screen (logo, accent color, headline) shown at
- * `/login?partner=<slug>`. Reads/writes GET/PUT /api/v1/partners/me/login-branding.
+ * Partner "Login Branding" settings card (#2183). Lets a partner admin brand
+ * the technician login screen (logo, accent color, headline). The login page
+ * shows the branding automatically when the instance resolves to exactly one
+ * partner (typical self-hosted setup) — there is no `?partner=` route or
+ * query param, and multi-partner instances show no branding (v2 slug
+ * discovery). Reads/writes GET/PUT /api/v1/partners/me/login-branding.
  *
  * PUT is FULL-REPLACE: we always send all three fields on every save, so an
- * omitted field is not treated as "unchanged" — it is nulled server-side. That
- * matches the server contract (Task 9) and keeps the UI the single source of truth.
+ * omitted field is not treated as "unchanged" — it is nulled server-side.
  */
 export default function LoginBrandingCard() {
   const [logoUrl, setLogoUrl] = useState('');
@@ -34,6 +31,10 @@ export default function LoginBrandingCard() {
   const [headline, setHeadline] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // Set when the initial GET fails (non-401 error response or thrown fetch
+  // error). The PUT is full-replace, so saving over an unloaded form would
+  // silently wipe any real saved branding — Save is disabled until this clears.
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,14 +46,23 @@ export default function LoginBrandingCard() {
           return;
         }
         if (res.ok) {
-          const body = (await res.json().catch(() => null)) as { data?: LoginBranding | null } | null;
+          const body = (await res.json().catch(() => null)) as { data?: LoginContextBranding | null } | null;
           const data = body?.data ?? null;
-          if (!cancelled && data) {
-            setLogoUrl(data.logoUrl ?? '');
-            setAccentColor(data.accentColor ?? '');
-            setHeadline(data.headline ?? '');
+          if (!cancelled) {
+            if (data) {
+              setLogoUrl(data.logoUrl ?? '');
+              setAccentColor(data.accentColor ?? '');
+              setHeadline(data.headline ?? '');
+            }
+            setLoadFailed(false);
           }
+        } else {
+          console.error('[login-branding] failed to load current branding', res.status);
+          if (!cancelled) setLoadFailed(true);
         }
+      } catch (err) {
+        console.error('[login-branding] failed to load current branding', err);
+        if (!cancelled) setLoadFailed(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -65,7 +75,7 @@ export default function LoginBrandingCard() {
   const save = async () => {
     setSaving(true);
     try {
-      await runAction<{ data: LoginBranding }>({
+      await runAction<{ data: LoginContextBranding }>({
         // Full-replace: always send all three fields. A blank field goes as null
         // (cleared), never omitted — omitting would NULL it server-side anyway,
         // but sending explicit null keeps request intent unambiguous.
@@ -117,10 +127,20 @@ export default function LoginBrandingCard() {
           <h2 className="text-lg font-semibold">Login Branding</h2>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
-          Brand the technician login screen your team sees at <code>/login?partner=…</code>. Applies to
-          all of your organizations.
+          Brand the technician login screen. Shown automatically when this deployment resolves to a
+          single partner (typical self-hosted setup).
         </p>
       </div>
+
+      {loadFailed && (
+        <div
+          role="alert"
+          className="mb-6 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          Couldn't load your current branding — reload the page before saving, or you may overwrite
+          existing settings.
+        </div>
+      )}
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Fields */}
@@ -221,7 +241,7 @@ export default function LoginBrandingCard() {
         <button
           type="button"
           onClick={save}
-          disabled={saving}
+          disabled={saving || loadFailed}
           data-testid="login-branding-save"
           className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
         >

--- a/apps/web/src/components/settings/SsoProviderForm.test.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import SsoProviderForm, { type Role } from './SsoProviderForm';
 
 const ROLES: Role[] = [
@@ -38,5 +38,28 @@ describe('SsoProviderForm ownership selector', () => {
     fireEvent.click(screen.getByTestId('sso-provider-owner-partner'));
     expect(screen.getByRole('option', { name: 'Partner Technician' })).toBeTruthy();
     expect(screen.queryByRole('option', { name: 'Org Technician' })).toBeNull();
+  });
+
+  it('submits ownerScope: "partner" in the payload when the partner radio is selected', async () => {
+    const onSubmit = vi.fn();
+    render(<SsoProviderForm showOwnerScope roles={ROLES} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Provider name/i), { target: { value: 'Acme Okta' } });
+    fireEvent.click(screen.getByTestId('sso-provider-owner-partner'));
+    fireEvent.click(screen.getByRole('button', { name: /save provider/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ ownerScope: 'partner' }));
+  });
+
+  it('submits ownerScope: "organization" on the default (unchanged) path', async () => {
+    const onSubmit = vi.fn();
+    render(<SsoProviderForm showOwnerScope roles={ROLES} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Provider name/i), { target: { value: 'Acme Okta' } });
+    fireEvent.click(screen.getByRole('button', { name: /save provider/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ ownerScope: 'organization' }));
   });
 });

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -116,4 +116,54 @@ describe('SsoProvidersPage partner-axis behavior', () => {
     // The partner-scoped role loads into the default-role dropdown.
     expect(screen.getByRole('option', { name: 'Partner Technician' })).toBeTruthy();
   });
+
+  it('PATCHes an edited provider without ownerScope in the body (create-only field)', async () => {
+    fetchWithAuth.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [PARTNER_PROVIDER] }));
+      if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/sso/providers/pp-1' && (!opts || !opts.method)) {
+        return Promise.resolve(
+          jsonRes({
+            data: {
+              name: 'Team Login',
+              type: 'oidc',
+              preset: '',
+              issuer: 'https://idp.example.com',
+              clientId: 'client-1',
+              scopes: 'openid profile email',
+              attributeMapping: { email: 'email', name: 'name' },
+              autoProvision: true,
+              defaultRoleId: '',
+              allowedDomains: '',
+              enforceSSO: false,
+              hasClientSecret: true,
+            },
+          })
+        );
+      }
+      if (url === '/sso/providers/pp-1' && opts?.method === 'PATCH') {
+        return Promise.resolve(jsonRes({ data: PARTNER_PROVIDER }));
+      }
+      return Promise.resolve(jsonRes({ data: [] }));
+    });
+
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuth.mock.calls.find(
+        (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+      );
+      expect(patchCall).toBeTruthy();
+      const body = JSON.parse((patchCall![1] as { body: string }).body);
+      expect(body).not.toHaveProperty('ownerScope');
+    });
+  });
 });

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -33,6 +33,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/AlertDetailPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
+  'src/components/settings/ConnectSsoCard.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
   'src/components/devices/DeviceInfoTab.tsx',
@@ -275,7 +276,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(56);
+    expect(absoluteFiles.length).toBe(57);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/loginContext.test.ts
+++ b/apps/web/src/lib/loginContext.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// getLoginContext memoizes in module scope, so each test that cares about
+// memoization behavior needs a fresh module instance — vi.resetModules() +
+// dynamic import() per test (see monacoLoader.test.ts for the same pattern).
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('loginContext', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the parsed body on the happy path', async () => {
+    const body = {
+      branding: { logoUrl: 'https://x/logo.png', accentColor: '#112233', headline: 'Acme IT' },
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: true },
+    };
+    vi.mocked(fetch).mockResolvedValue(jsonResponse(body));
+
+    const { getLoginContext } = await import('./loginContext');
+    const ctx = await getLoginContext();
+
+    expect(ctx).toEqual(body);
+  });
+
+  it('returns EMPTY when the response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({}, false, 500));
+
+    const { getLoginContext } = await import('./loginContext');
+    const ctx = await getLoginContext();
+
+    expect(ctx).toEqual({ branding: null, partnerSso: null });
+  });
+
+  it('returns EMPTY and warns when fetch throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(fetch).mockRejectedValue(new Error('network down'));
+
+    const { getLoginContext } = await import('./loginContext');
+    const ctx = await getLoginContext();
+
+    expect(ctx).toEqual({ branding: null, partnerSso: null });
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[login] login-context fetch failed; falling back to stock branding',
+      expect.any(Error)
+    );
+  });
+
+  it('memoizes: two getLoginContext() calls issue exactly one fetch', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ branding: null, partnerSso: null }));
+
+    const { getLoginContext } = await import('./loginContext');
+    await getLoginContext();
+    await getLoginContext();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces missing body fields to null', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({}));
+
+    const { getLoginContext } = await import('./loginContext');
+    const ctx = await getLoginContext();
+
+    expect(ctx).toEqual({ branding: null, partnerSso: null });
+  });
+});

--- a/apps/web/src/lib/loginContext.ts
+++ b/apps/web/src/lib/loginContext.ts
@@ -1,13 +1,6 @@
-export type LoginContextBranding = {
-  logoUrl: string | null;
-  accentColor: string | null;
-  headline: string | null;
-};
+import type { LoginContext, LoginContextBranding, LoginContextPartnerSso } from '@breeze/shared';
 
-export type LoginContext = {
-  branding: LoginContextBranding | null;
-  partnerSso: { available: boolean; providerName: string; loginUrl: string } | null;
-};
+export type { LoginContext, LoginContextBranding, LoginContextPartnerSso };
 
 const EMPTY: LoginContext = { branding: null, partnerSso: null };
 
@@ -22,7 +15,7 @@ export function getLoginContext(): Promise<LoginContext> {
 async function fetchLoginContext(): Promise<LoginContext> {
   try {
     const apiHost = import.meta.env.PUBLIC_API_URL || '';
-    // Same timeout rationale as the CF Access check (LoginPage.tsx:38-58):
+    // Same timeout rationale as checkCfAccessLoginEnabled (LoginPage.tsx):
     // a hung request must not stall the login page.
     const res = await fetch(`${apiHost}/api/v1/auth/login-context`, {
       signal: AbortSignal.timeout(4000)
@@ -30,7 +23,11 @@ async function fetchLoginContext(): Promise<LoginContext> {
     if (!res.ok) return EMPTY;
     const body = (await res.json()) as Partial<LoginContext>;
     return { branding: body.branding ?? null, partnerSso: body.partnerSso ?? null };
-  } catch {
-    return EMPTY; // fail open to stock Breeze branding
+  } catch (err) {
+    // Fail open to stock Breeze branding — but leave a trace, or a
+    // deployment-wide config/CORS regression silently disables the feature
+    // fleet-wide with no signal.
+    console.warn('[login] login-context fetch failed; falling back to stock branding', err);
+    return EMPTY;
   }
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -767,3 +767,9 @@ export * from './billing-enums';
 
 export * from './postureReport';
 export * from './executiveSummaryReport';
+
+// ============================================
+// Public login-context wire contract (#2183)
+// ============================================
+
+export * from './loginContext';

--- a/packages/shared/src/types/loginContext.ts
+++ b/packages/shared/src/types/loginContext.ts
@@ -1,0 +1,30 @@
+// Wire contract for the public GET /auth/login-context endpoint (#2183).
+// Single source of truth shared by the API route (apps/api/src/routes/auth/
+// loginContext.ts) and the web client (apps/web/src/lib/loginContext.ts) so
+// the two sides cannot silently drift.
+
+export type LoginContextBranding = {
+  logoUrl: string | null;
+  accentColor: string | null;
+  headline: string | null;
+};
+
+export type LoginContextPartnerSso = {
+  providerName: string;
+  loginUrl: string;
+  /**
+   * The partner's active provider has enforceSSO set. The login page uses
+   * this to de-emphasize the password form — enforcement itself always
+   * happens server-side at login (ssoPolicy), never from this flag.
+   */
+  enforceSSO: boolean;
+};
+
+// A null field means "not applicable / not configured" — branding null means
+// no branding row exists (or multi-partner instance), partnerSso null means
+// no active partner-axis provider. Presence of partnerSso IS the availability
+// signal; there is no separate `available` flag.
+export type LoginContext = {
+  branding: LoginContextBranding | null;
+  partnerSso: LoginContextPartnerSso | null;
+};


### PR DESCRIPTION
Follow-ups from the five-agent post-merge review of #2194 (all findings + all suggestions).

## Behavioral fixes
- **Password reset now respects partner-axis enforceSSO** (`passwordResetEligibility.ts`): partner-axis-only users (org_id null) were skipping the SSO gate entirely — a partner with an active `enforceSSO` provider still had a live password-reset path for its staff. The helper's `scope:'partner'` branch already existed; this was a missed call site. Covered by unit tests including a no-double-fire org regression case.
- **LoginBrandingCard data-loss trap**: a silently failed initial GET rendered a blank form identical to "never configured", and the full-replace PUT would then wipe real saved branding on Save. Failed loads now show a warning banner and disable Save until a successful load.
- **Misleading user-facing copy**: the card claimed branding shows at `/login?partner=…` — no such route/param exists. Copy + JSDoc now describe the real single-partner auto-detect mechanism.
- **ConnectSsoCard**: backend failures were indistinguishable from "no SSO to link" (card silently vanished). Failures now log and render an inline error line.
- **Login page enforceSSO treatment**: `login-context` now includes `enforceSSO`; when set, the password form collapses behind a "Sign in with password instead" toggle. The form stays reachable — org-axis users on the same instance are never SSO-gated (enforcement is per-user, server-side).

## Type/contract hardening
- New shared wire contract `LoginContext*` in `@breeze/shared` — previously the same shape was independently declared 4× (Drizzle/Zod/two web literals) and the server route returned `unknown`. Drift is now a compile error. Dropped the always-`true` `available` field (presence = availability).
- New migration `2026-07-04-partner-login-branding-accent-check.sql`: `#rrggbb` CHECK on `accent_color` (idempotent, guarded, row-count-reported cleanup) so the invariant no longer lives only in Zod.

## Test coverage (closes the review's gaps)
- Real-DB `status='testing'` exclusion: login initiation 404 + enforceSSO non-suppression — previously verified only by mocks whose `where()` ignored its arguments.
- New `loginContext.integration.test.ts`: first integration coverage of the public endpoint (single-partner payload, testing-provider exclusion, multi-partner leak-nothing, no-branding null).
- `partnerLoginBrandingRls`: org-scope forge case (org tokens never pass `breeze_has_partner_access`) + route-level full-replace null-clearing proven against real Postgres.
- Web: direct `loginContext` client tests (ok/!ok/throw/memoization/coalescing), `?error=sso_link_required` banner, enforceSSO collapse/reveal, `identity_in_use`/`user_gone` copy, client `ownerScope` contract (create sends, edit omits), `ConnectSsoCard` registered in the `no-silent-mutations` guard (56→57).

## Comment hygiene
- Rewrote dangling "Task 5/9/11" and "security review #2 (C-1/H-1/H-2)" references (the plan doc was never merged to main) to state each invariant standalone.
- Added a `KNOWN BUG (#2195)` marker above the bare `existingIdentity` read in the SSO callback — the one pre-auth read in that handler without an RLS-hazard comment, so its silence read as "this one's fine".

## Verification
- API: 117 unit tests passing, `tsc --noEmit` clean; migration exercised against real Postgres in a rolled-back transaction (idempotent re-run, cleanup WARNING, 23514 on bad insert).
- Web: 120 tests passing across all touched files, `astro check` clean.
- Integration: 19/19 passing against the real :5433 test DB (non-vacuous — `.env.test` RLS contexts verified).

Refs #2194 #2183. The callback bare-RLS-read fixes remain tracked in #2195 (marker comment added here; fix deliberately not duplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)