### PR TITLE
fix(sso): org SSO under RLS on public routes + identity/cascade hardening (#2195)

### DIFF
--- a/apps/api/migrations/2026-07-04-user-sso-identities-unique-external.sql
+++ b/apps/api/migrations/2026-07-04-user-sso-identities-unique-external.sql
@@ -6,6 +6,30 @@
 -- login in production-shaped deployments (bare read under FORCED RLS always
 -- 0-rowed, so the UPDATE branch was unreachable — see #2195).
 --
+-- Forensics BEFORE the dedupe: a duplicate whose rows span DIFFERENT users is
+-- not returning-login noise — it's evidence the TOCTOU race actually fired
+-- (two users linked to one IdP subject: identity confusion). The dedupe below
+-- resolves it by keeping the freshest row, which silently revokes the other
+-- user's link — so record exactly which identities collided, per row group,
+-- before anything is deleted. Idempotent: after the dedupe runs once, no
+-- group can span two users, so re-runs log nothing.
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT provider_id, external_id,
+           array_agg(DISTINCT user_id) AS user_ids,
+           count(*) AS row_count
+    FROM user_sso_identities
+    GROUP BY provider_id, external_id
+    HAVING count(DISTINCT user_id) > 1
+  LOOP
+    RAISE WARNING 'user_sso_identities CROSS-USER identity collision (investigate, #2195): provider=% external_id=% user_ids=% rows=% — dedupe keeps the freshest row and revokes the other user''s link',
+      rec.provider_id, rec.external_id, rec.user_ids, rec.row_count;
+  END LOOP;
+END $$;
+
 -- Dedupe BEFORE adding the index: keep, per (provider_id, external_id), the
 -- row with the freshest tokens (last_login_at DESC NULLS LAST, then
 -- created_at DESC, then id as a stable tiebreak) and delete the rest,

--- a/apps/api/migrations/2026-07-04-user-sso-identities-unique-external.sql
+++ b/apps/api/migrations/2026-07-04-user-sso-identities-unique-external.sql
@@ -1,0 +1,35 @@
+-- #2195: enforce one identity link per (provider_id, external_id) at the DB
+-- layer. The identity-in-use check in the SSO callback link flow was
+-- code-only (TOCTOU): two concurrent callbacks could both pass the check and
+-- insert the same (provider, subject) pair for different users. The callback
+-- login path additionally duplicated the SAME user's link on every returning
+-- login in production-shaped deployments (bare read under FORCED RLS always
+-- 0-rowed, so the UPDATE branch was unreachable — see #2195).
+--
+-- Dedupe BEFORE adding the index: keep, per (provider_id, external_id), the
+-- row with the freshest tokens (last_login_at DESC NULLS LAST, then
+-- created_at DESC, then id as a stable tiebreak) and delete the rest,
+-- reporting the count so the forensic trail lands in Postgres logs.
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+             PARTITION BY provider_id, external_id
+             ORDER BY last_login_at DESC NULLS LAST, created_at DESC, id DESC
+           ) AS rn
+    FROM user_sso_identities
+  )
+  DELETE FROM user_sso_identities u
+  USING ranked r
+  WHERE u.id = r.id AND r.rn > 1;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'cleaned % duplicate user_sso_identities rows (returning-login duplicates from the #2195 bare-RLS-read bug)', n;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_sso_identities_provider_external_idx
+  ON user_sso_identities (provider_id, external_id);

--- a/apps/api/src/__tests__/integration/ssoIdentityDedupeMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoIdentityDedupeMigration.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Replays the 2026-07-04-user-sso-identities-unique-external.sql migration
+ * against DIRTY data (#2195).
+ *
+ * CI databases are always created schema-fresh, so the migration's dedupe
+ * DO-block — whose entire purpose is cleaning up the duplicate rows the
+ * pre-#2195 returning-login bug produced in production — would otherwise
+ * never execute against non-empty data. This test drops the unique index,
+ * seeds the exact duplicate shape the bug created, re-runs the REAL
+ * migration file from disk, and asserts the freshest row per
+ * (provider_id, external_id) survives.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/ssoIdentityDedupeMigration.integration.test.ts
+ */
+import './setup';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { sql, and, eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { ssoProviders, userSsoIdentities, users } from '../../db/schema';
+import { createPartner } from './db-utils';
+
+const MIGRATION_FILE = join(__dirname, '../../../migrations/2026-07-04-user-sso-identities-unique-external.sql');
+
+describe('user_sso_identities dedupe migration replay (#2195)', () => {
+  it('keeps the freshest row per (provider_id, external_id), drops the rest, and restores the unique index', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const [provider] = await db
+      .insert(ssoProviders)
+      .values({
+        partnerId: partner.id,
+        orgId: null,
+        name: 'Dedupe IdP',
+        type: 'oidc',
+        status: 'active',
+        issuer: 'https://idp.dedupe.test',
+        clientId: 'dedupe-client',
+        autoProvision: false,
+      })
+      .returning();
+    const [user] = await db
+      .insert(users)
+      .values({
+        partnerId: partner.id,
+        orgId: null,
+        email: `dedupe-${randomUUID()}@example.com`,
+        name: 'Dedupe User',
+        passwordHash: null,
+        status: 'active',
+      })
+      .returning();
+    if (!provider || !user) throw new Error('fixture seed failed');
+
+    // Recreate the pre-migration world: no unique index, duplicate links.
+    await db.execute(sql`DROP INDEX IF EXISTS user_sso_identities_provider_external_idx`);
+
+    const mkRow = (lastLoginAt: Date | null, createdAt: Date, marker: string) =>
+      db.insert(userSsoIdentities).values({
+        userId: user.id,
+        providerId: provider.id,
+        externalId: 'dedupe-sub',
+        email: user.email,
+        accessToken: marker, // marker to identify the surviving row
+        lastLoginAt,
+        createdAt,
+      });
+
+    // The bug inserted one row per returning login. Survivor must be the one
+    // with the freshest last_login_at (NULLS LAST), created_at as tiebreak.
+    await mkRow(new Date('2026-06-01T00:00:00Z'), new Date('2026-05-01T00:00:00Z'), 'stale');
+    await mkRow(new Date('2026-07-01T00:00:00Z'), new Date('2026-04-01T00:00:00Z'), 'freshest');
+    await mkRow(null, new Date('2026-07-02T00:00:00Z'), 'never-logged-in');
+
+    // Replay the REAL migration file (multi-statement: DO-block + CREATE INDEX).
+    await db.execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+
+    const rows = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(and(
+        eq(userSsoIdentities.providerId, provider.id),
+        eq(userSsoIdentities.externalId, 'dedupe-sub')
+      ));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.accessToken).toBe('freshest');
+
+    // The unique index is back and enforcing.
+    await expect(
+      db.insert(userSsoIdentities).values({
+        userId: user.id,
+        providerId: provider.id,
+        externalId: 'dedupe-sub',
+        email: user.email,
+      })
+    ).rejects.toMatchObject({ cause: { code: '23505' } });
+
+    // Idempotency: re-applying the migration on clean data is a no-op.
+    await expect(db.execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')))).resolves.toBeDefined();
+  });
+
+  it('resolves a CROSS-USER collision (the fired TOCTOU race) by keeping the freshest link', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const [provider] = await db
+      .insert(ssoProviders)
+      .values({
+        partnerId: partner.id,
+        orgId: null,
+        name: 'Collision IdP',
+        type: 'oidc',
+        status: 'active',
+        issuer: 'https://idp.collision.test',
+        clientId: 'collision-client',
+        autoProvision: false,
+      })
+      .returning();
+    const mkUser = (tag: string) =>
+      db.insert(users).values({
+        partnerId: partner.id,
+        orgId: null,
+        email: `collision-${tag}-${randomUUID()}@example.com`,
+        name: `Collision ${tag}`,
+        passwordHash: null,
+        status: 'active',
+      }).returning();
+    const [[userA], [userB]] = await Promise.all([mkUser('a'), mkUser('b')]);
+    if (!provider || !userA || !userB) throw new Error('fixture seed failed');
+
+    await db.execute(sql`DROP INDEX IF EXISTS user_sso_identities_provider_external_idx`);
+    await db.insert(userSsoIdentities).values({
+      userId: userA.id,
+      providerId: provider.id,
+      externalId: 'collision-sub',
+      email: userA.email,
+      lastLoginAt: new Date('2026-06-01T00:00:00Z'),
+    });
+    await db.insert(userSsoIdentities).values({
+      userId: userB.id,
+      providerId: provider.id,
+      externalId: 'collision-sub',
+      email: userB.email,
+      lastLoginAt: new Date('2026-07-01T00:00:00Z'),
+    });
+
+    await db.execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+
+    // userB's link (freshest last_login_at) survives; userA's is revoked.
+    // The migration RAISE WARNINGs the collision with both user ids first —
+    // visible in Postgres logs, not assertable from here.
+    const rows = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(and(
+        eq(userSsoIdentities.providerId, provider.id),
+        eq(userSsoIdentities.externalId, 'collision-sub')
+      ));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.userId).toBe(userB.id);
+  });
+});

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -102,7 +102,7 @@ async function createPartnerAxisProvider(
 /** Org-axis sibling of createPartnerAxisProvider (#2195). */
 async function createOrgAxisProvider(
   orgId: string,
-  opts: { status?: 'active' | 'inactive' | 'testing'; enforceSSO?: boolean } = {},
+  opts: { status?: 'active' | 'inactive' | 'testing'; enforceSSO?: boolean; name?: string; createdAt?: Date } = {},
 ) {
   const db = getTestDb();
   const [row] = await db
@@ -110,9 +110,10 @@ async function createOrgAxisProvider(
     .values({
       orgId,
       partnerId: null,
-      name: 'Org Test IdP',
+      name: opts.name ?? 'Org Test IdP',
       type: 'oidc',
       status: opts.status ?? 'active',
+      ...(opts.createdAt ? { createdAt: opts.createdAt } : {}),
       issuer: ISSUER,
       clientId: 'test-client-id',
       clientSecret: encryptSecret('test-client-secret'),
@@ -183,7 +184,17 @@ function buildTestSsoStateCookie(state: string): string {
 describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', () => {
   let app: Hono;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Flush the SSO login rate-limit buckets between tests: the pure-IP
+    // bucket (sso:login:ip:*, 30/5min) is shared across BOTH initiation
+    // routes and real Redis persists across test files — enough accumulated
+    // initiations in one CI window would start 429ing unrelated tests.
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (redis) {
+      const keys = await redis.keys('sso:login:*');
+      if (keys.length > 0) await redis.del(...keys);
+    }
     app = new Hono();
     app.route('/sso', ssoRoutes);
     // Mounted for the enforceSSO-non-suppression case below, which drives a
@@ -743,6 +754,25 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     expect(rows).toHaveLength(1);
     expect(rows[0]?.userId).toBe(user.id);
     expect(rows[0]?.lastLoginAt).not.toBeNull();
+  });
+
+  it('#2195: with two active providers, /check and /login/:orgId agree on the OLDEST one (deterministic ORDER BY)', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // Insert the NEWER provider first so a "first row wins" accident (insert
+    // order / physical order) picks the wrong one without the ORDER BY.
+    await createOrgAxisProvider(org.id, { name: 'Newer IdP', createdAt: new Date('2026-02-01T00:00:00Z') });
+    const older = await createOrgAxisProvider(org.id, { name: 'Older IdP', createdAt: new Date('2026-01-01T00:00:00Z') });
+
+    const checkRes = await app.request(`/sso/check/${org.id}`);
+    expect(checkRes.status).toBe(200);
+    const checkBody = await checkRes.json();
+    expect(checkBody.provider?.id).toBe(older.id);
+
+    const { state } = await initiateOrgLogin(app, org.id);
+    const db = getTestDb();
+    const [sessionRow] = await db.select().from(ssoSessions).where(eq(ssoSessions.state, state)).limit(1);
+    expect(sessionRow?.providerId).toBe(older.id);
   });
 
   it('#2195: the DB unique index rejects a second (provider_id, external_id) link outright (23505)', async () => {

--- a/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
@@ -11,15 +11,17 @@
  * limiting) is real, the same pattern used by routes/sso.test.ts's mocked-db
  * unit suite but here against the genuine `breeze_app` RLS-enforced pool.
  *
- * Also includes ONE org-axis callback case (see "org-axis callback" test
- * below) to regression-lock the TWO `withSystemDbAccessContext` fixes to
- * the callback's shared plumbing (the provider read, and the org-membership
- * read in the org branch of the token-payload switch) — both are shared by
- * BOTH axes, so a partner-only suite wouldn't catch a regression on the org
- * side. That case seeds `sso_sessions` directly rather than going through
- * `GET /sso/login/:orgId`, because that route's own provider read is a
- * SEPARATE, still-pre-existing, unfixed bare-db bug (see PR description)
- * that always 404s independent of the callback fixes.
+ * Also includes org-axis coverage: ONE callback-only case (see "org-axis
+ * callback" test below) regression-locking the TWO `withSystemDbAccessContext`
+ * fixes to the callback's shared plumbing (the provider read, and the
+ * org-membership read in the org branch of the token-payload switch) — both
+ * shared by BOTH axes, so a partner-only suite wouldn't catch a regression on
+ * the org side. That case seeds `sso_sessions` directly to keep the callback
+ * isolated from the initiation route. The FULL org path — GET /sso/check/:orgId
+ * → GET /sso/login/:orgId → callback — is covered by the #2195 tests below,
+ * which regression-lock the initiation/check system-context fixes (those
+ * routes' bare reads 0-rowed under breeze_app RLS, so org SSO could never
+ * even start in production-shaped deployments).
  *
  * Prerequisites:
  *   docker compose -f docker-compose.test.yml up -d
@@ -32,7 +34,7 @@ import './setup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { decodeJwt } from 'jose';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { createHmac } from 'crypto';
 import { getTestDb } from './setup';
 import { ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
@@ -97,6 +99,35 @@ async function createPartnerAxisProvider(
   return row;
 }
 
+/** Org-axis sibling of createPartnerAxisProvider (#2195). */
+async function createOrgAxisProvider(
+  orgId: string,
+  opts: { status?: 'active' | 'inactive' | 'testing'; enforceSSO?: boolean } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId,
+      partnerId: null,
+      name: 'Org Test IdP',
+      type: 'oidc',
+      status: opts.status ?? 'active',
+      issuer: ISSUER,
+      clientId: 'test-client-id',
+      clientSecret: encryptSecret('test-client-secret'),
+      authorizationUrl: `${ISSUER}/authorize`,
+      tokenUrl: `${ISSUER}/token`,
+      userInfoUrl: `${ISSUER}/userinfo`,
+      jwksUrl: `${ISSUER}/jwks`,
+      enforceSSO: opts.enforceSSO ?? false,
+      autoProvision: false,
+    })
+    .returning();
+  if (!row) throw new Error('failed to create org-axis provider fixture');
+  return row;
+}
+
 /** Insert a user row directly (bypassing db-utils' createUser, which always
  * hashes a password) so passwordHash can be left null for SSO-only staff. */
 async function createPasswordlessUser(opts: { partnerId: string; orgId?: string | null; email: string; name?: string }) {
@@ -140,11 +171,9 @@ function extractSsoCodeFromLocation(location: string): string {
 }
 
 /** Reproduces routes/sso.ts's buildSsoStateCookieValue (not exported) so a
- * directly-seeded session (see the org-axis test) can present a
+ * directly-seeded session (see the callback-only org-axis test) can present a
  * browser-binding cookie the callback will accept without going through the
- * real /login/:orgId route — whose OWN provider read is a separate,
- * pre-existing, unfixed bare-db bug that always 404s regardless of this
- * suite's fix (see PR description). */
+ * initiation route — keeping that case a pure callback regression lock. */
 function buildTestSsoStateCookie(state: string): string {
   const secret = process.env.APP_ENCRYPTION_KEY!;
   const value = createHmac('sha256', secret).update(`sso-login-state:${state}`).digest('hex');
@@ -448,13 +477,11 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     // `provider_not_found`; reverting the membership-read fix yields
     // `no_org_access` — neither matches the asserted `#ssoCode=` success path.
     //
-    // We can't reach this via GET /sso/login/:orgId — that route's OWN
-    // provider read is a separate, still-pre-existing, unfixed bare-db bug
-    // (see PR description) that always 404s. So the sso_sessions row is
-    // seeded directly instead (that table carries no RLS policy at all —
-    // confirmed empirically and via migration grep — so a direct insert is a
-    // faithful stand-in for what a working initiation route would have
-    // written).
+    // The sso_sessions row is seeded directly (rather than via
+    // GET /sso/login/:orgId) to keep this case a PURE callback regression
+    // lock, independent of the initiation route. The full
+    // check → initiation → callback org path is exercised by the #2195
+    // tests below.
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
     const role = await createRole({ scope: 'organization', orgId: org.id });
@@ -619,6 +646,127 @@ describe('SSO partner-axis login + Connect SSO link — real-DB e2e (#2183)', ()
     expect(body.tokens?.accessToken).toBeDefined();
     expect(body.mfaRequired).toBe(false);
   });
+
+  // ── #2195: the org-axis PUBLIC entry surface (check + initiation) ────────
+  // GET /sso/check/:orgId and GET /sso/login/:orgId read the provider (and
+  // the initiation INSERTs the sso_sessions row) with bare `db` calls until
+  // #2195: under the real breeze_app FORCED-RLS pool they silently 0-rowed,
+  // so /check always answered ssoEnabled:false and /login/:orgId always
+  // 404'd — org SSO could never even START in production-shaped deployments.
+  // These cases drive the REAL routes end-to-end against that pool.
+
+  it('#2195 org-axis: /sso/check reports the provider and /sso/login/:orgId starts a flow that completes to a minted token', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const role = await createRole({ scope: 'organization', orgId: org.id });
+    const user = await createPasswordlessUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `org-e2e-${Date.now()}@example.com`,
+    });
+    await assignUserToOrganization(user.id, org.id, role.id);
+    const provider = await createOrgAxisProvider(org.id);
+
+    // The login page's "show the SSO button?" probe.
+    const checkRes = await app.request(`/sso/check/${org.id}`);
+    expect(checkRes.status).toBe(200);
+    const checkBody = await checkRes.json();
+    expect(checkBody.ssoEnabled).toBe(true);
+    expect(checkBody.provider?.id).toBe(provider.id);
+    expect(checkBody.loginUrl).toBe(`/api/v1/sso/login/${org.id}`);
+
+    // Initiation through the real route: 302 to the IdP, session persisted,
+    // binding cookie set.
+    const { state, nonce, cookiePair } = await initiateOrgLogin(app, org.id);
+
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor('external-sub-org-e2e', user.email, nonce));
+    vi.mocked(getUserInfo).mockResolvedValue({ sub: 'external-sub-org-e2e', email: user.email, name: 'Org User' });
+
+    const callbackRes = await app.request(`/sso/callback?code=idp-auth-code&state=${state}`, {
+      headers: { cookie: cookiePair },
+    });
+    expect(callbackRes.status).toBe(302);
+    const location = callbackRes.headers.get('location');
+    expect(location).toContain('#ssoCode=');
+
+    const exchangeRes = await app.request('/sso/exchange', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: extractSsoCodeFromLocation(location!) }),
+    });
+    expect(exchangeRes.status).toBe(200);
+    const payload = decodeJwt((await exchangeRes.json()).accessToken);
+    expect(payload.scope).toBe('organization');
+    expect(payload.orgId).toBe(org.id);
+    expect(payload.sub).toBe(user.id);
+  });
+
+  it('#2195: a returning SSO login UPDATEs the identity row instead of inserting a duplicate', async () => {
+    // Shared identity block (both axes) — before #2195 the existingIdentity
+    // read sat outside the system context, always 0-rowed under RLS, and
+    // every returning login INSERTed a duplicate (provider, sub) row. The
+    // unique index added in 2026-07-04-user-sso-identities-unique-external
+    // would turn that duplicate into a hard failure; with the fix the second
+    // login must take the UPDATE branch — exactly one row, refreshed stamp.
+    const partner = await createPartner();
+    const role = await createRole({ scope: 'partner', partnerId: partner.id });
+    const user = await createPasswordlessUser({
+      partnerId: partner.id,
+      email: `returning-${Date.now()}@example.com`,
+    });
+    await assignUserToPartner(user.id, partner.id, role.id, 'all');
+    const provider = await createPartnerAxisProvider(partner.id);
+    const externalSub = `returning-sub-${Date.now()}`;
+
+    const doFullLogin = async () => {
+      const { state, nonce, cookiePair } = await initiatePartnerLogin(app, partner.id);
+      vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaimsFor(externalSub, user.email, nonce));
+      vi.mocked(getUserInfo).mockResolvedValue({ sub: externalSub, email: user.email, name: 'Tech' });
+      const res = await app.request(`/sso/callback?code=idp-auth-code&state=${state}`, {
+        headers: { cookie: cookiePair },
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('#ssoCode=');
+    };
+
+    await doFullLogin();
+    await doFullLogin();
+
+    const db = getTestDb();
+    const rows = await db
+      .select()
+      .from(userSsoIdentities)
+      .where(and(
+        eq(userSsoIdentities.providerId, provider.id),
+        eq(userSsoIdentities.externalId, externalSub)
+      ));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.userId).toBe(user.id);
+    expect(rows[0]?.lastLoginAt).not.toBeNull();
+  });
+
+  it('#2195: the DB unique index rejects a second (provider_id, external_id) link outright (23505)', async () => {
+    const partner = await createPartner();
+    const provider = await createPartnerAxisProvider(partner.id);
+    const userA = await createPasswordlessUser({ partnerId: partner.id, email: `uniq-a-${Date.now()}@example.com` });
+    const userB = await createPasswordlessUser({ partnerId: partner.id, email: `uniq-b-${Date.now()}@example.com` });
+
+    const db = getTestDb();
+    await db.insert(userSsoIdentities).values({
+      userId: userA.id,
+      providerId: provider.id,
+      externalId: 'uniq-sub',
+      email: userA.email,
+    });
+    await expect(
+      db.insert(userSsoIdentities).values({
+        userId: userB.id,
+        providerId: provider.id,
+        externalId: 'uniq-sub',
+        email: userB.email,
+      })
+    ).rejects.toMatchObject({ cause: { code: '23505' } }); // DrizzleQueryError wraps the PostgresError
+  });
 });
 
 // ── shared helpers ──────────────────────────────────────────────────────────
