### PR TITLE
fix(patching): scope full-scan tombstoning to sources the scan covered (#2217)

### DIFF
--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/patching"
@@ -28,18 +29,27 @@ func handlePatchScan(h *Heartbeat, cmd Command) tools.CommandResult {
 		log.Info("patch scan requested", "source", source)
 	}
 
-	pendingItems, installedItems, err := h.collectPatchInventory()
+	pendingItems, installedItems, coveredSources, err := h.collectPatchInventory()
 	if err != nil && len(pendingItems) == 0 && len(installedItems) == 0 {
 		log.Error("patch scan failed", "source", source, "error", err.Error())
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 	if source != "" {
+		// A targeted upload sweeps the source's pending rows before re-upserting.
+		// If this source's provider didn't actually scan (skipped or failed),
+		// uploading the filtered-empty result would tombstone rows the scan never
+		// looked at (#2217) — fail the command instead.
+		if coveredSources != nil && !slices.Contains(coveredSources, source) {
+			err := fmt.Errorf("patch source %q could not be scanned (provider skipped or failed)", source)
+			log.Warn("patch scan did not cover requested source", "source", source)
+			return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+		}
 		pendingItems = filterPatchInventoryItemsBySource(pendingItems, source)
 		installedItems = filterPatchInventoryItemsBySource(installedItems, source)
 	}
 	installedItems = installedPatchStateItems(installedItems)
 
-	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, source, source == "")
+	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, source, source == "", coveredSources)
 	if pendingErr != nil {
 		err = fmt.Errorf("pending patch inventory send failed: %w", pendingErr)
 		log.Error("patch scan inventory send failed",

--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -34,6 +34,14 @@ func handlePatchScan(h *Heartbeat, cmd Command) tools.CommandResult {
 		log.Error("patch scan failed", "source", source, "error", err.Error())
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
+	if err != nil {
+		// Partial success: at least one provider produced items but another
+		// scan errored. The failed provider is excluded from coveredSources, so
+		// its bucket won't be swept — surface the error so that tombstoning
+		// change is explainable rather than silently swallowed (#2217).
+		log.Warn("patch scan partial failure; some providers did not scan",
+			"source", source, "error", err.Error())
+	}
 	if source != "" {
 		// A targeted upload sweeps the source's pending rows before re-upserting.
 		// If this source's provider didn't actually scan (skipped or failed),

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1873,7 +1873,7 @@ func (h *Heartbeat) sendPolicyConfigState() {
 }
 
 func (h *Heartbeat) sendPatchInventory() {
-	pendingItems, installedItems, err := h.collectPatchInventory()
+	pendingItems, installedItems, coveredSources, err := h.collectPatchInventory()
 	if err != nil {
 		log.Warn("patch inventory collection warning", "error", err.Error())
 	}
@@ -1884,7 +1884,7 @@ func (h *Heartbeat) sendPatchInventory() {
 		return
 	}
 
-	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", true)
+	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", true, coveredSources)
 	if pendingErr != nil {
 		log.Warn("failed to send pending patch inventory", "error", pendingErr.Error())
 	}
@@ -1893,7 +1893,12 @@ func (h *Heartbeat) sendPatchInventory() {
 	}
 }
 
-func (h *Heartbeat) sendPatchInventoryData(pendingItems, installedItems []map[string]any, source string, full bool) (error, error) {
+// sendPatchInventoryData uploads pending then installed patch inventory.
+// coveredSources only applies to full uploads: when non-nil it tells the API
+// which source buckets this scan actually covered, so pending rows from
+// skipped providers (e.g. winget without a helper session) aren't swept to
+// 'missing' (#2217). A nil coveredSources preserves the legacy full sweep.
+func (h *Heartbeat) sendPatchInventoryData(pendingItems, installedItems []map[string]any, source string, full bool, coveredSources []string) (error, error) {
 	installedItems = installedPatchStateItems(installedItems)
 	pendingPayload := map[string]any{
 		"patches": pendingItems,
@@ -1902,6 +1907,9 @@ func (h *Heartbeat) sendPatchInventoryData(pendingItems, installedItems []map[st
 		pendingPayload["source"] = source
 	} else if full {
 		pendingPayload["full"] = true
+		if coveredSources != nil {
+			pendingPayload["coveredSources"] = coveredSources
+		}
 	}
 
 	pendingErr := h.sendInventoryData(
@@ -1934,28 +1942,69 @@ func installedPatchStateItems(items []map[string]any) []map[string]any {
 	return filtered
 }
 
-func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any, error) {
+// collectPatchInventory gathers pending + installed patch inventory. The third
+// return value lists the source buckets the scan actually covered (see
+// coveredPatchSources); it is nil on the legacy collector path, which carries
+// no per-provider coverage information.
+func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any, []string, error) {
 	if h.patchMgr != nil && len(h.patchMgr.ProviderIDs()) > 0 {
-		available, scanErr := h.patchMgr.Scan()
+		available, coveredProviders, scanErr := h.patchMgr.ScanWithCoverage()
 		installed, installedErr := h.patchMgr.GetInstalled()
 
 		pendingItems := h.availablePatchesToMaps(available)
 		installedItems := h.installedPatchesToMaps(installed)
+		coveredSources := h.coveredPatchSources(h.patchMgr.ProviderIDs(), coveredProviders)
 
 		if scanErr != nil && installedErr != nil {
-			return pendingItems, installedItems, fmt.Errorf("patch scan failed: %v; installed scan failed: %v", scanErr, installedErr)
+			return pendingItems, installedItems, coveredSources, fmt.Errorf("patch scan failed: %v; installed scan failed: %v", scanErr, installedErr)
 		}
 		if scanErr != nil {
-			return pendingItems, installedItems, scanErr
+			return pendingItems, installedItems, coveredSources, scanErr
 		}
 		if installedErr != nil {
-			return pendingItems, installedItems, installedErr
+			return pendingItems, installedItems, coveredSources, installedErr
 		}
 
-		return pendingItems, installedItems, nil
+		return pendingItems, installedItems, coveredSources, nil
 	}
 
-	return h.collectPatchInventoryFromCollectors()
+	pendingItems, installedItems, err := h.collectPatchInventoryFromCollectors()
+	return pendingItems, installedItems, nil, err
+}
+
+// coveredPatchSources maps the provider IDs that actually scanned to the API
+// source buckets they feed. A bucket only counts as covered when EVERY
+// registered provider mapping to it ran: multiple providers can share a bucket
+// (winget + chocolatey → third_party), and sweeping the bucket while one of
+// them was skipped would tombstone the skipped provider's rows — the exact bug
+// this guards against (#2217). Always returns a non-nil slice so a scan where
+// everything was skipped serializes as an empty coveredSources array (sweep
+// nothing) rather than being omitted (legacy sweep-all).
+func (h *Heartbeat) coveredPatchSources(providerIDs, coveredProviders []string) []string {
+	coveredSet := make(map[string]bool, len(coveredProviders))
+	for _, id := range coveredProviders {
+		coveredSet[id] = true
+	}
+
+	fullyCovered := make(map[string]bool)
+	for _, id := range providerIDs {
+		source := h.mapPatchProviderSource(id)
+		if _, seen := fullyCovered[source]; !seen {
+			fullyCovered[source] = true
+		}
+		if !coveredSet[id] {
+			fullyCovered[source] = false
+		}
+	}
+
+	sources := make([]string, 0, len(fullyCovered))
+	for source, covered := range fullyCovered {
+		if covered {
+			sources = append(sources, source)
+		}
+	}
+	slices.Sort(sources)
+	return sources
 }
 
 func (h *Heartbeat) availablePatchesToMaps(patches []patching.AvailablePatch) []map[string]any {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1955,6 +1955,21 @@ func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any,
 		installedItems := h.installedPatchesToMaps(installed)
 		coveredSources := h.coveredPatchSources(h.patchMgr.ProviderIDs(), coveredProviders)
 
+		// Surface the coverage decision so a field operator can correlate a
+		// narrowed full-scan sweep on the server with which providers actually
+		// ran on the agent (#2217). When some registered source buckets weren't
+		// covered (a provider was skipped/failed — e.g. winget with no helper
+		// session), log at Info which buckets will NOT be swept this scan, so the
+		// chronically-unswept-bucket case is explainable in the field rather than
+		// mute on the happy path. Full coverage stays at Debug.
+		if uncovered := h.uncoveredPatchSources(h.patchMgr.ProviderIDs(), coveredSources); len(uncovered) > 0 {
+			log.Info("patch scan partial coverage; these source buckets will not be swept to missing this scan",
+				"coveredSources", coveredSources,
+				"uncoveredSources", uncovered)
+		} else {
+			log.Debug("patch scan full coverage", "coveredSources", coveredSources)
+		}
+
 		if scanErr != nil && installedErr != nil {
 			return pendingItems, installedItems, coveredSources, fmt.Errorf("patch scan failed: %v; installed scan failed: %v", scanErr, installedErr)
 		}
@@ -1980,6 +1995,16 @@ func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any,
 // this guards against (#2217). Always returns a non-nil slice so a scan where
 // everything was skipped serializes as an empty coveredSources array (sweep
 // nothing) rather than being omitted (legacy sweep-all).
+//
+// INTERIM LIMITATION (until #2216 lands): the coverage mechanism keys off
+// providers returning patching.ErrScanSkipped, but the current winget provider
+// still returns (nil, nil) when it can't run (no connected user helper session)
+// instead of the sentinel. So a skipped winget is counted as "scanned and found
+// nothing" and its third_party bucket is treated as COVERED — the coverage guard
+// is inert-but-correct for winget: it never wrongly narrows the sweep, it just
+// can't yet protect winget's own rows. #2216 splits winget.go and has its SYSTEM
+// provider adopt ErrScanSkipped, at which point this mechanism becomes fully
+// effective for winget with no change here. Do not edit winget.go for #2217.
 func (h *Heartbeat) coveredPatchSources(providerIDs, coveredProviders []string) []string {
 	coveredSet := make(map[string]bool, len(coveredProviders))
 	for _, id := range coveredProviders {
@@ -2005,6 +2030,30 @@ func (h *Heartbeat) coveredPatchSources(providerIDs, coveredProviders []string) 
 	}
 	slices.Sort(sources)
 	return sources
+}
+
+// uncoveredPatchSources returns the source buckets that the registered
+// providers map to but that coveredSources does NOT include — i.e. buckets a
+// full scan will leave untouched because a provider feeding them was skipped or
+// failed. Used purely for operator-facing logging (#2217).
+func (h *Heartbeat) uncoveredPatchSources(providerIDs, coveredSources []string) []string {
+	coveredSet := make(map[string]bool, len(coveredSources))
+	for _, s := range coveredSources {
+		coveredSet[s] = true
+	}
+
+	seen := make(map[string]bool)
+	uncovered := make([]string, 0)
+	for _, id := range providerIDs {
+		source := h.mapPatchProviderSource(id)
+		if coveredSet[source] || seen[source] {
+			continue
+		}
+		seen[source] = true
+		uncovered = append(uncovered, source)
+	}
+	slices.Sort(uncovered)
+	return uncovered
 }
 
 func (h *Heartbeat) availablePatchesToMaps(patches []patching.AvailablePatch) []map[string]any {

--- a/agent/internal/heartbeat/patch_inventory_test.go
+++ b/agent/internal/heartbeat/patch_inventory_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/breeze-rmm/agent/internal/config"
@@ -251,6 +252,61 @@ func TestSendPatchInventoryDataFullOmitsNilCoveredSources(t *testing.T) {
 	}
 }
 
+func TestSendPatchInventoryDataFullIncludesEmptyCoveredSources(t *testing.T) {
+	// A scan where every provider was skipped yields a non-nil but empty covered
+	// set. It MUST serialize as coveredSources: [] (present, empty) so the API
+	// scopes the sweep to nothing — distinct from nil/omitted, which the API
+	// treats as a legacy sweep-all. This is the exact schema-contract distinction
+	// the coverage mechanism depends on (#2217).
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		nil,
+		nil,
+		"",
+		true,
+		[]string{}, // non-nil, empty: every provider skipped
+	)
+	if pendingErr != nil {
+		t.Fatalf("pendingErr = %v", pendingErr)
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+
+	// Assert the raw JSON carries "coveredSources":[] — not omitted, not null.
+	if !strings.Contains(string(requests[0].body), `"coveredSources":[]`) {
+		t.Fatalf("payload should contain empty coveredSources array, got %s", requests[0].body)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(requests[0].body, &payload); err != nil {
+		t.Fatalf("pending JSON error = %v", err)
+	}
+	covered, ok := payload["coveredSources"].([]any)
+	if !ok {
+		t.Fatalf("coveredSources = %#v, want present empty array", payload["coveredSources"])
+	}
+	if len(covered) != 0 {
+		t.Fatalf("coveredSources = %#v, want empty", covered)
+	}
+}
+
 func TestCoveredPatchSources(t *testing.T) {
 	h := &Heartbeat{}
 
@@ -310,6 +366,50 @@ func TestCoveredPatchSources(t *testing.T) {
 			for i := range tt.want {
 				if got[i] != tt.want[i] {
 					t.Fatalf("coveredPatchSources = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestUncoveredPatchSources(t *testing.T) {
+	h := &Heartbeat{}
+
+	tests := []struct {
+		name        string
+		providerIDs []string
+		covered     []string
+		want        []string
+	}{
+		{
+			name:        "full coverage yields no uncovered buckets",
+			providerIDs: []string{"windows-update", "winget"},
+			covered:     []string{"microsoft", "third_party"},
+			want:        []string{},
+		},
+		{
+			name:        "skipped winget leaves third_party uncovered",
+			providerIDs: []string{"windows-update", "winget"},
+			covered:     []string{"microsoft"},
+			want:        []string{"third_party"},
+		},
+		{
+			name:        "nothing covered reports every mapped bucket once",
+			providerIDs: []string{"windows-update", "winget", "chocolatey"},
+			covered:     []string{},
+			want:        []string{"microsoft", "third_party"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := h.uncoveredPatchSources(tt.providerIDs, tt.covered)
+			if len(got) != len(tt.want) {
+				t.Fatalf("uncoveredPatchSources = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("uncoveredPatchSources = %v, want %v", got, tt.want)
 				}
 			}
 		})

--- a/agent/internal/heartbeat/patch_inventory_test.go
+++ b/agent/internal/heartbeat/patch_inventory_test.go
@@ -44,6 +44,7 @@ func TestSendPatchInventoryDataSendsPendingThenInstalled(t *testing.T) {
 		installed,
 		"microsoft",
 		false,
+		nil,
 	)
 	if pendingErr != nil {
 		t.Fatalf("pendingErr = %v", pendingErr)
@@ -104,6 +105,7 @@ func TestSendPatchInventoryDataSkipsLinuxInstalledPackageInventory(t *testing.T)
 		[]map[string]any{{"name": "openssl", "source": "linux"}},
 		"linux",
 		false,
+		nil,
 	)
 	if pendingErr != nil {
 		t.Fatalf("pendingErr = %v", pendingErr)
@@ -139,6 +141,7 @@ func TestSendPatchInventoryDataStopsWhenPendingUploadFails(t *testing.T) {
 		[]map[string]any{{"name": "pkg", "source": "linux"}},
 		"linux",
 		false,
+		nil,
 	)
 	if pendingErr == nil {
 		t.Fatal("expected pendingErr")
@@ -151,6 +154,165 @@ func TestSendPatchInventoryDataStopsWhenPendingUploadFails(t *testing.T) {
 	}
 	if requests[0].path != "/api/v1/agents/agent-1/patches/pending" {
 		t.Fatalf("path = %q", requests[0].path)
+	}
+}
+
+func TestSendPatchInventoryDataFullIncludesCoveredSources(t *testing.T) {
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		[]map[string]any{{"name": "KB5000001", "source": "microsoft"}},
+		nil,
+		"",
+		true,
+		[]string{"microsoft"},
+	)
+	if pendingErr != nil {
+		t.Fatalf("pendingErr = %v", pendingErr)
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(requests[0].body, &payload); err != nil {
+		t.Fatalf("pending JSON error = %v", err)
+	}
+	if payload["full"] != true {
+		t.Fatalf("full = %#v, want true", payload["full"])
+	}
+	covered, ok := payload["coveredSources"].([]any)
+	if !ok {
+		t.Fatalf("coveredSources = %#v, want array", payload["coveredSources"])
+	}
+	if len(covered) != 1 || covered[0] != "microsoft" {
+		t.Fatalf("coveredSources = %#v, want [microsoft]", covered)
+	}
+}
+
+func TestSendPatchInventoryDataFullOmitsNilCoveredSources(t *testing.T) {
+	// Legacy collector path has no coverage info (nil): the payload must omit
+	// coveredSources entirely so the API keeps the legacy full sweep.
+	var requests []patchInventoryRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, patchInventoryRequest{path: r.URL.Path, body: body})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := New(&config.Config{AgentID: "agent-1", ServerURL: ts.URL, AuthToken: "token"})
+	h.retryCfg = httputil.RetryConfig{MaxRetries: 0}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(
+		[]map[string]any{{"name": "KB5000001", "source": "microsoft"}},
+		nil,
+		"",
+		true,
+		nil,
+	)
+	if pendingErr != nil {
+		t.Fatalf("pendingErr = %v", pendingErr)
+	}
+	if installedErr != nil {
+		t.Fatalf("installedErr = %v", installedErr)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(requests[0].body, &payload); err != nil {
+		t.Fatalf("pending JSON error = %v", err)
+	}
+	if payload["full"] != true {
+		t.Fatalf("full = %#v, want true", payload["full"])
+	}
+	if _, ok := payload["coveredSources"]; ok {
+		t.Fatalf("coveredSources should be omitted for nil coverage, got %#v", payload["coveredSources"])
+	}
+}
+
+func TestCoveredPatchSources(t *testing.T) {
+	h := &Heartbeat{}
+
+	tests := []struct {
+		name        string
+		providerIDs []string
+		covered     []string
+		want        []string
+	}{
+		{
+			name:        "all providers ran",
+			providerIDs: []string{"windows-update", "winget"},
+			covered:     []string{"windows-update", "winget"},
+			want:        []string{"microsoft", "third_party"},
+		},
+		{
+			name:        "skipped winget removes third_party coverage",
+			providerIDs: []string{"windows-update", "winget"},
+			covered:     []string{"windows-update"},
+			want:        []string{"microsoft"},
+		},
+		{
+			name:        "shared bucket only covered when every provider ran",
+			providerIDs: []string{"windows-update", "chocolatey", "winget"},
+			covered:     []string{"windows-update", "chocolatey"},
+			want:        []string{"microsoft"},
+		},
+		{
+			name:        "shared bucket covered when both providers ran",
+			providerIDs: []string{"chocolatey", "winget"},
+			covered:     []string{"chocolatey", "winget"},
+			want:        []string{"third_party"},
+		},
+		{
+			name:        "nothing ran yields empty (not nil) coverage",
+			providerIDs: []string{"winget"},
+			covered:     nil,
+			want:        []string{},
+		},
+		{
+			name:        "linux providers map to linux bucket",
+			providerIDs: []string{"apt"},
+			covered:     []string{"apt"},
+			want:        []string{"linux"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := h.coveredPatchSources(tt.providerIDs, tt.covered)
+			if got == nil {
+				t.Fatal("coveredPatchSources returned nil, want non-nil slice")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("coveredPatchSources = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("coveredPatchSources = %v, want %v", got, tt.want)
+				}
+			}
+		})
 	}
 }
 

--- a/agent/internal/patching/errors.go
+++ b/agent/internal/patching/errors.go
@@ -1,6 +1,16 @@
 package patching
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrScanSkipped is a sentinel a provider's Scan returns when the provider
+// could not run at all (e.g. winget with no connected user helper session).
+// Skipped is distinct from "scanned and found nothing": the server must not
+// tombstone a skipped provider's previously reported patches, so skipped
+// providers are excluded from scan coverage (see PatchManager.ScanWithCoverage).
+var ErrScanSkipped = errors.New("patch provider scan skipped")
 
 // ErrPreflightFailed indicates a pre-flight check failed before patching could proceed.
 type ErrPreflightFailed struct {

--- a/agent/internal/patching/manager.go
+++ b/agent/internal/patching/manager.go
@@ -29,24 +29,39 @@ func NewPatchManager(providers ...PatchProvider) *PatchManager {
 
 // Scan aggregates available patches from all providers.
 func (m *PatchManager) Scan() ([]AvailablePatch, error) {
+	patches, _, err := m.ScanWithCoverage()
+	return patches, err
+}
+
+// ScanWithCoverage aggregates available patches from all providers and also
+// reports which provider IDs actually scanned. A provider that returned
+// ErrScanSkipped (couldn't run, e.g. winget without a user helper session) or
+// failed with an error is NOT covered: its previously reported patches must
+// not be treated as gone just because this scan didn't include them (#2217).
+func (m *PatchManager) ScanWithCoverage() ([]AvailablePatch, []string, error) {
 	var patches []AvailablePatch
+	covered := make([]string, 0, len(m.providers))
 	var errs []error
 
 	for _, provider := range m.providers {
 		providerPatches, err := provider.Scan()
+		if errors.Is(err, ErrScanSkipped) {
+			continue
+		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s scan failed: %w", provider.ID(), err))
 			continue
 		}
 
+		covered = append(covered, provider.ID())
 		patches = append(patches, m.decorateAvailable(provider.ID(), providerPatches)...)
 	}
 
 	if len(patches) == 0 && len(errs) > 0 {
-		return nil, errors.Join(errs...)
+		return nil, covered, errors.Join(errs...)
 	}
 
-	return patches, errors.Join(errs...)
+	return patches, covered, errors.Join(errs...)
 }
 
 // Install installs a patch by ID.

--- a/agent/internal/patching/manager_test.go
+++ b/agent/internal/patching/manager_test.go
@@ -2,6 +2,7 @@ package patching
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -9,6 +10,7 @@ import (
 type fakeProvider struct {
 	id            string
 	scan          []AvailablePatch
+	scanErr       error
 	installed     []InstalledPatch
 	installErr    error
 	installResult InstallResult
@@ -21,7 +23,7 @@ func (p *fakeProvider) ID() string { return p.id }
 
 func (p *fakeProvider) Name() string { return p.id }
 
-func (p *fakeProvider) Scan() ([]AvailablePatch, error) { return p.scan, nil }
+func (p *fakeProvider) Scan() ([]AvailablePatch, error) { return p.scan, p.scanErr }
 
 func (p *fakeProvider) Install(patchID string) (InstallResult, error) {
 	p.lastInstallID = patchID
@@ -66,6 +68,115 @@ func TestPatchManagerScanDecoratesProviderPatchIDs(t *testing.T) {
 	}
 	if patches[1].ID != "yum:kernel" || patches[1].Provider != "yum" {
 		t.Fatalf("unexpected second patch: %+v", patches[1])
+	}
+}
+
+func TestPatchManagerScanWithCoverage(t *testing.T) {
+	tests := []struct {
+		name        string
+		providers   []*fakeProvider
+		wantPatches int
+		wantCovered []string
+		wantErr     bool
+	}{
+		{
+			name: "all providers ran",
+			providers: []*fakeProvider{
+				{id: "windows-update", scan: []AvailablePatch{{ID: "kb1", Title: "KB1"}}},
+				{id: "winget", scan: []AvailablePatch{{ID: "Mozilla.Firefox", Title: "Firefox"}}},
+			},
+			wantPatches: 2,
+			wantCovered: []string{"windows-update", "winget"},
+		},
+		{
+			name: "empty result still counts as covered",
+			providers: []*fakeProvider{
+				{id: "windows-update"},
+			},
+			wantPatches: 0,
+			wantCovered: []string{"windows-update"},
+		},
+		{
+			name: "skipped provider is excluded from coverage without error",
+			providers: []*fakeProvider{
+				{id: "windows-update", scan: []AvailablePatch{{ID: "kb1", Title: "KB1"}}},
+				{id: "winget", scanErr: ErrScanSkipped},
+			},
+			wantPatches: 1,
+			wantCovered: []string{"windows-update"},
+		},
+		{
+			name: "wrapped skip sentinel is still a skip",
+			providers: []*fakeProvider{
+				{id: "winget", scanErr: fmt.Errorf("no helper session: %w", ErrScanSkipped)},
+			},
+			wantPatches: 0,
+			wantCovered: []string{},
+		},
+		{
+			name: "failed provider is excluded from coverage and surfaces the error",
+			providers: []*fakeProvider{
+				{id: "windows-update", scan: []AvailablePatch{{ID: "kb1", Title: "KB1"}}},
+				{id: "winget", scanErr: errors.New("timeout")},
+			},
+			wantPatches: 1,
+			wantCovered: []string{"windows-update"},
+			wantErr:     true,
+		},
+		{
+			name: "all providers skipped yields empty coverage and no error",
+			providers: []*fakeProvider{
+				{id: "winget", scanErr: ErrScanSkipped},
+				{id: "chocolatey", scanErr: ErrScanSkipped},
+			},
+			wantPatches: 0,
+			wantCovered: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providers := make([]PatchProvider, len(tt.providers))
+			for i, p := range tt.providers {
+				providers[i] = p
+			}
+			mgr := NewPatchManager(providers...)
+
+			patches, covered, err := mgr.ScanWithCoverage()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if len(patches) != tt.wantPatches {
+				t.Fatalf("expected %d patches, got %d: %+v", tt.wantPatches, len(patches), patches)
+			}
+			if len(covered) != len(tt.wantCovered) {
+				t.Fatalf("covered = %v, want %v", covered, tt.wantCovered)
+			}
+			for i, id := range tt.wantCovered {
+				if covered[i] != id {
+					t.Fatalf("covered = %v, want %v", covered, tt.wantCovered)
+				}
+			}
+		})
+	}
+}
+
+func TestPatchManagerScanIgnoresSkippedProviders(t *testing.T) {
+	// Legacy Scan() must not surface ErrScanSkipped as a failure.
+	mgr := NewPatchManager(
+		&fakeProvider{id: "windows-update", scan: []AvailablePatch{{ID: "kb1", Title: "KB1"}}},
+		&fakeProvider{id: "winget", scanErr: ErrScanSkipped},
+	)
+
+	patches, err := mgr.Scan()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
 	}
 }
 

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -589,6 +589,130 @@ describe('split patch ingest endpoints', () => {
   });
 });
 
+describe('PUT /agents/:id/patches/pending - full scan coverage scoping (#2217)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeviceLookup('windows');
+    vi.mocked(enrichmentModule.enrichFromCatalog).mockImplementation(async (input) => ({
+      title: input.title,
+      vendor: input.vendor,
+      severity: (input.severity as 'critical' | 'important' | 'moderate' | 'low' | 'unknown' | null) ?? null,
+      category: input.category ?? null,
+      matchedCatalogId: null,
+    }));
+  });
+
+  function captureUpdateWhere(tx: ReturnType<typeof mockPatchInsertTx>['tx']) {
+    const calls: unknown[] = [];
+    tx.update = vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn((condition) => {
+          calls.push(condition);
+          return Promise.resolve(undefined);
+        }),
+      })),
+    }));
+    return calls;
+  }
+
+  it('full scan with coveredSources only tombstones the covered sources and still upserts scanned patches', async () => {
+    const { tx } = mockPatchInsertTx();
+    const updateWheres = captureUpdateWhere(tx);
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        full: true,
+        coveredSources: ['microsoft'],
+        patches: [
+          { name: 'KB5000001', source: 'microsoft', externalId: 'KB5000001' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, pending: 1 });
+
+    expect(tx.update).toHaveBeenCalledTimes(1);
+    expect(tx.update).toHaveBeenCalledWith(tables.devicePatches);
+    const conditions = (updateWheres[0] as { conds?: unknown[] }).conds ?? [];
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.deviceId, right: DEVICE_ID });
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.status, right: 'pending' });
+    const serialized = JSON.stringify(updateWheres[0]);
+    expect(serialized).toContain('microsoft');
+    expect(serialized).not.toContain('third_party');
+
+    // The scanned patch is still re-upserted.
+    expect(tx.insert).toHaveBeenCalledWith(tables.patches);
+    expect(tx.insert).toHaveBeenCalledWith(tables.devicePatches);
+  });
+
+  it('legacy full scan without coveredSources sweeps all sources', async () => {
+    const { tx } = mockPatchInsertTx();
+    const updateWheres = captureUpdateWhere(tx);
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        full: true,
+        patches: [
+          { name: 'KB5000001', source: 'microsoft', externalId: 'KB5000001' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(tx.update).toHaveBeenCalledTimes(1);
+    // No source scoping: only the deviceId + pending-status conditions.
+    const conditions = (updateWheres[0] as { conds?: unknown[] }).conds ?? [];
+    expect(conditions).toHaveLength(2);
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.deviceId, right: DEVICE_ID });
+    expect(conditions).toContainEqual({ op: 'eq', left: tables.devicePatches.status, right: 'pending' });
+    expect(tx.insert).toHaveBeenCalledWith(tables.devicePatches);
+  });
+
+  it('full scan with empty coveredSources tombstones nothing', async () => {
+    const { tx } = mockPatchInsertTx();
+    vi.mocked(db.transaction).mockImplementation(async (fn) => fn(tx as unknown as Parameters<typeof fn>[0]));
+
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        full: true,
+        coveredSources: [],
+        patches: [],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, pending: 0 });
+    expect(tx.update).not.toHaveBeenCalled();
+    expect(tx.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects coveredSources values outside the source enum', async () => {
+    const res = await mountAgentPatchRoutes().request(`/agents/${AGENT_ID}/patches/pending`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        full: true,
+        coveredSources: ['not-a-source'],
+        patches: [],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+});
+
 const patchIngestEndpoints = [
   {
     label: 'legacy combined patch ingest',

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -314,7 +314,16 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
 
   await db.transaction(async (tx) => {
     if (data.full) {
-      await markPendingDevicePatchesMissing(tx, device.id, []);
+      if (data.coveredSources === undefined) {
+        // Legacy agents send full scans without coverage info: sweep all sources.
+        await markPendingDevicePatchesMissing(tx, device.id, []);
+      } else if (data.coveredSources.length > 0) {
+        // Coverage-aware full scan (#2217): only sweep sources whose providers
+        // actually ran. Skipped providers (e.g. winget without a helper
+        // session) keep their pending rows instead of being tombstoned.
+        await markPendingDevicePatchesMissing(tx, device.id, data.coveredSources);
+      }
+      // full with coveredSources: [] means every provider was skipped — sweep nothing.
     } else if (sources.length > 0) {
       await markPendingDevicePatchesMissing(tx, device.id, sources);
     }
@@ -334,6 +343,7 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
       pendingCount: data.patches.length,
       source: data.source ?? null,
       full: data.full,
+      coveredSources: data.coveredSources ?? null,
     },
   });
 

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -316,14 +316,24 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
     if (data.full) {
       if (data.coveredSources === undefined) {
         // Legacy agents send full scans without coverage info: sweep all sources.
+        // Log the path so an operator can tell a legacy sweep-all from a
+        // coverage-scoped sweep when diagnosing lingering-pending rows (#2217).
+        console.log(`[PATCHES] Agent ${agentId} full scan (legacy, no coverage): sweeping ALL pending sources`);
         await markPendingDevicePatchesMissing(tx, device.id, []);
       } else if (data.coveredSources.length > 0) {
         // Coverage-aware full scan (#2217): only sweep sources whose providers
         // actually ran. Skipped providers (e.g. winget without a helper
         // session) keep their pending rows instead of being tombstoned.
+        console.log(`[PATCHES] Agent ${agentId} full scan (coverage-scoped): sweeping only [${data.coveredSources.join(', ')}]`);
         await markPendingDevicePatchesMissing(tx, device.id, data.coveredSources);
+      } else {
+        // full with coveredSources: [] means EVERY registered provider on the
+        // device was skipped or failed — a genuinely degraded agent. We sweep
+        // nothing (correct: don't tombstone rows nothing looked at), but warn so
+        // "why are this device's pending patches never reconciled?" is greppable
+        // instead of a silent no-op (#2217).
+        console.warn(`[PATCHES] Agent ${agentId} full scan covered ZERO sources — every provider skipped/failed; no tombstoning performed`);
       }
-      // full with coveredSources: [] means every provider was skipped — sweep nothing.
     } else if (sources.length > 0) {
       await markPendingDevicePatchesMissing(tx, device.id, sources);
     }

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -549,7 +549,12 @@ const installedPatchSchema = z.object({
 export const submitPendingPatchesSchema = z.object({
   patches: z.array(pendingPatchSchema).max(5000),
   source: patchSourceSchema.optional(),
-  full: z.boolean().optional().default(false)
+  full: z.boolean().optional().default(false),
+  // Source buckets the full scan actually covered (#2217). When present on a
+  // full upload, only pending rows from these sources are swept to 'missing';
+  // sources whose providers were skipped (e.g. winget without a helper
+  // session) or failed keep their rows. Absent → legacy full sweep.
+  coveredSources: z.array(patchSourceSchema).max(10).optional()
 });
 
 export const submitInstalledPatchesSchema = z.object({

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -553,7 +553,14 @@ export const submitPendingPatchesSchema = z.object({
   // Source buckets the full scan actually covered (#2217). When present on a
   // full upload, only pending rows from these sources are swept to 'missing';
   // sources whose providers were skipped (e.g. winget without a helper
-  // session) or failed keep their rows. Absent → legacy full sweep.
+  // session) or failed keep their rows. Absent → legacy full sweep. Only read
+  // when full is true; ignored (harmlessly) on targeted/non-full uploads.
+  //
+  // Forward/backward compat: this object MUST stay non-strict. An old API
+  // silently drops this unknown field and falls back to sweep-all (safe
+  // degrade). If this schema is ever hardened to .strict(), a new agent's
+  // coveredSources payload would 400 and patch uploads would stop entirely —
+  // do not do that without a coordinated agent-fleet rollout.
   coveredSources: z.array(patchSourceSchema).max(10).optional()
 });
 


### PR DESCRIPTION
Closes #2217

## Problem

A full patch inventory upload (`PUT /:id/patches/pending` with `full:true`) marks every pending `device_patches` row `'missing'` before re-upserting what the current scan contained. A provider that **couldn't run at all** — winget without a user helper session, chocolatey not installed, a provider timeout — was indistinguishable from one that ran and found nothing, so its previously reported patches were swept to `'missing'`. Per-device third-party counts on Patch Compliance dropped to 0 while the global Patches catalog still showed the entries.

## Fix

**Agent — skip is now distinguishable from empty:**
- `patching.ErrScanSkipped` sentinel (`agent/internal/patching/errors.go`): a provider's `Scan` returns it when the provider could not run. `PatchManager.ScanWithCoverage()` (`manager.go`) returns the aggregated patches **plus the provider IDs that actually scanned**; skipped providers are silently excluded from coverage, failed providers are excluded and surface their error. `Scan()` now delegates to it.
- Full heartbeat uploads include a `coveredSources` array (`heartbeat.go`): the API source buckets whose registered providers **all** ran. winget + chocolatey share the `third_party` bucket, so one skipped provider withholds the whole bucket — sweeping it would tombstone the skipped provider's rows, which is the exact bug. The legacy collector path sends no coverage field, keeping its payload byte-identical.
- Targeted on-demand scans (`CmdPatchScan` with a `source`) now fail the command instead of uploading a filtered-empty payload that would sweep a source the scan never looked at (`handlers_patch.go`).

**API — backward compatible in both directions:**
- `submitPendingPatchesSchema` accepts optional `coveredSources` (enum-validated, `schemas.ts`).
- `full:true` **with** `coveredSources` scopes `markPendingDevicePatchesMissing` to those sources; `full:true` **without** it (old agents) keeps the exact legacy sweep-all; `coveredSources: []` (everything skipped) sweeps nothing (`patches.ts`).
- `coveredSources` is recorded in the ingest audit event.

**Coordination with #2216:** the winget-as-SYSTEM rework deletes the user-helper winget provider, so this PR deliberately does **not** touch `agent/internal/patching/winget.go`. The new SYSTEM provider signals unavailability with a one-line `return nil, patching.ErrScanSkipped`. Until it lands, this PR already stops tombstoning for failed providers and ships the wire protocol end to end.

## Tests

- Go table-driven: `TestPatchManagerScanWithCoverage` (ran / empty-but-ran / skipped / wrapped-skip / failed / all-skipped), `TestPatchManagerScanIgnoresSkippedProviders`, `TestCoveredPatchSources` (shared-bucket semantics), payload tests proving `coveredSources` is included on coverage-aware full uploads and omitted on the legacy path. `go test -race ./internal/patching/... ./internal/heartbeat/...` green.
- API route tests (Drizzle mocks): full+coveredSources only tombstones covered sources and still re-upserts scanned patches; legacy full without coveredSources sweeps all; empty coveredSources sweeps nothing; invalid source values 400. `vitest run` 41 passed; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)