### PR TITLE
fix(patches): ring view source counts + derived os in ring patches endpoint (#2215)

### DIFF
--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, eq, sql, desc, asc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, asc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   patchPolicies,
@@ -11,7 +11,7 @@ import {
   devicePatches,
 } from '../db/schema';
 import { resolveRingDeviceCounts, resolveRingDeviceIds } from './updateRingsHelpers';
-import { getPagination } from './patches/helpers';
+import { getPagination, inferPatchOs } from './patches/helpers';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
@@ -433,8 +433,15 @@ updateRingRoutes.get(
 
     const { page, limit, offset } = getPagination(query);
 
-    const conditions = [];
-    if (query.source) conditions.push(eq(patches.source, query.source));
+    // Mirror GET /patches (patches/list.ts): track the source predicate
+    // separately so the per-source counts ignore the source filter and the
+    // chips always reflect the full breakdown of visible patches.
+    const conditions: SQL[] = [];
+    let sourcePredicate: SQL | undefined;
+    if (query.source) {
+      sourcePredicate = eq(patches.source, query.source);
+      conditions.push(sourcePredicate);
+    }
     if (query.severity) conditions.push(eq(patches.severity, query.severity));
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -448,6 +455,17 @@ updateRingRoutes.get(
         severity: patches.severity,
         category: patches.category,
         osTypes: patches.osTypes,
+        // Same device-derived OS hint as GET /patches (list.ts): the most
+        // recently checked device reporting this patch. Feeds inferPatchOs so
+        // third_party/custom patches with empty osTypes still resolve an OS.
+        inferredOs: sql<string | null>`(
+          SELECT "devices"."os_type"
+          FROM "device_patches"
+          INNER JOIN "devices" ON "devices"."id" = "device_patches"."device_id"
+          WHERE "device_patches"."patch_id" = "patches"."id"
+          ORDER BY "device_patches"."last_checked_at" DESC NULLS LAST
+          LIMIT 1
+        )`,
         releaseDate: patches.releaseDate,
         requiresReboot: patches.requiresReboot,
         downloadSizeMb: patches.downloadSizeMb,
@@ -463,6 +481,24 @@ updateRingRoutes.get(
       .select({ count: sql<number>`count(*)` })
       .from(patches)
       .where(whereClause);
+
+    // Per-source counts for the web's source filter chips — same shape as
+    // GET /patches so the ring view doesn't render all-zero chips (#2215).
+    const sourceConditions = conditions.filter((c) => c !== sourcePredicate);
+    const sourceWhereClause = sourceConditions.length > 0 ? and(...sourceConditions) : undefined;
+    const sourceCounts = await db
+      .select({ source: patches.source, count: sql<number>`count(*)::int` })
+      .from(patches)
+      .where(sourceWhereClause)
+      .groupBy(patches.source);
+    const counts: Record<string, number> = {
+      microsoft: 0,
+      apple: 0,
+      linux: 0,
+      third_party: 0,
+      custom: 0,
+    };
+    for (const row of sourceCounts) counts[row.source] = Number(row.count);
 
     // Get ring-scoped approval statuses
     const patchIdsInPage = patchList.map((p) => p.id);
@@ -488,11 +524,15 @@ updateRingRoutes.get(
 
     const data = patchList.map((patch) => ({
       ...patch,
+      // Derived scalar `os` — same field GET /patches returns; the web's
+      // normalizePatch reads this to render the OS column (#2215).
+      os: inferPatchOs(patch.osTypes, patch.source, patch.inferredOs),
       approvalStatus: ringApprovals[patch.id] || 'pending',
     }));
 
     return c.json({
       data,
+      counts,
       pagination: { page, limit, total: Number(countResult[0]?.count ?? 0) },
     });
   }

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -457,7 +457,9 @@ updateRingRoutes.get(
         osTypes: patches.osTypes,
         // Same device-derived OS hint as GET /patches (list.ts): the most
         // recently checked device reporting this patch. Feeds inferPatchOs so
-        // third_party/custom patches with empty osTypes still resolve an OS.
+        // third_party/custom patches with empty osTypes can still resolve an
+        // OS when a reporting device exists (otherwise inferPatchOs falls
+        // back to the source mapping, then 'unknown').
         inferredOs: sql<string | null>`(
           SELECT "devices"."os_type"
           FROM "device_patches"

--- a/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
+++ b/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
@@ -312,6 +312,150 @@ describe('updateRings routes', () => {
       expect(body.counts.apple).toBe(1);
     });
 
+    it('derives os from the device-derived inferredOs hint when osTypes is empty (#2215)', async () => {
+      vi.mocked(db.select)
+        // ring lookup
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+            })
+          })
+        } as any)
+        // patches list — third_party (no source mapping) but a device reported it
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([
+                    {
+                      id: PATCH_ID,
+                      title: 'Chrome 130 Update',
+                      source: 'third_party',
+                      severity: 'moderate',
+                      osTypes: [],
+                      inferredOs: 'windows',
+                      createdAt: new Date('2026-01-01')
+                    }
+                  ])
+                })
+              })
+            })
+          })
+        } as any)
+        // count
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        // per-source counts
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([{ source: 'third_party', count: 1 }])
+            })
+          })
+        } as any)
+        // approval statuses
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([])
+          })
+        } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Proves the route threads the inferredOs SELECT column into inferPatchOs.
+      expect(body.data[0].os).toBe('windows');
+    });
+
+    it('counts ignore the active source filter so chips show the full breakdown (#2215)', async () => {
+      // where() spy for the per-source counts query: with only ?source= set,
+      // the source predicate must be excluded, leaving NO conditions at all —
+      // i.e. where(undefined). Reusing the filtered whereClause here would
+      // reintroduce the #2215 bug class (chips collapsing under a filter).
+      const sourceCountsWhere = vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockResolvedValue([
+          { source: 'apple', count: 2 },
+          { source: 'microsoft', count: 3 }
+        ])
+      });
+      vi.mocked(db.select)
+        // ring lookup
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+            })
+          })
+        } as any)
+        // patches list (source-filtered)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([
+                    {
+                      id: PATCH_ID,
+                      title: 'macOS Update',
+                      source: 'apple',
+                      severity: 'important',
+                      osTypes: ['macos'],
+                      inferredOs: null,
+                      createdAt: new Date('2026-01-01')
+                    }
+                  ])
+                })
+              })
+            })
+          })
+        } as any)
+        // count (source-filtered)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 2 }])
+          })
+        } as any)
+        // per-source counts (must NOT be source-filtered)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ where: sourceCountsWhere })
+        } as any)
+        // approval statuses
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([])
+          })
+        } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches?source=apple`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      // Only the source condition existed, and it must be dropped from the
+      // counts query → no where clause at all.
+      expect(sourceCountsWhere).toHaveBeenCalledWith(undefined);
+      const body = await res.json();
+      expect(body.counts).toEqual({
+        microsoft: 3,
+        apple: 2,
+        linux: 0,
+        third_party: 0,
+        custom: 0,
+      });
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].source).toBe('apple');
+    });
+
     // Pagination regression (#1316 follow-up): the ring endpoint must share the
     // /patches getPagination — default 50, capped at 200 (not the old local 100).
     // Selecting a ring previously collapsed the visible list because the web sent

--- a/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
+++ b/apps/api/src/routes/updateRings_patches_compliance_scope.test.ts
@@ -207,6 +207,16 @@ describe('updateRings routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 1 }])
           })
         } as any)