@@ -637,9 +785,18 @@ function idClaimsFor(sub: string, email: string, nonce: string) {
 }
 
 async function initiatePartnerLogin(app: Hono, partnerId: string): Promise<{ state: string; nonce: string; cookiePair: string }> {
-  const loginRes = await app.request(`/sso/login/partner/${partnerId}`);
+  return initiateLoginVia(app, `/sso/login/partner/${partnerId}`);
+}
+
+// Org-axis sibling (#2195): drives the real GET /sso/login/:orgId route.
+async function initiateOrgLogin(app: Hono, orgId: string): Promise<{ state: string; nonce: string; cookiePair: string }> {
+  return initiateLoginVia(app, `/sso/login/${orgId}`);
+}
+
+async function initiateLoginVia(app: Hono, path: string): Promise<{ state: string; nonce: string; cookiePair: string }> {
+  const loginRes = await app.request(path);
   if (loginRes.status !== 302) {
-    throw new Error(`expected 302 from /sso/login/partner/${partnerId}, got ${loginRes.status}: ${await loginRes.text()}`);
+    throw new Error(`expected 302 from ${path}, got ${loginRes.status}: ${await loginRes.text()}`);
   }
   const location = loginRes.headers.get('location');
   const setCookie = loginRes.headers.get('set-cookie');

--- a/apps/api/src/__tests__/integration/tenantCascadeSso.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantCascadeSso.integration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Real-DB tenant-cascade coverage for the SSO FK children (#2195).
+ *
+ * `user_sso_identities` and `sso_sessions` carry NO org_id/partner_id column —
+ * they hang off sso_providers and users. Until #2195 neither cascade cleared
+ * them, so any org (GDPR erasure) or canary partner (synthetic purge) that had
+ * ever exercised SSO failed its cascade with an FK violation on the
+ * sso_providers/users DELETEs. These cases run the REAL cascades against real
+ * Postgres with seeded SSO rows and assert they complete and sweep everything.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/tenantCascadeSso.integration.test.ts
+ */
+import './setup';
+import { randomUUID } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { organizations, partners, ssoProviders, ssoSessions, userSsoIdentities, users } from '../../db/schema';
+import { cascadeDeleteOrg, cascadeDeletePartner } from '../../services/tenantCascade';
+import { createPartner, createOrganization } from './db-utils';
+
+async function seedSsoRows(opts: { orgId?: string | null; partnerId?: string | null; userPartnerId: string; userOrgId?: string | null }) {
+  const db = getTestDb();
+  const [provider] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId: opts.orgId ?? null,
+      partnerId: opts.partnerId ?? null,
+      name: 'Cascade Test IdP',
+      type: 'oidc',
+      status: 'active',
+      issuer: 'https://idp.cascade.test',
+      clientId: 'cascade-client',
+      autoProvision: false,
+    })
+    .returning();
+  if (!provider) throw new Error('provider seed failed');
+
+  const [user] = await db
+    .insert(users)
+    .values({
+      partnerId: opts.userPartnerId,
+      orgId: opts.userOrgId ?? null,
+      email: `cascade-sso-${randomUUID()}@example.com`,
+      name: 'Cascade SSO User',
+      passwordHash: null,
+      status: 'active',
+    })
+    .returning();
+  if (!user) throw new Error('user seed failed');
+
+  await db.insert(userSsoIdentities).values({
+    userId: user.id,
+    providerId: provider.id,
+    externalId: `cascade-sub-${randomUUID()}`,
+    email: user.email,
+  });
+  await db.insert(ssoSessions).values({
+    providerId: provider.id,
+    state: randomUUID().replace(/-/g, ''),
+    nonce: 'cascade-nonce',
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+  });
+
+  return { provider, user };
+}
+
+describe('tenant cascades sweep SSO FK children (#2195)', () => {
+  it('cascadeDeleteOrg completes for an org with an SSO provider, identity link, and pending session', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const { provider } = await seedSsoRows({ orgId: org.id, userPartnerId: partner.id, userOrgId: org.id });
+
+    const stats = await cascadeDeleteOrg(org.id, randomUUID());
+
+    expect(stats.tablesDeleted['user_sso_identities']).toBe(1);
+    expect(stats.tablesDeleted['sso_sessions']).toBe(1);
+    const [orgRow] = await db.select().from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    expect(orgRow).toBeUndefined();
+    const providerRows = await db.select().from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    expect(providerRows).toHaveLength(0);
+    const sessionRows = await db.select().from(ssoSessions).where(eq(ssoSessions.providerId, provider.id));
+    expect(sessionRows).toHaveLength(0);
+  });
+
+  it('cascadeDeletePartner completes for a partner whose staff exercised partner-axis SSO', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const { provider } = await seedSsoRows({ partnerId: partner.id, userPartnerId: partner.id, userOrgId: null });
+
+    const stats = await cascadeDeletePartner(partner.id, randomUUID());
+
+    expect(stats.tablesDeleted['user_sso_identities']).toBe(1);
+    expect(stats.tablesDeleted['sso_sessions']).toBe(1);
+    expect(stats.tablesDeleted['partners']).toBe(1);
+    const [partnerRow] = await db.select().from(partners).where(eq(partners.id, partner.id)).limit(1);
+    expect(partnerRow).toBeUndefined();
+    const providerRows = await db.select().from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    expect(providerRows).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/tenantCascadeSso.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantCascadeSso.integration.test.ts
@@ -89,6 +89,47 @@ describe('tenant cascades sweep SSO FK children (#2195)', () => {
     expect(sessionRows).toHaveLength(0);
   });
 
+  // The org pre-clear is `provider_id IN (org's providers) OR user_id IN
+  // (org's users)` — these two cases each make only ONE side of the OR true,
+  // so a regression that drops either clause (or turns OR into AND) fails
+  // here even though the both-sides-true case above still passes.
+
+  it('org cascade clears an org USER\'s link to a PARTNER-axis provider (user_id clause only)', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // Provider belongs to the PARTNER (survives org erasure); the identity's
+    // user belongs to the org being erased.
+    const { provider, user } = await seedSsoRows({ partnerId: partner.id, userPartnerId: partner.id, userOrgId: org.id });
+
+    await cascadeDeleteOrg(org.id, randomUUID());
+
+    const identityRows = await db.select().from(userSsoIdentities).where(eq(userSsoIdentities.userId, user.id));
+    expect(identityRows).toHaveLength(0);
+    // The partner-axis provider is NOT the org's — it must survive.
+    const providerRows = await db.select().from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    expect(providerRows).toHaveLength(1);
+  });
+
+  it('org cascade clears a PARTNER STAFF link to the org\'s provider (provider_id clause only)', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    // Provider belongs to the org being erased; the identity's user is
+    // partner staff (org_id NULL — survives org erasure).
+    const { provider, user } = await seedSsoRows({ orgId: org.id, userPartnerId: partner.id, userOrgId: null });
+
+    await cascadeDeleteOrg(org.id, randomUUID());
+
+    const identityRows = await db.select().from(userSsoIdentities).where(eq(userSsoIdentities.providerId, provider.id));
+    expect(identityRows).toHaveLength(0);
+    const providerRows = await db.select().from(ssoProviders).where(eq(ssoProviders.id, provider.id));
+    expect(providerRows).toHaveLength(0);
+    // The staff user is not org-bound — it must survive.
+    const userRows = await db.select().from(users).where(eq(users.id, user.id));
+    expect(userRows).toHaveLength(1);
+  });
+
   it('cascadeDeletePartner completes for a partner whose staff exercised partner-axis SSO', async () => {
     const db = getTestDb();
     const partner = await createPartner();

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -61,7 +61,9 @@ export const ssoProviders = pgTable('sso_providers', {
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });
 
-// User SSO identity links
+// User SSO identity links. Unique (provider_id, external_id): one IdP subject
+// maps to at most one Breeze user — enforced at the DB layer (#2195) so the
+// callback's code-only identity-in-use check can't be raced (TOCTOU).
 export const userSsoIdentities = pgTable('user_sso_identities', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id').notNull().references(() => users.id),
@@ -82,7 +84,9 @@ export const userSsoIdentities = pgTable('user_sso_identities', {
   lastLoginAt: timestamp('last_login_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
-});
+}, (t) => ({
+  providerExternalUnique: uniqueIndex('user_sso_identities_provider_external_idx').on(t.providerId, t.externalId),
+}));
 
 // SSO Login sessions (for CSRF protection)
 export const ssoSessions = pgTable('sso_sessions', {

--- a/apps/api/src/routes/auth/loginContext.test.ts
+++ b/apps/api/src/routes/auth/loginContext.test.ts
@@ -71,17 +71,23 @@ describe('GET /auth/login-context (#2183)', () => {
     delete process.env.IS_HOSTED;
   });
 
-  it('short-circuits to all-null on a hosted instance without touching the DB (#2195)', async () => {
-    process.env.IS_HOSTED = 'true';
-    vi.mocked(db.select).mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any);
+  // Every hosted spelling the production config validator accepts must trip
+  // the guard (envFlag, not a bare === 'true') — an IS_HOSTED=1 deploy that
+  // missed the guard would publicly serve a single-partner region's branding.
+  it.each(['true', '1', 'yes', 'on'])(
+    'short-circuits to all-null on a hosted instance (IS_HOSTED=%s) without touching the DB (#2195)',
+    async (spelling) => {
+      process.env.IS_HOSTED = spelling;
+      vi.mocked(db.select).mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any);
 
-    const res = await getContext();
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ branding: null, partnerSso: null });
-    // The single-partner fast-path must never run on hosted — even a region
-    // with exactly one partner reveals nothing.
-    expect(db.select).not.toHaveBeenCalled();
-  });
+      const res = await getContext();
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ branding: null, partnerSso: null });
+      // The single-partner fast-path must never run on hosted — even a region
+      // with exactly one partner reveals nothing.
+      expect(db.select).not.toHaveBeenCalled();
+    }
+  );
 
   it('returns branding + partnerSso on a single-partner instance with both configured', async () => {
     vi.mocked(db.select)

--- a/apps/api/src/routes/auth/loginContext.test.ts
+++ b/apps/api/src/routes/auth/loginContext.test.ts
@@ -39,15 +39,20 @@ import { captureException } from '../../services/sentry';
 const PARTNER_UUID = '00000000-0000-4000-8000-000000000030';
 const PARTNER_UUID_2 = '00000000-0000-4000-8000-000000000031';
 
-// Builds a select() return value that supports both call shapes used by the
-// route: `.from(t).limit(n)` (the partner-count probe, no filter) and
-// `.from(t).where(cond).limit(n)` (the branding/provider lookups).
+// Builds a select() return value that supports the call shapes used by the
+// route: `.from(t).limit(n)` (the partner-count probe, no filter),
+// `.from(t).where(cond).limit(n)` (the branding lookup), and
+// `.from(t).where(cond).orderBy(...).limit(n)` (the deterministic provider
+// pick, #2195).
 function selectChain(rows: unknown[]) {
   return {
     from: vi.fn().mockReturnValue({
       limit: vi.fn().mockResolvedValue(rows),
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(rows),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows),
+        }),
       }),
     }),
   };
