### PR TITLE
feat(web): grouped sidebar nav for Partner + Org settings, honest save contracts

### DIFF
--- a/apps/web/src/components/settings/OrgSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.test.tsx
@@ -282,3 +282,65 @@ describe('OrgSettingsPage general tab — name editing', () => {
     });
   });
 });
+
+describe('OrgSettingsPage sidebar nav & save-state honesty', () => {
+  const orgDetails = {
+    id: 'org-1',
+    name: 'Acme Systems',
+    slug: 'acme',
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    settings: {}
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    useOrgStoreMock.mockReturnValue({ currentOrgId: 'org-1', organizations: [] } as never);
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      if (url.endsWith('/effective-settings')) return Promise.resolve(makeJsonResponse({ locked: [] }));
+      return Promise.resolve(makeJsonResponse(orgDetails));
+    });
+  });
+
+  it('never shows a fabricated "Saved at" timestamp on load', async () => {
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    await screen.findByTestId('org-name-input');
+    expect(screen.queryByText(/saved at/i)).toBeNull();
+    expect(screen.queryByText(/unsaved changes/i)).toBeNull();
+  });
+
+  it('renders the sections as grouped links and marks the active one with aria-current', async () => {
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    await screen.findByTestId('org-name-input');
+    const general = screen.getByRole('link', { name: /^general$/i });
+    expect(general.getAttribute('aria-current')).toBe('page');
+    // Approval Security no longer shares Security's icon slot — both links exist.
+    expect(screen.getByRole('link', { name: /^approval security$/i })).not.toBeNull();
+
+    await userEvent.click(screen.getByRole('link', { name: /^branding$/i }));
+    expect(window.location.hash).toBe('#branding');
+    expect(screen.getByRole('link', { name: /^branding$/i }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByTestId('branding-editor')).not.toBeNull();
+  });
+
+  it('deep-links the hash to the right section on mount', async () => {
+    window.location.hash = '#remote-access';
+
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    const link = await screen.findByRole('link', { name: /^remote access$/i });
+    expect(link.getAttribute('aria-current')).toBe('page');
+    expect(screen.getByTestId('remote-access')).not.toBeNull();
+  });
+
+  it('offers the compact section select for narrow viewports', async () => {
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    await screen.findByTestId('org-name-input');
+    const select = screen.getByLabelText('Settings section') as HTMLSelectElement;
+    expect(select.value).toBe('general');
+  });
+});

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -8,6 +8,7 @@ import {
   Copy,
   Check,
   FileSignature,
+  Fingerprint,
   Globe,
   Monitor,
   Paintbrush,
@@ -16,6 +17,7 @@ import {
   Ticket
 } from 'lucide-react';
 import ContractsList from '../contracts/ContractsList';
+import SettingsSectionNav, { type SettingsNavGroup } from './SettingsSectionNav';
 import OrgBrandingEditor from './OrgBrandingEditor';
 import OrgPortalSettingsEditor from './OrgPortalSettingsEditor';
 import OrgTicketSettingsEditor from './OrgTicketSettingsEditor';
@@ -32,83 +34,58 @@ import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
-const tabs = [
-  {
-    id: 'general',
-    label: 'General',
-    description: 'Organization profile and defaults',
-    icon: Building2
-  },
-  {
-    id: 'branding',
-    label: 'Branding',
-    description: 'Portal theme and visuals',
-    icon: Paintbrush
-  },
-  {
-    id: 'portal',
-    label: 'Customer Portal',
-    description: 'Portal features and support contact',
-    icon: Globe
-  },
-  {
-    id: 'notifications',
-    label: 'Notifications',
-    description: 'Email, Slack, and webhooks',
-    icon: Bell
-  },
-  {
-    id: 'security',
-    label: 'Security',
-    description: 'Access policies and MFA',
-    icon: Shield
-  },
-  {
-    id: 'approval-security',
-    label: 'Approval Security',
-    description: 'Step-up verification for approvals',
-    icon: Shield
-  },
-  {
-    id: 'event-logs',
-    label: 'Event Logs',
-    description: 'Forwarding and retention',
-    icon: ScrollText
-  },
-  {
-    id: 'remote-access',
-    label: 'Remote Access',
-    description: 'VNC, proxy, and tunnel settings',
-    icon: Monitor
-  },
-  {
-    id: 'ticketing',
-    label: 'Ticketing',
-    description: 'SLA overrides and billing defaults',
-    icon: Ticket
-  },
-  {
-    id: 'contracts',
-    label: 'Contracts',
-    description: 'Recurring billing agreements',
-    icon: FileSignature
-  }
-] as const;
+type TabKey =
+  | 'general' | 'branding' | 'portal' | 'notifications' | 'security'
+  | 'approval-security' | 'event-logs' | 'remote-access' | 'ticketing' | 'contracts';
 
-type TabKey = (typeof tabs)[number]['id'];
+// Grouped sidebar definition — same anatomy as PartnerSettingsPage (shared
+// SettingsSectionNav). Hashes are the section keys (already kebab-case).
+const TAB_GROUPS: (Omit<SettingsNavGroup, 'items'> & { items: (SettingsNavGroup['items'][number] & { key: TabKey })[] })[] = [
+  {
+    label: 'Organization',
+    items: [
+      { key: 'general', hash: 'general', label: 'General', description: 'Profile and defaults', icon: Building2 },
+      { key: 'contracts', hash: 'contracts', label: 'Contracts', description: 'Recurring agreements', icon: FileSignature },
+    ],
+  },
+  {
+    label: 'Portal & Branding',
+    items: [
+      { key: 'branding', hash: 'branding', label: 'Branding', description: 'Portal theme and visuals', icon: Paintbrush },
+      { key: 'portal', hash: 'portal', label: 'Customer Portal', description: 'Features and support', icon: Globe },
+    ],
+  },
+  {
+    label: 'Security & Access',
+    items: [
+      { key: 'security', hash: 'security', label: 'Security', description: 'Access policies and MFA', icon: Shield },
+      { key: 'approval-security', hash: 'approval-security', label: 'Approval Security', description: 'Step-up verification', icon: Fingerprint },
+      { key: 'remote-access', hash: 'remote-access', label: 'Remote Access', description: 'VNC, proxy, tunnels', icon: Monitor },
+      { key: 'event-logs', hash: 'event-logs', label: 'Event Logs', description: 'Forwarding and retention', icon: ScrollText },
+    ],
+  },
+  {
+    label: 'Communications',
+    items: [
+      { key: 'notifications', hash: 'notifications', label: 'Notifications', description: 'Email, Slack, webhooks', icon: Bell },
+      { key: 'ticketing', hash: 'ticketing', label: 'Ticketing', description: 'SLA and billing overrides', icon: Ticket },
+    ],
+  },
+];
 
-const VALID_TABS = tabs.map(t => t.id) as unknown as TabKey[];
+const ALL_TABS = TAB_GROUPS.flatMap(g => g.items);
+const TAB_BY_KEY = Object.fromEntries(ALL_TABS.map(t => [t.key, t])) as Record<TabKey, (typeof ALL_TABS)[number]>;
 
-function getTabFromHash(): TabKey {
-  if (typeof window === 'undefined') return 'general';
+function getTabFromHash(): TabKey | null {
+  if (typeof window === 'undefined') return null;
   const hash = window.location.hash.replace('#', '');
-  if (VALID_TABS.includes(hash as TabKey)) return hash as TabKey;
-  return 'general';
+  return hash in TAB_BY_KEY ? (hash as TabKey) : null;
 }
 
 type SaveState = {
   hasUnsavedChanges: boolean;
-  lastSavedAt: string;
+  // null until a real save happens this session — never fabricate a timestamp.
+  lastSavedAt: string | null;
 };
 
 type OrgDetails = {
@@ -186,11 +163,8 @@ type OrgDetails = {
   updatedAt?: string;
 };
 
-// Fixed reference time for SSR hydration consistency
-const REFERENCE_TIME = '12:00';
-
 const formatTime = (date: Date) =>
-  formatUserTime(date, { locale: 'en-US', hour: 'numeric', minute: '2-digit' });
+  formatUserTime(date, { hour: 'numeric', minute: '2-digit' });
 
 type OrgSettingsPageProps = {
   orgId?: string;
@@ -215,23 +189,50 @@ export async function runOrgNameSave(
 }
 
 export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPageProps) {
-  const [activeTab, setActiveTab] = useState<TabKey>(getTabFromHash);
+  // Seeded SSR-safe with the default tab; the hash is applied client-side in
+  // the effect below to avoid a hydration mismatch (same pattern as
+  // PartnerSettingsPage). Also tracks back/forward via hashchange.
+  const [activeTab, setActiveTab] = useState<TabKey>('general');
 
   useEffect(() => {
-    const onHashChange = () => setActiveTab(getTabFromHash());
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
+    const applyHash = () => {
+      const tab = getTabFromHash();
+      if (tab) setActiveTab(tab);
+    };
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => window.removeEventListener('hashchange', applyHash);
   }, []);
-
-  const switchTab = (tab: TabKey) => {
-    window.location.hash = tab;
-    setActiveTab(tab);
-  };
 
   const [saveState, setSaveState] = useState<SaveState>({
     hasUnsavedChanges: false,
-    lastSavedAt: REFERENCE_TIME
+    lastSavedAt: null
   });
+
+  // Editors hold their own draft state and unmount on tab switch, so switching
+  // away from a dirty section genuinely discards the edits — never do that
+  // silently. (Dirty state always belongs to the ACTIVE tab: onDirty only
+  // fires from the mounted editor, and we clear it here on a confirmed switch.)
+  const switchTab = (tab: TabKey) => {
+    if (tab === activeTab) return;
+    if (saveState.hasUnsavedChanges) {
+      const proceed = window.confirm(
+        'You have unsaved changes in this section. Switching will discard them. Continue?'
+      );
+      if (!proceed) return;
+      setSaveState(prev => ({ ...prev, hasUnsavedChanges: false }));
+    }
+    setActiveTab(tab);
+    if (window.location.hash !== `#${tab}`) window.location.hash = tab;
+  };
+
+  // Warn before a full navigation away discards unsaved edits.
+  useEffect(() => {
+    if (!saveState.hasUnsavedChanges) return;
+    const warn = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [saveState.hasUnsavedChanges]);
   const [orgDetails, setOrgDetails] = useState<OrgDetails | null>(null);
   const [locked, setLocked] = useState<string[]>([]);
   // Issue #2124: registered versions for the pin selectors + the partner's
@@ -324,15 +325,16 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         [section]: data
       };
 
-      const response = await fetchWithAuth(`/orgs/organizations/${effectiveOrgId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ settings: updatedSettings })
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/orgs/organizations/${effectiveOrgId}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ settings: updatedSettings })
+          }),
+        successMessage: 'Settings saved',
+        errorFallback: 'Failed to save settings',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        throw new Error(body.error || body.message || 'Failed to save settings');
-      }
 
       await fetchOrgDetails();
       setSaveState({
@@ -340,7 +342,10 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         lastSavedAt: formatTime(new Date())
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save settings');
+      // runAction already toasts non-401 ActionErrors; only surface unexpected errors.
+      if (!(err instanceof ActionError)) {
+        setError(err instanceof Error ? err.message : 'Failed to save settings');
+      }
     }
   }, [effectiveOrgId, orgDetails, fetchOrgDetails]);
 
@@ -373,34 +378,37 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
     try {
       setSavingType(true);
       setError(undefined);
-      const response = await fetchWithAuth(`/orgs/organizations/${effectiveOrgId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ type: typeDraft })
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/orgs/organizations/${effectiveOrgId}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ type: typeDraft })
+          }),
+        successMessage: 'Organization type saved',
+        errorFallback: 'Failed to save organization type',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        throw new Error(body.error || body.message || 'Failed to save organization type');
-      }
 
       await fetchOrgDetails();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save organization type');
