### PR TITLE
fix(patches): let ring auto-approve actually approve third-party patches (#2218)

### DIFF
--- a/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Third-party ring auto-approve severity exemption (#2218) — real Postgres.
+ *
+ * Winget/chocolatey/homebrew patches are ingested with severity='unknown' and
+ * no releaseDate, so the ring auto-approve severity gate (fail-closed on the
+ * configured severity set) could NEVER approve them — enabling third-party
+ * sources on a ring was dead configuration. When the policy explicitly opts
+ * into 'third_party' sources, a third-party candidate is exempt from the
+ * severity MEMBERSHIP check (OS patches keep full severity gating, and the
+ * source gate, empty-severities kill-switch, app rules, and deferral windows
+ * all still apply).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTestDb } from './setup';
+import { withDbAccessContext } from '../../db';
+import { devices, patches, devicePatches } from '../../db/schema';
+import {
+  resolveApprovedPatchesForDevice,
+  type ApprovalEvaluationConfig,
+} from '../../services/patchApprovalEvaluator';
+import { setupTestEnvironment } from './db-utils';
+
+let agentSeq = 0;
+async function seedDevice(orgId: string, siteId: string, hostname: string): Promise<string> {
+  const tdb = getTestDb();
+  agentSeq++;
+  const [row] = await tdb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-3p-${agentSeq}-${Date.now()}`,
+      hostname,
+      displayName: hostname,
+      osType: 'windows',
+      osVersion: '10.0.22631',
+      osBuild: '22631',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: no row');
+  return row.id;
+}
+
+/** Seed a pending device patch. No manual approval — auto-approve is what's under test. */
+async function seedPendingPatch(opts: {
+  orgId: string;
+  deviceId: string;
+  source: 'third_party' | 'microsoft';
+  severity: 'critical' | 'important' | 'moderate' | 'low' | 'unknown';
+  packageId?: string;
+}): Promise<string> {
+  const tdb = getTestDb();
+  const [patch] = await tdb
+    .insert(patches)
+    .values({
+      source: opts.source,
+      externalId: `${opts.source}:${randomUUID()}`,
+      title: opts.source === 'third_party' ? 'Mozilla Firefox 121.0' : 'Cumulative Update',
+      severity: opts.severity,
+      category: opts.source === 'third_party' ? 'application' : 'security',
+      packageId: opts.packageId ?? null,
+      version: opts.source === 'third_party' ? '121.0' : null,
+      // releaseDate deliberately omitted (NULL) — the winget shape.
+    })
+    .returning({ id: patches.id });
+  if (!patch) throw new Error('seedPendingPatch: no patch');
+  await tdb.insert(devicePatches).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    patchId: patch.id,
+    status: 'pending',
+    lastCheckedAt: new Date(),
+  });
+  return patch.id;
+}
+
+function ringConfig(partnerId: string, sources: string[]): ApprovalEvaluationConfig {
+  return {
+    ringId: randomUUID(),
+    ringPartnerId: partnerId,
+    categoryRules: [],
+    autoApprove: { enabled: true, severities: ['critical', 'important'], deferralDays: 0 },
+    deferralDays: 0,
+    sources,
+  };
+}
+
+describe('third-party ring auto-approve (#2218) — end-to-end against Postgres', () => {
+  let orgId: string;
+  let partnerId: string;
+  let siteId: string;
+
+  beforeEach(async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    orgId = env.organization.id;
+    partnerId = env.partner.id;
+    siteId = env.site.id;
+  });
+
+  async function evaluate(deviceId: string, config: ApprovalEvaluationConfig) {
+    return withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId,
+        accessibleOrgIds: [orgId],
+        // patch_approvals is partner-scoped (RLS: breeze_has_partner_access);
+        // the evaluator queries it by the device-org's partner.
+        accessiblePartnerIds: [partnerId],
+        userId: null,
+      },
+      () => resolveApprovedPatchesForDevice(deviceId, orgId, config),
+    );
+  }
+
+  it('auto-approves a winget-shaped patch (severity=unknown, releaseDate=null) on a third_party-enabled ring', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-a');
+    const patchId = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(deviceId, ringConfig(partnerId, ['third_party']));
+
+    expect(approved).toHaveLength(1);
+    expect(approved[0]!.patchId).toBe(patchId);
+    expect(approved[0]!.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('does NOT approve the same winget-shaped patch when the ring only enables OS sources', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-b');
+    await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(deviceId, ringConfig(partnerId, ['os']));
+
+    expect(approved).toEqual([]);
+  });
+
+  it('keeps OS severity gating unchanged on a third_party-enabled ring', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-c');
+    const unknownOsPatch = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'microsoft',
+      severity: 'unknown',
+    });
+    const criticalOsPatch = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'microsoft',
+      severity: 'critical',
+    });
+
+    const approved = await evaluate(deviceId, ringConfig(partnerId, ['os', 'third_party']));
+
+    expect(approved.map((p) => p.patchId)).toEqual([criticalOsPatch]);
+    expect(approved.map((p) => p.patchId)).not.toContain(unknownOsPatch);
+  });
+});

--- a/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
@@ -60,6 +60,12 @@ async function seedPendingPatch(opts: {
   source: 'third_party' | 'microsoft';
   severity: 'critical' | 'important' | 'moderate' | 'low' | 'unknown';
   packageId?: string;
+  /**
+   * Overrides device_patches.createdAt (the first-seen anchor for the deferral
+   * fallback). Omit to let the column default to now(). Backdate it to place a
+   * third-party patch outside a deferral window.
+   */
+  firstSeenAt?: Date;
 }): Promise<string> {
   const tdb = getTestDb();
   const [patch] = await tdb
@@ -82,16 +88,21 @@ async function seedPendingPatch(opts: {
     patchId: patch.id,
     status: 'pending',
     lastCheckedAt: new Date(),
+    ...(opts.firstSeenAt ? { createdAt: opts.firstSeenAt } : {}),
   });
   return patch.id;
 }
 
-function ringConfig(partnerId: string, sources: string[]): ApprovalEvaluationConfig {
+function ringConfig(
+  partnerId: string,
+  sources: string[],
+  deferralDays = 0,
+): ApprovalEvaluationConfig {
   return {
     ringId: randomUUID(),
     ringPartnerId: partnerId,
     categoryRules: [],
-    autoApprove: { enabled: true, severities: ['critical', 'important'], deferralDays: 0 },
+    autoApprove: { enabled: true, severities: ['critical', 'important'], deferralDays },
     deferralDays: 0,
     sources,
   };
@@ -175,5 +186,44 @@ describe('third-party ring auto-approve (#2218) — end-to-end against Postgres'
 
     expect(approved.map((p) => p.patchId)).toEqual([criticalOsPatch]);
     expect(approved.map((p) => p.patchId)).not.toContain(unknownOsPatch);
+  });
+
+  it('HOLDS a freshly-seen third-party patch under a deferral window (real device_patches.createdAt anchors it)', async () => {
+    // The winget shape has releaseDate=NULL, so the deferral window anchors on
+    // device_patches.createdAt — a column that only reaches the evaluator via
+    // the real SELECT projection. A just-seeded patch is created ~now, well
+    // inside a 7-day window, so it must be held. This exercises the first-seen
+    // fallback end-to-end (unit tests hand-feed firstSeenAt through the mock).
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-d');
+    await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(deviceId, ringConfig(partnerId, ['third_party'], 7));
+
+    expect(approved).toEqual([]);
+  });
+
+  it('APPROVES a third-party patch first seen before the deferral window (real createdAt past the hold)', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-e');
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+    const patchId = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+      firstSeenAt: tenDaysAgo,
+    });
+
+    const approved = await evaluate(deviceId, ringConfig(partnerId, ['third_party'], 7));
+
+    expect(approved).toHaveLength(1);
+    expect(approved[0]!.patchId).toBe(patchId);
+    expect(approved[0]!.approvalReason).toBe('ring_auto_approve');
   });
 });

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -5,7 +5,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  devicePatches: { id: 'id', patchId: 'patchId', deviceId: 'deviceId', status: 'status' },
+  devicePatches: { id: 'id', patchId: 'patchId', deviceId: 'deviceId', status: 'status', createdAt: 'createdAt' },
   patches: {
     id: 'id', externalId: 'externalId', title: 'title', category: 'category',
     severity: 'severity', releaseDate: 'releaseDate', requiresReboot: 'requiresReboot',
@@ -158,6 +158,7 @@ type PendingRow = {
   source: string;
   packageId: string | null;
   version: string | null;
+  firstSeenAt: Date | null;
 };
 
 function pendingRow(overrides: Partial<PendingRow>): PendingRow {
@@ -173,6 +174,7 @@ function pendingRow(overrides: Partial<PendingRow>): PendingRow {
     source: 'microsoft',
     packageId: null,
     version: null,
+    firstSeenAt: null,
     ...overrides,
   };
 }
@@ -1137,5 +1139,247 @@ describe('ring category include/exclude filtering in resolveApprovedPatchesForDe
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, baseRing);
 
     expect(approved).toHaveLength(2);
+  });
+});
+
+// ---- Third-party severity exemption for ring auto-approve (#2218) ----
+describe('third-party severity exemption for ring auto-approve (#2218)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  /** Winget-shaped patch: no vendor severity, no release date. */
+  const wingetRow = (overrides: Partial<PendingRow> = {}) =>
+    pendingRow({
+      patchId: P1,
+      source: 'third_party',
+      category: 'application',
+      severity: 'unknown',
+      releaseDate: null,
+      packageId: 'Mozilla.Firefox',
+      version: '121.0',
+      ...overrides,
+    });
+
+  const thirdPartyRing: RingConfig = {
+    ringId: RING_ID,
+    categoryRules: [],
+    autoApprove: { enabled: true, severities: ['critical', 'important'], deferralDays: 0 },
+    deferralDays: 0,
+    sources: ['os', 'third_party'],
+  };
+
+  it('auto-approves a winget-shaped patch (severity=unknown, releaseDate=null) on a third_party-enabled ring', async () => {
+    mockPendingAndApprovals([wingetRow()], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, thirdPartyRing);
+
+    expect(result.map((r) => r.patchId)).toEqual([P1]);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('also exempts a custom-source patch (third_party bucket)', async () => {
+    mockPendingAndApprovals([wingetRow({ source: 'custom' })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, thirdPartyRing);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('does NOT approve the same patch when sources is ["os"] (source gate still applies)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals([wingetRow()], []);
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ...thirdPartyRing,
+        sources: ['os'],
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does NOT exempt third-party severity when sources is absent (legacy: no explicit third_party opt-in)', async () => {
+    mockPendingAndApprovals([wingetRow()], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ...thirdPartyRing,
+      sources: undefined,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('OS patch severity gating is unchanged on a third_party-enabled ring', async () => {
+    mockPendingAndApprovals(
+      [
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'microsoft', severity: 'unknown' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'microsoft', severity: 'critical' }),
+      ],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, thirdPartyRing);
+
+    // Only the in-list OS severity approves; 'unknown' stays held.
+    expect(result.map((r) => r.patchId)).toEqual([P2]);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('empty-severities kill-switch still approves nothing, even for exempt third-party patches', async () => {
+    mockPendingAndApprovals([wingetRow()], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ...thirdPartyRing,
+      autoApprove: { enabled: true, severities: [], deferralDays: 0 },
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('app block rules still apply to exempt third-party patches', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals([wingetRow()], []);
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ...thirdPartyRing,
+        apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+// ---- Deferral fallback to first-seen for third-party patches (#2218) ----
+describe('deferral first-seen fallback for third-party patches (#2218)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  const deferredRing: RingConfig = {
+    ringId: RING_ID,
+    categoryRules: [],
+    autoApprove: { enabled: true, severities: ['critical'], deferralDays: 7 },
+    deferralDays: 0,
+    sources: ['third_party'],
+  };
+
+  it('holds a third-party patch first seen inside the deferral window', async () => {
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: yesterday })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+    expect(result).toEqual([]);
+  });
+
+  it('approves a third-party patch first seen past the deferral window', async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: tenDaysAgo })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('prefers releaseDate over first-seen when both exist', async () => {
+    // Released 10 days ago but only first seen yesterday: releaseDate anchors
+    // the window, so the patch is past the 7-day hold.
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000).toISOString();
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: tenDaysAgo, firstSeenAt: yesterday })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('still fails closed for a third-party patch with neither releaseDate nor firstSeenAt', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPendingAndApprovals(
+        [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: null })],
+        []
+      );
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cannot prove its age'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does NOT extend the first-seen fallback to OS patches (fail-closed unchanged)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+      mockPendingAndApprovals(
+        [pendingRow({ patchId: P1, source: 'microsoft', severity: 'critical', releaseDate: null, firstSeenAt: tenDaysAgo })],
+        []
+      );
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+        ...deferredRing,
+        sources: ['os'],
+      });
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cannot prove its age'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('applies the first-seen fallback on a third_party_app category deferral too', async () => {
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: yesterday, category: 'homebrew' })],
+      []
+    );
+
+    const held = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+    });
+    expect(held).toEqual([]);
+
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: tenDaysAgo, category: 'homebrew' })],
+      []
+    );
+
+    const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
+      autoApprove: {},
+      deferralDays: 0,
+      sources: ['third_party'],
+    });
+    expect(approved).toHaveLength(1);
+    expect(approved[0]?.approvalReason).toBe('category_rule');
   });
 });

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -1214,6 +1214,22 @@ describe('third-party severity exemption for ring auto-approve (#2218)', () => {
     expect(result).toEqual([]);
   });
 
+  it('does NOT exempt severity when sources is ["custom"] without an explicit "third_party" selection', async () => {
+    // A custom-source patch passes the source gate on sources:['custom']
+    // (buildAllowedPatchSources admits explicit 'custom'), but the exemption
+    // reads the RAW policy array for the literal 'third_party', which is
+    // absent here — so the unknown-severity custom patch stays held. This pins
+    // the raw-array vs expanded-bucket lockstep documented in the source.
+    mockPendingAndApprovals([wingetRow({ source: 'custom' })], []);
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ...thirdPartyRing,
+      sources: ['custom'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it('OS patch severity gating is unchanged on a third_party-enabled ring', async () => {
     mockPendingAndApprovals(
       [
@@ -1297,7 +1313,7 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     expect(result[0]?.approvalReason).toBe('ring_auto_approve');
   });
 
-  it('prefers releaseDate over first-seen when both exist', async () => {
+  it('prefers releaseDate over first-seen when releaseDate is past the window', async () => {
     // Released 10 days ago but only first seen yesterday: releaseDate anchors
     // the window, so the patch is past the 7-day hold.
     const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000).toISOString();
@@ -1310,6 +1326,43 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
 
     expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('prefers releaseDate over first-seen when releaseDate is inside the window (held)', async () => {
+    // Complementary direction: released yesterday (inside the 7-day hold) but
+    // first seen 10 days ago. releaseDate must win, so the patch is HELD — a
+    // bug that anchored on the older/more-permissive first-seen would approve.
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: yesterday, firstSeenAt: tenDaysAgo })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+    expect(result).toEqual([]);
+  });
+
+  it('fails closed for a third-party patch with an unparseable releaseDate (does NOT fall through to first-seen)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // A present-but-garbage releaseDate is a truthy Invalid Date, so the
+      // first-seen fallback is skipped; the Number.isNaN guard then holds it.
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+      mockPendingAndApprovals(
+        [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: 'not-a-date', firstSeenAt: tenDaysAgo })],
+        []
+      );
+
+      const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('its releaseDate value is unparseable'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('still fails closed for a third-party patch with neither releaseDate nor firstSeenAt', async () => {
@@ -1323,7 +1376,11 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
       const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, deferredRing);
 
       expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cannot prove its age'));
+      // Assert the specific reason so the anchor-differentiation feature can't
+      // silently regress to the generic message.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('it has no releaseDate and no first-seen fallback timestamp')
+      );
     } finally {
       warnSpy.mockRestore();
     }
@@ -1344,7 +1401,10 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
       });
 
       expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cannot prove its age'));
+      // OS path never mentions a first-seen fallback: bare "it has no releaseDate".
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('but it has no releaseDate, so it cannot prove its age')
+      );
     } finally {
       warnSpy.mockRestore();
     }

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -584,6 +584,12 @@ function evaluatePatchApproval(
     // `{ enabled: true }` row stays inert), OS patches keep full severity
     // gating, and the source, category, app-rule, and deferral gates all still
     // apply to third-party candidates.
+    // NOTE: this reads the RAW policy sources array for the literal
+    // 'third_party' selection, while isThirdPartyPatchSource matches the
+    // expanded patch-source bucket ('third_party' | 'custom'). The two stay in
+    // lockstep because buildAllowedPatchSources only admits 'custom' rows via
+    // the 'third_party' selection (or an explicit 'custom' entry) — if that
+    // expansion table ever changes, revisit this line too.
     const severityExempt =
       isThirdPartyPatchSource(patch.source) &&
       (ringConfig.sources ?? []).includes('third_party');
@@ -610,6 +616,11 @@ function isHeldByDeferral(
 ): boolean {
   if (deferralDays <= 0) return false;
 
+  // CAREFUL: new Date('garbage') is a truthy Invalid Date — validity is
+  // decided by the Number.isNaN check below, never by `!ageAnchor` alone. A
+  // present-but-unparseable releaseDate therefore does NOT fall through to the
+  // first-seen fallback; it fails closed (with a log line naming the anchor).
+  let anchorLabel = 'releaseDate';
   let ageAnchor: Date | null = patch.releaseDate ? new Date(patch.releaseDate) : null;
 
   if (!ageAnchor && isThirdPartyPatchSource(patch.source) && patch.firstSeenAt) {
@@ -619,15 +630,24 @@ function isHeldByDeferral(
     // (device_patches.createdAt) instead — a conservative proxy (never earlier
     // than the vendor release), so the patch is held at least as long as the
     // window intends. OS patches keep the fail-closed posture below.
+    anchorLabel = 'first-seen (device_patches.createdAt)';
     ageAnchor = new Date(patch.firstSeenAt);
   }
 
   if (!ageAnchor || Number.isNaN(ageAnchor.getTime())) {
     // Fail closed: with a deferral window configured, a patch without a
     // release date (or usable first-seen fallback) cannot prove its age,
-    // consistent with pin rules.
+    // consistent with pin rules. The reason names which anchor failed so a
+    // broken first-seen fallback (e.g. the column dropped from the select, a
+    // malformed timestamp) is distinguishable in logs from the routine
+    // "third-party patch has no releaseDate at all" case.
+    const reason = ageAnchor
+      ? `its ${anchorLabel} value is unparseable`
+      : isThirdPartyPatchSource(patch.source)
+        ? 'it has no releaseDate and no first-seen fallback timestamp'
+        : 'it has no releaseDate';
     console.warn(
-      `[PatchApproval] patch ${patch.patchId} held: ${source} deferral of ${deferralDays} day(s) configured but the patch has no releaseDate, so it cannot prove its age`
+      `[PatchApproval] patch ${patch.patchId} held: ${source} deferral of ${deferralDays} day(s) configured but ${reason}, so it cannot prove its age`
     );
     return true;
   }

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -341,6 +341,10 @@ export async function resolveApprovedPatchesForDevice(
       source: patches.source,
       packageId: patches.packageId,
       version: patches.version,
+      // First-seen timestamp for this device+patch. Third-party entries have no
+      // vendor releaseDate, so deferral windows anchor on when we first saw the
+      // patch instead of failing closed (#2218).
+      firstSeenAt: devicePatches.createdAt,
     })
     .from(devicePatches)
     .innerJoin(patches, eq(devicePatches.patchId, patches.id))
@@ -497,6 +501,12 @@ interface PatchCandidate {
   source: string;
   packageId: string | null;
   version: string | null;
+  /**
+   * device_patches.createdAt — when this device first reported the patch as
+   * pending. Deferral fallback anchor for third-party patches, which carry no
+   * vendor releaseDate (#2218).
+   */
+  firstSeenAt?: Date | string | null;
 }
 
 function evaluatePatchApproval(
@@ -563,7 +573,24 @@ function evaluatePatchApproval(
       // Enabled but no severities selected = approve nothing (fail-closed).
       return null;
     }
-    if (!patch.severity || !ringAutoApprove.severities.includes(patch.severity)) {
+    // Third-party severity exemption (#2218): winget/chocolatey/homebrew
+    // updates have no vendor severity concept — the agent/API ingest them with
+    // severity='unknown' — so requiring membership in the ring's severity set
+    // made third-party auto-approval dead configuration. When the policy has
+    // EXPLICITLY opted into third-party sources ('third_party' in sources; the
+    // default is ['os']) and this candidate is a third-party patch, skip the
+    // severity MEMBERSHIP check only. Everything else stays fail-closed: the
+    // empty-severities kill-switch above still approves nothing (a malformed
+    // `{ enabled: true }` row stays inert), OS patches keep full severity
+    // gating, and the source, category, app-rule, and deferral gates all still
+    // apply to third-party candidates.
+    const severityExempt =
+      isThirdPartyPatchSource(patch.source) &&
+      (ringConfig.sources ?? []).includes('third_party');
+    if (
+      !severityExempt &&
+      (!patch.severity || !ringAutoApprove.severities.includes(patch.severity))
+    ) {
       return null;
     }
     if (isHeldByDeferral(patch, ringAutoApprove.deferralDays, now, 'ring')) {
@@ -583,17 +610,29 @@ function isHeldByDeferral(
 ): boolean {
   if (deferralDays <= 0) return false;
 
-  if (!patch.releaseDate) {
+  let ageAnchor: Date | null = patch.releaseDate ? new Date(patch.releaseDate) : null;
+
+  if (!ageAnchor && isThirdPartyPatchSource(patch.source) && patch.firstSeenAt) {
+    // Third-party fallback (#2218): winget/homebrew entries carry no vendor
+    // releaseDate, so a configured deferral window used to hold them forever.
+    // Anchor the window on when this device first reported the patch
+    // (device_patches.createdAt) instead — a conservative proxy (never earlier
+    // than the vendor release), so the patch is held at least as long as the
+    // window intends. OS patches keep the fail-closed posture below.
+    ageAnchor = new Date(patch.firstSeenAt);
+  }
+
+  if (!ageAnchor || Number.isNaN(ageAnchor.getTime())) {
     // Fail closed: with a deferral window configured, a patch without a
-    // release date cannot prove its age, consistent with pin rules.
+    // release date (or usable first-seen fallback) cannot prove its age,
+    // consistent with pin rules.
     console.warn(
       `[PatchApproval] patch ${patch.patchId} held: ${source} deferral of ${deferralDays} day(s) configured but the patch has no releaseDate, so it cannot prove its age`
     );
     return true;
   }
 
-  const releaseDate = new Date(patch.releaseDate);
-  const deferralEnd = new Date(releaseDate.getTime() + deferralDays * 24 * 60 * 60 * 1000);
+  const deferralEnd = new Date(ageAnchor.getTime() + deferralDays * 24 * 60 * 60 * 1000);
   return deferralEnd > now;
 }
 

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -372,6 +372,15 @@ export default function UpdateRingForm({
                   {errors.autoApprove?.severities && (
                     <p className="mt-1.5 text-xs text-destructive">{errors.autoApprove.severities.message}</p>
                   )}
+                  <p
+                    className="mt-1.5 max-w-md text-xs text-muted-foreground"
+                    data-testid="ring-third-party-severity-note"
+                  >
+                    Severities apply to OS updates. Third-party app updates (winget, Homebrew)
+                    have no vendor severity — when a policy enables other-software sources, they
+                    auto-approve on this ring&apos;s cadence regardless of the severities selected
+                    here.
+                  </p>
                 </div>
                 <HoldField field={register('autoApprove.deferralDays')} testId="ring-auto-approve-deferral" />
               </div>


### PR DESCRIPTION
## Summary

Implements option (a) from #2218: third-party auto-approval on update rings was dead configuration because winget/chocolatey/homebrew patches are ingested with `severity='unknown'` and no `releaseDate`, so the fail-closed ring severity gate (and any deferral window) could never pass them.

## Changes

**`apps/api/src/services/patchApprovalEvaluator.ts`**
- **Severity exemption (Priority 3 ring auto-approve):** when the policy `sources` explicitly includes `third_party` (the default is `['os']`, so this is an operator opt-in) and the candidate's source is in `{third_party, custom}`, the candidate is exempt from the severity **membership** check only. Fail-closed posture otherwise preserved:
  - the empty-severities kill-switch still approves nothing (a malformed `{enabled: true}` row or legacy boolean `true` stays inert),
  - OS-source patches keep full severity gating,
  - the source gate, category include/exclude, app block/pin rules, and deferral windows all still apply to third-party candidates.
- **Deferral first-seen fallback:** a third-party candidate with no `releaseDate` now anchors the deferral window on `device_patches.createdAt` (first-seen on that device) instead of being held forever. First-seen is a conservative proxy — never earlier than the vendor release — so the patch is held at least as long as the window intends. OS patches with no `releaseDate` keep the existing fail-closed hold. (Plumbing was one extra column on the existing join, so the fallback was implemented rather than documented away.)

**`apps/web/src/components/patches/UpdateRingForm.tsx`**
- Helper note under the auto-approve severity chips: severities apply to OS updates; third-party app updates carry no vendor severity and approve on the ring's cadence when a policy enables other-software sources.

## Tests

- **Unit (`patchApprovalEvaluator.test.ts`, 90 passing):** winget-shaped patch (source=`third_party`, severity=`unknown`, releaseDate=`null`) auto-approved on a `third_party`-enabled ring; same patch NOT approved with `sources=['os']` or with sources absent; OS severity gating unchanged; empty-severities kill-switch still holds for exempt candidates; app block rules still apply; first-seen deferral fallback (held inside window, approved past it, releaseDate preferred when present, fail-closed with neither, no fallback for OS patches, works on `third_party_app` category deferrals too).
- **Integration (`patchThirdPartyRingAutoApprove.integration.test.ts`, real Postgres, 3 passing):** end-to-end proof that a winget-shaped pending device patch auto-approves with reason `ring_auto_approve` on a `third_party`-enabled ring, is not approved on `sources=['os']`, and OS severity gating is unchanged.
- `tsc --noEmit` clean in `apps/api` and `apps/web`; related suites (`patchJobExecutor`, `patchJobSnapshot`, `configurationPolicies/patchJobs`, `UpdateRingForm`, tombstone integration) all green.

Closes #2218

🤖 Generated with [Claude Code](https://claude.com/claude-code)