@@ -63,6 +68,19 @@ describe('GET /auth/login-context (#2183)', () => {
     vi.mocked(getRedis).mockReturnValue({} as any);
     vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 29, resetAt: new Date() } as any);
     vi.mocked(db.select).mockReset().mockReturnValue(selectChain([]) as any);
+    delete process.env.IS_HOSTED;
+  });
+
+  it('short-circuits to all-null on a hosted instance without touching the DB (#2195)', async () => {
+    process.env.IS_HOSTED = 'true';
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([{ id: PARTNER_UUID }]) as any);
+
+    const res = await getContext();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ branding: null, partnerSso: null });
+    // The single-partner fast-path must never run on hosted — even a region
+    // with exactly one partner reveals nothing.
+    expect(db.select).not.toHaveBeenCalled();
   });
 
   it('returns branding + partnerSso on a single-partner instance with both configured', async () => {

--- a/apps/api/src/routes/auth/loginContext.ts
+++ b/apps/api/src/routes/auth/loginContext.ts
@@ -24,6 +24,15 @@ loginContextRoutes.get('/login-context', async (c) => {
     return c.json({ error: 'Too many requests' }, 429);
   }
 
+  // Hosted guard (#2195): the single-partner fast-path is a self-hosted
+  // convenience. A hosted region that happened to shrink to exactly one
+  // partner must not publicly serve that partner's branding/SSO entry —
+  // hosted discovery is the v2 slug path (#2183).
+  if (process.env.IS_HOSTED === 'true') {
+    c.header('Cache-Control', 'public, max-age=60');
+    return c.json({ branding: null, partnerSso: null } satisfies LoginContext);
+  }
+
   let context: LoginContext;
   try {
     context = await withSystemDbAccessContext(async () => {
@@ -43,6 +52,10 @@ loginContextRoutes.get('/login-context', async (c) => {
         .where(eq(partnerLoginBranding.partnerId, partnerId))
         .limit(1);
 
+      // Deterministic pick when several providers are active (#2195): oldest
+      // first, id as tiebreak — the same ORDER BY the SSO entry routes use,
+      // so the button on the login page always names the provider the entry
+      // route will actually start a flow with.
       const [provider] = await db
         .select({ name: ssoProviders.name, enforceSSO: ssoProviders.enforceSSO })
         .from(ssoProviders)
@@ -50,6 +63,7 @@ loginContextRoutes.get('/login-context', async (c) => {
           eq(ssoProviders.partnerId, partnerId),
           eq(ssoProviders.status, 'active')
         ))
+        .orderBy(ssoProviders.createdAt, ssoProviders.id)
         .limit(1);
 
       return {

--- a/apps/api/src/routes/auth/loginContext.ts
+++ b/apps/api/src/routes/auth/loginContext.ts
@@ -6,6 +6,7 @@ import { partners, ssoProviders, partnerLoginBranding } from '../../db/schema';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { getRedis, rateLimiter } from '../../services';
 import { captureException } from '../../services/sentry';
+import { envFlag } from '../../utils/envFlag';
 
 export const loginContextRoutes = new Hono();
 
@@ -27,8 +28,11 @@ loginContextRoutes.get('/login-context', async (c) => {
   // Hosted guard (#2195): the single-partner fast-path is a self-hosted
   // convenience. A hosted region that happened to shrink to exactly one
   // partner must not publicly serve that partner's branding/SSO entry —
-  // hosted discovery is the v2 slug path (#2183).
-  if (process.env.IS_HOSTED === 'true') {
+  // hosted discovery is the v2 slug path (#2183). envFlag (not a bare
+  // === 'true') so every hosted spelling the production config validator
+  // accepts (1/yes/on) trips the guard; production refuses to boot with
+  // IS_HOSTED unset, so unset here means a self-hosted dev instance.
+  if (envFlag('IS_HOSTED', false)) {
     c.header('Cache-Control', 'public, max-age=60');
     return c.json({ branding: null, partnerSso: null } satisfies LoginContext);
   }

--- a/apps/api/src/routes/partnerLoginBranding.test.ts
+++ b/apps/api/src/routes/partnerLoginBranding.test.ts
@@ -196,6 +196,30 @@ describe('partner login branding routes (#2183)', () => {
     expect(res.status).toBe(400);
   });
 
+  it('PUT 400s a data:image subtype the login page will not render (svg) (#2195)', async () => {
+    // sanitizeImageSrc renders only png/jpeg/webp — accepting other subtypes
+    // here let a partner save a logo that silently never displayed.
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ logoUrl: 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=' })
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT accepts a base64 data:image/png logoUrl', async () => {
+    resetAuth({ partnerOrgAccess: 'all' });
+    const applied = { logoUrl: 'data:image/png;base64,iVBORw0KGgo=', accentColor: null, headline: null };
+    dbUpsertReturning.mockResolvedValueOnce([applied]);
+
+    const res = await makeApp().request('/partners/me/login-branding', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ logoUrl: applied.logoUrl })
+    });
+    expect(res.status).toBe(200);
+  });
+
   it('PUT 400s a headline over 120 chars', async () => {
     const res = await makeApp().request('/partners/me/login-branding', {
       method: 'PUT',

--- a/apps/api/src/routes/partnerLoginBranding.ts
+++ b/apps/api/src/routes/partnerLoginBranding.ts
@@ -14,10 +14,15 @@ import { writeRouteAudit } from '../services/auditEvents';
 // final URL is /api/v1/partners/me/login-branding.
 export const partnerLoginBrandingRoutes = new Hono();
 
+// Only the subtypes the login page will actually render (see
+// apps/web/src/lib/safeImageSrc.ts) — accepting any data:image/* here let a
+// partner save an SVG/GIF logo that then silently never displayed (#2195).
+const LOGO_DATA_URI_PATTERN = /^data:image\/(png|jpeg|webp);base64,/;
+
 const brandingSchema = z.object({
   logoUrl: z.string().max(400_000)
-    .refine((v) => v.startsWith('https://') || v.startsWith('data:image/'), {
-      message: 'logoUrl must be an https:// URL or a data:image/ URI'
+    .refine((v) => v.startsWith('https://') || LOGO_DATA_URI_PATTERN.test(v), {
+      message: 'logoUrl must be an https:// URL or a base64 data:image/png, jpeg, or webp URI'
     })
     .nullable().optional(),
   accentColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'accentColor must be a #rrggbb hex color')

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -261,10 +261,25 @@ describe('sso routes', () => {
       where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
     } as any);
     vi.mocked(db.select).mockReset().mockReturnValue({
-      from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })) }))
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+          // Public entry routes order the provider pick deterministically
+          // (#2195): where().orderBy().limit().
+          orderBy: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) }))
+        }))
+      }))
     } as any);
     vi.mocked(db.insert).mockReset().mockReturnValue({
-      values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([])),
+        // Callback identity insert (#2195): values().onConflictDoNothing().returning().
+        // Defaults to a NON-empty result (= the insert landed, no conflict) so
+        // the conflict re-select branch doesn't consume per-test select queues.
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'new-identity-id' }]))
+        }))
+      }))
     } as any);
     vi.mocked(db.update).mockReset().mockReturnValue({
       set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) })) }))