+      if (!(err instanceof ActionError)) {
+        setError(err instanceof Error ? err.message : 'Failed to save organization type');
+      }
     } finally {
       setSavingType(false);
     }
-  }, [effectiveOrgId, typeDraft, orgDetails, fetchOrgDetails]);
+  }, [effectiveOrgId, typeDraft, fetchOrgDetails]);
 
   // Fallback display data — prefer fetched orgDetails; when accessed via URL prop the org
   // might not be in the store's organizations array, so fall back to a minimal object.
   const displayOrg = orgDetails || organizations.find(org => org.id === effectiveOrgId) || { id: effectiveOrgId, name: 'Organization' } as OrgDetails;
 
+  // No fabricated timestamps: the pill only appears once there is something
+  // true to say — unsaved edits exist, or a save actually happened.
   const statusLabel = useMemo(() => {
-    if (saveState.hasUnsavedChanges) {
-      return 'Unsaved changes';
-    }
-
-    return `Saved at ${saveState.lastSavedAt}`;
+    if (saveState.hasUnsavedChanges) return 'Unsaved changes';
+    if (saveState.lastSavedAt) return `Saved at ${saveState.lastSavedAt}`;
+    return null;
   }, [saveState.hasUnsavedChanges, saveState.lastSavedAt]);
 
   const handleDirty = () => {
@@ -443,8 +451,10 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
     );
   }
 
