### PR TITLE
fix(web): qualify stale pending-reboot on compliance table for offline devices (#2219)

### DIFF
--- a/apps/web/src/components/patches/PatchComplianceView.test.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.test.tsx
@@ -421,6 +421,32 @@ describe('PatchComplianceView', () => {
                 pendingReboot: true,
                 lastSeen: '2026-04-01T18:00:00.000Z',
               },
+              {
+                id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+                name: 'Offline-NoLastSeen',
+                os: 'windows',
+                missingCount: 1,
+                approvedMissing: 0,
+                unapprovedMissing: 1,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 1,
+                thirdPartyMissing: 0,
+                pendingReboot: true,
+              },
+              {
+                id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                name: 'Legacy-NoStatus',
+                os: 'windows',
+                missingCount: 1,
+                approvedMissing: 0,
+                unapprovedMissing: 1,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 1,
+                thirdPartyMissing: 0,
+                pendingReboot: true,
+              },
             ],
           },
         });
@@ -441,6 +467,21 @@ describe('PatchComplianceView', () => {
               osType: 'windows',
               status: 'offline',
               lastSeenAt: '2026-04-01T18:00:00.000Z',
+            },
+            {
+              // Offline with no last-seen anywhere: badge must be muted but
+              // must not render "as of Invalid Date" or a dangling "as of".
+              id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+              hostname: 'Offline-NoLastSeen',
+              osType: 'windows',
+              status: 'offline',
+            },
+            {
+              // Older API payload with no status field: fail open to the
+              // unqualified live badge (pre-#2219 behavior), never to stale.
+              id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+              hostname: 'Legacy-NoStatus',
+              osType: 'windows',
             },
           ],
         });
@@ -466,6 +507,21 @@ describe('PatchComplianceView', () => {
     expect(staleBadge).toHaveAttribute('title', expect.stringMatching(/offline.*last check-in.*stale/i));
     expect(
       screen.queryByTestId('compliance-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-pending-reboot')
+    ).toBeNull();
+
+    // Offline with no last-seen anywhere: still muted, but a bare "Yes" —
+    // no dangling "as of" and no "Invalid Date".
+    const noLastSeenBadge = screen.getByTestId('compliance-cccccccc-cccc-cccc-cccc-cccccccccccc-pending-reboot-stale');
+    expect(noLastSeenBadge.textContent).toBe('Yes');
+    expect(noLastSeenBadge.className).toContain('text-muted-foreground');
+
+    // Older API payload without a status field: fail open to the unqualified
+    // live badge (pre-#2219 behavior) — never misclassified as stale.
+    const legacyBadge = screen.getByTestId('compliance-dddddddd-dddd-dddd-dddd-dddddddddddd-pending-reboot');
+    expect(legacyBadge.textContent).toBe('Yes');
+    expect(legacyBadge.className).toContain('text-orange-700');
+    expect(
+      screen.queryByTestId('compliance-dddddddd-dddd-dddd-dddd-dddddddddddd-pending-reboot-stale')
     ).toBeNull();
 
     // Column header explains what REBOOT actually means (agent-reported OS

--- a/apps/web/src/components/patches/PatchComplianceView.test.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.test.tsx
@@ -384,6 +384,99 @@ describe('PatchComplianceView', () => {
     expect(dialogText).not.toMatch(/on \d+ device[s]? in Acme Corp/i);
   });
 
+  it('mutes the pending-reboot badge with an "as of" qualifier for offline devices and explains the column semantics (#2219)', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/patches/compliance') {
+        return makeJsonResponse({
+          data: {
+            totalDevices: 2,
+            compliantDevices: 0,
+            devicesNeedingPatches: [
+              {
+                id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                name: 'Online-Box',
+                os: 'windows',
+                missingCount: 1,
+                approvedMissing: 0,
+                unapprovedMissing: 1,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 1,
+                thirdPartyMissing: 0,
+                pendingReboot: true,
+                lastSeen: '2026-04-01T18:00:00.000Z',
+              },
+              {
+                id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+                name: 'Offline-Box',
+                os: 'windows',
+                missingCount: 1,
+                approvedMissing: 0,
+                unapprovedMissing: 1,
+                criticalCount: 0,
+                importantCount: 0,
+                osMissing: 1,
+                thirdPartyMissing: 0,
+                pendingReboot: true,
+                lastSeen: '2026-04-01T18:00:00.000Z',
+              },
+            ],
+          },
+        });
+      }
+      if (url === '/devices?limit=200') {
+        return makeJsonResponse({
+          devices: [
+            {
+              id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+              hostname: 'Online-Box',
+              osType: 'windows',
+              status: 'online',
+              lastSeenAt: '2026-04-01T18:00:00.000Z',
+            },
+            {
+              id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+              hostname: 'Offline-Box',
+              osType: 'windows',
+              status: 'offline',
+              lastSeenAt: '2026-04-01T18:00:00.000Z',
+            },
+          ],
+        });
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<PatchComplianceView ringId={null} />);
+
+    await screen.findByText('Online-Box');
+
+    // Online device: unqualified orange "Yes" badge.
+    const liveBadge = screen.getByTestId('compliance-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-pending-reboot');
+    expect(liveBadge.textContent).toBe('Yes');
+    expect(liveBadge.className).toContain('text-orange-700');
+
+    // Offline device: muted badge qualified with "as of <last seen>", not an
+    // unqualified "Yes" — and not hidden outright.
+    const staleBadge = screen.getByTestId('compliance-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-pending-reboot-stale');
+    expect(staleBadge.textContent).toMatch(/^Yes · as of /);
+    expect(staleBadge.className).toContain('text-muted-foreground');
+    expect(staleBadge.className).not.toContain('text-orange-700');
+    expect(staleBadge).toHaveAttribute('title', expect.stringMatching(/offline.*last check-in.*stale/i));
+    expect(
+      screen.queryByTestId('compliance-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-pending-reboot')
+    ).toBeNull();
+
+    // Column header explains what REBOOT actually means (agent-reported OS
+    // pending-reboot signal, any cause — not "reboot to install patches").
+    const rebootHeader = screen.getByRole('columnheader', { name: 'Reboot' });
+    expect(rebootHeader).toHaveAttribute(
+      'title',
+      expect.stringMatching(/OS reports a pending reboot.*reported by the agent/i)
+    );
+  });
+
   it('surfaces a distinct message when the install endpoint returns 409 approval failure', async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);