@@ -1754,15 +1769,41 @@ describe('sso routes', () => {
     });
   });
 
+  // Public entry routes pick the provider with where().orderBy().limit()
+  // (#2195 deterministic pick), so provider-select mocks need the orderBy hop.
+  const providerSelectChain = (rows: unknown[]) => ({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows)
+        })
+      })
+    })
+  });
+
+  const ACTIVE_OIDC_PROVIDER_ROW = {
+    id: PROVIDER_UUID,
+    orgId: null as string | null,
+    partnerId: PARTNER_UUID as string | null,
+    type: 'oidc',
+    status: 'active',
+    issuer: 'https://issuer.example.com',
+    authorizationUrl: 'https://issuer.example.com/auth',
+    tokenUrl: 'https://issuer.example.com/token',
+    userInfoUrl: 'https://issuer.example.com/userinfo',
+    jwksUrl: 'https://issuer.example.com/jwks',
+    clientId: 'client-id',
+    clientSecret: 'client-secret',
+    scopes: 'openid profile email',
+    attributeMapping: { email: 'email', name: 'name' },
+    autoProvision: false,
+    allowedDomains: null,
+    defaultRoleId: null
+  };
+
   describe('GET /sso/login/partner/:partnerId (#2183)', () => {
     it('404s when the partner has no active partner-axis provider', async () => {
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValue(providerSelectChain([]) as any);
 
       const res = await app.request(`/sso/login/partner/${PARTNER_UUID}`);
 
@@ -1771,31 +1812,7 @@ describe('sso routes', () => {
     });
 
     it('redirects to the IdP authorization URL and sets the state cookie for an active provider', async () => {
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: PROVIDER_UUID,
-              orgId: null,
-              partnerId: PARTNER_UUID,
-              type: 'oidc',
-              status: 'active',
-              issuer: 'https://issuer.example.com',
-              authorizationUrl: 'https://issuer.example.com/auth',
-              tokenUrl: 'https://issuer.example.com/token',
-              userInfoUrl: 'https://issuer.example.com/userinfo',
-              jwksUrl: 'https://issuer.example.com/jwks',
-              clientId: 'client-id',
-              clientSecret: 'client-secret',
-              scopes: 'openid profile email',
-              attributeMapping: { email: 'email', name: 'name' },
-              autoProvision: false,
-              allowedDomains: null,
-              defaultRoleId: null
-            }])
-          })
-        })
-      } as any);
+      vi.mocked(db.select).mockReturnValueOnce(providerSelectChain([ACTIVE_OIDC_PROVIDER_ROW]) as any);
 
       const valuesMock = vi.fn().mockResolvedValue(undefined);
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as any);
@@ -1812,12 +1829,12 @@ describe('sso routes', () => {
       expect(setCookie).toContain('breeze_sso_state=');
     });
 
