### PR TITLE
fix(web): bump no-silent-mutations targeted-set count to 58

### DIFF
--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -277,7 +277,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(57);
+    expect(absoluteFiles.length).toBe(58);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }


### PR DESCRIPTION
**Fix-forward for red main.** #2204 added `OrgSettingsPage.tsx` to the `TARGET_GLOBS` targeted set in `no-silent-mutations.test.ts` without bumping the hard-coded file-count assertion (`expect(absoluteFiles.length).toBe(57)`), so `Test Web` fails on main with `expected 58 to be 57`.

The new file itself passes all runAction contract checks — all other 71 assertions are green. Only the count was stale. Verified locally: 72/72 pass with the bump.

This unblocks cutting v0.91.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)