+        // per-source counts (#2215)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([
+                { source: 'microsoft', count: 1 }
+              ])
+            })
+          })
+        } as any)
         // approval statuses (partner-scoped)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
@@ -225,7 +235,81 @@ describe('updateRings routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.data[0].approvalStatus).toBe('approved');
+      // Ring endpoint must return the same shape as GET /patches (#2215):
+      // a derived scalar `os` per patch and a per-source `counts` aggregate.
+      expect(body.data[0].os).toBe('windows');
+      expect(body.counts).toEqual({
+        microsoft: 1,
+        apple: 0,
+        linux: 0,
+        third_party: 0,
+        custom: 0,
+      });
       expect(body.pagination).toBeDefined();
+    });
+
+    it('derives os from source when osTypes is empty (#2215)', async () => {
+      vi.mocked(db.select)
+        // ring lookup
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+            })
+          })
+        } as any)
+        // patches list — no osTypes, no device-derived hint → source fallback
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue([
+                    {
+                      id: PATCH_ID,
+                      title: 'macOS Sequoia Update',
+                      source: 'apple',
+                      severity: 'important',
+                      osTypes: [],
+                      inferredOs: null,
+                      createdAt: new Date('2026-01-01')
+                    }
+                  ])
+                })
+              })
+            })
+          })
+        } as any)
+        // count
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 1 }])
+          })
+        } as any)
+        // per-source counts
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([{ source: 'apple', count: 1 }])
+            })
+          })
+        } as any)
+        // approval statuses
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([])
+          })
+        } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}/patches`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data[0].os).toBe('macos');
+      expect(body.counts.apple).toBe(1);
     });
 
     // Pagination regression (#1316 follow-up): the ring endpoint must share the
@@ -257,6 +341,14 @@ describe('updateRings routes', () => {
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockResolvedValue([{ count: 0 }])
+          })
+        } as any)
+        // per-source counts (#2215)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([])
+            })
           })
         } as any);
       return limitSpy;

--- a/apps/web/src/components/patches/patchHelpers.test.ts
+++ b/apps/web/src/components/patches/patchHelpers.test.ts
@@ -25,6 +25,12 @@ describe('normalizePatch — os resolution (#2215)', () => {
     expect(normalizePatch({ id: 'p1', title: 'KB1', osTypes: [] }, 0).os).toBe('Unknown');
     expect(normalizePatch({ id: 'p1', title: 'KB1' }, 0).os).toBe('Unknown');
   });
+
+  it("renders the API's literal 'unknown' with Unknown casing", () => {
+    // inferPatchOs returns the literal string 'unknown' when it can't resolve
+    // an OS — it must not leak through lowercase.
+    expect(normalizePatch({ id: 'p1', title: 'KB1', os: 'unknown' }, 0).os).toBe('Unknown');
+  });
 });
 
 // #1317: normalizeRing must coerce the ring's stored autoApprove JSONB into the

--- a/apps/web/src/components/patches/patchHelpers.test.ts
+++ b/apps/web/src/components/patches/patchHelpers.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeRing } from './patchHelpers';
+import { normalizePatch, normalizeRing } from './patchHelpers';
+
+// #2215: rows from endpoints that omit the derived scalar `os` (historically
+// the ring-scoped patches endpoint) must fall back to the raw osTypes[] array
+// instead of rendering every row as "Unknown".
+describe('normalizePatch — os resolution (#2215)', () => {
+  it('prefers the scalar os field when present', () => {
+    const patch = normalizePatch({ id: 'p1', title: 'KB1', os: 'windows', osTypes: ['linux'] }, 0);
+    expect(patch.os).toBe('Windows');
+  });
+
+  it('falls back to osTypes[0] when no scalar os field is present', () => {
+    const patch = normalizePatch({ id: 'p1', title: 'KB1', osTypes: ['macos'] }, 0);
+    expect(patch.os).toBe('macOS');
+  });
+
+  it('falls back to snake_case os_types[0] as well', () => {
+    const patch = normalizePatch({ id: 'p1', title: 'KB1', os_types: ['linux'] }, 0);
+    expect(patch.os).toBe('Linux');
+  });
+
+  it('renders Unknown when osTypes is empty and no scalar os exists', () => {
+    expect(normalizePatch({ id: 'p1', title: 'KB1', osTypes: [] }, 0).os).toBe('Unknown');
+    expect(normalizePatch({ id: 'p1', title: 'KB1' }, 0).os).toBe('Unknown');
+  });
+});
 
 // #1317: normalizeRing must coerce the ring's stored autoApprove JSONB into the
 // typed editor shape, tolerant of legacy values the API may still return.

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -60,7 +60,12 @@ export function normalizePatch(raw: Record<string, unknown>, index: number): Pat
   const id = raw.id ?? raw.patchId ?? raw.patch_id ?? `patch-${index}`;
   const title = raw.title ?? raw.name ?? raw.patchTitle ?? 'Untitled patch';
   const source = raw.source ?? raw.sourceName ?? raw.source_label;
-  const os = raw.os ?? raw.osType ?? raw.os_type ?? raw.platform;
+  // Prefer a scalar os field; fall back to the first entry of an osTypes
+  // array (the raw patch-catalog shape) so endpoints that omit the derived
+  // scalar don't render every row as "Unknown" (#2215).
+  const osTypesRaw = raw.osTypes ?? raw.os_types;
+  const os = raw.os ?? raw.osType ?? raw.os_type ?? raw.platform
+    ?? (Array.isArray(osTypesRaw) && osTypesRaw.length > 0 ? osTypesRaw[0] : undefined);
   const releaseDate = raw.releaseDate ?? raw.releasedAt ?? raw.release_date ?? raw.createdAt ?? '';
   const approvalStatus = raw.approvalStatus ?? raw.approval_status ?? raw.status;
   const vendor = raw.vendor ?? null;

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -26,7 +26,10 @@ const approvalMap: Record<string, PatchApprovalStatus> = {
 const osLabels: Record<string, string> = {
   windows: 'Windows',
   macos: 'macOS',
-  linux: 'Linux'
+  linux: 'Linux',
+  // The API's inferPatchOs returns the literal 'unknown' when it can't
+  // resolve an OS — render it with the same casing as the no-value label.
+  unknown: 'Unknown'
 };
 
 function formatSourceLabel(value: unknown): string {


### PR DESCRIPTION
## Summary

On Patch Management → Patches, selecting a specific update ring showed **0** on every source filter chip and **Unknown** in every OS column, while "All Rings" rendered both correctly for the same patches.

Root cause: the ring selector swaps endpoints, and `GET /update-rings/:id/patches` returned neither the per-source `counts` aggregate nor the derived scalar `os` field that `GET /patches` returns — so the web fell back to `setSourceCounts({})` and `normalizePatch` (which only read scalar os fields) rendered "Unknown".

## Changes

**API — `apps/api/src/routes/updateRings.ts` (ring patches endpoint)**
- Adds the same per-source `counts` aggregate as `GET /patches` (grouped count that ignores the `source` filter so the chips always show the full breakdown).
- Adds the derived scalar `os` per patch via the shared `inferPatchOs` helper (`apps/api/src/routes/patches/helpers.ts`), including the same device-derived `inferredOs` hint subquery so third_party/custom patches with empty `osTypes` resolve an OS from the most recently checked device reporting them.

**Web — `apps/web/src/components/patches/patchHelpers.ts`**
- `normalizePatch` now falls back to `osTypes[0]` / `os_types[0]` when no scalar os field is present, so raw-catalog-shaped responses no longer render every row as "Unknown".

## Tests

- `updateRings_patches_compliance_scope.test.ts`: ring response now asserted to include `counts` and a derived `os`; new case covering the source-based fallback when `osTypes` is empty; existing pagination mocks extended for the new counts query. (13 passed)
- `patchHelpers.test.ts`: new `normalizePatch` suite — scalar `os` precedence, `osTypes[0]`/`os_types[0]` fallback, Unknown when neither exists. (35 passed across patches web suites)
- `tsc --noEmit` clean in both `apps/api` and `apps/web`.

Closes #2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)