-    it('429s when the per-IP+partner rate limit is exceeded, without touching the DB', async () => {
-      const resetAt = new Date(Date.now() + 45_000);
+    it('429s when the shared pure-IP rate limit is exceeded, without touching the DB (#2195)', async () => {
+      // First bucket checked is the pure-IP one shared with /login/:orgId.
       vi.mocked(rateLimiter).mockResolvedValueOnce({
         allowed: false,
         remaining: 0,
-        resetAt
+        resetAt: new Date(Date.now() + 45_000)
       } as any);
 
       const res = await app.request(`/sso/login/partner/${PARTNER_UUID}`);
@@ -1826,8 +1843,97 @@ describe('sso routes', () => {
       const body = await res.json();
       expect(body.error).toBe('Too many login attempts. Please try again later.');
       expect(body.retryAfter).toBeGreaterThan(0);
+      expect(vi.mocked(rateLimiter).mock.calls[0]?.[1]).toMatch(/^sso:login:ip:/);
       expect(db.select).not.toHaveBeenCalled();
       expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('429s when the per-IP+partner rate limit is exceeded, without touching the DB', async () => {
+      const resetAt = new Date(Date.now() + 45_000);
+      vi.mocked(rateLimiter)
+        .mockResolvedValueOnce({ allowed: true, remaining: 20, resetAt } as any) // pure-IP bucket
+        .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt } as any); // per-(ip,partner)
+
+      const res = await app.request(`/sso/login/partner/${PARTNER_UUID}`);
+
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.error).toBe('Too many login attempts. Please try again later.');
+      expect(body.retryAfter).toBeGreaterThan(0);
+      expect(vi.mocked(rateLimiter).mock.calls[1]?.[1]).toMatch(/^sso:login:partner:/);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sso/login/:orgId (#2195)', () => {
+    it('404s when the org has no active provider', async () => {
+      vi.mocked(db.select).mockReturnValue(providerSelectChain([]) as any);
+
+      const res = await app.request(`/sso/login/${ORG_UUID}`);
+
+      expect(res.status).toBe(404);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the IdP authorization URL and sets the state cookie for an active org provider', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(
+        providerSelectChain([{ ...ACTIVE_OIDC_PROVIDER_ROW, orgId: ORG_UUID, partnerId: null }]) as any
+      );
+
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as any);
+
+      const res = await app.request(`/sso/login/${ORG_UUID}?redirect=/dashboard`);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://idp.example.com/auth');
+      expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({
+        providerId: PROVIDER_UUID,
+        redirectUrl: '/dashboard'
+      }));
+      expect(res.headers.get('set-cookie') ?? '').toContain('breeze_sso_state=');
+    });
+
+    it('429s on the per-(IP, org) bucket without touching the DB', async () => {
+      const resetAt = new Date(Date.now() + 45_000);
+      vi.mocked(rateLimiter)
+        .mockResolvedValueOnce({ allowed: true, remaining: 20, resetAt } as any)
+        .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt } as any);
+
+      const res = await app.request(`/sso/login/${ORG_UUID}`);
+
+      expect(res.status).toBe(429);
+      expect(vi.mocked(rateLimiter).mock.calls[1]?.[1]).toMatch(/^sso:login:org:/);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sso/check/:orgId (#2195)', () => {
+    it('returns ssoEnabled false when the org has no active provider', async () => {
+      vi.mocked(db.select).mockReturnValue(providerSelectChain([]) as any);
+
+      const res = await app.request(`/sso/check/${ORG_UUID}`);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ssoEnabled: false });
+    });
+
+    it('returns the provider summary and login URL when an active provider exists', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(
+        providerSelectChain([{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', enforceSSO: true }]) as any
+      );
+
+      const res = await app.request(`/sso/check/${ORG_UUID}`);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ssoEnabled: true,
+        provider: { id: PROVIDER_UUID, name: 'Okta', type: 'oidc' },
+        enforceSSO: true,
+        loginUrl: `/api/v1/sso/login/${ORG_UUID}`
+      });
     });
   });
 
@@ -1907,6 +2013,55 @@ describe('sso routes', () => {
         .mockReturnValueOnce(sel([]))                                // no other-provider link → safe to link
         .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }]))
         .mockReturnValueOnce(sel([]));                               // existingIdentity none → insert
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toMatch(/ssoCode=/);
+      expect(createTokenPair).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'partner', partnerId: PARTNER_UUID, orgId: null }),
+        expect.any(Object)
+      );
+    });
+
+    it('redirects identity_in_use when the identity INSERT loses the unique-index race to a DIFFERENT user (#2195)', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no (provider, sub) link yet
+        .mockReturnValueOnce(sel([STAFF]))                           // byEmail (safe JIT link)
+        .mockReturnValueOnce(sel([]))                                // no other-provider link
+        .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }]))
+        .mockReturnValueOnce(sel([]))                                // existingIdentity none → insert path
+        .mockReturnValueOnce(sel([{ userId: '00000000-0000-4000-8000-0000000000aa' }])); // conflict row → someone else
+      // ON CONFLICT DO NOTHING returns no rows → a concurrent callback linked
+      // this (provider, sub) first.
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+        }))
+      } as any);
+
+      const res = await doCallback();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location') ?? '').toContain('error=identity_in_use');
+      expect(createTokenPair).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when the identity INSERT loses the race to the SAME user (parallel logins)', async () => {
+      prime();
+      vi.mocked(db.select)
+        .mockReturnValueOnce(sel([PARTNER_PROVIDER]))
+        .mockReturnValueOnce(sel([]))                                // no link yet
+        .mockReturnValueOnce(sel([STAFF]))                           // byEmail (safe JIT link)
+        .mockReturnValueOnce(sel([]))                                // no other-provider link
+        .mockReturnValueOnce(selJoin([{ roleId: 'prole-1', roleScope: 'partner' }]))
+        .mockReturnValueOnce(sel([]))                                // existingIdentity none → insert path
+        .mockReturnValueOnce(sel([{ userId: USER_UUID }]));          // conflict row → same user
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+        }))
+      } as any);
 
       const res = await doCallback();
       expect(res.status).toBe(302);

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1135,6 +1135,16 @@ const partnerIdParamSchema = z.object({ partnerId: z.string().guid() });
 // per-(IP,email) bucket in routes/auth/login.ts.
 const PARTNER_SSO_LOGIN_RATE_LIMIT = { limit: 10, windowSeconds: 5 * 60 };
 
