### PR TITLE
feat(enrollment-keys): auto-purge expired keys, delete-expired action, short-code column

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -173,6 +173,10 @@ import { initializeMlOutputRetention, shutdownMlOutputRetention } from './jobs/m
 import { initializeIPHistoryRetention, shutdownIPHistoryRetention } from './jobs/ipHistoryRetention';
 import { initializeChangeLogRetention, shutdownChangeLogRetention } from './jobs/changeLogRetention';
 import { initializeOauthCleanupWorker, shutdownOauthCleanupWorker } from './jobs/oauthCleanup';
+import {
+  initializeEnrollmentKeyCleanupWorker,
+  shutdownEnrollmentKeyCleanupWorker,
+} from './jobs/enrollmentKeyCleanup';
 import { initializeAuditRetentionWorker, shutdownAuditRetentionWorker } from './jobs/auditRetention';
 import {
   initializeAuditChainVerifyWorker,
@@ -1155,6 +1159,7 @@ async function initializeWorkers(): Promise<void> {
     ['processSampleRetention', initializeProcessSampleRetention],
     ['changeLogRetention', initializeChangeLogRetention],
     ['oauthCleanup', initializeOauthCleanupWorker],
+    ['enrollmentKeyCleanup', initializeEnrollmentKeyCleanupWorker],
     ['auditRetention', initializeAuditRetentionWorker],
     ['auditChainVerify', initializeAuditChainVerifyWorker],
     ['auditChainAnchor', initializeAuditChainAnchorWorker],
@@ -1346,6 +1351,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownProcessSampleRetention,
     shutdownChangeLogRetention,
     shutdownOauthCleanupWorker,
+    shutdownEnrollmentKeyCleanupWorker,
     shutdownAuditRetentionWorker,
     shutdownAuditChainVerifyWorker,
     shutdownAuditChainAnchorWorker,

--- a/apps/api/src/jobs/enrollmentKeyCleanup.test.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  deleteMock,
+  whereMock,
+  returningMock,
+  withSystemDbAccessContextMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  deleteMock: vi.fn(),
+  whereMock: vi.fn(),
+  returningMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  capturedWorkerProcessor: { current: null as null | ((job: unknown) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    name: string;
+    constructor(name: string, processor: (job: unknown) => Promise<unknown>) {
+      this.name = name;
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+    db: {
+      delete: (...args: unknown[]) => deleteMock(...(args as [])),
+    },
+  };
+});
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  __testOnly,
+  createEnrollmentKeyCleanupWorker,
+  initializeEnrollmentKeyCleanupWorker,
+  scheduleEnrollmentKeyCleanup,
+  shutdownEnrollmentKeyCleanupWorker,
+} from './enrollmentKeyCleanup';
+
+const ORIGINAL_ENABLED_FLAG = process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
+const ORIGINAL_PURGE_DAYS = process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+
+/**
+ * Flattens a drizzle condition (built via `and`/`lt`/`isNotNull`) to its
+ * static text — column names and operator/keyword chunks. Bound Date values
+ * are rendered via `toISOString()`. Same introspection approach as
+ * `ticketSlaWorker.test.ts` / `auditRetention.test.ts`, extended to resolve
+ * drizzle column objects (which carry a `columnType` + `name`) to their
+ * column name instead of recursing into the table they belong to (which is
+ * circular).
+ */
+function sqlText(q: unknown): string {
+  if (q == null) return '';
+  if (typeof q === 'string') return q;
+  if (q instanceof Date) return q.toISOString();
+  const obj = q as {
+    queryChunks?: unknown[];
+    value?: unknown;
+    name?: string;
+    columnType?: unknown;
+  };
+  if (typeof obj.name === 'string' && 'columnType' in obj) {
+    return obj.name;
+  }
+  if (Array.isArray(obj.queryChunks)) {
+    return obj.queryChunks.map(sqlText).join(' ');
+  }
+  if (Array.isArray(obj.value)) {
+    return (obj.value as unknown[]).map(sqlText).join('');
+  }
+  if (obj.value instanceof Date) {
+    return obj.value.toISOString();
+  }
+  if (typeof obj.value === 'string' || typeof obj.value === 'number') {
+    return String(obj.value);
+  }
+  return '';
+}
+
+describe('enrollmentKeyCleanup worker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    addMock.mockResolvedValue(undefined);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    returningMock.mockResolvedValue([]);
+    whereMock.mockImplementation(() => ({ returning: returningMock }));
+    deleteMock.mockImplementation(() => ({ where: whereMock }));
+    capturedWorkerProcessor.current = null;
+    delete process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
+    delete process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+  });
+
+  afterEach(async () => {
+    await shutdownEnrollmentKeyCleanupWorker();
+    if (ORIGINAL_ENABLED_FLAG === undefined) {
+      delete process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
+    } else {
+      process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = ORIGINAL_ENABLED_FLAG;
+    }
+    if (ORIGINAL_PURGE_DAYS === undefined) {
+      delete process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+    } else {
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = ORIGINAL_PURGE_DAYS;
+    }
+    vi.useRealTimers();
+  });
+
+  it('exposes the daily cron pattern at 04:00 UTC', () => {
+    expect(__testOnly.DAILY_CRON).toBe('0 4 * * *');
+    expect(__testOnly.JOB_NAME).toBe('enrollment-key-cleanup');
+    expect(__testOnly.REPEAT_JOB_ID).toBe('enrollment-key-cleanup');
+    expect(__testOnly.QUEUE_NAME).not.toContain(':');
+    expect(__testOnly.JOB_NAME).not.toContain(':');
+    expect(__testOnly.REPEAT_JOB_ID).not.toContain(':');
+  });
+
+  it('isCleanupEnabled defaults ON and accepts standard falsy values', () => {
+    delete process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
+    expect(__testOnly.isCleanupEnabled()).toBe(true);
+    process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = 'false';
+    expect(__testOnly.isCleanupEnabled()).toBe(false);
+    process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = '0';
+    expect(__testOnly.isCleanupEnabled()).toBe(false);
+    process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = 'off';
+    expect(__testOnly.isCleanupEnabled()).toBe(false);
+    process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = 'true';
+    expect(__testOnly.isCleanupEnabled()).toBe(true);
+  });
+
+  describe('getPurgeAfterDays', () => {
+    it('defaults to 7 days when unset', () => {
+      delete process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+      expect(__testOnly.getPurgeAfterDays()).toBe(7);
+      expect(__testOnly.DEFAULT_PURGE_AFTER_DAYS).toBe(7);
+    });
+
+    it('respects a configured integer value', () => {
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = '30';
+      expect(__testOnly.getPurgeAfterDays()).toBe(30);
+    });
+
+    it('falls back to the default for invalid values', () => {
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = 'not-a-number';
+      expect(__testOnly.getPurgeAfterDays()).toBe(7);
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = '-5';
+      expect(__testOnly.getPurgeAfterDays()).toBe(7);
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = '0';
+      expect(__testOnly.getPurgeAfterDays()).toBe(7);
+    });
+  });
+
+  describe('scheduling', () => {
+    it('registers the daily cron with a stable jobId for multi-replica dedup', async () => {
+      await scheduleEnrollmentKeyCleanup();
+      expect(addMock).toHaveBeenCalledTimes(1);
+      const call = addMock.mock.calls[0]!;
+      const [name, data, opts] = call;
+      expect(name).toBe('enrollment-key-cleanup');
+      expect(data).toEqual({});
+      expect(opts).toMatchObject({
+        jobId: 'enrollment-key-cleanup',
+        repeat: { pattern: '0 4 * * *' },
+      });
+    });
+
+    it('removes prior repeatable jobs before adding a fresh one', async () => {
+      getRepeatableJobsMock.mockResolvedValue([
+        { name: 'enrollment-key-cleanup', key: 'old-key' },
+        { name: 'unrelated-job', key: 'other-key' },
+      ]);
+      await scheduleEnrollmentKeyCleanup();
+      expect(removeRepeatableByKeyMock).toHaveBeenCalledTimes(1);
+      expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('old-key');
+      expect(addMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('kill switch (ENROLLMENT_KEY_CLEANUP_ENABLED=false) prevents scheduling', async () => {
+      process.env.ENROLLMENT_KEY_CLEANUP_ENABLED = 'false';
+      await scheduleEnrollmentKeyCleanup();
+      expect(addMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('worker processor', () => {
+    it('deletes expired keys within a system DB context and reports the count', async () => {
+      returningMock.mockResolvedValue([{ id: 'k1' }, { id: 'k2' }]);
+      createEnrollmentKeyCleanupWorker();
+      expect(capturedWorkerProcessor.current).toBeTypeOf('function');
+
+      const result = await capturedWorkerProcessor.current!({
+        name: 'enrollment-key-cleanup',
+        id: 'j1',
+      });
+
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+      expect(deleteMock).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({ deletedCount: 2 });
+    });
+
+    it('cutoff math respects ENROLLMENT_KEY_PURGE_AFTER_DAYS', async () => {
+      process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = '14';
+      vi.useFakeTimers();
+      const now = new Date('2026-07-03T00:00:00.000Z');
+      vi.setSystemTime(now);
+
+      createEnrollmentKeyCleanupWorker();
+      await capturedWorkerProcessor.current!({ name: 'enrollment-key-cleanup', id: 'j2' });
+
+      expect(whereMock).toHaveBeenCalledTimes(1);
+      const cond = whereMock.mock.calls[0]![0];
+      const text = sqlText(cond);
+
+      const expectedCutoff = new Date(now.getTime() - 14 * 86_400_000);
+      expect(text).toContain(expectedCutoff.toISOString());
+    });
+
+    it('null-expiry rows are never matched — where clause carries the not-null guard', async () => {
+      createEnrollmentKeyCleanupWorker();
+      await capturedWorkerProcessor.current!({ name: 'enrollment-key-cleanup', id: 'j3' });
+
+      expect(whereMock).toHaveBeenCalledTimes(1);
+      const cond = whereMock.mock.calls[0]![0];
+      const text = sqlText(cond);
+
+      expect(text).toContain('expires_at');
+      expect(text).toContain('is not null');
+      expect(text).toContain('and');
+      expect(text).toContain('<');
+    });
+
+    it('ignores unknown job names without touching the DB', async () => {
+      createEnrollmentKeyCleanupWorker();
+      const result = await capturedWorkerProcessor.current!({ name: 'something-else', id: 'j4' });
+      expect(deleteMock).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ skipped: true, deletedCount: 0 });
+    });
+  });
+
+  it('initializeEnrollmentKeyCleanupWorker creates worker, schedules cron, and shuts down idempotently', async () => {
+    await initializeEnrollmentKeyCleanupWorker();
+    expect(addMock).toHaveBeenCalledTimes(1);
+    await shutdownEnrollmentKeyCleanupWorker();
+    expect(workerCloseMock).toHaveBeenCalled();
+    expect(queueCloseMock).toHaveBeenCalled();
+    // Second shutdown must not throw or double-close.
+    await shutdownEnrollmentKeyCleanupWorker();
+  });
+});

--- a/apps/api/src/jobs/enrollmentKeyCleanup.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.ts
@@ -1,0 +1,209 @@
+/**
+ * Enrollment Key Cleanup Worker
+ *
+ * Part of the enrollment-key cleanup work (#2196). Task 1 added an on-demand
+ * `POST /enrollment-keys/purge-expired` route that purges immediately-expired
+ * keys within the caller's tenant scope (see `routes/enrollmentKeys.ts`).
+ * This worker complements that route with a system-wide scheduled sweep: it
+ * hard-deletes `enrollment_keys` rows that expired more than
+ * `ENROLLMENT_KEY_PURGE_AFTER_DAYS` days ago (default 7), across all
+ * partners/orgs, so the table doesn't grow unbounded from routine installer
+ * churn even when nobody calls the manual purge route.
+ *
+ * Hard delete is safe: `installer_bootstrap_tokens` and `deployment_invites`
+ * both carry `ON DELETE CASCADE` against `enrollment_keys`. Keys with
+ * `expires_at IS NULL` never satisfy the `lt` condition below and are
+ * therefore never deleted (explicit `isNotNull` guard makes that intent
+ * unambiguous rather than relying only on SQL NULL comparison semantics).
+ *
+ * Scheduling:
+ *   - Repeat cron: 04:00 UTC daily (pattern "0 4 * * *")
+ *   - `jobId: 'enrollment-key-cleanup'` dedupes the repeatable job across
+ *     multiple API replicas — BullMQ will only let one replica claim the
+ *     scheduled job at each fire time.
+ *
+ * Env flags:
+ *   - `ENROLLMENT_KEY_CLEANUP_ENABLED` defaults to ON. Operators can set it
+ *     to `false` / `0` to disable scheduling in an emergency without a code
+ *     deploy. The worker is still initialized (so the queue is reachable for
+ *     manual `add()` calls), but no repeatable job is registered.
+ *   - `ENROLLMENT_KEY_PURGE_AFTER_DAYS` — integer grace period (days) past
+ *     expiry before a key is purged. Default 7.
+ *
+ * Idempotency:
+ *   - A single `DELETE ... WHERE`; running twice in one window simply finds
+ *     zero matching rows the second time. Safe to retry on failure.
+ *
+ * RLS:
+ *   - Background jobs have no request-scoped AsyncLocalStorage context, so
+ *     the delete is wrapped in `withSystemDbAccessContext` here — the sweep
+ *     operates at system scope (no tenant filter), matching the intent of
+ *     purging expired keys across all partners.
+ */
+
+import { Queue, Worker, Job } from 'bullmq';
+import { and, isNotNull, lt } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { enrollmentKeys } from '../db/schema';
+import { captureException } from '../services/sentry';
+import { getBullMQConnection } from '../services/redis';
+
+const QUEUE_NAME = 'enrollment-key-cleanup';
+const JOB_NAME = 'enrollment-key-cleanup';
+const REPEAT_JOB_ID = 'enrollment-key-cleanup';
+// Daily at 04:00 UTC — off-peak, and staggered from the other 03:00/02:00
+// cron jobs (oauthCleanup, reliabilityWorker) to avoid contention.
+const DAILY_CRON = '0 4 * * *';
+const DEFAULT_PURGE_AFTER_DAYS = 7;
+
+function isCleanupEnabled(): boolean {
+  const raw = process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
+  if (raw === undefined || raw === '') return true; // default ON
+  const v = raw.trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}
+
+function getPurgeAfterDays(): number {
+  const raw = process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+  if (raw === undefined || raw === '') return DEFAULT_PURGE_AFTER_DAYS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PURGE_AFTER_DAYS;
+}
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error(
+      '[EnrollmentKeyCleanup] withSystemDbAccessContext is not available — DB module may not have loaded correctly',
+    );
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+let cleanupQueue: Queue | null = null;
+let cleanupWorker: Worker | null = null;
+
+export function getEnrollmentKeyCleanupQueue(): Queue {
+  if (!cleanupQueue) {
+    cleanupQueue = new Queue(QUEUE_NAME, {
+      connection: getBullMQConnection(),
+    });
+  }
+  return cleanupQueue;
+}
+
+export function createEnrollmentKeyCleanupWorker(): Worker {
+  return new Worker(
+    QUEUE_NAME,
+    async (job: Job) => {
+      if (job.name !== JOB_NAME) {
+        // Unknown job — treat as a no-op so we don't crash the worker.
+        console.warn(`[EnrollmentKeyCleanup] Ignoring unknown job name: ${job.name}`);
+        return { deletedCount: 0, skipped: true };
+      }
+      return runWithSystemDbAccess(async () => {
+        const startedAt = Date.now();
+        const purgeAfterDays = getPurgeAfterDays();
+        const cutoff = new Date(Date.now() - purgeAfterDays * 86_400_000);
+
+        const deletedRows = await dbModule.db
+          .delete(enrollmentKeys)
+          .where(and(isNotNull(enrollmentKeys.expiresAt), lt(enrollmentKeys.expiresAt, cutoff)))
+          .returning({ id: enrollmentKeys.id });
+        const deletedCount = deletedRows.length;
+
+        const durationMs = Date.now() - startedAt;
+        console.log(
+          `[EnrollmentKeyCleanup] Deleted ${deletedCount} expired enrollment key(s) (purge-after=${purgeAfterDays}d) in ${durationMs}ms`,
+        );
+        return { deletedCount, durationMs };
+      });
+    },
+    {
+      connection: getBullMQConnection(),
+      concurrency: 1,
+    },
+  );
+}
+
+export async function scheduleEnrollmentKeyCleanup(
+  queue: Queue = getEnrollmentKeyCleanupQueue(),
+): Promise<void> {
+  // Always clear any previously-registered repeatable so a changed cron
+  // pattern takes effect on redeploy (BullMQ keys repeatables by the full
+  // option set; stale keys would otherwise accumulate).
+  const existingJobs = await queue.getRepeatableJobs();
+  for (const job of existingJobs) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  if (!isCleanupEnabled()) {
+    console.log(
+      '[EnrollmentKeyCleanup] ENROLLMENT_KEY_CLEANUP_ENABLED=false — skipping schedule registration',
+    );
+    return;
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      // `jobId` guarantees multi-replica dedup: whichever API replica wins
+      // the race to create the scheduled job owns it, and BullMQ will
+      // refuse duplicate inserts with the same id. Workers on every
+      // replica still share processing — only the scheduling is singleton.
+      jobId: REPEAT_JOB_ID,
+      repeat: { pattern: DAILY_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 25 },
+    },
+  );
+  console.log(
+    `[EnrollmentKeyCleanup] Scheduled daily cleanup (cron "${DAILY_CRON}", jobId=${REPEAT_JOB_ID})`,
+  );
+}
+
+export async function initializeEnrollmentKeyCleanupWorker(): Promise<void> {
+  try {
+    cleanupWorker = createEnrollmentKeyCleanupWorker();
+
+    cleanupWorker.on('error', (error) => {
+      console.error('[EnrollmentKeyCleanup] Worker error:', error);
+      captureException(error);
+    });
+
+    cleanupWorker.on('failed', (job, error) => {
+      console.error(`[EnrollmentKeyCleanup] Job ${job?.id} failed:`, error);
+      captureException(error);
+    });
+
+    await scheduleEnrollmentKeyCleanup();
+    console.log('[EnrollmentKeyCleanup] Worker initialized');
+  } catch (error) {
+    console.error('[EnrollmentKeyCleanup] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownEnrollmentKeyCleanupWorker(): Promise<void> {
+  if (cleanupWorker) {
+    await cleanupWorker.close();
+    cleanupWorker = null;
+  }
+  if (cleanupQueue) {
+    await cleanupQueue.close();
+    cleanupQueue = null;
+  }
+}
+
+// Exported for test introspection.
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  DAILY_CRON,
+  DEFAULT_PURGE_AFTER_DAYS,
+  isCleanupEnabled,
+  getPurgeAfterDays,
+};

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -722,6 +722,79 @@ enrollmentKeyRoutes.post(
   },
 );
 
+// POST /enrollment-keys/purge-expired - Bulk hard-delete all expired
+// enrollment keys visible to the caller (org/partner/system scoped, same as
+// the GET / list route). Keys with expiresAt IS NULL are never matched by
+// the `lt` condition below and are therefore never deleted. Hard delete is
+// safe here: installer_bootstrap_tokens and deployment_invites both carry
+// ON DELETE CASCADE against enrollment_keys.
+//
+// Registered BEFORE the /:id-parameterized routes (GET /:id, POST
+// /:id/rotate, DELETE /:id, etc.) so "purge-expired" is never captured as an
+// :id param.
+enrollmentKeyRoutes.post(
+  "/purge-expired",
+  requireScope("organization", "partner", "system"),
+  requirePermission(
+    PERMISSIONS.ORGS_WRITE.resource,
+    PERMISSIONS.ORGS_WRITE.action,
+  ),
+  userRateLimit("enroll-write", 10, 60),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get("auth");
+
+    const conditions: ReturnType<typeof eq>[] = [];
+
+    if (auth.scope === "organization") {
+      if (!auth.orgId) {
+        return c.json({ error: "Organization context required" }, 403);
+      }
+      conditions.push(eq(enrollmentKeys.orgId, auth.orgId));
+    } else if (auth.scope === "partner") {
+      const orgIds = auth.accessibleOrgIds ?? [];
+      if (orgIds.length === 0) {
+        return c.json({ success: true, deletedCount: 0 });
+      }
+      conditions.push(
+        inArray(enrollmentKeys.orgId, orgIds) as ReturnType<typeof eq>,
+      );
+    }
+    // scope === "system": no org restriction — purge across all orgs.
+
+    // Same expired condition the list route builds for ?expired=true
+    // (line ~575 above). expiresAt IS NULL never satisfies `lt`, so
+    // never-expiring keys are never touched.
+    conditions.push(
+      lt(enrollmentKeys.expiresAt, new Date()) as ReturnType<typeof eq>,
+    );
+
+    const deletedRows = await db
+      .delete(enrollmentKeys)
+      .where(and(...conditions))
+      .returning({ id: enrollmentKeys.id });
+    const deletedCount = deletedRows.length;
+
+    // Bulk purge can span multiple orgs (partner/system scope), so this
+    // calls createAuditLogAsync directly rather than the writeEnrollmentKeyAudit
+    // helper, which requires a single event.orgId (mirrors the direct-call
+    // pattern already used for enrollment_key.installer_build_failed above).
+    createAuditLogAsync({
+      orgId: auth.scope === "organization" ? auth.orgId : null,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: "enrollment_key.purge_expired",
+      resourceType: "enrollment_key",
+      details: { deletedCount },
+      ipAddress: getTrustedClientIpOrUndefined(c),
+      userAgent: c.req.header("user-agent"),
+      result: "success",
+    });
+
+    return c.json({ success: true, deletedCount });
+  },
+);
+
 // GET /enrollment-keys/:id - Get enrollment key details
 enrollmentKeyRoutes.get(
   "/:id",

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -351,7 +351,7 @@ describe('enrollment key routes — get, rotate, delete', () => {
       );
     });
 
-    it('returns deletedCount 0 and does not call delete when nothing matches', async () => {
+    it('returns deletedCount 0 when the delete matches nothing', async () => {
       const getCaptured = mockDeleteWhereReturningCapture([]);
 
       const res = await app.request('/enrollment-keys/purge-expired', {

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+// Shared mutable gates so individual tests can flip MFA/permission denial at
+// request time — the route registers `requireMfa()` / `requirePermission()`
+// once at import time, so the returned middleware must re-check a gate on
+// every invocation rather than baking in a decision at registration.
+const { mfaGate, permissionGate } = vi.hoisted(() => ({
+  mfaGate: { deny: false },
+  permissionGate: { deny: false },
+}));
+
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -42,8 +51,14 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (permissionGate.deny) return c.json({ error: 'Forbidden' }, 403);
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (mfaGate.deny) return c.json({ error: 'MFA required' }, 403);
+    return next();
+  }),
 }));
 
 vi.mock('../services/auditService', () => ({
@@ -122,11 +137,31 @@ function mockDeleteWhere() {
   } as any);
 }
 
+/**
+ * Mock for db.delete().where().returning() that captures the exact `where`
+ * condition passed in, so a test can assert on the composed scope + expired
+ * condition (via its JSON-serialized SQL chunks — drizzle SQL objects stringify
+ * to their operator/column/value shape, e.g. `"enrollmentKeys.orgId"`, `" = "`,
+ * `"enrollmentKeys.expiresAt"`, `" < "`) without needing a real DB.
+ */
+function mockDeleteWhereReturningCapture(rows: any[]): () => any {
+  let captured: any;
+  vi.mocked(db.delete).mockReturnValueOnce({
+    where: vi.fn((cond: any) => {
+      captured = cond;
+      return { returning: vi.fn().mockResolvedValue(rows) };
+    }),
+  } as any);
+  return () => captured;
+}
+
 describe('enrollment key routes — get, rotate, delete', () => {
   let app: Hono;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mfaGate.deny = false;
+    permissionGate.deny = false;
     app = new Hono();
     app.route('/enrollment-keys', enrollmentKeyRoutes);
   });
@@ -278,6 +313,188 @@ describe('enrollment key routes — get, rotate, delete', () => {
       });
 
       expect(res.status).toBe(403);
+    });
+  });
+
+  // ============================================
+  // POST /purge-expired — Bulk-delete expired enrollment keys in caller scope
+  // ============================================
+  describe('POST /enrollment-keys/purge-expired', () => {
+    it('purges expired keys within the org-scoped caller\'s org and returns the count', async () => {
+      const getCaptured = mockDeleteWhereReturningCapture([
+        { id: 'key-1' },
+        { id: 'key-2' },
+      ]);
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true, deletedCount: 2 });
+
+      // Composed condition scopes to the caller's org AND filters expired —
+      // asserted via the serialized SQL chunk shape (see helper docstring).
+      const conditionJson = JSON.stringify(getCaptured());
+      expect(conditionJson).toContain('enrollmentKeys.orgId');
+      expect(conditionJson).toContain(ORG_ID);
+      expect(conditionJson).toContain('enrollmentKeys.expiresAt');
+      expect(conditionJson).toContain(' < ');
+
+      expect(createAuditLogAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'enrollment_key.purge_expired',
+          details: { deletedCount: 2 },
+        }),
+      );
+    });
+
+    it('returns deletedCount 0 and does not call delete when nothing matches', async () => {
+      const getCaptured = mockDeleteWhereReturningCapture([]);
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true, deletedCount: 0 });
+      expect(getCaptured()).toBeDefined();
+      expect(createAuditLogAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ details: { deletedCount: 0 } }),
+      );
+    });
+
+    it('returns 403 when org-scoped caller has no orgId', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-1', email: 'test@example.com' },
+          scope: 'organization',
+          orgId: null,
+          accessibleOrgIds: [],
+          canAccessOrg: () => false,
+        });
+        return next();
+      });
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('scopes to all accessible orgs for a partner-scoped caller', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-1', email: 'test@example.com' },
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: ['org-a', 'org-b'],
+          canAccessOrg: (id: string) => ['org-a', 'org-b'].includes(id),
+        });
+        return next();
+      });
+      const getCaptured = mockDeleteWhereReturningCapture([{ id: 'key-1' }]);
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true, deletedCount: 1 });
+      const conditionJson = JSON.stringify(getCaptured());
+      expect(conditionJson).toContain('org-a');
+      expect(conditionJson).toContain('org-b');
+    });
+
+    it('returns deletedCount 0 without querying when partner caller has no accessible orgs', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-1', email: 'test@example.com' },
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: [],
+          canAccessOrg: () => false,
+        });
+        return next();
+      });
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true, deletedCount: 0 });
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('purges across all orgs (no org restriction) for a system-scoped caller', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'admin-1', email: 'admin@example.com' },
+          scope: 'system',
+          orgId: null,
+          accessibleOrgIds: null,
+          canAccessOrg: () => true,
+        });
+        return next();
+      });
+      const getCaptured = mockDeleteWhereReturningCapture([
+        { id: 'key-1' },
+        { id: 'key-2' },
+        { id: 'key-3' },
+      ]);
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true, deletedCount: 3 });
+      const conditionJson = JSON.stringify(getCaptured());
+      // No org-scoping column present — only the expired condition.
+      expect(conditionJson).not.toContain('enrollmentKeys.orgId');
+      expect(conditionJson).toContain('enrollmentKeys.expiresAt');
+    });
+
+    it('is blocked without MFA (requireMfa)', async () => {
+      mfaGate.deny = true;
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('is blocked without the required permission (requirePermission)', async () => {
+      permissionGate.deny = true;
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
@@ -122,11 +122,13 @@ describe('EnrollmentKeyManager — hide expired toggle', () => {
 });
 
 describe('EnrollmentKeyManager — delete expired', () => {
-  it('disables the button when no listed key is expired', async () => {
+  it('keeps the button enabled even when no listed key is expired', async () => {
+    // The button must stay enabled regardless of what's on the current page/filter,
+    // since expired keys may exist off-page or be hidden by the "Hide expired" toggle.
     routeFetch([makeRow({ expiresAt: FUTURE })]);
     render(<EnrollmentKeyManager />);
     await screen.findByText('Prod key');
-    expect((screen.getByTestId('delete-expired-keys') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('delete-expired-keys') as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('purges via POST and refetches page 1 when an expired key is present', async () => {

--- a/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ currentOrgId: 'org-1' }) },
+}));
+// Pass-through runAction so the request fn (and thus fetchWithAuth) actually runs.
+vi.mock('../../lib/runAction', () => ({
+  ActionError: class ActionError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+  runAction: async (o: {
+    request: () => Promise<Response>;
+    parseSuccess?: (d: unknown) => unknown;
+  }) => {
+    const r = await o.request();
+    const data = await r.json().catch(() => null);
+    return o.parseSuccess ? o.parseSuccess(data) : data;
+  },
+}));
+
+import EnrollmentKeyManager from './EnrollmentKeyManager';
+
+function jsonRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+interface Row {
+  id: string;
+  orgId: string;
+  siteId: string | null;
+  name: string;
+  shortCode?: string | null;
+  usageCount: number;
+  maxUsage: number | null;
+  expiresAt: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+const PAST = new Date(Date.now() - 86_400_000).toISOString();
+const FUTURE = new Date(Date.now() + 86_400_000).toISOString();
+
+function makeRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'k-1',
+    orgId: 'org-1',
+    siteId: null,
+    name: 'Prod key',
+    shortCode: 'ABC123XYZ0',
+    usageCount: 0,
+    maxUsage: null,
+    expiresAt: FUTURE,
+    createdBy: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** Route all fetches; returns the recorded call list for assertions. */
+function routeFetch(list: Row[]) {
+  const calls: Array<{ url: string; method: string }> = [];
+  fetchWithAuth.mockImplementation((rawUrl: unknown, opts?: { method?: string }) => {
+    const url = String(rawUrl ?? '');
+    const method = opts?.method ?? 'GET';
+    calls.push({ url, method });
+    if (url.startsWith('/enrollment-keys/purge-expired') && method === 'POST') {
+      return Promise.resolve(jsonRes({ success: true, deletedCount: 2 }));
+    }
+    if (url.startsWith('/enrollment-keys?')) {
+      return Promise.resolve(
+        jsonRes({ data: list, pagination: { page: 1, limit: 50, total: list.length } }),
+      );
+    }
+    return Promise.resolve(jsonRes({ data: [], pagination: { page: 1, limit: 50, total: 0 } }));
+  });
+  return calls;
+}
+
+beforeEach(() => fetchWithAuth.mockReset());
+
+describe('EnrollmentKeyManager — short code column', () => {
+  it('renders the short code in the row and no legacy "Hidden" text', async () => {
+    routeFetch([makeRow({ shortCode: 'ABC123XYZ0' })]);
+    render(<EnrollmentKeyManager />);
+    expect(await screen.findByText('ABC123XYZ0')).toBeTruthy();
+    expect(screen.getByText('Short code')).toBeTruthy();
+    expect(screen.queryByText('Hidden')).toBeNull();
+  });
+
+  it('renders a dash when short code is absent', async () => {
+    routeFetch([makeRow({ shortCode: null })]);
+    render(<EnrollmentKeyManager />);
+    await screen.findByText('Prod key');
+    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.queryByText('Hidden')).toBeNull();
+  });
+});
+
+describe('EnrollmentKeyManager — hide expired toggle', () => {
+  it('refetches with expired=false when toggled on', async () => {
+    const calls = routeFetch([makeRow()]);
+    render(<EnrollmentKeyManager />);
+    await screen.findByText('Prod key');
+
+    fireEvent.click(screen.getByTestId('hide-expired-toggle'));
+
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === 'GET' && c.url.includes('expired=false'))).toBe(true);
+    });
+    // Initial load must NOT carry the filter.
+    expect(calls[0].url.includes('expired=false')).toBe(false);
+  });
+});
+
+describe('EnrollmentKeyManager — delete expired', () => {
+  it('disables the button when no listed key is expired', async () => {
+    routeFetch([makeRow({ expiresAt: FUTURE })]);
+    render(<EnrollmentKeyManager />);
+    await screen.findByText('Prod key');
+    expect((screen.getByTestId('delete-expired-keys') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('purges via POST and refetches page 1 when an expired key is present', async () => {
+    const calls = routeFetch([makeRow({ id: 'k-exp', name: 'Old key', expiresAt: PAST })]);
+    render(<EnrollmentKeyManager />);
+    await screen.findByText('Old key');
+
+    const btn = screen.getByTestId('delete-expired-keys') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+
+    // ConfirmDialog appears; confirm it.
+    fireEvent.click(await screen.findByTestId('confirm-delete-expired-keys'));
+
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.method === 'POST' && c.url.startsWith('/enrollment-keys/purge-expired')),
+      ).toBe(true);
+    });
+    // A refetch (GET) happens after the purge.
+    const postIdx = calls.findIndex((c) => c.method === 'POST');
+    expect(calls.slice(postIdx + 1).some((c) => c.method === 'GET')).toBe(true);
+  });
+});

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -292,8 +292,6 @@ export default function EnrollmentKeyManager() {
     return { label: 'Active', className: 'bg-green-500/10 text-green-400 border-green-500/30' };
   };
 
-  const hasExpiredKeys = keys.some((key) => isExpired(key));
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -391,7 +389,7 @@ export default function EnrollmentKeyManager() {
           type="button"
           data-testid="delete-expired-keys"
           onClick={() => setPurgeConfirmOpen(true)}
-          disabled={!hasExpiredKeys || submitting}
+          disabled={submitting}
           className="inline-flex h-9 items-center justify-center rounded-md border border-destructive/40 px-3 text-sm font-medium text-destructive transition hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Delete expired

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -6,6 +6,7 @@ import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { showToast } from '../shared/Toast';
+import { runAction, ActionError } from '../../lib/runAction';
 
 interface EnrollmentKey {
   id: string;
@@ -13,6 +14,7 @@ interface EnrollmentKey {
   siteId: string | null;
   name: string;
   key?: string | null;
+  shortCode?: string | null;
   usageCount: number;
   maxUsage: number | null;
   expiresAt: string | null;
@@ -44,6 +46,8 @@ export default function EnrollmentKeyManager() {
   const [rotateTarget, setRotateTarget] = useState<EnrollmentKey | null>(null);
   const [downloadDropdownId, setDownloadDropdownId] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
+  const [hideExpired, setHideExpired] = useState(false);
+  const [purgeConfirmOpen, setPurgeConfirmOpen] = useState(false);
 
   // Create form state
   const [formName, setFormName] = useState('');
@@ -54,7 +58,9 @@ export default function EnrollmentKeyManager() {
     try {
       setLoading(true);
       setError(undefined);
-      const response = await fetchWithAuth(`/enrollment-keys?page=${page}`);
+      const params = new URLSearchParams({ page: String(page) });
+      if (hideExpired) params.set('expired', 'false');
+      const response = await fetchWithAuth(`/enrollment-keys?${params.toString()}`);
       if (!response.ok) {
         if (response.status === 401) {
           void navigateTo('/login', { replace: true });
@@ -73,7 +79,7 @@ export default function EnrollmentKeyManager() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [hideExpired]);
 
   useEffect(() => {
     fetchKeys();
@@ -213,6 +219,35 @@ export default function EnrollmentKeyManager() {
     }
   };
 
+  const handleConfirmPurgeExpired = async () => {
+    setPurgeConfirmOpen(false);
+    setSubmitting(true);
+    try {
+      await runAction<{ success: boolean; deletedCount: number }>({
+        request: () =>
+          fetchWithAuth('/enrollment-keys/purge-expired', {
+            method: 'POST',
+            body: JSON.stringify({})
+          }),
+        errorFallback: 'Failed to delete expired enrollment keys',
+        successMessage: (data) =>
+          `Deleted ${data.deletedCount} expired enrollment ${data.deletedCount === 1 ? 'key' : 'keys'}`,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      await fetchKeys(1);
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) {
+        showToast({
+          type: 'error',
+          message: err instanceof Error ? err.message : 'Failed to delete expired enrollment keys'
+        });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const handleDownloadInstaller = async (keyId: string, platform: 'windows' | 'macos') => {
     if (downloading) return;
     setDownloading(true);
@@ -256,6 +291,8 @@ export default function EnrollmentKeyManager() {
     if (isExhausted(key)) return { label: 'Exhausted', className: 'bg-amber-500/10 text-amber-400 border-amber-500/30' };
     return { label: 'Active', className: 'bg-green-500/10 text-green-400 border-green-500/30' };
   };
+
+  const hasExpiredKeys = keys.some((key) => isExpired(key));
 
   if (loading) {
     return (
@@ -338,6 +375,29 @@ export default function EnrollmentKeyManager() {
         </div>
       )}
 
+      {/* Table toolbar: hide-expired toggle + purge-expired action */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            data-testid="hide-expired-toggle"
+            checked={hideExpired}
+            onChange={(e) => setHideExpired(e.target.checked)}
+            className="h-4 w-4 rounded border"
+          />
+          Hide expired
+        </label>
+        <button
+          type="button"
+          data-testid="delete-expired-keys"
+          onClick={() => setPurgeConfirmOpen(true)}
+          disabled={!hasExpiredKeys || submitting}
+          className="inline-flex h-9 items-center justify-center rounded-md border border-destructive/40 px-3 text-sm font-medium text-destructive transition hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Delete expired
+        </button>
+      </div>
+
       {/* Keys Table */}
       <div className="rounded-lg border bg-card">
         <div className="overflow-x-auto">
@@ -345,7 +405,7 @@ export default function EnrollmentKeyManager() {
             <thead className="bg-muted/40">
               <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 <th className="px-4 py-3">Name</th>
-                <th className="px-4 py-3">Key</th>
+                <th className="px-4 py-3">Short code</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Usage</th>
                 <th className="px-4 py-3">Expires</th>
@@ -367,16 +427,16 @@ export default function EnrollmentKeyManager() {
                     <tr key={key.id} className="border-b last:border-b-0 hover:bg-muted/50">
                       <td className="px-4 py-3 font-medium">{key.name}</td>
                       <td className="px-4 py-3">
-                        {key.key ? (
+                        {key.shortCode ? (
                           <div className="flex items-center gap-2">
                             <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
-                              {key.key.slice(0, 12)}...
+                              {key.shortCode}
                             </code>
                             <button
                               type="button"
-                              onClick={() => handleCopyKey(key.key as string, key.id)}
+                              onClick={() => handleCopyKey(key.shortCode as string, key.id)}
                               className="text-muted-foreground hover:text-foreground"
-                              title="Copy full key"
+                              title="Copy short code"
                             >
                               {copiedId === key.id ? (
                                 <svg className="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -390,7 +450,7 @@ export default function EnrollmentKeyManager() {
                             </button>
                           </div>
                         ) : (
-                          <span className="text-xs text-muted-foreground">Hidden</span>
+                          <span className="text-xs text-muted-foreground">—</span>
                         )}
                       </td>
                       <td className="px-4 py-3">
@@ -612,6 +672,17 @@ export default function EnrollmentKeyManager() {
         confirmLabel="Rotate Key"
         variant="warning"
         isLoading={submitting}
+      />
+      <ConfirmDialog
+        open={purgeConfirmOpen}
+        onClose={() => setPurgeConfirmOpen(false)}
+        onConfirm={handleConfirmPurgeExpired}
+        title="Delete expired enrollment keys"
+        message="Delete all expired enrollment keys? This cannot be undone."
+        confirmLabel="Delete expired"
+        variant="destructive"
+        isLoading={submitting}
+        confirmTestId="confirm-delete-expired-keys"
       />
     </div>
   );

--- a/docs/superpowers/plans/2026-07-03-enrollment-keys-cleanup.md
+++ b/docs/superpowers/plans/2026-07-03-enrollment-keys-cleanup.md
@@ -1,0 +1,112 @@
+# Enrollment Keys Cleanup — Implementation Plan
+
+Issues: #2196 (auto-purge + delete-expired action), #2197 (dead KEY column).
+Branch: `ToddHebebrand/Enrollment-Keys-Cleanup` (base `4a09d92d0`).
+
+## Background
+
+The Add Device flows and onboarding-token endpoint auto-create single-use enrollment keys
+(60-min TTL parents, 24h TTL children) that linger forever after expiry. There is no cleanup
+worker, no bulk delete, and the UI KEY column always renders "Hidden" because the list
+endpoint strips the key (only a hash is stored; plaintext is shown once at create/rotate).
+
+## Global Constraints
+
+- **No schema changes, no migrations.** Hard delete of `enrollment_keys` rows is safe: the
+  only FK references (`installer_bootstrap_tokens.enrollment_key_id`,
+  `deployment_invites.enrollment_key_id`) are both `ON DELETE CASCADE`.
+- Keys with `expires_at IS NULL` are NEVER deleted by any purge path.
+- Background job DB access MUST use `withSystemDbAccessContext` (`apps/api/src/db/index.ts`).
+  Bare pool is forbidden.
+- BullMQ job IDs must not contain `:` — use `-` separators.
+- Web mutation handlers MUST use `runAction` (`apps/web/src/lib/runAction.ts`) with the
+  standard catch pattern (401 ActionError → return; non-ActionError → showToast error).
+- Tests live alongside source files. Unit tests mock the db; any test needing real Postgres
+  goes in the integration config lists (not needed for this plan — unit only).
+- New interactive UI elements get `data-testid` attributes.
+- The purge endpoint is MFA-gated and permission-gated exactly like the existing
+  `DELETE /enrollment-keys/:id` (see `apps/api/src/routes/enrollmentKeys.ts:832-878`).
+
+## Task 1 — API: `POST /enrollment-keys/purge-expired`
+
+**Files:** `apps/api/src/routes/enrollmentKeys.ts` (add route),
+`apps/api/src/routes/enrollmentKeys.test.ts` (or the existing sibling test file — find and
+extend it; do not create a duplicate suite).
+
+Add a `POST /purge-expired` route to `enrollmentKeysRoutes`:
+
+- Auth/gates: mirror `DELETE /:id` exactly — same middleware chain (`requireMfa()`, same
+  permission requirement, same rate limiter class as other enrollment-key writes).
+- No request body. Scope: delete all enrollment keys **visible to the caller** (same
+  org/partner/system scoping the `GET /` list route builds, see lines 530-608) where
+  `expires_at IS NOT NULL AND expires_at < now()`. Reuse/extract the same condition the
+  list route builds for `?expired=true` (`lt(enrollmentKeys.expiresAt, new Date())`,
+  line ~575).
+- Implementation: single `db.delete(enrollmentKeys).where(and(scopeCondition, expiredCondition)).returning({ id: enrollmentKeys.id })`.
+- Response: `200 { success: true, deletedCount: n }`.
+- Audit: if `DELETE /:id` writes an audit log entry, write one equivalent entry for the bulk
+  purge (action e.g. `enrollment_keys.purge_expired`, details `{ deletedCount }`). Follow the
+  existing audit call pattern in this file; do not invent a new helper.
+- **Route ordering:** register `POST /purge-expired` BEFORE any `/:id`-parameterized POST
+  routes so it is not captured as an id.
+
+Tests (Vitest + Drizzle mock pattern per repo convention): purge deletes only expired keys
+in caller scope; keys with null `expiresAt` survive; response contains count; MFA/permission
+gates enforced (mirror the DELETE /:id test cases).
+
+## Task 2 — API: scheduled auto-purge worker
+
+**Files:** `apps/api/src/jobs/enrollmentKeyCleanup.ts` (new),
+`apps/api/src/jobs/enrollmentKeyCleanup.test.ts` (new),
+`apps/api/src/index.ts` (register in the worker init array, alongside
+`['oauthCleanup', initializeOauthCleanupWorker]` at ~line 1157).
+
+Model the worker file closely on `apps/api/src/jobs/oauthCleanup.ts` (same structure:
+Queue + Worker, daily cron `'0 4 * * *'`, dedup jobId — use `-` separators, env kill
+switch, `initialize*/shutdown*/schedule*` exports, `__testOnly` introspection).
+
+- Env vars:
+  - `ENROLLMENT_KEY_CLEANUP_ENABLED` — default ON (same parsing as `OAUTH_CLEANUP_ENABLED`).
+  - `ENROLLMENT_KEY_PURGE_AFTER_DAYS` — integer, default `7`. Grace period past expiry.
+- Job body: inside `withSystemDbAccessContext`, delete rows where
+  `expires_at IS NOT NULL AND expires_at < now() - interval '<N> days'` (compute the cutoff
+  Date in JS: `new Date(Date.now() - days * 86400_000)` and use `lt(enrollmentKeys.expiresAt, cutoff)`).
+- Log the deleted count at info level (count = `.returning({id})` length or delete result
+  count, matching how oauthCleanup reports counts).
+- Unit tests: mock `../db` (the repo has a known green-local/red-CI trap when worker tests
+  leave db context unmocked — mock it explicitly). Cover: cutoff math respects
+  `ENROLLMENT_KEY_PURGE_AFTER_DAYS`; null-expiry rows are not matched (assert the where
+  condition includes the not-null guard); kill switch prevents scheduling.
+
+## Task 3 — Web UI: EnrollmentKeyManager changes
+
+**Files:** `apps/web/src/components/settings/EnrollmentKeyManager.tsx`, plus its sibling
+test file if one exists (extend, don't duplicate).
+
+Three changes:
+
+1. **KEY column → SHORT CODE** (#2197): remove the dead masked-key/"Hidden" cell
+   (lines ~369-395; `key.key` is never populated on list rows). Replace the column header
+   with `Short code` and render `key.shortCode` in monospace with the existing
+   copy-to-clipboard affordance when present, else a dim `—`. Verify the list API returns
+   `shortCode` (sanitize only strips `key`); if it doesn't, include it in the API response
+   in this task. Keep the one-time creation banner untouched.
+2. **Delete expired button** (#2196): a `Delete expired` button near the table header,
+   visible/enabled when at least one listed key is expired (client-side `getKeyStatus`
+   already computes this). ConfirmDialog ("Delete all expired enrollment keys? This cannot
+   be undone."), then `runAction` POST to `/enrollment-keys/purge-expired`, success toast
+   with the deleted count, then refetch page 1. `data-testid="delete-expired-keys"`.
+3. **Hide-expired toggle**: a checkbox/toggle `Hide expired` (default OFF — current
+   behavior unchanged) that refetches the list with `?expired=false` (the API already
+   supports it). Persist nothing; plain component state. `data-testid="hide-expired-toggle"`.
+
+Tests (Vitest + jsdom, per repo web conventions): purge button calls the endpoint via
+runAction and refetches; toggle adds `expired=false` to the fetch; short-code cell renders
+code when present and `—` when absent; no "Hidden" text remains.
+
+## Out of Scope
+
+- Checkbox multi-select / generic bulk delete.
+- Changing how Add Device flows create keys.
+- Purging exhausted-but-unexpired keys.
+- Docs/release notes (handled at release time).


### PR DESCRIPTION
## Summary

Expired single-use enrollment keys (auto-created by the Add Device flows and onboarding tokens) accumulated forever with no cleanup path, and the KEY column always showed "Hidden" because only a hash is stored. Reported by @SemoTech.

Refs #2196
Refs #2197

## Changes

**API**
- `POST /enrollment-keys/purge-expired` — deletes all expired keys visible to the caller (org/partner/system scoping mirrors the list route exactly; MFA + `ORGS_WRITE` + rate limit identical to `DELETE /:id`). Returns `{ success, deletedCount }` and writes an `enrollment_key.purge_expired` audit entry.
- New scheduled worker `apps/api/src/jobs/enrollmentKeyCleanup.ts` (modeled on `oauthCleanup.ts`): daily at 04:00, deletes keys expired more than `ENROLLMENT_KEY_PURGE_AFTER_DAYS` (default 7) days ago, inside `withSystemDbAccessContext`, logs the deleted count. Kill switch: `ENROLLMENT_KEY_CLEANUP_ENABLED` (default on). Both env vars are optional — no deploy changes required.

**Web** (`EnrollmentKeyManager.tsx`)
- Dead KEY/"Hidden" column replaced with a Short code column (monospace + copy button, `—` when absent). The one-time key banner at creation is unchanged.
- "Delete expired" button (ConfirmDialog → purge endpoint via `runAction`, toast reports deleted count).
- "Hide expired" toggle using the existing `?expired=false` filter.

## Safety notes

- Keys with `expires_at IS NULL` are never touched by either purge path (explicit `IS NOT NULL` guard in the worker; `lt()` NULL semantics plus scope parity in the endpoint).
- Hard delete cascades to `installer_bootstrap_tokens` and `deployment_invites`. Bootstrap tokens are TTL-capped at parent-key expiry at issuance, so only already-expired tokens can be cascade-deleted — no installed-but-unenrolled MSI can be orphaned. **Recorded decision:** deployment-invite history rows (including enrolled ones) are erased when their parent key is purged 7+ days after expiry; nothing reads them from the web UI today.
- No schema changes or migrations.

## Tests

- API: 18/18 route tests (`enrollmentKeys_get_rotate_delete.test.ts`, incl. all three auth scopes + gate denials), 13/13 worker tests (`enrollmentKeyCleanup.test.ts`, cutoff math / null-expiry guard / kill switch).
- Web: 5/5 component tests (`EnrollmentKeyManager.test.tsx`).
- `tsc --noEmit` clean on both packages.
- Full SDD review cycle: per-task spec+quality reviews plus a whole-branch final review (scope parity, null-expiry and cascade safety verified against source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)