### PR TITLE
fix(auth): persist passkey MFA metadata under system DB context (#2210)

### DIFF
--- a/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
+++ b/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Real-DB regression lock for the passkey MFA verify write-context fix (#2210).
+ *
+ * Drives the actual POST /auth/mfa/passkey/verify handler against real
+ * Postgres (breeze_app, RLS-enforced) + Redis. Only the WebAuthn assertion
+ * verification is stubbed (verifyPasskeyAuthentication) — the pending-MFA
+ * redis record, the user_passkeys read/write, RLS, token minting and audit
+ * are all real, the same pattern as ssoPartnerLogin.integration.test.ts.
+ *
+ * The bug: passkey MFA runs BEFORE the user is authenticated, so the handler
+ * has no user RLS context. The `user_passkeys` update that persists the
+ * WebAuthn signature counter + last_used_at was issued with a bare `db.update`,
+ * which under breeze_app matches 0 rows (Shape 6: user_id = current_user OR
+ * scope = 'system'). Result: last_used_at stayed `Never` AND the counter never
+ * advanced — silently defeating clone detection. The fix wraps the update in
+ * withSystemDbAccessContext, mirroring the users.last_login_at update in the
+ * same handler. Without the fix this test fails (counter/last_used_at unchanged).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/passkeyMfaVerify.integration.test.ts
+ */
+import './setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { userPasskeys } from '../../db/schema';
+import { createPartner, createUser } from './db-utils';
+
+vi.mock('../../services/passkeys', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/passkeys')>();
+  return {
+    ...actual,
+    verifyPasskeyAuthentication: vi.fn()
+  };
+});
+
+import { verifyPasskeyAuthentication } from '../../services/passkeys';
+import { passkeyRoutes } from '../../routes/auth/passkeys';
+
+describe('POST /auth/mfa/passkey/verify — passkey metadata persists under RLS (#2210)', () => {
+  let app: Hono;
+  const tempTokens: string[] = [];
+
+  beforeEach(() => {
+    app = new Hono();
+    app.route('/auth', passkeyRoutes);
+    vi.mocked(verifyPasskeyAuthentication).mockReset();
+  });
+
+  afterEach(async () => {
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (redis && tempTokens.length > 0) {
+      await redis.del(...tempTokens.map((t) => `mfa:pending:${t}`));
+    }
+    tempTokens.length = 0;
+  });
+
+  it('persists last_used_at and the WebAuthn counter after a successful verify', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    // withMembership so resolveCurrentUserTokenContext can mint a real token.
+    const user = await createUser({ partnerId: partner.id, withMembership: true });
+
+    const credentialId = `cred-${user.id}`;
+    const [passkey] = await db
+      .insert(userPasskeys)
+      .values({
+        userId: user.id,
+        credentialId,
+        publicKey: 'dGVzdC1wdWJsaWMta2V5', // base64url placeholder; verifier is stubbed
+        counter: 0,
+        deviceType: 'singleDevice',
+        backedUp: false,
+        lastUsedAt: null
+      })
+      .returning();
+
+    if (!passkey) throw new Error('failed to insert test passkey');
+    expect(passkey.lastUsedAt).toBeNull();
+    expect(passkey.counter).toBe(0);
+
+    // Seed the pre-auth pending MFA session the login path would have written.
+    const { getRedis } = await import('../../services');
+    const redis = getRedis();
+    if (!redis) throw new Error('Redis unavailable in integration environment');
+    const tempToken = `test-passkey-mfa-${user.id}`;
+    tempTokens.push(tempToken);
+    await redis.set(
+      `mfa:pending:${tempToken}`,
+      JSON.stringify({ userId: user.id, mfaMethod: 'passkey', passkeyAvailable: true }),
+      'EX',
+      300
+    );
+
+    // The authenticator reports an advanced signature counter.
+    vi.mocked(verifyPasskeyAuthentication).mockResolvedValue({
+      verified: true,
+      authenticationInfo: {
+        newCounter: 42,
+        credentialDeviceType: 'multiDevice',
+        credentialBackedUp: true
+      }
+    } as Awaited<ReturnType<typeof verifyPasskeyAuthentication>>);
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken, credential: { id: credentialId } })
+    });
+
+    expect(res.status).toBe(200);
+
+    // The whole point of #2210: the metadata must actually land in the DB.
+    const [after] = await db
+      .select()
+      .from(userPasskeys)
+      .where(eq(userPasskeys.id, passkey.id))
+      .limit(1);
+
+    if (!after) throw new Error('passkey row missing after verify');
+    expect(after.lastUsedAt).not.toBeNull();
+    expect(after.counter).toBe(42);
+    expect(after.deviceType).toBe('multiDevice');
+    expect(after.backedUp).toBe(true);
+  });
+});

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -335,16 +335,24 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
   }
 
   const updateFields = authenticationInfoToPasskeyUpdateFields(verification);