+// Org-axis initiation gets the same per-(IP, target) bucket (#2195 — it
+// previously had none at all).
+const ORG_SSO_LOGIN_RATE_LIMIT = { limit: 10, windowSeconds: 5 * 60 };
+
+// Pure-IP bucket SHARED by both SSO initiation routes, mirroring password
+// login's `login:ip:` bucket (#2195): without it, one IP can rotate through
+// partnerIds/orgIds to dodge the per-target buckets while farming state
+// cookies / sso_sessions rows.
+const SSO_LOGIN_IP_RATE_LIMIT = { limit: 30, windowSeconds: 5 * 60 };
+
 // Initiate partner-axis SSO login (#2183) — the MSP's own technician login.
 // Public route: all DB access MUST run under system context (no request scope
 // exists yet; bare `db` silently returns 0 rows under RLS). Mounted ABOVE
@@ -1147,6 +1157,18 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
 
   const ip = getClientIP(c);
   const redis = getRedis();
+  const ipRateCheck = await rateLimiter(
+    redis,
+    `sso:login:ip:${ip}`,
+    SSO_LOGIN_IP_RATE_LIMIT.limit,
+    SSO_LOGIN_IP_RATE_LIMIT.windowSeconds
+  );
+  if (!ipRateCheck.allowed) {
+    return c.json({
+      error: 'Too many login attempts. Please try again later.',
+      retryAfter: Math.ceil((ipRateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
   const rateCheck = await rateLimiter(
     redis,
     `sso:login:partner:${ip}:${partnerId}`,
@@ -1160,6 +1182,9 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
     }, 429);
   }
 
+  // Deterministic pick when several providers are active: oldest first, id as
+  // tiebreak — the same order every SSO-discovery surface uses (login-context,
+  // /check/:orgId, /login/:orgId), so they always describe the same provider.
   const [provider] = await withSystemDbAccessContext(async () =>
     db
       .select()
@@ -1168,6 +1193,7 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
         eq(ssoProviders.partnerId, partnerId),
         eq(ssoProviders.status, 'active')
       ))
+      .orderBy(ssoProviders.createdAt, ssoProviders.id)
       .limit(1)
   );
 
@@ -1213,19 +1239,55 @@ ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSch
   return c.redirect(authUrl);
 });
 