-  // Error state
-  if (error) {
+  // Full-page error only when there is nothing to show yet (initial load
+  // failed). Later failures (e.g. a section save) render an inline banner
+  // below instead — replacing the page here would destroy the user's form state.
+  if (error && !orgDetails) {
     return (
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
         <p className="text-sm text-destructive">{error}</p>
@@ -628,6 +638,7 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
                       type="button"
                       className="inline-flex items-center rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
                       title="Copy Organization ID"
+                      aria-label="Copy Organization ID"
                       onClick={() => {
                         navigator.clipboard.writeText(displayOrg.id);
                         setCopiedOrgId(true);
@@ -680,61 +691,53 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
             Configure preferences for {displayOrg.name}.
           </p>
         </div>
-        <div className="flex items-center gap-2 rounded-full border bg-card px-4 py-2 text-sm">
-          {saveState.hasUnsavedChanges ? (
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
-          ) : (
-            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-          )}
-          <span className="text-xs font-medium">{statusLabel}</span>
-        </div>
+        {statusLabel && (
+          <div className="flex items-center gap-2 rounded-full border bg-card px-4 py-2 text-sm">
+            {saveState.hasUnsavedChanges ? (
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            ) : (
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            )}
+            <span className="text-xs font-medium">{statusLabel}</span>
+          </div>
+        )}
       </header>
 
       {saveState.hasUnsavedChanges ? (
         <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
           <AlertTriangle className="mt-0.5 h-5 w-5" />
           <div>
-            <p className="text-sm font-medium">You have unsaved changes</p>
+            <p className="text-sm font-medium">
+              You have unsaved changes in {TAB_BY_KEY[activeTab].label}
+            </p>
             <p className="text-xs text-amber-800">
-              Review each section and save to keep your updates.
+              Save in that section to keep your updates.
             </p>
           </div>
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[240px_1fr]">
-        <aside className="space-y-2 rounded-lg border bg-card p-4 shadow-xs">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Settings
-          </p>
-          <nav className="space-y-1">
-            {tabs.map(tab => {
-              const Icon = tab.icon;
-              const isActive = activeTab === tab.id;
+      {error && orgDetails && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
 
-              return (
-                <button
-                  key={tab.id}
-                  type="button"
-                  onClick={() => switchTab(tab.id)}
-                  className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition ${
-                    isActive
-                      ? 'bg-muted font-semibold text-foreground'
-                      : 'text-muted-foreground hover:bg-muted/60'
-                  }`}
-                >
-                  <Icon className="h-4 w-4" />
-                  <div>
-                    <p>{tab.label}</p>
-                    <p className="text-xs text-muted-foreground">{tab.description}</p>
-                  </div>
-                </button>
-              );
-            })}
-          </nav>
-        </aside>
+      <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <SettingsSectionNav
+          groups={TAB_GROUPS.map(group => ({
+            label: group.label,
+            items: group.items.map(item => ({
+              ...item,
+              dirty: saveState.hasUnsavedChanges && item.key === activeTab,
+            })),
+          }))}
+          activeKey={activeTab}
+          onNavigate={key => switchTab(key as TabKey)}
+          selectId="org-settings-section"
+        />
 
-        <main className="space-y-6">{renderContent()}</main>
+        <div className="min-w-0 space-y-6">{renderContent()}</div>
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/PartnerRegionalTab.tsx
+++ b/apps/web/src/components/settings/PartnerRegionalTab.tsx
@@ -1,0 +1,167 @@
+import { Clock, Globe } from 'lucide-react';
+import KnownGuestsSettings from './KnownGuestsSettings';
+import type { BusinessHoursPreset, DateFormat, TimeFormat, DaySchedule } from '@breeze/shared';
+
+const TIMEZONES = [
+  'UTC', 'America/New_York', 'America/Chicago', 'America/Denver',
+  'America/Los_Angeles', 'America/Phoenix', 'America/Anchorage',
+  'Pacific/Honolulu', 'Europe/London', 'Europe/Paris', 'Europe/Berlin',
+  'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Singapore', 'Australia/Sydney'
+];
+
+const DATE_FORMATS: { value: DateFormat; label: string }[] = [
+  { value: 'MM/DD/YYYY', label: 'MM/DD/YYYY (US)' },
+  { value: 'DD/MM/YYYY', label: 'DD/MM/YYYY (International)' },
+  { value: 'YYYY-MM-DD', label: 'YYYY-MM-DD (ISO)' }
+];
+
+const BUSINESS_HOURS_PRESETS: { value: BusinessHoursPreset; label: string; description: string }[] = [
+  { value: '24/7', label: '24/7', description: 'Always available' },
+  { value: 'business', label: 'Business Hours', description: 'Mon-Fri 9am-5pm' },
+  { value: 'extended', label: 'Extended Hours', description: 'Mon-Fri 7am-7pm, Sat 9am-1pm' },
+  { value: 'custom', label: 'Custom', description: 'Set your own schedule' }
+];
+
+const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+const DAY_LABELS: Record<string, string> = { mon: 'Monday', tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' };
+const BH: DaySchedule = { start: '09:00', end: '17:00' };
+const BH_CLOSED: DaySchedule = { start: '09:00', end: '17:00', closed: true };
+export const DEFAULT_BUSINESS_HOURS: Record<string, DaySchedule> = { mon: BH, tue: BH, wed: BH, thu: BH, fri: BH, sat: BH_CLOSED, sun: BH_CLOSED };
+
+type PartnerRegionalTabProps = {
+  timezone: string;
+  dateFormat: DateFormat;
+  timeFormat: TimeFormat;
+  businessHoursPreset: BusinessHoursPreset;
+  customHours: Record<string, DaySchedule>;
+  onTimezoneChange: (value: string) => void;
+  onDateFormatChange: (value: DateFormat) => void;
+  onTimeFormatChange: (value: TimeFormat) => void;
+  onBusinessHoursPresetChange: (value: BusinessHoursPreset) => void;
+  onCustomHoursChange: (day: string, field: keyof DaySchedule, value: string | boolean) => void;
+};
+
+export default function PartnerRegionalTab({
+  timezone,
+  dateFormat,
+  timeFormat,
+  businessHoursPreset,
+  customHours,
+  onTimezoneChange,
+  onDateFormatChange,
+  onTimeFormatChange,
+  onBusinessHoursPresetChange,
+  onCustomHoursChange,
+}: PartnerRegionalTabProps) {
+  return (
+    <>
+      <section className="rounded-lg border bg-card p-6 shadow-xs">
+        <div className="mb-6">
+          <div className="flex items-center gap-2">
+            <Globe className="h-5 w-5 text-muted-foreground" />
+            <h2 className="text-lg font-semibold">Regional Settings</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            These defaults apply to new organizations and sites.
+          </p>
+        </div>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Timezone</label>
+            <select value={timezone} onChange={e => onTimezoneChange(e.target.value)}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm">
+              {TIMEZONES.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Date Format</label>
+            <select value={dateFormat} onChange={e => onDateFormatChange(e.target.value as DateFormat)}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm">
+              {DATE_FORMATS.map(fmt => <option key={fmt.value} value={fmt.value}>{fmt.label}</option>)}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Time Format</label>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2">
+                <input type="radio" name="timeFormat" checked={timeFormat === '12h'}
+                  onChange={() => onTimeFormatChange('12h')} className="h-4 w-4" />
+                <span className="text-sm">12-hour</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="radio" name="timeFormat" checked={timeFormat === '24h'}
+                  onChange={() => onTimeFormatChange('24h')} className="h-4 w-4" />
+                <span className="text-sm">24-hour</span>
+              </label>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Language</label>
+            <div className="flex h-10 w-full items-center rounded-md border bg-muted px-3 text-sm text-muted-foreground">
+              English
+            </div>
+            <p className="text-xs text-muted-foreground">Default language for partner settings.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Business Hours */}
+      <section className="rounded-lg border bg-card p-6 shadow-xs">
+        <div className="mb-6">
+          <div className="flex items-center gap-2">
+            <Clock className="h-5 w-5 text-muted-foreground" />
+            <h2 className="text-lg font-semibold">Business Hours</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Set your standard operating hours for support and alerts.
+          </p>
+        </div>
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {BUSINESS_HOURS_PRESETS.map(preset => (
+              <label key={preset.value}
+                className={`cursor-pointer rounded-lg border p-4 transition ${
+                  businessHoursPreset === preset.value
+                    ? 'border-primary bg-primary/5' : 'hover:border-muted-foreground/50'
+                }`}>
+                <input type="radio" name="businessHoursPreset" value={preset.value}
+                  checked={businessHoursPreset === preset.value}
+                  onChange={() => onBusinessHoursPresetChange(preset.value)} className="sr-only" />
+                <div className="font-medium">{preset.label}</div>
+                <div className="text-xs text-muted-foreground">{preset.description}</div>
+              </label>
+            ))}
+          </div>
+          {businessHoursPreset === 'custom' && (
+            <div className="mt-4 space-y-3 rounded-lg border bg-muted/40 p-4">
+              <p className="text-sm font-medium">Custom Schedule</p>
+              {DAYS.map(day => (
+                <div key={day} className="flex items-center gap-4">
+                  <div className="w-24 text-sm font-medium">{DAY_LABELS[day]}</div>
+                  <label className="flex items-center gap-2">
+                    <input type="checkbox" checked={!customHours[day]?.closed}
+                      onChange={e => onCustomHoursChange(day, 'closed', !e.target.checked)} className="h-4 w-4" />
+                    <span className="text-sm">Open</span>
+                  </label>
+                  {!customHours[day]?.closed && (
+                    <>
+                      <input type="time" value={customHours[day]?.start || '09:00'}
+                        onChange={e => onCustomHoursChange(day, 'start', e.target.value)}
+                        className="h-8 rounded-md border bg-background px-2 text-sm" />
+                      <span className="text-sm text-muted-foreground">to</span>
+                      <input type="time" value={customHours[day]?.end || '17:00'}
+                        onChange={e => onCustomHoursChange(day, 'end', e.target.value)}
+                        className="h-8 rounded-md border bg-background px-2 text-sm" />
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <KnownGuestsSettings />
+    </>
+  );
+}

--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -175,7 +175,7 @@ describe('PartnerSettingsPage language control', () => {
 
     await screen.findByText('Partner Settings');
     // Company is the default tab now; switch to Regional to check the language copy.
-    const regionalTab = screen.getByRole('button', { name: /^regional$/i });
+    const regionalTab = screen.getByRole('link', { name: /^regional$/i });
     const user = userEvent.setup();
     await user.click(regionalTab);
 
@@ -299,14 +299,14 @@ describe('PartnerSettingsPage Ticketing tab', () => {
     useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
   });
 
-  it('exposes a Ticketing tab in the tab bar', async () => {
+  it('exposes a Ticketing tab in the settings nav', async () => {
     fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
     fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
 
     render(<PartnerSettingsPage />);
 
     await screen.findByText('Partner Settings');
-    expect(screen.getByRole('button', { name: /^ticketing$/i })).not.toBeNull();
+    expect(screen.getByRole('link', { name: /^ticketing$/i })).not.toBeNull();
     // Not the active tab by default, so the embedded tabs are not mounted yet.
     expect(screen.queryByTestId('stub-ticketing-settings-tabs')).toBeNull();
   });
@@ -319,7 +319,7 @@ describe('PartnerSettingsPage Ticketing tab', () => {
 
     await screen.findByText('Partner Settings');
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /^ticketing$/i }));
+    await user.click(screen.getByRole('link', { name: /^ticketing$/i }));
 
     expect(screen.getByTestId('stub-ticketing-settings-tabs')).not.toBeNull();
     // The hub owns the top-level tab hash, so the embedded group must NOT sync it.
@@ -338,6 +338,91 @@ describe('PartnerSettingsPage Ticketing tab', () => {
     render(<PartnerSettingsPage />);
 
     expect(await screen.findByTestId('stub-ticketing-settings-tabs')).not.toBeNull();
+  });
+});
+
+describe('PartnerSettingsPage sidebar nav & save contract', () => {
+  const partnerResponse = {
+    id: 'partner-1',
+    name: 'Acme MSP',
+    slug: 'acme',
+    type: 'partner',
+    plan: 'pro',
+    createdAt: '2026-02-09T00:00:00.000Z',
+    settings: {
+      timezone: 'UTC',
+      dateFormat: 'MM/DD/YYYY',
+      timeFormat: '12h',
+      language: 'en',
+      businessHours: { preset: 'business' },
+      contact: {},
+      address: {},
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerResponse));
+  });
+
+  it('disables Save while clean and enables it (with a nav dirty dot) after an edit', async () => {
+    render(<PartnerSettingsPage />);
+
+    const nameInput = await screen.findByLabelText(/company name/i);
+    const saveBtn = screen.getByRole('button', { name: /save settings/i }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+
+    const user = userEvent.setup();
+    await user.type(nameInput, ' Inc.');
+
+    expect(saveBtn.disabled).toBe(false);
+    // The Company nav item flags its unsaved changes for AT via the link name.
+    expect(screen.getByRole('link', { name: /^company \(unsaved changes\)$/i })).not.toBeNull();
+  });
+
+  it('replaces the global Save button with a note on self-saving tabs', async () => {
+    render(<PartnerSettingsPage />);
+
+    await screen.findByText('Partner Settings');
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('link', { name: /^ticketing$/i }));
+
+    expect(screen.queryByRole('button', { name: /save settings/i })).toBeNull();
+    expect(screen.getByText('This section saves its own changes.')).not.toBeNull();
+  });
+
+  it('marks the active tab with aria-current and pushes the canonical kebab hash on click', async () => {
+    render(<PartnerSettingsPage />);
+
+    await screen.findByText('Partner Settings');
+    const user = userEvent.setup();
+    const eventLogsLink = screen.getByRole('link', { name: /^event logs$/i });
+    await user.click(eventLogsLink);
+
+    expect(window.location.hash).toBe('#event-logs');
+    expect(eventLogsLink.getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: /^company$/i }).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('deep-links the legacy camelCase hash to the right tab', async () => {
+    window.location.hash = '#remoteAccess';
+
+    render(<PartnerSettingsPage />);
+
+    const link = await screen.findByRole('link', { name: /^remote access$/i });
+    expect(link.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('deep-links the canonical kebab-case hash to the right tab', async () => {
+    window.location.hash = '#event-logs';
+
+    render(<PartnerSettingsPage />);
+
+    const link = await screen.findByRole('link', { name: /^event logs$/i });
+    expect(link.getAttribute('aria-current')).toBe('page');
   });
 });
 

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -1,17 +1,25 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Bell,
   Building2,
-  Clock,
   Globe,
   Loader2,
+  LogIn,
+  MonitorSmartphone,
+  Palette,
   Save,
+  ScrollText,
+  Shield,
+  SlidersHorizontal,
+  Ticket,
+  Wallet,
+  type LucideIcon,
 } from 'lucide-react';
 import TicketingSettingsTabs from './TicketingSettingsTabs';
-import { cn } from '@/lib/utils';
+import SettingsSectionNav from './SettingsSectionNav';
 import { fetchWithAuth } from '../../stores/auth';
 import { getJwtClaims } from '../../lib/authScope';
 import { useOrgStore } from '../../stores/orgStore';
-import KnownGuestsSettings from './KnownGuestsSettings';
 import PartnerSecurityTab, { currentIpCovered } from './PartnerSecurityTab';
 import PartnerNotificationsTab from './PartnerNotificationsTab';
 import PartnerEventLogsTab from './PartnerEventLogsTab';
@@ -21,6 +29,7 @@ import PartnerBrandingTab from './PartnerBrandingTab';
 import PartnerAiBudgetsTab from './PartnerAiBudgetsTab';
 import PartnerRemoteAccessTab from './PartnerRemoteAccessTab';
 import PartnerCompanyTab from './PartnerCompanyTab';
+import PartnerRegionalTab, { DEFAULT_BUSINESS_HOURS } from './PartnerRegionalTab';
 import LoginBrandingCard from './LoginBrandingCard';
 import type {
   PartnerSettings,
@@ -55,21 +64,63 @@ type Partner = {
   createdAt: string;
 };
 
-const TABS: { key: TabKey; label: string }[] = [
-  { key: 'company', label: 'Company' },
-  { key: 'regional', label: 'Regional' },
-  { key: 'security', label: 'Security' },
-  { key: 'notifications', label: 'Notifications' },
-  { key: 'eventLogs', label: 'Event Logs' },
-  { key: 'defaults', label: 'Defaults' },
-  { key: 'branding', label: 'Branding' },
-  { key: 'loginBranding', label: 'Login Branding' },
-  { key: 'aiBudgets', label: 'AI Budgets' },
-  { key: 'remoteAccess', label: 'Remote' },
-  { key: 'ticketing', label: 'Ticketing' },
+type TabDef = {
+  key: TabKey;
+  /** Canonical URL fragment (kebab-case). Legacy camelCase keys still resolve. */
+  hash: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  /** Tab persists its own changes; the global Save button does not apply. */
+  selfSaving?: boolean;
+  /** Values set here are enforced across all organizations (inheritance banner). */
+  enforced?: boolean;
+};
+
+const TAB_GROUPS: { label: string; tabs: TabDef[] }[] = [
+  {
+    label: 'Company',
+    tabs: [
+      { key: 'company', hash: 'company', label: 'Company', description: 'Name, address, contacts', icon: Building2 },
+      { key: 'regional', hash: 'regional', label: 'Regional', description: 'Timezone, formats, hours', icon: Globe },
+      { key: 'defaults', hash: 'defaults', label: 'Defaults', description: 'Maintenance, agent pins', icon: SlidersHorizontal, enforced: true },
+    ],
+  },
+  {
+    label: 'Security & Access',
+    tabs: [
+      { key: 'security', hash: 'security', label: 'Security', description: 'IP allowlist and access', icon: Shield, enforced: true },
+      { key: 'remoteAccess', hash: 'remote-access', label: 'Remote Access', description: 'Remote desktop providers', icon: MonitorSmartphone, enforced: true },
+      { key: 'eventLogs', hash: 'event-logs', label: 'Event Logs', description: 'Forwarding and retention', icon: ScrollText, enforced: true },
+    ],
+  },
+  {
+    label: 'Communications',
+    tabs: [
+      { key: 'notifications', hash: 'notifications', label: 'Notifications', description: 'Email and webhook alerts', icon: Bell, enforced: true },
+      { key: 'ticketing', hash: 'ticketing', label: 'Ticketing', description: 'Statuses, SLAs, exports', icon: Ticket, selfSaving: true },
+      { key: 'aiBudgets', hash: 'ai-budgets', label: 'AI Budgets', description: 'AI spending limits', icon: Wallet, enforced: true },
+    ],
+  },
+  {
+    label: 'Branding',
+    tabs: [
+      { key: 'branding', hash: 'branding', label: 'Branding', description: 'Logo and colors', icon: Palette, enforced: true },
+      { key: 'loginBranding', hash: 'login-branding', label: 'Login Branding', description: 'Login page appearance', icon: LogIn, selfSaving: true },
+    ],
+  },
 ];
 
-const VALID_TAB_KEYS = TABS.map(t => t.key);
+const ALL_TABS: TabDef[] = TAB_GROUPS.flatMap(g => g.tabs);
+const TAB_BY_KEY = Object.fromEntries(ALL_TABS.map(t => [t.key, t])) as Record<TabKey, TabDef>;
+
+// Canonical kebab-case fragments plus the legacy camelCase keys this page used
+// to write (`#eventLogs`, `#remoteAccess`, ...) so old bookmarks keep working.
+const HASH_TO_TAB: Record<string, TabKey> = {};
+for (const t of ALL_TABS) {
+  HASH_TO_TAB[t.hash] = t.key;
+  HASH_TO_TAB[t.key] = t.key;
+}
 
 /**
  * Map a top-level URL hash to a partner settings tab. The Ticketing tab is
@@ -82,39 +133,14 @@ const VALID_TAB_KEYS = TABS.map(t => t.key);
 function getTabFromHash(): TabKey | null {
   if (typeof window === 'undefined') return null;
   const hash = window.location.hash.replace('#', '');
-  return (VALID_TAB_KEYS as string[]).includes(hash) ? (hash as TabKey) : null;
+  return HASH_TO_TAB[hash] ?? null;
 }
 
-const TIMEZONES = [
-  'UTC', 'America/New_York', 'America/Chicago', 'America/Denver',
-  'America/Los_Angeles', 'America/Phoenix', 'America/Anchorage',
-  'Pacific/Honolulu', 'Europe/London', 'Europe/Paris', 'Europe/Berlin',
-  'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Singapore', 'Australia/Sydney'
-];
-
-const DATE_FORMATS: { value: DateFormat; label: string }[] = [
-  { value: 'MM/DD/YYYY', label: 'MM/DD/YYYY (US)' },
-  { value: 'DD/MM/YYYY', label: 'DD/MM/YYYY (International)' },
-  { value: 'YYYY-MM-DD', label: 'YYYY-MM-DD (ISO)' }
-];
-
-const BUSINESS_HOURS_PRESETS: { value: BusinessHoursPreset; label: string; description: string }[] = [
-  { value: '24/7', label: '24/7', description: 'Always available' },
-  { value: 'business', label: 'Business Hours', description: 'Mon-Fri 9am-5pm' },
-  { value: 'extended', label: 'Extended Hours', description: 'Mon-Fri 7am-7pm, Sat 9am-1pm' },
-  { value: 'custom', label: 'Custom', description: 'Set your own schedule' }
-];
-
-const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
-const DAY_LABELS: Record<string, string> = { mon: 'Monday', tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' };
-const BH: DaySchedule = { start: '09:00', end: '17:00' };
-const BH_CLOSED: DaySchedule = { start: '09:00', end: '17:00', closed: true };
-const DEFAULT_BUSINESS_HOURS: Record<string, DaySchedule> = { mon: BH, tue: BH, wed: BH, thu: BH, fri: BH, sat: BH_CLOSED, sun: BH_CLOSED };
-
-/** Returns true if at least one value in the object is not undefined */
-function hasAnyValue(obj: object): boolean {
-  return Object.values(obj).some(v => v !== undefined);
-}
+// The per-tab keys whose form state participates in dirty tracking. Self-saving
+// tabs (Ticketing, Login Branding) persist independently and are never "dirty"
+// from this page's perspective.
+type SnapshotKey = Exclude<TabKey, 'ticketing' | 'loginBranding'>;
+type Snapshot = Record<SnapshotKey, string>;
 
 // Exported for unit-testing without mounting the full component.
 export async function runPartnerSave(
@@ -173,6 +199,55 @@ export default function PartnerSettingsPage() {
   // Registered agent/watchdog versions for the pin selectors (#2124).
   const [pinnableVersions, setPinnableVersions] = useState<PinnableVersions | null>(null);
 
+  // Dirty tracking: a per-tab serialized snapshot of the saveable form state,
+  // compared against the baseline captured after fetch (and reset after save).
+  // Drives the disabled-when-clean Save button and the per-tab dots in the nav.
+  const currentSnapshot: Snapshot = useMemo(() => ({
+    company: JSON.stringify({ companyName, address, contactName, contactEmail, contactPhone, contactWebsite }),
+    regional: JSON.stringify({ timezone, dateFormat, timeFormat, businessHoursPreset, customHours }),
+    security: JSON.stringify(securityData),
+    notifications: JSON.stringify(notificationsData),
+    eventLogs: JSON.stringify(eventLogsData),
+    defaults: JSON.stringify(defaultsData),
+    branding: JSON.stringify(brandingData),
+    aiBudgets: JSON.stringify(aiBudgetsData),
+    remoteAccess: JSON.stringify(remoteAccessData),
+  }), [
+    companyName, address, contactName, contactEmail, contactPhone, contactWebsite,
+    timezone, dateFormat, timeFormat, businessHoursPreset, customHours,
+    securityData, notificationsData, eventLogsData, defaultsData, brandingData,
+    aiBudgetsData, remoteAccessData,
+  ]);
+  const [baseline, setBaseline] = useState<Snapshot | null>(null);
+  // fetchPartner can't read the state it just set (updates are async), so it
+  // raises this flag and the every-render effect below captures the snapshot
+  // of the very next render — which reflects the freshly fetched values.
+  const baselinePending = useRef(false);
+  useEffect(() => {
+    if (baselinePending.current) {
+      baselinePending.current = false;
+      setBaseline(currentSnapshot);
+    }
+  });
+
+  const dirtyTabs: Partial<Record<TabKey, boolean>> = useMemo(() => {
+    if (!baseline) return {};
+    const dirty: Partial<Record<TabKey, boolean>> = {};
+    for (const key of Object.keys(currentSnapshot) as SnapshotKey[]) {
+      dirty[key] = currentSnapshot[key] !== baseline[key];
+    }
+    return dirty;
+  }, [currentSnapshot, baseline]);
+  const isDirty = Object.values(dirtyTabs).some(Boolean);
+
+  // Warn before a full navigation away discards unsaved edits.
+  useEffect(() => {
+    if (!isDirty) return;
+    const warn = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [isDirty]);
+
   const fetchPartner = useCallback(async () => {
     try {
       setLoading(true);
@@ -211,6 +286,9 @@ export default function PartnerSettingsPage() {
       setBrandingData(settings.branding || {});
       setAiBudgetsData(settings.aiBudgets || {});
       setRemoteAccessData(settings.remoteAccessProviders || {});
+
+      // Re-baseline dirty tracking against the values that were just fetched.
+      baselinePending.current = true;
 
       // Best-effort: IP allowlist status for the editor (non-blocking). On
       // failure we flag it explicitly so the editor can warn rather than
@@ -255,7 +333,7 @@ export default function PartnerSettingsPage() {
   // `/settings/partner#ticketing`, which the legacy `/settings/ticketing` route
   // redirects to). Seeded SSR-safe via the 'company' default above; the hash is
   // applied client-side here to avoid a hydration mismatch. Also tracks external
-  // hash changes (back/forward, in-app links).
+  // hash changes (back/forward, in-app links, the nav anchors below).
   useEffect(() => {
     const applyHash = () => {
       const tab = getTabFromHash();
@@ -265,6 +343,14 @@ export default function PartnerSettingsPage() {
     window.addEventListener('hashchange', applyHash);
     return () => window.removeEventListener('hashchange', applyHash);
   }, []);
+
+  // Activate a tab and push its canonical hash so the URL stays bookmarkable
+  // and browser back/forward walks the visited tabs.
+  const navigateToTab = (key: TabKey) => {
+    setActiveTab(key);
+    const canonical = `#${TAB_BY_KEY[key].hash}`;
+    if (window.location.hash !== canonical) window.location.hash = canonical;
+  };
 
   const handleSave = async () => {
     // Block a malformed maintenance window client-side (issue #1963) so the
@@ -339,6 +425,8 @@ export default function PartnerSettingsPage() {
         onUnauthorized: () => { void navigateTo('/login', { replace: true }); },
       });
       setPartner(updated);
+      // The just-sent values are now the persisted state.
+      setBaseline(currentSnapshot);
     } catch (err) {
       if (err instanceof ActionError && err.status === 401) return;
       if (!(err instanceof ActionError)) {
@@ -409,8 +497,10 @@ export default function PartnerSettingsPage() {
     );
   }
 
+  const activeDef = TAB_BY_KEY[activeTab];
+
   return (
-    <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Partner Settings</h1>
@@ -418,11 +508,17 @@ export default function PartnerSettingsPage() {
             Configure defaults for {partner?.name || 'your MSP'}.
           </p>
         </div>
-        <button type="button" onClick={handleSave} disabled={saving}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50">
-          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-          {saving ? 'Saving...' : 'Save Settings'}
-        </button>
+        {activeDef.selfSaving ? (
+          <p className="self-center text-sm text-muted-foreground">
+            This section saves its own changes.
+          </p>
+        ) : (
+          <button type="button" onClick={handleSave} disabled={saving || !isDirty}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50">
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            {saving ? 'Saving...' : 'Save Settings'}
+          </button>
+        )}
       </header>
 
       {error && (
@@ -431,229 +527,123 @@ export default function PartnerSettingsPage() {
         </div>
       )}
 
-      {/* Tab Navigation */}
-      <div className="flex gap-1 border-b overflow-x-auto">
-        {TABS.map(tab => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => {
-              setActiveTab(tab.key);
-              // Keep the URL hash in sync so the tab is bookmarkable / deep-linkable.
-              history.replaceState(null, '', `#${tab.key}`);
-            }}
-            className={cn(
-              'px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
-              activeTab === tab.key
-                ? 'border-primary text-primary'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {activeTab !== 'regional' && activeTab !== 'company' && activeTab !== 'ticketing' && activeTab !== 'loginBranding' && (
-        <div className="rounded-md border bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-700 dark:text-blue-300">
-          Values you set here are enforced across all organizations. Leave fields empty to let each organization configure individually.
-        </div>
-      )}
-
-      {/* Company Tab */}
-      {activeTab === 'company' && (
-        <PartnerCompanyTab
-          name={companyName}
-          address={address}
-          contact={{
-            name: contactName,
-            email: contactEmail,
-            phone: contactPhone,
-            website: contactWebsite,
-          }}
-          onNameChange={setCompanyName}
-          onAddressChange={setAddress}
-          onContactChange={(c) => {
-            setContactName(c.name || '');
-            setContactEmail(c.email || '');
-            setContactPhone(c.phone || '');
-            setContactWebsite(c.website || '');
-          }}
+      <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <SettingsSectionNav
+          groups={TAB_GROUPS.map(group => ({
+            label: group.label,
+            items: group.tabs.map(tab => ({ ...tab, dirty: !!dirtyTabs[tab.key] })),
+          }))}
+          activeKey={activeTab}
+          onNavigate={key => navigateToTab(key as TabKey)}
+          selectId="partner-settings-section"
         />
-      )}
 
-      {/* Regional Tab */}
-      {activeTab === 'regional' && (
-        <>
-          <section className="rounded-lg border bg-card p-6 shadow-xs">
-            <div className="mb-6">
-              <div className="flex items-center gap-2">
-                <Globe className="h-5 w-5 text-muted-foreground" />
-                <h2 className="text-lg font-semibold">Regional Settings</h2>
-              </div>
-              <p className="mt-1 text-sm text-muted-foreground">
-                These defaults apply to new organizations and sites.
+        <div className="min-w-0 space-y-6">
+          {activeDef.enforced && (
+            <div className="rounded-md border bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-700 dark:text-blue-300">
+              Values you set here are enforced across all organizations. Leave fields empty to let each organization configure individually.
+            </div>
+          )}
+
+          {/* Company Tab */}
+          {activeTab === 'company' && (
+            <PartnerCompanyTab
+              name={companyName}
+              address={address}
+              contact={{
+                name: contactName,
+                email: contactEmail,
+                phone: contactPhone,
+                website: contactWebsite,
+              }}
+              onNameChange={setCompanyName}
+              onAddressChange={setAddress}
+              onContactChange={(c) => {
+                setContactName(c.name || '');
+                setContactEmail(c.email || '');
+                setContactPhone(c.phone || '');
+                setContactWebsite(c.website || '');
+              }}
+            />
+          )}
+
+          {/* Regional Tab */}
+          {activeTab === 'regional' && (
+            <PartnerRegionalTab
+              timezone={timezone}
+              dateFormat={dateFormat}
+              timeFormat={timeFormat}
+              businessHoursPreset={businessHoursPreset}
+              customHours={customHours}
+              onTimezoneChange={setTimezone}
+              onDateFormatChange={setDateFormat}
+              onTimeFormatChange={setTimeFormat}
+              onBusinessHoursPresetChange={setBusinessHoursPreset}
+              onCustomHoursChange={updateCustomHours}
+            />
+          )}
+
+          {/* Inheritable Settings Tabs */}
+          {activeTab === 'security' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerSecurityTab data={securityData} onChange={setSecurityData} status={ipStatus} statusUnavailable={ipStatusUnavailable} />
+            </section>
+          )}
+
+          {activeTab === 'notifications' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerNotificationsTab data={notificationsData} onChange={setNotificationsData} />
+            </section>
+          )}
+
+          {activeTab === 'eventLogs' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerEventLogsTab data={eventLogsData} onChange={setEventLogsData} />
+            </section>
+          )}
+
+          {activeTab === 'defaults' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerDefaultsTab data={defaultsData} onChange={setDefaultsData} pinnableVersions={pinnableVersions} />
+            </section>
+          )}
+
+          {activeTab === 'branding' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerBrandingTab data={brandingData} onChange={setBrandingData} />
+            </section>
+          )}
+
+          {/* Login Branding: self-contained card with its own load/save (the
+              top-level "Save Settings" button does not apply here). */}
+          {activeTab === 'loginBranding' && <LoginBrandingCard />}
+
+          {activeTab === 'aiBudgets' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} />
+            </section>
+          )}
+
+          {activeTab === 'remoteAccess' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerRemoteAccessTab data={remoteAccessData} onChange={setRemoteAccessData} />
+            </section>
+          )}
+
+          {/* Ticketing: partner-wide statuses, priority SLAs, categories, and billing
+              export. Each sub-tab persists independently, so the top-level "Save
+              Settings" button does not apply here. */}
+          {activeTab === 'ticketing' && (
+            <section className="space-y-2" data-testid="partner-ticketing-tab">
+              <p className="text-sm text-muted-foreground">
+                Configure ticket statuses, priority SLA defaults, categories, and billing exports.
+                These apply across all of your organizations.
               </p>
-            </div>
-            <div className="grid gap-6 sm:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Timezone</label>
-                <select value={timezone} onChange={e => setTimezone(e.target.value)}
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm">
-                  {TIMEZONES.map(tz => <option key={tz} value={tz}>{tz}</option>)}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Date Format</label>
-                <select value={dateFormat} onChange={e => setDateFormat(e.target.value as DateFormat)}
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm">
-                  {DATE_FORMATS.map(fmt => <option key={fmt.value} value={fmt.value}>{fmt.label}</option>)}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Time Format</label>
-                <div className="flex gap-4">
-                  <label className="flex items-center gap-2">
-                    <input type="radio" name="timeFormat" checked={timeFormat === '12h'}
-                      onChange={() => setTimeFormat('12h')} className="h-4 w-4" />
-                    <span className="text-sm">12-hour</span>
-                  </label>
-                  <label className="flex items-center gap-2">
-                    <input type="radio" name="timeFormat" checked={timeFormat === '24h'}
-                      onChange={() => setTimeFormat('24h')} className="h-4 w-4" />
-                    <span className="text-sm">24-hour</span>
-                  </label>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Language</label>
-                <div className="flex h-10 w-full items-center rounded-md border bg-muted px-3 text-sm text-muted-foreground">
-                  English
-                </div>
-                <p className="text-xs text-muted-foreground">Default language for partner settings.</p>
-              </div>
-            </div>
-          </section>
-
-          {/* Business Hours */}
-          <section className="rounded-lg border bg-card p-6 shadow-xs">
-            <div className="mb-6">
-              <div className="flex items-center gap-2">
-                <Clock className="h-5 w-5 text-muted-foreground" />
-                <h2 className="text-lg font-semibold">Business Hours</h2>
-              </div>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Set your standard operating hours for support and alerts.
-              </p>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                {BUSINESS_HOURS_PRESETS.map(preset => (
-                  <label key={preset.value}
-                    className={`cursor-pointer rounded-lg border p-4 transition ${
-                      businessHoursPreset === preset.value
-                        ? 'border-primary bg-primary/5' : 'hover:border-muted-foreground/50'
-                    }`}>
-                    <input type="radio" name="businessHoursPreset" value={preset.value}
-                      checked={businessHoursPreset === preset.value}
-                      onChange={() => setBusinessHoursPreset(preset.value)} className="sr-only" />
-                    <div className="font-medium">{preset.label}</div>
-                    <div className="text-xs text-muted-foreground">{preset.description}</div>
-                  </label>
-                ))}
-              </div>
-              {businessHoursPreset === 'custom' && (
-                <div className="mt-4 space-y-3 rounded-lg border bg-muted/40 p-4">
-                  <p className="text-sm font-medium">Custom Schedule</p>
-                  {DAYS.map(day => (
-                    <div key={day} className="flex items-center gap-4">
-                      <div className="w-24 text-sm font-medium">{DAY_LABELS[day]}</div>
-                      <label className="flex items-center gap-2">
-                        <input type="checkbox" checked={!customHours[day]?.closed}
-                          onChange={e => updateCustomHours(day, 'closed', !e.target.checked)} className="h-4 w-4" />
-                        <span className="text-sm">Open</span>
-                      </label>
-                      {!customHours[day]?.closed && (
-                        <>
-                          <input type="time" value={customHours[day]?.start || '09:00'}
-                            onChange={e => updateCustomHours(day, 'start', e.target.value)}
-                            className="h-8 rounded-md border bg-background px-2 text-sm" />
-                          <span className="text-sm text-muted-foreground">to</span>
-                          <input type="time" value={customHours[day]?.end || '17:00'}
-                            onChange={e => updateCustomHours(day, 'end', e.target.value)}
-                            className="h-8 rounded-md border bg-background px-2 text-sm" />
-                        </>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </section>
-
-          <KnownGuestsSettings />
-        </>
-      )}
-
-      {/* Inheritable Settings Tabs */}
-      {activeTab === 'security' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerSecurityTab data={securityData} onChange={setSecurityData} status={ipStatus} statusUnavailable={ipStatusUnavailable} />
-        </section>
-      )}
-
-      {activeTab === 'notifications' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerNotificationsTab data={notificationsData} onChange={setNotificationsData} />
-        </section>
-      )}
-
-      {activeTab === 'eventLogs' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerEventLogsTab data={eventLogsData} onChange={setEventLogsData} />
-        </section>
-      )}
-
-      {activeTab === 'defaults' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerDefaultsTab data={defaultsData} onChange={setDefaultsData} pinnableVersions={pinnableVersions} />
-        </section>
-      )}
-
-      {activeTab === 'branding' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerBrandingTab data={brandingData} onChange={setBrandingData} />
-        </section>
-      )}
-
-      {/* Login Branding: self-contained card with its own load/save (the
-          top-level "Save Settings" button does not apply here). */}
-      {activeTab === 'loginBranding' && <LoginBrandingCard />}
-
-      {activeTab === 'aiBudgets' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} />
-        </section>
-      )}
-
-      {activeTab === 'remoteAccess' && (
-        <section className="rounded-lg border bg-card p-6 shadow-xs">
-          <PartnerRemoteAccessTab data={remoteAccessData} onChange={setRemoteAccessData} />
-        </section>
-      )}
-
-      {/* Ticketing: partner-wide statuses, priority SLAs, categories, and billing
-          export. Each sub-tab persists independently, so the top-level "Save
-          Settings" button does not apply here. */}
-      {activeTab === 'ticketing' && (
-        <section className="space-y-2" data-testid="partner-ticketing-tab">
-          <p className="text-sm text-muted-foreground">
-            Configure ticket statuses, priority SLA defaults, categories, and billing exports.
-            These apply across all of your organizations.
-          </p>
-          <TicketingSettingsTabs syncHash={false} initialTab={deepLinkTicketMailbox ? 'inbound' : undefined} />
-        </section>
-      )}
+              <TicketingSettingsTabs syncHash={false} initialTab={deepLinkTicketMailbox ? 'inbound' : undefined} />
+            </section>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/SettingsSectionNav.tsx
+++ b/apps/web/src/components/settings/SettingsSectionNav.tsx
@@ -1,0 +1,108 @@
+import { type LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type SettingsNavItem = {
+  /** Stable key identifying the section (used as the select value). */
+  key: string;
+  /** Canonical URL fragment for deep-linking (kebab-case). */
+  hash: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  /** Section has unsaved changes — shows a dot and announces it to AT. */
+  dirty?: boolean;
+};
+
+export type SettingsNavGroup = {
+  label: string;
+  items: SettingsNavItem[];
+};
+
+type SettingsSectionNavProps = {
+  groups: SettingsNavGroup[];
+  activeKey: string;
+  /** Activate a section. The caller owns state + pushing the URL hash. */
+  onNavigate: (key: string) => void;
+  /** Unique id for the compact mobile select (label association). */
+  selectId: string;
+};
+
+/**
+ * Shared grouped sidebar for the big settings surfaces (Partner Settings,
+ * Organization Settings). Renders a descriptive rail at lg+ (real anchors so
+ * middle-click / copy-link work) and collapses to a compact select below lg —
+ * the full rail would otherwise stack ~600px of nav above the content.
+ */
+export default function SettingsSectionNav({ groups, activeKey, onNavigate, selectId }: SettingsSectionNavProps) {
+  return (
+    <div>
+      <div className="lg:hidden">
+        <label htmlFor={selectId} className="sr-only">Settings section</label>
+        <select
+          id={selectId}
+          value={activeKey}
+          onChange={e => onNavigate(e.target.value)}
+          className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+        >
+          {groups.map(group => (
+            <optgroup key={group.label} label={group.label}>
+              {group.items.map(item => (
+                <option key={item.key} value={item.key}>
+                  {item.label}{item.dirty ? ' •' : ''}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+
+      <nav aria-label="Settings sections" className="hidden lg:block lg:sticky lg:top-6 space-y-4">
+        {groups.map(group => (
+          <div key={group.label}>
+            <p className="px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {group.label}
+            </p>
+            <ul className="mt-2 space-y-1">
+              {group.items.map(item => {
+                const Icon = item.icon;
+                const isActive = activeKey === item.key;
+                return (
+                  <li key={item.key}>
+                    <a
+                      href={`#${item.hash}`}
+                      aria-current={isActive ? 'page' : undefined}
+                      aria-label={item.dirty ? `${item.label} (unsaved changes)` : item.label}
+                      onClick={e => {
+                        // Let modified clicks do their native thing (new tab, etc.).
+                        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                        e.preventDefault();
+                        onNavigate(item.key);
+                      }}
+                      className={cn(
+                        'flex items-start gap-3 rounded-md px-3 py-2 text-sm transition-colors',
+                        isActive
+                          ? 'bg-muted font-semibold text-foreground'
+                          : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                      )}
+                    >
+                      <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block">{item.label}</span>
+                        <span className="block text-xs font-normal text-muted-foreground">
+                          {item.description}
+                        </span>
+                      </span>
+                      {item.dirty && (
+                        <span aria-hidden="true" className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                      )}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -32,6 +32,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/AlertsPage.tsx',
   'src/components/alerts/AlertDetailPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
+  'src/components/settings/OrgSettingsPage.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
   'src/components/patches/PatchesPage.tsx',
   'src/components/settings/RolesPage.tsx',
@@ -275,7 +276,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(56);
+    expect(absoluteFiles.length).toBe(57);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }


### PR DESCRIPTION
## Summary

A community user reported the Partner Settings tab bar scrolling horizontally while the UI had unused width. Root cause: 11 tabs in an `overflow-x-auto` row inside a `max-w-4xl` container. Rather than patch the tab bar, this converts Partner Settings to the sidebar layout Organization Settings already uses — and fixes the weaknesses a design critique found in that sidebar before adopting it, on both pages.

## Partner Settings

- Grouped sidebar nav (Company / Security & Access / Communications / Branding) with icons + one-line descriptions, via the new shared `SettingsSectionNav`
- Real `<a href="#…">` nav items — middle-click/copy-link work, `aria-current="page"`, labeled `<nav>`
- Per-tab **dirty dots**; global Save is **disabled when clean** and **hidden on self-saving tabs** (Ticketing, Login Branding — previously the button rendered there and silently saved *other* tabs' data)
- `beforeunload` guard when dirty
- Canonical kebab-case hashes (`#event-logs`, `#remote-access`, …) with legacy camelCase fragments still honored; pushState history so back/forward walk visited tabs
- Compact grouped `<select>` below `lg` (no more 600px of stacked nav), sticky rail at `lg+`, `max-w-4xl` → `max-w-6xl`
- Regional tab extracted to `PartnerRegionalTab.tsx`; "Remote" renamed "Remote Access"
- "Enforced across all organizations" banner driven by a tab-definition property instead of a hand-maintained exclusion list

## Organization Settings (parity + honesty fixes)

- Same grouped rail via `SettingsSectionNav` (Organization / Portal & Branding / Security & Access / Communications); Approval Security gets a distinct icon instead of duplicating Security's Shield
- **Removed the fabricated "Saved at 12:00" status pill** — the pill now renders only when there are real unsaved edits or an actual save happened (real time, locale-respecting)
- **Tab switches no longer silently discard unsaved editor state** — confirm dialog before discarding, dirty flag cleared on confirmed discard, banner names the dirty section, dirty dot on the nav item, `beforeunload` guard
- **Failed saves no longer wipe the page** — full-page error only when the initial load fails; save failures render an inline banner with form state intact
- Section saves and org-type save routed through `runAction` (success/error toasts); `OrgSettingsPage.tsx` added to the `no-silent-mutations` adopted set (56 → 57)
- Hash read moved out of the `useState` initializer (hydration-mismatch risk) to the client-side effect pattern

## Testing

- 45 settings test files / 333 tests green, including 9 new tests (dirty contract, self-saving tabs, legacy + canonical deep-links, `aria-current`, no-fabricated-timestamp, mobile select)
- `no-silent-mutations` guard green; `tsc --noEmit` clean
- Verified live in an isolated worktree stack via Playwright on both pages: tab switching, hash deep-links, back/forward, dirty→save→clean cycle with toasts, confirm-before-discard, sticky rail, and the narrow-viewport select (no horizontal scroll at any width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)