-  await db
-    .update(userPasskeys)
-    .set({
-      counter: updateFields.counter,
-      deviceType: updateFields.deviceType,
-      backedUp: updateFields.backedUp,
-      lastUsedAt: updateFields.lastUsedAt,
-      updatedAt: new Date()
-    })
-    .where(eq(userPasskeys.id, passkey.id));
+  // System DB context required: passkey MFA runs before the user is
+  // authenticated, so without it this `user_passkeys` RLS UPDATE silently
+  // matches 0 rows under breeze_app (Shape 6: user_id = breeze_current_user_id()
+  // OR scope = 'system'). last_used_at never moves AND the WebAuthn signature
+  // counter is never persisted — defeating clone detection. Same root cause as
+  // the users.last_login_at update below (#2210, #1375).
+  await withSystemDbAccessContext(() =>
+    db
+      .update(userPasskeys)
+      .set({
+        counter: updateFields.counter,
+        deviceType: updateFields.deviceType,
+        backedUp: updateFields.backedUp,
+        lastUsedAt: updateFields.lastUsedAt,
+        updatedAt: new Date()
+      })
+      .where(eq(userPasskeys.id, passkey.id))
+  );
 
   // Single-use: consume the pending token. `redis` is guarded non-null above,
   // so this can't silently no-op the way `getRedis()?.del(...)` would.


### PR DESCRIPTION
Fixes #2210.

## Root cause
`POST /auth/mfa/passkey/verify` persists the authenticator's advanced signature counter + `last_used_at` with a bare `db.update(userPasskeys)`. Passkey MFA runs **before** the user is authenticated, so there is no user RLS context. `user_passkeys` is a Shape-6 (user-scoped) table — its policy allows a write only when `user_id = breeze_current_user_id()` **or** `scope = 'system'`. Under `breeze_app` with neither satisfied, the update **silently matches 0 rows**:

- `Last used` stays `Never` in User Profile → Passkeys.
- The WebAuthn signature **counter never advances** — so clone/replay detection is defeated (the security-relevant half, not just cosmetic).

The `users.last_login_at` update ~30 lines below in the same handler already wraps itself in `withSystemDbAccessContext` for exactly this reason (#1375); the passkey update was missed.

## Fix
Wrap the `user_passkeys` update in `withSystemDbAccessContext`, matching the sibling `users` update. One statement; no schema or behavior change beyond making the write actually land.

## Test
Adds `passkeyMfaVerify.integration.test.ts` — drives the real handler against real Postgres (`breeze_app`, RLS enforced) + Redis, stubbing only the WebAuthn assertion verification (same pattern as `ssoPartnerLogin.integration.test.ts`). It seeds the pre-auth pending-MFA record, posts a successful verify, and asserts `last_used_at` and `counter` are persisted. **Verified fail-before / pass-after**: against the unfixed handler it fails with `expected null not to be null` (the exact bug); with the fix it passes.

## Local gate (OrbStack, node 22.20.0, pnpm 10.33.4)
- `tsc --noEmit --project apps/api/tsconfig.json` (exact CI cmd) — clean
- `eslint` on both changed files — clean
- New integration test — pass (proven fail-before/pass-after)
- `silent-write-contract` + `dbContextTripwire` write-context guards — 11 pass
- Code-only change (no deps/Dockerfile/Go touched), so Trivy / govulncheck / pnpm-audit have no delta.