-// Initiate SSO login
+// Initiate SSO login (org axis). Public pre-auth route: the provider read and
+// the session insert MUST run under system DB context — under breeze_app's
+// FORCED RLS with no request scope, a bare `db` read silently matches 0 rows,
+// which made this route 404 for EVERY org in production-shaped deployments
+// (#2195; same class as the callback reads fixed in #2194).
 ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) => {
   const { orgId } = c.req.valid('param');
   const redirectUrl = normalizeRedirectPath(c.req.query('redirect'));
 
-  const [provider] = await db
-    .select()
-    .from(ssoProviders)
-    .where(and(
-      eq(ssoProviders.orgId, orgId),
-      eq(ssoProviders.status, 'active')
-    ))
-    .limit(1);
+  // Same two-bucket shape as password login and the partner entry route
+  // (#2195 — this route previously had no rate limit at all).
+  const ip = getClientIP(c);
+  const redis = getRedis();
+  const ipRateCheck = await rateLimiter(
+    redis,
+    `sso:login:ip:${ip}`,
+    SSO_LOGIN_IP_RATE_LIMIT.limit,
+    SSO_LOGIN_IP_RATE_LIMIT.windowSeconds
+  );
+  if (!ipRateCheck.allowed) {
+    return c.json({
+      error: 'Too many login attempts. Please try again later.',
+      retryAfter: Math.ceil((ipRateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
+  const rateCheck = await rateLimiter(
+    redis,
+    `sso:login:org:${ip}:${orgId}`,
+    ORG_SSO_LOGIN_RATE_LIMIT.limit,
+    ORG_SSO_LOGIN_RATE_LIMIT.windowSeconds
+  );
+  if (!rateCheck.allowed) {
+    return c.json({
+      error: 'Too many login attempts. Please try again later.',
+      retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
+
+  const [provider] = await withSystemDbAccessContext(async () =>
+    db
+      .select()
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.orgId, orgId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .orderBy(ssoProviders.createdAt, ssoProviders.id)
+      .limit(1)
+  );
 
   if (!provider) {
     return c.json({ error: 'No active SSO provider for this organization' }, 404);
@@ -1244,14 +1306,16 @@ ssoRoutes.get('/login/:orgId', zValidator('param', orgIdParamSchema), async (c) 
 
   // Store session for callback verification
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
-  await db.insert(ssoSessions).values({
-    providerId: provider.id,
-    state,
-    nonce,
-    codeVerifier: pkce.codeVerifier,
-    redirectUrl,
-    expiresAt
-  });
+  await withSystemDbAccessContext(async () =>
+    db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl,
+      expiresAt
+    })
+  );
 
   // Build callback URL
   const callbackUri = buildSsoCallbackUri();
@@ -1811,28 +1875,23 @@ ssoRoutes.get('/callback', async (c) => {
       };
     }
 
-    // Update or create SSO identity link (shared across both axes)
-    // KNOWN BUG (#2195): this read is not wrapped in withSystemDbAccessContext,
-    // so on this unauthenticated callback route (no request context has been
-    // established) FORCED RLS silently matches 0 rows here — existingIdentity
-    // is always undefined regardless of whether a link already exists. That
-    // makes the UPDATE branch below unreachable and every returning SSO login
-    // INSERTs a duplicate identity row instead of updating the existing one.
-    // Fix tracked in the #2195 follow-up — do not copy this pattern elsewhere.
-    const [existingIdentity] = await db
-      .select()
-      .from(userSsoIdentities)
-      .where(and(
-        eq(userSsoIdentities.userId, user.id),
-        eq(userSsoIdentities.providerId, provider.id)
-      ))
-      .limit(1);
+    // Update or create SSO identity link (shared across both axes). System DB
+    // context required for ALL of it: the callback is unauthenticated, so bare
+    // reads/writes silently match 0 rows under breeze_app RLS. The read below
+    // used to sit OUTSIDE the wrap (#2195) — existingIdentity was always
+    // undefined under FORCED RLS, so every returning login INSERTed a
+    // duplicate identity row instead of updating the existing one. Also stamps
+    // last_login_at (#1375).
+    const identityOutcome = await withSystemDbAccessContext(async () => {
+      const [existingIdentity] = await db
+        .select({ id: userSsoIdentities.id })
+        .from(userSsoIdentities)
+        .where(and(
+          eq(userSsoIdentities.userId, user.id),
+          eq(userSsoIdentities.providerId, provider.id)
+        ))
+        .limit(1);
 
-    // System DB context required: the SSO callback is unauthenticated, so these
-    // writes would silently match 0 rows under breeze_app RLS without it —
-    // dropping the SSO identity/token persistence AND the last_login_at stamp
-    // (#1375).
-    await withSystemDbAccessContext(async () => {
       if (existingIdentity) {
         await db
           .update(userSsoIdentities)
@@ -1849,19 +1908,47 @@ ssoRoutes.get('/callback', async (c) => {
           })
           .where(eq(userSsoIdentities.id, existingIdentity.id));
       } else {
-        await db.insert(userSsoIdentities).values({
-          userId: user.id,
-          providerId: provider.id,
-          externalId: externalSub,
-          email: attrs.email,
-          profile: userInfo,
-          accessToken: encryptSecret(tokens.access_token),
-          refreshToken: encryptSecret(tokens.refresh_token),
-          tokenExpiresAt: tokens.expires_in
-            ? new Date(Date.now() + tokens.expires_in * 1000)
-            : null,
-          lastLoginAt: new Date()
-        });
+        // Race-safe against the unique (provider_id, external_id) index
+        // (#2195): a concurrent callback that linked this subject first turns
+        // this INSERT into a no-op rather than a 23505 throw — postgres.js
+        // rethrows errors through the transaction wrapper even when caught,
+        // so ON CONFLICT is the only clean path here.
+        const inserted = await db
+          .insert(userSsoIdentities)
+          .values({
+            userId: user.id,
+            providerId: provider.id,
+            externalId: externalSub,
+            email: attrs.email,
+            profile: userInfo,
+            accessToken: encryptSecret(tokens.access_token),
+            refreshToken: encryptSecret(tokens.refresh_token),
+            tokenExpiresAt: tokens.expires_in
+              ? new Date(Date.now() + tokens.expires_in * 1000)
+              : null,
+            lastLoginAt: new Date()
+          })
+          .onConflictDoNothing({
+            target: [userSsoIdentities.providerId, userSsoIdentities.externalId]
+          })
+          .returning({ id: userSsoIdentities.id });
+
+        if (inserted.length === 0) {
+          // Conflict row already exists. Same user (two parallel logins) →
+          // the link is in place, proceed. Different user → this (provider,
+          // sub) identity belongs to someone else; never mint tokens for it.
+          const [conflict] = await db
+            .select({ userId: userSsoIdentities.userId })
+            .from(userSsoIdentities)
+            .where(and(
+              eq(userSsoIdentities.providerId, provider.id),
+              eq(userSsoIdentities.externalId, externalSub)
+            ))
+            .limit(1);
+          if (conflict && conflict.userId !== user.id) {
+            return { error: 'identity_in_use' as const };
+          }
+        }
       }
 
       // Update last login
@@ -1869,7 +1956,13 @@ ssoRoutes.get('/callback', async (c) => {
         .update(users)
         .set({ lastLoginAt: new Date() })
         .where(eq(users.id, user.id));
+      return { ok: true as const };
     });
+
+    if ('error' in identityOutcome) {
+      clearStateCookie();
+      return c.redirect(`/login?error=${identityOutcome.error}`);
+    }
 
     // The SSO session row was already consumed atomically up-front
     // (delete().returning()), so there is nothing left to clean up here.
@@ -1957,23 +2050,29 @@ ssoRoutes.post('/exchange', zValidator('json', tokenExchangeSchema), async (c) =
   });
 });
 
-// Get SSO login URL for organization (public endpoint for login page)
+// Get SSO login URL for organization (public endpoint for login page).
+// System DB context required (#2195): this runs pre-auth, so a bare `db`
+// read 0-rows under breeze_app RLS and the login page never shows the SSO
+// button (`ssoEnabled` was always false in production-shaped deployments).
 ssoRoutes.get('/check/:orgId', zValidator('param', orgIdParamSchema), async (c) => {
   const { orgId } = c.req.valid('param');
 
-  const [provider] = await db
-    .select({
-      id: ssoProviders.id,
-      name: ssoProviders.name,
-      type: ssoProviders.type,
-      enforceSSO: ssoProviders.enforceSSO
-    })
-    .from(ssoProviders)
-    .where(and(
-      eq(ssoProviders.orgId, orgId),
-      eq(ssoProviders.status, 'active')
-    ))
-    .limit(1);
+  const [provider] = await withSystemDbAccessContext(async () =>
+    db
+      .select({
+        id: ssoProviders.id,
+        name: ssoProviders.name,
+        type: ssoProviders.type,
+        enforceSSO: ssoProviders.enforceSSO
+      })
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.orgId, orgId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .orderBy(ssoProviders.createdAt, ssoProviders.id)
+      .limit(1)
+  );
 
   if (!provider) {
     return c.json({ ssoEnabled: false });

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -37,6 +37,7 @@ import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiT
 import { writeRouteAudit } from '../services/auditEvents';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
 import { getTrustedClientIp } from '../services/clientIp';
+import { captureException } from '../services/sentry';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
 import { PERMISSIONS } from '../services/permissions';
 import { envFlag } from '../utils/envFlag';
@@ -1948,6 +1949,16 @@ ssoRoutes.get('/callback', async (c) => {
           if (conflict && conflict.userId !== user.id) {
             return { error: 'identity_in_use' as const };
           }
+          if (!conflict) {
+            // Anomaly: the insert reported a conflict but the conflicting row
+            // vanished before the re-select (concurrent unlink/revocation).
+            // Proceeding is safe — the user was already resolved — but this
+            // login completes WITHOUT a persisted identity row, so leave a
+            // trace for anyone debugging a future linkage report.
+            console.warn(
+              `[sso/callback] identity insert conflicted but conflicting row vanished: provider=${provider.id} user=${user.id}`
+            );
+          }
         }
       }
 
@@ -2014,7 +2025,10 @@ ssoRoutes.get('/callback', async (c) => {
     // The session was already consumed atomically, so even on a failed IdP
     // token exchange the captured state cannot be replayed. Surface the error
     // to the login page exactly as before; the user simply re-initiates.
+    // Sentry too (#2195): this catch wraps the account-takeover-critical
+    // identity-linking path, so failures need more visibility than stderr.
     console.error('SSO callback error:', error);
+    captureException(error, c);
     clearStateCookie();
     return c.redirect(`/login?error=sso_error&message=${encodeURIComponent(error.message || 'Authentication failed')}`);
   }

--- a/apps/api/src/services/tenantCascade.partner.test.ts
+++ b/apps/api/src/services/tenantCascade.partner.test.ts
@@ -24,6 +24,9 @@ describe('cascadeDeletePartner', () => {
 
     execMock
       .mockResolvedValueOnce([{ id: 'org-1' }])
+      // SSO FK-child pre-clears (#2195): user_sso_identities, then sso_sessions
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ table_name: 'scripts' }, { table_name: 'users' }])
       .mockResolvedValue([]);
 
@@ -36,8 +39,21 @@ describe('cascadeDeletePartner', () => {
     // topo sort received the discovered partner tables
     expect(mod.topologicalCascadeOrder).toHaveBeenCalledWith(['scripts', 'users']);
 
-    // exactly one partners delete, and it is the LAST execute() call
     const calls = execMock.mock.calls.map((c) => JSON.stringify(c[0]));
+
+    // SSO FK children with no partner_id column are pre-cleared BEFORE the
+    // partner-axis sweep (#2195) — without this, a canary partner that
+    // exercised SSO fails the sweep on sso_providers/users FK violations.
+    const identityClearIdx = calls.findIndex((c) => c.includes('user_sso_identities'));
+    const sessionsClearIdx = calls.findIndex((c) => c.includes('sso_sessions'));
+    const firstSweepIdx = calls.findIndex((c) => c.includes('scripts'));
+    expect(identityClearIdx).toBeGreaterThan(-1);
+    expect(sessionsClearIdx).toBeGreaterThan(-1);
+    expect(firstSweepIdx).toBeGreaterThan(-1);
+    expect(identityClearIdx).toBeLessThan(firstSweepIdx);
+    expect(sessionsClearIdx).toBeLessThan(firstSweepIdx);
+
+    // exactly one partners delete, and it is the LAST execute() call
     expect(calls.filter((c) => c.includes('partners')).length).toBe(1);
 
     // audit event emitted with the right action and details shape

--- a/apps/api/src/services/tenantCascade.test.ts
+++ b/apps/api/src/services/tenantCascade.test.ts
@@ -229,7 +229,11 @@ describe('cascadeDeleteOrg', () => {
   });
 
   it('re-throws and aborts cascade on a non-42P01 error', async () => {
-    // FK edge query returns []; the next DELETE call throws a non-42P01.
+    // FK edge query returns []; the first DELETE call AFTER the associated
+    // pre-clears (device_commands + the two SSO FK children, #2195) throws a
+    // non-42P01 — i.e. the first ordered cascade-table DELETE, which is the
+    // path that wraps errors with `DELETE from "<table>"` context.
+    const associatedCount = __testOnly.ASSOCIATED_SYSTEM_SCOPED_TABLES.length;
     let callIdx = 0;
     vi.mocked(db.execute).mockImplementation(((q: unknown) => {
       const text = sqlToText(q);
@@ -237,7 +241,7 @@ describe('cascadeDeleteOrg', () => {
         return Promise.resolve([]);
       }
       callIdx += 1;
-      if (callIdx === 2) {
+      if (callIdx === associatedCount + 1) {
         return Promise.reject(new Error('boom'));
       }
       return Promise.resolve({ rowCount: 0 });

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -518,22 +518,32 @@ export async function cascadeDeleteOrg(
   // detected we throw and abort BEFORE deleting anything.
   const order = await topologicalCascadeOrder();
 
-  await dbModule.withSystemDbAccessContext(async () => {
-    // 1. Clear system-scoped associated tables (e.g. device_commands)
-    //    that hold FKs into the cascade set.
-    for (const assoc of ASSOCIATED_SYSTEM_SCOPED_TABLES) {
-      try {
+  // 1. Clear system-scoped associated tables (e.g. device_commands, the
+  //    SSO FK children) that hold FKs into the cascade set. One system
+  //    context per table so the audit write in the catch below never runs
+  //    inside an open DB context (nesting poisons the pool).
+  for (const assoc of ASSOCIATED_SYSTEM_SCOPED_TABLES) {
+    try {
+      const count = await dbModule.withSystemDbAccessContext(async () => {
         const result = await dbModule.db.execute(assoc.clearSql(orgId));
-        const count = extractRowCount(result);
-        stats.tablesDeleted[assoc.table] = (stats.tablesDeleted[assoc.table] ?? 0) + count;
-        stats.totalRowsDeleted += count;
-      } catch (err) {
-        // Tolerate missing tables (e.g. a deployment that doesn't have
-        // every optional table). Re-throw on anything else.
-        if (!isUndefinedTable(err)) throw err;
+        return extractRowCount(result);
+      });
+      stats.tablesDeleted[assoc.table] = (stats.tablesDeleted[assoc.table] ?? 0) + count;
+      stats.totalRowsDeleted += count;
+    } catch (err) {
+      // Tolerate missing tables (e.g. a deployment that doesn't have
+      // every optional table). Anything else aborts the erasure — record
+      // it forensically first (#2195), same as the main loop below.
+      if (!isUndefinedTable(err)) {
+        await writeErasureFailedAudit(orgId, performedBy, performedByEmail, assoc.table, stats, err);
+        throw new Error(
+          `[tenantCascade] DELETE from "${assoc.table}" failed for org=${orgId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     }
-  });
+  }
 
   // 2. Walk the cascade list in FK-safe order, each table in its OWN
   //    system-context transaction so a failure on one table aborts
@@ -558,7 +568,10 @@ export async function cascadeDeleteOrg(
     } catch (err) {
       // A single table failure aborts the cascade — partial deletion is
       // worse than no deletion (the org sits in an inconsistent state).
-      // Re-throw with context.
+      // Best-effort forensic record of how far the erasure got (#2195 —
+      // mirrors the partner purge's purge_failed breadcrumb), then re-throw
+      // with context.
+      await writeErasureFailedAudit(orgId, performedBy, performedByEmail, table, stats, err);
       throw new Error(
         `[tenantCascade] DELETE from "${table}" failed for org=${orgId}: ${
           err instanceof Error ? err.message : String(err)
@@ -588,6 +601,41 @@ export async function cascadeDeleteOrg(
   });
 
   return stats;
+}
+
+/** Best-effort forensic breadcrumb when a tenant.erasure aborts mid-cascade
+ * (#2195): records the failed table and per-table progress so a partial
+ * erasure is reconstructable. org_id=NULL so the row survives regardless of
+ * how far the cascade got. Never throws — the original error is what the
+ * caller must see. */
+async function writeErasureFailedAudit(
+  orgId: string,
+  performedBy: string,
+  performedByEmail: string | undefined,
+  failedTable: string,
+  stats: CascadeStats,
+  err: unknown,
+): Promise<void> {
+  try {
+    await createAuditLog({
+      orgId: null,
+      actorType: 'user',
+      actorId: performedBy,
+      actorEmail: performedByEmail,
+      action: 'tenant.erasure.failed',
+      resourceType: 'organization',
+      resourceId: orgId,
+      details: {
+        failedTable,
+        tablesDeleted: stats.tablesDeleted,
+        totalRowsDeleted: stats.totalRowsDeleted,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      result: 'failure',
+    });
+  } catch (auditErr) {
+    console.warn('[tenantCascade] erasure-failed audit write failed:', auditErr);
+  }
 }
 
 function deleteOrgRows(

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -330,6 +330,28 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
       WHERE device_id IN (SELECT id FROM devices WHERE org_id = ${orgId})
     `,
   },
+  // SSO FK children with NO org_id/partner_id column (#2195): they hang off
+  // sso_providers/users, so without a pre-clear the cascade's DELETEs on
+  // those parents fail on FK for any org that ever exercised SSO.
+  // user_sso_identities keys off BOTH parents (its provider may be
+  // partner-axis while the user is org-bound, and vice versa).
+  {
+    table: 'user_sso_identities',
+    clearSql: (orgId) => sql`
+      DELETE FROM user_sso_identities
+      WHERE provider_id IN (SELECT id FROM sso_providers WHERE org_id = ${orgId})
+         OR user_id IN (SELECT id FROM users WHERE org_id = ${orgId})
+    `,
+  },
+  // sso_sessions.link_user_id already cascades on user delete; the provider
+  // FK does not.
+  {
+    table: 'sso_sessions',
+    clearSql: (orgId) => sql`
+      DELETE FROM sso_sessions
+      WHERE provider_id IN (SELECT id FROM sso_providers WHERE org_id = ${orgId})
+    `,
+  },
 ];
 
 /**
@@ -677,6 +699,48 @@ export async function cascadeDeletePartner(
   for (const row of orgRows) {
     const orgStats = await self.cascadeDeleteOrg(row.id, performedBy);
     totalRowsDeleted += orgStats.totalRowsDeleted;
+  }
+
+  // SSO FK children with NO partner_id column (#2195): the partner-axis sweep
+  // below only reaches tables that HAVE a partner_id column, so a canary
+  // partner that ever exercised SSO would fail the sweep on the
+  // sso_providers/users DELETEs (FK violation) without this pre-clear.
+  // Mirrors the ASSOCIATED_SYSTEM_SCOPED_TABLES step in cascadeDeleteOrg.
+  const partnerSsoPreClears: ReadonlyArray<{ table: string; clearSql: ReturnType<typeof sql> }> = [
+    {
+      table: 'user_sso_identities',
+      clearSql: sql`
+        DELETE FROM user_sso_identities
+        WHERE provider_id IN (SELECT id FROM sso_providers WHERE partner_id = ${partnerId})
+           OR user_id IN (SELECT id FROM users WHERE partner_id = ${partnerId})
+      `,
+    },
+    {
+      table: 'sso_sessions',
+      clearSql: sql`
+        DELETE FROM sso_sessions
+        WHERE provider_id IN (SELECT id FROM sso_providers WHERE partner_id = ${partnerId})
+      `,
+    },
+  ];
+  for (const assoc of partnerSsoPreClears) {
+    try {
+      const count = await dbModule.withSystemDbAccessContext(async () => {
+        const result = await dbModule.db.execute(assoc.clearSql);
+        return extractRowCount(result);
+      });
+      tablesDeleted[assoc.table] = (tablesDeleted[assoc.table] ?? 0) + count;
+      totalRowsDeleted += count;
+    } catch (err) {
+      if (!isUndefinedTable(err)) {
+        await writePurgeFailedAudit(performedBy, partnerId, assoc.table, tablesDeleted, err);
+        throw new Error(
+          `[tenantCascade] DELETE from "${assoc.table}" failed for partner=${partnerId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
   }
 
   // information_schema is not RLS-protected — bare db.execute is fine here.

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -199,6 +199,26 @@ describe('LoginPage partner SSO button', () => {
     Object.defineProperty(window, 'location', { configurable: true, value: realWindow });
   });
 
+  // #2195: callback bounces that previously landed with NO guidance at all.
+  it.each([
+    ['invite_required', /no account here is linked/i],
+    ['no_partner_access', /does not have access to this workspace/i],
+    ['identity_in_use', /already linked to a different account/i],
+  ])('renders guidance copy for ?error=%s', async (error, copy) => {
+    const realWindow = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...realWindow, search: `?error=${error}` },
+    });
+
+    render(<LoginPage />);
+
+    const notice = await screen.findByRole('alert');
+    expect(notice).toHaveTextContent(copy);
+
+    Object.defineProperty(window, 'location', { configurable: true, value: realWindow });
+  });
+
   it('enforceSSO=true hides the password form initially and shows the SSO button', async () => {
     vi.mocked(getLoginContext).mockResolvedValue({
       branding: null,

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -29,7 +29,17 @@ function getRegistrationDisabledNotice(): string | undefined {
 // session instead (Profile → Security → Connect SSO).
 const SSO_LOGIN_ERROR_COPY: Record<string, string> = {
   sso_link_required:
-    'This account already has a password. Sign in with your password, then connect SSO under Profile → Security.'
+    'This account already has a password. Sign in with your password, then connect SSO under Profile → Security.',
+  // Partner axis (#2183): identity-first, no JIT — an unrecognized identity
+  // needs an out-of-band invite before SSO can sign it in.
+  invite_required:
+    'Your sign-in succeeded, but no account here is linked to that identity yet. Ask your administrator for an invite, then try again.',
+  no_partner_access:
+    'That account does not have access to this workspace. Contact your administrator.',
+  // The verified IdP identity is already linked to a DIFFERENT account
+  // (#2195 unique-index race guard in the callback).
+  identity_in_use:
+    'That sign-in identity is already linked to a different account. Contact your administrator.'
 };
 
 function getSsoLoginNotice(): string | undefined {


### PR DESCRIPTION
Completes the #2194 callback fixes. Org SSO login was silently non-functional in production-shaped deployments because the remaining public (pre-auth) SSO routes still read the DB through bare `db` calls — under `breeze_app` FORCED RLS with no request context, every read 0-rows silently.

## RLS fixes (the core #2195 items)

- **`GET /sso/login/:orgId`**: provider read AND the `sso_sessions` INSERT (a fourth bare call the issue didn't list, same class — the partner sibling wraps it) now run under `withSystemDbAccessContext`. Org SSO initiation 404'd for every org before this.
- **`GET /sso/check/:orgId`**: provider read wrapped — the org login page can now actually discover SSO (`ssoEnabled` was always `false`).
- **Callback `existingIdentity` read**: moved inside the existing system-context write block. It always 0-rowed, so every returning login INSERTed a duplicate `user_sso_identities` row instead of updating; the `KNOWN BUG (#2195)` marker from #2202 is gone.

## Hardening

- **Unique `(provider_id, external_id)` index** (`2026-07-04-user-sso-identities-unique-external.sql`): dedupes existing returning-login duplicates first (keeps the freshest row, `RAISE WARNING` row count), then adds the index; Drizzle schema updated. The callback INSERT uses `ON CONFLICT DO NOTHING` + a conflict re-select (postgres.js rethrows through the transaction wrapper, so no 23505 catch): same-user race proceeds, different-user race redirects `identity_in_use`. This closes the TOCTOU on the link flow's code-only identity-in-use check.
- **Tenant cascades**: `user_sso_identities` and `sso_sessions` (no org/partner column — FK children of `sso_providers`/`users`) are now pre-cleared in BOTH `cascadeDeleteOrg` (via `ASSOCIATED_SYSTEM_SCOPED_TABLES`) and `cascadeDeletePartner`. Previously any org erasure or canary-partner purge that had exercised SSO failed on FK violations.
- **Rate limiting**: org initiation gets a per-(IP, org) bucket (it had none), and BOTH initiation routes now share a pure-IP bucket mirroring password login's `login:ip:` bucket, so one IP can't rotate targets to dodge the per-target buckets.

## Review-triaged polish (rest of the issue's list)

- Deterministic provider pick: `ORDER BY created_at, id` on all four active-provider lookups (partner/org initiation, `/check`, `login-context`) so every surface describes the same provider.
- `login-context` hosted guard: `IS_HOSTED=true` short-circuits the single-partner fast-path to all-null without touching the DB — a hosted region that shrinks to one partner can never publicly serve that partner's branding (v2 slug discovery, #2183, is the hosted path).
- `logoUrl` refine narrowed to `https://` or base64 `data:image/(png|jpeg|webp)` — matching what `safeImageSrc` will actually render.
- Login-page copy for `invite_required`, `no_partner_access`, and the new `identity_in_use` bounce (previously landed with no guidance).

## Verification

- **Integration (real `breeze_app` RLS pool, :5433)**: new org-axis e2e drives the REAL routes — `/sso/check/:orgId` → `/sso/login/:orgId` → callback → exchange → minted org token; returning-login case proves the second login UPDATEs (1 row) instead of duplicating; 23505 case proves the index; new `tenantCascadeSso.integration.test.ts` runs both real cascades over seeded SSO rows. 13/13 passing, plus `loginContext.integration.test.ts` 5/5.
- **Unit**: 119 passing across `sso.test.ts` (incl. new org-login/check/rate-limit/identity-race cases), `loginContext.test.ts` (incl. hosted guard), `partnerLoginBranding.test.ts` (svg rejected / png accepted), both tenantCascade suites. Web: `LoginPage.test.tsx` 18 passing. `autoMigrate.test.ts` 43 passing.
- `tsc --noEmit` clean in api + web; `pnpm db:check-drift` clean (372 files, no drift); migration exercised for real via the integration DB's autoMigrate.

Closes #2195
Refs #2183 #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)