--- a/apps/web/src/components/patches/PatchComplianceView.tsx
+++ b/apps/web/src/components/patches/PatchComplianceView.tsx
@@ -116,6 +116,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
             lastInstalledAt: n?.lastInstalledAt ? String(n.lastInstalledAt) : undefined,
             lastScannedAt: n?.lastScannedAt ? String(n.lastScannedAt) : undefined,
             pendingReboot: Boolean(n?.pendingReboot),
+            status: raw.status ? String(raw.status) : undefined,
             orgId,
           });
         }
@@ -532,7 +533,7 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
               <th className="px-3 py-3" title="Outstanding updates from third-party or custom sources">3rd-Party</th>
               <th className="px-3 py-3" title="Outstanding patches rated critical severity">Critical</th>
               <th className="px-3 py-3" title="Most recent patch install or scan activity">Last Activity</th>
-              <th className="px-3 py-3" title="Device needs a reboot to complete patch installation">Reboot</th>
+              <th className="px-3 py-3" title="OS reports a pending reboot — any cause (Windows updates, CBS, pending file renames); reported by the agent. For offline devices this reflects the state at their last check-in.">Reboot</th>
               <th className="px-3 py-3 text-right">Actions</th>
             </tr>
           </thead>
@@ -639,10 +640,30 @@ export default function PatchComplianceView({ ringId }: PatchComplianceViewProps
                     </td>
                     <td className="px-3 py-2.5">
                       {device.pendingReboot ? (
-                        <span className="inline-flex items-center gap-1 rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-700">
-                          <RotateCcw className="h-3 w-3" />
-                          Yes
-                        </span>
+                        device.status === 'offline' ? (
+                          // Offline: the pending-reboot flag is frozen at the last
+                          // heartbeat and may be stale, so mute it and qualify with
+                          // "as of <last seen>" rather than an unqualified "Yes".
+                          // Same rationale as the Devices list suppression
+                          // (DeviceList.tsx), but compliance still wants the
+                          // signal visible, not hidden (#2219).
+                          <span
+                            data-testid={`compliance-${device.id}-pending-reboot-stale`}
+                            title="Device is offline — this reflects the OS state at its last check-in and may be stale."
+                            className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                          >
+                            <RotateCcw className="h-3 w-3" />
+                            Yes{device.lastSeenAt ? ` · as of ${formatRelativeTime(device.lastSeenAt)}` : ''}
+                          </span>
+                        ) : (
+                          <span
+                            data-testid={`compliance-${device.id}-pending-reboot`}
+                            className="inline-flex items-center gap-1 rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-700"
+                          >
+                            <RotateCcw className="h-3 w-3" />
+                            Yes
+                          </span>
+                        )
                       ) : (
                         <span className="text-muted-foreground">-</span>
                       )}

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -139,6 +139,10 @@ export type DevicePatchRow = {
   lastInstalledAt?: string;
   lastScannedAt?: string;
   pendingReboot: boolean;
+  /** Device status from the /devices API ('online' | 'offline' | ...). Used to
+   *  mute the pending-reboot badge for offline devices, whose reboot flag is
+   *  frozen at the last heartbeat and may be stale (#2219). */
+  status?: string;
   /** The org this device belongs to, as returned by the /devices API. Used to
    *  derive the true target scope for bulk-action confirmation messages. */
   orgId?: string;


### PR DESCRIPTION
## Summary

The Patch Compliance per-device table showed an unqualified REBOOT: **Yes** for devices that have been down for days, while the Devices list intentionally suppresses its pending-reboot dot when a device is offline (`DeviceList.tsx:956`) — so the two pages disagreed exactly for down devices, which is the confusing case. The column's meaning (live agent-reported OS pending-reboot signal, any cause — not "reboot to finish installing patches") was also unexplained.

## Changes

- **Header tooltip** on the REBOOT column: "OS reports a pending reboot — any cause (Windows updates, CBS, pending file renames); reported by the agent. For offline devices this reflects the state at their last check-in."
- **Offline treatment on the cell**: when the device is offline, the badge renders muted (`text-muted-foreground` on `bg-muted`) with a `Yes · as of <last seen>` qualifier and a cell tooltip, instead of the unqualified orange "Yes". The signal stays **visible** (compliance context wants it) rather than being hidden like the Devices list dot — matching the suppression *rationale* without copying the suppression.
- **No API change needed**: the view already merges `/devices?limit=200` (which carries `status`) with `/patches/compliance` (which already carries `lastSeen`), so the cell has everything it needs. Added `status` to `DevicePatchRow` and populated it in the merge.

## Testing

- New component test: online device keeps the unqualified orange badge; offline device gets the muted "Yes · as of …" badge with tooltip and is not rendered as the live badge; header tooltip present. (`vitest run src/components/patches/PatchComplianceView.test.tsx` — 8 passed)
- `tsc --noEmit` clean in `apps/web`.

Closes #2219

🤖 Generated with [Claude Code](https://claude.com/claude-code)