### PR TITLE
feat(web): vulnerabilities fleet triage UI

### DIFF
--- a/apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql
+++ b/apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql
@@ -1,0 +1,22 @@
+-- Vulnerabilities fleet triage UI: link findings to native tickets.
+-- Spec: docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md
+-- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file in a transaction).
+
+ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS ticket_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'device_vulnerabilities_ticket_id_tickets_id_fk'
+      AND table_name = 'device_vulnerabilities'
+  ) THEN
+    ALTER TABLE device_vulnerabilities
+      ADD CONSTRAINT device_vulnerabilities_ticket_id_tickets_id_fk
+      FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Partial index: most findings have no ticket; only index linked rows.
+CREATE INDEX IF NOT EXISTS device_vuln_ticket_id_idx
+  ON device_vulnerabilities (ticket_id) WHERE ticket_id IS NOT NULL;

--- a/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRemediate.integration.test.ts
@@ -211,7 +211,7 @@ describe('POST /api/v1/vulnerabilities/remediate', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
     expect(body.scheduled).toBe(0);
-    expect(body.skipped[0]!.reason).toMatch(/not approved/i);
+    expect(body.skipped[0]!.reason).toBe('patch_not_approved');
   });
 
   runDb('skips a vuln with no pending matching patch', async () => {
@@ -224,7 +224,7 @@ describe('POST /api/v1/vulnerabilities/remediate', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { scheduled: number; skipped: Array<{ reason: string }> };
     expect(body.scheduled).toBe(0);
-    expect(body.skipped[0]!.reason).toMatch(/no available patch/i);
+    expect(body.skipped[0]!.reason).toBe('no_available_patch');
   });
 
   runDb('rejects an unauthenticated caller', async () => {

--- a/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
@@ -180,13 +180,16 @@ describe('vulnerabilityRoutes', () => {
           epssScore: number | null;
           riskScore: number | null;
           deviceCount: number;
+          patchAvailable: boolean;
+          statuses: string[];
         }>;
       };
 
       // Only org A's two CVEs returned
       expect(body.items).toHaveLength(2);
 
-      // Fleet rows have EXACTLY the aggregated shape — no status, no deviceId, no patchAvailable
+      // Fleet rows have the aggregated shape — CVE metadata plus deviceCount,
+      // patchAvailable, and aggregated statuses; never a per-device deviceId or singular status
       const firstItem = body.items[0]!;
       expect(firstItem).toHaveProperty('id');
       expect(firstItem).toHaveProperty('cveId');
@@ -196,8 +199,9 @@ describe('vulnerabilityRoutes', () => {
       expect(firstItem).toHaveProperty('epssScore');
       expect(firstItem).toHaveProperty('riskScore');
       expect(firstItem).toHaveProperty('deviceCount');
+      expect(firstItem).toHaveProperty('patchAvailable');
+      expect(firstItem).toHaveProperty('statuses');
       expect(firstItem).not.toHaveProperty('deviceId');
-      expect(firstItem).not.toHaveProperty('patchAvailable');
       expect(firstItem).not.toHaveProperty('status');
 
       // criticalVuln (riskScore 9.8) sorts first

--- a/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/vulnerabilitiesRoutes.integration.test.ts
@@ -2,19 +2,22 @@ import './setup';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
 
 import { db, withSystemDbAccessContext } from '../../db';
 import {
   devices,
   deviceVulnerabilities,
+  organizationUsers,
   softwareProducts,
   softwareVulnerabilities,
   vulnerabilities,
   vulnerabilitySources,
 } from '../../db/schema';
 import { vulnerabilityRoutes } from '../../routes/vulnerabilities';
+import { clearPermissionCache } from '../../services/permissions';
 import { getTestDb } from './setup';
-import { setupTestEnvironment, type TestEnvironment } from './db-utils';
+import { createSite, setupTestEnvironment, type TestEnvironment } from './db-utils';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -28,6 +31,39 @@ function authHeaders(env: TestEnvironment) {
   return { Authorization: `Bearer ${env.token}` };
 }
 
+async function postJson(env: TestEnvironment, path: string, body: unknown): Promise<Response> {
+  return buildApp().request(path, {
+    method: 'POST',
+    headers: { ...authHeaders(env), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Read a device_vulnerabilities row bypassing RLS, to verify persisted state. */
+async function readFinding(id: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select()
+      .from(deviceVulnerabilities)
+      .where(eq(deviceVulnerabilities.id, id))
+      .limit(1);
+    return row;
+  });
+}
+
+/** Restrict an org-scope user to a specific set of sites (drives allowedSiteIds). */
+async function restrictUserToSites(env: TestEnvironment, siteIds: string[]) {
+  await withSystemDbAccessContext(async () => {
+    await db
+      .update(organizationUsers)
+      .set({ siteIds })
+      .where(and(eq(organizationUsers.userId, env.user.id), eq(organizationUsers.orgId, env.organization.id)));
+  });
+  // Permissions (incl. allowedSiteIds) are hot-cached per user — invalidate so
+  // the next request re-resolves the mutated membership.
+  await clearPermissionCache(env.user.id);
+}
+
 beforeEach(async () => {
   await withSystemDbAccessContext(async () => {
     await db.delete(deviceVulnerabilities);
@@ -38,12 +74,12 @@ beforeEach(async () => {
   });
 });
 
-async function seedDevice(env: TestEnvironment, suffix: string): Promise<string> {
+async function seedDevice(env: TestEnvironment, suffix: string, siteId?: string): Promise<string> {
   const [device] = await getTestDb()
     .insert(devices)
     .values({
       orgId: env.organization.id,
-      siteId: env.site.id,
+      siteId: siteId ?? env.site.id,
       agentId: `vuln-route-agent-${suffix}-${Date.now()}`,
       hostname: `vuln-route-host-${suffix}`,
       osType: 'windows',
@@ -495,5 +531,184 @@ describe('vulnerabilityRoutes', () => {
         patchAvailable: true,
       }),
     ]);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // fetchFleetFindingRows-backed endpoints (GET /software, GET /stats) exercised
+  // against the REAL DB layer. Every unit test mocks this query; these prove the
+  // org-RLS + system-context catalog join actually runs end-to-end.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // System-context catalog join returns data: a regression that breaks the
+  // runOutsideDbContext+withSystemDbAccessContext catalog read makes every
+  // finding look orphaned (catalog row missing) and the queue silently empty.
+  runDb('GET /api/v1/vulnerabilities/software returns findings (system-context catalog join works)', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const deviceId = await seedDevice(env, 'sw-join');
+    const vuln = await seedCatalogVulnerability({
+      cveId: 'CVE-2026-90001',
+      severity: 'critical',
+      cvssScore: '9.5',
+      knownExploited: true,
+      patchAvailable: true,
+    });
+    await seedDeviceFinding({ orgId: env.organization.id, deviceId, vulnerabilityId: vuln, riskScore: '9.50' });
+
+    const res = await buildApp().request('/api/v1/vulnerabilities/software', { headers: authHeaders(env) });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: Array<{ deviceCount: number; cveIds: string[] }> };
+    // Not empty — the catalog join resolved the CVE so the finding stayed in the queue.
+    expect(body.items.length).toBeGreaterThan(0);
+    const totalDevices = body.items.reduce((sum, g) => sum + g.deviceCount, 0);
+    expect(totalDevices).toBe(1);
+    expect(body.items.some((g) => g.cveIds.includes('CVE-2026-90001'))).toBe(true);
+  });
+
+  // C2: cross-org isolation of the fleet queue. The software group key collapses
+  // same-product findings across orgs, so a leak here is fleet-wide. Seed findings
+  // in TWO orgs and prove an org-A caller sees only org-A rows/counts.
+  runDb('GET /software and GET /stats do not leak another org\'s findings into the fleet queue', async () => {
+    const envA = await setupTestEnvironment({ scope: 'organization' });
+    const envB = await setupTestEnvironment({ scope: 'organization' });
+    const deviceA = await seedDevice(envA, 'iso-a');
+    const deviceB = await seedDevice(envB, 'iso-b');
+
+    // Org A: a plain high finding, no KEV. Org B: a KEV critical finding — if it
+    // leaked, org A's kev/critical counts would be inflated.
+    const vulnA = await seedCatalogVulnerability({ cveId: 'CVE-2026-91001', severity: 'high', cvssScore: '7.5' });
+    const vulnB = await seedCatalogVulnerability({
+      cveId: 'CVE-2026-91002',
+      severity: 'critical',
+      cvssScore: '9.9',
+      knownExploited: true,
+    });
+    await seedDeviceFinding({ orgId: envA.organization.id, deviceId: deviceA, vulnerabilityId: vulnA, riskScore: '7.50' });
+    await seedDeviceFinding({ orgId: envB.organization.id, deviceId: deviceB, vulnerabilityId: vulnB, riskScore: '9.90' });
+
+    const swRes = await buildApp().request('/api/v1/vulnerabilities/software', { headers: authHeaders(envA) });
+    expect(swRes.status).toBe(200);
+    const swBody = await swRes.json() as { items: Array<{ deviceCount: number; cveIds: string[]; kevCveCount: number }> };
+    // Exactly org A's single device across all groups; org B's device never appears.
+    expect(swBody.items.reduce((sum, g) => sum + g.deviceCount, 0)).toBe(1);
+    expect(swBody.items.some((g) => g.cveIds.includes('CVE-2026-91002'))).toBe(false);
+    expect(swBody.items.every((g) => g.kevCveCount === 0)).toBe(true);
+
+    const statsRes = await buildApp().request('/api/v1/vulnerabilities/stats', { headers: authHeaders(envA) });
+    expect(statsRes.status).toBe(200);
+    const stats = await statsRes.json() as {
+      totalFindings: number;
+      criticalOpen: number;
+      kevCveCount: number;
+      kevDeviceCount: number;
+    };
+    expect(stats.totalFindings).toBe(1); // only org A's finding
+    expect(stats.criticalOpen).toBe(0); // org B's critical must not leak
+    expect(stats.kevCveCount).toBe(0);
+    expect(stats.kevDeviceCount).toBe(0);
+  });
+
+  // Site narrowing + fail-closed: an org-scope caller restricted to a site sees
+  // only that site's findings; an empty allowed-sites set returns nothing.
+  runDb('GET /software narrows to the caller\'s allowed sites and fails closed when empty', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const siteB = await createSite({ orgId: env.organization.id, name: 'Second Site' });
+    const deviceInSiteA = await seedDevice(env, 'site-a', env.site.id);
+    const deviceInSiteB = await seedDevice(env, 'site-b', siteB.id);
+
+    const vulnA = await seedCatalogVulnerability({ cveId: 'CVE-2026-92001', severity: 'high', cvssScore: '7.5' });
+    const vulnB = await seedCatalogVulnerability({ cveId: 'CVE-2026-92002', severity: 'high', cvssScore: '7.4' });
+    await seedDeviceFinding({ orgId: env.organization.id, deviceId: deviceInSiteA, vulnerabilityId: vulnA, riskScore: '7.50' });
+    await seedDeviceFinding({ orgId: env.organization.id, deviceId: deviceInSiteB, vulnerabilityId: vulnB, riskScore: '7.40' });
+
+    // Restrict to site A only: only site-A's finding is visible.
+    await restrictUserToSites(env, [env.site.id]);
+    const narrowedRes = await buildApp().request('/api/v1/vulnerabilities/software', { headers: authHeaders(env) });
+    expect(narrowedRes.status).toBe(200);
+    const narrowed = await narrowedRes.json() as { items: Array<{ deviceCount: number; cveIds: string[] }> };
+    expect(narrowed.items.reduce((sum, g) => sum + g.deviceCount, 0)).toBe(1);
+    expect(narrowed.items.some((g) => g.cveIds.includes('CVE-2026-92002'))).toBe(false);
+
+    // Empty allowed-sites → fail closed (no findings at all).
+    await restrictUserToSites(env, []);
+    const closedRes = await buildApp().request('/api/v1/vulnerabilities/software', { headers: authHeaders(env) });
+    expect(closedRes.status).toBe(200);
+    const closed = await closedRes.json() as { items: unknown[] };
+    expect(closed.items).toEqual([]);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Bulk-write isolation + lifecycle against the REAL DB.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // test#3: a cross-org finding id submitted to /bulk/accept-risk is SKIPPED
+  // (RLS hides it → not_found) and the row stays untouched in the other org.
+  runDb('POST /bulk/accept-risk skips a cross-org finding id and leaves the row untouched', async () => {
+    const envA = await setupTestEnvironment({ scope: 'organization' });
+    const envB = await setupTestEnvironment({ scope: 'organization' });
+    const deviceB = await seedDevice(envB, 'xorg-b');
+    const vulnB = await seedCatalogVulnerability({ cveId: 'CVE-2026-93001', severity: 'high', cvssScore: '7.5' });
+    const findingB = await seedDeviceFinding({
+      orgId: envB.organization.id,
+      deviceId: deviceB,
+      vulnerabilityId: vulnB,
+      status: 'open',
+    });
+
+    const future = new Date(Date.now() + 30 * 864e5).toISOString();
+    const res = await postJson(envA, '/api/v1/vulnerabilities/bulk/accept-risk', {
+      deviceVulnerabilityIds: [findingB],
+      reason: 'attempted cross-org accept',
+      acceptedUntil: future,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; succeeded: number; skipped: Array<{ id: string; reason: string }> };
+    expect(body.success).toBe(false);
+    expect(body.succeeded).toBe(0);
+    expect(body.skipped).toEqual([{ id: findingB, reason: 'not_found' }]);
+
+    // The org-B row is unchanged: still open, no acceptance metadata written.
+    const row = await readFinding(findingB);
+    expect(row?.status).toBe('open');
+    expect(row?.acceptedBy).toBeNull();
+    expect(row?.acceptedUntil).toBeNull();
+    expect(row?.mitigationNote).toBeNull();
+  });
+
+  // test#4: reopen clears every resolution field so the finding is newly-open.
+  runDb('POST /:id/reopen clears status + acceptedBy/acceptedUntil/mitigationNote/resolvedAt', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const deviceId = await seedDevice(env, 'reopen');
+    const vuln = await seedCatalogVulnerability({ cveId: 'CVE-2026-94001', severity: 'high', cvssScore: '7.5' });
+    const finding = await seedDeviceFinding({
+      orgId: env.organization.id,
+      deviceId,
+      vulnerabilityId: vuln,
+      status: 'open',
+    });
+
+    const future = new Date(Date.now() + 30 * 864e5).toISOString();
+    const acceptRes = await postJson(env, `/api/v1/vulnerabilities/${finding}/accept-risk`, {
+      reason: 'temporary waiver',
+      acceptedUntil: future,
+    });
+    expect(acceptRes.status).toBe(200);
+
+    // Acceptance persisted the full waiver metadata.
+    const accepted = await readFinding(finding);
+    expect(accepted?.status).toBe('accepted');
+    expect(accepted?.acceptedBy).toBe(env.user.id);
+    expect(accepted?.acceptedUntil).not.toBeNull();
+    expect(accepted?.mitigationNote).toBe('temporary waiver');
+
+    const reopenRes = await postJson(env, `/api/v1/vulnerabilities/${finding}/reopen`, {});
+    expect(reopenRes.status).toBe(200);
+
+    // Reopen wiped every resolution field.
+    const reopened = await readFinding(finding);
+    expect(reopened?.status).toBe('open');
+    expect(reopened?.acceptedBy).toBeNull();
+    expect(reopened?.acceptedUntil).toBeNull();
+    expect(reopened?.mitigationNote).toBeNull();
+    expect(reopened?.resolvedAt).toBeNull();
   });
 });

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -10,6 +10,7 @@ import {
   index,
   uniqueIndex
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { organizations } from './orgs';
 import { devices } from './devices';
 import { users } from './users';
@@ -113,5 +114,5 @@ export const deviceVulnerabilities = pgTable('device_vulnerabilities', {
 }, (table) => ({
   orgDeviceIdx: index('device_vuln_org_device_idx').on(table.orgId, table.deviceId),
   statusIdx: index('device_vuln_status_idx').on(table.status),
-  ticketIdx: index('device_vuln_ticket_id_idx').on(table.ticketId),
+  ticketIdx: index('device_vuln_ticket_id_idx').on(table.ticketId).where(sql`ticket_id IS NOT NULL`),
 }));

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -14,6 +14,7 @@ import { organizations } from './orgs';
 import { devices } from './devices';
 import { users } from './users';
 import { softwareInventory } from './software';
+import { tickets } from './portal';
 
 // Sync health per source (nvd | msrc | apple | osv)
 export const vulnerabilitySources = pgTable('vulnerability_sources', {
@@ -106,9 +107,11 @@ export const deviceVulnerabilities = pgTable('device_vulnerabilities', {
   mitigationNote: text('mitigation_note'),
   acceptedBy: uuid('accepted_by').references(() => users.id),
   acceptedUntil: timestamp('accepted_until'),
+  ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => ({
   orgDeviceIdx: index('device_vuln_org_device_idx').on(table.orgId, table.deviceId),
   statusIdx: index('device_vuln_status_idx').on(table.status),
+  ticketIdx: index('device_vuln_ticket_id_idx').on(table.ticketId),
 }));

--- a/apps/api/src/db/schema/vulnerabilityManagement.ts
+++ b/apps/api/src/db/schema/vulnerabilityManagement.ts
@@ -101,7 +101,7 @@ export const deviceVulnerabilities = pgTable('device_vulnerabilities', {
   deviceId: uuid('device_id').notNull().references(() => devices.id),
   vulnerabilityId: uuid('vulnerability_id').notNull().references(() => vulnerabilities.id),
   softwareInventoryId: uuid('software_inventory_id').references(() => softwareInventory.id),
-  status: varchar('status', { length: 20 }).notNull().default('open'), // open|patched|mitigated|accepted
+  status: varchar('status', { length: 20 }).notNull().default('open'), // lifecycle: see VULN_STATUSES in @breeze/shared (source of truth: open|patched|mitigated|accepted)
   riskScore: numeric('risk_score', { precision: 5, scale: 2 }),         // CVSS-primary
   detectedAt: timestamp('detected_at').notNull(),
   resolvedAt: timestamp('resolved_at'),

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -316,6 +316,83 @@ describe('GET /vulnerabilities/software (fleet work queue)', () => {
   });
 });
 
+describe('GET /vulnerabilities/software/:groupKey (drawer payload)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('404s for an unknown group', async () => {
+    const res = await app().request(`/vulnerabilities/software/${encodeURIComponent('sw:nope|')}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('400s on a key without the sw:/os: prefix', async () => {
+    const res = await app().request('/vulnerabilities/software/garbage');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns group + cves + findings for a URL-encoded key, across ALL statuses', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', status: 'accepted', cveId: 'CVE-2026-0002', vulnerabilityId: 'v-2' }),
+    ]);
+    const res = await app().request(`/vulnerabilities/software/${encodeURIComponent('sw:google chrome|google llc')}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all' }),
+    );
+    const body = await res.json();
+    expect(body.group.groupKey).toBe('sw:google chrome|google llc');
+    expect(body.cves).toHaveLength(2);
+    expect(body.findings).toHaveLength(2);
+    expect(body.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String) });
+  });
+});
+
+describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+    vi.mocked(fetchCveCatalogRecord).mockReset().mockResolvedValue(null);
+  });
+
+  it('400s on a non-CVE-shaped id', async () => {
+    const res = await app().request('/vulnerabilities/not-a-cve/devices');
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the CVE is not in the catalog', async () => {
+    const res = await app().request('/vulnerabilities/CVE-2026-0001/devices');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the catalog record + fleet findings for the CVE (case-insensitive match)', async () => {
+    vi.mocked(fetchCveCatalogRecord).mockResolvedValue({
+      cveId: 'CVE-2026-0001',
+      description: 'Bad bug',
+      references: ['https://example.test/advisory'],
+      cvssVersion: '3.1',
+      cvssVector: 'CVSS:3.1/AV:N',
+      cvssScore: 9.1,
+      epssScore: 0.4,
+      knownExploited: true,
+      patchAvailable: true,
+      severity: 'critical',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: null,
+    });
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', cveId: 'CVE-2026-9999', vulnerabilityId: 'v-9' }), // other CVE — excluded
+    ]);
+    const res = await app().request('/vulnerabilities/cve-2026-0001/devices');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cve.cveId).toBe('CVE-2026-0001');
+    expect(body.findings).toHaveLength(1);
+    expect(body.findings[0].deviceVulnerabilityId).toBe('dv-1');
+  });
+});
+
 describe('GET /vulnerabilities/stats', () => {
   beforeEach(() => {
     vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -49,7 +49,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  deviceVulnerabilities: { id: 'dv.id', orgId: 'dv.orgId', deviceId: 'dv.deviceId', status: 'dv.status' },
+  deviceVulnerabilities: { id: 'dv.id', orgId: 'dv.orgId', deviceId: 'dv.deviceId', status: 'dv.status', acceptedUntil: 'dv.acceptedUntil' },
   devices: { id: 'd.id', orgId: 'd.orgId', siteId: 'd.siteId' },
   vulnerabilities: {},
 }));
@@ -104,6 +104,7 @@ function fleetRow(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
     detectedAt: '2026-06-01T00:00:00.000Z',
     acceptedUntil: null,
     ticketId: null,
+    ticketNumber: null,
     softwareInventoryId: 'sw-1',
     softwareName: 'Google Chrome',
     softwareVendor: 'Google LLC',
@@ -249,12 +250,26 @@ describe('GET /vulnerabilities — kevOnly/patchAvailable params', () => {
     } as never);
     const res = await app().request('/vulnerabilities?kevOnly=true&patchAvailable=false');
     expect(res.status).toBe(200);
-    expect((await res.json()).items).toEqual([]);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    // Fleet list mirrors /software's truncation contract: items + hasMore.
+    expect(body.hasMore).toBe(false);
   });
 
   it('400s on malformed boolean params', async () => {
     const res = await app().request('/vulnerabilities?kevOnly=1');
     expect(res.status).toBe(400);
+  });
+
+  it('accepts expiringWithinDays and rejects out-of-range / non-numeric values', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    } as never);
+    const ok = await app().request('/vulnerabilities?status=accepted&expiringWithinDays=14');
+    expect(ok.status).toBe(200);
+    expect((await app().request('/vulnerabilities?expiringWithinDays=abc')).status).toBe(400);
+    expect((await app().request('/vulnerabilities?expiringWithinDays=0')).status).toBe(400);
+    expect((await app().request('/vulnerabilities?expiringWithinDays=366')).status).toBe(400);
   });
 });
 
@@ -343,6 +358,26 @@ describe('GET /vulnerabilities/software (fleet work queue)', () => {
 
   it('400s on an invalid boolean param', async () => {
     const res = await app().request('/vulnerabilities/software?kevOnly=yes');
+    expect(res.status).toBe(400);
+  });
+
+  it('applies the expiringWithinDays window to accepted findings', async () => {
+    const soon = new Date(Date.now() + 5 * 864e5).toISOString();
+    const far = new Date(Date.now() + 60 * 864e5).toISOString();
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow({ deviceVulnerabilityId: 'dv-soon', status: 'accepted', acceptedUntil: soon }),
+      fleetRow({ deviceVulnerabilityId: 'dv-far', deviceId: 'dev-2', status: 'accepted', acceptedUntil: far }),
+    ]);
+    const res = await app().request('/vulnerabilities/software?status=accepted&expiringWithinDays=14');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Only the finding expiring inside the window survives; the group counts reflect that.
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].deviceCount).toBe(1);
+  });
+
+  it('400s on a non-numeric expiringWithinDays', async () => {
+    const res = await app().request('/vulnerabilities/software?expiringWithinDays=soon');
     expect(res.status).toBe(400);
   });
 });
@@ -529,7 +564,7 @@ describe('GET /vulnerabilities/stats', () => {
     expect(res.status).toBe(403);
   });
 
-  it('fetches ALL statuses and returns the four stat numbers', async () => {
+  it('fetches ALL statuses and returns the stat numbers plus detection activity', async () => {
     vi.mocked(fetchFleetFindingRows).mockResolvedValue([
       fleetRow(), // open critical KEV patch-ready
       fleetRow({ deviceVulnerabilityId: 'dv-2', status: 'accepted', acceptedUntil: new Date(Date.now() + 5 * 864e5).toISOString() }),
@@ -546,6 +581,8 @@ describe('GET /vulnerabilities/stats', () => {
       kevDeviceCount: 1,
       patchReadyFindingCount: 1,
       acceptedExpiringSoon: 1,
+      totalFindings: 2,
+      lastDetectedAt: '2026-06-01T00:00:00.000Z',
     });
   });
 });

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -418,6 +418,100 @@ describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
   });
 });
 
+function mockBulkSelects(findingRows: unknown[], deviceRows: unknown[]) {
+  const selectMock = vi.mocked(db.select);
+  selectMock.mockReset();
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(findingRows) }),
+  } as never);
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(deviceRows) }),
+  } as never);
+}
+
+const DV1 = '11111111-1111-1111-8111-111111111111';
+const DV2 = '22222222-2222-2222-8222-222222222222';
+
+describe('POST /vulnerabilities/bulk/accept-risk', () => {
+  beforeEach(() => {
+    vi.mocked(writeRouteAudit).mockClear();
+  });
+
+  it('403s without vulnerabilities:accept_risk', async () => {
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1], reason: 'x', acceptedUntil: future });
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on validation failures (empty ids, >200 ids, past acceptedUntil)', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    expect((await post('/bulk/accept-risk', { deviceVulnerabilityIds: [], reason: 'x', acceptedUntil: future })).status).toBe(400);
+    expect((await post('/bulk/accept-risk', {
+      deviceVulnerabilityIds: Array.from({ length: 201 }, () => DV1),
+      reason: 'x',
+      acceptedUntil: future,
+    })).status).toBe(400);
+    expect((await post('/bulk/accept-risk', {
+      deviceVulnerabilityIds: [DV1],
+      reason: 'x',
+      acceptedUntil: new Date(Date.now() - 864e5).toISOString(),
+    })).status).toBe(400);
+  });
+
+  it('updates valid findings, skips unknown ids per-item, audits each success', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1, DV2], reason: 'compensating control', acceptedUntil: future });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      succeeded: 1,
+      skipped: [{ id: DV2, reason: 'finding not found' }],
+    });
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.accept_risk', resourceId: DV1 }),
+    );
+  });
+
+  it('reports success:false when every item is skipped', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    mockBulkSelects([], []);
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1], reason: 'x', acceptedUntil: future });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.skipped).toHaveLength(1);
+  });
+});
+
+describe('POST /vulnerabilities/bulk/mitigate', () => {
+  it('403s for a caller without devices:write', async () => {
+    const res = await post('/bulk/mitigate', { deviceVulnerabilityIds: [DV1], note: 'firewalled' });
+    expect(res.status).toBe(403);
+  });
+
+  it('mitigates valid findings with per-item audit', async () => {
+    granted.add('devices:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    vi.mocked(writeRouteAudit).mockClear();
+    const res = await post('/bulk/mitigate', { deviceVulnerabilityIds: [DV1], note: 'firewalled' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, succeeded: 1, skipped: [] });
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.mitigate', resourceId: DV1 }),
+    );
+  });
+});
+
 describe('GET /vulnerabilities/stats', () => {
   beforeEach(() => {
     vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -227,6 +227,31 @@ describe('vulnerability fleet GET / — site-axis narrowing', () => {
   });
 });
 
+describe('GET /vulnerabilities — kevOnly/patchAvailable params', () => {
+  beforeEach(() => {
+    granted.clear();
+    delete permissionsState.allowedSiteIds;
+    granted.add('devices:read');
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('accepts kevOnly/patchAvailable and still 200s', async () => {
+    // db.select falls back to the default mock chain (resolves []), so an
+    // empty fleet is fine — this asserts schema acceptance, not data flow.
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    } as never);
+    const res = await app().request('/vulnerabilities?kevOnly=true&patchAvailable=false');
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual([]);
+  });
+
+  it('400s on malformed boolean params', async () => {
+    const res = await app().request('/vulnerabilities?kevOnly=1');
+    expect(res.status).toBe(400);
+  });
+});
+
 import { enqueueVulnCorrelation } from '../jobs/vulnerabilityJobs';
 import { writeRouteAudit } from '../services/auditEvents';
 

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -459,15 +459,34 @@ describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
   });
 });
 
-function mockBulkSelects(findingRows: unknown[], deviceRows: unknown[]) {
+/**
+ * Stub the db.select chain for a bulk-write route.
+ *
+ * loadFindingsForBulkWrite issues TWO selects (findings, then the site-gate
+ * devices lookup). The /tickets route issues TWO MORE after that when it has
+ * accessible findings: a device-name lookup (hostname/displayName) and a
+ * system-context CVE-id catalog lookup used to build each per-org ticket
+ * description server-side. Pass `deviceNameRows`/`cveRows` for /tickets; omit
+ * them for accept-risk / mitigate (which only consume the first two).
+ */
+function mockBulkSelects(
+  findingRows: unknown[],
+  deviceRows: unknown[],
+  deviceNameRows?: unknown[],
+  cveRows?: unknown[],
+) {
   const selectMock = vi.mocked(db.select);
   selectMock.mockReset();
-  selectMock.mockReturnValueOnce({
-    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(findingRows) }),
-  } as never);
-  selectMock.mockReturnValueOnce({
-    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(deviceRows) }),
-  } as never);
+  const resolveWhere = (rows: unknown[]) =>
+    ({ from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }) }) as never;
+  selectMock.mockReturnValueOnce(resolveWhere(findingRows));
+  selectMock.mockReturnValueOnce(resolveWhere(deviceRows));
+  if (deviceNameRows !== undefined) {
+    selectMock.mockReturnValueOnce(resolveWhere(deviceNameRows));
+  }
+  if (cveRows !== undefined) {
+    selectMock.mockReturnValueOnce(resolveWhere(cveRows));
+  }
 }
 
 const DV1 = '11111111-1111-1111-8111-111111111111';
@@ -510,7 +529,7 @@ describe('POST /vulnerabilities/bulk/accept-risk', () => {
     expect(body).toMatchObject({
       success: true,
       succeeded: 1,
-      skipped: [{ id: DV2, reason: 'finding not found' }],
+      skipped: [{ id: DV2, reason: 'not_found' }],
     });
     expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
@@ -550,6 +569,57 @@ describe('POST /vulnerabilities/bulk/mitigate', () => {
       expect.anything(),
       expect.objectContaining({ action: 'vulnerability.mitigate', resourceId: DV1 }),
     );
+  });
+
+  // Parity with bulk/accept-risk: validation bounds + all-skipped outcome.
+  it('400s on validation failures (empty ids, >200 ids)', async () => {
+    granted.add('devices:write');
+    expect((await post('/bulk/mitigate', { deviceVulnerabilityIds: [], note: 'x' })).status).toBe(400);
+    expect((await post('/bulk/mitigate', {
+      deviceVulnerabilityIds: Array.from({ length: 201 }, () => DV1),
+      note: 'x',
+    })).status).toBe(400);
+  });
+
+  it('reports success:false when every item is skipped', async () => {
+    granted.add('devices:write');
+    mockBulkSelects([], []);
+    const res = await post('/bulk/mitigate', { deviceVulnerabilityIds: [DV1], note: 'firewalled' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.skipped).toHaveLength(1);
+  });
+});
+
+import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
+
+describe('POST /vulnerabilities/remediate — all-skipped surfacing', () => {
+  beforeEach(() => {
+    vi.mocked(remediateVulnerabilities).mockReset();
+  });
+
+  // SF#2: when nothing is scheduled but items were skipped, the route reports
+  // success:false AND a `message` naming the distinct skip reasons, so the
+  // client shows the real cause instead of a generic failure toast.
+  it('returns success:false plus a message when scheduled is 0 and items are skipped', async () => {
+    granted.add('devices:execute');
+    vi.mocked(remediateVulnerabilities).mockResolvedValue({
+      scheduled: 0,
+      skipped: [
+        { id: DV1, reason: 'no_available_patch' },
+        { id: DV2, reason: 'patch_not_approved' },
+      ],
+    });
+    const res = await post('/remediate', { deviceVulnerabilityIds: [DV1, DV2] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.scheduled).toBe(0);
+    expect(typeof body.message).toBe('string');
+    // Human labels for the distinct skip codes appear in the summary.
+    expect(body.message).toContain('no available patch');
+    expect(body.message).toContain('patch not approved');
   });
 });
 
@@ -613,13 +683,23 @@ describe('POST /vulnerabilities/tickets', () => {
     granted.add('tickets:write');
     mockBulkSelects(
       [
-        { id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
-        { id: DV2, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
-        { id: DV_ORG2, orgId: 'org-2', deviceId: 'dev-2', status: 'open' },
+        { id: DV1, orgId: 'org-1', deviceId: 'dev-1', vulnerabilityId: 'v-1', status: 'open' },
+        { id: DV2, orgId: 'org-1', deviceId: 'dev-1', vulnerabilityId: 'v-1', status: 'open' },
+        { id: DV_ORG2, orgId: 'org-2', deviceId: 'dev-2', vulnerabilityId: 'v-2', status: 'open' },
       ],
       [
         { id: 'dev-1', siteId: 'site-1' },
         { id: 'dev-2', siteId: 'site-2' },
+      ],
+      // device-name lookup + CVE catalog lookup (the two new server-side selects
+      // that build each per-org ticket description).
+      [
+        { id: 'dev-1', hostname: 'host-1', displayName: 'WS-01' },
+        { id: 'dev-2', hostname: 'host-2', displayName: 'WS-02' },
+      ],
+      [
+        { id: 'v-1', cveId: 'CVE-2026-0001' },
+        { id: 'v-2', cveId: 'CVE-2026-0002' },
       ],
     );
     vi.mocked(createTicket)
@@ -629,7 +709,7 @@ describe('POST /vulnerabilities/tickets', () => {
     const res = await post('/tickets', {
       deviceVulnerabilityIds: [DV1, DV2, DV_ORG2],
       title: 'Patch Chrome fleet-wide',
-      description: 'CVE-2026-0001',
+      note: 'Coordinate with the affected teams.',
       priority: 'high',
     });
     expect(res.status).toBe(200);
@@ -652,28 +732,111 @@ describe('POST /vulnerabilities/tickets', () => {
 
   it('skips findings in an org the caller cannot access', async () => {
     granted.add('tickets:write');
+    // The finding passes the org(RLS)+site gate (valid), so the two per-org
+    // description selects DO run before the byOrg canAccessOrg check rejects it.
     mockBulkSelects(
-      [{ id: DV1, orgId: 'org-denied', deviceId: 'dev-1', status: 'open' }],
+      [{ id: DV1, orgId: 'org-denied', deviceId: 'dev-1', vulnerabilityId: 'v-1', status: 'open' }],
       [{ id: 'dev-1', siteId: 'site-1' }],
+      [{ id: 'dev-1', hostname: 'host-1', displayName: 'WS-01' }],
+      [{ id: 'v-1', cveId: 'CVE-2026-0001' }],
     );
     const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
     const body = await res.json();
     expect(body.success).toBe(false);
     expect(body.tickets).toEqual([]);
-    expect(body.skipped).toEqual([{ id: DV1, reason: 'access to organization denied' }]);
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'org_access_denied' }]);
     expect(vi.mocked(createTicket)).not.toHaveBeenCalled();
   });
 
-  it('maps a TicketServiceError into per-item skips without failing the batch', async () => {
+  it('maps a TicketServiceError into per-item skips (ticket_create_failed) without failing the batch', async () => {
     granted.add('tickets:write');
     mockBulkSelects(
-      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', vulnerabilityId: 'v-1', status: 'open' }],
       [{ id: 'dev-1', siteId: 'site-1' }],
+      [{ id: 'dev-1', hostname: 'host-1', displayName: 'WS-01' }],
+      [{ id: 'v-1', cveId: 'CVE-2026-0001' }],
     );
     vi.mocked(createTicket).mockRejectedValue(new TicketServiceError('Organization not found', 404));
     const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
     const body = await res.json();
     expect(body.success).toBe(false);
-    expect(body.skipped).toEqual([{ id: DV1, reason: 'Organization not found' }]);
+    // Dynamic TicketServiceError prose collapses to the stable skip code.
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'ticket_create_failed' }]);
+  });
+
+  // C1 REGRESSION GUARD (critical cross-tenant leak fix): the server now builds
+  // each per-org ticket's description ITSELF from ONLY that org's rows. Prove
+  // org A's description references org A's device/CVE and NEVER org B's, and vice
+  // versa — the old client-supplied `description` enumerated every org's data and
+  // was passed verbatim into every ticket, leaking hostnames/CVEs across tenants.
+  it('C1: per-org ticket description contains only that org\'s device names and CVEs (no cross-tenant leak)', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [
+        { id: DV1, orgId: 'org-1', deviceId: 'dev-a', vulnerabilityId: 'v-a', status: 'open' },
+        { id: DV_ORG2, orgId: 'org-2', deviceId: 'dev-b', vulnerabilityId: 'v-b', status: 'open' },
+      ],
+      [
+        { id: 'dev-a', siteId: 'site-1' },
+        { id: 'dev-b', siteId: 'site-2' },
+      ],
+      [
+        { id: 'dev-a', hostname: 'host-a', displayName: 'WS-ALPHA' },
+        { id: 'dev-b', hostname: 'host-b', displayName: 'WS-BRAVO' },
+      ],
+      [
+        { id: 'v-a', cveId: 'CVE-2026-AAAA' },
+        { id: 'v-b', cveId: 'CVE-2026-BBBB' },
+      ],
+    );
+    vi.mocked(createTicket)
+      .mockResolvedValueOnce({ id: 't-a' } as never)
+      .mockResolvedValueOnce({ id: 't-b' } as never);
+
+    const res = await post('/tickets', {
+      deviceVulnerabilityIds: [DV1, DV_ORG2],
+      title: 'Remediate fleet',
+    });
+    expect(res.status).toBe(200);
+
+    // Map each createTicket call's org to the description the server built for it.
+    const descByOrg = new Map<string, string>();
+    for (const [payload] of vi.mocked(createTicket).mock.calls) {
+      descByOrg.set((payload as { orgId: string }).orgId, (payload as { description: string }).description);
+    }
+
+    const orgADesc = descByOrg.get('org-1')!;
+    const orgBDesc = descByOrg.get('org-2')!;
+    expect(orgADesc).toBeDefined();
+    expect(orgBDesc).toBeDefined();
+
+    // Org A's ticket carries ONLY org A's device + CVE.
+    expect(orgADesc).toContain('WS-ALPHA');
+    expect(orgADesc).toContain('CVE-2026-AAAA');
+    expect(orgADesc).not.toContain('WS-BRAVO');
+    expect(orgADesc).not.toContain('CVE-2026-BBBB');
+
+    // Org B's ticket carries ONLY org B's device + CVE.
+    expect(orgBDesc).toContain('WS-BRAVO');
+    expect(orgBDesc).toContain('CVE-2026-BBBB');
+    expect(orgBDesc).not.toContain('WS-ALPHA');
+    expect(orgBDesc).not.toContain('CVE-2026-AAAA');
+  });
+
+  // SF#1: all-skipped /tickets surfaces WHY via a `message` (not a silent
+  // success:false). Every id is unknown → not_found; no ticket is created.
+  it('SF#1: returns success:false plus a message summarizing skip reasons when nothing is ticketed', async () => {
+    granted.add('tickets:write');
+    // Empty findings → every id skipped as not_found; the two per-org selects
+    // never run (no accessible findings), so only the first select is consumed.
+    mockBulkSelects([], []);
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1, DV2], title: 'x' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.tickets).toEqual([]);
+    expect(typeof body.message).toBe('string');
+    // Message summarizes the distinct skip reasons using the human label.
+    expect(body.message).toContain('finding not found');
   });
 });

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -17,6 +17,7 @@ vi.mock('../middleware/auth', () => ({
       user: { id: 'u1', email: 't@example.test' },
       orgCondition: () => undefined,
       canAccessSite: () => true,
+      canAccessOrg: (id: string) => id !== 'org-denied',
     });
     return next();
   },
@@ -61,6 +62,10 @@ vi.mock('../services/vulnerabilityFleetQueries', () => ({
   fetchCveCatalogRecord: vi.fn(async () => null),
 }));
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/ticketService', async () => {
+  const actual = await vi.importActual<typeof import('../services/ticketService')>('../services/ticketService');
+  return { ...actual, createTicket: vi.fn() };
+});
 vi.mock('../middleware/platformAdmin', () => ({ platformAdminMiddleware: (_c: any, next: any) => next() }));
 vi.mock('../middleware/userRateLimit', () => ({ userRateLimit: () => (_c: any, next: any) => next() }));
 vi.mock('../jobs/vulnerabilityJobs', () => ({
@@ -71,6 +76,7 @@ vi.mock('../jobs/vulnerabilityJobs', () => ({
 import { vulnerabilityRoutes, vulnerabilitySyncRoutes } from './vulnerabilities';
 import { fetchFleetFindingRows, fetchCveCatalogRecord } from '../services/vulnerabilityFleetQueries';
 import type { FleetFindingRow } from '../services/vulnerabilityFleetAggregation';
+import { createTicket, TicketServiceError } from '../services/ticketService';
 
 const ID = '11111111-1111-1111-8111-111111111111';
 
@@ -541,5 +547,96 @@ describe('GET /vulnerabilities/stats', () => {
       patchReadyFindingCount: 1,
       acceptedExpiringSoon: 1,
     });
+  });
+});
+
+describe('POST /vulnerabilities/tickets', () => {
+  const DV_ORG2 = '33333333-3333-3333-8333-333333333333';
+
+  beforeEach(() => {
+    vi.mocked(createTicket).mockReset();
+    vi.mocked(writeRouteAudit).mockClear();
+  });
+
+  it('403s without tickets:write', async () => {
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'Patch Chrome' });
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on validation failures (missing title, >200 ids)', async () => {
+    granted.add('tickets:write');
+    expect((await post('/tickets', { deviceVulnerabilityIds: [DV1] })).status).toBe(400);
+    expect((await post('/tickets', {
+      deviceVulnerabilityIds: Array.from({ length: 201 }, () => DV1),
+      title: 'x',
+    })).status).toBe(400);
+  });
+
+  it('splits a cross-org selection into one ticket per org and stamps ticket_id', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [
+        { id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
+        { id: DV2, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
+        { id: DV_ORG2, orgId: 'org-2', deviceId: 'dev-2', status: 'open' },
+      ],
+      [
+        { id: 'dev-1', siteId: 'site-1' },
+        { id: 'dev-2', siteId: 'site-2' },
+      ],
+    );
+    vi.mocked(createTicket)
+      .mockResolvedValueOnce({ id: 't-1' } as never)
+      .mockResolvedValueOnce({ id: 't-2' } as never);
+
+    const res = await post('/tickets', {
+      deviceVulnerabilityIds: [DV1, DV2, DV_ORG2],
+      title: 'Patch Chrome fleet-wide',
+      description: 'CVE-2026-0001',
+      priority: 'high',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.tickets).toEqual([
+      { ticketId: 't-1', orgId: 'org-1', findingCount: 2 },
+      { ticketId: 't-2', orgId: 'org-2', findingCount: 1 },
+    ]);
+    expect(vi.mocked(createTicket)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(createTicket)).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-1', subject: 'Patch Chrome fleet-wide', priority: 'high', source: 'manual' }),
+      expect.objectContaining({ userId: 'u1' }),
+    );
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.ticket_create', resourceType: 'ticket', resourceId: 't-1' }),
+    );
+  });
+
+  it('skips findings in an org the caller cannot access', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-denied', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.tickets).toEqual([]);
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'access to organization denied' }]);
+    expect(vi.mocked(createTicket)).not.toHaveBeenCalled();
+  });
+
+  it('maps a TicketServiceError into per-item skips without failing the batch', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    vi.mocked(createTicket).mockRejectedValue(new TicketServiceError('Organization not found', 404));
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'Organization not found' }]);
   });
 });

--- a/apps/api/src/routes/vulnerabilities.test.ts
+++ b/apps/api/src/routes/vulnerabilities.test.ts
@@ -56,6 +56,10 @@ vi.mock('../db/schema', () => ({
 vi.mock('../services/vulnerabilityRemediation', () => ({
   remediateVulnerabilities: vi.fn(async () => ({ scheduled: 0, skipped: [] })),
 }));
+vi.mock('../services/vulnerabilityFleetQueries', () => ({
+  fetchFleetFindingRows: vi.fn(async () => []),
+  fetchCveCatalogRecord: vi.fn(async () => null),
+}));
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../middleware/platformAdmin', () => ({ platformAdminMiddleware: (_c: any, next: any) => next() }));
 vi.mock('../middleware/userRateLimit', () => ({ userRateLimit: () => (_c: any, next: any) => next() }));
@@ -65,6 +69,8 @@ vi.mock('../jobs/vulnerabilityJobs', () => ({
 }));
 
 import { vulnerabilityRoutes, vulnerabilitySyncRoutes } from './vulnerabilities';
+import { fetchFleetFindingRows, fetchCveCatalogRecord } from '../services/vulnerabilityFleetQueries';
+import type { FleetFindingRow } from '../services/vulnerabilityFleetAggregation';
 
 const ID = '11111111-1111-1111-8111-111111111111';
 
@@ -80,6 +86,34 @@ async function post(path: string, body: unknown) {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+function fleetRow(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    orgId: 'org-1',
+    status: 'open',
+    riskScore: 75,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    acceptedUntil: null,
+    ticketId: null,
+    softwareInventoryId: 'sw-1',
+    softwareName: 'Google Chrome',
+    softwareVendor: 'Google LLC',
+    softwareVersion: '126.0.1',
+    deviceName: 'WS-01',
+    deviceOsType: 'windows',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    vulnerabilityId: 'v-1',
+    severity: 'critical',
+    cvssScore: 9.1,
+    epssScore: 0.4,
+    knownExploited: true,
+    patchAvailable: true,
+    ...overrides,
+  };
 }
 
 const future = new Date(Date.now() + 7 * 864e5).toISOString();
@@ -224,5 +258,92 @@ describe('POST /vulnerabilities/sync/correlate (admin manual trigger)', () => {
       expect.anything(),
       expect.objectContaining({ action: 'vulnerability.manual_correlate', resourceType: 'vulnerability_source' }),
     );
+  });
+});
+
+describe('GET /vulnerabilities/software (fleet work queue)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('403s without devices:read', async () => {
+    granted.clear();
+    const res = await app().request('/vulnerabilities/software');
+    expect(res.status).toBe(403);
+  });
+
+  it('groups findings and returns items + hasMore', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', softwareName: 'google chrome ' }),
+    ]);
+    const res = await app().request('/vulnerabilities/software');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasMore).toBe(false);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toMatchObject({
+      groupKey: 'sw:google chrome|google llc',
+      kind: 'software',
+      deviceCount: 2,
+    });
+  });
+
+  it('passes status through and forwards allowedSiteIds from the permissions context', async () => {
+    permissionsState.allowedSiteIds = ['site-1'];
+    const res = await app().request('/vulnerabilities/software?status=accepted');
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith({
+      status: 'accepted',
+      allowedSiteIds: ['site-1'],
+    });
+  });
+
+  it('applies severity/kevOnly/patchAvailable/search filters', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', softwareName: 'Zoom', softwareVendor: 'Zoom', severity: 'low', knownExploited: false, patchAvailable: false, cveId: 'CVE-2026-2' }),
+    ]);
+    const res = await app().request('/vulnerabilities/software?severity=critical&kevOnly=true&patchAvailable=true&search=chrome');
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].name).toBe('Google Chrome');
+  });
+
+  it('400s on an invalid boolean param', async () => {
+    const res = await app().request('/vulnerabilities/software?kevOnly=yes');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /vulnerabilities/stats', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('403s without devices:read', async () => {
+    granted.clear();
+    const res = await app().request('/vulnerabilities/stats');
+    expect(res.status).toBe(403);
+  });
+
+  it('fetches ALL statuses and returns the four stat numbers', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(), // open critical KEV patch-ready
+      fleetRow({ deviceVulnerabilityId: 'dv-2', status: 'accepted', acceptedUntil: new Date(Date.now() + 5 * 864e5).toISOString() }),
+    ]);
+    const res = await app().request('/vulnerabilities/stats');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all' }),
+    );
+    expect(body).toEqual({
+      criticalOpen: 1,
+      kevCveCount: 1,
+      kevDeviceCount: 1,
+      patchReadyFindingCount: 1,
+      acceptedExpiringSoon: 1,
+    });
   });
 });

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -8,8 +8,8 @@ import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
-import { computeStats, filterFindings, groupFindings } from '../services/vulnerabilityFleetAggregation';
-import { fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
+import { buildGroupDetail, computeStats, filterFindings, groupFindings, toGroupFinding } from '../services/vulnerabilityFleetAggregation';
+import { fetchCveCatalogRecord, fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
 import { writeRouteAudit } from '../services/auditEvents';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
 import { userRateLimit } from '../middleware/userRateLimit';
@@ -78,6 +78,17 @@ const softwareQuerySchema = z.object({
 });
 
 const SOFTWARE_GROUP_CAP = 500;
+
+const groupKeyParamSchema = z.object({
+  // Opaque group key: sw:<name>|<vendor> or os:<platform>. Hono decodes the
+  // URL-encoded segment before validation.
+  groupKey: z.string().min(4).max(600).regex(/^(sw:|os:)/),
+});
+
+const cveIdParamSchema = z.object({
+  // Real-world CVE ids are CVE-YYYY-NNNN+, but seeded/e2e ids use letters too.
+  cveId: z.string().trim().regex(/^CVE-\d{4}-[A-Za-z0-9-]{1,32}$/i),
+});
 
 const requireVulnerabilityWrite = requirePermission(
   PERMISSIONS.DEVICES_WRITE.resource,
@@ -395,6 +406,20 @@ vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), a
   });
 });
 
+// Software-group drawer payload: group summary + per-CVE rollup + raw findings.
+vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParamSchema), async (c) => {
+  const { groupKey } = c.req.valid('param');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  // status 'all' so the drawer can show accepted/mitigated findings alongside
+  // open ones (reopen lives in the drawers).
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const detail = buildGroupDetail(groupKey, rows);
+  if (!detail) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  return c.json(detail);
+});
+
 // The four stat-card numbers in one call. Needs every status: open findings
 // feed three cards, accepted findings feed the expiring-soon card.
 vulnerabilityRoutes.get('/stats', async (c) => {
@@ -423,6 +448,26 @@ vulnerabilityRoutes.get(
     return c.json({ items });
   },
 );
+
+// CVE drawer payload: catalog record + fleet findings for that CVE. Registered
+// LAST among the GET routes — a param in the first path segment would
+// otherwise shadow every static-first-segment GET route above it
+// (/software, /software/:groupKey, /stats, /devices/:deviceId).
+vulnerabilityRoutes.get('/:cveId/devices', zValidator('param', cveIdParamSchema), async (c) => {
+  const { cveId } = c.req.valid('param');
+  const cve = await fetchCveCatalogRecord(cveId);
+  if (!cve) {
+    return c.json({ error: 'CVE not found' }, 404);
+  }
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const target = cveId.toLowerCase();
+  const findings = rows
+    .filter((r) => r.cveId.toLowerCase() === target)
+    .map(toGroupFinding)
+    .sort((a, b) => a.deviceName.localeCompare(b.deviceName));
+  return c.json({ cve, findings });
+});
 
 // POST /remediate — schedule per-device install commands for a set of findings.
 // The `*` middleware already enforces auth + scope + DEVICES_READ; this high-power

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -3,6 +3,15 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { and, desc, eq, gt, ilike, inArray, lte, type SQL } from 'drizzle-orm';
 
+import {
+  VULN_STATUS_FILTERS,
+  VULN_SEVERITIES,
+  VULN_TICKET_PRIORITIES,
+  VULN_SKIP_REASON_LABELS,
+  type SkippedItem,
+  type VulnSkipReason,
+} from '@breeze/shared';
+
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
@@ -11,7 +20,7 @@ import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
 import { buildGroupDetail, computeStats, filterFindings, groupFindings, toGroupFinding } from '../services/vulnerabilityFleetAggregation';
 import { fetchCveCatalogRecord, fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
 import { writeRouteAudit } from '../services/auditEvents';
-import { createTicket, TicketServiceError } from '../services/ticketService';
+import { createTicket } from '../services/ticketService';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { enqueueVulnSourceSync, enqueueVulnCorrelation } from '../jobs/vulnerabilityJobs';
@@ -27,13 +36,13 @@ const statusSchema = z
   .string()
   .trim()
   .transform((value) => value.toLowerCase())
-  .pipe(z.enum(['open', 'patched', 'mitigated', 'accepted', 'all']));
+  .pipe(z.enum(VULN_STATUS_FILTERS));
 
 const severitySchema = z
   .string()
   .trim()
   .transform((value) => value.toLowerCase())
-  .pipe(z.enum(['low', 'medium', 'high', 'critical']));
+  .pipe(z.enum(VULN_SEVERITIES));
 
 // Query-string boolean: accepts "true"/"false" (any case), rejects everything else.
 const boolQuerySchema = z
@@ -88,11 +97,17 @@ const bulkMitigateSchema = z.object({
   note: z.string().trim().min(1).max(2000),
 });
 
+// The client sends ONLY the finding ids, a title, a priority, and an optional
+// free-text note. It does NOT send a `description`: the old `description` field
+// enumerated device names + CVE ids across ALL selected orgs and was passed
+// verbatim into every per-org ticket, leaking one org's hostnames/CVEs into
+// another org's (org-readable) ticket. The server now builds each ticket's
+// description itself, per org, from that org's rows only (see the /tickets route).
 const bulkTicketSchema = z.object({
   deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
   title: z.string().trim().min(1).max(255),
-  description: z.string().max(50_000).optional(),
-  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+  note: z.string().trim().max(50_000).optional(),
+  priority: z.enum(VULN_TICKET_PRIORITIES).default('normal'),
 });
 
 const softwareQuerySchema = z.object({
@@ -184,8 +199,44 @@ async function loadFindingForWrite(id: string, auth: AuthContext): Promise<Findi
   return { ok: true, row };
 }
 
-type BulkFindingRow = { id: string; orgId: string; deviceId: string; status: string };
-type BulkAccess = { valid: BulkFindingRow[]; skipped: Array<{ id: string; reason: string }> };
+type BulkFindingRow = { id: string; orgId: string; deviceId: string; vulnerabilityId: string; status: string };
+type BulkAccess = { valid: BulkFindingRow[]; skipped: SkippedItem[] };
+
+/** Summarize distinct skip CODES as human prose for an all-skipped outcome, e.g.
+ *  "5 no available patch, 2 not an open vulnerability" (labels from the shared map). */
+function describeSkips(skipped: SkippedItem[]): string {
+  const counts = new Map<VulnSkipReason, number>();
+  for (const s of skipped) counts.set(s.reason, (counts.get(s.reason) ?? 0) + 1);
+  return [...counts.entries()].map(([reason, n]) => `${n} ${VULN_SKIP_REASON_LABELS[reason]}`).join(', ');
+}
+
+/**
+ * Build a ticket description for ONE org's findings, from server-resolved data
+ * only. `rows` MUST all belong to the same org (the caller groups by org first),
+ * so the deduped CVE ids and device names below reference nothing outside that
+ * tenant. The optional user `note` is appended verbatim. Ids missing from the
+ * lookup maps (device deleted / catalog purged mid-request) are dropped rather
+ * than surfaced as blanks.
+ */
+function buildTicketDescription(
+  rows: BulkFindingRow[],
+  deviceNameById: Map<string, string>,
+  cveByVulnId: Map<string, string>,
+  note?: string,
+): string {
+  const cves = [...new Set(rows.map((r) => cveByVulnId.get(r.vulnerabilityId)).filter((v): v is string => !!v))].sort();
+  const deviceNames = [
+    ...new Set(rows.map((r) => deviceNameById.get(r.deviceId)).filter((v): v is string => !!v)),
+  ].sort((a, b) => a.localeCompare(b));
+
+  const lines = [`Vulnerability remediation request covering ${rows.length} finding(s).`, ''];
+  lines.push(`CVEs (${cves.length}): ${cves.length > 0 ? cves.join(', ') : 'n/a'}`);
+  lines.push(`Affected devices (${deviceNames.length}): ${deviceNames.length > 0 ? deviceNames.join(', ') : 'n/a'}`);
+  if (note) {
+    lines.push('', note);
+  }
+  return lines.join('\n');
+}
 
 /**
  * Batch analogue of loadFindingForWrite: resolves each id to a finding the
@@ -200,6 +251,7 @@ async function loadFindingsForBulkWrite(ids: string[], auth: AuthContext): Promi
       id: deviceVulnerabilities.id,
       orgId: deviceVulnerabilities.orgId,
       deviceId: deviceVulnerabilities.deviceId,
+      vulnerabilityId: deviceVulnerabilities.vulnerabilityId,
       status: deviceVulnerabilities.status,
     })
     .from(deviceVulnerabilities)
@@ -218,21 +270,21 @@ async function loadFindingsForBulkWrite(ids: string[], auth: AuthContext): Promi
   const deviceById = new Map(deviceRows.map((d) => [d.id, d]));
 
   const valid: BulkFindingRow[] = [];
-  const skipped: Array<{ id: string; reason: string }> = [];
+  const skipped: SkippedItem[] = [];
   for (const id of unique) {
     const row = byId.get(id);
     if (!row) {
-      skipped.push({ id, reason: 'finding not found' });
+      skipped.push({ id, reason: 'not_found' });
       continue;
     }
     const device = deviceById.get(row.deviceId);
     if (!device) {
       // Device outside the caller's org scope reads as not-found (no existence leak).
-      skipped.push({ id, reason: 'finding not found' });
+      skipped.push({ id, reason: 'not_found' });
       continue;
     }
     if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
-      skipped.push({ id, reason: 'site access denied' });
+      skipped.push({ id, reason: 'site_access_denied' });
       continue;
     }
     valid.push(row);
@@ -619,10 +671,17 @@ vulnerabilityRoutes.post(
       auth,
     );
     // runAction treats {success:false} as a failure; report success when at least
-    // one finding was scheduled (or nothing was asked).
+    // one finding was scheduled (or nothing was asked). When nothing was scheduled
+    // but items were skipped, surface WHY (distinct skip reasons) so the client
+    // shows the real cause instead of a generic "Failed to schedule remediation."
+    const message =
+      result.scheduled === 0 && result.skipped.length > 0
+        ? `Nothing scheduled: ${describeSkips(result.skipped)}`
+        : undefined;
     return c.json({
       success: result.scheduled > 0 || deviceVulnerabilityIds.length === 0,
       ...result,
+      ...(message ? { message } : {}),
     });
   },
 );
@@ -704,15 +763,20 @@ vulnerabilityRoutes.post(
 // POST /tickets — create native ticket(s) from vulnerability findings, splitting
 // a cross-org selection into one ticket per org (a ticket is org-owned, so
 // grouping by org avoids leaking device/finding data across tenants into a
-// single ticket). Static single-segment path — registered alongside the other
-// bulk POST routes above, before the `/:id/*` POST routes below.
+// single ticket). BOTH the finding<->ticket linkage AND the ticket description
+// CONTENT are org-scoped server-side: each ticket's description is built here
+// from ONLY that org's findings (its own device names + CVE ids, resolved from
+// server-side data, never from client input), so org A's hostnames/CVEs can
+// never appear in org B's ticket. The client supplies only ids/title/priority
+// and an optional free-text note. Static single-segment path — registered
+// alongside the other bulk POST routes above, before the `/:id/*` POST routes.
 vulnerabilityRoutes.post(
   '/tickets',
   requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
   zValidator('json', bulkTicketSchema),
   async (c) => {
     const auth = c.get('auth');
-    const { deviceVulnerabilityIds, title, description, priority } = c.req.valid('json');
+    const { deviceVulnerabilityIds, title, note, priority } = c.req.valid('json');
 
     const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
 
@@ -723,12 +787,43 @@ vulnerabilityRoutes.post(
       else byOrg.set(row.orgId, [row]);
     }
 
+    // Resolve display data (device names + CVE ids) for the accessible findings
+    // ONCE, from server-side tables — NOT from client input. Device names come
+    // from the request (RLS-scoped) context; the CVE catalog is global reference
+    // data read under a system context (mirrors readCatalogRows). These maps are
+    // consumed per-org below so each ticket's description contains only its own
+    // org's data.
+    const validDeviceIds = [...new Set(valid.map((r) => r.deviceId))];
+    const deviceNameRows =
+      validDeviceIds.length > 0
+        ? await db
+            .select({ id: devices.id, hostname: devices.hostname, displayName: devices.displayName })
+            .from(devices)
+            .where(inArray(devices.id, validDeviceIds))
+        : [];
+    const deviceNameById = new Map(deviceNameRows.map((d) => [d.id, d.displayName ?? d.hostname]));
+
+    const validVulnIds = [...new Set(valid.map((r) => r.vulnerabilityId))];
+    const cveRows =
+      validVulnIds.length > 0
+        ? await runOutsideDbContext(() =>
+            withSystemDbAccessContext(() =>
+              db
+                .select({ id: vulnerabilities.id, cveId: vulnerabilities.cveId })
+                .from(vulnerabilities)
+                .where(inArray(vulnerabilities.id, validVulnIds)),
+            ),
+          )
+        : [];
+    const cveByVulnId = new Map(cveRows.map((v) => [v.id, v.cveId]));
+
     const tickets: Array<{ ticketId: string; orgId: string; findingCount: number }> = [];
     for (const [orgId, rows] of byOrg) {
       if (!auth.canAccessOrg(orgId)) {
-        for (const r of rows) skipped.push({ id: r.id, reason: 'access to organization denied' });
+        for (const r of rows) skipped.push({ id: r.id, reason: 'org_access_denied' });
         continue;
       }
+      const description = buildTicketDescription(rows, deviceNameById, cveByVulnId, note);
       try {
         const ticket = await createTicket(
           { orgId, subject: title, description, priority, source: 'manual' },
@@ -746,13 +841,19 @@ vulnerabilityRoutes.post(
           details: { deviceVulnerabilityIds: rows.map((r) => r.id), title },
         });
         tickets.push({ ticketId: ticket.id, orgId, findingCount: rows.length });
-      } catch (err) {
-        const reason = err instanceof TicketServiceError ? err.message : 'failed to create ticket';
-        for (const r of rows) skipped.push({ id: r.id, reason });
+      } catch {
+        // TicketServiceError message is dynamic prose; collapse to the closest code.
+        for (const r of rows) skipped.push({ id: r.id, reason: 'ticket_create_failed' });
       }
     }
 
-    return c.json({ success: tickets.length > 0, tickets, skipped });
+    // All-skipped surfacing: when no ticket was created but items were skipped,
+    // tell the client WHY (distinct skip reasons) instead of a generic failure.
+    const message =
+      tickets.length === 0 && skipped.length > 0
+        ? `No tickets created: ${describeSkips(skipped)}`
+        : undefined;
+    return c.json({ success: tickets.length > 0, tickets, skipped, ...(message ? { message } : {}) });
   },
 );
 

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -11,6 +11,7 @@ import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
 import { buildGroupDetail, computeStats, filterFindings, groupFindings, toGroupFinding } from '../services/vulnerabilityFleetAggregation';
 import { fetchCveCatalogRecord, fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
 import { writeRouteAudit } from '../services/auditEvents';
+import { createTicket, TicketServiceError } from '../services/ticketService';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { enqueueVulnSourceSync, enqueueVulnCorrelation } from '../jobs/vulnerabilityJobs';
@@ -80,6 +81,13 @@ const bulkAcceptRiskSchema = z.object({
 const bulkMitigateSchema = z.object({
   deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
   note: z.string().trim().min(1).max(2000),
+});
+
+const bulkTicketSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  title: z.string().trim().min(1).max(255),
+  description: z.string().max(50_000).optional(),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
 });
 
 const softwareQuerySchema = z.object({
@@ -664,6 +672,61 @@ vulnerabilityRoutes.post(
       }
     }
     return c.json({ success: valid.length > 0, succeeded: valid.length, skipped });
+  },
+);
+
+// POST /tickets — create native ticket(s) from vulnerability findings, splitting
+// a cross-org selection into one ticket per org (a ticket is org-owned, so
+// grouping by org avoids leaking device/finding data across tenants into a
+// single ticket). Static single-segment path — registered alongside the other
+// bulk POST routes above, before the `/:id/*` POST routes below.
+vulnerabilityRoutes.post(
+  '/tickets',
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('json', bulkTicketSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, title, description, priority } = c.req.valid('json');
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+
+    const byOrg = new Map<string, BulkFindingRow[]>();
+    for (const row of valid) {
+      const bucket = byOrg.get(row.orgId);
+      if (bucket) bucket.push(row);
+      else byOrg.set(row.orgId, [row]);
+    }
+
+    const tickets: Array<{ ticketId: string; orgId: string; findingCount: number }> = [];
+    for (const [orgId, rows] of byOrg) {
+      if (!auth.canAccessOrg(orgId)) {
+        for (const r of rows) skipped.push({ id: r.id, reason: 'access to organization denied' });
+        continue;
+      }
+      try {
+        const ticket = await createTicket(
+          { orgId, subject: title, description, priority, source: 'manual' },
+          { userId: auth.user.id, name: auth.user.name, email: auth.user.email },
+        );
+        await db
+          .update(deviceVulnerabilities)
+          .set({ ticketId: ticket.id, updatedAt: new Date() })
+          .where(inArray(deviceVulnerabilities.id, rows.map((r) => r.id)));
+        writeRouteAudit(c, {
+          orgId,
+          action: 'vulnerability.ticket_create',
+          resourceType: 'ticket',
+          resourceId: ticket.id,
+          details: { deviceVulnerabilityIds: rows.map((r) => r.id), title },
+        });
+        tickets.push({ ticketId: ticket.id, orgId, findingCount: rows.length });
+      } catch (err) {
+        const reason = err instanceof TicketServiceError ? err.message : 'failed to create ticket';
+        for (const r of rows) skipped.push({ id: r.id, reason });
+      }
+    }
+
+    return c.json({ success: tickets.length > 0, tickets, skipped });
   },
 );
 

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -34,10 +34,20 @@ const severitySchema = z
   .transform((value) => value.toLowerCase())
   .pipe(z.enum(['low', 'medium', 'high', 'critical']));
 
+// Query-string boolean: accepts "true"/"false" (any case), rejects everything else.
+const boolQuerySchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toLowerCase())
+  .pipe(z.enum(['true', 'false']))
+  .transform((value) => value === 'true');
+
 const listQuerySchema = z.object({
   status: statusSchema.default('open'),
   severity: severitySchema.optional(),
   cve: z.string().trim().min(1).max(32).optional(),
+  kevOnly: boolQuerySchema.optional(),
+  patchAvailable: boolQuerySchema.optional(),
 });
 
 const deviceParamSchema = z.object({
@@ -60,14 +70,6 @@ const acceptRiskSchema = z.object({
 const mitigateSchema = z.object({
   note: z.string().trim().min(1).max(2000),
 });
-
-// Query-string boolean: accepts "true"/"false" (any case), rejects everything else.
-const boolQuerySchema = z
-  .string()
-  .trim()
-  .transform((value) => value.toLowerCase())
-  .pipe(z.enum(['true', 'false']))
-  .transform((value) => value === 'true');
 
 const softwareQuerySchema = z.object({
   status: statusSchema.default('open'),
@@ -224,7 +226,7 @@ function mergeRows(deviceRows: DeviceVulnerabilityRow[], catalogRows: CatalogRow
 
 async function readCatalogRows(
   vulnerabilityIds: string[],
-  filters: { severity?: string; cve?: string },
+  filters: { severity?: string; cve?: string; kevOnly?: boolean; patchAvailable?: boolean },
 ): Promise<CatalogRow[]> {
   if (vulnerabilityIds.length === 0) return [];
 
@@ -233,7 +235,13 @@ async function readCatalogRows(
     conditions.push(eq(vulnerabilities.severity, filters.severity));
   }
   if (filters.cve) {
-    conditions.push(ilike(vulnerabilities.cveId, filters.cve));
+    conditions.push(ilike(vulnerabilities.cveId, `%${filters.cve}%`));
+  }
+  if (filters.kevOnly) {
+    conditions.push(eq(vulnerabilities.knownExploited, true));
+  }
+  if (filters.patchAvailable) {
+    conditions.push(eq(vulnerabilities.patchAvailable, true));
   }
 
   return runOutsideDbContext(() =>
@@ -261,6 +269,8 @@ async function listVulnerabilities(filters: {
   deviceId?: string;
   severity?: string;
   cve?: string;
+  kevOnly?: boolean;
+  patchAvailable?: boolean;
   /** Site-axis narrowing: when set, only return findings for devices in these sites.
    *  Empty array = caller has no in-scope sites → return nothing (fail-closed). */
   allowedSiteIds?: string[];
@@ -309,6 +319,8 @@ async function listVulnerabilities(filters: {
   const catalogRows = await readCatalogRows(vulnerabilityIds, {
     severity: filters.severity,
     cve: filters.cve,
+    kevOnly: filters.kevOnly,
+    patchAvailable: filters.patchAvailable,
   });
 
   return mergeRows(deviceRows, catalogRows);
@@ -325,6 +337,8 @@ type FleetRow = {
   epssScore: number | null;
   riskScore: number | null;
   deviceCount: number;
+  patchAvailable: boolean;
+  statuses: string[];
 };
 
 /**
@@ -335,7 +349,15 @@ type FleetRow = {
  */
 function aggregateFleet(items: MergedItem[]): FleetRow[] {
   const byVuln = new Map<string, FleetRow>();
+  const statusesByVuln = new Map<string, Set<string>>();
   for (const item of items) {
+    const statuses = statusesByVuln.get(item.vulnerabilityId);
+    if (statuses) {
+      statuses.add(item.status);
+    } else {
+      statusesByVuln.set(item.vulnerabilityId, new Set([item.status]));
+    }
+
     const existing = byVuln.get(item.vulnerabilityId);
     if (existing) {
       existing.deviceCount += 1;
@@ -353,7 +375,14 @@ function aggregateFleet(items: MergedItem[]): FleetRow[] {
       epssScore: item.epssScore,
       riskScore: item.riskScore,
       deviceCount: 1,
+      patchAvailable: item.patchAvailable,
+      statuses: [],
     });
+  }
+
+  for (const row of byVuln.values()) {
+    const statuses = statusesByVuln.get(row.id);
+    row.statuses = statuses ? [...statuses].sort() : [];
   }
 
   return Array.from(byVuln.values()).sort((a, b) => {

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -71,6 +71,17 @@ const mitigateSchema = z.object({
   note: z.string().trim().min(1).max(2000),
 });
 
+const bulkAcceptRiskSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  reason: z.string().trim().min(1).max(2000),
+  acceptedUntil: z.string().datetime(),
+});
+
+const bulkMitigateSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  note: z.string().trim().min(1).max(2000),
+});
+
 const softwareQuerySchema = z.object({
   status: statusSchema.default('open'),
   severity: severitySchema.optional(),
@@ -154,6 +165,62 @@ async function loadFindingForWrite(id: string, auth: AuthContext): Promise<Findi
     };
   }
   return { ok: true, row };
+}
+
+type BulkFindingRow = { id: string; orgId: string; deviceId: string; status: string };
+type BulkAccess = { valid: BulkFindingRow[]; skipped: Array<{ id: string; reason: string }> };
+
+/**
+ * Batch analogue of loadFindingForWrite: resolves each id to a finding the
+ * caller may write (org via RLS + orgCondition on the device row, site via
+ * canAccessSite), collecting per-item skip reasons instead of failing the
+ * batch. Duplicate ids are collapsed.
+ */
+async function loadFindingsForBulkWrite(ids: string[], auth: AuthContext): Promise<BulkAccess> {
+  const unique = [...new Set(ids)];
+  const rows = await db
+    .select({
+      id: deviceVulnerabilities.id,
+      orgId: deviceVulnerabilities.orgId,
+      deviceId: deviceVulnerabilities.deviceId,
+      status: deviceVulnerabilities.status,
+    })
+    .from(deviceVulnerabilities)
+    .where(inArray(deviceVulnerabilities.id, unique));
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const deviceIds = [...new Set(rows.map((r) => r.deviceId))];
+  const orgCond = auth.orgCondition(devices.orgId);
+  const deviceRows =
+    deviceIds.length > 0
+      ? await db
+          .select({ id: devices.id, siteId: devices.siteId })
+          .from(devices)
+          .where(orgCond ? and(inArray(devices.id, deviceIds), orgCond) : inArray(devices.id, deviceIds))
+      : [];
+  const deviceById = new Map(deviceRows.map((d) => [d.id, d]));
+
+  const valid: BulkFindingRow[] = [];
+  const skipped: Array<{ id: string; reason: string }> = [];
+  for (const id of unique) {
+    const row = byId.get(id);
+    if (!row) {
+      skipped.push({ id, reason: 'finding not found' });
+      continue;
+    }
+    const device = deviceById.get(row.deviceId);
+    if (!device) {
+      // Device outside the caller's org scope reads as not-found (no existence leak).
+      skipped.push({ id, reason: 'finding not found' });
+      continue;
+    }
+    if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+      skipped.push({ id, reason: 'site access denied' });
+      continue;
+    }
+    valid.push(row);
+  }
+  return { valid, skipped };
 }
 
 type DeviceVulnerabilityRow = {
@@ -523,6 +590,80 @@ vulnerabilityRoutes.post(
       success: result.scheduled > 0 || deviceVulnerabilityIds.length === 0,
       ...result,
     });
+  },
+);
+
+// POST /bulk/accept-risk — accept risk for many findings at once, fault-tolerant
+// per item. MUST be registered before /:id/accept-risk below: Hono's router
+// matches in registration order, so a param route registered first would
+// otherwise shadow this static path (bound as id="bulk").
+vulnerabilityRoutes.post(
+  '/bulk/accept-risk',
+  requirePermission(PERMISSIONS.VULN_RISK_ACCEPT.resource, PERMISSIONS.VULN_RISK_ACCEPT.action),
+  zValidator('json', bulkAcceptRiskSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, reason, acceptedUntil } = c.req.valid('json');
+
+    if (new Date(acceptedUntil).getTime() <= Date.now()) {
+      return c.json({ success: false, error: 'acceptedUntil must be in the future' }, 400);
+    }
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+    if (valid.length > 0) {
+      await db
+        .update(deviceVulnerabilities)
+        .set({
+          status: 'accepted',
+          acceptedBy: auth.user.id,
+          acceptedUntil: new Date(acceptedUntil),
+          // Acceptance rationale reuses mitigation_note — same as the
+          // per-finding accept-risk endpoint (no dedicated reason column).
+          mitigationNote: reason,
+          updatedAt: new Date(),
+        })
+        .where(inArray(deviceVulnerabilities.id, valid.map((v) => v.id)));
+      for (const row of valid) {
+        writeRouteAudit(c, {
+          orgId: row.orgId,
+          action: 'vulnerability.accept_risk',
+          resourceType: 'device_vulnerability',
+          resourceId: row.id,
+          details: { acceptedUntil, reason, bulk: true },
+        });
+      }
+    }
+    return c.json({ success: valid.length > 0, succeeded: valid.length, skipped });
+  },
+);
+
+// POST /bulk/mitigate — mitigate many findings at once, fault-tolerant per item.
+// MUST be registered before /:id/mitigate below (same shadowing reason as above).
+vulnerabilityRoutes.post(
+  '/bulk/mitigate',
+  requireVulnerabilityWrite,
+  zValidator('json', bulkMitigateSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, note } = c.req.valid('json');
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+    if (valid.length > 0) {
+      await db
+        .update(deviceVulnerabilities)
+        .set({ status: 'mitigated', mitigationNote: note, resolvedAt: new Date(), updatedAt: new Date() })
+        .where(inArray(deviceVulnerabilities.id, valid.map((v) => v.id)));
+      for (const row of valid) {
+        writeRouteAudit(c, {
+          orgId: row.orgId,
+          action: 'vulnerability.mitigate',
+          resourceType: 'device_vulnerability',
+          resourceId: row.id,
+          details: { note, bulk: true },
+        });
+      }
+    }
+    return c.json({ success: valid.length > 0, succeeded: valid.length, skipped });
   },
 );
 

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { and, desc, eq, ilike, inArray, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, ilike, inArray, lte, type SQL } from 'drizzle-orm';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
@@ -43,12 +43,17 @@ const boolQuerySchema = z
   .pipe(z.enum(['true', 'false']))
   .transform((value) => value === 'true');
 
+// Query-string integer: accepted-risk expiry window in days (the stat card
+// sends 14). Coerced from the raw string; bounded to keep the window sane.
+const expiringWithinDaysSchema = z.coerce.number().int().min(1).max(365);
+
 const listQuerySchema = z.object({
   status: statusSchema.default('open'),
   severity: severitySchema.optional(),
   cve: z.string().trim().min(1).max(32).optional(),
   kevOnly: boolQuerySchema.optional(),
   patchAvailable: boolQuerySchema.optional(),
+  expiringWithinDays: expiringWithinDaysSchema.optional(),
 });
 
 const deviceParamSchema = z.object({
@@ -96,9 +101,13 @@ const softwareQuerySchema = z.object({
   search: z.string().trim().min(1).max(200).optional(),
   kevOnly: boolQuerySchema.optional(),
   patchAvailable: boolQuerySchema.optional(),
+  expiringWithinDays: expiringWithinDaysSchema.optional(),
 });
 
 const SOFTWARE_GROUP_CAP = 500;
+// Same cap + hasMore contract for the by-CVE fleet view (one row per CVE, so
+// cardinality is catalog-bounded; a cap with a truncation notice beats pagination).
+const FLEET_CVE_CAP = 500;
 
 const groupKeyParamSchema = z.object({
   // Opaque group key: sw:<name>|<vendor> or os:<platform>. Hono decodes the
@@ -346,6 +355,8 @@ async function listVulnerabilities(filters: {
   cve?: string;
   kevOnly?: boolean;
   patchAvailable?: boolean;
+  /** Only findings whose accepted-risk window expires within N days from now. */
+  expiringWithinDays?: number;
   /** Site-axis narrowing: when set, only return findings for devices in these sites.
    *  Empty array = caller has no in-scope sites → return nothing (fail-closed). */
   allowedSiteIds?: string[];
@@ -358,6 +369,14 @@ async function listVulnerabilities(filters: {
   }
   if (filters.deviceId) {
     conditions.push(eq(deviceVulnerabilities.deviceId, filters.deviceId));
+  }
+  // Accepted-risk expiry window (backs the "Accepted, expiring soon" stat card,
+  // matching computeStats in vulnerabilityFleetAggregation.ts: acceptedUntil in
+  // (now, now + N days]). Rows without acceptedUntil never match.
+  if (filters.expiringWithinDays !== undefined) {
+    const now = new Date();
+    const soon = new Date(now.getTime() + filters.expiringWithinDays * 24 * 60 * 60 * 1000);
+    conditions.push(gt(deviceVulnerabilities.acceptedUntil, now), lte(deviceVulnerabilities.acceptedUntil, soon));
   }
   // Site-axis (app-layer only; RLS does NOT enforce site isolation). Mirrors
   // assertDeviceSiteAccess used by per-device routes in this file and
@@ -484,7 +503,11 @@ vulnerabilityRoutes.get('/', zValidator('query', listQuerySchema), async (c) => 
     ...query,
     allowedSiteIds: perms?.allowedSiteIds,
   });
-  return c.json({ items: aggregateFleet(items) });
+  const rows = aggregateFleet(items);
+  return c.json({
+    items: rows.slice(0, FLEET_CVE_CAP),
+    hasMore: rows.length > FLEET_CVE_CAP,
+  });
 });
 
 // Fleet work queue: one row per remediation unit (software product or OS
@@ -502,6 +525,7 @@ vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), a
     severity: query.severity,
     kevOnly: query.kevOnly,
     patchAvailable: query.patchAvailable,
+    expiringWithinDays: query.expiringWithinDays,
   });
   const groups = groupFindings(filtered, { search: query.search });
   return c.json({
@@ -525,7 +549,9 @@ vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParam
 });
 
 // The four stat-card numbers in one call. Needs every status: open findings
-// feed three cards, accepted findings feed the expiring-soon card.
+// feed three cards, accepted findings feed the expiring-soon card. Also carries
+// totalFindings/lastDetectedAt (computed from the same rows — no extra query)
+// so the empty states can tell a clean fleet from one that never produced data.
 vulnerabilityRoutes.get('/stats', async (c) => {
   const perms = c.get('permissions') as UserPermissions | undefined;
   const rows = await fetchFleetFindingRows({

--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -8,6 +8,8 @@ import { deviceVulnerabilities, devices, vulnerabilities } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { remediateVulnerabilities } from '../services/vulnerabilityRemediation';
+import { computeStats, filterFindings, groupFindings } from '../services/vulnerabilityFleetAggregation';
+import { fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
 import { writeRouteAudit } from '../services/auditEvents';
 import { platformAdminMiddleware } from '../middleware/platformAdmin';
 import { userRateLimit } from '../middleware/userRateLimit';
@@ -58,6 +60,24 @@ const acceptRiskSchema = z.object({
 const mitigateSchema = z.object({
   note: z.string().trim().min(1).max(2000),
 });
+
+// Query-string boolean: accepts "true"/"false" (any case), rejects everything else.
+const boolQuerySchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toLowerCase())
+  .pipe(z.enum(['true', 'false']))
+  .transform((value) => value === 'true');
+
+const softwareQuerySchema = z.object({
+  status: statusSchema.default('open'),
+  severity: severitySchema.optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  kevOnly: boolQuerySchema.optional(),
+  patchAvailable: boolQuerySchema.optional(),
+});
+
+const SOFTWARE_GROUP_CAP = 500;
 
 const requireVulnerabilityWrite = requirePermission(
   PERMISSIONS.DEVICES_WRITE.resource,
@@ -350,6 +370,40 @@ vulnerabilityRoutes.get('/', zValidator('query', listQuerySchema), async (c) => 
     allowedSiteIds: perms?.allowedSiteIds,
   });
   return c.json({ items: aggregateFleet(items) });
+});
+
+// Fleet work queue: one row per remediation unit (software product or OS
+// pseudo-group). Group cardinality is fleet-bounded; hard cap + hasMore
+// instead of pagination.
+vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), async (c) => {
+  const query = c.req.valid('query');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({
+    status: query.status,
+    allowedSiteIds: perms?.allowedSiteIds,
+  });
+  const filtered = filterFindings(rows, {
+    status: query.status,
+    severity: query.severity,
+    kevOnly: query.kevOnly,
+    patchAvailable: query.patchAvailable,
+  });
+  const groups = groupFindings(filtered, { search: query.search });
+  return c.json({
+    items: groups.slice(0, SOFTWARE_GROUP_CAP),
+    hasMore: groups.length > SOFTWARE_GROUP_CAP,
+  });
+});
+
+// The four stat-card numbers in one call. Needs every status: open findings
+// feed three cards, accepted findings feed the expiring-soon card.
+vulnerabilityRoutes.get('/stats', async (c) => {
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({
+    status: 'all',
+    allowedSiteIds: perms?.allowedSiteIds,
+  });
+  return c.json(computeStats(rows, new Date()));
 });
 
 vulnerabilityRoutes.get(

--- a/apps/api/src/services/aiToolsVulnerability.ts
+++ b/apps/api/src/services/aiToolsVulnerability.ts
@@ -15,6 +15,8 @@
 
 import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 
+import { VULN_SKIP_REASON_LABELS } from '@breeze/shared';
+
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../db';
 import { deviceVulnerabilities, vulnerabilities } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
@@ -284,7 +286,11 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
         const result = await remediationService.remediateVulnerabilities(orgId, ids, actorUserId, auth);
         return JSON.stringify({
           scheduled: result.scheduled,
-          skipped: result.skipped,
+          // Map the machine-readable skip codes to human prose for the LLM/user.
+          skipped: result.skipped.map((s) => ({
+            id: s.id,
+            reason: VULN_SKIP_REASON_LABELS[s.reason] ?? s.reason,
+          })),
           message: `Scheduled ${result.scheduled} remediation(s); ${result.skipped.length} skipped.`,
         });
       } catch (err) {

--- a/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
@@ -18,6 +18,7 @@ function row(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
     detectedAt: '2026-06-01T00:00:00.000Z',
     acceptedUntil: null,
     ticketId: null,
+    ticketNumber: null,
     softwareInventoryId: 'sw-1',
     softwareName: 'Google Chrome',
     softwareVendor: 'Google LLC',
@@ -67,6 +68,21 @@ describe('filterFindings', () => {
     expect(filterFindings(rows, { status: 'all', severity: 'critical' }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
     expect(filterFindings(rows, { status: 'all', kevOnly: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
     expect(filterFindings(rows, { status: 'all', patchAvailable: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a', 'c']);
+  });
+
+  it('applies the expiringWithinDays window with computeStats semantics: (now, now + N days]', () => {
+    const now = new Date('2026-07-05T00:00:00.000Z');
+    const windowed = [
+      row({ deviceVulnerabilityId: 'soon', status: 'accepted', acceptedUntil: '2026-07-10T00:00:00.000Z' }),   // in window
+      row({ deviceVulnerabilityId: 'edge', status: 'accepted', acceptedUntil: '2026-07-19T00:00:00.000Z' }),   // exactly now+14d — inclusive
+      row({ deviceVulnerabilityId: 'far', status: 'accepted', acceptedUntil: '2026-12-01T00:00:00.000Z' }),    // beyond window
+      row({ deviceVulnerabilityId: 'past', status: 'accepted', acceptedUntil: '2026-07-01T00:00:00.000Z' }),   // already expired
+      row({ deviceVulnerabilityId: 'none', status: 'accepted', acceptedUntil: null }),                          // no expiry set
+      row({ deviceVulnerabilityId: 'open', status: 'open' }),                                                   // wrong status anyway
+    ];
+    expect(
+      filterFindings(windowed, { status: 'accepted', expiringWithinDays: 14 }, now).map((r) => r.deviceVulnerabilityId),
+    ).toEqual(['soon', 'edge']);
   });
 });
 
@@ -129,13 +145,13 @@ describe('groupFindings', () => {
     expect(groupFindings(rows, { search: 'nomatch' })).toHaveLength(0);
   });
 
-  it('collects distinct ticketIds and versions', () => {
+  it('collects distinct tickets (id + human number) and versions', () => {
     const g = groupFindings([
-      row({ ticketId: 't-1', softwareVersion: '2.0' }),
-      row({ deviceVulnerabilityId: 'b', ticketId: 't-1', softwareVersion: '10.0' }),
+      row({ ticketId: 't-1', ticketNumber: 'T-2026-C001', softwareVersion: '2.0' }),
+      row({ deviceVulnerabilityId: 'b', ticketId: 't-1', ticketNumber: 'T-2026-C001', softwareVersion: '10.0' }),
       row({ deviceVulnerabilityId: 'c', ticketId: null, softwareVersion: '2.0' }),
     ])[0]!;
-    expect(g.ticketIds).toEqual(['t-1']);
+    expect(g.tickets).toEqual([{ id: 't-1', number: 'T-2026-C001' }]);
     expect(g.versions).toEqual(['2.0', '10.0']); // numeric-aware sort
   });
 });
@@ -158,6 +174,22 @@ describe('computeStats', () => {
     expect(stats.patchReadyFindingCount).toBe(1);
     expect(stats.acceptedExpiringSoon).toBe(1);
   });
+
+  it('reports detection activity: totalFindings across ALL statuses and the max detectedAt', () => {
+    const stats = computeStats([
+      row({ status: 'open', detectedAt: '2026-06-01T00:00:00.000Z' }),
+      row({ deviceVulnerabilityId: 'b', status: 'patched', detectedAt: '2026-07-02T00:00:00.000Z' }),
+      row({ deviceVulnerabilityId: 'c', status: 'accepted', detectedAt: '2026-05-01T00:00:00.000Z' }),
+    ], now);
+    expect(stats.totalFindings).toBe(3);
+    expect(stats.lastDetectedAt).toBe('2026-07-02T00:00:00.000Z');
+  });
+
+  it('reports zero detection activity for an empty fleet (never scanned / nothing ever found)', () => {
+    const stats = computeStats([], now);
+    expect(stats.totalFindings).toBe(0);
+    expect(stats.lastDetectedAt).toBeNull();
+  });
 });
 
 describe('buildGroupDetail', () => {
@@ -178,5 +210,15 @@ describe('buildGroupDetail', () => {
     expect(detail!.findings).toHaveLength(3);
     expect(detail!.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String), status: 'open' });
     expect(detail!.group.deviceCount).toBe(2);
+  });
+
+  it('passes acceptedUntil through to findings so the UI can say "accepted until <date>"', () => {
+    const until = '2026-08-01T23:59:59.999Z';
+    const detail = buildGroupDetail('sw:google chrome|google llc', [
+      row({ deviceVulnerabilityId: 'a', status: 'accepted', acceptedUntil: until }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', deviceName: 'WS-02' }),
+    ]);
+    expect(detail!.findings.find((f) => f.deviceVulnerabilityId === 'a')!.acceptedUntil).toBe(until);
+    expect(detail!.findings.find((f) => f.deviceVulnerabilityId === 'b')!.acceptedUntil).toBeNull();
   });
 });

--- a/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildGroupKey,
+  buildGroupDetail,
+  computeStats,
+  filterFindings,
+  groupFindings,
+  type FleetFindingRow,
+} from './vulnerabilityFleetAggregation';
+
+function row(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    orgId: 'org-1',
+    status: 'open',
+    riskScore: 75,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    acceptedUntil: null,
+    ticketId: null,
+    softwareInventoryId: 'sw-1',
+    softwareName: 'Google Chrome',
+    softwareVendor: 'Google LLC',
+    softwareVersion: '126.0.1',
+    deviceName: 'WS-01',
+    deviceOsType: 'windows',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    vulnerabilityId: 'v-1',
+    severity: 'high',
+    cvssScore: 8.1,
+    epssScore: 0.4,
+    knownExploited: false,
+    patchAvailable: true,
+    ...overrides,
+  };
+}
+
+describe('buildGroupKey', () => {
+  it('normalizes software name/vendor with lower(trim(...)) matching the correlation JOIN', () => {
+    expect(buildGroupKey(row({ softwareName: '  Google Chrome ', softwareVendor: ' Google LLC ' })))
+      .toBe('sw:google chrome|google llc');
+  });
+
+  it('treats null vendor as empty string', () => {
+    expect(buildGroupKey(row({ softwareVendor: null }))).toBe('sw:google chrome|');
+  });
+
+  it('maps OS findings (null softwareInventoryId) to per-platform pseudo-groups', () => {
+    expect(buildGroupKey(row({ softwareInventoryId: null, deviceOsType: 'macos' }))).toBe('os:macos');
+  });
+});
+
+describe('filterFindings', () => {
+  const rows = [
+    row({ deviceVulnerabilityId: 'a', status: 'open', severity: 'critical', knownExploited: true }),
+    row({ deviceVulnerabilityId: 'b', status: 'accepted', severity: 'high', patchAvailable: false }),
+    row({ deviceVulnerabilityId: 'c', status: 'open', severity: 'low', knownExploited: false }),
+  ];
+
+  it('filters by status, passing everything through for "all"', () => {
+    expect(filterFindings(rows, { status: 'open' }).map((r) => r.deviceVulnerabilityId)).toEqual(['a', 'c']);
+    expect(filterFindings(rows, { status: 'all' })).toHaveLength(3);
+  });
+
+  it('applies severity, kevOnly, and patchAvailable finding-level filters', () => {
+    expect(filterFindings(rows, { status: 'all', severity: 'critical' }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
+    expect(filterFindings(rows, { status: 'all', kevOnly: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
+    expect(filterFindings(rows, { status: 'all', patchAvailable: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a', 'c']);
+  });
+});
+
+describe('groupFindings', () => {
+  it('groups by normalized software identity and counts distinct devices/CVEs', () => {
+    const groups = groupFindings([
+      row({ deviceVulnerabilityId: 'a', deviceId: 'dev-1', cveId: 'CVE-1' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-1', softwareName: 'google chrome' }),
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-1', cveId: 'CVE-2' }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.deviceCount).toBe(2);
+    expect(groups[0]!.cveCount).toBe(2);
+    expect(groups[0]!.kind).toBe('software');
+  });
+
+  it('rolls OS findings into per-platform pseudo-groups with display names', () => {
+    const groups = groupFindings([
+      row({ softwareInventoryId: null, deviceOsType: 'windows' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', softwareInventoryId: null, deviceOsType: 'macos' }),
+    ]);
+    const names = groups.map((g) => g.name).sort();
+    expect(names).toEqual(['Windows OS updates', 'macOS updates']);
+    expect(groups.every((g) => g.kind === 'os' && g.vendor === null)).toBe(true);
+  });
+
+  it('computes worstSeverity / maxRiskScore / maxEpss / kevCveCount / patch-ready counts', () => {
+    const groups = groupFindings([
+      row({ deviceVulnerabilityId: 'a', deviceId: 'dev-1', cveId: 'CVE-1', severity: 'high', riskScore: 70, epssScore: 0.2, knownExploited: false, patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-2', severity: 'critical', riskScore: 95, epssScore: 0.9, knownExploited: true, patchAvailable: false, status: 'open' }),
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-2', cveId: 'CVE-1', severity: 'high', riskScore: 60, epssScore: 0.2, knownExploited: false, patchAvailable: true, status: 'accepted' }),
+    ]);
+    const g = groups[0]!;
+    expect(g.worstSeverity).toBe('critical');
+    expect(g.maxRiskScore).toBe(95);
+    expect(g.maxEpss).toBe(0.9);
+    expect(g.kevCveCount).toBe(1);
+    // patch-ready counts only OPEN findings with a patch-available CVE
+    expect(g.patchReadyFindingCount).toBe(1);
+    expect(g.patchReadyDeviceCount).toBe(1);
+  });
+
+  it('sorts by maxRiskScore desc with nulls last', () => {
+    const groups = groupFindings([
+      row({ softwareName: 'Low', riskScore: 10 }),
+      row({ deviceVulnerabilityId: 'b', softwareName: 'None', riskScore: null }),
+      row({ deviceVulnerabilityId: 'c', softwareName: 'High', riskScore: 90 }),
+    ]);
+    expect(groups.map((g) => g.name)).toEqual(['High', 'Low', 'None']);
+  });
+
+  it('applies search across group name, vendor, and member CVE ids (case-insensitive)', () => {
+    const rows = [
+      row({ softwareName: 'Google Chrome', cveId: 'CVE-2026-0001' }),
+      row({ deviceVulnerabilityId: 'b', softwareName: 'Zoom', softwareVendor: 'Zoom Video', cveId: 'CVE-2026-9999' }),
+    ];
+    expect(groupFindings(rows, { search: 'chrome' })).toHaveLength(1);
+    expect(groupFindings(rows, { search: '9999' })[0]!.name).toBe('Zoom');
+    expect(groupFindings(rows, { search: 'ZOOM VIDEO' })).toHaveLength(1);
+    expect(groupFindings(rows, { search: 'nomatch' })).toHaveLength(0);
+  });
+
+  it('collects distinct ticketIds and versions', () => {
+    const g = groupFindings([
+      row({ ticketId: 't-1', softwareVersion: '2.0' }),
+      row({ deviceVulnerabilityId: 'b', ticketId: 't-1', softwareVersion: '10.0' }),
+      row({ deviceVulnerabilityId: 'c', ticketId: null, softwareVersion: '2.0' }),
+    ])[0]!;
+    expect(g.ticketIds).toEqual(['t-1']);
+    expect(g.versions).toEqual(['2.0', '10.0']); // numeric-aware sort
+  });
+});
+
+describe('computeStats', () => {
+  const now = new Date('2026-07-05T00:00:00.000Z');
+
+  it('computes the four stat-card numbers', () => {
+    const stats = computeStats([
+      row({ status: 'open', severity: 'critical' }),                                   // criticalOpen + patchReady
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', status: 'open', severity: 'high', knownExploited: true, cveId: 'CVE-K', patchAvailable: false }), // kev
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-3', status: 'open', severity: 'high', knownExploited: true, cveId: 'CVE-K', patchAvailable: false }), // same kev cve, 2nd device
+      row({ deviceVulnerabilityId: 'd', status: 'accepted', acceptedUntil: '2026-07-10T00:00:00.000Z' }),  // expiring within 14d
+      row({ deviceVulnerabilityId: 'e', status: 'accepted', acceptedUntil: '2026-12-01T00:00:00.000Z' }),  // not expiring soon
+      row({ deviceVulnerabilityId: 'f', status: 'accepted', acceptedUntil: '2026-07-01T00:00:00.000Z' }),  // already expired — not counted
+    ], now);
+    expect(stats.criticalOpen).toBe(1);
+    expect(stats.kevCveCount).toBe(1);
+    expect(stats.kevDeviceCount).toBe(2);
+    expect(stats.patchReadyFindingCount).toBe(1);
+    expect(stats.acceptedExpiringSoon).toBe(1);
+  });
+});
+
+describe('buildGroupDetail', () => {
+  it('returns null for an unknown group', () => {
+    expect(buildGroupDetail('sw:nope|', [row()])).toBeNull();
+  });
+
+  it('returns group summary + distinct CVEs (max risk each) + flat findings', () => {
+    const detail = buildGroupDetail('sw:google chrome|google llc', [
+      row({ deviceVulnerabilityId: 'a', cveId: 'CVE-1', riskScore: 60 }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-1', riskScore: 80 }),
+      row({ deviceVulnerabilityId: 'c', cveId: 'CVE-2', riskScore: 40 }),
+      row({ deviceVulnerabilityId: 'x', softwareName: 'Other App' }), // different group — excluded
+    ]);
+    expect(detail).not.toBeNull();
+    expect(detail!.cves.map((c) => c.cveId)).toEqual(['CVE-1', 'CVE-2']); // sorted by maxRiskScore desc
+    expect(detail!.cves[0]!.maxRiskScore).toBe(80);
+    expect(detail!.findings).toHaveLength(3);
+    expect(detail!.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String), status: 'open' });
+    expect(detail!.group.deviceCount).toBe(2);
+  });
+});

--- a/apps/api/src/services/vulnerabilityFleetAggregation.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.ts
@@ -1,0 +1,292 @@
+/**
+ * Pure aggregation logic for the fleet vulnerabilities triage UI.
+ *
+ * Grouping key contract (opaque, URL-safe once encodeURIComponent'd, stable
+ * across requests so `#software/<groupKey>` deep links work):
+ *   software finding:  sw:<lower(trim(name))>|<lower(trim(coalesce(vendor,'')))>
+ *   OS finding:        os:<devices.osType>          (softwareInventoryId IS NULL)
+ * The lower(trim(...)) normalization deliberately matches the correlation
+ * pipeline's JOIN (services/vulnerabilityCorrelation.ts) so one product maps
+ * to one queue row regardless of inventory casing.
+ *
+ * No db access here — routes fetch FleetFindingRow[] via
+ * services/vulnerabilityFleetQueries.ts and pass them in.
+ */
+
+export interface FleetFindingRow {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  orgId: string;
+  status: string; // open | patched | mitigated | accepted
+  riskScore: number | null;
+  detectedAt: string; // ISO
+  acceptedUntil: string | null; // ISO
+  ticketId: string | null;
+  softwareInventoryId: string | null;
+  softwareName: string | null;
+  softwareVendor: string | null;
+  softwareVersion: string | null;
+  deviceName: string;
+  deviceOsType: 'windows' | 'macos' | 'linux';
+  orgName: string | null;
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+}
+
+export interface FleetFindingFilters {
+  status: string; // open | patched | mitigated | accepted | all
+  severity?: string;
+  kevOnly?: boolean;
+  patchAvailable?: boolean;
+}
+
+export interface SoftwareGroup {
+  groupKey: string;
+  kind: 'software' | 'os';
+  name: string;
+  vendor: string | null;
+  versions: string[];
+  deviceCount: number;
+  cveCount: number;
+  cveIds: string[];
+  worstSeverity: string | null;
+  maxRiskScore: number | null;
+  kevCveCount: number;
+  maxEpss: number | null;
+  /** Open findings whose CVE has a patch available ("fixable right now"). */
+  patchReadyFindingCount: number;
+  /** Distinct devices with at least one patch-ready open finding. */
+  patchReadyDeviceCount: number;
+  ticketIds: string[];
+}
+
+export interface FleetVulnStats {
+  criticalOpen: number;
+  kevCveCount: number;
+  kevDeviceCount: number;
+  patchReadyFindingCount: number;
+  acceptedExpiringSoon: number;
+}
+
+export interface GroupCve {
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  maxRiskScore: number | null;
+}
+
+export interface GroupFinding {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  deviceName: string;
+  orgId: string;
+  orgName: string | null;
+  cveId: string;
+  status: string;
+  patchAvailable: boolean;
+  riskScore: number | null;
+  detectedAt: string;
+  ticketId: string | null;
+}
+
+export interface SoftwareGroupDetail {
+  group: SoftwareGroup;
+  cves: GroupCve[];
+  findings: GroupFinding[];
+}
+
+const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+const OS_GROUP_NAMES: Record<FleetFindingRow['deviceOsType'], string> = {
+  windows: 'Windows OS updates',
+  macos: 'macOS updates',
+  linux: 'Linux OS updates',
+};
+
+const ACCEPTED_EXPIRING_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function buildGroupKey(
+  row: Pick<FleetFindingRow, 'softwareInventoryId' | 'softwareName' | 'softwareVendor' | 'deviceOsType'>,
+): string {
+  if (row.softwareInventoryId === null) return `os:${row.deviceOsType}`;
+  const name = (row.softwareName ?? '').trim().toLowerCase();
+  const vendor = (row.softwareVendor ?? '').trim().toLowerCase();
+  return `sw:${name}|${vendor}`;
+}
+
+export function filterFindings(rows: FleetFindingRow[], f: FleetFindingFilters): FleetFindingRow[] {
+  return rows.filter((r) => {
+    if (f.status !== 'all' && r.status !== f.status) return false;
+    if (f.severity && (r.severity ?? '').toLowerCase() !== f.severity) return false;
+    if (f.kevOnly && !r.knownExploited) return false;
+    if (f.patchAvailable && !r.patchAvailable) return false;
+    return true;
+  });
+}
+
+function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGroup {
+  const first = bucket[0]!;
+  const kind: SoftwareGroup['kind'] = groupKey.startsWith('os:') ? 'os' : 'software';
+  const cveIds = new Set<string>();
+  const kevCves = new Set<string>();
+  const deviceIds = new Set<string>();
+  const patchReadyDevices = new Set<string>();
+  const versions = new Set<string>();
+  const ticketIds = new Set<string>();
+  let worst: string | null = null;
+  let maxRisk: number | null = null;
+  let maxEpss: number | null = null;
+  let patchReadyFindingCount = 0;
+
+  for (const r of bucket) {
+    cveIds.add(r.cveId);
+    if (r.knownExploited) kevCves.add(r.cveId);
+    deviceIds.add(r.deviceId);
+    if (r.softwareVersion) versions.add(r.softwareVersion);
+    if (r.ticketId) ticketIds.add(r.ticketId);
+    if (r.patchAvailable && r.status === 'open') {
+      patchReadyFindingCount += 1;
+      patchReadyDevices.add(r.deviceId);
+    }
+    const sev = (r.severity ?? '').toLowerCase();
+    if ((SEVERITY_RANK[sev] ?? 0) > (worst ? (SEVERITY_RANK[worst] ?? 0) : 0)) worst = sev;
+    if (r.riskScore !== null && (maxRisk === null || r.riskScore > maxRisk)) maxRisk = r.riskScore;
+    if (r.epssScore !== null && (maxEpss === null || r.epssScore > maxEpss)) maxEpss = r.epssScore;
+  }
+
+  return {
+    groupKey,
+    kind,
+    name: kind === 'os' ? OS_GROUP_NAMES[first.deviceOsType] : ((first.softwareName ?? '').trim() || 'Unknown software'),
+    vendor: kind === 'os' ? null : (first.softwareVendor?.trim() || null),
+    versions: [...versions].sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+    deviceCount: deviceIds.size,
+    cveCount: cveIds.size,
+    cveIds: [...cveIds].sort(),
+    worstSeverity: worst,
+    maxRiskScore: maxRisk,
+    kevCveCount: kevCves.size,
+    maxEpss,
+    patchReadyFindingCount,
+    patchReadyDeviceCount: patchReadyDevices.size,
+    ticketIds: [...ticketIds],
+  };
+}
+
+export function groupFindings(rows: FleetFindingRow[], opts: { search?: string } = {}): SoftwareGroup[] {
+  const buckets = new Map<string, FleetFindingRow[]>();
+  for (const row of rows) {
+    const key = buildGroupKey(row);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(row);
+    else buckets.set(key, [row]);
+  }
+
+  let groups = [...buckets.entries()].map(([key, bucket]) => summarizeGroup(key, bucket));
+
+  const search = opts.search?.trim().toLowerCase();
+  if (search) {
+    groups = groups.filter(
+      (g) =>
+        g.name.toLowerCase().includes(search) ||
+        (g.vendor ?? '').toLowerCase().includes(search) ||
+        g.cveIds.some((id) => id.toLowerCase().includes(search)),
+    );
+  }
+
+  return groups.sort((a, b) => {
+    const riskA = a.maxRiskScore ?? -1;
+    const riskB = b.maxRiskScore ?? -1;
+    if (riskB !== riskA) return riskB - riskA;
+    if (b.deviceCount !== a.deviceCount) return b.deviceCount - a.deviceCount;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats {
+  const kevCves = new Set<string>();
+  const kevDevices = new Set<string>();
+  let criticalOpen = 0;
+  let patchReadyFindingCount = 0;
+  let acceptedExpiringSoon = 0;
+  const nowMs = now.getTime();
+  const soonMs = nowMs + ACCEPTED_EXPIRING_WINDOW_MS;
+
+  for (const r of rows) {
+    if (r.status === 'open') {
+      if ((r.severity ?? '').toLowerCase() === 'critical') criticalOpen += 1;
+      if (r.knownExploited) {
+        kevCves.add(r.cveId);
+        kevDevices.add(r.deviceId);
+      }
+      if (r.patchAvailable) patchReadyFindingCount += 1;
+    } else if (r.status === 'accepted' && r.acceptedUntil) {
+      const t = new Date(r.acceptedUntil).getTime();
+      if (t > nowMs && t <= soonMs) acceptedExpiringSoon += 1;
+    }
+  }
+
+  return {
+    criticalOpen,
+    kevCveCount: kevCves.size,
+    kevDeviceCount: kevDevices.size,
+    patchReadyFindingCount,
+    acceptedExpiringSoon,
+  };
+}
+
+export function toGroupFinding(r: FleetFindingRow): GroupFinding {
+  return {
+    deviceVulnerabilityId: r.deviceVulnerabilityId,
+    deviceId: r.deviceId,
+    deviceName: r.deviceName,
+    orgId: r.orgId,
+    orgName: r.orgName,
+    cveId: r.cveId,
+    status: r.status,
+    patchAvailable: r.patchAvailable,
+    riskScore: r.riskScore,
+    detectedAt: r.detectedAt,
+    ticketId: r.ticketId,
+  };
+}
+
+export function buildGroupDetail(groupKey: string, rows: FleetFindingRow[]): SoftwareGroupDetail | null {
+  const bucket = rows.filter((r) => buildGroupKey(r) === groupKey);
+  if (bucket.length === 0) return null;
+
+  const cveMap = new Map<string, GroupCve>();
+  for (const r of bucket) {
+    const existing = cveMap.get(r.cveId);
+    if (!existing) {
+      cveMap.set(r.cveId, {
+        cveId: r.cveId,
+        vulnerabilityId: r.vulnerabilityId,
+        severity: r.severity,
+        cvssScore: r.cvssScore,
+        epssScore: r.epssScore,
+        knownExploited: r.knownExploited,
+        patchAvailable: r.patchAvailable,
+        maxRiskScore: r.riskScore,
+      });
+    } else if (r.riskScore !== null && (existing.maxRiskScore === null || r.riskScore > existing.maxRiskScore)) {
+      existing.maxRiskScore = r.riskScore;
+    }
+  }
+
+  const cves = [...cveMap.values()].sort((a, b) => (b.maxRiskScore ?? -1) - (a.maxRiskScore ?? -1));
+  const findings = bucket
+    .map(toGroupFinding)
+    .sort((a, b) => a.deviceName.localeCompare(b.deviceName) || a.cveId.localeCompare(b.cveId));
+
+  return { group: summarizeGroup(groupKey, bucket), cves, findings };
+}

--- a/apps/api/src/services/vulnerabilityFleetAggregation.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.ts
@@ -5,42 +5,41 @@
  * across requests so `#software/<groupKey>` deep links work):
  *   software finding:  sw:<lower(trim(name))>|<lower(trim(coalesce(vendor,'')))>
  *   OS finding:        os:<devices.osType>          (softwareInventoryId IS NULL)
- * The lower(trim(...)) normalization deliberately matches the correlation
- * pipeline's JOIN (services/vulnerabilityCorrelation.ts) so one product maps
- * to one queue row regardless of inventory casing.
+ * The lower(trim(...)) normalization of the NAME deliberately matches the
+ * correlation pipeline's JOIN (services/vulnerabilityCorrelation.ts), which
+ * normalizes only the software name — so one product maps to one queue row
+ * regardless of inventory casing. Vendor is NOT normalized by that JOIN; here it
+ * is only a local discriminator to keep same-named products from different
+ * vendors in distinct groups.
  *
  * No db access here — routes fetch FleetFindingRow[] via
  * services/vulnerabilityFleetQueries.ts and pass them in.
+ *
+ * The wire DTOs (FleetFindingRow, SoftwareGroup, GroupCve, GroupFinding,
+ * SoftwareGroupDetail, FleetVulnStats) are single-sourced in @breeze/shared;
+ * this module imports them so api + web share one contract.
  */
 
-export interface FleetFindingRow {
-  deviceVulnerabilityId: string;
-  deviceId: string;
-  orgId: string;
-  status: string; // open | patched | mitigated | accepted
-  riskScore: number | null;
-  detectedAt: string; // ISO
-  acceptedUntil: string | null; // ISO
-  ticketId: string | null;
-  /** Human ticket number (tickets.internal_number) for display; null when the
-   *  ticket predates numbering or is outside the caller's read scope. */
-  ticketNumber: string | null;
-  softwareInventoryId: string | null;
-  softwareName: string | null;
-  softwareVendor: string | null;
-  softwareVersion: string | null;
-  deviceName: string;
-  deviceOsType: 'windows' | 'macos' | 'linux';
-  orgName: string | null;
-  cveId: string;
-  vulnerabilityId: string;
-  severity: string | null;
-  cvssScore: number | null;
-  epssScore: number | null;
-  knownExploited: boolean;
-  patchAvailable: boolean;
-}
+import type {
+  FleetFindingRow,
+  SoftwareGroup,
+  FleetVulnStats,
+  GroupCve,
+  GroupFinding,
+  SoftwareGroupDetail,
+  VulnSeverity,
+} from '@breeze/shared';
 
+export type {
+  FleetFindingRow,
+  SoftwareGroup,
+  FleetVulnStats,
+  GroupCve,
+  GroupFinding,
+  SoftwareGroupDetail,
+};
+
+/** Filter inputs for the fleet queue (route-local; not a wire DTO). */
 export interface FleetFindingFilters {
   status: string; // open | patched | mitigated | accepted | all
   severity?: string;
@@ -48,75 +47,6 @@ export interface FleetFindingFilters {
   patchAvailable?: boolean;
   /** Only findings whose accepted-risk window expires within N days from `now`. */
   expiringWithinDays?: number;
-}
-
-export interface SoftwareGroup {
-  groupKey: string;
-  kind: 'software' | 'os';
-  name: string;
-  vendor: string | null;
-  versions: string[];
-  deviceCount: number;
-  cveCount: number;
-  cveIds: string[];
-  worstSeverity: string | null;
-  maxRiskScore: number | null;
-  kevCveCount: number;
-  maxEpss: number | null;
-  /** Open findings whose CVE has a patch available ("fixable right now"). */
-  patchReadyFindingCount: number;
-  /** Distinct devices with at least one patch-ready open finding. */
-  patchReadyDeviceCount: number;
-  /** Distinct linked tickets with their human numbers (for the drawer chips). */
-  tickets: Array<{ id: string; number: string | null }>;
-}
-
-export interface FleetVulnStats {
-  criticalOpen: number;
-  kevCveCount: number;
-  kevDeviceCount: number;
-  patchReadyFindingCount: number;
-  acceptedExpiringSoon: number;
-  /** Findings across ALL statuses — the UI's "has scanning ever produced data"
-   *  signal, distinguishing a clean fleet from never-scanned. */
-  totalFindings: number;
-  /** Most recent detectedAt across all findings (ISO), null when none exist. */
-  lastDetectedAt: string | null;
-}
-
-export interface GroupCve {
-  cveId: string;
-  vulnerabilityId: string;
-  severity: string | null;
-  cvssScore: number | null;
-  epssScore: number | null;
-  knownExploited: boolean;
-  patchAvailable: boolean;
-  maxRiskScore: number | null;
-}
-
-export interface GroupFinding {
-  deviceVulnerabilityId: string;
-  deviceId: string;
-  deviceName: string;
-  orgId: string;
-  orgName: string | null;
-  cveId: string;
-  status: string;
-  patchAvailable: boolean;
-  riskScore: number | null;
-  detectedAt: string;
-  /** ISO expiry of an accepted-risk window; null unless status is 'accepted'.
-   *  Lets the drawers say "accepted until <date>" instead of a bare chip. */
-  acceptedUntil: string | null;
-  ticketId: string | null;
-  ticketNumber: string | null;
-}
-
-export interface SoftwareGroupDetail {
-  group: SoftwareGroup;
-  cves: GroupCve[];
-  findings: GroupFinding[];
 }
 
 const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
@@ -164,7 +94,8 @@ function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGr
   const patchReadyDevices = new Set<string>();
   const versions = new Set<string>();
   const ticketsById = new Map<string, string | null>();
-  let worst: string | null = null;
+  // Only ever set to a ranked severity key (empty/unknown scores 0 and never wins).
+  let worst: VulnSeverity | null = null;
   let maxRisk: number | null = null;
   let maxEpss: number | null = null;
   let patchReadyFindingCount = 0;
@@ -180,7 +111,7 @@ function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGr
       patchReadyDevices.add(r.deviceId);
     }
     const sev = (r.severity ?? '').toLowerCase();
-    if ((SEVERITY_RANK[sev] ?? 0) > (worst ? (SEVERITY_RANK[worst] ?? 0) : 0)) worst = sev;
+    if ((SEVERITY_RANK[sev] ?? 0) > (worst ? (SEVERITY_RANK[worst] ?? 0) : 0)) worst = sev as VulnSeverity;
     if (r.riskScore !== null && (maxRisk === null || r.riskScore > maxRisk)) maxRisk = r.riskScore;
     if (r.epssScore !== null && (maxEpss === null || r.epssScore > maxEpss)) maxEpss = r.epssScore;
   }

--- a/apps/api/src/services/vulnerabilityFleetAggregation.ts
+++ b/apps/api/src/services/vulnerabilityFleetAggregation.ts
@@ -22,6 +22,9 @@ export interface FleetFindingRow {
   detectedAt: string; // ISO
   acceptedUntil: string | null; // ISO
   ticketId: string | null;
+  /** Human ticket number (tickets.internal_number) for display; null when the
+   *  ticket predates numbering or is outside the caller's read scope. */
+  ticketNumber: string | null;
   softwareInventoryId: string | null;
   softwareName: string | null;
   softwareVendor: string | null;
@@ -43,6 +46,8 @@ export interface FleetFindingFilters {
   severity?: string;
   kevOnly?: boolean;
   patchAvailable?: boolean;
+  /** Only findings whose accepted-risk window expires within N days from `now`. */
+  expiringWithinDays?: number;
 }
 
 export interface SoftwareGroup {
@@ -62,7 +67,8 @@ export interface SoftwareGroup {
   patchReadyFindingCount: number;
   /** Distinct devices with at least one patch-ready open finding. */
   patchReadyDeviceCount: number;
-  ticketIds: string[];
+  /** Distinct linked tickets with their human numbers (for the drawer chips). */
+  tickets: Array<{ id: string; number: string | null }>;
 }
 
 export interface FleetVulnStats {
@@ -71,6 +77,11 @@ export interface FleetVulnStats {
   kevDeviceCount: number;
   patchReadyFindingCount: number;
   acceptedExpiringSoon: number;
+  /** Findings across ALL statuses — the UI's "has scanning ever produced data"
+   *  signal, distinguishing a clean fleet from never-scanned. */
+  totalFindings: number;
+  /** Most recent detectedAt across all findings (ISO), null when none exist. */
+  lastDetectedAt: string | null;
 }
 
 export interface GroupCve {
@@ -95,7 +106,11 @@ export interface GroupFinding {
   patchAvailable: boolean;
   riskScore: number | null;
   detectedAt: string;
+  /** ISO expiry of an accepted-risk window; null unless status is 'accepted'.
+   *  Lets the drawers say "accepted until <date>" instead of a bare chip. */
+  acceptedUntil: string | null;
   ticketId: string | null;
+  ticketNumber: string | null;
 }
 
 export interface SoftwareGroupDetail {
@@ -123,12 +138,19 @@ export function buildGroupKey(
   return `sw:${name}|${vendor}`;
 }
 
-export function filterFindings(rows: FleetFindingRow[], f: FleetFindingFilters): FleetFindingRow[] {
+export function filterFindings(rows: FleetFindingRow[], f: FleetFindingFilters, now: Date = new Date()): FleetFindingRow[] {
+  const nowMs = now.getTime();
   return rows.filter((r) => {
     if (f.status !== 'all' && r.status !== f.status) return false;
     if (f.severity && (r.severity ?? '').toLowerCase() !== f.severity) return false;
     if (f.kevOnly && !r.knownExploited) return false;
     if (f.patchAvailable && !r.patchAvailable) return false;
+    if (f.expiringWithinDays !== undefined) {
+      // Same window semantics as computeStats: acceptedUntil in (now, now + N days].
+      if (!r.acceptedUntil) return false;
+      const t = new Date(r.acceptedUntil).getTime();
+      if (!(t > nowMs && t <= nowMs + f.expiringWithinDays * 24 * 60 * 60 * 1000)) return false;
+    }
     return true;
   });
 }
@@ -141,7 +163,7 @@ function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGr
   const deviceIds = new Set<string>();
   const patchReadyDevices = new Set<string>();
   const versions = new Set<string>();
-  const ticketIds = new Set<string>();
+  const ticketsById = new Map<string, string | null>();
   let worst: string | null = null;
   let maxRisk: number | null = null;
   let maxEpss: number | null = null;
@@ -152,7 +174,7 @@ function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGr
     if (r.knownExploited) kevCves.add(r.cveId);
     deviceIds.add(r.deviceId);
     if (r.softwareVersion) versions.add(r.softwareVersion);
-    if (r.ticketId) ticketIds.add(r.ticketId);
+    if (r.ticketId && !ticketsById.has(r.ticketId)) ticketsById.set(r.ticketId, r.ticketNumber);
     if (r.patchAvailable && r.status === 'open') {
       patchReadyFindingCount += 1;
       patchReadyDevices.add(r.deviceId);
@@ -178,7 +200,7 @@ function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGr
     maxEpss,
     patchReadyFindingCount,
     patchReadyDeviceCount: patchReadyDevices.size,
-    ticketIds: [...ticketIds],
+    tickets: [...ticketsById].map(([id, number]) => ({ id, number })),
   };
 }
 
@@ -218,10 +240,13 @@ export function computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats
   let criticalOpen = 0;
   let patchReadyFindingCount = 0;
   let acceptedExpiringSoon = 0;
+  let lastDetectedAt: string | null = null;
   const nowMs = now.getTime();
   const soonMs = nowMs + ACCEPTED_EXPIRING_WINDOW_MS;
 
   for (const r of rows) {
+    // ISO-8601 UTC strings compare correctly as strings.
+    if (lastDetectedAt === null || r.detectedAt > lastDetectedAt) lastDetectedAt = r.detectedAt;
     if (r.status === 'open') {
       if ((r.severity ?? '').toLowerCase() === 'critical') criticalOpen += 1;
       if (r.knownExploited) {
@@ -241,6 +266,8 @@ export function computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats
     kevDeviceCount: kevDevices.size,
     patchReadyFindingCount,
     acceptedExpiringSoon,
+    totalFindings: rows.length,
+    lastDetectedAt,
   };
 }
 
@@ -256,7 +283,9 @@ export function toGroupFinding(r: FleetFindingRow): GroupFinding {
     patchAvailable: r.patchAvailable,
     riskScore: r.riskScore,
     detectedAt: r.detectedAt,
+    acceptedUntil: r.acceptedUntil,
     ticketId: r.ticketId,
+    ticketNumber: r.ticketNumber,
   };
 }
 

--- a/apps/api/src/services/vulnerabilityFleetQueries.ts
+++ b/apps/api/src/services/vulnerabilityFleetQueries.ts
@@ -1,0 +1,199 @@
+/**
+ * DB fetch layer for the fleet vulnerabilities triage UI.
+ *
+ * Org isolation: RLS on the request's db context (same as the existing fleet
+ * list in routes/vulnerabilities.ts). Site axis: app-layer narrowing via
+ * allowedSiteIds -> devices.siteId (RLS does NOT cover sites). The global
+ * `vulnerabilities` catalog is system-scoped reference data and is read under
+ * a system context, mirroring readCatalogRows in routes/vulnerabilities.ts.
+ */
+import { and, eq, ilike, inArray, type SQL } from 'drizzle-orm';
+
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { deviceVulnerabilities, devices, organizations, softwareInventory, vulnerabilities } from '../db/schema';
+import type { FleetFindingRow } from './vulnerabilityFleetAggregation';
+
+export interface CveCatalogRecord {
+  cveId: string;
+  description: string;
+  references: unknown;
+  cvssVersion: string | null;
+  cvssVector: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  severity: string | null;
+  publishedAt: string | null;
+  modifiedAt: string | null;
+}
+
+function toNumber(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function fetchFleetFindingRows(filters: {
+  status: string;
+  /** Site-axis narrowing; empty array = fail closed (return nothing). */
+  allowedSiteIds?: string[];
+}): Promise<FleetFindingRow[]> {
+  const conditions: SQL[] = [];
+  if (filters.status !== 'all') {
+    conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.allowedSiteIds !== undefined) {
+    if (filters.allowedSiteIds.length === 0) return [];
+    const allowedDeviceRows = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .where(inArray(devices.siteId, filters.allowedSiteIds));
+    const allowedDeviceIds = allowedDeviceRows.map((r) => r.id);
+    if (allowedDeviceIds.length === 0) return [];
+    conditions.push(inArray(deviceVulnerabilities.deviceId, allowedDeviceIds));
+  }
+
+  const findingRows = await db
+    .select({
+      id: deviceVulnerabilities.id,
+      orgId: deviceVulnerabilities.orgId,
+      deviceId: deviceVulnerabilities.deviceId,
+      vulnerabilityId: deviceVulnerabilities.vulnerabilityId,
+      softwareInventoryId: deviceVulnerabilities.softwareInventoryId,
+      status: deviceVulnerabilities.status,
+      riskScore: deviceVulnerabilities.riskScore,
+      detectedAt: deviceVulnerabilities.detectedAt,
+      acceptedUntil: deviceVulnerabilities.acceptedUntil,
+      ticketId: deviceVulnerabilities.ticketId,
+    })
+    .from(deviceVulnerabilities)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+
+  if (findingRows.length === 0) return [];
+
+  const deviceIds = [...new Set(findingRows.map((r) => r.deviceId))];
+  const deviceRows = await db
+    .select({
+      id: devices.id,
+      hostname: devices.hostname,
+      displayName: devices.displayName,
+      osType: devices.osType,
+    })
+    .from(devices)
+    .where(inArray(devices.id, deviceIds));
+  const deviceById = new Map(deviceRows.map((d) => [d.id, d]));
+
+  const orgIds = [...new Set(findingRows.map((r) => r.orgId))];
+  const orgRows = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+  const orgById = new Map(orgRows.map((o) => [o.id, o]));
+
+  const swIds = [...new Set(findingRows.map((r) => r.softwareInventoryId).filter((v): v is string => v !== null))];
+  const swRows =
+    swIds.length > 0
+      ? await db
+          .select({
+            id: softwareInventory.id,
+            name: softwareInventory.name,
+            vendor: softwareInventory.vendor,
+            version: softwareInventory.version,
+          })
+          .from(softwareInventory)
+          .where(inArray(softwareInventory.id, swIds))
+      : [];
+  const swById = new Map(swRows.map((s) => [s.id, s]));
+
+  const vulnIds = [...new Set(findingRows.map((r) => r.vulnerabilityId))];
+  const catalogRows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          id: vulnerabilities.id,
+          cveId: vulnerabilities.cveId,
+          severity: vulnerabilities.severity,
+          cvssScore: vulnerabilities.cvssScore,
+          epssScore: vulnerabilities.epssScore,
+          knownExploited: vulnerabilities.knownExploited,
+          patchAvailable: vulnerabilities.patchAvailable,
+        })
+        .from(vulnerabilities)
+        .where(inArray(vulnerabilities.id, vulnIds)),
+    ),
+  );
+  const catalogById = new Map(catalogRows.map((v) => [v.id, v]));
+
+  const rows: FleetFindingRow[] = [];
+  for (const f of findingRows) {
+    const device = deviceById.get(f.deviceId);
+    const catalog = catalogById.get(f.vulnerabilityId);
+    // Orphaned rows (device deleted mid-request, catalog purge) — skip rather
+    // than crash the whole queue.
+    if (!device || !catalog) continue;
+    const sw = f.softwareInventoryId ? swById.get(f.softwareInventoryId) : undefined;
+    rows.push({
+      deviceVulnerabilityId: f.id,
+      deviceId: f.deviceId,
+      orgId: f.orgId,
+      status: f.status,
+      riskScore: toNumber(f.riskScore),
+      detectedAt: f.detectedAt.toISOString(),
+      acceptedUntil: f.acceptedUntil ? f.acceptedUntil.toISOString() : null,
+      ticketId: f.ticketId ?? null,
+      softwareInventoryId: f.softwareInventoryId,
+      // Inventory row can vanish between correlation and read; keep the finding
+      // in the queue under a recognizable name instead of dropping it.
+      softwareName: f.softwareInventoryId ? (sw?.name ?? 'Unknown software') : null,
+      softwareVendor: sw?.vendor ?? null,
+      softwareVersion: sw?.version ?? null,
+      deviceName: device.displayName ?? device.hostname,
+      deviceOsType: device.osType,
+      orgName: orgById.get(f.orgId)?.name ?? null,
+      cveId: catalog.cveId,
+      vulnerabilityId: f.vulnerabilityId,
+      severity: catalog.severity,
+      cvssScore: toNumber(catalog.cvssScore),
+      epssScore: toNumber(catalog.epssScore),
+      knownExploited: catalog.knownExploited ?? false,
+      patchAvailable: catalog.patchAvailable ?? false,
+    });
+  }
+  return rows;
+}
+
+export async function fetchCveCatalogRecord(cveId: string): Promise<CveCatalogRecord | null> {
+  const [row] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          cveId: vulnerabilities.cveId,
+          description: vulnerabilities.description,
+          references: vulnerabilities.references,
+          cvssVersion: vulnerabilities.cvssVersion,
+          cvssVector: vulnerabilities.cvssVector,
+          cvssScore: vulnerabilities.cvssScore,
+          epssScore: vulnerabilities.epssScore,
+          knownExploited: vulnerabilities.knownExploited,
+          patchAvailable: vulnerabilities.patchAvailable,
+          severity: vulnerabilities.severity,
+          publishedAt: vulnerabilities.publishedAt,
+          modifiedAt: vulnerabilities.modifiedAt,
+        })
+        .from(vulnerabilities)
+        .where(ilike(vulnerabilities.cveId, cveId))
+        .limit(1),
+    ),
+  );
+  if (!row) return null;
+  return {
+    ...row,
+    cvssScore: toNumber(row.cvssScore),
+    epssScore: toNumber(row.epssScore),
+    knownExploited: row.knownExploited ?? false,
+    patchAvailable: row.patchAvailable ?? false,
+    publishedAt: row.publishedAt ? row.publishedAt.toISOString() : null,
+    modifiedAt: row.modifiedAt ? row.modifiedAt.toISOString() : null,
+  };
+}

--- a/apps/api/src/services/vulnerabilityFleetQueries.ts
+++ b/apps/api/src/services/vulnerabilityFleetQueries.ts
@@ -9,24 +9,12 @@
  */
 import { and, eq, ilike, inArray, type SQL } from 'drizzle-orm';
 
+import type { CveCatalogRecord, CveReference, FleetFindingRow, VulnSeverity, VulnStatus } from '@breeze/shared';
+
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceVulnerabilities, devices, organizations, softwareInventory, tickets, vulnerabilities } from '../db/schema';
-import type { FleetFindingRow } from './vulnerabilityFleetAggregation';
 
-export interface CveCatalogRecord {
-  cveId: string;
-  description: string;
-  references: unknown;
-  cvssVersion: string | null;
-  cvssVector: string | null;
-  cvssScore: number | null;
-  epssScore: number | null;
-  knownExploited: boolean;
-  patchAvailable: boolean;
-  severity: string | null;
-  publishedAt: string | null;
-  modifiedAt: string | null;
-}
+export type { CveCatalogRecord };
 
 function toNumber(value: string | number | null | undefined): number | null {
   if (value === null || value === undefined) return null;
@@ -150,7 +138,9 @@ export async function fetchFleetFindingRows(filters: {
       deviceVulnerabilityId: f.id,
       deviceId: f.deviceId,
       orgId: f.orgId,
-      status: f.status,
+      // status/severity are free varchars in the DB; the wire contract narrows
+      // them to the shared unions (values are produced by our own correlation).
+      status: f.status as VulnStatus,
       riskScore: toNumber(f.riskScore),
       detectedAt: f.detectedAt.toISOString(),
       acceptedUntil: f.acceptedUntil ? f.acceptedUntil.toISOString() : null,
@@ -167,7 +157,7 @@ export async function fetchFleetFindingRows(filters: {
       orgName: orgById.get(f.orgId)?.name ?? null,
       cveId: catalog.cveId,
       vulnerabilityId: f.vulnerabilityId,
-      severity: catalog.severity,
+      severity: catalog.severity as VulnSeverity | null,
       cvssScore: toNumber(catalog.cvssScore),
       epssScore: toNumber(catalog.epssScore),
       knownExploited: catalog.knownExploited ?? false,
@@ -203,6 +193,11 @@ export async function fetchCveCatalogRecord(cveId: string): Promise<CveCatalogRe
   if (!row) return null;
   return {
     ...row,
+    // jsonb column is typed `unknown`; the shape is source-dependent (bare URL
+    // string or {url,source?}). Web normalizes defensively — pass through as-is
+    // (may be null for older rows; unchanged wire behavior).
+    references: row.references as CveReference[],
+    severity: row.severity as VulnSeverity | null,
     cvssScore: toNumber(row.cvssScore),
     epssScore: toNumber(row.epssScore),
     knownExploited: row.knownExploited ?? false,

--- a/apps/api/src/services/vulnerabilityFleetQueries.ts
+++ b/apps/api/src/services/vulnerabilityFleetQueries.ts
@@ -10,7 +10,7 @@
 import { and, eq, ilike, inArray, type SQL } from 'drizzle-orm';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { deviceVulnerabilities, devices, organizations, softwareInventory, vulnerabilities } from '../db/schema';
+import { deviceVulnerabilities, devices, organizations, softwareInventory, tickets, vulnerabilities } from '../db/schema';
 import type { FleetFindingRow } from './vulnerabilityFleetAggregation';
 
 export interface CveCatalogRecord {
@@ -106,6 +106,19 @@ export async function fetchFleetFindingRows(filters: {
       : [];
   const swById = new Map(swRows.map((s) => [s.id, s]));
 
+  // Human ticket numbers for the drawer chips (UUID prefixes mean nothing to a
+  // tech). Same request/RLS context as the findings — a linked ticket lives in
+  // the finding's own org; anything filtered out just falls back to null.
+  const ticketIds = [...new Set(findingRows.map((r) => r.ticketId).filter((v): v is string => v !== null))];
+  const ticketRows =
+    ticketIds.length > 0
+      ? await db
+          .select({ id: tickets.id, internalNumber: tickets.internalNumber })
+          .from(tickets)
+          .where(inArray(tickets.id, ticketIds))
+      : [];
+  const ticketNumberById = new Map(ticketRows.map((t) => [t.id, t.internalNumber]));
+
   const vulnIds = [...new Set(findingRows.map((r) => r.vulnerabilityId))];
   const catalogRows = await runOutsideDbContext(() =>
     withSystemDbAccessContext(() =>
@@ -142,6 +155,7 @@ export async function fetchFleetFindingRows(filters: {
       detectedAt: f.detectedAt.toISOString(),
       acceptedUntil: f.acceptedUntil ? f.acceptedUntil.toISOString() : null,
       ticketId: f.ticketId ?? null,
+      ticketNumber: f.ticketId ? (ticketNumberById.get(f.ticketId) ?? null) : null,
       softwareInventoryId: f.softwareInventoryId,
       // Inventory row can vanish between correlation and read; keep the finding
       // in the queue under a recognizable name instead of dropping it.

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -1,5 +1,7 @@
 import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 
+import type { RemediateResult } from '@breeze/shared';
+
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
   deviceVulnerabilities,
@@ -15,10 +17,7 @@ import { queueCommandForExecution } from './commandQueue';
 import { createAuditLogAsync } from './auditService';
 import { publishEvent } from './eventBus';
 
-export interface RemediateResult {
-  scheduled: number;
-  skipped: Array<{ id: string; reason: string }>;
-}
+export type { RemediateResult };
 
 /**
  * Partner-wide manual-approval gate (duplicated from the module-private
@@ -79,7 +78,7 @@ export async function remediateVulnerabilities(
       .where(eq(deviceVulnerabilities.id, dvId))
       .limit(1);
     if (!row || row.status !== 'open') {
-      result.skipped.push({ id: dvId, reason: 'not an open vulnerability' });
+      result.skipped.push({ id: dvId, reason: 'not_open' });
       continue;
     }
 
@@ -97,7 +96,7 @@ export async function remediateVulnerabilities(
       )
     );
     if (!catalog) {
-      result.skipped.push({ id: dvId, reason: 'no available patch' });
+      result.skipped.push({ id: dvId, reason: 'no_available_patch' });
       continue;
     }
     const cveId = catalog.cveId;
@@ -112,18 +111,18 @@ export async function remediateVulnerabilities(
       .where(orgCond ? and(eq(devices.id, row.deviceId), orgCond) : eq(devices.id, row.deviceId))
       .limit(1);
     if (!device) {
-      result.skipped.push({ id: dvId, reason: 'device not found' });
+      result.skipped.push({ id: dvId, reason: 'device_not_found' });
       continue;
     }
     // Defense in depth: an org-scoped caller's device must match their org (RLS
     // already guarantees this; partner/system callers pass an empty orgId and
     // rely on orgCondition + RLS).
     if (orgId && device.orgId !== orgId) {
-      result.skipped.push({ id: dvId, reason: 'device not found' });
+      result.skipped.push({ id: dvId, reason: 'device_not_found' });
       continue;
     }
     if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
-      result.skipped.push({ id: dvId, reason: 'site access denied' });
+      result.skipped.push({ id: dvId, reason: 'site_access_denied' });
       continue;
     }
 
@@ -144,7 +143,7 @@ export async function remediateVulnerabilities(
       ))
       .orderBy(desc(patches.releaseDate));
     if (candidates.length === 0) {
-      result.skipped.push({ id: dvId, reason: 'no available patch' });
+      result.skipped.push({ id: dvId, reason: 'no_available_patch' });
       continue;
     }
 
@@ -156,7 +155,7 @@ export async function remediateVulnerabilities(
       : new Set<string>();
     const target = candidates.find((p) => approved.has(p.patchId));
     if (!target) {
-      result.skipped.push({ id: dvId, reason: 'patch not approved' });
+      result.skipped.push({ id: dvId, reason: 'patch_not_approved' });
       continue;
     }
 
@@ -168,7 +167,8 @@ export async function remediateVulnerabilities(
       { userId: actorUserId, preferHeartbeat: false },
     );
     if (!queued.command) {
-      result.skipped.push({ id: dvId, reason: queued.error ?? 'failed to queue install command' });
+      // queued.error is a dynamic driver string; collapse to the closest code.
+      result.skipped.push({ id: dvId, reason: 'queue_failed' });
       continue;
     }
 

--- a/apps/web/src/components/ai/AiChatSidebar.tsx
+++ b/apps/web/src/components/ai/AiChatSidebar.tsx
@@ -122,8 +122,9 @@ export default function AiChatSidebar() {
           isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none'
         }`}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b bg-card px-4 py-3">
+        {/* Header — one flat surface with the panel (no stacked card-on-card
+            backgrounds); the bottom border alone separates it. */}
+        <div className="flex items-center justify-between border-b px-4 py-3">
           <div className="flex items-center gap-2">
             {showHistory ? (
               <button

--- a/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
+++ b/apps/web/src/components/devices/DeviceVulnerabilitiesTab.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../lib/api/vulnerabilities', () => ({
   reopenVuln: vi.fn(),
 }));
 
-const sampleItem = {
+const sampleItem: api.DeviceVulnerabilityItem = {
   id: 'dv1',
   deviceId: 'd1',
   vulnerabilityId: 'v1',
@@ -42,14 +42,14 @@ const sampleItem = {
   patchAvailable: true,
 };
 
-const noPatchItem = {
+const noPatchItem: api.DeviceVulnerabilityItem = {
   ...sampleItem,
   id: 'dv3',
   cveId: 'CVE-2025-3',
   patchAvailable: false,
 };
 
-const acceptedItem = {
+const acceptedItem: api.DeviceVulnerabilityItem = {
   ...sampleItem,
   id: 'dv2',
   status: 'accepted',

--- a/apps/web/src/components/remote/FileManager.tsx
+++ b/apps/web/src/components/remote/FileManager.tsx
@@ -1127,7 +1127,8 @@ export default function FileManager({
         >
           <div className="flex items-center gap-2">
             <Sparkles className="h-4 w-4 text-violet-400" />
-            <span className="text-sm font-medium bg-linear-to-r from-violet-400 to-blue-400 bg-clip-text text-transparent">Disk Cleanup Intelligence</span>
+            {/* Solid brand color + weight (gradient text is banned — PRODUCT.md). */}
+            <span className="text-sm font-semibold text-primary">Disk Cleanup Intelligence</span>
           </div>
           {showDiskIntel ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
         </button>

--- a/apps/web/src/components/security/SecurityStatCard.test.tsx
+++ b/apps/web/src/components/security/SecurityStatCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Shield } from 'lucide-react';
+
+import SecurityStatCard from './SecurityStatCard';
+
+function card(props: Partial<Parameters<typeof SecurityStatCard>[0]> = {}) {
+  return <SecurityStatCard icon={Shield} label="Stat" value={7} {...props} />;
+}
+
+describe('SecurityStatCard', () => {
+  it('renders label, value, and detail with no interactive styling by default', () => {
+    const { container } = render(card({ detail: '7 things' }));
+    expect(screen.getByText('Stat')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('7 things')).toBeInTheDocument();
+    const root = container.firstElementChild as HTMLElement;
+    // Additive props default off — existing consumers keep the static card.
+    expect(root.className).not.toContain('hover:');
+    expect(root).not.toHaveAttribute('data-active');
+  });
+
+  it('adds a hover affordance when interactive', () => {
+    const { container } = render(card({ interactive: true }));
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('hover:shadow-sm');
+    expect(root.className).toContain('hover:border-primary/40');
+  });
+
+  it('renders the selected treatment (and data-active hook) when active', () => {
+    const { container } = render(card({ interactive: true, active: true }));
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('border-primary');
+    expect(root.className).toContain('bg-primary/5');
+    expect(root).toHaveAttribute('data-active', 'true');
+  });
+
+  it('still shows the loading skeleton with the new props set', () => {
+    render(card({ interactive: true, active: true, loading: true }));
+    expect(screen.getByTestId('stat-card-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('7')).toBeNull();
+  });
+});

--- a/apps/web/src/components/security/SecurityStatCard.tsx
+++ b/apps/web/src/components/security/SecurityStatCard.tsx
@@ -19,6 +19,11 @@ interface SecurityStatCardProps {
   /** Calm skeleton while the stat is being fetched — distinct from the
    *  "—" placeholder, which callers reserve for missing/failed data. */
   loading?: boolean;
+  /** Hover affordance for cards wrapped in a button (filter shortcuts).
+   *  Purely visual — the wrapping button owns focus/aria semantics. */
+  interactive?: boolean;
+  /** Selected treatment when the card's filter preset is currently applied. */
+  active?: boolean;
 }
 
 export default function SecurityStatCard({
@@ -27,10 +32,20 @@ export default function SecurityStatCard({
   value,
   variant = 'default',
   detail,
-  loading = false
+  loading = false,
+  interactive = false,
+  active = false
 }: SecurityStatCardProps) {
   return (
-    <div className="h-full rounded-lg border bg-card p-4 shadow-xs">
+    <div
+      className={cn(
+        'h-full rounded-lg border bg-card p-4 shadow-xs',
+        interactive && 'transition hover:shadow-sm',
+        interactive && !active && 'hover:border-primary/40',
+        active && 'border-primary bg-primary/5'
+      )}
+      data-active={active || undefined}
+    >
       <div className="flex items-center gap-3">
         <div className="rounded-full border bg-muted/30 p-2">
           <Icon className="h-4 w-4 text-muted-foreground" />

--- a/apps/web/src/components/security/SecurityStatCard.tsx
+++ b/apps/web/src/components/security/SecurityStatCard.tsx
@@ -16,6 +16,9 @@ interface SecurityStatCardProps {
   value: string | number;
   variant?: Variant;
   detail?: string;
+  /** Calm skeleton while the stat is being fetched — distinct from the
+   *  "—" placeholder, which callers reserve for missing/failed data. */
+  loading?: boolean;
 }
 
 export default function SecurityStatCard({
@@ -23,21 +26,30 @@ export default function SecurityStatCard({
   label,
   value,
   variant = 'default',
-  detail
+  detail,
+  loading = false
 }: SecurityStatCardProps) {
   return (
-    <div className="rounded-lg border bg-card p-4 shadow-xs">
+    <div className="h-full rounded-lg border bg-card p-4 shadow-xs">
       <div className="flex items-center gap-3">
         <div className="rounded-full border bg-muted/30 p-2">
           <Icon className="h-4 w-4 text-muted-foreground" />
         </div>
         <div className="min-w-0">
           <p className="text-xs text-muted-foreground">{label}</p>
-          <p className={cn('text-xl font-semibold', variantStyles[variant])}>
-            {value}
-          </p>
-          {detail && (
-            <p className="text-xs text-muted-foreground">{detail}</p>
+          {loading ? (
+            <div className="py-1.5" aria-hidden="true" data-testid="stat-card-skeleton">
+              <div className="h-5 w-10 rounded bg-muted motion-safe:animate-pulse" />
+            </div>
+          ) : (
+            <>
+              <p className={cn('text-xl font-semibold', variantStyles[variant])}>
+                {value}
+              </p>
+              {detail && (
+                <p className="text-xs text-muted-foreground">{detail}</p>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/apps/web/src/components/shared/Drawer.test.tsx
+++ b/apps/web/src/components/shared/Drawer.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Drawer } from './Drawer';
+
+describe('Drawer', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Drawer open={false} onClose={() => {}} title="Details">
+        <p>body</p>
+      </Drawer>,
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders title, children, and dialog semantics when open', () => {
+    render(
+      <Drawer open onClose={() => {}} title="Details" dataTestId="my-drawer">
+        <p>body</p>
+      </Drawer>,
+    );
+    const panel = screen.getByTestId('my-drawer');
+    expect(panel).toHaveAttribute('role', 'dialog');
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+  });
+
+  it('calls onClose on Escape and on backdrop click, but not on panel click', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" dataTestId="my-drawer">
+        <button type="button">inner</button>
+      </Drawer>,
+    );
+    fireEvent.click(screen.getByText('inner'));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('my-drawer-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(screen.getByTestId('my-drawer'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppresses backdrop close when closeDisabled', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" dataTestId="my-drawer" closeDisabled>
+        <p>body</p>
+      </Drawer>,
+    );
+    fireEvent.click(screen.getByTestId('my-drawer-backdrop'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('applies a custom width class and the close button works', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" width="max-w-xl" dataTestId="my-drawer">
+        <p>body</p>
+      </Drawer>,
+    );
+    expect(screen.getByTestId('my-drawer').className).toContain('max-w-xl');
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/shared/Drawer.tsx
+++ b/apps/web/src/components/shared/Drawer.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useId, useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-// Extracted verbatim from settings/CatalogItemEditorDrawer.tsx so both drawers
-// keep identical chrome, animations, and a11y behavior.
+// Chrome/animation/a11y were copied from settings/CatalogItemEditorDrawer.tsx,
+// which still carries its own inline copy and was NOT migrated onto this
+// primitive — the two are independent duplicates; changes here do not
+// propagate there.
 const FOCUSABLE =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
 

--- a/apps/web/src/components/shared/Drawer.tsx
+++ b/apps/web/src/components/shared/Drawer.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useId, useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// Extracted verbatim from settings/CatalogItemEditorDrawer.tsx so both drawers
+// keep identical chrome, animations, and a11y behavior.
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  /** Tailwind max-width class for the panel. */
+  width?: string;
+  dataTestId?: string;
+  /** Blocks backdrop-click close (e.g. while a mutation is in flight). */
+  closeDisabled?: boolean;
+  children: ReactNode;
+}
+
+export function Drawer({
+  open,
+  onClose,
+  title,
+  width = 'max-w-md',
+  dataTestId = 'drawer',
+  closeDisabled = false,
+  children,
+}: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  // ---- a11y: focus, scroll-lock, escape, focus-trap -----------------------
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = document.activeElement;
+    const raf = requestAnimationFrame(() => {
+      const first = panelRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+      (first ?? panelRef.current)?.focus();
+    });
+    document.body.style.overflow = 'hidden';
+    return () => {
+      cancelAnimationFrame(raf);
+      document.body.style.overflow = '';
+      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
+    };
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && panelRef.current) {
+        const nodes = Array.from(panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE));
+        if (nodes.length === 0) return;
+        const first = nodes[0];
+        const last = nodes[nodes.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last!.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first!.focus();
+        }
+      }
+    },
+    [onClose],
+  );
+
+  const handleBackdropClick = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget && !closeDisabled) onClose();
+    },
+    [onClose, closeDisabled],
+  );
+
+  if (!open || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="dialog-backdrop fixed inset-0 z-50 flex justify-end bg-background/80"
+      style={{ animation: 'dialog-backdrop-in 150ms ease-out' }}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      data-testid={`${dataTestId}-backdrop`}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={`drawer-panel flex h-full w-full ${width} flex-col border-l bg-card shadow-xl focus:outline-hidden`}
+        style={{ animation: 'slide-in-from-right 220ms cubic-bezier(0.22, 1, 0.36, 1)' }}
+        data-testid={dataTestId}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-5 py-4">
+          <h2 id={titleId} className="min-w-0 text-base font-semibold">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close"
+            data-testid={`${dataTestId}-close`}
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6 6 18M6 6l12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default Drawer;

--- a/apps/web/src/components/shared/HelpTooltip.tsx
+++ b/apps/web/src/components/shared/HelpTooltip.tsx
@@ -1,15 +1,37 @@
 import { HelpCircle } from 'lucide-react';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 
 interface HelpTooltipProps {
   text: string;
   className?: string;
+  /** Accessible name for the trigger — name the topic (e.g. "About the risk
+   *  score") so icon-only triggers make sense to screen readers. */
+  ariaLabel?: string;
+  /** Which side the bubble opens on. Use 'bottom' when the trigger sits inside
+   *  an overflow container (e.g. table headers inside the ResponsiveTable
+   *  scroll wrapper): it positions the bubble `fixed` from the trigger's
+   *  viewport rect, so the container can't clip it. Don't use 'bottom' inside
+   *  transformed ancestors (drawers/dialogs), where fixed misplaces. */
+  side?: 'top' | 'bottom';
 }
 
-export default function HelpTooltip({ text, className = '' }: HelpTooltipProps) {
+export default function HelpTooltip({ text, className = '', ariaLabel = 'Help', side = 'top' }: HelpTooltipProps) {
   const [show, setShow] = useState(false);
+  // Viewport coords for the side='bottom' fixed-position strategy, measured
+  // from the trigger at open time (a hover tooltip closes before scroll
+  // position can meaningfully drift).
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const tooltipId = useId();
+
+  const open = () => {
+    if (side === 'bottom' && triggerRef.current) {
+      const r = triggerRef.current.getBoundingClientRect();
+      setPos({ top: r.bottom + 8, left: r.left + r.width / 2 });
+    }
+    setShow(true);
+  };
 
   useEffect(() => {
     if (!show) return;
@@ -23,27 +45,51 @@ export default function HelpTooltip({ text, className = '' }: HelpTooltipProps) 
     return () => document.removeEventListener('mousedown', handleClick);
   }, [show]);
 
+  const bubbleBase =
+    'w-56 rounded-md border bg-card px-3 py-2 text-left text-xs font-normal normal-case tracking-normal text-muted-foreground shadow-lg z-50';
+
   return (
     <span className={`relative inline-flex ${className}`}>
       <button
         ref={triggerRef}
         type="button"
-        onClick={() => setShow(!show)}
-        onMouseEnter={() => setShow(true)}
+        onClick={() => (show ? setShow(false) : open())}
+        onMouseEnter={open}
         onMouseLeave={() => setShow(false)}
+        onFocus={open}
+        onBlur={() => setShow(false)}
+        onKeyDown={(e) => {
+          // Escape dismisses without moving focus — the tooltip never traps
+          // or blocks keyboard flow.
+          if (e.key === 'Escape') setShow(false);
+        }}
         className="rounded-full p-0.5 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-        aria-label="Help"
+        aria-label={ariaLabel}
+        aria-describedby={show ? tooltipId : undefined}
       >
         <HelpCircle className="h-3.5 w-3.5" />
       </button>
-      {show && (
+      {show && side === 'top' && (
         <div
           ref={tooltipRef}
+          id={tooltipId}
           role="tooltip"
-          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-md border bg-card px-3 py-2 text-xs text-muted-foreground shadow-lg z-50"
+          className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 ${bubbleBase}`}
         >
           {text}
           <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
+        </div>
+      )}
+      {show && side === 'bottom' && (
+        <div
+          ref={tooltipRef}
+          id={tooltipId}
+          role="tooltip"
+          style={pos ? { top: pos.top, left: pos.left } : undefined}
+          className={`fixed -translate-x-1/2 ${bubbleBase}`}
+        >
+          {text}
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-border" />
         </div>
       )}
     </span>

--- a/apps/web/src/components/shared/ResponsiveTable.tsx
+++ b/apps/web/src/components/shared/ResponsiveTable.tsx
@@ -35,7 +35,10 @@ export function ResponsiveTable({
 }) {
   return (
     <div className={className} data-testid="responsive-table">
-      <div className="hidden overflow-x-auto rounded-md border sm:block" data-testid="responsive-table-desktop">
+      {/* Card chrome matches the app's other card-wrapped tables
+          (rounded border + bg-card + shadow-xs, e.g. security pages, invoices)
+          and the mobile DataCard below, so the two surfaces read as one. */}
+      <div className="hidden overflow-x-auto rounded-md border bg-card shadow-xs sm:block" data-testid="responsive-table-desktop">
         {table}
       </div>
       <div className="space-y-2 sm:hidden" data-testid="responsive-table-cards">

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
@@ -23,7 +23,7 @@ function finding(overrides: Partial<GroupFinding> = {}): GroupFinding {
 }
 
 describe('CreateVulnTicketModal', () => {
-  it('pre-fills the title and a description listing CVEs and devices', () => {
+  it('pre-fills the title, starts with an empty note, and shows the auto-detail helper', () => {
     render(
       <CreateVulnTicketModal
         findings={[finding(), finding({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', deviceName: 'WS-02', cveId: 'CVE-2026-0002' })]}
@@ -34,9 +34,11 @@ describe('CreateVulnTicketModal', () => {
       />,
     );
     expect(screen.getByTestId('vuln-ticket-title')).toHaveValue('Remediate Google Chrome');
-    const description = screen.getByTestId('vuln-ticket-description');
-    expect((description as HTMLTextAreaElement).value).toContain('CVE-2026-0001');
-    expect((description as HTMLTextAreaElement).value).toContain('WS-02');
+    // The note is optional and empty by default — device/CVE enumeration is server-side now.
+    expect(screen.getByTestId('vuln-ticket-note')).toHaveValue('');
+    expect(screen.getByTestId('vuln-ticket-auto-detail-note')).toHaveTextContent(
+      'Device and CVE details are added automatically, per organization.',
+    );
   });
 
   it('warns when the selection spans multiple organizations', () => {
@@ -71,14 +73,16 @@ describe('CreateVulnTicketModal', () => {
     expect(screen.getByTestId('vuln-ticket-submit')).toBeDisabled();
   });
 
-  it('submits title/description/priority and blocks empty titles', () => {
+  it('submits title/priority/note and blocks empty titles', () => {
     const onSubmit = vi.fn();
     render(<CreateVulnTicketModal findings={[finding()]} defaultTitle="T" busy={false} onCancel={() => {}} onSubmit={onSubmit} />);
     fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: '' } });
     expect(screen.getByTestId('vuln-ticket-submit')).toBeDisabled();
     fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: 'Patch it' } });
     fireEvent.change(screen.getByTestId('vuln-ticket-priority'), { target: { value: 'high' } });
+    // The optional note flows into the payload.
+    fireEvent.change(screen.getByTestId('vuln-ticket-note'), { target: { value: 'Handle during the next window' } });
     fireEvent.click(screen.getByTestId('vuln-ticket-submit'));
-    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ title: 'Patch it', priority: 'high' }));
+    expect(onSubmit).toHaveBeenCalledWith({ title: 'Patch it', priority: 'high', note: 'Handle during the next window' });
   });
 });

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CreateVulnTicketModal } from './CreateVulnTicketModal';
+import type { GroupFinding } from '../../lib/api/vulnerabilities';
+
+function finding(overrides: Partial<GroupFinding> = {}): GroupFinding {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    deviceName: 'WS-01',
+    orgId: 'org-1',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    status: 'open',
+    patchAvailable: true,
+    riskScore: 95,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    ticketId: null,
+    ...overrides,
+  };
+}
+
+describe('CreateVulnTicketModal', () => {
+  it('pre-fills the title and a description listing CVEs and devices', () => {
+    render(
+      <CreateVulnTicketModal
+        findings={[finding(), finding({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', deviceName: 'WS-02', cveId: 'CVE-2026-0002' })]}
+        defaultTitle="Remediate Google Chrome"
+        busy={false}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('vuln-ticket-title')).toHaveValue('Remediate Google Chrome');
+    const description = screen.getByTestId('vuln-ticket-description');
+    expect((description as HTMLTextAreaElement).value).toContain('CVE-2026-0001');
+    expect((description as HTMLTextAreaElement).value).toContain('WS-02');
+  });
+
+  it('warns when the selection spans multiple organizations', () => {
+    render(
+      <CreateVulnTicketModal
+        findings={[finding(), finding({ deviceVulnerabilityId: 'dv-2', orgId: 'org-2', orgName: 'Beta' })]}
+        defaultTitle="T"
+        busy={false}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('vuln-ticket-cross-org-note')).toHaveTextContent('2 organizations');
+  });
+
+  it('submits title/description/priority and blocks empty titles', () => {
+    const onSubmit = vi.fn();
+    render(<CreateVulnTicketModal findings={[finding()]} defaultTitle="T" busy={false} onCancel={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: '' } });
+    expect(screen.getByTestId('vuln-ticket-submit')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: 'Patch it' } });
+    fireEvent.change(screen.getByTestId('vuln-ticket-priority'), { target: { value: 'high' } });
+    fireEvent.click(screen.getByTestId('vuln-ticket-submit'));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ title: 'Patch it', priority: 'high' }));
+  });
+});

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx
@@ -15,7 +15,9 @@ function finding(overrides: Partial<GroupFinding> = {}): GroupFinding {
     patchAvailable: true,
     riskScore: 95,
     detectedAt: '2026-06-01T00:00:00.000Z',
+    acceptedUntil: null,
     ticketId: null,
+    ticketNumber: null,
     ...overrides,
   };
 }
@@ -48,6 +50,25 @@ describe('CreateVulnTicketModal', () => {
       />,
     );
     expect(screen.getByTestId('vuln-ticket-cross-org-note')).toHaveTextContent('2 organizations');
+  });
+
+  it('is a named dialog and closes on Escape without submitting', () => {
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    render(<CreateVulnTicketModal findings={[finding()]} defaultTitle="T" busy={false} onCancel={onCancel} onSubmit={onSubmit} />);
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Create ticket — 1 finding');
+    fireEvent.keyDown(screen.getByTestId('vuln-ticket-modal'), { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('ignores Escape and disables buttons while busy', () => {
+    const onCancel = vi.fn();
+    render(<CreateVulnTicketModal findings={[finding()]} defaultTitle="T" busy onCancel={onCancel} onSubmit={() => {}} />);
+    fireEvent.keyDown(screen.getByTestId('vuln-ticket-modal'), { key: 'Escape' });
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByTestId('vuln-ticket-cancel')).toBeDisabled();
+    expect(screen.getByTestId('vuln-ticket-submit')).toBeDisabled();
   });
 
   it('submits title/description/priority and blocks empty titles', () => {

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
@@ -1,5 +1,7 @@
 import { useId, useMemo, useState } from 'react';
 
+import { VULN_TICKET_PRIORITIES, type VulnTicketPriority } from '@breeze/shared';
+
 import { Dialog } from '../shared/Dialog';
 import type { GroupFinding } from '../../lib/api/vulnerabilities';
 
@@ -8,20 +10,6 @@ const BTN =
 
 const INPUT =
   'mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
-
-const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
-type Priority = (typeof PRIORITIES)[number];
-
-function buildDescription(findings: GroupFinding[]): string {
-  const cves = [...new Set(findings.map((f) => f.cveId))].sort();
-  const devices = [...new Set(findings.map((f) => f.deviceName))].sort();
-  return [
-    `CVEs (${cves.length}): ${cves.join(', ')}`,
-    `Devices (${devices.length}): ${devices.join(', ')}`,
-    '',
-    'Created from the Breeze vulnerabilities triage queue.',
-  ].join('\n');
-}
 
 export function CreateVulnTicketModal({
   findings,
@@ -34,11 +22,11 @@ export function CreateVulnTicketModal({
   defaultTitle: string;
   busy: boolean;
   onCancel: () => void;
-  onSubmit: (payload: { title: string; description: string; priority: Priority }) => void;
+  onSubmit: (payload: { title: string; priority: VulnTicketPriority; note: string }) => void;
 }) {
   const [title, setTitle] = useState(defaultTitle);
-  const [description, setDescription] = useState(() => buildDescription(findings));
-  const [priority, setPriority] = useState<Priority>('normal');
+  const [note, setNote] = useState('');
+  const [priority, setPriority] = useState<VulnTicketPriority>('normal');
   const titleId = useId();
 
   const orgCount = useMemo(() => new Set(findings.map((f) => f.orgId)).size, [findings]);
@@ -73,24 +61,31 @@ export function CreateVulnTicketModal({
             />
           </label>
           <label className="block text-sm">
-            <span className="text-muted-foreground">Description</span>
+            <span className="text-muted-foreground">Note (optional)</span>
             <textarea
-              data-testid="vuln-ticket-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={5}
+              data-testid="vuln-ticket-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={4}
+              placeholder="Add any context for the technician (optional)"
               className={INPUT}
             />
           </label>
+          {/* The affected devices and CVEs are enumerated server-side, scoped to
+              each organization, so a cross-org selection never leaks one org's
+              device/CVE list into another org's ticket. */}
+          <p data-testid="vuln-ticket-auto-detail-note" className="text-xs text-muted-foreground">
+            Device and CVE details are added automatically, per organization.
+          </p>
           <label className="block text-sm">
             <span className="text-muted-foreground">Priority</span>
             <select
               data-testid="vuln-ticket-priority"
               value={priority}
-              onChange={(e) => setPriority(e.target.value as Priority)}
+              onChange={(e) => setPriority(e.target.value as VulnTicketPriority)}
               className={INPUT}
             >
-              {PRIORITIES.map((p) => (
+              {VULN_TICKET_PRIORITIES.map((p) => (
                 <option key={p} value={p}>{p[0]!.toUpperCase() + p.slice(1)}</option>
               ))}
             </select>
@@ -105,7 +100,7 @@ export function CreateVulnTicketModal({
             data-testid="vuln-ticket-submit"
             className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
             disabled={busy || title.trim().length === 0}
-            onClick={() => onSubmit({ title: title.trim(), description, priority })}
+            onClick={() => onSubmit({ title: title.trim(), priority, note: note.trim() })}
           >
             Create ticket
           </button>

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react';
+
+import type { GroupFinding } from '../../lib/api/vulnerabilities';
+
+const BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+
+const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
+type Priority = (typeof PRIORITIES)[number];
+
+function buildDescription(findings: GroupFinding[]): string {
+  const cves = [...new Set(findings.map((f) => f.cveId))].sort();
+  const devices = [...new Set(findings.map((f) => f.deviceName))].sort();
+  return [
+    `CVEs (${cves.length}): ${cves.join(', ')}`,
+    `Devices (${devices.length}): ${devices.join(', ')}`,
+    '',
+    'Created from the Breeze vulnerabilities triage queue.',
+  ].join('\n');
+}
+
+export function CreateVulnTicketModal({
+  findings,
+  defaultTitle,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  findings: GroupFinding[];
+  defaultTitle: string;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: { title: string; description: string; priority: Priority }) => void;
+}) {
+  const [title, setTitle] = useState(defaultTitle);
+  const [description, setDescription] = useState(() => buildDescription(findings));
+  const [priority, setPriority] = useState<Priority>('normal');
+
+  const orgCount = useMemo(() => new Set(findings.map((f) => f.orgId)).size, [findings]);
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-ticket-modal">
+        <h3 className="text-base font-semibold">Create ticket — {findings.length} finding{findings.length === 1 ? '' : 's'}</h3>
+        {orgCount > 1 && (
+          <p data-testid="vuln-ticket-cross-org-note" className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+            Selection spans {orgCount} organizations — one ticket per organization will be created.
+          </p>
+        )}
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Title</span>
+            <input
+              data-testid="vuln-ticket-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={255}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Description</span>
+            <textarea
+              data-testid="vuln-ticket-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Priority</span>
+            <select
+              data-testid="vuln-ticket-priority"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as Priority)}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>{p[0]!.toUpperCase() + p.slice(1)}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="vuln-ticket-submit"
+            className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+            disabled={busy || title.trim().length === 0}
+            onClick={() => onSubmit({ title: title.trim(), description, priority })}
+          >
+            Create ticket
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CreateVulnTicketModal;

--- a/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
+++ b/apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx
@@ -1,9 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 
+import { Dialog } from '../shared/Dialog';
 import type { GroupFinding } from '../../lib/api/vulnerabilities';
 
 const BTN =
-  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50';
+
+const INPUT =
+  'mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
 
 const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
 type Priority = (typeof PRIORITIES)[number];
@@ -35,13 +39,23 @@ export function CreateVulnTicketModal({
   const [title, setTitle] = useState(defaultTitle);
   const [description, setDescription] = useState(() => buildDescription(findings));
   const [priority, setPriority] = useState<Priority>('normal');
+  const titleId = useId();
 
   const orgCount = useMemo(() => new Set(findings.map((f) => f.orgId)).size, [findings]);
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
-      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-ticket-modal">
-        <h3 className="text-base font-semibold">Create ticket — {findings.length} finding{findings.length === 1 ? '' : 's'}</h3>
+    <Dialog
+      open
+      onClose={() => {
+        if (!busy) onCancel();
+      }}
+      title="Create ticket"
+      labelledBy={titleId}
+      maxWidth="md"
+      className="p-5"
+    >
+      <div data-testid="vuln-ticket-modal">
+        <h3 id={titleId} className="text-base font-semibold">Create ticket — {findings.length} finding{findings.length === 1 ? '' : 's'}</h3>
         {orgCount > 1 && (
           <p data-testid="vuln-ticket-cross-org-note" className="mt-1 text-xs text-amber-600 dark:text-amber-400">
             Selection spans {orgCount} organizations — one ticket per organization will be created.
@@ -55,7 +69,7 @@ export function CreateVulnTicketModal({
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               maxLength={255}
-              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              className={INPUT}
             />
           </label>
           <label className="block text-sm">
@@ -65,7 +79,7 @@ export function CreateVulnTicketModal({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={5}
-              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              className={INPUT}
             />
           </label>
           <label className="block text-sm">
@@ -74,7 +88,7 @@ export function CreateVulnTicketModal({
               data-testid="vuln-ticket-priority"
               value={priority}
               onChange={(e) => setPriority(e.target.value as Priority)}
-              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              className={INPUT}
             >
               {PRIORITIES.map((p) => (
                 <option key={p} value={p}>{p[0]!.toUpperCase() + p.slice(1)}</option>
@@ -83,7 +97,7 @@ export function CreateVulnTicketModal({
           </label>
         </div>
         <div className="mt-5 flex justify-end gap-2">
-          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+          <button type="button" data-testid="vuln-ticket-cancel" className={`${BTN} hover:bg-muted`} onClick={onCancel} disabled={busy}>
             Cancel
           </button>
           <button
@@ -97,7 +111,7 @@ export function CreateVulnTicketModal({
           </button>
         </div>
       </div>
-    </div>
+    </Dialog>
   );
 }
 

--- a/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
@@ -52,7 +52,9 @@ const PAYLOAD: CveDevicesPayload = {
       patchAvailable: true,
       riskScore: 95,
       detectedAt: '2026-06-01T00:00:00.000Z',
+      acceptedUntil: null,
       ticketId: null,
+      ticketNumber: null,
     },
     {
       deviceVulnerabilityId: 'dv-2',
@@ -65,7 +67,9 @@ const PAYLOAD: CveDevicesPayload = {
       patchAvailable: true,
       riskScore: 95,
       detectedAt: '2026-06-01T00:00:00.000Z',
+      acceptedUntil: '2026-08-01T12:00:00.000Z',
       ticketId: null,
+      ticketNumber: null,
     },
   ],
 };
@@ -85,6 +89,19 @@ describe('CveDrawer', () => {
     expect(meta).toHaveTextContent('42.0%');
     expect(meta).toHaveTextContent('KEV');
     expect(screen.getByTestId('vuln-cve-reference-0')).toHaveAttribute('href', 'https://example.test/advisory');
+  });
+
+  it('shows an empty message instead of a bare heading when the CVE has no fleet findings', async () => {
+    vi.mocked(api.fetchCveDevices).mockResolvedValue({ ...PAYLOAD, findings: [] });
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    expect(await screen.findByTestId('vuln-drawer-no-findings')).toHaveTextContent('No devices in your fleet are affected');
+    expect(screen.queryByTestId('vuln-finding-check-dv-1')).toBeNull();
+  });
+
+  it('shows when an accepted finding expires ("Accepted until"), not a bare status chip', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    const drawer = await screen.findByTestId('vuln-cve-drawer');
+    expect(drawer).toHaveTextContent(`Accepted until ${new Date('2026-08-01T12:00:00.000Z').toLocaleDateString()}`);
   });
 
   it('shows Reopen only on accepted/mitigated findings and calls the API', async () => {
@@ -113,5 +130,37 @@ describe('CveDrawer', () => {
     fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
     fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
     await waitFor(() => expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], expect.anything()));
+  });
+
+  it('remediate opens a confirmation and only fires on confirm', async () => {
+    vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    expect(api.remediateVuln).not.toHaveBeenCalled();
+    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent('1 finding on 1 device');
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
+  });
+
+  it('surfaces a remediate failure inline in the confirmation modal (not just the toast)', async () => {
+    vi.mocked(api.remediateVuln).mockRejectedValue(new Error('No available patch mapped to these findings'));
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    expect(await screen.findByTestId('vuln-bulk-error')).toHaveTextContent('No available patch mapped to these findings');
+    expect(screen.getByTestId('vuln-bulk-modal')).toBeInTheDocument();
+  });
+
+  it('pluralizes the findings heading for a single finding', async () => {
+    vi.mocked(api.fetchCveDevices).mockResolvedValue({ ...PAYLOAD, findings: [PAYLOAD.findings[0]!] });
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    const drawer = await screen.findByTestId('vuln-cve-drawer');
+    expect(drawer).toHaveTextContent('Devices (1 finding)');
+    expect(drawer).not.toHaveTextContent('1 findings');
+  });
+
+  it('names each finding checkbox after its device for screen readers', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    expect(await screen.findByTestId('vuln-finding-check-dv-1')).toHaveAttribute('aria-label', 'Select finding on WS-01');
   });
 });

--- a/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchCveDevices: vi.fn(),
+  remediateVuln: vi.fn(),
+  bulkAcceptVulnRisk: vi.fn(),
+  bulkMitigateVulns: vi.fn(),
+  reopenVuln: vi.fn(),
+  createVulnTicket: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { CveDrawer } from './CveDrawer';
+import type { CveDevicesPayload } from '../../lib/api/vulnerabilities';
+
+const PAYLOAD: CveDevicesPayload = {
+  cve: {
+    cveId: 'CVE-2026-0001',
+    description: 'Heap overflow in the render pipeline.',
+    references: ['https://example.test/advisory'],
+    cvssVersion: '3.1',
+    cvssVector: 'CVSS:3.1/AV:N/AC:L',
+    cvssScore: 9.1,
+    epssScore: 0.42,
+    knownExploited: true,
+    patchAvailable: true,
+    severity: 'critical',
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-02-01T00:00:00.000Z',
+  },
+  findings: [
+    {
+      deviceVulnerabilityId: 'dv-1',
+      deviceId: 'dev-1',
+      deviceName: 'WS-01',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'open',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+    {
+      deviceVulnerabilityId: 'dv-2',
+      deviceId: 'dev-2',
+      deviceName: 'WS-02',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'accepted',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+  ],
+};
+
+describe('CveDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    vi.mocked(api.fetchCveDevices).mockResolvedValue(PAYLOAD);
+  });
+
+  it('renders CVE metadata, vector, EPSS, KEV, and reference links', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    const meta = await screen.findByTestId('vuln-cve-meta');
+    expect(meta).toHaveTextContent('Heap overflow');
+    expect(meta).toHaveTextContent('CVSS:3.1/AV:N/AC:L');
+    expect(meta).toHaveTextContent('42.0%');
+    expect(meta).toHaveTextContent('KEV');
+    expect(screen.getByTestId('vuln-cve-reference-0')).toHaveAttribute('href', 'https://example.test/advisory');
+  });
+
+  it('shows Reopen only on accepted/mitigated findings and calls the API', async () => {
+    vi.mocked(api.reopenVuln).mockResolvedValue(undefined as never);
+    const onActionComplete = vi.fn();
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={onActionComplete} />);
+    await screen.findByTestId('vuln-cve-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-1')).toBeNull();      // open finding
+    fireEvent.click(screen.getByTestId('vuln-reopen-dv-2'));          // accepted finding
+    await waitFor(() => expect(api.reopenVuln).toHaveBeenCalledWith('dv-2'));
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+  });
+
+  it('hides Reopen without vulnerabilities:accept_risk', async () => {
+    authState.permissions = [{ resource: 'devices', action: 'read' }];
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    await screen.findByTestId('vuln-cve-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-2')).toBeNull();
+  });
+
+  it('runs bulk accept-risk against the selected findings scoped to this CVE', async () => {
+    vi.mocked(api.bulkAcceptVulnRisk).mockResolvedValue({ success: true, succeeded: 1, skipped: [] });
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'ok' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() => expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], expect.anything()));
+  });
+});

--- a/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
@@ -137,7 +137,7 @@ describe('CveDrawer', () => {
     render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
     fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
     expect(api.remediateVuln).not.toHaveBeenCalled();
-    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent('1 finding on 1 device');
+    expect(screen.getByTestId('vuln-bulk-consequence')).toHaveTextContent('on 1 device (1 finding)');
     fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
     await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
   });
@@ -162,5 +162,34 @@ describe('CveDrawer', () => {
   it('names each finding checkbox after its device for screen readers', async () => {
     render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
     expect(await screen.findByTestId('vuln-finding-check-dv-1')).toHaveAttribute('aria-label', 'Select finding on WS-01');
+  });
+
+  it('select-all toggles between every finding and none, with indeterminate for partial selection', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    const selectAll = (await screen.findByTestId('vuln-select-all')) as HTMLInputElement;
+    // Pre-selection is open-only (dv-1 of 2) — partial, so indeterminate.
+    expect(selectAll.checked).toBe(false);
+    expect(selectAll.indeterminate).toBe(true);
+    expect(selectAll).toHaveAccessibleName('Select all findings');
+
+    fireEvent.click(selectAll); // partial → all
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).toBeChecked();
+    expect(selectAll.checked).toBe(true);
+    expect(selectAll.indeterminate).toBe(false);
+    expect(selectAll).toHaveAccessibleName('Deselect all findings');
+
+    fireEvent.click(selectAll); // all → none
+    expect(screen.getByTestId('vuln-finding-check-dv-1')).not.toBeChecked();
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).not.toBeChecked();
+    expect(selectAll.indeterminate).toBe(false);
+    expect(screen.getByTestId('vuln-action-remediate')).toBeDisabled();
+  });
+
+  it('passes the selected device names (no CVE id — the drawer IS the CVE) to the bulk modal summary', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    const summary = screen.getByTestId('vuln-bulk-selection');
+    expect(summary).toHaveTextContent('WS-01');
+    expect(summary).not.toHaveTextContent('CVE-2026-0001');
   });
 });

--- a/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.test.tsx
@@ -192,4 +192,32 @@ describe('CveDrawer', () => {
     expect(summary).toHaveTextContent('WS-01');
     expect(summary).not.toHaveTextContent('CVE-2026-0001');
   });
+
+  it('shows an inline retry on fetch failure and recovers on retry', async () => {
+    vi.mocked(api.fetchCveDevices).mockRejectedValueOnce(new Error('boom'));
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    expect(await screen.findByTestId('vuln-drawer-error')).toHaveTextContent('boom');
+    fireEvent.click(screen.getByTestId('vuln-drawer-retry'));
+    expect(await screen.findByTestId('vuln-finding-check-dv-1')).toBeInTheDocument();
+  });
+
+  it('reloads and notifies after a partial-skip bulk accept (some findings skipped)', async () => {
+    // A partial success (non-empty skipped) is still a success: the drawer reloads
+    // and notifies. The summarized skip prose is produced by runAction inside the
+    // (mocked-out) api layer; that string is unit-tested in bulkSummary/summarizeSkipReasons.
+    vi.mocked(api.bulkAcceptVulnRisk).mockResolvedValue({
+      success: true,
+      succeeded: 1,
+      skipped: [{ id: 'dv-1', reason: 'site_access_denied' }],
+    });
+    const onActionComplete = vi.fn();
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={onActionComplete} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'ok' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() => expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], expect.anything()));
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+    expect(api.fetchCveDevices).toHaveBeenCalledTimes(2); // initial + reload
+  });
 });

--- a/apps/web/src/components/vulnerabilities/CveDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.tsx
@@ -3,11 +3,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { Drawer } from '../shared/Drawer';
 import { SeverityBadge } from './SeverityBadge';
 import { VulnBulkActionModal } from './VulnBulkActionModal';
+import { CreateVulnTicketModal } from './CreateVulnTicketModal';
 import { usePermissions } from '../../lib/permissions';
 import { handleActionError } from '../../lib/runAction';
 import {
   bulkAcceptVulnRisk,
   bulkMitigateVulns,
+  createVulnTicket,
   fetchCveDevices,
   remediateVuln,
   reopenVuln,
@@ -50,11 +52,13 @@ export function CveDrawer({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | 'reopen' | null>(null);
   const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+  const [ticketModal, setTicketModal] = useState(false);
 
   const { can } = usePermissions();
   const canRemediate = can('devices', 'execute');
   const canAcceptRisk = can('vulnerabilities', 'accept_risk');
   const canMitigate = can('devices', 'write');
+  const canCreateTicket = can('tickets', 'write');
 
   const load = useCallback(async () => {
     setError(null);
@@ -265,6 +269,17 @@ export function CveDrawer({
               Mitigate
             </button>
           )}
+          {canCreateTicket && (
+            <button
+              type="button"
+              data-testid="vuln-action-ticket"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setTicketModal(true)}
+            >
+              Create ticket
+            </button>
+          )}
         </div>
       )}
 
@@ -284,6 +299,19 @@ export function CveDrawer({
             } else {
               void runBulk('mitigate', () => bulkMitigateVulns(selectedIds, { note: bulkPayload.note ?? '' }), 'Failed to mitigate');
             }
+          }}
+        />
+      )}
+
+      {ticketModal && payload && (
+        <CreateVulnTicketModal
+          findings={payload.findings.filter((f) => selected.has(f.deviceVulnerabilityId))}
+          defaultTitle={`Remediate ${cveId}`}
+          busy={busy !== null}
+          onCancel={() => setTicketModal(false)}
+          onSubmit={(ticketPayload) => {
+            setTicketModal(false);
+            void runBulk('ticket', () => createVulnTicket(selectedIds, ticketPayload), 'Failed to create ticket');
           }}
         />
       )}

--- a/apps/web/src/components/vulnerabilities/CveDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.tsx
@@ -97,9 +97,16 @@ export function CveDrawer({
   };
 
   const selectedIds = [...selected];
-  const selectedDeviceCount = payload
-    ? new Set(payload.findings.filter((f) => selected.has(f.deviceVulnerabilityId)).map((f) => f.deviceId)).size
-    : 0;
+  const selectedFindings = payload ? payload.findings.filter((f) => selected.has(f.deviceVulnerabilityId)) : [];
+  const selectedDeviceCount = new Set(selectedFindings.map((f) => f.deviceId)).size;
+
+  // All/none toggle for the pre-checked findings list — deselecting a large
+  // pre-selection one checkbox at a time is unreasonable.
+  const allSelected = payload !== null && payload.findings.length > 0 && payload.findings.every((f) => selected.has(f.deviceVulnerabilityId));
+  const toggleAll = () => {
+    if (!payload) return;
+    setSelected(allSelected ? new Set() : new Set(payload.findings.map((f) => f.deviceVulnerabilityId)));
+  };
 
   const runBulk = useCallback(
     async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
@@ -204,9 +211,28 @@ export function CveDrawer({
             </section>
 
             <section>
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Devices ({plural(payload.findings.length, 'finding')})
-              </h3>
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Devices ({plural(payload.findings.length, 'finding')})
+                </h3>
+                {payload.findings.length > 0 && (
+                  <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+                    <input
+                      type="checkbox"
+                      data-testid="vuln-select-all"
+                      aria-label={allSelected ? 'Deselect all findings' : 'Select all findings'}
+                      checked={allSelected}
+                      // Native indeterminate has no attribute form — set it via ref.
+                      ref={(el) => {
+                        if (el) el.indeterminate = !allSelected && selected.size > 0;
+                      }}
+                      onChange={toggleAll}
+                      className="h-4 w-4 rounded border"
+                    />
+                    Select all
+                  </label>
+                )}
+              </div>
               {payload.findings.length === 0 ? (
                 // Reachable when every finding was resolved (or moved out of the
                 // caller's scope) between the list loading and the drawer opening.
@@ -327,6 +353,9 @@ export function CveDrawer({
           kind={modal}
           count={selectedIds.length}
           deviceCount={selectedDeviceCount}
+          // Every finding here is the same CVE (it's in the drawer title), so
+          // the summary lists device names only.
+          selection={selectedFindings.map((f) => ({ deviceName: f.deviceName }))}
           busy={busy !== null}
           errorMessage={modalError}
           onCancel={() => {

--- a/apps/web/src/components/vulnerabilities/CveDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { Drawer } from '../shared/Drawer';
+import { SeverityBadge } from './SeverityBadge';
+import { VulnBulkActionModal } from './VulnBulkActionModal';
+import { usePermissions } from '../../lib/permissions';
+import { handleActionError } from '../../lib/runAction';
+import {
+  bulkAcceptVulnRisk,
+  bulkMitigateVulns,
+  fetchCveDevices,
+  remediateVuln,
+  reopenVuln,
+  type CveDevicesPayload,
+} from '../../lib/api/vulnerabilities';
+
+const ACTION_BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50';
+
+function fmtEpss(value: number | null): string {
+  return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
+
+// The catalog stores `references` as source-dependent jsonb — normalize defensively.
+function referenceUrls(references: unknown): string[] {
+  if (!Array.isArray(references)) return [];
+  return references
+    .map((r) =>
+      typeof r === 'string'
+        ? r
+        : typeof r === 'object' && r !== null && 'url' in r
+          ? String((r as { url: unknown }).url)
+          : null,
+    )
+    .filter((u): u is string => typeof u === 'string' && u.startsWith('http'))
+    .slice(0, 10);
+}
+
+export function CveDrawer({
+  cveId,
+  onClose,
+  onActionComplete,
+}: {
+  cveId: string;
+  onClose: () => void;
+  onActionComplete: () => void;
+}) {
+  const [payload, setPayload] = useState<CveDevicesPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | 'reopen' | null>(null);
+  const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+
+  const { can } = usePermissions();
+  const canRemediate = can('devices', 'execute');
+  const canAcceptRisk = can('vulnerabilities', 'accept_risk');
+  const canMitigate = can('devices', 'write');
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const p = await fetchCveDevices(cveId);
+      setPayload(p);
+      // Open findings are the actionable ones — pre-select them (spec: all selected by default).
+      setSelected(new Set(p.findings.filter((f) => f.status === 'open').map((f) => f.deviceVulnerabilityId)));
+    } catch (err) {
+      setPayload(null);
+      setError(err instanceof Error ? err.message : 'Failed to load CVE');
+    }
+  }, [cveId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectedIds = [...selected];
+
+  const runBulk = useCallback(
+    async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
+      if (busy || selectedIds.length === 0) return;
+      setBusy(kind);
+      try {
+        await action();
+        setModal(null);
+        await load();
+        onActionComplete();
+      } catch (err) {
+        handleActionError(err, fallback);
+      } finally {
+        setBusy(null);
+      }
+    },
+    // selectedIds is derived from `selected`; depend on the source set.
+    [busy, selected, load, onActionComplete],
+  );
+
+  const onReopen = useCallback(
+    async (id: string) => {
+      if (busy) return;
+      setBusy('reopen');
+      try {
+        await reopenVuln(id);
+        await load();
+        onActionComplete();
+      } catch (err) {
+        handleActionError(err, 'Failed to reopen finding');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, load, onActionComplete],
+  );
+
+  const title = payload ? (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{cveId}</span>
+      <SeverityBadge severity={payload.cve.severity} />
+    </span>
+  ) : (
+    cveId
+  );
+
+  return (
+    <Drawer open onClose={onClose} title={title} width="max-w-xl" dataTestId="vuln-cve-drawer" closeDisabled={busy !== null}>
+      <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+        {error && (
+          <div
+            data-testid="vuln-drawer-error"
+            className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+          >
+            <p>{error}</p>
+            <button type="button" data-testid="vuln-drawer-retry" className="mt-2 text-sm font-medium underline" onClick={() => void load()}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {payload && (
+          <>
+            <section data-testid="vuln-cve-meta" className="space-y-2 text-sm">
+              <p>{payload.cve.description}</p>
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                <dt className="text-muted-foreground">CVSS {payload.cve.cvssVersion ?? ''}</dt>
+                <dd className="tabular-nums">{payload.cve.cvssScore ?? '—'}</dd>
+                <dt className="text-muted-foreground">Vector</dt>
+                <dd className="break-all">{payload.cve.cvssVector ?? '—'}</dd>
+                <dt className="text-muted-foreground">EPSS</dt>
+                <dd className="tabular-nums">{fmtEpss(payload.cve.epssScore)}</dd>
+                <dt className="text-muted-foreground">Known exploited</dt>
+                <dd>{payload.cve.knownExploited ? 'KEV' : 'No'}</dd>
+                <dt className="text-muted-foreground">Published</dt>
+                <dd>{payload.cve.publishedAt ? new Date(payload.cve.publishedAt).toLocaleDateString() : '—'}</dd>
+                <dt className="text-muted-foreground">Modified</dt>
+                <dd>{payload.cve.modifiedAt ? new Date(payload.cve.modifiedAt).toLocaleDateString() : '—'}</dd>
+              </dl>
+              {referenceUrls(payload.cve.references).length > 0 && (
+                <ul className="space-y-1 text-xs">
+                  {referenceUrls(payload.cve.references).map((url, i) => (
+                    <li key={url}>
+                      <a
+                        data-testid={`vuln-cve-reference-${i}`}
+                        href={url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="break-all text-primary hover:underline"
+                      >
+                        {url}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Devices ({payload.findings.length} findings)
+              </h3>
+              <ul className="mt-2 divide-y rounded-md border">
+                {payload.findings.map((f) => (
+                  <li key={f.deviceVulnerabilityId} className="flex items-center gap-3 px-3 py-2 text-sm">
+                    <input
+                      type="checkbox"
+                      data-testid={`vuln-finding-check-${f.deviceVulnerabilityId}`}
+                      checked={selected.has(f.deviceVulnerabilityId)}
+                      onChange={() => toggle(f.deviceVulnerabilityId)}
+                      className="h-4 w-4 rounded border"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{f.deviceName}</span>
+                      <span className="block truncate text-xs text-muted-foreground">{f.orgName ?? ''}</span>
+                    </span>
+                    <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
+                    <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
+                    {f.ticketId && (
+                      <a
+                        href={`/tickets#${f.ticketId}`}
+                        data-testid={`vuln-finding-ticket-${f.deviceVulnerabilityId}`}
+                        className="text-xs underline"
+                      >
+                        Ticket
+                      </a>
+                    )}
+                    {canAcceptRisk && (f.status === 'accepted' || f.status === 'mitigated') && (
+                      <button
+                        type="button"
+                        data-testid={`vuln-reopen-${f.deviceVulnerabilityId}`}
+                        className="text-xs font-medium text-primary hover:underline disabled:opacity-50"
+                        disabled={busy !== null}
+                        onClick={() => void onReopen(f.deviceVulnerabilityId)}
+                      >
+                        Reopen
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </>
+        )}
+      </div>
+
+      {payload && (
+        <div className="flex flex-wrap items-center gap-2 border-t px-5 py-3">
+          <span className="mr-auto text-xs text-muted-foreground">{selectedIds.length} selected</span>
+          {canRemediate && (
+            <button
+              type="button"
+              data-testid="vuln-action-remediate"
+              className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation')}
+            >
+              Remediate
+            </button>
+          )}
+          {canAcceptRisk && (
+            <button
+              type="button"
+              data-testid="vuln-action-accept"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('accept')}
+            >
+              Accept risk
+            </button>
+          )}
+          {canMitigate && (
+            <button
+              type="button"
+              data-testid="vuln-action-mitigate"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('mitigate')}
+            >
+              Mitigate
+            </button>
+          )}
+        </div>
+      )}
+
+      {modal && (
+        <VulnBulkActionModal
+          kind={modal}
+          count={selectedIds.length}
+          busy={busy !== null}
+          onCancel={() => setModal(null)}
+          onSubmit={(bulkPayload) => {
+            if (modal === 'accept') {
+              void runBulk(
+                'accept',
+                () => bulkAcceptVulnRisk(selectedIds, { reason: bulkPayload.reason ?? '', acceptedUntil: bulkPayload.acceptedUntil ?? '' }),
+                'Failed to accept risk',
+              );
+            } else {
+              void runBulk('mitigate', () => bulkMitigateVulns(selectedIds, { note: bulkPayload.note ?? '' }), 'Failed to mitigate');
+            }
+          }}
+        />
+      )}
+    </Drawer>
+  );
+}
+
+export default CveDrawer;

--- a/apps/web/src/components/vulnerabilities/CveDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.tsx
@@ -75,7 +75,7 @@ export function CveDrawer({
     try {
       const p = await fetchCveDevices(cveId);
       setPayload(p);
-      // Open findings are the actionable ones — pre-select them (spec: all selected by default).
+      // Pre-select only OPEN findings — they're the actionable ones; accepted/mitigated/patched rows start unchecked.
       setSelected(new Set(p.findings.filter((f) => f.status === 'open').map((f) => f.deviceVulnerabilityId)));
     } catch (err) {
       setPayload(null);

--- a/apps/web/src/components/vulnerabilities/CveDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/CveDrawer.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Drawer } from '../shared/Drawer';
 import { SeverityBadge } from './SeverityBadge';
+import { KevBadge } from './KevBadge';
+import { CVSS_EXPLANATION, EPSS_EXPLANATION } from './vulnExplanations';
+import { FindingStatus } from './FindingStatus';
 import { VulnBulkActionModal } from './VulnBulkActionModal';
 import { CreateVulnTicketModal } from './CreateVulnTicketModal';
 import { usePermissions } from '../../lib/permissions';
 import { handleActionError } from '../../lib/runAction';
+import { plural } from '../../lib/utils';
 import {
   bulkAcceptVulnRisk,
   bulkMitigateVulns,
@@ -51,8 +55,14 @@ export function CveDrawer({
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | 'reopen' | null>(null);
-  const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+  const [modal, setModal] = useState<'remediate' | 'accept' | 'mitigate' | null>(null);
+  // Inline failure message for the bulk-action modal (in addition to the
+  // toast, which is easy to miss while the modal stays open).
+  const [modalError, setModalError] = useState<string | null>(null);
   const [ticketModal, setTicketModal] = useState(false);
+  // Synchronous double-submission guard: `busy` state lags one render behind,
+  // so a rapid double-activation could fire the mutation twice without this.
+  const busyRef = useRef(false);
 
   const { can } = usePermissions();
   const canRemediate = can('devices', 'execute');
@@ -87,10 +97,14 @@ export function CveDrawer({
   };
 
   const selectedIds = [...selected];
+  const selectedDeviceCount = payload
+    ? new Set(payload.findings.filter((f) => selected.has(f.deviceVulnerabilityId)).map((f) => f.deviceId)).size
+    : 0;
 
   const runBulk = useCallback(
     async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
-      if (busy || selectedIds.length === 0) return;
+      if (busy || busyRef.current || selectedIds.length === 0) return;
+      busyRef.current = true;
       setBusy(kind);
       try {
         await action();
@@ -99,7 +113,9 @@ export function CveDrawer({
         onActionComplete();
       } catch (err) {
         handleActionError(err, fallback);
+        setModalError(err instanceof Error && err.message ? err.message : fallback);
       } finally {
+        busyRef.current = false;
         setBusy(null);
       }
     },
@@ -109,7 +125,8 @@ export function CveDrawer({
 
   const onReopen = useCallback(
     async (id: string) => {
-      if (busy) return;
+      if (busy || busyRef.current) return;
+      busyRef.current = true;
       setBusy('reopen');
       try {
         await reopenVuln(id);
@@ -118,6 +135,7 @@ export function CveDrawer({
       } catch (err) {
         handleActionError(err, 'Failed to reopen finding');
       } finally {
+        busyRef.current = false;
         setBusy(null);
       }
     },
@@ -153,14 +171,14 @@ export function CveDrawer({
             <section data-testid="vuln-cve-meta" className="space-y-2 text-sm">
               <p>{payload.cve.description}</p>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                <dt className="text-muted-foreground">CVSS {payload.cve.cvssVersion ?? ''}</dt>
+                <dt className="text-muted-foreground" title={CVSS_EXPLANATION}>CVSS {payload.cve.cvssVersion ?? ''}</dt>
                 <dd className="tabular-nums">{payload.cve.cvssScore ?? '—'}</dd>
                 <dt className="text-muted-foreground">Vector</dt>
                 <dd className="break-all">{payload.cve.cvssVector ?? '—'}</dd>
-                <dt className="text-muted-foreground">EPSS</dt>
+                <dt className="text-muted-foreground" title={EPSS_EXPLANATION}>EPSS</dt>
                 <dd className="tabular-nums">{fmtEpss(payload.cve.epssScore)}</dd>
                 <dt className="text-muted-foreground">Known exploited</dt>
-                <dd>{payload.cve.knownExploited ? 'KEV' : 'No'}</dd>
+                <dd>{payload.cve.knownExploited ? <KevBadge /> : 'No'}</dd>
                 <dt className="text-muted-foreground">Published</dt>
                 <dd>{payload.cve.publishedAt ? new Date(payload.cve.publishedAt).toLocaleDateString() : '—'}</dd>
                 <dt className="text-muted-foreground">Modified</dt>
@@ -187,14 +205,25 @@ export function CveDrawer({
 
             <section>
               <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Devices ({payload.findings.length} findings)
+                Devices ({plural(payload.findings.length, 'finding')})
               </h3>
+              {payload.findings.length === 0 ? (
+                // Reachable when every finding was resolved (or moved out of the
+                // caller's scope) between the list loading and the drawer opening.
+                <p
+                  data-testid="vuln-drawer-no-findings"
+                  className="mt-2 rounded-md border border-dashed px-3 py-4 text-center text-xs text-muted-foreground"
+                >
+                  No devices in your fleet are affected by this CVE right now — nothing to act on.
+                </p>
+              ) : (
               <ul className="mt-2 divide-y rounded-md border">
                 {payload.findings.map((f) => (
                   <li key={f.deviceVulnerabilityId} className="flex items-center gap-3 px-3 py-2 text-sm">
                     <input
                       type="checkbox"
                       data-testid={`vuln-finding-check-${f.deviceVulnerabilityId}`}
+                      aria-label={`Select finding on ${f.deviceName}`}
                       checked={selected.has(f.deviceVulnerabilityId)}
                       onChange={() => toggle(f.deviceVulnerabilityId)}
                       className="h-4 w-4 rounded border"
@@ -203,15 +232,15 @@ export function CveDrawer({
                       <span className="block truncate font-medium">{f.deviceName}</span>
                       <span className="block truncate text-xs text-muted-foreground">{f.orgName ?? ''}</span>
                     </span>
-                    <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
+                    <FindingStatus status={f.status} acceptedUntil={f.acceptedUntil} />
                     <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
                     {f.ticketId && (
                       <a
-                        href={`/tickets#${f.ticketId}`}
+                        href={`/tickets#${f.ticketNumber ?? f.ticketId}`}
                         data-testid={`vuln-finding-ticket-${f.deviceVulnerabilityId}`}
                         className="text-xs underline"
                       >
-                        Ticket
+                        {f.ticketNumber ?? 'Ticket'}
                       </a>
                     )}
                     {canAcceptRisk && (f.status === 'accepted' || f.status === 'mitigated') && (
@@ -228,6 +257,7 @@ export function CveDrawer({
                   </li>
                 ))}
               </ul>
+              )}
             </section>
           </>
         )}
@@ -242,7 +272,10 @@ export function CveDrawer({
               data-testid="vuln-action-remediate"
               className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation')}
+              onClick={() => {
+                setModalError(null);
+                setModal('remediate');
+              }}
             >
               Remediate
             </button>
@@ -253,7 +286,10 @@ export function CveDrawer({
               data-testid="vuln-action-accept"
               className={ACTION_BTN}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => setModal('accept')}
+              onClick={() => {
+                setModalError(null);
+                setModal('accept');
+              }}
             >
               Accept risk
             </button>
@@ -264,7 +300,10 @@ export function CveDrawer({
               data-testid="vuln-action-mitigate"
               className={ACTION_BTN}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => setModal('mitigate')}
+              onClick={() => {
+                setModalError(null);
+                setModal('mitigate');
+              }}
             >
               Mitigate
             </button>
@@ -287,10 +326,18 @@ export function CveDrawer({
         <VulnBulkActionModal
           kind={modal}
           count={selectedIds.length}
+          deviceCount={selectedDeviceCount}
           busy={busy !== null}
-          onCancel={() => setModal(null)}
+          errorMessage={modalError}
+          onCancel={() => {
+            setModal(null);
+            setModalError(null);
+          }}
           onSubmit={(bulkPayload) => {
-            if (modal === 'accept') {
+            setModalError(null);
+            if (modal === 'remediate') {
+              void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation');
+            } else if (modal === 'accept') {
               void runBulk(
                 'accept',
                 () => bulkAcceptVulnRisk(selectedIds, { reason: bulkPayload.reason ?? '', acceptedUntil: bulkPayload.acceptedUntil ?? '' }),

--- a/apps/web/src/components/vulnerabilities/FindingStatus.tsx
+++ b/apps/web/src/components/vulnerabilities/FindingStatus.tsx
@@ -1,0 +1,17 @@
+/**
+ * Status text for a finding row in the drawers. Accepted findings say *until
+ * when* the risk acceptance runs ("Accepted until 8/1/2026") instead of a bare
+ * "accepted" chip — one shared component so both drawers phrase it the same.
+ */
+export function FindingStatus({ status, acceptedUntil }: { status: string; acceptedUntil: string | null }) {
+  if (status === 'accepted' && acceptedUntil) {
+    return (
+      <span className="whitespace-nowrap text-xs text-muted-foreground">
+        Accepted until {new Date(acceptedUntil).toLocaleDateString()}
+      </span>
+    );
+  }
+  return <span className="text-xs capitalize text-muted-foreground">{status}</span>;
+}
+
+export default FindingStatus;

--- a/apps/web/src/components/vulnerabilities/KevBadge.tsx
+++ b/apps/web/src/components/vulnerabilities/KevBadge.tsx
@@ -1,0 +1,24 @@
+import { KEV_EXPLANATION } from './vulnExplanations';
+
+/**
+ * CISA Known Exploited Vulnerability marker. One shared component so the
+ * badge can't drift between the group table, the drawers, and the CVE
+ * metadata (it previously existed as three slightly different copies).
+ *
+ * Deliberately a native `title` (not HelpTooltip): the badge repeats on every
+ * row, and a focusable trigger per row would litter the keyboard tab order.
+ * The KEV column header carries the accessible HelpTooltip with the same
+ * phrasing (vulnExplanations.ts keeps them identical).
+ */
+export function KevBadge() {
+  return (
+    <span
+      className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+      title={KEV_EXPLANATION}
+    >
+      KEV
+    </span>
+  );
+}
+
+export default KevBadge;

--- a/apps/web/src/components/vulnerabilities/SeverityBadge.tsx
+++ b/apps/web/src/components/vulnerabilities/SeverityBadge.tsx
@@ -2,7 +2,10 @@ const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
   critical: { label: 'Critical', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
   high: { label: 'High', className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300' },
   medium: { label: 'Medium', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' },
-  low: { label: 'Low', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
+  // Informational blue, not green: on a vulnerability page green reads
+  // "resolved/good", and a Low CVE is still an open finding. Keeps the ramp
+  // monotonic red → orange → amber → blue.
+  low: { label: 'Low', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' },
 };
 
 export function SeverityBadge({ severity }: { severity: string | null }) {

--- a/apps/web/src/components/vulnerabilities/SeverityBadge.tsx
+++ b/apps/web/src/components/vulnerabilities/SeverityBadge.tsx
@@ -1,0 +1,21 @@
+const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
+  critical: { label: 'Critical', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
+  high: { label: 'High', className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300' },
+  medium: { label: 'Medium', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' },
+  low: { label: 'Low', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
+};
+
+export function SeverityBadge({ severity }: { severity: string | null }) {
+  const key = severity?.toLowerCase() ?? '';
+  const badge = SEVERITY_BADGES[key] ?? {
+    label: severity ?? 'Unknown',
+    className: 'bg-slate-100 text-slate-700 dark:bg-slate-900/30 dark:text-slate-300',
+  };
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${badge.className}`}>
+      {badge.label}
+    </span>
+  );
+}
+
+export default SeverityBadge;

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
@@ -99,7 +99,23 @@ describe('SoftwareGroupDrawer', () => {
     expect(screen.getByTestId('vuln-drawer-cve-CVE-2026-0001')).toBeInTheDocument();
     expect(screen.getByTestId('vuln-finding-check-dv-1')).toBeChecked();       // open — pre-selected
     expect(screen.getByTestId('vuln-finding-check-dv-2')).not.toBeChecked();   // accepted — not pre-selected
+    expect(screen.getByTestId('vuln-finding-ticket-dv-2')).toBeInTheDocument();
+  });
+
+  it('renders distinct testids for the group ticket chip and a per-finding ticket link that share a ticketId', async () => {
+    const detailWithSharedTicket: SoftwareGroupDetail = {
+      ...DETAIL,
+      group: { ...DETAIL.group, ticketIds: ['t-9'] },
+    };
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue(detailWithSharedTicket);
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-software-drawer')).toHaveTextContent('Google Chrome');
+    // Group-level header chip (aggregate of group.ticketIds) — canonical vuln-ticket-chip-<ticketId>.
     expect(screen.getByTestId('vuln-ticket-chip-t-9')).toBeInTheDocument();
+    // Per-finding inline link for the finding whose own ticketId is also t-9 — distinct testid, no collision.
+    expect(screen.getByTestId('vuln-finding-ticket-dv-2')).toBeInTheDocument();
   });
 
   it('accept-risk flow: opens modal, submits selected ids, reloads and notifies', async () => {

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../lib/api/vulnerabilities', () => ({
   remediateVuln: vi.fn(),
   bulkAcceptVulnRisk: vi.fn(),
   bulkMitigateVulns: vi.fn(),
+  reopenVuln: vi.fn(),
   createVulnTicket: vi.fn(),
 }));
 
@@ -178,7 +179,7 @@ describe('SoftwareGroupDrawer', () => {
     // Nothing fired yet — the confirmation stands between the button and the mutation.
     expect(api.remediateVuln).not.toHaveBeenCalled();
     expect(screen.getByTestId('vuln-bulk-modal')).toHaveTextContent('Remediate findings — 1 finding');
-    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent('1 finding on 1 device');
+    expect(screen.getByTestId('vuln-bulk-consequence')).toHaveTextContent('on 1 device (1 finding)');
     fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
     await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
   });
@@ -272,6 +273,84 @@ describe('SoftwareGroupDrawer', () => {
     );
     await screen.findByTestId('vuln-software-drawer');
     expect(screen.queryByTestId('vuln-action-ticket')).toBeNull();
+  });
+
+  it('shows Reopen only on accepted/mitigated findings and calls the API', async () => {
+    vi.mocked(api.reopenVuln).mockResolvedValue(undefined as never);
+    const onActionComplete = vi.fn();
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={onActionComplete} onSelectCve={() => {}} />,
+    );
+    await screen.findByTestId('vuln-software-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-1')).toBeNull();      // open finding
+    fireEvent.click(screen.getByTestId('vuln-reopen-dv-2'));          // accepted finding
+    await waitFor(() => expect(api.reopenVuln).toHaveBeenCalledWith('dv-2'));
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+    expect(api.fetchSoftwareGroupDetail).toHaveBeenCalledTimes(2); // initial + reload
+  });
+
+  it('hides Reopen without vulnerabilities:accept_risk', async () => {
+    authState.permissions = [{ resource: 'devices', action: 'read' }];
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    await screen.findByTestId('vuln-software-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-2')).toBeNull();
+  });
+
+  it('select-all toggles between every finding and none, with indeterminate for partial selection', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    const selectAll = (await screen.findByTestId('vuln-select-all')) as HTMLInputElement;
+    // Pre-selection is open-only (dv-1 of 2) — partial, so indeterminate.
+    expect(selectAll.checked).toBe(false);
+    expect(selectAll.indeterminate).toBe(true);
+    expect(selectAll).toHaveAccessibleName('Select all findings');
+
+    fireEvent.click(selectAll); // partial → all
+    expect(screen.getByTestId('vuln-finding-check-dv-1')).toBeChecked();
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).toBeChecked();
+    expect(selectAll.checked).toBe(true);
+    expect(selectAll.indeterminate).toBe(false);
+    expect(selectAll).toHaveAccessibleName('Deselect all findings');
+
+    fireEvent.click(selectAll); // all → none
+    expect(screen.getByTestId('vuln-finding-check-dv-1')).not.toBeChecked();
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).not.toBeChecked();
+    expect(selectAll.checked).toBe(false);
+    expect(selectAll.indeterminate).toBe(false);
+    // Nothing selected — the bulk actions disable.
+    expect(screen.getByTestId('vuln-action-remediate')).toBeDisabled();
+  });
+
+  it('passes the selected devices (with CVE ids) to the bulk modal summary', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    // dv-1 (open) is pre-selected; the group context mixes CVEs so the CVE id is shown.
+    expect(screen.getByTestId('vuln-bulk-selection')).toHaveTextContent('WS-01 (CVE-2026-0001)');
+  });
+
+  it('hands focus to the By CVE tab before cross-navigating to the CVE drawer', async () => {
+    const onSelectCve = vi.fn();
+    render(
+      <div>
+        {/* Stand-in for the fleet page's persistent tab, which survives the drawer swap. */}
+        <button type="button" data-testid="vuln-tab-cves">
+          By CVE
+        </button>
+        <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={onSelectCve} />
+      </div>,
+    );
+    const cveLink = await screen.findByTestId('vuln-drawer-cve-CVE-2026-0001');
+    cveLink.focus();
+    fireEvent.click(cveLink);
+    expect(onSelectCve).toHaveBeenCalledWith('CVE-2026-0001');
+    // Focus moved off the soon-to-unmount link so the incoming CVE drawer
+    // captures a live focus-restore target.
+    expect(document.activeElement).toBe(screen.getByTestId('vuln-tab-cves'));
   });
 
   it('shows an inline retry on fetch failure', async () => {

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
@@ -40,7 +40,7 @@ const DETAIL: SoftwareGroupDetail = {
     maxEpss: 0.9,
     patchReadyFindingCount: 1,
     patchReadyDeviceCount: 1,
-    ticketIds: [],
+    tickets: [],
   },
   cves: [
     {
@@ -66,7 +66,9 @@ const DETAIL: SoftwareGroupDetail = {
       patchAvailable: true,
       riskScore: 95,
       detectedAt: '2026-06-01T00:00:00.000Z',
+      acceptedUntil: null,
       ticketId: null,
+      ticketNumber: null,
     },
     {
       deviceVulnerabilityId: 'dv-2',
@@ -79,7 +81,9 @@ const DETAIL: SoftwareGroupDetail = {
       patchAvailable: false,
       riskScore: 90,
       detectedAt: '2026-06-01T00:00:00.000Z',
+      acceptedUntil: '2026-08-01T12:00:00.000Z',
       ticketId: 't-9',
+      ticketNumber: 'T-2026-C009',
     },
   ],
 };
@@ -102,20 +106,45 @@ describe('SoftwareGroupDrawer', () => {
     expect(screen.getByTestId('vuln-finding-ticket-dv-2')).toBeInTheDocument();
   });
 
+  it('shows an empty message instead of a bare heading when the group has no findings', async () => {
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue({ ...DETAIL, findings: [] });
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-drawer-no-findings')).toHaveTextContent('No device findings remain in this group');
+    expect(screen.queryByTestId('vuln-finding-check-dv-1')).toBeNull();
+  });
+
   it('renders distinct testids for the group ticket chip and a per-finding ticket link that share a ticketId', async () => {
     const detailWithSharedTicket: SoftwareGroupDetail = {
       ...DETAIL,
-      group: { ...DETAIL.group, ticketIds: ['t-9'] },
+      group: { ...DETAIL.group, tickets: [{ id: 't-9', number: 'T-2026-C009' }] },
     };
     vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue(detailWithSharedTicket);
     render(
       <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
     );
     expect(await screen.findByTestId('vuln-software-drawer')).toHaveTextContent('Google Chrome');
-    // Group-level header chip (aggregate of group.ticketIds) — canonical vuln-ticket-chip-<ticketId>.
-    expect(screen.getByTestId('vuln-ticket-chip-t-9')).toBeInTheDocument();
+    // Group-level header chip (aggregate of group.tickets) — canonical vuln-ticket-chip-<ticketId>,
+    // labelled with the human ticket number, linking by number (TicketsPage resolves either).
+    const chip = screen.getByTestId('vuln-ticket-chip-t-9');
+    expect(chip).toHaveTextContent('Ticket T-2026-C009');
+    expect(chip).toHaveAttribute('href', '/tickets#T-2026-C009');
     // Per-finding inline link for the finding whose own ticketId is also t-9 — distinct testid, no collision.
-    expect(screen.getByTestId('vuln-finding-ticket-dv-2')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-finding-ticket-dv-2')).toHaveTextContent('T-2026-C009');
+  });
+
+  it('falls back to a generic chip label when the ticket has no human number', async () => {
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue({
+      ...DETAIL,
+      group: { ...DETAIL.group, tickets: [{ id: 't-9', number: null }] },
+    });
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    const chip = await screen.findByTestId('vuln-ticket-chip-t-9');
+    expect(chip).toHaveTextContent('View ticket');
+    expect(chip).toHaveAttribute('href', '/tickets#t-9');
   });
 
   it('accept-risk flow: opens modal, submits selected ids, reloads and notifies', async () => {
@@ -131,20 +160,79 @@ describe('SoftwareGroupDrawer', () => {
     await waitFor(() =>
       expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], {
         reason: 'compensating control',
-        acceptedUntil: new Date('2030-01-01T00:00:00Z').toISOString(),
+        // End of the picked day in the USER'S timezone (not UTC midnight, which
+        // is the previous local day west of UTC).
+        acceptedUntil: new Date(2030, 0, 1, 23, 59, 59, 999).toISOString(),
       }),
     );
     await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
     expect(api.fetchSoftwareGroupDetail).toHaveBeenCalledTimes(2); // initial + reload
   });
 
-  it('remediate acts on the selected findings', async () => {
+  it('remediate opens a confirmation with finding/device counts and only fires on confirm', async () => {
     vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
     render(
       <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
     );
     fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    // Nothing fired yet — the confirmation stands between the button and the mutation.
+    expect(api.remediateVuln).not.toHaveBeenCalled();
+    expect(screen.getByTestId('vuln-bulk-modal')).toHaveTextContent('Remediate findings — 1 finding');
+    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent('1 finding on 1 device');
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
     await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
+  });
+
+  it('surfaces a remediate failure inline in the confirmation modal (not just the toast)', async () => {
+    vi.mocked(api.remediateVuln).mockRejectedValue(new Error('No available patch mapped to these findings'));
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    // Modal stays open with the failure message inline.
+    expect(await screen.findByTestId('vuln-bulk-error')).toHaveTextContent('No available patch mapped to these findings');
+    expect(screen.getByTestId('vuln-bulk-modal')).toBeInTheDocument();
+    // Cancelling and reopening starts clean.
+    fireEvent.click(screen.getByTestId('vuln-bulk-cancel'));
+    fireEvent.click(screen.getByTestId('vuln-action-remediate'));
+    expect(screen.queryByTestId('vuln-bulk-error')).toBeNull();
+  });
+
+  it('pluralizes the devices meta line and findings heading', async () => {
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue({
+      ...DETAIL,
+      group: { ...DETAIL.group, deviceCount: 1 },
+      findings: [DETAIL.findings[0]!],
+    });
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    const drawer = await screen.findByTestId('vuln-software-drawer');
+    expect(drawer).toHaveTextContent('1 device ·');
+    expect(drawer).toHaveTextContent('Devices (1 finding)');
+    expect(drawer).not.toHaveTextContent('1 devices');
+    expect(drawer).not.toHaveTextContent('1 findings');
+  });
+
+  it('remediate confirmation can be cancelled without firing the mutation', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    fireEvent.click(screen.getByTestId('vuln-bulk-cancel'));
+    expect(screen.queryByTestId('vuln-bulk-modal')).toBeNull();
+    expect(api.remediateVuln).not.toHaveBeenCalled();
+  });
+
+  it('names each finding checkbox after its device for screen readers', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-finding-check-dv-1')).toHaveAttribute(
+      'aria-label',
+      'Select CVE-2026-0001 finding on WS-01',
+    );
   });
 
   it('hides permission-gated actions', async () => {

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
@@ -158,6 +158,34 @@ describe('SoftwareGroupDrawer', () => {
     expect(screen.queryByTestId('vuln-action-mitigate')).toBeNull();
   });
 
+  it('create-ticket flow: opens prefilled modal, submits, refreshes chips', async () => {
+    vi.mocked(api.createVulnTicket).mockResolvedValue({ success: true, tickets: [{ ticketId: 't-1', orgId: 'org-1', findingCount: 1 }], skipped: [] });
+    const onActionComplete = vi.fn();
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={onActionComplete} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-ticket'));
+    expect(screen.getByTestId('vuln-ticket-title')).toHaveValue('Remediate Google Chrome');
+    fireEvent.click(screen.getByTestId('vuln-ticket-submit'));
+    await waitFor(() =>
+      expect(api.createVulnTicket).toHaveBeenCalledWith(['dv-1'], expect.objectContaining({ title: 'Remediate Google Chrome', priority: 'normal' })),
+    );
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+  });
+
+  it('hides Create ticket without tickets:write', async () => {
+    authState.permissions = [
+      { resource: 'devices', action: 'execute' },
+      { resource: 'vulnerabilities', action: 'accept_risk' },
+      { resource: 'devices', action: 'write' },
+    ];
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    await screen.findByTestId('vuln-software-drawer');
+    expect(screen.queryByTestId('vuln-action-ticket')).toBeNull();
+  });
+
   it('shows an inline retry on fetch failure', async () => {
     vi.mocked(api.fetchSoftwareGroupDetail).mockRejectedValueOnce(new Error('boom'));
     render(

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchSoftwareGroupDetail: vi.fn(),
+  remediateVuln: vi.fn(),
+  bulkAcceptVulnRisk: vi.fn(),
+  bulkMitigateVulns: vi.fn(),
+  createVulnTicket: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { SoftwareGroupDrawer } from './SoftwareGroupDrawer';
+import type { SoftwareGroupDetail } from '../../lib/api/vulnerabilities';
+
+const DETAIL: SoftwareGroupDetail = {
+  group: {
+    groupKey: 'sw:google chrome|google llc',
+    kind: 'software',
+    name: 'Google Chrome',
+    vendor: 'Google LLC',
+    versions: ['126.0'],
+    deviceCount: 2,
+    cveCount: 1,
+    cveIds: ['CVE-2026-0001'],
+    worstSeverity: 'critical',
+    maxRiskScore: 95,
+    kevCveCount: 1,
+    maxEpss: 0.9,
+    patchReadyFindingCount: 1,
+    patchReadyDeviceCount: 1,
+    ticketIds: [],
+  },
+  cves: [
+    {
+      cveId: 'CVE-2026-0001',
+      vulnerabilityId: 'v-1',
+      severity: 'critical',
+      cvssScore: 9.1,
+      epssScore: 0.9,
+      knownExploited: true,
+      patchAvailable: true,
+      maxRiskScore: 95,
+    },
+  ],
+  findings: [
+    {
+      deviceVulnerabilityId: 'dv-1',
+      deviceId: 'dev-1',
+      deviceName: 'WS-01',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'open',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+    {
+      deviceVulnerabilityId: 'dv-2',
+      deviceId: 'dev-2',
+      deviceName: 'WS-02',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'accepted',
+      patchAvailable: false,
+      riskScore: 90,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: 't-9',
+    },
+  ],
+};
+
+describe('SoftwareGroupDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue(DETAIL);
+  });
+
+  it('renders header, CVE list, and device findings with open findings pre-selected', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-software-drawer')).toHaveTextContent('Google Chrome');
+    expect(screen.getByTestId('vuln-drawer-cve-CVE-2026-0001')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-finding-check-dv-1')).toBeChecked();       // open — pre-selected
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).not.toBeChecked();   // accepted — not pre-selected
+    expect(screen.getByTestId('vuln-ticket-chip-t-9')).toBeInTheDocument();
+  });
+
+  it('accept-risk flow: opens modal, submits selected ids, reloads and notifies', async () => {
+    vi.mocked(api.bulkAcceptVulnRisk).mockResolvedValue({ success: true, succeeded: 1, skipped: [] });
+    const onActionComplete = vi.fn();
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={onActionComplete} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'compensating control' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() =>
+      expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], {
+        reason: 'compensating control',
+        acceptedUntil: new Date('2030-01-01T00:00:00Z').toISOString(),
+      }),
+    );
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+    expect(api.fetchSoftwareGroupDetail).toHaveBeenCalledTimes(2); // initial + reload
+  });
+
+  it('remediate acts on the selected findings', async () => {
+    vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
+  });
+
+  it('hides permission-gated actions', async () => {
+    authState.permissions = [{ resource: 'devices', action: 'read' }];
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    await screen.findByTestId('vuln-software-drawer');
+    expect(screen.queryByTestId('vuln-action-remediate')).toBeNull();
+    expect(screen.queryByTestId('vuln-action-accept')).toBeNull();
+    expect(screen.queryByTestId('vuln-action-mitigate')).toBeNull();
+  });
+
+  it('shows an inline retry on fetch failure', async () => {
+    vi.mocked(api.fetchSoftwareGroupDetail).mockRejectedValueOnce(new Error('boom'));
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-drawer-error')).toHaveTextContent('boom');
+    fireEvent.click(screen.getByTestId('vuln-drawer-retry'));
+    expect(await screen.findByTestId('vuln-finding-check-dv-1')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -188,7 +188,11 @@ export function SoftwareGroupDrawer({
                     <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
                     <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
                     {f.ticketId && (
-                      <a href={`/tickets#${f.ticketId}`} data-testid={`vuln-ticket-chip-${f.ticketId}`} className="text-xs underline">
+                      <a
+                        href={`/tickets#${f.ticketId}`}
+                        data-testid={`vuln-finding-ticket-${f.deviceVulnerabilityId}`}
+                        className="text-xs underline"
+                      >
                         Ticket
                       </a>
                     )}

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -16,6 +16,7 @@ import {
   createVulnTicket,
   fetchSoftwareGroupDetail,
   remediateVuln,
+  reopenVuln,
   type SoftwareGroupDetail,
 } from '../../lib/api/vulnerabilities';
 
@@ -40,7 +41,7 @@ export function SoftwareGroupDrawer({
   const [detail, setDetail] = useState<SoftwareGroupDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | null>(null);
+  const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | 'reopen' | null>(null);
   const [modal, setModal] = useState<'remediate' | 'accept' | 'mitigate' | null>(null);
   // Inline failure message for the bulk-action modal (in addition to the
   // toast, which is easy to miss while the modal stays open).
@@ -83,9 +84,16 @@ export function SoftwareGroupDrawer({
   };
 
   const selectedIds = [...selected];
-  const selectedDeviceCount = detail
-    ? new Set(detail.findings.filter((f) => selected.has(f.deviceVulnerabilityId)).map((f) => f.deviceId)).size
-    : 0;
+  const selectedFindings = detail ? detail.findings.filter((f) => selected.has(f.deviceVulnerabilityId)) : [];
+  const selectedDeviceCount = new Set(selectedFindings.map((f) => f.deviceId)).size;
+
+  // All/none toggle for the pre-checked findings list — deselecting a large
+  // pre-selection one checkbox at a time is unreasonable.
+  const allSelected = detail !== null && detail.findings.length > 0 && detail.findings.every((f) => selected.has(f.deviceVulnerabilityId));
+  const toggleAll = () => {
+    if (!detail) return;
+    setSelected(allSelected ? new Set() : new Set(detail.findings.map((f) => f.deviceVulnerabilityId)));
+  };
 
   const runBulk = useCallback(
     async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
@@ -107,6 +115,28 @@ export function SoftwareGroupDrawer({
     },
     // selectedIds is derived from `selected`; depend on the source set.
     [busy, selected, load, onActionComplete],
+  );
+
+  // Per-finding Reopen for accepted/mitigated rows — same behavior as the CVE
+  // drawer, so a tech reviewing a waiver in the software view doesn't have to
+  // re-find the finding under By CVE.
+  const onReopen = useCallback(
+    async (id: string) => {
+      if (busy || busyRef.current) return;
+      busyRef.current = true;
+      setBusy('reopen');
+      try {
+        await reopenVuln(id);
+        await load();
+        onActionComplete();
+      } catch (err) {
+        handleActionError(err, 'Failed to reopen finding');
+      } finally {
+        busyRef.current = false;
+        setBusy(null);
+      }
+    },
+    [busy, load, onActionComplete],
   );
 
   const title = detail ? (
@@ -169,7 +199,16 @@ export function SoftwareGroupDrawer({
                       type="button"
                       data-testid={`vuln-drawer-cve-${cve.cveId}`}
                       className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-muted/40"
-                      onClick={() => onSelectCve(cve.cveId)}
+                      onClick={() => {
+                        // Cross-nav to the CVE drawer unmounts this drawer AND the
+                        // By-software tab content, so the new drawer would capture a
+                        // soon-to-be-detached element as its focus-restore target and
+                        // Escape would strand focus. Hand focus to the persistent
+                        // "By CVE" tab first so Escape restores somewhere real. No-op
+                        // when this drawer is rendered outside the fleet page.
+                        document.querySelector<HTMLElement>('[data-testid="vuln-tab-cves"]')?.focus();
+                        onSelectCve(cve.cveId);
+                      }}
                     >
                       <span className="font-medium">{cve.cveId}</span>
                       <span className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -185,9 +224,28 @@ export function SoftwareGroupDrawer({
             </section>
 
             <section>
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Devices ({plural(detail.findings.length, 'finding')})
-              </h3>
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Devices ({plural(detail.findings.length, 'finding')})
+                </h3>
+                {detail.findings.length > 0 && (
+                  <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+                    <input
+                      type="checkbox"
+                      data-testid="vuln-select-all"
+                      aria-label={allSelected ? 'Deselect all findings' : 'Select all findings'}
+                      checked={allSelected}
+                      // Native indeterminate has no attribute form — set it via ref.
+                      ref={(el) => {
+                        if (el) el.indeterminate = !allSelected && selected.size > 0;
+                      }}
+                      onChange={toggleAll}
+                      className="h-4 w-4 rounded border"
+                    />
+                    Select all
+                  </label>
+                )}
+              </div>
               {detail.findings.length === 0 ? (
                 // Reachable when every finding was resolved (or moved out of the
                 // caller's scope) between the list loading and the drawer opening.
@@ -225,6 +283,17 @@ export function SoftwareGroupDrawer({
                       >
                         {f.ticketNumber ?? 'Ticket'}
                       </a>
+                    )}
+                    {canAcceptRisk && (f.status === 'accepted' || f.status === 'mitigated') && (
+                      <button
+                        type="button"
+                        data-testid={`vuln-reopen-${f.deviceVulnerabilityId}`}
+                        className="text-xs font-medium text-primary hover:underline disabled:opacity-50"
+                        disabled={busy !== null}
+                        onClick={() => void onReopen(f.deviceVulnerabilityId)}
+                      >
+                        Reopen
+                      </button>
                     )}
                   </li>
                 ))}
@@ -299,6 +368,9 @@ export function SoftwareGroupDrawer({
           kind={modal}
           count={selectedIds.length}
           deviceCount={selectedDeviceCount}
+          // Software groups span CVEs — include the CVE id per device so the
+          // summary says which finding, not just which machine.
+          selection={selectedFindings.map((f) => ({ deviceName: f.deviceName, cveId: f.cveId }))}
           busy={busy !== null}
           errorMessage={modalError}
           onCancel={() => {

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Drawer } from '../shared/Drawer';
 import { SeverityBadge } from './SeverityBadge';
+import { KevBadge } from './KevBadge';
+import { CVSS_EXPLANATION, EPSS_EXPLANATION } from './vulnExplanations';
+import { FindingStatus } from './FindingStatus';
 import { VulnBulkActionModal } from './VulnBulkActionModal';
 import { CreateVulnTicketModal } from './CreateVulnTicketModal';
 import { usePermissions } from '../../lib/permissions';
 import { handleActionError } from '../../lib/runAction';
+import { plural } from '../../lib/utils';
 import {
   bulkAcceptVulnRisk,
   bulkMitigateVulns,
@@ -37,8 +41,14 @@ export function SoftwareGroupDrawer({
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | null>(null);
-  const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+  const [modal, setModal] = useState<'remediate' | 'accept' | 'mitigate' | null>(null);
+  // Inline failure message for the bulk-action modal (in addition to the
+  // toast, which is easy to miss while the modal stays open).
+  const [modalError, setModalError] = useState<string | null>(null);
   const [ticketModal, setTicketModal] = useState(false);
+  // Synchronous double-submission guard: `busy` state lags one render behind,
+  // so a rapid double-activation could fire the mutation twice without this.
+  const busyRef = useRef(false);
 
   const { can } = usePermissions();
   const canRemediate = can('devices', 'execute');
@@ -73,10 +83,14 @@ export function SoftwareGroupDrawer({
   };
 
   const selectedIds = [...selected];
+  const selectedDeviceCount = detail
+    ? new Set(detail.findings.filter((f) => selected.has(f.deviceVulnerabilityId)).map((f) => f.deviceId)).size
+    : 0;
 
   const runBulk = useCallback(
     async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
-      if (busy || selectedIds.length === 0) return;
+      if (busy || busyRef.current || selectedIds.length === 0) return;
+      busyRef.current = true;
       setBusy(kind);
       try {
         await action();
@@ -85,7 +99,9 @@ export function SoftwareGroupDrawer({
         onActionComplete();
       } catch (err) {
         handleActionError(err, fallback);
+        setModalError(err instanceof Error && err.message ? err.message : fallback);
       } finally {
+        busyRef.current = false;
         setBusy(null);
       }
     },
@@ -97,11 +113,7 @@ export function SoftwareGroupDrawer({
     <span className="flex min-w-0 items-center gap-2">
       <span className="truncate">{detail.group.name}</span>
       <SeverityBadge severity={detail.group.worstSeverity} />
-      {detail.group.kevCveCount > 0 && (
-        <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-          KEV
-        </span>
-      )}
+      {detail.group.kevCveCount > 0 && <KevBadge />}
     </span>
   ) : (
     'Software group'
@@ -125,21 +137,24 @@ export function SoftwareGroupDrawer({
         {detail && (
           <>
             <div className="text-sm text-muted-foreground">
-              {[detail.group.vendor, `${detail.group.deviceCount} devices`, `max risk ${detail.group.maxRiskScore ?? '—'}`]
+              {/* Round the risk score the same way the tables do, so the same
+                  number never shows two different values. */}
+              {[detail.group.vendor, plural(detail.group.deviceCount, 'device'), `max risk ${detail.group.maxRiskScore === null ? '—' : Math.round(detail.group.maxRiskScore)}`]
                 .filter(Boolean)
                 .join(' · ')}
             </div>
 
-            {detail.group.ticketIds.length > 0 && (
+            {detail.group.tickets.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {detail.group.ticketIds.map((tid) => (
+                {detail.group.tickets.map((t) => (
                   <a
-                    key={tid}
-                    href={`/tickets#${tid}`}
-                    data-testid={`vuln-ticket-chip-${tid}`}
+                    key={t.id}
+                    // TicketsPage resolves the hash by internalNumber or id.
+                    href={`/tickets#${t.number ?? t.id}`}
+                    data-testid={`vuln-ticket-chip-${t.id}`}
                     className="inline-flex items-center rounded-full border bg-muted/40 px-2.5 py-1 text-xs font-medium hover:bg-muted"
                   >
-                    Ticket · {tid.slice(0, 8)}
+                    {t.number ? `Ticket ${t.number}` : 'View ticket'}
                   </a>
                 ))}
               </div>
@@ -159,9 +174,9 @@ export function SoftwareGroupDrawer({
                       <span className="font-medium">{cve.cveId}</span>
                       <span className="flex items-center gap-2 text-xs text-muted-foreground">
                         <SeverityBadge severity={cve.severity} />
-                        <span className="tabular-nums">CVSS {cve.cvssScore ?? '—'}</span>
-                        <span className="tabular-nums">EPSS {fmtEpss(cve.epssScore)}</span>
-                        {cve.knownExploited && <span className="font-semibold text-red-600">KEV</span>}
+                        <span className="tabular-nums" title={CVSS_EXPLANATION}>CVSS {cve.cvssScore ?? '—'}</span>
+                        <span className="tabular-nums" title={EPSS_EXPLANATION}>EPSS {fmtEpss(cve.epssScore)}</span>
+                        {cve.knownExploited && <KevBadge />}
                       </span>
                     </button>
                   </li>
@@ -171,14 +186,25 @@ export function SoftwareGroupDrawer({
 
             <section>
               <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Devices ({detail.findings.length} findings)
+                Devices ({plural(detail.findings.length, 'finding')})
               </h3>
+              {detail.findings.length === 0 ? (
+                // Reachable when every finding was resolved (or moved out of the
+                // caller's scope) between the list loading and the drawer opening.
+                <p
+                  data-testid="vuln-drawer-no-findings"
+                  className="mt-2 rounded-md border border-dashed px-3 py-4 text-center text-xs text-muted-foreground"
+                >
+                  No device findings remain in this group — nothing to act on.
+                </p>
+              ) : (
               <ul className="mt-2 divide-y rounded-md border">
                 {detail.findings.map((f) => (
                   <li key={f.deviceVulnerabilityId} className="flex items-center gap-3 px-3 py-2 text-sm">
                     <input
                       type="checkbox"
                       data-testid={`vuln-finding-check-${f.deviceVulnerabilityId}`}
+                      aria-label={`Select ${f.cveId} finding on ${f.deviceName}`}
                       checked={selected.has(f.deviceVulnerabilityId)}
                       onChange={() => toggle(f.deviceVulnerabilityId)}
                       className="h-4 w-4 rounded border"
@@ -189,20 +215,21 @@ export function SoftwareGroupDrawer({
                         {[f.orgName, f.cveId].filter(Boolean).join(' · ')}
                       </span>
                     </span>
-                    <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
+                    <FindingStatus status={f.status} acceptedUntil={f.acceptedUntil} />
                     <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
                     {f.ticketId && (
                       <a
-                        href={`/tickets#${f.ticketId}`}
+                        href={`/tickets#${f.ticketNumber ?? f.ticketId}`}
                         data-testid={`vuln-finding-ticket-${f.deviceVulnerabilityId}`}
                         className="text-xs underline"
                       >
-                        Ticket
+                        {f.ticketNumber ?? 'Ticket'}
                       </a>
                     )}
                   </li>
                 ))}
               </ul>
+              )}
             </section>
           </>
         )}
@@ -217,7 +244,10 @@ export function SoftwareGroupDrawer({
               data-testid="vuln-action-remediate"
               className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation')}
+              onClick={() => {
+                setModalError(null);
+                setModal('remediate');
+              }}
             >
               Remediate
             </button>
@@ -228,7 +258,10 @@ export function SoftwareGroupDrawer({
               data-testid="vuln-action-accept"
               className={ACTION_BTN}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => setModal('accept')}
+              onClick={() => {
+                setModalError(null);
+                setModal('accept');
+              }}
             >
               Accept risk
             </button>
@@ -239,7 +272,10 @@ export function SoftwareGroupDrawer({
               data-testid="vuln-action-mitigate"
               className={ACTION_BTN}
               disabled={busy !== null || selectedIds.length === 0}
-              onClick={() => setModal('mitigate')}
+              onClick={() => {
+                setModalError(null);
+                setModal('mitigate');
+              }}
             >
               Mitigate
             </button>
@@ -262,10 +298,18 @@ export function SoftwareGroupDrawer({
         <VulnBulkActionModal
           kind={modal}
           count={selectedIds.length}
+          deviceCount={selectedDeviceCount}
           busy={busy !== null}
-          onCancel={() => setModal(null)}
+          errorMessage={modalError}
+          onCancel={() => {
+            setModal(null);
+            setModalError(null);
+          }}
           onSubmit={(payload) => {
-            if (modal === 'accept') {
+            setModalError(null);
+            if (modal === 'remediate') {
+              void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation');
+            } else if (modal === 'accept') {
               void runBulk(
                 'accept',
                 () => bulkAcceptVulnRisk(selectedIds, { reason: payload.reason ?? '', acceptedUntil: payload.acceptedUntil ?? '' }),

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { Drawer } from '../shared/Drawer';
+import { SeverityBadge } from './SeverityBadge';
+import { VulnBulkActionModal } from './VulnBulkActionModal';
+import { usePermissions } from '../../lib/permissions';
+import { handleActionError } from '../../lib/runAction';
+import {
+  bulkAcceptVulnRisk,
+  bulkMitigateVulns,
+  fetchSoftwareGroupDetail,
+  remediateVuln,
+  type SoftwareGroupDetail,
+} from '../../lib/api/vulnerabilities';
+
+const ACTION_BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50';
+
+function fmtEpss(value: number | null): string {
+  return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
+
+export function SoftwareGroupDrawer({
+  groupKey,
+  onClose,
+  onActionComplete,
+  onSelectCve,
+}: {
+  groupKey: string;
+  onClose: () => void;
+  onActionComplete: () => void;
+  onSelectCve: (cveId: string) => void;
+}) {
+  const [detail, setDetail] = useState<SoftwareGroupDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | null>(null);
+  const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+
+  const { can } = usePermissions();
+  const canRemediate = can('devices', 'execute');
+  const canAcceptRisk = can('vulnerabilities', 'accept_risk');
+  const canMitigate = can('devices', 'write');
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const d = await fetchSoftwareGroupDetail(groupKey);
+      setDetail(d);
+      // Open findings are the actionable ones — pre-select them (spec: all selected by default).
+      setSelected(new Set(d.findings.filter((f) => f.status === 'open').map((f) => f.deviceVulnerabilityId)));
+    } catch (err) {
+      setDetail(null);
+      setError(err instanceof Error ? err.message : 'Failed to load software group');
+    }
+  }, [groupKey]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectedIds = [...selected];
+
+  const runBulk = useCallback(
+    async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
+      if (busy || selectedIds.length === 0) return;
+      setBusy(kind);
+      try {
+        await action();
+        setModal(null);
+        await load();
+        onActionComplete();
+      } catch (err) {
+        handleActionError(err, fallback);
+      } finally {
+        setBusy(null);
+      }
+    },
+    // selectedIds is derived from `selected`; depend on the source set.
+    [busy, selected, load, onActionComplete],
+  );
+
+  const title = detail ? (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{detail.group.name}</span>
+      <SeverityBadge severity={detail.group.worstSeverity} />
+      {detail.group.kevCveCount > 0 && (
+        <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+          KEV
+        </span>
+      )}
+    </span>
+  ) : (
+    'Software group'
+  );
+
+  return (
+    <Drawer open onClose={onClose} title={title} width="max-w-xl" dataTestId="vuln-software-drawer" closeDisabled={busy !== null}>
+      <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+        {error && (
+          <div
+            data-testid="vuln-drawer-error"
+            className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+          >
+            <p>{error}</p>
+            <button type="button" data-testid="vuln-drawer-retry" className="mt-2 text-sm font-medium underline" onClick={() => void load()}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {detail && (
+          <>
+            <div className="text-sm text-muted-foreground">
+              {[detail.group.vendor, `${detail.group.deviceCount} devices`, `max risk ${detail.group.maxRiskScore ?? '—'}`]
+                .filter(Boolean)
+                .join(' · ')}
+            </div>
+
+            {detail.group.ticketIds.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {detail.group.ticketIds.map((tid) => (
+                  <a
+                    key={tid}
+                    href={`/tickets#${tid}`}
+                    data-testid={`vuln-ticket-chip-${tid}`}
+                    className="inline-flex items-center rounded-full border bg-muted/40 px-2.5 py-1 text-xs font-medium hover:bg-muted"
+                  >
+                    Ticket · {tid.slice(0, 8)}
+                  </a>
+                ))}
+              </div>
+            )}
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">CVEs ({detail.cves.length})</h3>
+              <ul className="mt-2 divide-y rounded-md border">
+                {detail.cves.map((cve) => (
+                  <li key={cve.cveId}>
+                    <button
+                      type="button"
+                      data-testid={`vuln-drawer-cve-${cve.cveId}`}
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-muted/40"
+                      onClick={() => onSelectCve(cve.cveId)}
+                    >
+                      <span className="font-medium">{cve.cveId}</span>
+                      <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <SeverityBadge severity={cve.severity} />
+                        <span className="tabular-nums">CVSS {cve.cvssScore ?? '—'}</span>
+                        <span className="tabular-nums">EPSS {fmtEpss(cve.epssScore)}</span>
+                        {cve.knownExploited && <span className="font-semibold text-red-600">KEV</span>}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Devices ({detail.findings.length} findings)
+              </h3>
+              <ul className="mt-2 divide-y rounded-md border">
+                {detail.findings.map((f) => (
+                  <li key={f.deviceVulnerabilityId} className="flex items-center gap-3 px-3 py-2 text-sm">
+                    <input
+                      type="checkbox"
+                      data-testid={`vuln-finding-check-${f.deviceVulnerabilityId}`}
+                      checked={selected.has(f.deviceVulnerabilityId)}
+                      onChange={() => toggle(f.deviceVulnerabilityId)}
+                      className="h-4 w-4 rounded border"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{f.deviceName}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {[f.orgName, f.cveId].filter(Boolean).join(' · ')}
+                      </span>
+                    </span>
+                    <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
+                    <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
+                    {f.ticketId && (
+                      <a href={`/tickets#${f.ticketId}`} data-testid={`vuln-ticket-chip-${f.ticketId}`} className="text-xs underline">
+                        Ticket
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </>
+        )}
+      </div>
+
+      {detail && (
+        <div className="flex flex-wrap items-center gap-2 border-t px-5 py-3">
+          <span className="mr-auto text-xs text-muted-foreground">{selectedIds.length} selected</span>
+          {canRemediate && (
+            <button
+              type="button"
+              data-testid="vuln-action-remediate"
+              className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation')}
+            >
+              Remediate
+            </button>
+          )}
+          {canAcceptRisk && (
+            <button
+              type="button"
+              data-testid="vuln-action-accept"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('accept')}
+            >
+              Accept risk
+            </button>
+          )}
+          {canMitigate && (
+            <button
+              type="button"
+              data-testid="vuln-action-mitigate"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('mitigate')}
+            >
+              Mitigate
+            </button>
+          )}
+        </div>
+      )}
+
+      {modal && (
+        <VulnBulkActionModal
+          kind={modal}
+          count={selectedIds.length}
+          busy={busy !== null}
+          onCancel={() => setModal(null)}
+          onSubmit={(payload) => {
+            if (modal === 'accept') {
+              void runBulk(
+                'accept',
+                () => bulkAcceptVulnRisk(selectedIds, { reason: payload.reason ?? '', acceptedUntil: payload.acceptedUntil ?? '' }),
+                'Failed to accept risk',
+              );
+            } else {
+              void runBulk('mitigate', () => bulkMitigateVulns(selectedIds, { note: payload.note ?? '' }), 'Failed to mitigate');
+            }
+          }}
+        />
+      )}
+    </Drawer>
+  );
+}
+
+export default SoftwareGroupDrawer;

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -62,7 +62,7 @@ export function SoftwareGroupDrawer({
     try {
       const d = await fetchSoftwareGroupDetail(groupKey);
       setDetail(d);
-      // Open findings are the actionable ones — pre-select them (spec: all selected by default).
+      // Pre-select only OPEN findings — they're the actionable ones; accepted/mitigated/patched rows start unchecked.
       setSelected(new Set(d.findings.filter((f) => f.status === 'open').map((f) => f.deviceVulnerabilityId)));
     } catch (err) {
       setDetail(null);

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx
@@ -3,11 +3,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { Drawer } from '../shared/Drawer';
 import { SeverityBadge } from './SeverityBadge';
 import { VulnBulkActionModal } from './VulnBulkActionModal';
+import { CreateVulnTicketModal } from './CreateVulnTicketModal';
 import { usePermissions } from '../../lib/permissions';
 import { handleActionError } from '../../lib/runAction';
 import {
   bulkAcceptVulnRisk,
   bulkMitigateVulns,
+  createVulnTicket,
   fetchSoftwareGroupDetail,
   remediateVuln,
   type SoftwareGroupDetail,
@@ -36,11 +38,13 @@ export function SoftwareGroupDrawer({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | null>(null);
   const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+  const [ticketModal, setTicketModal] = useState(false);
 
   const { can } = usePermissions();
   const canRemediate = can('devices', 'execute');
   const canAcceptRisk = can('vulnerabilities', 'accept_risk');
   const canMitigate = can('devices', 'write');
+  const canCreateTicket = can('tickets', 'write');
 
   const load = useCallback(async () => {
     setError(null);
@@ -240,6 +244,17 @@ export function SoftwareGroupDrawer({
               Mitigate
             </button>
           )}
+          {canCreateTicket && (
+            <button
+              type="button"
+              data-testid="vuln-action-ticket"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setTicketModal(true)}
+            >
+              Create ticket
+            </button>
+          )}
         </div>
       )}
 
@@ -259,6 +274,19 @@ export function SoftwareGroupDrawer({
             } else {
               void runBulk('mitigate', () => bulkMitigateVulns(selectedIds, { note: payload.note ?? '' }), 'Failed to mitigate');
             }
+          }}
+        />
+      )}
+
+      {ticketModal && detail && (
+        <CreateVulnTicketModal
+          findings={detail.findings.filter((f) => selected.has(f.deviceVulnerabilityId))}
+          defaultTitle={`Remediate ${detail.group.name}`}
+          busy={busy !== null}
+          onCancel={() => setTicketModal(false)}
+          onSubmit={(payload) => {
+            setTicketModal(false);
+            void runBulk('ticket', () => createVulnTicket(selectedIds, payload), 'Failed to create ticket');
           }}
         />
       )}

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx
@@ -27,7 +27,7 @@ function group(overrides: Partial<SoftwareGroup> = {}): SoftwareGroup {
     maxEpss: 0.9,
     patchReadyFindingCount: 12,
     patchReadyDeviceCount: 12,
-    ticketIds: [],
+    tickets: [],
     ...overrides,
   };
 }
@@ -38,8 +38,15 @@ describe('SoftwareGroupTable', () => {
     vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [group()], hasMore: false });
   });
 
+  it('explains the Risk column via a header help tooltip', async () => {
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(desktop.getByRole('button', { name: 'About the risk score' }));
+    expect(desktop.getByRole('tooltip')).toHaveTextContent('Higher = fix sooner');
+  });
+
   it('renders one row per group with patch readiness and KEV flag', async () => {
-    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     const row = desktop.getByTestId('software-group-row-sw:google chrome|google llc');
     expect(row).toHaveTextContent('Google Chrome');
@@ -50,22 +57,51 @@ describe('SoftwareGroupTable', () => {
 
   it('invokes onSelectGroup with the groupKey on row click', async () => {
     const onSelect = vi.fn();
-    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={onSelect} onClearFilters={() => {}} />);
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={onSelect} onClearFilters={() => {}} />);
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     fireEvent.click(desktop.getByTestId('software-group-row-sw:google chrome|google llc'));
     expect(onSelect).toHaveBeenCalledWith('sw:google chrome|google llc');
   });
 
+  it('exposes a keyboard-activatable button in the primary cell (single activation)', async () => {
+    const onSelect = vi.fn();
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={onSelect} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const openBtn = desktop.getByTestId('software-group-open-sw:google chrome|google llc');
+    expect(openBtn.tagName).toBe('BUTTON'); // real button => focusable + Enter/Space for free
+    expect(openBtn).toHaveAccessibleName('Open Google Chrome vulnerability details');
+    fireEvent.click(openBtn); // Enter/Space on a native button dispatches click
+    expect(onSelect).toHaveBeenCalledTimes(1); // stopPropagation: no double fire via the row handler
+    expect(onSelect).toHaveBeenCalledWith('sw:google chrome|google llc');
+  });
+
   it('refetches when filters or refreshKey change', async () => {
     const { rerender } = render(
-      <SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+      <SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />,
     );
     await screen.findByTestId('responsive-table-desktop');
     rerender(
-      <SoftwareGroupTable filters={{ ...FILTERS, severity: 'critical' }} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+      <SoftwareGroupTable filters={{ ...FILTERS, severity: 'critical' }} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />,
     );
     await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalledTimes(2));
     expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'critical' }));
+  });
+
+  it('renders skeleton rows under the header while the first fetch is in flight', async () => {
+    let resolve!: (v: { items: SoftwareGroup[]; hasMore: boolean }) => void;
+    vi.mocked(api.fetchSoftwareGroups).mockReturnValue(new Promise((r) => { resolve = r; }));
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    expect(screen.getByTestId('software-group-table-skeleton')).toBeInTheDocument();
+    resolve({ items: [group()], hasMore: false });
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(await desktop.findByTestId('software-group-row-sw:google chrome|google llc')).toBeInTheDocument();
+    expect(screen.queryByTestId('software-group-table-skeleton')).toBeNull();
+  });
+
+  it('shows the truncation notice when the server reports more groups than the cap', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [group()], hasMore: true });
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    expect(await screen.findByTestId('software-group-has-more')).toHaveTextContent('top 500 groups');
   });
 
   it('shows the filtered-empty state with a clear-filters link', async () => {
@@ -74,18 +110,53 @@ describe('SoftwareGroupTable', () => {
     render(
       <SoftwareGroupTable
         filters={{ ...FILTERS, severity: 'low' }}
-        refreshKey={0}
+        refreshKey={0} emptyVariant="filtered"
         onSelectGroup={() => {}}
         onClearFilters={onClear}
       />,
     );
-    fireEvent.click(await screen.findByTestId('software-group-clear-filters'));
+    expect(await screen.findByTestId('vuln-empty-filtered')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('software-group-clear-filters'));
     expect(onClear).toHaveBeenCalled();
+  });
+
+  it('renders the clean-fleet and unscanned zero-states when the page resolves them', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
+    const { rerender } = render(
+      <SoftwareGroupTable
+        filters={FILTERS}
+        refreshKey={0} emptyVariant="clean"
+        lastDetectedAt="2026-06-30T00:00:00.000Z"
+        onSelectGroup={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    expect(await screen.findByTestId('vuln-empty-clean')).toHaveTextContent('No open vulnerabilities across your fleet');
+    rerender(
+      <SoftwareGroupTable
+        filters={FILTERS}
+        refreshKey={0} emptyVariant="unscanned"
+        onSelectGroup={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    expect(await screen.findByTestId('vuln-empty-unscanned')).toHaveTextContent('No vulnerability findings yet');
   });
 
   it('shows the error state on fetch failure', async () => {
     vi.mocked(api.fetchSoftwareGroups).mockRejectedValue(new Error('boom'));
-    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
     expect(await screen.findByTestId('software-group-table-error')).toHaveTextContent('boom');
+  });
+
+  it('recovers from a fetch failure via the Retry button', async () => {
+    vi.mocked(api.fetchSoftwareGroups)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ items: [group()], hasMore: false });
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    fireEvent.click(await screen.findByTestId('software-group-table-retry'));
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(desktop.getByTestId('software-group-row-sw:google chrome|google llc')).toBeInTheDocument();
+    expect(api.fetchSoftwareGroups).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchSoftwareGroups: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { SoftwareGroupTable } from './SoftwareGroupTable';
+import type { SoftwareGroup, VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const FILTERS: VulnFleetFilters = { search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false };
+
+function group(overrides: Partial<SoftwareGroup> = {}): SoftwareGroup {
+  return {
+    groupKey: 'sw:google chrome|google llc',
+    kind: 'software',
+    name: 'Google Chrome',
+    vendor: 'Google LLC',
+    versions: ['125.0', '126.0'],
+    deviceCount: 14,
+    cveCount: 6,
+    cveIds: ['CVE-2026-0001'],
+    worstSeverity: 'critical',
+    maxRiskScore: 95,
+    kevCveCount: 1,
+    maxEpss: 0.9,
+    patchReadyFindingCount: 12,
+    patchReadyDeviceCount: 12,
+    ticketIds: [],
+    ...overrides,
+  };
+}
+
+describe('SoftwareGroupTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [group()], hasMore: false });
+  });
+
+  it('renders one row per group with patch readiness and KEV flag', async () => {
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const row = desktop.getByTestId('software-group-row-sw:google chrome|google llc');
+    expect(row).toHaveTextContent('Google Chrome');
+    expect(row).toHaveTextContent('Google LLC');
+    expect(row).toHaveTextContent('Ready · 12/14 devices');
+    expect(row).toHaveTextContent('KEV');
+  });
+
+  it('invokes onSelectGroup with the groupKey on row click', async () => {
+    const onSelect = vi.fn();
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={onSelect} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(desktop.getByTestId('software-group-row-sw:google chrome|google llc'));
+    expect(onSelect).toHaveBeenCalledWith('sw:google chrome|google llc');
+  });
+
+  it('refetches when filters or refreshKey change', async () => {
+    const { rerender } = render(
+      <SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+    );
+    await screen.findByTestId('responsive-table-desktop');
+    rerender(
+      <SoftwareGroupTable filters={{ ...FILTERS, severity: 'critical' }} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+    );
+    await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalledTimes(2));
+    expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'critical' }));
+  });
+
+  it('shows the filtered-empty state with a clear-filters link', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
+    const onClear = vi.fn();
+    render(
+      <SoftwareGroupTable
+        filters={{ ...FILTERS, severity: 'low' }}
+        refreshKey={0}
+        onSelectGroup={() => {}}
+        onClearFilters={onClear}
+      />,
+    );
+    fireEvent.click(await screen.findByTestId('software-group-clear-filters'));
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('shows the error state on fetch failure', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockRejectedValue(new Error('boom'));
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    expect(await screen.findByTestId('software-group-table-error')).toHaveTextContent('boom');
+  });
+});

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import { SeverityBadge } from './SeverityBadge';
+import {
+  fetchSoftwareGroups,
+  type SoftwareGroup,
+  type VulnFleetFilters,
+} from '../../lib/api/vulnerabilities';
+
+function fmtRisk(value: number | null): string {
+  return value === null ? '—' : String(Math.round(value));
+}
+
+function versionRange(versions: string[]): string {
+  if (versions.length === 0) return '';
+  if (versions.length === 1) return versions[0]!;
+  return `${versions[0]} – ${versions[versions.length - 1]}`;
+}
+
+function patchLabel(g: SoftwareGroup): string {
+  return g.patchReadyFindingCount > 0 ? `Ready · ${g.patchReadyDeviceCount}/${g.deviceCount} devices` : '—';
+}
+
+const KEV_BADGE = (
+  <span className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+    KEV
+  </span>
+);
+
+export function SoftwareGroupTable({
+  filters,
+  refreshKey,
+  onSelectGroup,
+  onClearFilters,
+}: {
+  filters: VulnFleetFilters;
+  refreshKey: number;
+  onSelectGroup: (groupKey: string) => void;
+  onClearFilters: () => void;
+}) {
+  const [items, setItems] = useState<SoftwareGroup[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchSoftwareGroups(filters)
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.items);
+        setHasMore(res.hasMore);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load software groups');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, refreshKey]);
+
+  const table = useMemo(
+    () => (
+      <table className="min-w-full divide-y">
+        <thead className="bg-muted/40">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <th className="px-4 py-3">Software</th>
+            <th className="px-4 py-3">Severity</th>
+            <th className="px-4 py-3">Risk</th>
+            <th className="px-4 py-3">CVEs</th>
+            <th className="px-4 py-3">Devices</th>
+            <th className="px-4 py-3">Patch</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {items.map((g) => (
+            <tr
+              key={g.groupKey}
+              data-testid={`software-group-row-${g.groupKey}`}
+              className="cursor-pointer transition hover:bg-muted/40"
+              onClick={() => onSelectGroup(g.groupKey)}
+            >
+              <td className="px-4 py-3 text-sm">
+                <div className="font-medium">{g.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {[g.vendor, versionRange(g.versions)].filter(Boolean).join(' · ')}
+                </div>
+              </td>
+              <td className="px-4 py-3 text-sm">
+                <span className="inline-flex items-center gap-1.5">
+                  <SeverityBadge severity={g.worstSeverity} />
+                  {g.kevCveCount > 0 && KEV_BADGE}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</td>
+              <td className="px-4 py-3 text-sm tabular-nums">{g.cveCount}</td>
+              <td className="px-4 py-3 text-sm tabular-nums">{g.deviceCount}</td>
+              <td className="px-4 py-3 text-sm">{patchLabel(g)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ),
+    [items, onSelectGroup],
+  );
+
+  const cards = useMemo(
+    () =>
+      items.map((g) => (
+        <DataCard key={g.groupKey} onClick={() => onSelectGroup(g.groupKey)}>
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-sm font-semibold">{g.name}</span>
+            <span className="inline-flex shrink-0 items-center gap-1.5">
+              <SeverityBadge severity={g.worstSeverity} />
+              {g.kevCveCount > 0 && KEV_BADGE}
+            </span>
+          </div>
+          <div className="mt-3 space-y-2 border-t pt-3">
+            <CardField label="Risk"><span className="text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</span></CardField>
+            <CardField label="CVEs"><span className="text-sm tabular-nums">{g.cveCount}</span></CardField>
+            <CardField label="Devices"><span className="text-sm tabular-nums">{g.deviceCount}</span></CardField>
+            <CardField label="Patch"><span className="text-sm">{patchLabel(g)}</span></CardField>
+          </div>
+        </DataCard>
+      )),
+    [items, onSelectGroup],
+  );
+
+  if (error) {
+    return (
+      <div
+        data-testid="software-group-table-error"
+        className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return (
+      <div
+        data-testid="software-group-table-empty"
+        className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
+      >
+        <p>No vulnerabilities match the current filters.</p>
+        <button
+          type="button"
+          data-testid="software-group-clear-filters"
+          className="mt-2 text-sm font-medium text-primary hover:underline"
+          onClick={onClearFilters}
+        >
+          Clear filters
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <ResponsiveTable table={table} cards={cards} />
+      {hasMore && (
+        <p data-testid="software-group-has-more" className="text-xs text-muted-foreground">
+          Showing the top 500 groups by risk — narrow the filters to see the rest.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default SoftwareGroupTable;

--- a/apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx
+++ b/apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx
@@ -1,12 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import HelpTooltip from '../shared/HelpTooltip';
 import { SeverityBadge } from './SeverityBadge';
+import { KevBadge } from './KevBadge';
+import { RISK_EXPLANATION } from './vulnExplanations';
+import { VulnEmptyState, type VulnEmptyVariant } from './VulnEmptyState';
+import { densityTableClasses, readDensity, subscribeDensity, type Density } from '../../lib/density';
 import {
   fetchSoftwareGroups,
   type SoftwareGroup,
   type VulnFleetFilters,
 } from '../../lib/api/vulnerabilities';
+
+// Keyboard path into the drawer: the whole row stays mouse-clickable, but the
+// primary cell carries a real <button> so keyboard/screen-reader users can
+// reach and activate every row.
+const ROW_BUTTON =
+  'block w-full rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
+
+const RETRY_BTN =
+  'mt-2 inline-flex items-center rounded-md border border-red-300 px-3 py-1 text-sm font-medium transition hover:bg-red-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary dark:border-red-800 dark:hover:bg-red-900/40';
+
+const SKELETON_BAR = 'h-4 rounded bg-muted motion-safe:animate-pulse';
 
 function fmtRisk(value: number | null): string {
   return value === null ? '—' : String(Math.round(value));
@@ -22,20 +38,19 @@ function patchLabel(g: SoftwareGroup): string {
   return g.patchReadyFindingCount > 0 ? `Ready · ${g.patchReadyDeviceCount}/${g.deviceCount} devices` : '—';
 }
 
-const KEV_BADGE = (
-  <span className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-    KEV
-  </span>
-);
-
 export function SoftwareGroupTable({
   filters,
   refreshKey,
+  emptyVariant,
+  lastDetectedAt,
   onSelectGroup,
   onClearFilters,
 }: {
   filters: VulnFleetFilters;
   refreshKey: number;
+  /** Zero-rows story, decided by the page (needs filters + stats). */
+  emptyVariant: VulnEmptyVariant;
+  lastDetectedAt?: string | null;
   onSelectGroup: (groupKey: string) => void;
   onClearFilters: () => void;
 }) {
@@ -43,6 +58,11 @@ export function SoftwareGroupTable({
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+  // Table density reflects the account-wide preference (breeze.density) set in
+  // the top-bar theme/display menu — same mechanism as DeviceList.
+  const [density, setDensity] = useState<Density>(() => readDensity());
+  useEffect(() => subscribeDensity(setDensity), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,73 +83,135 @@ export function SoftwareGroupTable({
     return () => {
       cancelled = true;
     };
-  }, [filters, refreshKey]);
+  }, [filters, refreshKey, retryKey]);
+
+  // Skeleton only on empty loads (first paint / after an error retry). A
+  // filter-change refetch keeps the previous rows on screen instead of flashing.
+  const showSkeleton = loading && items.length === 0;
 
   const table = useMemo(
     () => (
-      <table className="min-w-full divide-y">
+      <table className={`min-w-full divide-y ${densityTableClasses(density)}`}>
         <thead className="bg-muted/40">
           <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             <th className="px-4 py-3">Software</th>
             <th className="px-4 py-3">Severity</th>
-            <th className="px-4 py-3">Risk</th>
+            <th className="px-4 py-3">
+              <span className="inline-flex items-center gap-1">
+                Risk
+                {/* side="bottom": an upward bubble would clip against the
+                    ResponsiveTable overflow-x-auto wrapper's top edge. */}
+                <HelpTooltip side="bottom" ariaLabel="About the risk score" text={RISK_EXPLANATION} />
+              </span>
+            </th>
             <th className="px-4 py-3">CVEs</th>
             <th className="px-4 py-3">Devices</th>
             <th className="px-4 py-3">Patch</th>
           </tr>
         </thead>
-        <tbody className="divide-y">
-          {items.map((g) => (
-            <tr
-              key={g.groupKey}
-              data-testid={`software-group-row-${g.groupKey}`}
-              className="cursor-pointer transition hover:bg-muted/40"
-              onClick={() => onSelectGroup(g.groupKey)}
-            >
-              <td className="px-4 py-3 text-sm">
-                <div className="font-medium">{g.name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {[g.vendor, versionRange(g.versions)].filter(Boolean).join(' · ')}
-                </div>
-              </td>
-              <td className="px-4 py-3 text-sm">
-                <span className="inline-flex items-center gap-1.5">
-                  <SeverityBadge severity={g.worstSeverity} />
-                  {g.kevCveCount > 0 && KEV_BADGE}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</td>
-              <td className="px-4 py-3 text-sm tabular-nums">{g.cveCount}</td>
-              <td className="px-4 py-3 text-sm tabular-nums">{g.deviceCount}</td>
-              <td className="px-4 py-3 text-sm">{patchLabel(g)}</td>
-            </tr>
-          ))}
-        </tbody>
+        {showSkeleton ? (
+          <tbody className="divide-y" data-testid="software-group-table-skeleton" aria-hidden="true">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i}>
+                <td className="px-4 py-3">
+                  <div className={`${SKELETON_BAR} w-40`} />
+                  <div className={`${SKELETON_BAR} mt-1.5 h-3 w-24`} />
+                </td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} h-5 w-16 rounded-full`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-24`} /></td>
+              </tr>
+            ))}
+          </tbody>
+        ) : (
+          <tbody className="divide-y">
+            {items.map((g) => (
+              <tr
+                key={g.groupKey}
+                data-testid={`software-group-row-${g.groupKey}`}
+                className="cursor-pointer transition hover:bg-muted/40"
+                onClick={() => onSelectGroup(g.groupKey)}
+              >
+                <td className="px-4 py-3 text-sm">
+                  <button
+                    type="button"
+                    data-testid={`software-group-open-${g.groupKey}`}
+                    aria-label={`Open ${g.name} vulnerability details`}
+                    className={ROW_BUTTON}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelectGroup(g.groupKey);
+                    }}
+                  >
+                    <span className="block font-medium">{g.name}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {[g.vendor, versionRange(g.versions)].filter(Boolean).join(' · ')}
+                    </span>
+                  </button>
+                </td>
+                <td className="px-4 py-3 text-sm">
+                  <span className="inline-flex items-center gap-1.5">
+                    <SeverityBadge severity={g.worstSeverity} />
+                    {g.kevCveCount > 0 && <KevBadge />}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{g.cveCount}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{g.deviceCount}</td>
+                <td className="px-4 py-3 text-sm">{patchLabel(g)}</td>
+              </tr>
+            ))}
+          </tbody>
+        )}
       </table>
     ),
-    [items, onSelectGroup],
+    [items, onSelectGroup, density, showSkeleton],
   );
 
   const cards = useMemo(
     () =>
-      items.map((g) => (
-        <DataCard key={g.groupKey} onClick={() => onSelectGroup(g.groupKey)}>
-          <div className="flex items-center justify-between gap-2">
-            <span className="truncate text-sm font-semibold">{g.name}</span>
-            <span className="inline-flex shrink-0 items-center gap-1.5">
-              <SeverityBadge severity={g.worstSeverity} />
-              {g.kevCveCount > 0 && KEV_BADGE}
-            </span>
-          </div>
-          <div className="mt-3 space-y-2 border-t pt-3">
-            <CardField label="Risk"><span className="text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</span></CardField>
-            <CardField label="CVEs"><span className="text-sm tabular-nums">{g.cveCount}</span></CardField>
-            <CardField label="Devices"><span className="text-sm tabular-nums">{g.deviceCount}</span></CardField>
-            <CardField label="Patch"><span className="text-sm">{patchLabel(g)}</span></CardField>
-          </div>
-        </DataCard>
-      )),
-    [items, onSelectGroup],
+      showSkeleton
+        ? Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} aria-hidden="true">
+              <DataCard>
+                <div className={`${SKELETON_BAR} w-36`} />
+                <div className="mt-3 space-y-2 border-t pt-3">
+                  <div className={`${SKELETON_BAR} w-full`} />
+                  <div className={`${SKELETON_BAR} w-2/3`} />
+                </div>
+              </DataCard>
+            </div>
+          ))
+        : items.map((g) => (
+            <DataCard key={g.groupKey} onClick={() => onSelectGroup(g.groupKey)}>
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  aria-label={`Open ${g.name} vulnerability details`}
+                  className={`${ROW_BUTTON} min-w-0 flex-1 truncate text-sm font-semibold`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelectGroup(g.groupKey);
+                  }}
+                >
+                  {g.name}
+                </button>
+                <span className="inline-flex shrink-0 items-center gap-1.5">
+                  <SeverityBadge severity={g.worstSeverity} />
+                  {g.kevCveCount > 0 && <KevBadge />}
+                </span>
+              </div>
+              <div className="mt-3 space-y-2 border-t pt-3">
+                <CardField label="Risk"><span className="text-sm tabular-nums" title={RISK_EXPLANATION}>{fmtRisk(g.maxRiskScore)}</span></CardField>
+                <CardField label="CVEs"><span className="text-sm tabular-nums">{g.cveCount}</span></CardField>
+                <CardField label="Devices"><span className="text-sm tabular-nums">{g.deviceCount}</span></CardField>
+                <CardField label="Patch"><span className="text-sm">{patchLabel(g)}</span></CardField>
+              </div>
+            </DataCard>
+          )),
+    [items, onSelectGroup, showSkeleton],
   );
 
   if (error) {
@@ -138,27 +220,28 @@ export function SoftwareGroupTable({
         data-testid="software-group-table-error"
         className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
       >
-        {error}
+        <p>{error}</p>
+        <button
+          type="button"
+          data-testid="software-group-table-retry"
+          className={RETRY_BTN}
+          onClick={() => setRetryKey((k) => k + 1)}
+        >
+          Retry
+        </button>
       </div>
     );
   }
 
   if (!loading && items.length === 0) {
     return (
-      <div
-        data-testid="software-group-table-empty"
-        className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
-      >
-        <p>No vulnerabilities match the current filters.</p>
-        <button
-          type="button"
-          data-testid="software-group-clear-filters"
-          className="mt-2 text-sm font-medium text-primary hover:underline"
-          onClick={onClearFilters}
-        >
-          Clear filters
-        </button>
-      </div>
+      <VulnEmptyState
+        variant={emptyVariant}
+        lastDetectedAt={lastDetectedAt}
+        onClearFilters={onClearFilters}
+        containerTestId="software-group-table-empty"
+        clearFiltersTestId="software-group-clear-filters"
+      />
     );
   }
 

--- a/apps/web/src/components/vulnerabilities/VulnBulkActionModal.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnBulkActionModal.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 
-import { VulnBulkActionModal, localEndOfDayIso } from './VulnBulkActionModal';
+import { VulnBulkActionModal, formatSelectionPreview, localEndOfDayIso } from './VulnBulkActionModal';
 
 describe('localEndOfDayIso', () => {
   it('serializes the picked date as end-of-day in the local timezone', () => {
@@ -10,20 +10,90 @@ describe('localEndOfDayIso', () => {
   });
 });
 
+describe('formatSelectionPreview', () => {
+  it('lists up to three device names, appending CVE ids only when provided', () => {
+    expect(formatSelectionPreview([{ deviceName: 'WS-01' }])).toBe('WS-01');
+    expect(
+      formatSelectionPreview([
+        { deviceName: 'WS-01', cveId: 'CVE-2026-0001' },
+        { deviceName: 'WS-02', cveId: null },
+        { deviceName: 'WS-03' },
+      ]),
+    ).toBe('WS-01 (CVE-2026-0001), WS-02, WS-03');
+  });
+
+  it('collapses everything past the third entry into "and N more"', () => {
+    expect(
+      formatSelectionPreview([
+        { deviceName: 'WS-01' },
+        { deviceName: 'WS-02' },
+        { deviceName: 'WS-03' },
+        { deviceName: 'WS-04' },
+        { deviceName: 'WS-05' },
+      ]),
+    ).toBe('WS-01, WS-02, WS-03 and 2 more');
+  });
+});
+
 describe('VulnBulkActionModal', () => {
-  it('remediate: shows finding/device counts and submits an empty payload', () => {
+  it('remediate: shows finding/device counts, the true consequence, and submits an empty payload', () => {
     const onSubmit = vi.fn();
     render(
       <VulnBulkActionModal kind="remediate" count={3} deviceCount={2} busy={false} onCancel={() => {}} onSubmit={onSubmit} />,
     );
     expect(screen.getByTestId('vuln-bulk-modal')).toHaveTextContent('Remediate findings — 3 findings');
-    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent(
-      'This schedules remediation for 3 findings on 2 devices.',
+    expect(screen.getByTestId('vuln-bulk-consequence')).toHaveTextContent(
+      'Installs the approved patch for each CVE on 2 devices (3 findings). Findings without an approved, applicable patch are skipped.',
     );
     // No free-text inputs on the confirmation.
     expect(screen.queryByTestId('vuln-bulk-text')).toBeNull();
     fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
     expect(onSubmit).toHaveBeenCalledWith({});
+  });
+
+  it('accept: consequence says findings hide until the date and do NOT auto-reopen', () => {
+    render(
+      <VulnBulkActionModal kind="accept" count={2} deviceCount={2} busy={false} onCancel={() => {}} onSubmit={() => {}} />,
+    );
+    const consequence = screen.getByTestId('vuln-bulk-consequence');
+    expect(consequence).toHaveTextContent(
+      'Hides 2 findings on 2 devices from the open queue until the date you set.',
+    );
+    // Expiry does not reopen findings (no sweep exists) — the copy must not claim it does.
+    expect(consequence).toHaveTextContent('They do not reopen automatically — expiring acceptances surface in the “Accepted, expiring soon” card.');
+  });
+
+  it('mitigate: consequence says the note is the compensating control and devices are untouched', () => {
+    render(
+      <VulnBulkActionModal kind="mitigate" count={1} deviceCount={1} busy={false} onCancel={() => {}} onSubmit={() => {}} />,
+    );
+    expect(screen.getByTestId('vuln-bulk-consequence')).toHaveTextContent(
+      'Marks 1 finding on 1 device mitigated, with your note recorded as the compensating control. Breeze does not change the devices.',
+    );
+  });
+
+  it('shows a compact selection summary when selection is provided, and omits it otherwise', () => {
+    const { rerender } = render(
+      <VulnBulkActionModal kind="accept" count={1} deviceCount={1} busy={false} onCancel={() => {}} onSubmit={() => {}} />,
+    );
+    expect(screen.queryByTestId('vuln-bulk-selection')).toBeNull();
+    rerender(
+      <VulnBulkActionModal
+        kind="accept"
+        count={4}
+        deviceCount={4}
+        selection={[
+          { deviceName: 'WS-01', cveId: 'CVE-2026-0001' },
+          { deviceName: 'WS-02' },
+          { deviceName: 'WS-03' },
+          { deviceName: 'WS-04' },
+        ]}
+        busy={false}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('vuln-bulk-selection')).toHaveTextContent('WS-01 (CVE-2026-0001), WS-02, WS-03 and 1 more');
   });
 
   it('accept: requires reason + date, serializes acceptedUntil as local end-of-day', () => {

--- a/apps/web/src/components/vulnerabilities/VulnBulkActionModal.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnBulkActionModal.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+
+import { VulnBulkActionModal, localEndOfDayIso } from './VulnBulkActionModal';
+
+describe('localEndOfDayIso', () => {
+  it('serializes the picked date as end-of-day in the local timezone', () => {
+    expect(localEndOfDayIso('2030-01-01')).toBe(new Date(2030, 0, 1, 23, 59, 59, 999).toISOString());
+  });
+});
+
+describe('VulnBulkActionModal', () => {
+  it('remediate: shows finding/device counts and submits an empty payload', () => {
+    const onSubmit = vi.fn();
+    render(
+      <VulnBulkActionModal kind="remediate" count={3} deviceCount={2} busy={false} onCancel={() => {}} onSubmit={onSubmit} />,
+    );
+    expect(screen.getByTestId('vuln-bulk-modal')).toHaveTextContent('Remediate findings — 3 findings');
+    expect(screen.getByTestId('vuln-bulk-remediate-summary')).toHaveTextContent(
+      'This schedules remediation for 3 findings on 2 devices.',
+    );
+    // No free-text inputs on the confirmation.
+    expect(screen.queryByTestId('vuln-bulk-text')).toBeNull();
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    expect(onSubmit).toHaveBeenCalledWith({});
+  });
+
+  it('accept: requires reason + date, serializes acceptedUntil as local end-of-day', () => {
+    const onSubmit = vi.fn();
+    render(
+      <VulnBulkActionModal kind="accept" count={1} deviceCount={1} busy={false} onCancel={() => {}} onSubmit={onSubmit} />,
+    );
+    expect(screen.getByTestId('vuln-bulk-submit')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'compensating control' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-06-15' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    expect(onSubmit).toHaveBeenCalledWith({
+      reason: 'compensating control',
+      acceptedUntil: new Date(2030, 5, 15, 23, 59, 59, 999).toISOString(),
+    });
+  });
+
+  it('is a named dialog, closes on Escape, and restores focus to the trigger', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div>
+          <button type="button" data-testid="trigger" onClick={() => setOpen(true)}>
+            open
+          </button>
+          {open && (
+            <VulnBulkActionModal
+              kind="mitigate"
+              count={1}
+              deviceCount={1}
+              busy={false}
+              onCancel={() => setOpen(false)}
+              onSubmit={() => {}}
+            />
+          )}
+        </div>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const dialog = screen.getByRole('dialog');
+    // aria-labelledby points at the visible heading.
+    expect(dialog).toHaveAccessibleName('Mark mitigated — 1 finding');
+    // Initial focus moves into the dialog.
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+
+    fireEvent.keyDown(screen.getByTestId('vuln-bulk-modal'), { key: 'Escape' });
+    expect(screen.queryByTestId('vuln-bulk-modal')).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it('renders an inline error alert when errorMessage is set', () => {
+    const { rerender } = render(
+      <VulnBulkActionModal kind="remediate" count={1} deviceCount={1} busy={false} onCancel={() => {}} onSubmit={() => {}} />,
+    );
+    expect(screen.queryByTestId('vuln-bulk-error')).toBeNull();
+    rerender(
+      <VulnBulkActionModal
+        kind="remediate"
+        count={1}
+        deviceCount={1}
+        busy={false}
+        errorMessage="No available patch"
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    const alert = screen.getByTestId('vuln-bulk-error');
+    expect(alert).toHaveTextContent('No available patch');
+    expect(alert).toHaveAttribute('role', 'alert');
+  });
+
+  it('disables both buttons while busy', () => {
+    render(
+      <VulnBulkActionModal kind="remediate" count={1} deviceCount={1} busy onCancel={() => {}} onSubmit={() => {}} />,
+    );
+    expect(screen.getByTestId('vuln-bulk-submit')).toBeDisabled();
+    expect(screen.getByTestId('vuln-bulk-cancel')).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+
+const BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+
+export function VulnBulkActionModal({
+  kind,
+  count,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  kind: 'accept' | 'mitigate';
+  count: number;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: { reason?: string; acceptedUntil?: string; note?: string }) => void;
+}) {
+  const [text, setText] = useState('');
+  const [until, setUntil] = useState('');
+  const isAccept = kind === 'accept';
+  const canSubmit = isAccept ? text.trim().length > 0 && until.length > 0 : text.trim().length > 0;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-bulk-modal">
+        <h3 className="text-base font-semibold">
+          {isAccept ? 'Accept risk' : 'Mark mitigated'} — {count} finding{count === 1 ? '' : 's'}
+        </h3>
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">{isAccept ? 'Reason' : 'Mitigation note'}</span>
+            <textarea
+              data-testid="vuln-bulk-text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          {isAccept && (
+            <label className="block text-sm">
+              <span className="text-muted-foreground">Accepted until</span>
+              <input
+                type="date"
+                data-testid="vuln-bulk-until"
+                value={until}
+                min={(() => {
+                  const d = new Date();
+                  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+                })()}
+                onChange={(e) => setUntil(e.target.value)}
+                className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              />
+            </label>
+          )}
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="vuln-bulk-submit"
+            className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+            disabled={!canSubmit || busy}
+            onClick={() =>
+              onSubmit(
+                isAccept
+                  ? { reason: text.trim(), acceptedUntil: new Date(`${until}T00:00:00Z`).toISOString() }
+                  : { note: text.trim() },
+              )
+            }
+          >
+            {isAccept ? 'Accept risk' : 'Mark mitigated'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VulnBulkActionModal;

--- a/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
@@ -23,6 +23,24 @@ const HEADINGS: Record<'remediate' | 'accept' | 'mitigate', string> = {
   mitigate: 'Mark mitigated',
 };
 
+/** One entry per selected finding, for the "which devices" summary line. */
+export interface SelectionPreviewItem {
+  deviceName: string;
+  /** Shown after the device name when set — the software drawer's selection
+   *  mixes CVEs, so "WS-01 (CVE-2026-0001)" disambiguates. The CVE drawer
+   *  omits it (every finding there is the same CVE). */
+  cveId?: string | null;
+}
+
+// "WS-01 (CVE-2026-0001), WS-02, WS-03 and 4 more" — the first three findings
+// by device name, so the user can see WHAT they selected behind the overlay
+// without the modal becoming a wall.
+export function formatSelectionPreview(items: SelectionPreviewItem[]): string {
+  const shown = items.slice(0, 3).map((i) => (i.cveId ? `${i.deviceName} (${i.cveId})` : i.deviceName));
+  const rest = items.length - shown.length;
+  return rest > 0 ? `${shown.join(', ')} and ${rest} more` : shown.join(', ');
+}
+
 const CONFIRM_LABELS: Record<'remediate' | 'accept' | 'mitigate', string> = {
   remediate: 'Remediate',
   accept: 'Accept risk',
@@ -33,6 +51,7 @@ export function VulnBulkActionModal({
   kind,
   count,
   deviceCount,
+  selection,
   busy,
   errorMessage,
   onCancel,
@@ -42,6 +61,10 @@ export function VulnBulkActionModal({
   count: number;
   /** Distinct devices in the selection (shown in the confirmation copy). */
   deviceCount: number;
+  /** The selected findings (device name + optional CVE id), shown as a compact
+   *  summary so the user doesn't have to remember what's checked behind the
+   *  overlay. Optional to stay additive for existing callers/tests. */
+  selection?: SelectionPreviewItem[];
   busy: boolean;
   /** Failure from the last submit, surfaced inline (the toast alone is easy to
    *  miss while the modal stays open). */
@@ -55,6 +78,18 @@ export function VulnBulkActionModal({
   const isAccept = kind === 'accept';
   const isRemediate = kind === 'remediate';
   const canSubmit = isRemediate ? true : isAccept ? text.trim().length > 0 && until.length > 0 : text.trim().length > 0;
+
+  // One factually-accurate consequence sentence per action, matching what the
+  // API really does (see routes/vulnerabilities.ts + vulnerabilityRemediation.ts):
+  // remediate queues targeted install commands for approved patches; accept
+  // hides findings until the expiry date but NOTHING auto-reopens them (they
+  // surface via the "Accepted, expiring soon" card); mitigate only records the
+  // note as a compensating control.
+  const consequence = isRemediate
+    ? `Installs the approved patch for each CVE on ${plural(deviceCount, 'device')} (${plural(count, 'finding')}). Findings without an approved, applicable patch are skipped.`
+    : isAccept
+      ? `Hides ${plural(count, 'finding')} on ${plural(deviceCount, 'device')} from the open queue until the date you set. They do not reopen automatically — expiring acceptances surface in the “Accepted, expiring soon” card.`
+      : `Marks ${plural(count, 'finding')} on ${plural(deviceCount, 'device')} mitigated, with your note recorded as the compensating control. Breeze does not change the devices.`;
 
   return (
     <Dialog
@@ -71,11 +106,15 @@ export function VulnBulkActionModal({
         <h3 id={titleId} className="text-base font-semibold">
           {HEADINGS[kind]} — {plural(count, 'finding')}
         </h3>
-        {isRemediate ? (
-          <p data-testid="vuln-bulk-remediate-summary" className="mt-3 text-sm text-muted-foreground">
-            This schedules remediation for {plural(count, 'finding')} on {plural(deviceCount, 'device')}.
+        {selection && selection.length > 0 && (
+          <p data-testid="vuln-bulk-selection" className="mt-2 text-sm">
+            {formatSelectionPreview(selection)}
           </p>
-        ) : (
+        )}
+        <p data-testid="vuln-bulk-consequence" className="mt-2 text-sm text-muted-foreground">
+          {consequence}
+        </p>
+        {!isRemediate && (
           <div className="mt-4 space-y-3">
             <label className="block text-sm">
               <span className="text-muted-foreground">{isAccept ? 'Reason' : 'Mitigation note'}</span>

--- a/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx
@@ -1,62 +1,121 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
+
+import { Dialog } from '../shared/Dialog';
+import { plural } from '../../lib/utils';
 
 const BTN =
-  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50';
+
+const INPUT =
+  'mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
+
+// Serialize the picked YYYY-MM-DD as end-of-day in the USER'S timezone. The
+// previous `new Date(`${d}T00:00:00Z`)` treated the date as UTC midnight,
+// which lands on the previous local day for anyone west of UTC.
+export function localEndOfDayIso(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y!, m! - 1, d!, 23, 59, 59, 999).toISOString();
+}
+
+const HEADINGS: Record<'remediate' | 'accept' | 'mitigate', string> = {
+  remediate: 'Remediate findings',
+  accept: 'Accept risk',
+  mitigate: 'Mark mitigated',
+};
+
+const CONFIRM_LABELS: Record<'remediate' | 'accept' | 'mitigate', string> = {
+  remediate: 'Remediate',
+  accept: 'Accept risk',
+  mitigate: 'Mark mitigated',
+};
 
 export function VulnBulkActionModal({
   kind,
   count,
+  deviceCount,
   busy,
+  errorMessage,
   onCancel,
   onSubmit,
 }: {
-  kind: 'accept' | 'mitigate';
+  kind: 'remediate' | 'accept' | 'mitigate';
   count: number;
+  /** Distinct devices in the selection (shown in the confirmation copy). */
+  deviceCount: number;
   busy: boolean;
+  /** Failure from the last submit, surfaced inline (the toast alone is easy to
+   *  miss while the modal stays open). */
+  errorMessage?: string | null;
   onCancel: () => void;
   onSubmit: (payload: { reason?: string; acceptedUntil?: string; note?: string }) => void;
 }) {
   const [text, setText] = useState('');
   const [until, setUntil] = useState('');
+  const titleId = useId();
   const isAccept = kind === 'accept';
-  const canSubmit = isAccept ? text.trim().length > 0 && until.length > 0 : text.trim().length > 0;
+  const isRemediate = kind === 'remediate';
+  const canSubmit = isRemediate ? true : isAccept ? text.trim().length > 0 && until.length > 0 : text.trim().length > 0;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
-      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-bulk-modal">
-        <h3 className="text-base font-semibold">
-          {isAccept ? 'Accept risk' : 'Mark mitigated'} — {count} finding{count === 1 ? '' : 's'}
+    <Dialog
+      open
+      onClose={() => {
+        if (!busy) onCancel();
+      }}
+      title={HEADINGS[kind]}
+      labelledBy={titleId}
+      maxWidth="md"
+      className="p-5"
+    >
+      <div data-testid="vuln-bulk-modal">
+        <h3 id={titleId} className="text-base font-semibold">
+          {HEADINGS[kind]} — {plural(count, 'finding')}
         </h3>
-        <div className="mt-4 space-y-3">
-          <label className="block text-sm">
-            <span className="text-muted-foreground">{isAccept ? 'Reason' : 'Mitigation note'}</span>
-            <textarea
-              data-testid="vuln-bulk-text"
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              rows={3}
-              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
-            />
-          </label>
-          {isAccept && (
+        {isRemediate ? (
+          <p data-testid="vuln-bulk-remediate-summary" className="mt-3 text-sm text-muted-foreground">
+            This schedules remediation for {plural(count, 'finding')} on {plural(deviceCount, 'device')}.
+          </p>
+        ) : (
+          <div className="mt-4 space-y-3">
             <label className="block text-sm">
-              <span className="text-muted-foreground">Accepted until</span>
-              <input
-                type="date"
-                data-testid="vuln-bulk-until"
-                value={until}
-                min={(() => {
-                  const d = new Date();
-                  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-                })()}
-                onChange={(e) => setUntil(e.target.value)}
-                className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              <span className="text-muted-foreground">{isAccept ? 'Reason' : 'Mitigation note'}</span>
+              <textarea
+                data-testid="vuln-bulk-text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                rows={3}
+                className={INPUT}
               />
             </label>
-          )}
-        </div>
+            {isAccept && (
+              <label className="block text-sm">
+                <span className="text-muted-foreground">Accepted until</span>
+                <input
+                  type="date"
+                  data-testid="vuln-bulk-until"
+                  value={until}
+                  min={(() => {
+                    const d = new Date();
+                    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+                  })()}
+                  onChange={(e) => setUntil(e.target.value)}
+                  className={INPUT}
+                />
+              </label>
+            )}
+          </div>
+        )}
+        {errorMessage && (
+          <div
+            data-testid="vuln-bulk-error"
+            role="alert"
+            className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+          >
+            {errorMessage}
+          </div>
+        )}
         <div className="mt-5 flex justify-end gap-2">
-          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+          <button type="button" data-testid="vuln-bulk-cancel" className={`${BTN} hover:bg-muted`} onClick={onCancel} disabled={busy}>
             Cancel
           </button>
           <button
@@ -66,17 +125,19 @@ export function VulnBulkActionModal({
             disabled={!canSubmit || busy}
             onClick={() =>
               onSubmit(
-                isAccept
-                  ? { reason: text.trim(), acceptedUntil: new Date(`${until}T00:00:00Z`).toISOString() }
-                  : { note: text.trim() },
+                isRemediate
+                  ? {}
+                  : isAccept
+                    ? { reason: text.trim(), acceptedUntil: localEndOfDayIso(until) }
+                    : { note: text.trim() },
               )
             }
           >
-            {isAccept ? 'Accept risk' : 'Mark mitigated'}
+            {busy ? 'Working…' : CONFIRM_LABELS[kind]}
           </button>
         </div>
       </div>
-    </div>
+    </Dialog>
   );
 }
 

--- a/apps/web/src/components/vulnerabilities/VulnEmptyState.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnEmptyState.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  DEFAULT_FILTERS,
+  isDefaultVulnFilters,
+  resolveVulnEmptyVariant,
+  VulnEmptyState,
+} from './VulnEmptyState';
+import type { FleetVulnStats } from '../../lib/api/vulnerabilities';
+
+function stats(overrides: Partial<FleetVulnStats> = {}): FleetVulnStats {
+  return {
+    criticalOpen: 0,
+    kevCveCount: 0,
+    kevDeviceCount: 0,
+    patchReadyFindingCount: 0,
+    acceptedExpiringSoon: 0,
+    totalFindings: 0,
+    lastDetectedAt: null,
+    ...overrides,
+  };
+}
+
+describe('isDefaultVulnFilters', () => {
+  it('accepts the exact default filter set', () => {
+    expect(isDefaultVulnFilters({ ...DEFAULT_FILTERS })).toBe(true);
+  });
+
+  it.each([
+    ['search', { search: 'chrome' }],
+    ['severity', { severity: 'critical' }],
+    ['status accepted', { status: 'accepted' }],
+    ['status all', { status: 'all' }],
+    ['kevOnly', { kevOnly: true }],
+    ['patchAvailable', { patchAvailable: true }],
+    ['expiringWithinDays', { expiringWithinDays: 14 }],
+  ] as const)('flags %s as non-default', (_label, override) => {
+    expect(isDefaultVulnFilters({ ...DEFAULT_FILTERS, ...override })).toBe(false);
+  });
+});
+
+describe('resolveVulnEmptyVariant', () => {
+  it('is "filtered" whenever any non-default filter is active, regardless of stats', () => {
+    expect(resolveVulnEmptyVariant({ ...DEFAULT_FILTERS, severity: 'low' }, stats({ totalFindings: 9 }))).toBe('filtered');
+    expect(resolveVulnEmptyVariant({ ...DEFAULT_FILTERS, status: 'accepted' }, null)).toBe('filtered');
+  });
+
+  it('is "clean" with default filters when scanning has produced findings before', () => {
+    expect(resolveVulnEmptyVariant({ ...DEFAULT_FILTERS }, stats({ totalFindings: 3 }))).toBe('clean');
+  });
+
+  it('is "unscanned" with default filters when no finding has ever existed', () => {
+    expect(resolveVulnEmptyVariant({ ...DEFAULT_FILTERS }, stats({ totalFindings: 0 }))).toBe('unscanned');
+  });
+
+  it('is "unknown" with default filters when stats are unavailable', () => {
+    expect(resolveVulnEmptyVariant({ ...DEFAULT_FILTERS }, null)).toBe('unknown');
+  });
+});
+
+describe('VulnEmptyState', () => {
+  const baseProps = {
+    onClearFilters: () => {},
+    containerTestId: 'vulnerability-table-empty',
+    clearFiltersTestId: 'vulnerability-clear-filters',
+  };
+
+  it('filtered: names the filters as the reason and wires Clear filters', () => {
+    const onClear = vi.fn();
+    render(<VulnEmptyState {...baseProps} variant="filtered" onClearFilters={onClear} />);
+    expect(screen.getByTestId('vuln-empty-filtered')).toHaveTextContent('No vulnerabilities match the current filters.');
+    fireEvent.click(screen.getByTestId('vulnerability-clear-filters'));
+    expect(onClear).toHaveBeenCalled();
+    expect(screen.getByTestId('vulnerability-table-empty')).toBeInTheDocument();
+  });
+
+  it('clean: calm positive state with last-detection context, no clear-filters action', () => {
+    render(<VulnEmptyState {...baseProps} variant="clean" lastDetectedAt="2026-06-30T12:00:00.000Z" />);
+    const el = screen.getByTestId('vuln-empty-clean');
+    expect(el).toHaveTextContent('No open vulnerabilities across your fleet');
+    expect(el).toHaveTextContent('Last finding detected');
+    expect(screen.queryByTestId('vulnerability-clear-filters')).toBeNull();
+  });
+
+  it('clean: omits the last-detection line when the timestamp is missing', () => {
+    render(<VulnEmptyState {...baseProps} variant="clean" lastDetectedAt={null} />);
+    expect(screen.getByTestId('vuln-empty-clean')).not.toHaveTextContent('Last finding detected');
+  });
+
+  it('unscanned: teaches what appears here and links to configuration policies', () => {
+    render(<VulnEmptyState {...baseProps} variant="unscanned" />);
+    const el = screen.getByTestId('vuln-empty-unscanned');
+    expect(el).toHaveTextContent('No vulnerability findings yet');
+    expect(el).toHaveTextContent('configuration policy');
+    const link = screen.getByTestId('vuln-empty-setup-link');
+    expect(link).toHaveAttribute('href', '/configuration-policies');
+  });
+
+  it('unknown: stays neutral when stats are unavailable', () => {
+    render(<VulnEmptyState {...baseProps} variant="unknown" />);
+    expect(screen.getByTestId('vuln-empty-unknown')).toHaveTextContent('No vulnerabilities to show.');
+    expect(screen.queryByTestId('vuln-empty-clean')).toBeNull();
+    expect(screen.queryByTestId('vuln-empty-unscanned')).toBeNull();
+  });
+});

--- a/apps/web/src/components/vulnerabilities/VulnEmptyState.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnEmptyState.tsx
@@ -1,0 +1,131 @@
+import { ScanSearch, ShieldCheck } from 'lucide-react';
+
+import type { FleetVulnStats, VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+/** The page's baseline filter state — anything else counts as "filtered". */
+export const DEFAULT_FILTERS: VulnFleetFilters = {
+  search: '',
+  severity: '',
+  status: 'open',
+  kevOnly: false,
+  patchAvailable: false,
+};
+
+export function isDefaultVulnFilters(filters: VulnFleetFilters): boolean {
+  return (
+    filters.search === DEFAULT_FILTERS.search &&
+    filters.severity === DEFAULT_FILTERS.severity &&
+    filters.status === DEFAULT_FILTERS.status &&
+    filters.kevOnly === DEFAULT_FILTERS.kevOnly &&
+    filters.patchAvailable === DEFAULT_FILTERS.patchAvailable &&
+    filters.expiringWithinDays === undefined
+  );
+}
+
+/**
+ * Which zero-rows story to tell:
+ *  - 'filtered'  — a non-default filter is active; the filters are the reason.
+ *  - 'clean'     — default filters, and scanning HAS produced findings before
+ *                  (stats.totalFindings > 0), so zero open findings is a
+ *                  genuinely clean fleet. The best possible outcome.
+ *  - 'unscanned' — default filters and zero findings EVER: either vulnerability
+ *                  scanning was never enabled, or it has genuinely never found
+ *                  anything. The copy stays honest about both.
+ *  - 'unknown'   — default filters but stats are unavailable (still loading or
+ *                  failed), so we cannot make either claim.
+ */
+export type VulnEmptyVariant = 'filtered' | 'clean' | 'unscanned' | 'unknown';
+
+export function resolveVulnEmptyVariant(
+  filters: VulnFleetFilters,
+  stats: FleetVulnStats | null,
+): VulnEmptyVariant {
+  if (!isDefaultVulnFilters(filters)) return 'filtered';
+  if (!stats) return 'unknown';
+  return stats.totalFindings > 0 ? 'clean' : 'unscanned';
+}
+
+const CLEAR_BTN =
+  'mt-2 text-sm font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
+
+/**
+ * Shared zero-rows treatment for both fleet vulnerability tables. Calm product
+ * UI: type + spacing + at most one icon per state, in the same dashed box the
+ * tables have always used so the layout doesn't jump between variants.
+ */
+export function VulnEmptyState({
+  variant,
+  lastDetectedAt,
+  onClearFilters,
+  containerTestId,
+  clearFiltersTestId,
+}: {
+  variant: VulnEmptyVariant;
+  lastDetectedAt?: string | null;
+  onClearFilters: () => void;
+  /** Preserved outer testid (`software-group-table-empty` / `vulnerability-table-empty`). */
+  containerTestId: string;
+  /** Preserved clear-filters testid, distinct per table. */
+  clearFiltersTestId: string;
+}) {
+  return (
+    <div
+      data-testid={containerTestId}
+      className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
+    >
+      {variant === 'filtered' && (
+        <div data-testid="vuln-empty-filtered">
+          <p>No vulnerabilities match the current filters.</p>
+          <button type="button" data-testid={clearFiltersTestId} className={CLEAR_BTN} onClick={onClearFilters}>
+            Clear filters
+          </button>
+        </div>
+      )}
+
+      {variant === 'clean' && (
+        <div data-testid="vuln-empty-clean" className="mx-auto max-w-md">
+          <ShieldCheck aria-hidden="true" className="mx-auto h-8 w-8 text-emerald-600 dark:text-emerald-400" />
+          <p className="mt-3 text-base font-semibold text-foreground">No open vulnerabilities across your fleet</p>
+          <p className="mt-1">
+            Every detected finding has been patched, mitigated, or accepted. New findings will appear here as scans
+            run.
+          </p>
+          {lastDetectedAt && (
+            <p className="mt-3 text-xs">
+              Last finding detected {new Date(lastDetectedAt).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      )}
+
+      {variant === 'unscanned' && (
+        <div data-testid="vuln-empty-unscanned" className="mx-auto max-w-md">
+          <ScanSearch aria-hidden="true" className="mx-auto h-8 w-8" />
+          <p className="mt-3 text-base font-semibold text-foreground">No vulnerability findings yet</p>
+          <p className="mt-1">
+            Breeze checks each device&apos;s software and OS inventory against known CVEs and queues anything that
+            needs patching, mitigation, or risk acceptance here.
+          </p>
+          <p className="mt-2">
+            Scanning is off by default — enable it on the Vulnerability tab of a configuration policy.
+          </p>
+          <a
+            href="/configuration-policies"
+            data-testid="vuln-empty-setup-link"
+            className="mt-3 inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            Set up vulnerability scanning
+          </a>
+        </div>
+      )}
+
+      {variant === 'unknown' && (
+        // Stats unavailable: no rows to show, but we can't honestly claim
+        // "clean" or "not set up" — stay neutral.
+        <p data-testid="vuln-empty-unknown">No vulnerabilities to show.</p>
+      )}
+    </div>
+  );
+}
+
+export default VulnEmptyState;

--- a/apps/web/src/components/vulnerabilities/VulnFilterBar.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnFilterBar.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import { VulnFilterBar } from './VulnFilterBar';
+import type { VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const FILTERS: VulnFleetFilters = { search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false };
+
+describe('VulnFilterBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces search typing: one onChange after the pause, not one per keystroke', () => {
+    const onChange = vi.fn();
+    render(<VulnFilterBar filters={FILTERS} onChange={onChange} />);
+    const input = screen.getByTestId('vuln-filter-search');
+
+    fireEvent.change(input, { target: { value: 'c' } });
+    fireEvent.change(input, { target: { value: 'ch' } });
+    fireEvent.change(input, { target: { value: 'chrome' } });
+    // Input echoes immediately, but nothing has been committed yet.
+    expect(input).toHaveValue('chrome');
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'chrome' }));
+  });
+
+  it('applies an emptied search box immediately (clearing feels instant)', () => {
+    const onChange = vi.fn();
+    render(<VulnFilterBar filters={{ ...FILTERS, search: 'chrome' }} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId('vuln-filter-search'), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+  });
+
+  it('keeps non-text controls immediate: severity/status/checkboxes fire onChange at once', () => {
+    const onChange = vi.fn();
+    render(<VulnFilterBar filters={FILTERS} onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('vuln-filter-severity'), { target: { value: 'high' } });
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'high' }));
+
+    fireEvent.click(screen.getByTestId('vuln-filter-kev'));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ kevOnly: true }));
+
+    fireEvent.change(screen.getByTestId('vuln-filter-status'), { target: { value: 'accepted' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'accepted', expiringWithinDays: undefined }),
+    );
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('a commit carries the latest non-search filters, not a stale snapshot', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<VulnFilterBar filters={FILTERS} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId('vuln-filter-search'), { target: { value: 'zoom' } });
+    // Severity changes (and the parent re-renders with new filters) before the debounce fires.
+    rerender(<VulnFilterBar filters={{ ...FILTERS, severity: 'critical' }} onChange={onChange} />);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'zoom', severity: 'critical' }));
+  });
+
+  it('keeps the search placeholder honest per tab (CVE endpoint only matches CVE ids)', () => {
+    const { rerender } = render(<VulnFilterBar filters={FILTERS} onChange={() => {}} searchScope="software" />);
+    expect(screen.getByTestId('vuln-filter-search')).toHaveAttribute('placeholder', 'Search software or CVE…');
+    rerender(<VulnFilterBar filters={FILTERS} onChange={() => {}} searchScope="cves" />);
+    expect(screen.getByTestId('vuln-filter-search')).toHaveAttribute('placeholder', 'Search CVE id…');
+  });
+
+  it('syncs the box when the parent resets filters externally', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<VulnFilterBar filters={{ ...FILTERS, search: 'chrome' }} onChange={onChange} />);
+    expect(screen.getByTestId('vuln-filter-search')).toHaveValue('chrome');
+    rerender(<VulnFilterBar filters={FILTERS} onChange={onChange} />);
+    expect(screen.getByTestId('vuln-filter-search')).toHaveValue('');
+  });
+});

--- a/apps/web/src/components/vulnerabilities/VulnFilterBar.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnFilterBar.tsx
@@ -1,0 +1,82 @@
+import type { VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'mitigated', label: 'Mitigated' },
+  { value: 'patched', label: 'Patched' },
+  { value: 'all', label: 'All statuses' },
+] as const;
+
+const selectCls = 'rounded-md border bg-background px-2 py-1 text-sm';
+
+export function VulnFilterBar({
+  filters,
+  onChange,
+}: {
+  filters: VulnFleetFilters;
+  onChange: (f: VulnFleetFilters) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <input
+        type="search"
+        data-testid="vuln-filter-search"
+        value={filters.search}
+        onChange={(e) => onChange({ ...filters, search: e.target.value })}
+        placeholder="Search software or CVE…"
+        className="w-56 rounded-md border bg-background px-2 py-1 text-sm"
+      />
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Severity</span>
+        <select
+          data-testid="vuln-filter-severity"
+          value={filters.severity}
+          onChange={(e) => onChange({ ...filters, severity: e.target.value })}
+          className={selectCls}
+        >
+          <option value="">All</option>
+          {SEVERITY_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s[0]!.toUpperCase() + s.slice(1)}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Status</span>
+        <select
+          data-testid="vuln-filter-status"
+          value={filters.status}
+          onChange={(e) => onChange({ ...filters, status: e.target.value })}
+          className={selectCls}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          data-testid="vuln-filter-kev"
+          checked={filters.kevOnly}
+          onChange={(e) => onChange({ ...filters, kevOnly: e.target.checked })}
+          className="h-4 w-4 rounded border"
+        />
+        <span>KEV only</span>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          data-testid="vuln-filter-patch"
+          checked={filters.patchAvailable}
+          onChange={(e) => onChange({ ...filters, patchAvailable: e.target.checked })}
+          className="h-4 w-4 rounded border"
+        />
+        <span>Patch available</span>
+      </label>
+    </div>
+  );
+}
+
+export default VulnFilterBar;

--- a/apps/web/src/components/vulnerabilities/VulnFilterBar.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnFilterBar.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useRef, useState } from 'react';
+
 import type { VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
 const STATUS_OPTIONS = [
@@ -11,21 +15,62 @@ const STATUS_OPTIONS = [
 
 const selectCls = 'rounded-md border bg-background px-2 py-1 text-sm';
 
+// Honest, tab-aware placeholder: the software endpoint matches name, vendor
+// and CVE ids, but the by-CVE endpoint only matches CVE ids (matching software
+// names there would mean joining per-device inventory into the CVE aggregate —
+// not a small or index-friendly change), so the placeholder must not promise it.
+const SEARCH_PLACEHOLDER: Record<'software' | 'cves', string> = {
+  software: 'Search software or CVE…',
+  cves: 'Search CVE id…',
+};
+
 export function VulnFilterBar({
   filters,
   onChange,
+  searchScope = 'software',
 }: {
   filters: VulnFleetFilters;
   onChange: (f: VulnFleetFilters) => void;
+  /** Active tab — controls what the search placeholder can honestly claim. */
+  searchScope?: 'software' | 'cves';
 }) {
+  // Local echo of the search box so typing is instant while the fetch-driving
+  // filter commits on a trailing debounce (one request per pause, not per
+  // keystroke — same pattern as TicketsPage). Clearing applies immediately.
+  const [searchText, setSearchText] = useState(filters.search);
+  // Latest filters/onChange without retriggering the debounce effect: the
+  // timer must only reset on *typing*, and a commit must never carry a stale
+  // copy of the other (non-debounced) filter fields.
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // External resets (Clear filters, stat-card presets) flow back into the box.
+  useEffect(() => {
+    setSearchText(filters.search);
+  }, [filters.search]);
+
+  useEffect(() => {
+    if (searchText === filtersRef.current.search) return;
+    const commit = () => onChangeRef.current({ ...filtersRef.current, search: searchText });
+    if (searchText === '') {
+      // An emptied box applies immediately — clearing a search should feel instant.
+      commit();
+      return;
+    }
+    const id = setTimeout(commit, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [searchText]);
+
   return (
     <div className="flex flex-wrap items-center gap-3">
       <input
         type="search"
         data-testid="vuln-filter-search"
-        value={filters.search}
-        onChange={(e) => onChange({ ...filters, search: e.target.value })}
-        placeholder="Search software or CVE…"
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        placeholder={SEARCH_PLACEHOLDER[searchScope]}
         className="w-56 rounded-md border bg-background px-2 py-1 text-sm"
       />
       <label className="flex items-center gap-2 text-sm">
@@ -47,7 +92,10 @@ export function VulnFilterBar({
         <select
           data-testid="vuln-filter-status"
           value={filters.status}
-          onChange={(e) => onChange({ ...filters, status: e.target.value })}
+          // Changing status drops the (invisible) expiring-soon window — it is
+          // only meaningful for accepted findings and must not silently narrow
+          // another status view.
+          onChange={(e) => onChange({ ...filters, status: e.target.value, expiringWithinDays: undefined })}
           className={selectCls}
         >
           {STATUS_OPTIONS.map((s) => (
@@ -75,6 +123,21 @@ export function VulnFilterBar({
         />
         <span>Patch available</span>
       </label>
+      {filters.expiringWithinDays !== undefined && (
+        // Active-filter chip for the stat-card-driven window: there is no
+        // visible control that sets it, so without this chip users would be
+        // trapped in an invisible filter.
+        <button
+          type="button"
+          data-testid="vuln-filter-expiring-clear"
+          className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2.5 py-1 text-xs font-medium transition hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary"
+          aria-label={`Clear the expiring within ${filters.expiringWithinDays} days filter`}
+          onClick={() => onChange({ ...filters, expiringWithinDays: undefined })}
+        >
+          Expiring within {filters.expiringWithinDays} days
+          <span aria-hidden="true">×</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
@@ -20,9 +20,11 @@ describe('VulnerabilityFleetPage', () => {
       kevDeviceCount: 5,
       patchReadyFindingCount: 12,
       acceptedExpiringSoon: 1,
+      totalFindings: 23,
+      lastDetectedAt: '2026-06-30T00:00:00.000Z',
     });
     vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
-    vi.mocked(api.fetchVulnerabilities).mockResolvedValue({ items: [] });
+    vi.mocked(api.fetchVulnerabilities).mockResolvedValue({ items: [], hasMore: false });
   });
 
   it('defaults to the software tab and renders the four stat cards', async () => {
@@ -62,7 +64,38 @@ describe('VulnerabilityFleetPage', () => {
     );
     fireEvent.click(screen.getByTestId('vuln-stat-accepted-expiring'));
     await vi.waitFor(() =>
-      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'accepted' })),
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(
+        // Honest card: the table must apply the same 14-day expiry window the
+        // stat number is computed from, not just status=accepted.
+        expect.objectContaining({ status: 'accepted', expiringWithinDays: 14 }),
+      ),
+    );
+  });
+
+  it('surfaces the invisible expiring-soon window as a clearable filter chip', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-stat-accepted-expiring'));
+    const chip = await screen.findByTestId('vuln-filter-expiring-clear');
+    expect(chip).toHaveTextContent('Expiring within 14 days');
+    fireEvent.click(chip);
+    expect(screen.queryByTestId('vuln-filter-expiring-clear')).toBeNull();
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'accepted', expiringWithinDays: undefined }),
+      ),
+    );
+  });
+
+  it('drops the expiring-soon window when the status filter changes', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-stat-accepted-expiring'));
+    await screen.findByTestId('vuln-filter-expiring-clear');
+    fireEvent.change(screen.getByTestId('vuln-filter-status'), { target: { value: 'open' } });
+    expect(screen.queryByTestId('vuln-filter-expiring-clear')).toBeNull();
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'open', expiringWithinDays: undefined }),
+      ),
     );
   });
 
@@ -79,6 +112,83 @@ describe('VulnerabilityFleetPage', () => {
     vi.mocked(api.fetchVulnStats).mockRejectedValue(new Error('stats boom'));
     render(<VulnerabilityFleetPage />);
     await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalled());
-    expect(await screen.findByTestId('vuln-stat-critical')).toHaveTextContent('—');
+    // Failure state is "—" (unavailable), not the loading skeleton.
+    await vi.waitFor(() => expect(screen.getByTestId('vuln-stat-critical')).toHaveTextContent('—'));
+    expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(0);
+  });
+
+  it('shows a calm skeleton (not "—") on the stat cards while stats load', async () => {
+    let resolveStats!: (s: Awaited<ReturnType<typeof api.fetchVulnStats>>) => void;
+    vi.mocked(api.fetchVulnStats).mockReturnValue(new Promise((r) => { resolveStats = r; }));
+    render(<VulnerabilityFleetPage />);
+    expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(4);
+    expect(screen.getByTestId('vuln-stat-critical')).not.toHaveTextContent('—');
+    resolveStats({ criticalOpen: 3, kevCveCount: 2, kevDeviceCount: 5, patchReadyFindingCount: 12, acceptedExpiringSoon: 1, totalFindings: 23, lastDetectedAt: '2026-06-30T00:00:00.000Z' });
+    await vi.waitFor(() => expect(screen.getByTestId('vuln-stat-critical')).toHaveTextContent('3'));
+    expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(0);
+  });
+
+  it('names each stat card unit explicitly in its detail line', async () => {
+    render(<VulnerabilityFleetPage />);
+    // beforeEach stats: criticalOpen 3, kevCveCount 2, kevDeviceCount 5,
+    // patchReadyFindingCount 12, acceptedExpiringSoon 1.
+    expect(await screen.findByTestId('vuln-stat-critical')).toHaveTextContent('3 open findings rated critical');
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveTextContent('2 known-exploited CVEs · 5 devices');
+    expect(screen.getByTestId('vuln-stat-patch-ready')).toHaveTextContent('12 open findings with a patch available');
+    expect(screen.getByTestId('vuln-stat-accepted-expiring')).toHaveTextContent('1 accepted finding expiring within 14 days');
+  });
+
+  it('pluralizes the KEV detail correctly for one CVE on one device', async () => {
+    vi.mocked(api.fetchVulnStats).mockResolvedValue({
+      criticalOpen: 0,
+      kevCveCount: 1,
+      kevDeviceCount: 1,
+      patchReadyFindingCount: 0,
+      acceptedExpiringSoon: 0,
+      totalFindings: 2,
+      lastDetectedAt: '2026-06-30T00:00:00.000Z',
+    });
+    render(<VulnerabilityFleetPage />);
+    await vi.waitFor(() => expect(screen.getByTestId('vuln-stat-kev')).toHaveTextContent('1 known-exploited CVE · 1 device'));
+    expect(screen.getByTestId('vuln-stat-kev')).not.toHaveTextContent('1 devices');
+  });
+
+  it('zero rows with default filters and prior findings reads as a clean fleet', async () => {
+    // beforeEach: tables return no rows, stats.totalFindings = 23.
+    render(<VulnerabilityFleetPage />);
+    expect(await screen.findByTestId('vuln-empty-clean')).toHaveTextContent('No open vulnerabilities across your fleet');
+    expect(screen.queryByTestId('vuln-empty-filtered')).toBeNull();
+  });
+
+  it('zero rows with zero findings ever reads as not-set-up, with a policies link', async () => {
+    vi.mocked(api.fetchVulnStats).mockResolvedValue({
+      criticalOpen: 0,
+      kevCveCount: 0,
+      kevDeviceCount: 0,
+      patchReadyFindingCount: 0,
+      acceptedExpiringSoon: 0,
+      totalFindings: 0,
+      lastDetectedAt: null,
+    });
+    render(<VulnerabilityFleetPage />);
+    expect(await screen.findByTestId('vuln-empty-unscanned')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-empty-setup-link')).toHaveAttribute('href', '/configuration-policies');
+  });
+
+  it('zero rows under an active filter blames the filters (never the clean state), on both tabs', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.change(await screen.findByTestId('vuln-filter-severity'), { target: { value: 'low' } });
+    expect(await screen.findByTestId('vuln-empty-filtered')).toBeInTheDocument();
+    expect(screen.queryByTestId('vuln-empty-clean')).toBeNull();
+    // Same logic drives the CVE tab.
+    fireEvent.click(screen.getByTestId('vuln-tab-cves'));
+    expect(await screen.findByTestId('vuln-empty-filtered')).toBeInTheDocument();
+  });
+
+  it('keeps the search placeholder honest per tab (CVE endpoint only matches CVE ids)', async () => {
+    render(<VulnerabilityFleetPage />);
+    expect(await screen.findByTestId('vuln-filter-search')).toHaveAttribute('placeholder', 'Search software or CVE…');
+    fireEvent.click(screen.getByTestId('vuln-tab-cves'));
+    expect(screen.getByTestId('vuln-filter-search')).toHaveAttribute('placeholder', 'Search CVE id…');
   });
 });

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchVulnStats: vi.fn(),
+  fetchSoftwareGroups: vi.fn(),
+  fetchVulnerabilities: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import VulnerabilityFleetPage from './VulnerabilityFleetPage';
+
+describe('VulnerabilityFleetPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    vi.mocked(api.fetchVulnStats).mockResolvedValue({
+      criticalOpen: 3,
+      kevCveCount: 2,
+      kevDeviceCount: 5,
+      patchReadyFindingCount: 12,
+      acceptedExpiringSoon: 1,
+    });
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
+    vi.mocked(api.fetchVulnerabilities).mockResolvedValue({ items: [] });
+  });
+
+  it('defaults to the software tab and renders the four stat cards', async () => {
+    render(<VulnerabilityFleetPage />);
+    expect(await screen.findByTestId('vuln-stat-critical')).toHaveTextContent('3');
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveTextContent('2');
+    expect(screen.getByTestId('vuln-stat-patch-ready')).toHaveTextContent('12');
+    expect(screen.getByTestId('vuln-stat-accepted-expiring')).toHaveTextContent('1');
+    await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalled());
+    expect(api.fetchVulnerabilities).not.toHaveBeenCalled();
+  });
+
+  it('switches tabs via click and writes the hash', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-tab-cves'));
+    expect(window.location.hash).toBe('#cves');
+    await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
+  });
+
+  it('honors a #cves deep link on mount', async () => {
+    window.location.hash = '#cves';
+    render(<VulnerabilityFleetPage />);
+    await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
+  });
+
+  it('applies the matching filter when a stat card is clicked', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-stat-critical'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(
+        expect.objectContaining({ severity: 'critical', status: 'open' }),
+      ),
+    );
+    fireEvent.click(screen.getByTestId('vuln-stat-kev'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ kevOnly: true })),
+    );
+    fireEvent.click(screen.getByTestId('vuln-stat-accepted-expiring'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'accepted' })),
+    );
+  });
+
+  it('changes filters through the filter bar', async () => {
+    render(<VulnerabilityFleetPage />);
+    await screen.findByTestId('vuln-filter-severity');
+    fireEvent.change(screen.getByTestId('vuln-filter-severity'), { target: { value: 'high' } });
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'high' })),
+    );
+  });
+});

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
@@ -74,4 +74,11 @@ describe('VulnerabilityFleetPage', () => {
       expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'high' })),
     );
   });
+
+  it('does not break the software table when the stats fetch fails', async () => {
+    vi.mocked(api.fetchVulnStats).mockRejectedValue(new Error('stats boom'));
+    render(<VulnerabilityFleetPage />);
+    await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalled());
+    expect(await screen.findByTestId('vuln-stat-critical')).toHaveTextContent('—');
+  });
 });

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 vi.mock('../../lib/api/vulnerabilities', () => ({
   fetchVulnStats: vi.fn(),
@@ -44,6 +44,49 @@ describe('VulnerabilityFleetPage', () => {
     await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
   });
 
+  it('exposes the view switcher as a WAI-ARIA tablist with aria-selected and panel pairing', async () => {
+    render(<VulnerabilityFleetPage />);
+    const tablist = await screen.findByRole('tablist', { name: 'Vulnerability views' });
+    const software = screen.getByTestId('vuln-tab-software');
+    const cves = screen.getByTestId('vuln-tab-cves');
+    expect(within(tablist).getAllByRole('tab')).toHaveLength(2);
+    expect(software).toHaveAttribute('aria-selected', 'true');
+    expect(cves).toHaveAttribute('aria-selected', 'false');
+    // Roving tabindex: only the active tab is in the tab order.
+    expect(software).toHaveAttribute('tabindex', '0');
+    expect(cves).toHaveAttribute('tabindex', '-1');
+    // Tab ↔ panel pairing.
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('id', 'vuln-tabpanel-software');
+    expect(software).toHaveAttribute('aria-controls', 'vuln-tabpanel-software');
+    expect(panel).toHaveAttribute('aria-labelledby', 'vuln-tab-software');
+    fireEvent.click(cves);
+    expect(cves).toHaveAttribute('aria-selected', 'true');
+    expect(software).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'vuln-tabpanel-cves');
+  });
+
+  it('moves between tabs with Left/Right arrows (activating, focusing, and writing the hash)', async () => {
+    render(<VulnerabilityFleetPage />);
+    const tablist = await screen.findByRole('tablist', { name: 'Vulnerability views' });
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getByTestId('vuln-tab-cves')).toHaveAttribute('aria-selected', 'true');
+    expect(window.location.hash).toBe('#cves');
+    expect(document.activeElement).toBe(screen.getByTestId('vuln-tab-cves'));
+    await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
+    // Wraps around at the ends.
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getByTestId('vuln-tab-software')).toHaveAttribute('aria-selected', 'true');
+    expect(window.location.hash).toBe('#software');
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('vuln-tab-cves')).toHaveAttribute('aria-selected', 'true');
+    // Home/End jump to the ends.
+    fireEvent.keyDown(tablist, { key: 'Home' });
+    expect(screen.getByTestId('vuln-tab-software')).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(tablist, { key: 'End' });
+    expect(screen.getByTestId('vuln-tab-cves')).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('honors a #cves deep link on mount', async () => {
     window.location.hash = '#cves';
     render(<VulnerabilityFleetPage />);
@@ -70,6 +113,25 @@ describe('VulnerabilityFleetPage', () => {
         expect.objectContaining({ status: 'accepted', expiringWithinDays: 14 }),
       ),
     );
+  });
+
+  it('marks the applied stat-card preset with aria-pressed and drops it when filters diverge', async () => {
+    render(<VulnerabilityFleetPage />);
+    const critical = await screen.findByTestId('vuln-stat-critical');
+    // Nothing applied yet.
+    for (const id of ['vuln-stat-critical', 'vuln-stat-kev', 'vuln-stat-patch-ready', 'vuln-stat-accepted-expiring']) {
+      expect(screen.getByTestId(id)).toHaveAttribute('aria-pressed', 'false');
+    }
+    fireEvent.click(critical);
+    expect(critical).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveAttribute('aria-pressed', 'false');
+    // Switching preset moves the pressed state.
+    fireEvent.click(screen.getByTestId('vuln-stat-kev'));
+    expect(critical).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveAttribute('aria-pressed', 'true');
+    // Manually diverging from the preset (severity change) unpresses it.
+    fireEvent.change(screen.getByTestId('vuln-filter-severity'), { target: { value: 'high' } });
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('surfaces the invisible expiring-soon window as a clearable filter chip', async () => {

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type KeyboardEvent } from 'react';
 import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
 
 import SecurityStatCard from '../security/SecurityStatCard';
@@ -17,6 +17,32 @@ export { DEFAULT_FILTERS };
 
 type Tab = 'software' | 'cves';
 const VALID_TABS: Tab[] = ['software', 'cves'];
+const TAB_LABELS: Record<Tab, string> = { software: 'By software', cves: 'By CVE' };
+
+// Each stat card is a filter shortcut; its preset is compared against the live
+// filters so the currently-applied card can render pressed (aria-pressed).
+const STAT_PRESETS = {
+  critical: { ...DEFAULT_FILTERS, severity: 'critical' },
+  kev: { ...DEFAULT_FILTERS, kevOnly: true },
+  patchReady: { ...DEFAULT_FILTERS, patchAvailable: true },
+  acceptedExpiring: { ...DEFAULT_FILTERS, status: 'accepted', expiringWithinDays: 14 },
+} satisfies Record<string, VulnFleetFilters>;
+
+function filtersMatchPreset(filters: VulnFleetFilters, preset: VulnFleetFilters): boolean {
+  return (
+    filters.search === preset.search &&
+    filters.severity === preset.severity &&
+    filters.status === preset.status &&
+    filters.kevOnly === preset.kevOnly &&
+    filters.patchAvailable === preset.patchAvailable &&
+    filters.expiringWithinDays === preset.expiringWithinDays
+  );
+}
+
+// Keyboard focus ring for the stat-card shortcut buttons; hover + pressed
+// styling lives on the card itself (SecurityStatCard interactive/active).
+const STAT_BUTTON =
+  'block h-full w-full rounded-lg text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
 function getTabFromHash(): Tab {
   if (typeof window === 'undefined') return 'software';
@@ -94,11 +120,28 @@ export function VulnerabilityFleetPage() {
   const clearFilters = () => setFilters(DEFAULT_FILTERS);
 
   const tabCls = (tab: Tab) =>
-    `border-b-2 px-3 py-2 text-sm font-medium transition ${
+    `-mb-px border-b-2 px-3 py-2 text-sm font-medium transition ${
       activeTab === tab
         ? 'border-primary text-foreground'
         : 'border-transparent text-muted-foreground hover:text-foreground'
     }`;
+
+  // Roving keyboard navigation across the tablist (WAI-ARIA tabs pattern):
+  // Left/Right move between tabs, Home/End jump to the ends, and the moved-to
+  // tab is both activated (hash included, via switchTab) and focused.
+  const onTabKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const idx = VALID_TABS.indexOf(activeTab);
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight') nextIdx = (idx + 1) % VALID_TABS.length;
+    else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + VALID_TABS.length) % VALID_TABS.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = VALID_TABS.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const next = VALID_TABS[nextIdx]!;
+    switchTab(next);
+    if (typeof document !== 'undefined') document.getElementById(`vuln-tab-${next}`)?.focus();
+  };
 
   // Loading and unavailable are distinct states: a calm skeleton while the
   // first fetch is in flight, "—" only when the fetch actually failed.
@@ -117,7 +160,13 @@ export function VulnerabilityFleetPage() {
         {/* Every detail line leads with "N <unit>" so the four cards compare at
             a glance — three count findings, KEV counts CVEs (plus the device
             blast radius), and the copy says which. */}
-        <button type="button" data-testid="vuln-stat-critical" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, severity: 'critical' })}>
+        <button
+          type="button"
+          data-testid="vuln-stat-critical"
+          className={STAT_BUTTON}
+          aria-pressed={filtersMatchPreset(filters, STAT_PRESETS.critical)}
+          onClick={() => setFilters(STAT_PRESETS.critical)}
+        >
           <SecurityStatCard
             icon={AlertTriangle}
             label="Critical open"
@@ -125,9 +174,17 @@ export function VulnerabilityFleetPage() {
             variant="danger"
             detail={stats ? `${plural(stats.criticalOpen, 'open finding')} rated critical` : undefined}
             loading={statsLoading}
+            interactive
+            active={filtersMatchPreset(filters, STAT_PRESETS.critical)}
           />
         </button>
-        <button type="button" data-testid="vuln-stat-kev" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, kevOnly: true })}>
+        <button
+          type="button"
+          data-testid="vuln-stat-kev"
+          className={STAT_BUTTON}
+          aria-pressed={filtersMatchPreset(filters, STAT_PRESETS.kev)}
+          onClick={() => setFilters(STAT_PRESETS.kev)}
+        >
           <SecurityStatCard
             icon={ShieldAlert}
             label="KEV exposure"
@@ -135,9 +192,17 @@ export function VulnerabilityFleetPage() {
             variant="warning"
             detail={stats ? `${plural(stats.kevCveCount, 'known-exploited CVE')} · ${plural(stats.kevDeviceCount, 'device')}` : undefined}
             loading={statsLoading}
+            interactive
+            active={filtersMatchPreset(filters, STAT_PRESETS.kev)}
           />
         </button>
-        <button type="button" data-testid="vuln-stat-patch-ready" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, patchAvailable: true })}>
+        <button
+          type="button"
+          data-testid="vuln-stat-patch-ready"
+          className={STAT_BUTTON}
+          aria-pressed={filtersMatchPreset(filters, STAT_PRESETS.patchReady)}
+          onClick={() => setFilters(STAT_PRESETS.patchReady)}
+        >
           <SecurityStatCard
             icon={Wrench}
             label="Patch ready"
@@ -145,49 +210,82 @@ export function VulnerabilityFleetPage() {
             variant="success"
             detail={stats ? `${plural(stats.patchReadyFindingCount, 'open finding')} with a patch available` : undefined}
             loading={statsLoading}
+            interactive
+            active={filtersMatchPreset(filters, STAT_PRESETS.patchReady)}
           />
         </button>
-        <button type="button" data-testid="vuln-stat-accepted-expiring" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, status: 'accepted', expiringWithinDays: 14 })}>
+        <button
+          type="button"
+          data-testid="vuln-stat-accepted-expiring"
+          className={STAT_BUTTON}
+          aria-pressed={filtersMatchPreset(filters, STAT_PRESETS.acceptedExpiring)}
+          onClick={() => setFilters(STAT_PRESETS.acceptedExpiring)}
+        >
           <SecurityStatCard
             icon={Clock}
             label="Accepted, expiring soon"
             value={stats?.acceptedExpiringSoon ?? '—'}
             detail={stats ? `${plural(stats.acceptedExpiringSoon, 'accepted finding')} expiring within 14 days` : undefined}
             loading={statsLoading}
+            interactive
+            active={filtersMatchPreset(filters, STAT_PRESETS.acceptedExpiring)}
           />
         </button>
       </div>
 
-      <div className="flex items-center gap-1 border-b">
-        <button type="button" data-testid="vuln-tab-software" className={tabCls('software')} onClick={() => switchTab('software')}>
-          By software
-        </button>
-        <button type="button" data-testid="vuln-tab-cves" className={tabCls('cves')} onClick={() => switchTab('cves')}>
-          By CVE
-        </button>
+      <div
+        role="tablist"
+        aria-label="Vulnerability views"
+        className="flex items-center gap-1 border-b"
+        onKeyDown={onTabKeyDown}
+      >
+        {VALID_TABS.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            id={`vuln-tab-${tab}`}
+            aria-selected={activeTab === tab}
+            aria-controls={`vuln-tabpanel-${tab}`}
+            tabIndex={activeTab === tab ? 0 : -1}
+            data-testid={`vuln-tab-${tab}`}
+            className={tabCls(tab)}
+            onClick={() => switchTab(tab)}
+          >
+            {TAB_LABELS[tab]}
+          </button>
+        ))}
       </div>
 
       <VulnFilterBar filters={filters} onChange={setFilters} searchScope={activeTab} />
 
-      {activeTab === 'software' ? (
-        <SoftwareGroupTable
-          filters={filters}
-          refreshKey={refreshKey}
-          emptyVariant={emptyVariant}
-          lastDetectedAt={lastDetectedAt}
-          onSelectGroup={(groupKey) => select('software', groupKey)}
-          onClearFilters={clearFilters}
-        />
-      ) : (
-        <VulnerabilityTable
-          filters={filters}
-          refreshKey={refreshKey}
-          emptyVariant={emptyVariant}
-          lastDetectedAt={lastDetectedAt}
-          onSelectCve={(cveId) => select('cves', cveId)}
-          onClearFilters={clearFilters}
-        />
-      )}
+      {/* Only the active panel is mounted; its id/labelledby swap with the tab. */}
+      <div
+        role="tabpanel"
+        id={`vuln-tabpanel-${activeTab}`}
+        aria-labelledby={`vuln-tab-${activeTab}`}
+        data-testid={`vuln-tabpanel-${activeTab}`}
+      >
+        {activeTab === 'software' ? (
+          <SoftwareGroupTable
+            filters={filters}
+            refreshKey={refreshKey}
+            emptyVariant={emptyVariant}
+            lastDetectedAt={lastDetectedAt}
+            onSelectGroup={(groupKey) => select('software', groupKey)}
+            onClearFilters={clearFilters}
+          />
+        ) : (
+          <VulnerabilityTable
+            filters={filters}
+            refreshKey={refreshKey}
+            emptyVariant={emptyVariant}
+            lastDetectedAt={lastDetectedAt}
+            onSelectCve={(cveId) => select('cves', cveId)}
+            onClearFilters={clearFilters}
+          />
+        )}
+      </div>
       {selection && activeTab === 'software' && (
         <SoftwareGroupDrawer
           groupKey={selection}

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -2,23 +2,21 @@ import { useEffect, useState } from 'react';
 import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
 
 import SecurityStatCard from '../security/SecurityStatCard';
+import { plural } from '../../lib/utils';
 import { VulnFilterBar } from './VulnFilterBar';
 import { SoftwareGroupTable } from './SoftwareGroupTable';
 import { SoftwareGroupDrawer } from './SoftwareGroupDrawer';
 import { CveDrawer } from './CveDrawer';
 import { VulnerabilityTable } from './VulnerabilityTable';
+import { DEFAULT_FILTERS, resolveVulnEmptyVariant } from './VulnEmptyState';
 import { fetchVulnStats, type FleetVulnStats, type VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+// Filter baseline lives with the empty-state logic (which compares against it);
+// re-exported here because this is the page-level public surface.
+export { DEFAULT_FILTERS };
 
 type Tab = 'software' | 'cves';
 const VALID_TABS: Tab[] = ['software', 'cves'];
-
-export const DEFAULT_FILTERS: VulnFleetFilters = {
-  search: '',
-  severity: '',
-  status: 'open',
-  kevOnly: false,
-  patchAvailable: false,
-};
 
 function getTabFromHash(): Tab {
   if (typeof window === 'undefined') return 'software';
@@ -45,6 +43,7 @@ export function VulnerabilityFleetPage() {
   const [selection, setSelection] = useState<string | undefined>(getSelectionFromHash);
   const [filters, setFilters] = useState<VulnFleetFilters>(DEFAULT_FILTERS);
   const [stats, setStats] = useState<FleetVulnStats | null>(null);
+  const [statsError, setStatsError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
@@ -60,10 +59,14 @@ export function VulnerabilityFleetPage() {
     let cancelled = false;
     fetchVulnStats()
       .then((s) => {
-        if (!cancelled) setStats(s);
+        if (cancelled) return;
+        setStats(s);
+        setStatsError(false);
       })
       .catch(() => {
-        /* stat cards are non-blocking; tables surface their own errors */
+        // Stat cards are non-blocking (tables surface their own errors), but
+        // record the failure so "—" reads as unavailable, not still-loading.
+        if (!cancelled) setStatsError(true);
       });
     return () => {
       cancelled = true;
@@ -97,26 +100,61 @@ export function VulnerabilityFleetPage() {
         : 'border-transparent text-muted-foreground hover:text-foreground'
     }`;
 
+  // Loading and unavailable are distinct states: a calm skeleton while the
+  // first fetch is in flight, "—" only when the fetch actually failed.
+  const statsLoading = stats === null && !statsError;
+
+  // Which zero-rows story the tables should tell (filtered vs clean fleet vs
+  // never scanned) — decided here because it needs both filters and stats.
+  const emptyVariant = resolveVulnEmptyVariant(filters, stats);
+  const lastDetectedAt = stats?.lastDetectedAt ?? null;
+
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-4">
-        <button type="button" data-testid="vuln-stat-critical" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, severity: 'critical' })}>
-          <SecurityStatCard icon={AlertTriangle} label="Critical open" value={stats?.criticalOpen ?? '—'} variant="danger" />
+      {/* 1 → 2 → 4 columns: the 2-col step keeps the cards comfortable around
+          tablet widths; h-full keeps the row's card heights even. */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {/* Every detail line leads with "N <unit>" so the four cards compare at
+            a glance — three count findings, KEV counts CVEs (plus the device
+            blast radius), and the copy says which. */}
+        <button type="button" data-testid="vuln-stat-critical" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, severity: 'critical' })}>
+          <SecurityStatCard
+            icon={AlertTriangle}
+            label="Critical open"
+            value={stats?.criticalOpen ?? '—'}
+            variant="danger"
+            detail={stats ? `${plural(stats.criticalOpen, 'open finding')} rated critical` : undefined}
+            loading={statsLoading}
+          />
         </button>
-        <button type="button" data-testid="vuln-stat-kev" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, kevOnly: true })}>
+        <button type="button" data-testid="vuln-stat-kev" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, kevOnly: true })}>
           <SecurityStatCard
             icon={ShieldAlert}
             label="KEV exposure"
             value={stats?.kevCveCount ?? '—'}
             variant="warning"
-            detail={stats ? `${stats.kevDeviceCount} devices affected` : undefined}
+            detail={stats ? `${plural(stats.kevCveCount, 'known-exploited CVE')} · ${plural(stats.kevDeviceCount, 'device')}` : undefined}
+            loading={statsLoading}
           />
         </button>
-        <button type="button" data-testid="vuln-stat-patch-ready" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, patchAvailable: true })}>
-          <SecurityStatCard icon={Wrench} label="Patch ready" value={stats?.patchReadyFindingCount ?? '—'} variant="success" detail="fixable right now" />
+        <button type="button" data-testid="vuln-stat-patch-ready" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, patchAvailable: true })}>
+          <SecurityStatCard
+            icon={Wrench}
+            label="Patch ready"
+            value={stats?.patchReadyFindingCount ?? '—'}
+            variant="success"
+            detail={stats ? `${plural(stats.patchReadyFindingCount, 'open finding')} with a patch available` : undefined}
+            loading={statsLoading}
+          />
         </button>
-        <button type="button" data-testid="vuln-stat-accepted-expiring" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, status: 'accepted' })}>
-          <SecurityStatCard icon={Clock} label="Accepted, expiring soon" value={stats?.acceptedExpiringSoon ?? '—'} detail="within 14 days" />
+        <button type="button" data-testid="vuln-stat-accepted-expiring" className="h-full text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, status: 'accepted', expiringWithinDays: 14 })}>
+          <SecurityStatCard
+            icon={Clock}
+            label="Accepted, expiring soon"
+            value={stats?.acceptedExpiringSoon ?? '—'}
+            detail={stats ? `${plural(stats.acceptedExpiringSoon, 'accepted finding')} expiring within 14 days` : undefined}
+            loading={statsLoading}
+          />
         </button>
       </div>
 
@@ -129,12 +167,14 @@ export function VulnerabilityFleetPage() {
         </button>
       </div>
 
-      <VulnFilterBar filters={filters} onChange={setFilters} />
+      <VulnFilterBar filters={filters} onChange={setFilters} searchScope={activeTab} />
 
       {activeTab === 'software' ? (
         <SoftwareGroupTable
           filters={filters}
           refreshKey={refreshKey}
+          emptyVariant={emptyVariant}
+          lastDetectedAt={lastDetectedAt}
           onSelectGroup={(groupKey) => select('software', groupKey)}
           onClearFilters={clearFilters}
         />
@@ -142,6 +182,8 @@ export function VulnerabilityFleetPage() {
         <VulnerabilityTable
           filters={filters}
           refreshKey={refreshKey}
+          emptyVariant={emptyVariant}
+          lastDetectedAt={lastDetectedAt}
           onSelectCve={(cveId) => select('cves', cveId)}
           onClearFilters={clearFilters}
         />

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
+
+import SecurityStatCard from '../security/SecurityStatCard';
+import { VulnFilterBar } from './VulnFilterBar';
+import { SoftwareGroupTable } from './SoftwareGroupTable';
+import { VulnerabilityTable } from './VulnerabilityTable';
+import { fetchVulnStats, type FleetVulnStats, type VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+type Tab = 'software' | 'cves';
+const VALID_TABS: Tab[] = ['software', 'cves'];
+
+export const DEFAULT_FILTERS: VulnFleetFilters = {
+  search: '',
+  severity: '',
+  status: 'open',
+  kevOnly: false,
+  patchAvailable: false,
+};
+
+function getTabFromHash(): Tab {
+  if (typeof window === 'undefined') return 'software';
+  const hash = window.location.hash.replace('#', '').split('/')[0] ?? '';
+  if (VALID_TABS.includes(hash as Tab)) return hash as Tab;
+  return 'software';
+}
+
+function getSelectionFromHash(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const [tab, ...rest] = window.location.hash.replace('#', '').split('/');
+  if (!VALID_TABS.includes(tab as Tab) || rest.length === 0) return undefined;
+  // groupKey segments may themselves contain encoded slashes — rejoin.
+  const raw = rest.join('/');
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export function VulnerabilityFleetPage() {
+  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
+  const [selection, setSelection] = useState<string | undefined>(getSelectionFromHash);
+  const [filters, setFilters] = useState<VulnFleetFilters>(DEFAULT_FILTERS);
+  const [stats, setStats] = useState<FleetVulnStats | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const onHashChange = () => {
+      setActiveTab(getTabFromHash());
+      setSelection(getSelectionFromHash());
+    };
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchVulnStats()
+      .then((s) => {
+        if (!cancelled) setStats(s);
+      })
+      .catch(() => {
+        /* stat cards are non-blocking; tables surface their own errors */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const switchTab = (tab: Tab) => {
+    window.location.hash = tab;
+    setActiveTab(tab);
+    setSelection(undefined);
+  };
+
+  const select = (tab: Tab, id: string) => {
+    window.location.hash = `${tab}/${encodeURIComponent(id)}`;
+    setActiveTab(tab);
+    setSelection(id);
+  };
+
+  const closeSelection = () => {
+    window.location.hash = activeTab;
+    setSelection(undefined);
+  };
+
+  const refresh = () => setRefreshKey((k) => k + 1);
+  const clearFilters = () => setFilters(DEFAULT_FILTERS);
+
+  const tabCls = (tab: Tab) =>
+    `border-b-2 px-3 py-2 text-sm font-medium transition ${
+      activeTab === tab
+        ? 'border-primary text-foreground'
+        : 'border-transparent text-muted-foreground hover:text-foreground'
+    }`;
+
+  // selection/closeSelection/refresh are consumed by the drawers wired in Tasks 13–14.
+  void selection;
+  void closeSelection;
+  void refresh;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-4">
+        <button type="button" data-testid="vuln-stat-critical" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, severity: 'critical' })}>
+          <SecurityStatCard icon={AlertTriangle} label="Critical open" value={stats?.criticalOpen ?? '—'} variant="danger" />
+        </button>
+        <button type="button" data-testid="vuln-stat-kev" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, kevOnly: true })}>
+          <SecurityStatCard
+            icon={ShieldAlert}
+            label="KEV exposure"
+            value={stats?.kevCveCount ?? '—'}
+            variant="warning"
+            detail={stats ? `${stats.kevDeviceCount} devices affected` : undefined}
+          />
+        </button>
+        <button type="button" data-testid="vuln-stat-patch-ready" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, patchAvailable: true })}>
+          <SecurityStatCard icon={Wrench} label="Patch ready" value={stats?.patchReadyFindingCount ?? '—'} variant="success" detail="fixable right now" />
+        </button>
+        <button type="button" data-testid="vuln-stat-accepted-expiring" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, status: 'accepted' })}>
+          <SecurityStatCard icon={Clock} label="Accepted, expiring soon" value={stats?.acceptedExpiringSoon ?? '—'} detail="within 14 days" />
+        </button>
+      </div>
+
+      <div className="flex items-center gap-1 border-b">
+        <button type="button" data-testid="vuln-tab-software" className={tabCls('software')} onClick={() => switchTab('software')}>
+          By software
+        </button>
+        <button type="button" data-testid="vuln-tab-cves" className={tabCls('cves')} onClick={() => switchTab('cves')}>
+          By CVE
+        </button>
+      </div>
+
+      <VulnFilterBar filters={filters} onChange={setFilters} />
+
+      {activeTab === 'software' ? (
+        <SoftwareGroupTable
+          filters={filters}
+          refreshKey={refreshKey}
+          onSelectGroup={(groupKey) => select('software', groupKey)}
+          onClearFilters={clearFilters}
+        />
+      ) : (
+        <VulnerabilityTable
+          filters={filters}
+          refreshKey={refreshKey}
+          onSelectCve={(cveId) => select('cves', cveId)}
+          onClearFilters={clearFilters}
+        />
+      )}
+      {/* Drawers mount here (Tasks 13–14): selection + activeTab decide which. */}
+    </div>
+  );
+}
+
+export default VulnerabilityFleetPage;

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -89,9 +89,12 @@ export function VulnerabilityFleetPage() {
         setStats(s);
         setStatsError(false);
       })
-      .catch(() => {
+      .catch((err) => {
         // Stat cards are non-blocking (tables surface their own errors), but
-        // record the failure so "—" reads as unavailable, not still-loading.
+        // log the cause so "the four cards always show dashes" reports are
+        // debuggable, then record the failure so "—" reads as unavailable,
+        // not still-loading.
+        console.error('[VulnerabilityFleetPage] stats fetch failed', err);
         if (!cancelled) setStatsError(true);
       });
     return () => {

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
 import SecurityStatCard from '../security/SecurityStatCard';
 import { VulnFilterBar } from './VulnFilterBar';
 import { SoftwareGroupTable } from './SoftwareGroupTable';
+import { SoftwareGroupDrawer } from './SoftwareGroupDrawer';
 import { VulnerabilityTable } from './VulnerabilityTable';
 import { fetchVulnStats, type FleetVulnStats, type VulnFleetFilters } from '../../lib/api/vulnerabilities';
 
@@ -95,11 +96,6 @@ export function VulnerabilityFleetPage() {
         : 'border-transparent text-muted-foreground hover:text-foreground'
     }`;
 
-  // selection/closeSelection/refresh are consumed by the drawers wired in Tasks 13–14.
-  void selection;
-  void closeSelection;
-  void refresh;
-
   return (
     <div className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-4">
@@ -149,7 +145,14 @@ export function VulnerabilityFleetPage() {
           onClearFilters={clearFilters}
         />
       )}
-      {/* Drawers mount here (Tasks 13–14): selection + activeTab decide which. */}
+      {selection && activeTab === 'software' && (
+        <SoftwareGroupDrawer
+          groupKey={selection}
+          onClose={closeSelection}
+          onActionComplete={refresh}
+          onSelectCve={(cveId) => select('cves', cveId)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx
@@ -5,6 +5,7 @@ import SecurityStatCard from '../security/SecurityStatCard';
 import { VulnFilterBar } from './VulnFilterBar';
 import { SoftwareGroupTable } from './SoftwareGroupTable';
 import { SoftwareGroupDrawer } from './SoftwareGroupDrawer';
+import { CveDrawer } from './CveDrawer';
 import { VulnerabilityTable } from './VulnerabilityTable';
 import { fetchVulnStats, type FleetVulnStats, type VulnFleetFilters } from '../../lib/api/vulnerabilities';
 
@@ -152,6 +153,9 @@ export function VulnerabilityFleetPage() {
           onActionComplete={refresh}
           onSelectCve={(cveId) => select('cves', cveId)}
         />
+      )}
+      {selection && activeTab === 'cves' && (
+        <CveDrawer cveId={selection} onClose={closeSelection} onActionComplete={refresh} />
       )}
     </div>
   );

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
@@ -98,9 +98,30 @@ describe('VulnerabilityTable', () => {
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     const row = desktop.getByTestId('vulnerability-row-1');
     expect(row).toHaveTextContent('42.0%'); // EPSS 0.42
-    expect(row).toHaveTextContent('Yes'); // patchAvailable
+    // Patch vocabulary matches the software tab ("Ready"/"—"), never Yes/No.
+    expect(row).toHaveTextContent('Ready'); // patchAvailable
+    expect(row).not.toHaveTextContent('Yes');
+    expect(desktop.getByTestId('vulnerability-row-2')).not.toHaveTextContent('Ready');
     fireEvent.click(row);
     expect(onSelect).toHaveBeenCalledWith('CVE-2025-1');
+  });
+
+  it('encodes KEV as the shared red badge (and "—" for absence), matching the software tab', async () => {
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const kevRow = desktop.getByTestId('vulnerability-row-1'); // knownExploited: true
+    expect(within(kevRow).getByText('KEV')).toBeInTheDocument();
+    expect(within(kevRow).getByText('KEV')).toHaveAttribute('title', expect.stringContaining('Known Exploited'));
+    const nonKevRow = desktop.getByTestId('vulnerability-row-2'); // knownExploited: false
+    expect(within(nonKevRow).queryByText('KEV')).toBeNull();
+    expect(nonKevRow).not.toHaveTextContent('Yes');
+  });
+
+  it('never wraps the CVE id cell (ids are opaque — the column widens instead)', async () => {
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const idCell = desktop.getByTestId('vulnerability-open-1').closest('td');
+    expect(idCell).toHaveClass('whitespace-nowrap');
   });
 
   it('shows the Status column only when the status filter is not open', async () => {

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
@@ -18,8 +18,8 @@ describe('VulnerabilityTable', () => {
   it('renders rows in risk order and shows a severity badge', async () => {
     mockFetch.mockResolvedValue({
       items: [
-        { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.9, riskScore: 100, deviceCount: 12 },
-        { id: '2', cveId: 'CVE-2025-2', cvssScore: 5.0, severity: 'medium', knownExploited: false, epssScore: 0.1, riskScore: 60, deviceCount: 3 },
+        { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.9, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
+        { id: '2', cveId: 'CVE-2025-2', cvssScore: 5.0, severity: 'medium', knownExploited: false, epssScore: 0.1, riskScore: 60, deviceCount: 3, patchAvailable: false, statuses: ['open'] },
       ],
     });
 

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
@@ -20,12 +20,13 @@ beforeEach(() => {
       { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.42, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
       { id: '2', cveId: 'CVE-2025-2', cvssScore: 5.0, severity: 'medium', knownExploited: false, epssScore: 0.1, riskScore: 60, deviceCount: 3, patchAvailable: false, statuses: ['open'] },
     ],
+    hasMore: false,
   });
 });
 
 describe('VulnerabilityTable', () => {
   it('renders rows in risk order and shows a severity badge', async () => {
-    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
 
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     const rows = await desktop.findAllByTestId(/^vulnerability-row-/);
@@ -35,11 +36,23 @@ describe('VulnerabilityTable', () => {
     expect(rows[0]).toHaveTextContent('12'); // affected device count
   });
 
+  it('explains the CVSS, Risk, EPSS, and KEV columns via header help tooltips', async () => {
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    for (const label of ['About the CVSS score', 'About the risk score', 'About the EPSS score', 'About the KEV flag']) {
+      expect(desktop.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+    fireEvent.click(desktop.getByRole('button', { name: 'About the risk score' }));
+    // The tooltip copy must reflect the real formula (vulnerabilityRiskScore.ts).
+    expect(desktop.getByRole('tooltip')).toHaveTextContent('CVSS score scaled to 100');
+    expect(desktop.getByRole('tooltip')).toHaveTextContent('never score below 85');
+  });
+
   it('maps the shared filter bar onto API filters (search -> cve substring)', async () => {
     render(
       <VulnerabilityTable
         filters={{ ...FILTERS, search: '0001', severity: 'critical', kevOnly: true }}
-        refreshKey={0}
+        refreshKey={0} emptyVariant="filtered"
         onSelectCve={() => {}}
         onClearFilters={() => {}}
       />,
@@ -51,9 +64,37 @@ describe('VulnerabilityTable', () => {
     );
   });
 
+  it('forwards the expiringWithinDays window to the API', async () => {
+    render(
+      <VulnerabilityTable
+        filters={{ ...FILTERS, status: 'accepted', expiringWithinDays: 14 }}
+        refreshKey={0} emptyVariant="filtered"
+        onSelectCve={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    await vi.waitFor(() =>
+      expect(api.fetchVulnerabilities).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'accepted', expiringWithinDays: 14 }),
+      ),
+    );
+  });
+
+  it('exposes a keyboard-activatable button on the CVE cell (single activation)', async () => {
+    const onSelect = vi.fn();
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={onSelect} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const openBtn = desktop.getByTestId('vulnerability-open-1');
+    expect(openBtn.tagName).toBe('BUTTON'); // real button => focusable + Enter/Space for free
+    expect(openBtn).toHaveAccessibleName('Open CVE-2025-1 details');
+    fireEvent.click(openBtn);
+    expect(onSelect).toHaveBeenCalledTimes(1); // stopPropagation: no double fire via the row handler
+    expect(onSelect).toHaveBeenCalledWith('CVE-2025-1');
+  });
+
   it('renders EPSS and Patch columns and fires onSelectCve on row click', async () => {
     const onSelect = vi.fn();
-    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={onSelect} onClearFilters={() => {}} />);
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={onSelect} onClearFilters={() => {}} />);
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     const row = desktop.getByTestId('vulnerability-row-1');
     expect(row).toHaveTextContent('42.0%'); // EPSS 0.42
@@ -64,30 +105,91 @@ describe('VulnerabilityTable', () => {
 
   it('shows the Status column only when the status filter is not open', async () => {
     const { rerender } = render(
-      <VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />,
+      <VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />,
     );
     const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     expect(desktop.queryByText('Status')).toBeNull();
     rerender(
-      <VulnerabilityTable filters={{ ...FILTERS, status: 'accepted' }} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />,
+      <VulnerabilityTable filters={{ ...FILTERS, status: 'accepted' }} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />,
     );
     await vi.waitFor(() =>
       expect(within(screen.getByTestId('responsive-table-desktop')).getByText('Status')).toBeInTheDocument(),
     );
   });
 
-  it('shows an empty state with a clear-filters button when there are no findings', async () => {
-    mockFetch.mockResolvedValue({ items: [] });
-    const onClear = vi.fn();
-    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={onClear} />);
+  it('renders skeleton rows under the header while the first fetch is in flight', async () => {
+    let resolve!: (v: { items: never[]; hasMore: boolean }) => void;
+    mockFetch.mockReturnValue(new Promise((r) => { resolve = r; }));
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    expect(screen.getByTestId('vulnerability-table-skeleton')).toBeInTheDocument();
+    resolve({ items: [], hasMore: false });
     expect(await screen.findByTestId('vulnerability-table-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('vulnerability-table-skeleton')).toBeNull();
+  });
+
+  it('shows a truncation notice when the server reports more rows than the cap', async () => {
+    mockFetch.mockResolvedValue({
+      items: [
+        { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.42, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
+      ],
+      hasMore: true,
+    });
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    expect(await screen.findByTestId('vulnerability-has-more')).toHaveTextContent('top 500 CVEs');
+  });
+
+  it('shows an empty state with a clear-filters button when there are no findings', async () => {
+    mockFetch.mockResolvedValue({ items: [], hasMore: false });
+    const onClear = vi.fn();
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={onClear} />);
+    expect(await screen.findByTestId('vulnerability-table-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-empty-filtered')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('vulnerability-clear-filters'));
     expect(onClear).toHaveBeenCalled();
   });
 
+  it('renders the clean-fleet and unscanned zero-states when the page resolves them', async () => {
+    mockFetch.mockResolvedValue({ items: [], hasMore: false });
+    const { rerender } = render(
+      <VulnerabilityTable
+        filters={FILTERS}
+        refreshKey={0} emptyVariant="clean"
+        lastDetectedAt="2026-06-30T00:00:00.000Z"
+        onSelectCve={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    expect(await screen.findByTestId('vuln-empty-clean')).toHaveTextContent('No open vulnerabilities across your fleet');
+    rerender(
+      <VulnerabilityTable
+        filters={FILTERS}
+        refreshKey={0} emptyVariant="unscanned"
+        onSelectCve={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    expect(await screen.findByTestId('vuln-empty-unscanned')).toHaveTextContent('No vulnerability findings yet');
+  });
+
   it('shows an error state when the fetch fails', async () => {
     mockFetch.mockRejectedValue(new Error('boom'));
-    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
     expect(await screen.findByTestId('vulnerability-table-error')).toHaveTextContent('boom');
+  });
+
+  it('recovers from a fetch failure via the Retry button', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        items: [
+          { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.42, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
+        ],
+        hasMore: false,
+      });
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} emptyVariant="filtered" onSelectCve={() => {}} onClearFilters={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vulnerability-table-retry'));
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(desktop.getByTestId('vulnerability-row-1')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
@@ -1,31 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 
 import { VulnerabilityTable } from './VulnerabilityTable';
-import { fetchVulnerabilities } from '../../lib/api/vulnerabilities';
+import * as api from '../../lib/api/vulnerabilities';
+import type { VulnFleetFilters } from '../../lib/api/vulnerabilities';
 
 vi.mock('../../lib/api/vulnerabilities', () => ({
   fetchVulnerabilities: vi.fn(),
 }));
 
-const mockFetch = vi.mocked(fetchVulnerabilities);
+const mockFetch = vi.mocked(api.fetchVulnerabilities);
+
+const FILTERS: VulnFleetFilters = { search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false };
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockFetch.mockResolvedValue({
+    items: [
+      { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.42, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
+      { id: '2', cveId: 'CVE-2025-2', cvssScore: 5.0, severity: 'medium', knownExploited: false, epssScore: 0.1, riskScore: 60, deviceCount: 3, patchAvailable: false, statuses: ['open'] },
+    ],
+  });
 });
 
 describe('VulnerabilityTable', () => {
   it('renders rows in risk order and shows a severity badge', async () => {
-    mockFetch.mockResolvedValue({
-      items: [
-        { id: '1', cveId: 'CVE-2025-1', cvssScore: 9.8, severity: 'critical', knownExploited: true, epssScore: 0.9, riskScore: 100, deviceCount: 12, patchAvailable: true, statuses: ['open'] },
-        { id: '2', cveId: 'CVE-2025-2', cvssScore: 5.0, severity: 'medium', knownExploited: false, epssScore: 0.1, riskScore: 60, deviceCount: 3, patchAvailable: false, statuses: ['open'] },
-      ],
-    });
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
 
-    render(<VulnerabilityTable />);
-
-    const desktop = within(screen.getByTestId('responsive-table-desktop'));
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
     const rows = await desktop.findAllByTestId(/^vulnerability-row-/);
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveTextContent('CVE-2025-1'); // highest risk first
@@ -33,9 +35,59 @@ describe('VulnerabilityTable', () => {
     expect(rows[0]).toHaveTextContent('12'); // affected device count
   });
 
-  it('shows an empty state when there are no findings', async () => {
+  it('maps the shared filter bar onto API filters (search -> cve substring)', async () => {
+    render(
+      <VulnerabilityTable
+        filters={{ ...FILTERS, search: '0001', severity: 'critical', kevOnly: true }}
+        refreshKey={0}
+        onSelectCve={() => {}}
+        onClearFilters={() => {}}
+      />,
+    );
+    await vi.waitFor(() =>
+      expect(api.fetchVulnerabilities).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'open', severity: 'critical', cve: '0001', kevOnly: true }),
+      ),
+    );
+  });
+
+  it('renders EPSS and Patch columns and fires onSelectCve on row click', async () => {
+    const onSelect = vi.fn();
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={onSelect} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const row = desktop.getByTestId('vulnerability-row-1');
+    expect(row).toHaveTextContent('42.0%'); // EPSS 0.42
+    expect(row).toHaveTextContent('Yes'); // patchAvailable
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith('CVE-2025-1');
+  });
+
+  it('shows the Status column only when the status filter is not open', async () => {
+    const { rerender } = render(
+      <VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />,
+    );
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    expect(desktop.queryByText('Status')).toBeNull();
+    rerender(
+      <VulnerabilityTable filters={{ ...FILTERS, status: 'accepted' }} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />,
+    );
+    await vi.waitFor(() =>
+      expect(within(screen.getByTestId('responsive-table-desktop')).getByText('Status')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows an empty state with a clear-filters button when there are no findings', async () => {
     mockFetch.mockResolvedValue({ items: [] });
-    render(<VulnerabilityTable />);
+    const onClear = vi.fn();
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={onClear} />);
     expect(await screen.findByTestId('vulnerability-table-empty')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('vulnerability-clear-filters'));
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('shows an error state when the fetch fails', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'));
+    render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+    expect(await screen.findByTestId('vulnerability-table-error')).toHaveTextContent('boom');
   });
 });

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
@@ -1,31 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import { SeverityBadge } from './SeverityBadge';
 import {
   fetchVulnerabilities,
   type FleetVulnerability,
   type VulnerabilityFilters,
 } from '../../lib/api/vulnerabilities';
-
-const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
-  critical: { label: 'Critical', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
-  high: { label: 'High', className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300' },
-  medium: { label: 'Medium', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' },
-  low: { label: 'Low', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
-};
-
-function SeverityBadge({ severity }: { severity: string | null }) {
-  const key = severity?.toLowerCase() ?? '';
-  const badge = SEVERITY_BADGES[key] ?? {
-    label: severity ?? 'Unknown',
-    className: 'bg-slate-100 text-slate-700 dark:bg-slate-900/30 dark:text-slate-300',
-  };
-  return (
-    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${badge.className}`}>
-      {badge.label}
-    </span>
-  );
-}
 
 function fmtScore(value: number | null): string {
   return value === null ? '—' : value.toFixed(1);

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
@@ -1,13 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import HelpTooltip from '../shared/HelpTooltip';
 import { SeverityBadge } from './SeverityBadge';
+import { CVSS_EXPLANATION, EPSS_EXPLANATION, KEV_EXPLANATION, RISK_EXPLANATION } from './vulnExplanations';
+import { VulnEmptyState, type VulnEmptyVariant } from './VulnEmptyState';
+import { densityTableClasses, readDensity, subscribeDensity, type Density } from '../../lib/density';
 import {
   fetchVulnerabilities,
   type FleetVulnerability,
   type VulnerabilityFilters,
   type VulnFleetFilters,
 } from '../../lib/api/vulnerabilities';
+
+// Keyboard path into the drawer: the whole row stays mouse-clickable, but the
+// primary cell carries a real <button> so keyboard/screen-reader users can
+// reach and activate every row.
+const ROW_BUTTON =
+  'block w-full rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary';
+
+const RETRY_BTN =
+  'mt-2 inline-flex items-center rounded-md border border-red-300 px-3 py-1 text-sm font-medium transition hover:bg-red-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary dark:border-red-800 dark:hover:bg-red-900/40';
+
+const SKELETON_BAR = 'h-4 rounded bg-muted motion-safe:animate-pulse';
 
 function fmtScore(value: number | null): string {
   return value === null ? '—' : value.toFixed(1);
@@ -20,18 +35,29 @@ function fmtEpss(value: number | null): string {
 export function VulnerabilityTable({
   filters,
   refreshKey,
+  emptyVariant,
+  lastDetectedAt,
   onSelectCve,
   onClearFilters,
 }: {
   filters: VulnFleetFilters;
   refreshKey: number;
+  /** Zero-rows story, decided by the page (needs filters + stats). */
+  emptyVariant: VulnEmptyVariant;
+  lastDetectedAt?: string | null;
   onSelectCve: (cveId: string) => void;
   onClearFilters: () => void;
 }) {
   const [items, setItems] = useState<FleetVulnerability[]>([]);
+  const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
   const showStatusColumn = filters.status !== 'open';
+  // Table density reflects the account-wide preference (breeze.density) set in
+  // the top-bar theme/display menu — same mechanism as DeviceList.
+  const [density, setDensity] = useState<Density>(() => readDensity());
+  useEffect(() => subscribeDensity(setDensity), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,9 +68,12 @@ export function VulnerabilityTable({
     if (filters.search) apiFilters.cve = filters.search;
     if (filters.kevOnly) apiFilters.kevOnly = true;
     if (filters.patchAvailable) apiFilters.patchAvailable = true;
+    if (filters.expiringWithinDays !== undefined) apiFilters.expiringWithinDays = filters.expiringWithinDays;
     fetchVulnerabilities(apiFilters)
       .then((res) => {
-        if (!cancelled) setItems(res.items);
+        if (cancelled) return;
+        setItems(res.items);
+        setHasMore(res.hasMore);
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load vulnerabilities');
@@ -55,95 +84,187 @@ export function VulnerabilityTable({
     return () => {
       cancelled = true;
     };
-  }, [filters, refreshKey]);
+  }, [filters, refreshKey, retryKey]);
+
+  // Skeleton only on empty loads (first paint / after an error retry). A
+  // filter-change refetch keeps the previous rows on screen instead of flashing.
+  const showSkeleton = loading && items.length === 0;
 
   const table = useMemo(
     () => (
-      <table className="min-w-full divide-y">
+      <table className={`min-w-full divide-y ${densityTableClasses(density)}`}>
         <thead className="bg-muted/40">
           <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             <th className="px-4 py-3">CVE</th>
             <th className="px-4 py-3">Severity</th>
-            <th className="px-4 py-3">CVSS</th>
-            <th className="px-4 py-3">Risk</th>
-            <th className="px-4 py-3">EPSS</th>
+            {/* side="bottom" on all header tooltips: an upward bubble would
+                clip against the ResponsiveTable overflow-x-auto wrapper. */}
+            <th className="px-4 py-3">
+              <span className="inline-flex items-center gap-1">
+                CVSS
+                <HelpTooltip side="bottom" ariaLabel="About the CVSS score" text={CVSS_EXPLANATION} />
+              </span>
+            </th>
+            <th className="px-4 py-3">
+              <span className="inline-flex items-center gap-1">
+                Risk
+                <HelpTooltip side="bottom" ariaLabel="About the risk score" text={RISK_EXPLANATION} />
+              </span>
+            </th>
+            <th className="px-4 py-3">
+              <span className="inline-flex items-center gap-1">
+                EPSS
+                <HelpTooltip side="bottom" ariaLabel="About the EPSS score" text={EPSS_EXPLANATION} />
+              </span>
+            </th>
             <th className="px-4 py-3">Patch</th>
             <th className="px-4 py-3">Affected devices</th>
-            <th className="px-4 py-3">KEV</th>
+            <th className="px-4 py-3">
+              <span className="inline-flex items-center gap-1">
+                KEV
+                <HelpTooltip side="bottom" ariaLabel="About the KEV flag" text={KEV_EXPLANATION} />
+              </span>
+            </th>
             {showStatusColumn && <th className="px-4 py-3">Status</th>}
           </tr>
         </thead>
-        <tbody className="divide-y">
-          {items.map((v) => (
-            <tr
-              key={v.id}
-              data-testid={`vulnerability-row-${v.id}`}
-              className="cursor-pointer transition hover:bg-muted/40"
-              onClick={() => onSelectCve(v.cveId)}
-            >
-              <td className="px-4 py-3 text-sm font-medium">{v.cveId}</td>
-              <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
-              <td className="px-4 py-3 text-sm tabular-nums">{fmtScore(v.cvssScore)}</td>
-              <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
-              <td className="px-4 py-3 text-sm tabular-nums">{fmtEpss(v.epssScore)}</td>
-              <td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Yes' : '—'}</td>
-              <td className="px-4 py-3 text-sm tabular-nums">{v.deviceCount}</td>
-              <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
-              {showStatusColumn && <td className="px-4 py-3 text-sm capitalize">{v.statuses.join(', ')}</td>}
-            </tr>
-          ))}
-        </tbody>
+        {showSkeleton ? (
+          <tbody className="divide-y" data-testid="vulnerability-table-skeleton" aria-hidden="true">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i}>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-32`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} h-5 w-16 rounded-full`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-10`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-8`} /></td>
+                {showStatusColumn && <td className="px-4 py-3"><div className={`${SKELETON_BAR} w-16`} /></td>}
+              </tr>
+            ))}
+          </tbody>
+        ) : (
+          <tbody className="divide-y">
+            {items.map((v) => (
+              <tr
+                key={v.id}
+                data-testid={`vulnerability-row-${v.id}`}
+                className="cursor-pointer transition hover:bg-muted/40"
+                onClick={() => onSelectCve(v.cveId)}
+              >
+                <td className="px-4 py-3 text-sm font-medium">
+                  <button
+                    type="button"
+                    data-testid={`vulnerability-open-${v.id}`}
+                    aria-label={`Open ${v.cveId} details`}
+                    className={ROW_BUTTON}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelectCve(v.cveId);
+                    }}
+                  >
+                    {v.cveId}
+                  </button>
+                </td>
+                <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
+                <td className="px-4 py-3 text-sm tabular-nums">{fmtScore(v.cvssScore)}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{fmtEpss(v.epssScore)}</td>
+                <td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Yes' : '—'}</td>
+                <td className="px-4 py-3 text-sm tabular-nums">{v.deviceCount}</td>
+                <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
+                {showStatusColumn && <td className="px-4 py-3 text-sm capitalize">{v.statuses.join(', ')}</td>}
+              </tr>
+            ))}
+          </tbody>
+        )}
       </table>
     ),
-    [items, showStatusColumn, onSelectCve],
+    [items, showStatusColumn, onSelectCve, density, showSkeleton],
   );
 
   const cards = useMemo(
     () =>
-      items.map((v) => (
-        <DataCard key={v.id} onClick={() => onSelectCve(v.cveId)}>
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-semibold">{v.cveId}</span>
-            <SeverityBadge severity={v.severity} />
-          </div>
-          <div className="mt-3 space-y-2 border-t pt-3">
-            <CardField label="CVSS"><span className="text-sm tabular-nums">{fmtScore(v.cvssScore)}</span></CardField>
-            <CardField label="Risk"><span className="text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
-            <CardField label="EPSS"><span className="text-sm tabular-nums">{fmtEpss(v.epssScore)}</span></CardField>
-            <CardField label="Patch"><span className="text-sm">{v.patchAvailable ? 'Yes' : '—'}</span></CardField>
-            <CardField label="Affected devices"><span className="text-sm tabular-nums">{v.deviceCount}</span></CardField>
-            <CardField label="Known exploited"><span className="text-sm">{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
-            {showStatusColumn && (
-              <CardField label="Status"><span className="text-sm capitalize">{v.statuses.join(', ')}</span></CardField>
-            )}
-          </div>
-        </DataCard>
-      )),
-    [items, showStatusColumn, onSelectCve],
+      showSkeleton
+        ? Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} aria-hidden="true">
+              <DataCard>
+                <div className={`${SKELETON_BAR} w-32`} />
+                <div className="mt-3 space-y-2 border-t pt-3">
+                  <div className={`${SKELETON_BAR} w-full`} />
+                  <div className={`${SKELETON_BAR} w-2/3`} />
+                </div>
+              </DataCard>
+            </div>
+          ))
+        : items.map((v) => (
+            <DataCard key={v.id} onClick={() => onSelectCve(v.cveId)}>
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  aria-label={`Open ${v.cveId} details`}
+                  className={`${ROW_BUTTON} min-w-0 flex-1 text-sm font-semibold`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelectCve(v.cveId);
+                  }}
+                >
+                  {v.cveId}
+                </button>
+                <SeverityBadge severity={v.severity} />
+              </div>
+              <div className="mt-3 space-y-2 border-t pt-3">
+                <CardField label="CVSS"><span className="text-sm tabular-nums" title={CVSS_EXPLANATION}>{fmtScore(v.cvssScore)}</span></CardField>
+                <CardField label="Risk"><span className="text-sm tabular-nums" title={RISK_EXPLANATION}>{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
+                <CardField label="EPSS"><span className="text-sm tabular-nums" title={EPSS_EXPLANATION}>{fmtEpss(v.epssScore)}</span></CardField>
+                <CardField label="Patch"><span className="text-sm">{v.patchAvailable ? 'Yes' : '—'}</span></CardField>
+                <CardField label="Affected devices"><span className="text-sm tabular-nums">{v.deviceCount}</span></CardField>
+                <CardField label="Known exploited"><span className="text-sm" title={KEV_EXPLANATION}>{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
+                {showStatusColumn && (
+                  <CardField label="Status"><span className="text-sm capitalize">{v.statuses.join(', ')}</span></CardField>
+                )}
+              </div>
+            </DataCard>
+          )),
+    [items, showStatusColumn, onSelectCve, showSkeleton],
   );
 
   return (
     <div className="space-y-4">
       {error && (
         <div data-testid="vulnerability-table-error" className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-          {error}
+          <p>{error}</p>
+          <button
+            type="button"
+            data-testid="vulnerability-table-retry"
+            className={RETRY_BTN}
+            onClick={() => setRetryKey((k) => k + 1)}
+          >
+            Retry
+          </button>
         </div>
       )}
 
       {!loading && !error && items.length === 0 ? (
-        <div data-testid="vulnerability-table-empty" className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
-          <p>No vulnerabilities match the current filters.</p>
-          <button
-            type="button"
-            data-testid="vulnerability-clear-filters"
-            className="mt-2 text-sm font-medium text-primary hover:underline"
-            onClick={onClearFilters}
-          >
-            Clear filters
-          </button>
-        </div>
+        <VulnEmptyState
+          variant={emptyVariant}
+          lastDetectedAt={lastDetectedAt}
+          onClearFilters={onClearFilters}
+          containerTestId="vulnerability-table-empty"
+          clearFiltersTestId="vulnerability-clear-filters"
+        />
       ) : (
-        <ResponsiveTable table={table} cards={cards} />
+        !error && (
+          <div className="space-y-2">
+            <ResponsiveTable table={table} cards={cards} />
+            {hasMore && (
+              <p data-testid="vulnerability-has-more" className="text-xs text-muted-foreground">
+                Showing the top 500 CVEs by risk — narrow the filters to see the rest.
+              </p>
+            )}
+          </div>
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
@@ -6,27 +6,43 @@ import {
   fetchVulnerabilities,
   type FleetVulnerability,
   type VulnerabilityFilters,
+  type VulnFleetFilters,
 } from '../../lib/api/vulnerabilities';
 
 function fmtScore(value: number | null): string {
   return value === null ? '—' : value.toFixed(1);
 }
 
-const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
+function fmtEpss(value: number | null): string {
+  return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
 
-export function VulnerabilityTable() {
+export function VulnerabilityTable({
+  filters,
+  refreshKey,
+  onSelectCve,
+  onClearFilters,
+}: {
+  filters: VulnFleetFilters;
+  refreshKey: number;
+  onSelectCve: (cveId: string) => void;
+  onClearFilters: () => void;
+}) {
   const [items, setItems] = useState<FleetVulnerability[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [severity, setSeverity] = useState<string>('');
+  const showStatusColumn = filters.status !== 'open';
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    const filters: VulnerabilityFilters = { status: 'open' };
-    if (severity) filters.severity = severity;
-    fetchVulnerabilities(filters)
+    const apiFilters: VulnerabilityFilters = { status: filters.status };
+    if (filters.severity) apiFilters.severity = filters.severity;
+    if (filters.search) apiFilters.cve = filters.search;
+    if (filters.kevOnly) apiFilters.kevOnly = true;
+    if (filters.patchAvailable) apiFilters.patchAvailable = true;
+    fetchVulnerabilities(apiFilters)
       .then((res) => {
         if (!cancelled) setItems(res.items);
       })
@@ -39,7 +55,7 @@ export function VulnerabilityTable() {
     return () => {
       cancelled = true;
     };
-  }, [severity]);
+  }, [filters, refreshKey]);
 
   const table = useMemo(
     () => (
@@ -50,31 +66,42 @@ export function VulnerabilityTable() {
             <th className="px-4 py-3">Severity</th>
             <th className="px-4 py-3">CVSS</th>
             <th className="px-4 py-3">Risk</th>
+            <th className="px-4 py-3">EPSS</th>
+            <th className="px-4 py-3">Patch</th>
             <th className="px-4 py-3">Affected devices</th>
             <th className="px-4 py-3">KEV</th>
+            {showStatusColumn && <th className="px-4 py-3">Status</th>}
           </tr>
         </thead>
         <tbody className="divide-y">
           {items.map((v) => (
-            <tr key={v.id} data-testid={`vulnerability-row-${v.id}`} className="transition hover:bg-muted/40">
+            <tr
+              key={v.id}
+              data-testid={`vulnerability-row-${v.id}`}
+              className="cursor-pointer transition hover:bg-muted/40"
+              onClick={() => onSelectCve(v.cveId)}
+            >
               <td className="px-4 py-3 text-sm font-medium">{v.cveId}</td>
               <td className="px-4 py-3 text-sm"><SeverityBadge severity={v.severity} /></td>
               <td className="px-4 py-3 text-sm tabular-nums">{fmtScore(v.cvssScore)}</td>
               <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
+              <td className="px-4 py-3 text-sm tabular-nums">{fmtEpss(v.epssScore)}</td>
+              <td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Yes' : '—'}</td>
               <td className="px-4 py-3 text-sm tabular-nums">{v.deviceCount}</td>
               <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
+              {showStatusColumn && <td className="px-4 py-3 text-sm capitalize">{v.statuses.join(', ')}</td>}
             </tr>
           ))}
         </tbody>
       </table>
     ),
-    [items],
+    [items, showStatusColumn, onSelectCve],
   );
 
   const cards = useMemo(
     () =>
       items.map((v) => (
-        <DataCard key={v.id}>
+        <DataCard key={v.id} onClick={() => onSelectCve(v.cveId)}>
           <div className="flex items-center justify-between">
             <span className="text-sm font-semibold">{v.cveId}</span>
             <SeverityBadge severity={v.severity} />
@@ -82,33 +109,21 @@ export function VulnerabilityTable() {
           <div className="mt-3 space-y-2 border-t pt-3">
             <CardField label="CVSS"><span className="text-sm tabular-nums">{fmtScore(v.cvssScore)}</span></CardField>
             <CardField label="Risk"><span className="text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
+            <CardField label="EPSS"><span className="text-sm tabular-nums">{fmtEpss(v.epssScore)}</span></CardField>
+            <CardField label="Patch"><span className="text-sm">{v.patchAvailable ? 'Yes' : '—'}</span></CardField>
             <CardField label="Affected devices"><span className="text-sm tabular-nums">{v.deviceCount}</span></CardField>
             <CardField label="Known exploited"><span className="text-sm">{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
+            {showStatusColumn && (
+              <CardField label="Status"><span className="text-sm capitalize">{v.statuses.join(', ')}</span></CardField>
+            )}
           </div>
         </DataCard>
       )),
-    [items],
+    [items, showStatusColumn, onSelectCve],
   );
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-3">
-        <label className="flex items-center gap-2 text-sm">
-          <span className="text-muted-foreground">Severity</span>
-          <select
-            data-testid="vulnerability-severity-filter"
-            value={severity}
-            onChange={(e) => setSeverity(e.target.value)}
-            className="rounded-md border bg-background px-2 py-1 text-sm"
-          >
-            <option value="">All</option>
-            {SEVERITY_OPTIONS.map((s) => (
-              <option key={s} value={s}>{s[0]!.toUpperCase() + s.slice(1)}</option>
-            ))}
-          </select>
-        </label>
-      </div>
-
       {error && (
         <div data-testid="vulnerability-table-error" className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
           {error}
@@ -117,7 +132,15 @@ export function VulnerabilityTable() {
 
       {!loading && !error && items.length === 0 ? (
         <div data-testid="vulnerability-table-empty" className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
-          No open vulnerabilities detected across your fleet.
+          <p>No vulnerabilities match the current filters.</p>
+          <button
+            type="button"
+            data-testid="vulnerability-clear-filters"
+            className="mt-2 text-sm font-medium text-primary hover:underline"
+            onClick={onClearFilters}
+          >
+            Clear filters
+          </button>
         </div>
       ) : (
         <ResponsiveTable table={table} cards={cards} />

--- a/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
+++ b/apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
 import HelpTooltip from '../shared/HelpTooltip';
 import { SeverityBadge } from './SeverityBadge';
+import { KevBadge } from './KevBadge';
 import { CVSS_EXPLANATION, EPSS_EXPLANATION, KEV_EXPLANATION, RISK_EXPLANATION } from './vulnExplanations';
 import { VulnEmptyState, type VulnEmptyVariant } from './VulnEmptyState';
 import { densityTableClasses, readDensity, subscribeDensity, type Density } from '../../lib/density';
@@ -153,7 +154,9 @@ export function VulnerabilityTable({
                 className="cursor-pointer transition hover:bg-muted/40"
                 onClick={() => onSelectCve(v.cveId)}
               >
-                <td className="px-4 py-3 text-sm font-medium">
+                {/* whitespace-nowrap: CVE ids are opaque identifiers — a
+                    wrapped id is unreadable, so the column widens instead. */}
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-medium">
                   <button
                     type="button"
                     data-testid={`vulnerability-open-${v.id}`}
@@ -171,9 +174,12 @@ export function VulnerabilityTable({
                 <td className="px-4 py-3 text-sm tabular-nums">{fmtScore(v.cvssScore)}</td>
                 <td className="px-4 py-3 text-sm tabular-nums">{v.riskScore === null ? '—' : Math.round(v.riskScore)}</td>
                 <td className="px-4 py-3 text-sm tabular-nums">{fmtEpss(v.epssScore)}</td>
-                <td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Yes' : '—'}</td>
+                {/* Same vocabulary as the software tab's Patch/KEV cells
+                    ("Ready …" / KevBadge, "—" for absence) so the two views
+                    encode the same facts the same way. */}
+                <td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Ready' : '—'}</td>
                 <td className="px-4 py-3 text-sm tabular-nums">{v.deviceCount}</td>
-                <td className="px-4 py-3 text-sm">{v.knownExploited ? 'Yes' : '—'}</td>
+                <td className="px-4 py-3 text-sm">{v.knownExploited ? <KevBadge /> : '—'}</td>
                 {showStatusColumn && <td className="px-4 py-3 text-sm capitalize">{v.statuses.join(', ')}</td>}
               </tr>
             ))}
@@ -204,7 +210,7 @@ export function VulnerabilityTable({
                 <button
                   type="button"
                   aria-label={`Open ${v.cveId} details`}
-                  className={`${ROW_BUTTON} min-w-0 flex-1 text-sm font-semibold`}
+                  className={`${ROW_BUTTON} min-w-0 flex-1 truncate text-sm font-semibold`}
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelectCve(v.cveId);
@@ -218,9 +224,11 @@ export function VulnerabilityTable({
                 <CardField label="CVSS"><span className="text-sm tabular-nums" title={CVSS_EXPLANATION}>{fmtScore(v.cvssScore)}</span></CardField>
                 <CardField label="Risk"><span className="text-sm tabular-nums" title={RISK_EXPLANATION}>{v.riskScore === null ? '—' : Math.round(v.riskScore)}</span></CardField>
                 <CardField label="EPSS"><span className="text-sm tabular-nums" title={EPSS_EXPLANATION}>{fmtEpss(v.epssScore)}</span></CardField>
-                <CardField label="Patch"><span className="text-sm">{v.patchAvailable ? 'Yes' : '—'}</span></CardField>
+                <CardField label="Patch"><span className="text-sm">{v.patchAvailable ? 'Ready' : '—'}</span></CardField>
                 <CardField label="Affected devices"><span className="text-sm tabular-nums">{v.deviceCount}</span></CardField>
-                <CardField label="Known exploited"><span className="text-sm" title={KEV_EXPLANATION}>{v.knownExploited ? 'Yes' : 'No'}</span></CardField>
+                <CardField label="Known exploited">
+                  {v.knownExploited ? <KevBadge /> : <span className="text-sm" title={KEV_EXPLANATION}>—</span>}
+                </CardField>
                 {showStatusColumn && (
                   <CardField label="Status"><span className="text-sm capitalize">{v.statuses.join(', ')}</span></CardField>
                 )}

--- a/apps/web/src/components/vulnerabilities/vulnExplanations.ts
+++ b/apps/web/src/components/vulnerabilities/vulnExplanations.ts
@@ -1,0 +1,22 @@
+/**
+ * One source of truth for the plain-language score explanations on the fleet
+ * vulnerabilities page — column-header tooltips, drawer title attrs, and the
+ * KEV badge all pull from here so the phrasing can't drift.
+ *
+ * RISK_EXPLANATION must track the actual formula in
+ * apps/api/src/services/vulnerabilityRiskScore.ts (computeRiskScore): CVSS×10
+ * is the spine, EPSS adds up to 10 points, and KEV CVEs are floored to 80 then
+ * nudged +5 — so a known-exploited CVE never scores below 85.
+ */
+
+export const RISK_EXPLANATION =
+  'Breeze priority score (0–100): the CVSS score scaled to 100, plus a bump for exploitation likelihood (EPSS). Known-exploited (KEV) CVEs never score below 85. Higher = fix sooner.';
+
+export const CVSS_EXPLANATION =
+  'Industry-standard severity score (0–10) for how damaging exploitation would be — not how likely it is.';
+
+export const EPSS_EXPLANATION =
+  'Likelihood of exploitation in the next 30 days (FIRST.org EPSS).';
+
+export const KEV_EXPLANATION =
+  "On CISA's Known Exploited Vulnerabilities catalog — actively exploited in the wild.";

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -81,6 +81,7 @@ const TARGET_GLOBS = [
   'src/components/devices/DeviceVulnerabilitiesTab.tsx',
   'src/components/vulnerabilities/VulnerabilityFleetPage.tsx',
   'src/components/vulnerabilities/SoftwareGroupDrawer.tsx',
+  'src/components/vulnerabilities/CveDrawer.tsx',
   'src/components/vulnerabilities/VulnBulkActionModal.tsx',
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
@@ -280,7 +281,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(61);
+    expect(absoluteFiles.length).toBe(62);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -79,6 +79,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/CorrelatedAlertGroups.tsx',
   'src/components/integrations/SecurityIntegration.tsx',
   'src/components/devices/DeviceVulnerabilitiesTab.tsx',
+  'src/components/vulnerabilities/VulnerabilityFleetPage.tsx',
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
   'src/lib/edr.ts',
@@ -277,7 +278,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(58);
+    expect(absoluteFiles.length).toBe(59);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -80,6 +80,8 @@ const TARGET_GLOBS = [
   'src/components/integrations/SecurityIntegration.tsx',
   'src/components/devices/DeviceVulnerabilitiesTab.tsx',
   'src/components/vulnerabilities/VulnerabilityFleetPage.tsx',
+  'src/components/vulnerabilities/SoftwareGroupDrawer.tsx',
+  'src/components/vulnerabilities/VulnBulkActionModal.tsx',
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
   'src/lib/edr.ts',
@@ -278,7 +280,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(59);
+    expect(absoluteFiles.length).toBe(61);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -82,6 +82,7 @@ const TARGET_GLOBS = [
   'src/components/vulnerabilities/VulnerabilityFleetPage.tsx',
   'src/components/vulnerabilities/SoftwareGroupDrawer.tsx',
   'src/components/vulnerabilities/CveDrawer.tsx',
+  'src/components/vulnerabilities/CreateVulnTicketModal.tsx',
   'src/components/vulnerabilities/VulnBulkActionModal.tsx',
   'src/lib/api/vulnerabilities.ts',
   'src/components/settings/TdSynnexEcExpressPanel.tsx',
@@ -281,7 +282,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(62);
+    expect(absoluteFiles.length).toBe(63);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
+++ b/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
@@ -11,6 +11,11 @@ describe('buildVulnQuery', () => {
   it('returns empty string when nothing is set', () => {
     expect(buildVulnQuery({ severity: undefined, kevOnly: false })).toBe('');
   });
+
+  it('serializes numeric params (expiringWithinDays)', () => {
+    expect(buildVulnQuery({ status: 'accepted', expiringWithinDays: 14 })).toBe('?status=accepted&expiringWithinDays=14');
+    expect(buildVulnQuery({ expiringWithinDays: undefined })).toBe('');
+  });
 });
 
 describe('bulkSummary', () => {

--- a/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
+++ b/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
@@ -23,12 +23,25 @@ describe('bulkSummary', () => {
     expect(bulkSummary('accepted', 12, [])).toBe('12 accepted');
   });
 
-  it('appends skip count and first skip reason (partial success)', () => {
+  it('appends skip count and the reason label for a single distinct reason', () => {
+    // reason is a VulnSkipReason CODE; the summary renders it via VULN_SKIP_REASON_LABELS.
     expect(
       bulkSummary('scheduled', 12, [
-        { id: 'a', reason: 'no approved patch' },
-        { id: 'b', reason: 'no approved patch' },
+        { id: 'a', reason: 'no_available_patch' },
+        { id: 'b', reason: 'no_available_patch' },
       ]),
-    ).toBe('12 scheduled, 2 skipped — no approved patch');
+    ).toBe('12 scheduled, 2 skipped — 2 no available patch');
+  });
+
+  it('summarizes DISTINCT reason codes with per-reason counts', () => {
+    const summary = bulkSummary('accepted', 20, [
+      { id: 'a', reason: 'not_found' },
+      { id: 'b', reason: 'not_found' },
+      { id: 'c', reason: 'site_access_denied' },
+    ]);
+    expect(summary).toContain('2 finding not found');
+    expect(summary).toContain('1 site access denied');
+    // Full form: succeeded verb, total skipped, then the distinct-reason breakdown.
+    expect(summary).toBe('20 accepted, 3 skipped — 2 finding not found, 1 site access denied');
   });
 });

--- a/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
+++ b/apps/web/src/lib/api/vulnerabilities.helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildVulnQuery, bulkSummary } from './vulnerabilities';
+
+describe('buildVulnQuery', () => {
+  it('serializes set params, drops empty/false/undefined, and URL-encodes', () => {
+    expect(
+      buildVulnQuery({ status: 'open', severity: '', search: 'google chrome', kevOnly: true, patchAvailable: false }),
+    ).toBe('?status=open&search=google+chrome&kevOnly=true');
+  });
+
+  it('returns empty string when nothing is set', () => {
+    expect(buildVulnQuery({ severity: undefined, kevOnly: false })).toBe('');
+  });
+});
+
+describe('bulkSummary', () => {
+  it('reports plain success', () => {
+    expect(bulkSummary('accepted', 12, [])).toBe('12 accepted');
+  });
+
+  it('appends skip count and first skip reason (partial success)', () => {
+    expect(
+      bulkSummary('scheduled', 12, [
+        { id: 'a', reason: 'no approved patch' },
+        { id: 'b', reason: 'no approved patch' },
+      ]),
+    ).toBe('12 scheduled, 2 skipped — no approved patch');
+  });
+});

--- a/apps/web/src/lib/api/vulnerabilities.ts
+++ b/apps/web/src/lib/api/vulnerabilities.ts
@@ -1,5 +1,37 @@
+import {
+  VULN_SKIP_REASON_LABELS,
+  type BulkActionResult,
+  type CveCatalogRecord,
+  type FleetVulnStats,
+  type GroupFinding,
+  type RemediateResult,
+  type SkippedItem,
+  type SoftwareGroup,
+  type SoftwareGroupDetail,
+  type VulnSeverity,
+  type VulnSkipReason,
+  type VulnStatus,
+  type VulnTicketPriority,
+  type VulnTicketResult,
+} from '@breeze/shared';
+
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction } from '../runAction';
+
+// Re-export the shared fleet-triage domain types so existing web call sites that
+// import them from this module keep working (single source of truth is
+// @breeze/shared; this module is just the web-side barrel for them).
+export type {
+  BulkActionResult,
+  CveCatalogRecord,
+  FleetVulnStats,
+  GroupCve,
+  GroupFinding,
+  RemediateResult,
+  SoftwareGroup,
+  SoftwareGroupDetail,
+  VulnTicketResult,
+} from '@breeze/shared';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -11,11 +43,11 @@ export interface DeviceVulnerabilityItem {
   cveId: string;
   cvssScore: number | null;
   cvssVector: string | null;
-  severity: string | null;
+  severity: VulnSeverity | null;
   knownExploited: boolean;
   epssScore: number | null;
   riskScore: number | null;
-  status: string;
+  status: VulnStatus;
   detectedAt: string;
   patchAvailable: boolean;
 }
@@ -25,13 +57,13 @@ export interface FleetVulnerability {
   id: string; // vulnerabilityId (stable aggregate key)
   cveId: string;
   cvssScore: number | null;
-  severity: string | null;
+  severity: VulnSeverity | null;
   knownExploited: boolean;
   epssScore: number | null;
   riskScore: number | null;
   deviceCount: number;
   patchAvailable: boolean;
-  statuses: string[];
+  statuses: VulnStatus[];
 }
 
 export interface VulnerabilityFilters {
@@ -99,102 +131,10 @@ export interface VulnFleetFilters {
   expiringWithinDays?: number;
 }
 
-export interface SoftwareGroup {
-  groupKey: string;
-  kind: 'software' | 'os';
-  name: string;
-  vendor: string | null;
-  versions: string[];
-  deviceCount: number;
-  cveCount: number;
-  cveIds: string[];
-  worstSeverity: string | null;
-  maxRiskScore: number | null;
-  kevCveCount: number;
-  maxEpss: number | null;
-  patchReadyFindingCount: number;
-  patchReadyDeviceCount: number;
-  /** Distinct linked tickets; `number` is the human ticket number (null for legacy tickets). */
-  tickets: Array<{ id: string; number: string | null }>;
-}
-
-export interface GroupCve {
-  cveId: string;
-  vulnerabilityId: string;
-  severity: string | null;
-  cvssScore: number | null;
-  epssScore: number | null;
-  knownExploited: boolean;
-  patchAvailable: boolean;
-  maxRiskScore: number | null;
-}
-
-export interface GroupFinding {
-  deviceVulnerabilityId: string;
-  deviceId: string;
-  deviceName: string;
-  orgId: string;
-  orgName: string | null;
-  cveId: string;
-  status: string;
-  patchAvailable: boolean;
-  riskScore: number | null;
-  detectedAt: string;
-  /** ISO expiry of an accepted-risk window; null unless status is 'accepted'. */
-  acceptedUntil: string | null;
-  ticketId: string | null;
-  ticketNumber: string | null;
-}
-
-export interface SoftwareGroupDetail {
-  group: SoftwareGroup;
-  cves: GroupCve[];
-  findings: GroupFinding[];
-}
-
-export interface FleetVulnStats {
-  criticalOpen: number;
-  kevCveCount: number;
-  kevDeviceCount: number;
-  patchReadyFindingCount: number;
-  acceptedExpiringSoon: number;
-  /** Findings across ALL statuses — "has scanning ever produced data". Feeds
-   *  the clean-fleet vs never-scanned empty-state split. */
-  totalFindings: number;
-  /** Most recent detectedAt across all findings (ISO), null when none exist. */
-  lastDetectedAt: string | null;
-}
-
-export interface CveCatalogRecord {
-  cveId: string;
-  description: string;
-  references: unknown;
-  cvssVersion: string | null;
-  cvssVector: string | null;
-  cvssScore: number | null;
-  epssScore: number | null;
-  knownExploited: boolean;
-  patchAvailable: boolean;
-  severity: string | null;
-  publishedAt: string | null;
-  modifiedAt: string | null;
-}
-
+/** GET /vulnerabilities/:cveId/devices — the catalog record plus its findings. Web-only wire wrapper. */
 export interface CveDevicesPayload {
   cve: CveCatalogRecord;
   findings: GroupFinding[];
-}
-
-export interface BulkActionResult {
-  success: boolean;
-  succeeded: number;
-  skipped: Array<{ id: string; reason: string }>;
-}
-
-export interface VulnTicketResult {
-  success: boolean;
-  tickets: Array<{ ticketId: string; orgId: string; findingCount: number }>;
-  skipped: Array<{ id: string; reason: string }>;
 }
 
 // ---- Pure helpers (exported for tests) ----
@@ -209,10 +149,25 @@ export function buildVulnQuery(params: Record<string, string | number | boolean 
   return s ? `?${s}` : '';
 }
 
-export function bulkSummary(verb: string, succeeded: number, skipped: Array<{ id: string; reason: string }>): string {
+/**
+ * Summarize a `skipped[]` list as distinct reasons with counts, mapping each
+ * `VulnSkipReason` CODE to its human label (`VULN_SKIP_REASON_LABELS`). Unknown
+ * codes fall back to the 'unknown' label so a new server code never renders raw.
+ * e.g. "10 not found, 8 site access denied".
+ */
+export function summarizeSkipReasons(skipped: SkippedItem[]): string {
+  const counts = new Map<string, number>();
+  for (const { reason } of skipped) {
+    const label = VULN_SKIP_REASON_LABELS[reason as VulnSkipReason] ?? VULN_SKIP_REASON_LABELS.unknown;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([label, count]) => `${count} ${label}`).join(', ');
+}
+
+export function bulkSummary(verb: string, succeeded: number, skipped: SkippedItem[]): string {
   const base = `${succeeded} ${verb}`;
   if (skipped.length === 0) return base;
-  return `${base}, ${skipped.length} skipped — ${skipped[0]!.reason}`;
+  return `${base}, ${skipped.length} skipped — ${summarizeSkipReasons(skipped)}`;
 }
 
 // ---- Reads: fleet triage ----
@@ -254,11 +209,6 @@ export async function fetchCveDevices(cveId: string): Promise<CveDevicesPayload>
 
 // ---- Mutations (all wrapped in runAction so every outcome surfaces a toast) ----
 
-export interface RemediateResult {
-  scheduled: number;
-  skipped: Array<{ id: string; reason: string }>;
-}
-
 export async function remediateVuln(deviceVulnerabilityIds: string[]): Promise<RemediateResult> {
   return runAction<RemediateResult>({
     request: () =>
@@ -270,7 +220,7 @@ export async function remediateVuln(deviceVulnerabilityIds: string[]): Promise<R
     errorFallback: 'Failed to schedule remediation',
     successMessage: (d) => bulkSummary(`remediation${d.scheduled === 1 ? '' : 's'} scheduled`, d.scheduled, d.skipped),
     parseSuccess: (data) => {
-      const d = data as { scheduled?: number; skipped?: Array<{ id: string; reason: string }> };
+      const d = data as { scheduled?: number; skipped?: SkippedItem[] };
       return { scheduled: d.scheduled ?? 0, skipped: d.skipped ?? [] };
     },
   });
@@ -323,6 +273,11 @@ function parseBulk(data: unknown): BulkActionResult {
   return { success: d.success ?? false, succeeded: d.succeeded ?? 0, skipped: d.skipped ?? [] };
 }
 
+/** Trailing skip clause for a ticket toast, e.g. ", 18 skipped — 18 access denied". */
+function ticketSkipSuffix(skipped: SkippedItem[]): string {
+  return skipped.length === 0 ? '' : `, ${skipped.length} skipped — ${summarizeSkipReasons(skipped)}`;
+}
+
 export async function bulkAcceptVulnRisk(
   deviceVulnerabilityIds: string[],
   payload: { reason: string; acceptedUntil: string },
@@ -359,7 +314,7 @@ export async function bulkMitigateVulns(
 
 export async function createVulnTicket(
   deviceVulnerabilityIds: string[],
-  payload: { title: string; description?: string; priority: 'low' | 'normal' | 'high' | 'urgent' },
+  payload: { title: string; priority: VulnTicketPriority; note?: string },
 ): Promise<VulnTicketResult> {
   return runAction<VulnTicketResult>({
     request: () =>
@@ -369,8 +324,15 @@ export async function createVulnTicket(
         body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
       }),
     errorFallback: 'Failed to create ticket',
-    successMessage: (d) =>
-      d.tickets.length === 1 ? 'Ticket created' : `${d.tickets.length} tickets created (one per organization)`,
+    // The server builds each org's device/CVE description itself, one ticket per
+    // org. Surface both the created count AND any per-org skips (SF#1) so a
+    // partial success (e.g. access denied on some orgs) is never silent. When
+    // ALL orgs are skipped the server returns success:false and runAction
+    // surfaces its message instead — this only runs on success.
+    successMessage: (d) => {
+      const base = d.tickets.length === 1 ? 'Ticket created' : `${d.tickets.length} tickets created (one per organization)`;
+      return `${base}${ticketSkipSuffix(d.skipped)}`;
+    },
     parseSuccess: (data) => {
       const d = data as Partial<VulnTicketResult>;
       return { success: d.success ?? false, tickets: d.tickets ?? [], skipped: d.skipped ?? [] };

--- a/apps/web/src/lib/api/vulnerabilities.ts
+++ b/apps/web/src/lib/api/vulnerabilities.ts
@@ -30,28 +30,31 @@ export interface FleetVulnerability {
   epssScore: number | null;
   riskScore: number | null;
   deviceCount: number;
+  patchAvailable: boolean;
+  statuses: string[];
 }
 
 export interface VulnerabilityFilters {
   status?: string;
   severity?: string;
   cve?: string;
-}
-
-function buildQuery(filters: VulnerabilityFilters): string {
-  const params = new URLSearchParams();
-  if (filters.status) params.set('status', filters.status);
-  if (filters.severity) params.set('severity', filters.severity);
-  if (filters.cve) params.set('cve', filters.cve);
-  const qs = params.toString();
-  return qs ? `?${qs}` : '';
+  kevOnly?: boolean;
+  patchAvailable?: boolean;
 }
 
 /** Fleet dashboard: CVEs across all accessible devices, aggregated + risk-sorted by the server. */
 export async function fetchVulnerabilities(
   filters: VulnerabilityFilters = {},
 ): Promise<{ items: FleetVulnerability[] }> {
-  const res = await fetchWithAuth(`/vulnerabilities${buildQuery(filters)}`);
+  const res = await fetchWithAuth(
+    `/vulnerabilities${buildVulnQuery({
+      status: filters.status,
+      severity: filters.severity,
+      cve: filters.cve,
+      kevOnly: filters.kevOnly,
+      patchAvailable: filters.patchAvailable,
+    })}`,
+  );
   if (!res.ok) {
     throw new Error(`Failed to load vulnerabilities (${res.status})`);
   }
@@ -64,12 +67,173 @@ export async function fetchDeviceVulnerabilities(
   deviceId: string,
   filters: VulnerabilityFilters = {},
 ): Promise<{ items: DeviceVulnerabilityItem[] }> {
-  const res = await fetchWithAuth(`/vulnerabilities/devices/${deviceId}${buildQuery(filters)}`);
+  const res = await fetchWithAuth(
+    `/vulnerabilities/devices/${deviceId}${buildVulnQuery({
+      status: filters.status,
+      severity: filters.severity,
+      cve: filters.cve,
+      kevOnly: filters.kevOnly,
+      patchAvailable: filters.patchAvailable,
+    })}`,
+  );
   if (!res.ok) {
     throw new Error(`Failed to load device vulnerabilities (${res.status})`);
   }
   const body = (await res.json()) as { items?: DeviceVulnerabilityItem[] };
   return { items: body.items ?? [] };
+}
+
+// ---- Fleet triage: software groups, stats, CVE detail ----
+
+export interface VulnFleetFilters {
+  search: string;
+  severity: string; // '' = all
+  status: string; // 'open' default
+  kevOnly: boolean;
+  patchAvailable: boolean;
+}
+
+export interface SoftwareGroup {
+  groupKey: string;
+  kind: 'software' | 'os';
+  name: string;
+  vendor: string | null;
+  versions: string[];
+  deviceCount: number;
+  cveCount: number;
+  cveIds: string[];
+  worstSeverity: string | null;
+  maxRiskScore: number | null;
+  kevCveCount: number;
+  maxEpss: number | null;
+  patchReadyFindingCount: number;
+  patchReadyDeviceCount: number;
+  ticketIds: string[];
+}
+
+export interface GroupCve {
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  maxRiskScore: number | null;
+}
+
+export interface GroupFinding {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  deviceName: string;
+  orgId: string;
+  orgName: string | null;
+  cveId: string;
+  status: string;
+  patchAvailable: boolean;
+  riskScore: number | null;
+  detectedAt: string;
+  ticketId: string | null;
+}
+
+export interface SoftwareGroupDetail {
+  group: SoftwareGroup;
+  cves: GroupCve[];
+  findings: GroupFinding[];
+}
+
+export interface FleetVulnStats {
+  criticalOpen: number;
+  kevCveCount: number;
+  kevDeviceCount: number;
+  patchReadyFindingCount: number;
+  acceptedExpiringSoon: number;
+}
+
+export interface CveCatalogRecord {
+  cveId: string;
+  description: string;
+  references: unknown;
+  cvssVersion: string | null;
+  cvssVector: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  severity: string | null;
+  publishedAt: string | null;
+  modifiedAt: string | null;
+}
+
+export interface CveDevicesPayload {
+  cve: CveCatalogRecord;
+  findings: GroupFinding[];
+}
+
+export interface BulkActionResult {
+  success: boolean;
+  succeeded: number;
+  skipped: Array<{ id: string; reason: string }>;
+}
+
+export interface VulnTicketResult {
+  success: boolean;
+  tickets: Array<{ ticketId: string; orgId: string; findingCount: number }>;
+  skipped: Array<{ id: string; reason: string }>;
+}
+
+// ---- Pure helpers (exported for tests) ----
+
+export function buildVulnQuery(params: Record<string, string | boolean | undefined>): string {
+  const q = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === '' || value === false) continue;
+    q.set(key, String(value));
+  }
+  const s = q.toString();
+  return s ? `?${s}` : '';
+}
+
+export function bulkSummary(verb: string, succeeded: number, skipped: Array<{ id: string; reason: string }>): string {
+  const base = `${succeeded} ${verb}`;
+  if (skipped.length === 0) return base;
+  return `${base}, ${skipped.length} skipped — ${skipped[0]!.reason}`;
+}
+
+// ---- Reads: fleet triage ----
+
+export async function fetchSoftwareGroups(
+  filters: VulnFleetFilters,
+): Promise<{ items: SoftwareGroup[]; hasMore: boolean }> {
+  const res = await fetchWithAuth(
+    `/vulnerabilities/software${buildVulnQuery({
+      status: filters.status,
+      severity: filters.severity,
+      search: filters.search,
+      kevOnly: filters.kevOnly,
+      patchAvailable: filters.patchAvailable,
+    })}`,
+  );
+  if (!res.ok) throw new Error('Failed to load software groups');
+  return res.json() as Promise<{ items: SoftwareGroup[]; hasMore: boolean }>;
+}
+
+export async function fetchSoftwareGroupDetail(groupKey: string): Promise<SoftwareGroupDetail> {
+  const res = await fetchWithAuth(`/vulnerabilities/software/${encodeURIComponent(groupKey)}`);
+  if (!res.ok) throw new Error('Failed to load software group');
+  return res.json() as Promise<SoftwareGroupDetail>;
+}
+
+export async function fetchVulnStats(): Promise<FleetVulnStats> {
+  const res = await fetchWithAuth('/vulnerabilities/stats');
+  if (!res.ok) throw new Error('Failed to load vulnerability stats');
+  return res.json() as Promise<FleetVulnStats>;
+}
+
+export async function fetchCveDevices(cveId: string): Promise<CveDevicesPayload> {
+  const res = await fetchWithAuth(`/vulnerabilities/${encodeURIComponent(cveId)}/devices`);
+  if (!res.ok) throw new Error('Failed to load CVE details');
+  return res.json() as Promise<CveDevicesPayload>;
 }
 
 // ---- Mutations (all wrapped in runAction so every outcome surfaces a toast) ----
@@ -88,7 +252,7 @@ export async function remediateVuln(deviceVulnerabilityIds: string[]): Promise<R
         body: JSON.stringify({ deviceVulnerabilityIds }),
       }),
     errorFallback: 'Failed to schedule remediation',
-    successMessage: (d) => `Scheduled ${d.scheduled} remediation${d.scheduled === 1 ? '' : 's'}`,
+    successMessage: (d) => bulkSummary(`remediation${d.scheduled === 1 ? '' : 's'} scheduled`, d.scheduled, d.skipped),
     parseSuccess: (data) => {
       const d = data as { scheduled?: number; skipped?: Array<{ id: string; reason: string }> };
       return { scheduled: d.scheduled ?? 0, skipped: d.skipped ?? [] };
@@ -133,5 +297,67 @@ export async function reopenVuln(id: string): Promise<void> {
       }),
     errorFallback: 'Failed to reopen finding',
     successMessage: 'Finding reopened',
+  });
+}
+
+// ---- Mutations: bulk fleet actions ----
+
+function parseBulk(data: unknown): BulkActionResult {
+  const d = data as Partial<BulkActionResult>;
+  return { success: d.success ?? false, succeeded: d.succeeded ?? 0, skipped: d.skipped ?? [] };
+}
+
+export async function bulkAcceptVulnRisk(
+  deviceVulnerabilityIds: string[],
+  payload: { reason: string; acceptedUntil: string },
+): Promise<BulkActionResult> {
+  return runAction<BulkActionResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/bulk/accept-risk', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to accept risk',
+    successMessage: (d) => bulkSummary('accepted', d.succeeded, d.skipped),
+    parseSuccess: parseBulk,
+  });
+}
+
+export async function bulkMitigateVulns(
+  deviceVulnerabilityIds: string[],
+  payload: { note: string },
+): Promise<BulkActionResult> {
+  return runAction<BulkActionResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/bulk/mitigate', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to mitigate',
+    successMessage: (d) => bulkSummary('mitigated', d.succeeded, d.skipped),
+    parseSuccess: parseBulk,
+  });
+}
+
+export async function createVulnTicket(
+  deviceVulnerabilityIds: string[],
+  payload: { title: string; description?: string; priority: 'low' | 'normal' | 'high' | 'urgent' },
+): Promise<VulnTicketResult> {
+  return runAction<VulnTicketResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/tickets', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to create ticket',
+    successMessage: (d) =>
+      d.tickets.length === 1 ? 'Ticket created' : `${d.tickets.length} tickets created (one per organization)`,
+    parseSuccess: (data) => {
+      const d = data as Partial<VulnTicketResult>;
+      return { success: d.success ?? false, tickets: d.tickets ?? [], skipped: d.skipped ?? [] };
+    },
   });
 }

--- a/apps/web/src/lib/api/vulnerabilities.ts
+++ b/apps/web/src/lib/api/vulnerabilities.ts
@@ -40,12 +40,14 @@ export interface VulnerabilityFilters {
   cve?: string;
   kevOnly?: boolean;
   patchAvailable?: boolean;
+  /** Only findings whose accepted-risk window expires within N days. */
+  expiringWithinDays?: number;
 }
 
 /** Fleet dashboard: CVEs across all accessible devices, aggregated + risk-sorted by the server. */
 export async function fetchVulnerabilities(
   filters: VulnerabilityFilters = {},
-): Promise<{ items: FleetVulnerability[] }> {
+): Promise<{ items: FleetVulnerability[]; hasMore: boolean }> {
   const res = await fetchWithAuth(
     `/vulnerabilities${buildVulnQuery({
       status: filters.status,
@@ -53,13 +55,14 @@ export async function fetchVulnerabilities(
       cve: filters.cve,
       kevOnly: filters.kevOnly,
       patchAvailable: filters.patchAvailable,
+      expiringWithinDays: filters.expiringWithinDays,
     })}`,
   );
   if (!res.ok) {
     throw new Error(`Failed to load vulnerabilities (${res.status})`);
   }
-  const body = (await res.json()) as { items?: FleetVulnerability[] };
-  return { items: body.items ?? [] };
+  const body = (await res.json()) as { items?: FleetVulnerability[]; hasMore?: boolean };
+  return { items: body.items ?? [], hasMore: body.hasMore ?? false };
 }
 
 /** Per-device findings (one row per CVE on the device) for the device tab. */
@@ -91,6 +94,9 @@ export interface VulnFleetFilters {
   status: string; // 'open' default
   kevOnly: boolean;
   patchAvailable: boolean;
+  /** Only findings whose accepted-risk window expires within N days (set by the
+   *  "Accepted, expiring soon" stat card; no visible filter-bar control). */
+  expiringWithinDays?: number;
 }
 
 export interface SoftwareGroup {
@@ -108,7 +114,8 @@ export interface SoftwareGroup {
   maxEpss: number | null;
   patchReadyFindingCount: number;
   patchReadyDeviceCount: number;
-  ticketIds: string[];
+  /** Distinct linked tickets; `number` is the human ticket number (null for legacy tickets). */
+  tickets: Array<{ id: string; number: string | null }>;
 }
 
 export interface GroupCve {
@@ -133,7 +140,10 @@ export interface GroupFinding {
   patchAvailable: boolean;
   riskScore: number | null;
   detectedAt: string;
+  /** ISO expiry of an accepted-risk window; null unless status is 'accepted'. */
+  acceptedUntil: string | null;
   ticketId: string | null;
+  ticketNumber: string | null;
 }
 
 export interface SoftwareGroupDetail {
@@ -148,6 +158,11 @@ export interface FleetVulnStats {
   kevDeviceCount: number;
   patchReadyFindingCount: number;
   acceptedExpiringSoon: number;
+  /** Findings across ALL statuses — "has scanning ever produced data". Feeds
+   *  the clean-fleet vs never-scanned empty-state split. */
+  totalFindings: number;
+  /** Most recent detectedAt across all findings (ISO), null when none exist. */
+  lastDetectedAt: string | null;
 }
 
 export interface CveCatalogRecord {
@@ -184,7 +199,7 @@ export interface VulnTicketResult {
 
 // ---- Pure helpers (exported for tests) ----
 
-export function buildVulnQuery(params: Record<string, string | boolean | undefined>): string {
+export function buildVulnQuery(params: Record<string, string | number | boolean | undefined>): string {
   const q = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === '' || value === false) continue;
@@ -212,6 +227,7 @@ export async function fetchSoftwareGroups(
       search: filters.search,
       kevOnly: filters.kevOnly,
       patchAvailable: filters.patchAvailable,
+      expiringWithinDays: filters.expiringWithinDays,
     })}`,
   );
   if (!res.ok) throw new Error('Failed to load software groups');

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+
+import { plural } from './utils';
+
+describe('plural', () => {
+  it('uses the singular form for exactly 1', () => {
+    expect(plural(1, 'device')).toBe('1 device');
+    expect(plural(1, 'finding')).toBe('1 finding');
+  });
+
+  it('adds an s for 0 and many', () => {
+    expect(plural(0, 'device')).toBe('0 devices');
+    expect(plural(3, 'finding')).toBe('3 findings');
+  });
+
+  it('supports an explicit plural form for irregular nouns', () => {
+    expect(plural(2, 'entry', 'entries')).toBe('2 entries');
+    expect(plural(1, 'entry', 'entries')).toBe('1 entry');
+  });
+});

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -9,6 +9,15 @@ export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
 }
 
+/**
+ * Count + correctly pluralized noun: `plural(1, 'device')` → "1 device",
+ * `plural(3, 'finding')` → "3 findings". Pass `pluralWord` for irregular
+ * nouns (`plural(2, 'entry', 'entries')`).
+ */
+export function plural(n: number, word: string, pluralWord?: string): string {
+  return `${n} ${n === 1 ? word : (pluralWord ?? `${word}s`)}`;
+}
+
 export function formatBytes(bytes: number, decimals = 2): string {
   if (bytes === 0) return '0 Bytes';
 

--- a/apps/web/src/pages/vulnerabilities.astro
+++ b/apps/web/src/pages/vulnerabilities.astro
@@ -1,6 +1,6 @@
 ---
 import DashboardLayout from '../layouts/DashboardLayout.astro';
-import VulnerabilityTable from '../components/vulnerabilities/VulnerabilityTable';
+import VulnerabilityFleetPage from '../components/vulnerabilities/VulnerabilityFleetPage';
 ---
 
 <DashboardLayout title="Vulnerabilities">
@@ -8,9 +8,9 @@ import VulnerabilityTable from '../components/vulnerabilities/VulnerabilityTable
     <div>
       <h1 class="text-2xl font-semibold">Vulnerabilities</h1>
       <p class="text-sm text-muted-foreground">
-        CVEs detected across your fleet, prioritized by risk (CVSS, with KEV/EPSS modifiers).
+        Fleet-wide CVE exposure grouped into remediation actions — triage, remediate, accept, or ticket from here.
       </p>
     </div>
-    <VulnerabilityTable client:load />
+    <VulnerabilityFleetPage client:load />
   </div>
 </DashboardLayout>

--- a/apps/web/src/pages/vulnerabilities.astro
+++ b/apps/web/src/pages/vulnerabilities.astro
@@ -7,8 +7,8 @@ import VulnerabilityFleetPage from '../components/vulnerabilities/VulnerabilityF
   <div class="space-y-6">
     <div>
       <h1 class="text-2xl font-semibold">Vulnerabilities</h1>
-      <p class="text-sm text-muted-foreground">
-        Fleet-wide CVE exposure grouped into remediation actions — triage, remediate, accept, or ticket from here.
+      <p class="max-w-prose text-sm text-muted-foreground">
+        Fleet CVE exposure grouped for triage — remediate, accept risk, or ticket.
       </p>
     </div>
     <VulnerabilityFleetPage client:load />

--- a/docs/superpowers/plans/2026-07-05-vulnerabilities-triage-api.md
+++ b/docs/superpowers/plans/2026-07-05-vulnerabilities-triage-api.md
@@ -1,0 +1,1886 @@
+# Vulnerabilities Fleet Triage UI Implementation Plan — Part 1: API (Tasks 1–7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the read-only fleet `/vulnerabilities` page into a triage work queue: software-grouped table + CVE table, stat cards, slide-over drawers with remediate / accept-risk / mitigate / reopen / create-ticket actions, backed by 4 new read endpoints, 2 bulk mutation endpoints, a ticket-creation endpoint, and one migration adding `device_vulnerabilities.ticket_id`.
+
+**Architecture:** Backend fetches raw per-finding rows (RLS org-scoped + app-layer site narrowing, catalog read under system context) and feeds them to a pure, unit-testable aggregation service. Frontend is a hash-routed page shell (`#software` default / `#cves`) with shared filter state, two table islands, and two drawers built on a `shared/Drawer.tsx` primitive extracted verbatim from the catalog editor drawer.
+
+**Tech Stack:** Hono + Drizzle + Zod (API), Astro + React islands + Tailwind (web), Vitest (+jsdom), Playwright e2e.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md` (approved).
+
+**Continues in:** `2026-07-05-vulnerabilities-triage-web.md` (Part 2: Web, Tasks 8–17). Task numbering is shared across both documents.
+
+## Global Constraints
+
+- **Group key format (opaque, stable):** `sw:<lower(trim(name))>|<lower(trim(coalesce(vendor,'')))>` for software findings; `os:<devices.osType>` (`os:windows` | `os:macos` | `os:linux`) for OS findings (`software_inventory_id IS NULL`). Normalization MUST be `lower(trim(...))` — that's what the correlation JOIN uses (`vulnerabilityCorrelation.ts:199-207`).
+- **Bulk caps:** `deviceVulnerabilityIds` arrays are `z.array(z.string().uuid()).min(1).max(200)`. `reason`/`note` are `z.string().trim().min(1).max(2000)`. `acceptedUntil` is `z.string().datetime()` and must be in the future.
+- **Bulk contract:** per-item fault-tolerant — `{ success, succeeded, skipped: [{id, reason}] }`; never fail the whole batch on one bad id. `success` is `true` iff at least one item succeeded (matches remediate's contract, `routes/vulnerabilities.ts:392-398`).
+- **Group list cap:** hard cap 500 groups + `hasMore` boolean. No pagination.
+- **Migration:** idempotent, no inner `BEGIN;`/`COMMIT;`, never edit shipped migrations. Filename `2026-07-04-device-vulnerabilities-ticket-link.sql`.
+- **No new tables** → no RLS policy or allowlist changes anywhere.
+- **Web:** all mutations via `runAction` (`apps/web/src/lib/runAction.ts`); new mutating/action components added to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` with the count constant bumped in the same commit (current value **58**; all bumps happen in Part 2, ending at **63**).
+- **URL state:** hash only (`#software`, `#cves`, `#software/<encodeURIComponent(groupKey)>`, `#cves/<cveId>`). Filters are transient React state — NOT query params.
+- **Permissions (exact strings):** remediate = `devices:execute` + MFA (server-side `requireMfa()`); accept-risk & reopen = `vulnerabilities:accept_risk`; mitigate = `devices:write`; create-ticket = `tickets:write`; all reads = `devices:read` (router-level).
+- **E2E:** `data-testid` attributes only, never text/role/CSS selectors.
+- **Test commands:** API: `cd apps/api && pnpm vitest run <file>`. Web: `cd apps/web && pnpm vitest run <file>`. Drift: `export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift` (repo root, needs local Postgres).
+- Route file `apps/api/src/routes/vulnerabilities.ts` is ~575 lines already — new query logic goes in NEW service files, not the route file.
+
+---
+
+### Task 1: Migration + Drizzle schema for `device_vulnerabilities.ticket_id`
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql`
+- Modify: `apps/api/src/db/schema/vulnerabilityManagement.ts` (imports at top; `deviceVulnerabilities` table at lines 96–114)
+
+**Interfaces:**
+- Consumes: existing `tickets` table (`apps/api/src/db/schema/portal.ts`, `id: uuid` PK).
+- Produces: `deviceVulnerabilities.ticketId` Drizzle column (`uuid, nullable, FK → tickets.id ON DELETE SET NULL`) used by Tasks 3 (fetcher) and 7 (ticket endpoint).
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql`:
+
+```sql
+-- Vulnerabilities fleet triage UI: link findings to native tickets.
+-- Spec: docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md
+-- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file in a transaction).
+
+ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS ticket_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'device_vulnerabilities_ticket_id_tickets_id_fk'
+      AND table_name = 'device_vulnerabilities'
+  ) THEN
+    ALTER TABLE device_vulnerabilities
+      ADD CONSTRAINT device_vulnerabilities_ticket_id_tickets_id_fk
+      FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Partial index: most findings have no ticket; only index linked rows.
+CREATE INDEX IF NOT EXISTS device_vuln_ticket_id_idx
+  ON device_vulnerabilities (ticket_id) WHERE ticket_id IS NOT NULL;
+```
+
+The constraint name follows Drizzle's `<table>_<col>_<reftable>_<refcol>_fk` convention so `db:check-drift` sees no difference.
+
+- [ ] **Step 2: Update the Drizzle schema**
+
+In `apps/api/src/db/schema/vulnerabilityManagement.ts`, add to the imports block (which already imports from `./orgs`, `./devices`, `./users`, `./software`):
+
+```ts
+import { tickets } from './portal';
+```
+
+In the `deviceVulnerabilities` table definition, after the `acceptedUntil` column, add:
+
+```ts
+  ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+```
+
+And add to the table's index object (third argument), after `statusIdx`:
+
+```ts
+  ticketIdx: index('device_vuln_ticket_id_idx').on(table.ticketId),
+```
+
+**Note on the partial index:** Drizzle's `index()` builder here declares a plain index while the SQL creates a partial one. If `pnpm db:check-drift` flags the `WHERE` clause mismatch, use Drizzle's `.where(sql\`ticket_id IS NOT NULL\`)` on the index builder (import `sql` from `drizzle-orm`) to match. If importing `tickets` from `./portal` creates a module cycle (build/test failure with undefined table), fall back to a plain `uuid('ticket_id')` column without `.references()` and keep the FK SQL-only — `portal.ts` itself uses this dodge for `categoryId`/`statusId`.
+
+- [ ] **Step 3: Run the migration-ordering regression test and typecheck**
+
+Run: `cd apps/api && pnpm vitest run src/db/autoMigrate.test.ts`
+Expected: PASS
+
+Run: `cd apps/api && pnpm tsc --noEmit 2>&1 | head -30`
+Expected: no NEW errors mentioning `vulnerabilityManagement` or `portal` (pre-existing unrelated errors, if any, are fine).
+
+- [ ] **Step 4: Verify drift check passes (requires local Postgres running)**
+
+Run:
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd apps/api && pnpm db:migrate 2>/dev/null || true   # apply if a migrate script exists; otherwise the API dev server applies on boot
+pnpm db:check-drift
+```
+Expected: exit 0, no drift reported. If the local DB is unavailable, note it in the commit message and rely on CI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql apps/api/src/db/schema/vulnerabilityManagement.ts
+git commit -m "feat(api): add device_vulnerabilities.ticket_id linkage column"
+```
+
+---
+
+### Task 2: Pure aggregation service `vulnerabilityFleetAggregation.ts`
+
+**Files:**
+- Create: `apps/api/src/services/vulnerabilityFleetAggregation.ts`
+- Test: `apps/api/src/services/vulnerabilityFleetAggregation.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure functions, no db).
+- Produces (used by Tasks 3–4 routes and mirrored by web types in Task 9):
+  - `interface FleetFindingRow` — the raw per-finding row shape (see code below).
+  - `buildGroupKey(row): string`
+  - `filterFindings(rows: FleetFindingRow[], f: FleetFindingFilters): FleetFindingRow[]`
+  - `groupFindings(rows: FleetFindingRow[], opts?: { search?: string }): SoftwareGroup[]` — sorted `maxRiskScore` desc.
+  - `computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats`
+  - `buildGroupDetail(groupKey: string, rows: FleetFindingRow[]): SoftwareGroupDetail | null`
+  - `toGroupFinding(row: FleetFindingRow): GroupFinding`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/services/vulnerabilityFleetAggregation.test.ts` (pure-function pattern, zero mocks — same style as `vulnerabilityRiskScore.test.ts`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  buildGroupKey,
+  buildGroupDetail,
+  computeStats,
+  filterFindings,
+  groupFindings,
+  type FleetFindingRow,
+} from './vulnerabilityFleetAggregation';
+
+function row(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    orgId: 'org-1',
+    status: 'open',
+    riskScore: 75,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    acceptedUntil: null,
+    ticketId: null,
+    softwareInventoryId: 'sw-1',
+    softwareName: 'Google Chrome',
+    softwareVendor: 'Google LLC',
+    softwareVersion: '126.0.1',
+    deviceName: 'WS-01',
+    deviceOsType: 'windows',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    vulnerabilityId: 'v-1',
+    severity: 'high',
+    cvssScore: 8.1,
+    epssScore: 0.4,
+    knownExploited: false,
+    patchAvailable: true,
+    ...overrides,
+  };
+}
+
+describe('buildGroupKey', () => {
+  it('normalizes software name/vendor with lower(trim(...)) matching the correlation JOIN', () => {
+    expect(buildGroupKey(row({ softwareName: '  Google Chrome ', softwareVendor: ' Google LLC ' })))
+      .toBe('sw:google chrome|google llc');
+  });
+
+  it('treats null vendor as empty string', () => {
+    expect(buildGroupKey(row({ softwareVendor: null }))).toBe('sw:google chrome|');
+  });
+
+  it('maps OS findings (null softwareInventoryId) to per-platform pseudo-groups', () => {
+    expect(buildGroupKey(row({ softwareInventoryId: null, deviceOsType: 'macos' }))).toBe('os:macos');
+  });
+});
+
+describe('filterFindings', () => {
+  const rows = [
+    row({ deviceVulnerabilityId: 'a', status: 'open', severity: 'critical', knownExploited: true }),
+    row({ deviceVulnerabilityId: 'b', status: 'accepted', severity: 'high', patchAvailable: false }),
+    row({ deviceVulnerabilityId: 'c', status: 'open', severity: 'low', knownExploited: false }),
+  ];
+
+  it('filters by status, passing everything through for "all"', () => {
+    expect(filterFindings(rows, { status: 'open' }).map((r) => r.deviceVulnerabilityId)).toEqual(['a', 'c']);
+    expect(filterFindings(rows, { status: 'all' })).toHaveLength(3);
+  });
+
+  it('applies severity, kevOnly, and patchAvailable finding-level filters', () => {
+    expect(filterFindings(rows, { status: 'all', severity: 'critical' }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
+    expect(filterFindings(rows, { status: 'all', kevOnly: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a']);
+    expect(filterFindings(rows, { status: 'all', patchAvailable: true }).map((r) => r.deviceVulnerabilityId)).toEqual(['a', 'c']);
+  });
+});
+
+describe('groupFindings', () => {
+  it('groups by normalized software identity and counts distinct devices/CVEs', () => {
+    const groups = groupFindings([
+      row({ deviceVulnerabilityId: 'a', deviceId: 'dev-1', cveId: 'CVE-1' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-1', softwareName: 'google chrome' }),
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-1', cveId: 'CVE-2' }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.deviceCount).toBe(2);
+    expect(groups[0]!.cveCount).toBe(2);
+    expect(groups[0]!.kind).toBe('software');
+  });
+
+  it('rolls OS findings into per-platform pseudo-groups with display names', () => {
+    const groups = groupFindings([
+      row({ softwareInventoryId: null, deviceOsType: 'windows' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', softwareInventoryId: null, deviceOsType: 'macos' }),
+    ]);
+    const names = groups.map((g) => g.name).sort();
+    expect(names).toEqual(['Windows OS updates', 'macOS updates']);
+    expect(groups.every((g) => g.kind === 'os' && g.vendor === null)).toBe(true);
+  });
+
+  it('computes worstSeverity / maxRiskScore / maxEpss / kevCveCount / patch-ready counts', () => {
+    const groups = groupFindings([
+      row({ deviceVulnerabilityId: 'a', deviceId: 'dev-1', cveId: 'CVE-1', severity: 'high', riskScore: 70, epssScore: 0.2, knownExploited: false, patchAvailable: true, status: 'open' }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-2', severity: 'critical', riskScore: 95, epssScore: 0.9, knownExploited: true, patchAvailable: false, status: 'open' }),
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-2', cveId: 'CVE-1', severity: 'high', riskScore: 60, epssScore: 0.2, knownExploited: false, patchAvailable: true, status: 'accepted' }),
+    ]);
+    const g = groups[0]!;
+    expect(g.worstSeverity).toBe('critical');
+    expect(g.maxRiskScore).toBe(95);
+    expect(g.maxEpss).toBe(0.9);
+    expect(g.kevCveCount).toBe(1);
+    // patch-ready counts only OPEN findings with a patch-available CVE
+    expect(g.patchReadyFindingCount).toBe(1);
+    expect(g.patchReadyDeviceCount).toBe(1);
+  });
+
+  it('sorts by maxRiskScore desc with nulls last', () => {
+    const groups = groupFindings([
+      row({ softwareName: 'Low', riskScore: 10 }),
+      row({ deviceVulnerabilityId: 'b', softwareName: 'None', riskScore: null }),
+      row({ deviceVulnerabilityId: 'c', softwareName: 'High', riskScore: 90 }),
+    ]);
+    expect(groups.map((g) => g.name)).toEqual(['High', 'Low', 'None']);
+  });
+
+  it('applies search across group name, vendor, and member CVE ids (case-insensitive)', () => {
+    const rows = [
+      row({ softwareName: 'Google Chrome', cveId: 'CVE-2026-0001' }),
+      row({ deviceVulnerabilityId: 'b', softwareName: 'Zoom', softwareVendor: 'Zoom Video', cveId: 'CVE-2026-9999' }),
+    ];
+    expect(groupFindings(rows, { search: 'chrome' })).toHaveLength(1);
+    expect(groupFindings(rows, { search: '9999' })[0]!.name).toBe('Zoom');
+    expect(groupFindings(rows, { search: 'ZOOM VIDEO' })).toHaveLength(1);
+    expect(groupFindings(rows, { search: 'nomatch' })).toHaveLength(0);
+  });
+
+  it('collects distinct ticketIds and versions', () => {
+    const g = groupFindings([
+      row({ ticketId: 't-1', softwareVersion: '2.0' }),
+      row({ deviceVulnerabilityId: 'b', ticketId: 't-1', softwareVersion: '10.0' }),
+      row({ deviceVulnerabilityId: 'c', ticketId: null, softwareVersion: '2.0' }),
+    ])[0]!;
+    expect(g.ticketIds).toEqual(['t-1']);
+    expect(g.versions).toEqual(['2.0', '10.0']); // numeric-aware sort
+  });
+});
+
+describe('computeStats', () => {
+  const now = new Date('2026-07-05T00:00:00.000Z');
+
+  it('computes the four stat-card numbers', () => {
+    const stats = computeStats([
+      row({ status: 'open', severity: 'critical' }),                                   // criticalOpen + patchReady
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', status: 'open', severity: 'high', knownExploited: true, cveId: 'CVE-K', patchAvailable: false }), // kev
+      row({ deviceVulnerabilityId: 'c', deviceId: 'dev-3', status: 'open', severity: 'high', knownExploited: true, cveId: 'CVE-K', patchAvailable: false }), // same kev cve, 2nd device
+      row({ deviceVulnerabilityId: 'd', status: 'accepted', acceptedUntil: '2026-07-10T00:00:00.000Z' }),  // expiring within 14d
+      row({ deviceVulnerabilityId: 'e', status: 'accepted', acceptedUntil: '2026-12-01T00:00:00.000Z' }),  // not expiring soon
+      row({ deviceVulnerabilityId: 'f', status: 'accepted', acceptedUntil: '2026-07-01T00:00:00.000Z' }),  // already expired — not counted
+    ], now);
+    expect(stats.criticalOpen).toBe(1);
+    expect(stats.kevCveCount).toBe(1);
+    expect(stats.kevDeviceCount).toBe(2);
+    expect(stats.patchReadyFindingCount).toBe(1);
+    expect(stats.acceptedExpiringSoon).toBe(1);
+  });
+});
+
+describe('buildGroupDetail', () => {
+  it('returns null for an unknown group', () => {
+    expect(buildGroupDetail('sw:nope|', [row()])).toBeNull();
+  });
+
+  it('returns group summary + distinct CVEs (max risk each) + flat findings', () => {
+    const detail = buildGroupDetail('sw:google chrome|google llc', [
+      row({ deviceVulnerabilityId: 'a', cveId: 'CVE-1', riskScore: 60 }),
+      row({ deviceVulnerabilityId: 'b', deviceId: 'dev-2', cveId: 'CVE-1', riskScore: 80 }),
+      row({ deviceVulnerabilityId: 'c', cveId: 'CVE-2', riskScore: 40 }),
+      row({ deviceVulnerabilityId: 'x', softwareName: 'Other App' }), // different group — excluded
+    ]);
+    expect(detail).not.toBeNull();
+    expect(detail!.cves.map((c) => c.cveId)).toEqual(['CVE-1', 'CVE-2']); // sorted by maxRiskScore desc
+    expect(detail!.cves[0]!.maxRiskScore).toBe(80);
+    expect(detail!.findings).toHaveLength(3);
+    expect(detail!.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String), status: 'open' });
+    expect(detail!.group.deviceCount).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/services/vulnerabilityFleetAggregation.test.ts`
+Expected: FAIL — cannot resolve `./vulnerabilityFleetAggregation`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/services/vulnerabilityFleetAggregation.ts`:
+
+```ts
+/**
+ * Pure aggregation logic for the fleet vulnerabilities triage UI.
+ *
+ * Grouping key contract (opaque, URL-safe once encodeURIComponent'd, stable
+ * across requests so `#software/<groupKey>` deep links work):
+ *   software finding:  sw:<lower(trim(name))>|<lower(trim(coalesce(vendor,'')))>
+ *   OS finding:        os:<devices.osType>          (softwareInventoryId IS NULL)
+ * The lower(trim(...)) normalization deliberately matches the correlation
+ * pipeline's JOIN (services/vulnerabilityCorrelation.ts) so one product maps
+ * to one queue row regardless of inventory casing.
+ *
+ * No db access here — routes fetch FleetFindingRow[] via
+ * services/vulnerabilityFleetQueries.ts and pass them in.
+ */
+
+export interface FleetFindingRow {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  orgId: string;
+  status: string; // open | patched | mitigated | accepted
+  riskScore: number | null;
+  detectedAt: string; // ISO
+  acceptedUntil: string | null; // ISO
+  ticketId: string | null;
+  softwareInventoryId: string | null;
+  softwareName: string | null;
+  softwareVendor: string | null;
+  softwareVersion: string | null;
+  deviceName: string;
+  deviceOsType: 'windows' | 'macos' | 'linux';
+  orgName: string | null;
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+}
+
+export interface FleetFindingFilters {
+  status: string; // open | patched | mitigated | accepted | all
+  severity?: string;
+  kevOnly?: boolean;
+  patchAvailable?: boolean;
+}
+
+export interface SoftwareGroup {
+  groupKey: string;
+  kind: 'software' | 'os';
+  name: string;
+  vendor: string | null;
+  versions: string[];
+  deviceCount: number;
+  cveCount: number;
+  cveIds: string[];
+  worstSeverity: string | null;
+  maxRiskScore: number | null;
+  kevCveCount: number;
+  maxEpss: number | null;
+  /** Open findings whose CVE has a patch available ("fixable right now"). */
+  patchReadyFindingCount: number;
+  /** Distinct devices with at least one patch-ready open finding. */
+  patchReadyDeviceCount: number;
+  ticketIds: string[];
+}
+
+export interface FleetVulnStats {
+  criticalOpen: number;
+  kevCveCount: number;
+  kevDeviceCount: number;
+  patchReadyFindingCount: number;
+  acceptedExpiringSoon: number;
+}
+
+export interface GroupCve {
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  maxRiskScore: number | null;
+}
+
+export interface GroupFinding {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  deviceName: string;
+  orgId: string;
+  orgName: string | null;
+  cveId: string;
+  status: string;
+  patchAvailable: boolean;
+  riskScore: number | null;
+  detectedAt: string;
+  ticketId: string | null;
+}
+
+export interface SoftwareGroupDetail {
+  group: SoftwareGroup;
+  cves: GroupCve[];
+  findings: GroupFinding[];
+}
+
+const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+const OS_GROUP_NAMES: Record<FleetFindingRow['deviceOsType'], string> = {
+  windows: 'Windows OS updates',
+  macos: 'macOS updates',
+  linux: 'Linux OS updates',
+};
+
+const ACCEPTED_EXPIRING_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function buildGroupKey(
+  row: Pick<FleetFindingRow, 'softwareInventoryId' | 'softwareName' | 'softwareVendor' | 'deviceOsType'>,
+): string {
+  if (row.softwareInventoryId === null) return `os:${row.deviceOsType}`;
+  const name = (row.softwareName ?? '').trim().toLowerCase();
+  const vendor = (row.softwareVendor ?? '').trim().toLowerCase();
+  return `sw:${name}|${vendor}`;
+}
+
+export function filterFindings(rows: FleetFindingRow[], f: FleetFindingFilters): FleetFindingRow[] {
+  return rows.filter((r) => {
+    if (f.status !== 'all' && r.status !== f.status) return false;
+    if (f.severity && (r.severity ?? '').toLowerCase() !== f.severity) return false;
+    if (f.kevOnly && !r.knownExploited) return false;
+    if (f.patchAvailable && !r.patchAvailable) return false;
+    return true;
+  });
+}
+
+function summarizeGroup(groupKey: string, bucket: FleetFindingRow[]): SoftwareGroup {
+  const first = bucket[0]!;
+  const kind: SoftwareGroup['kind'] = groupKey.startsWith('os:') ? 'os' : 'software';
+  const cveIds = new Set<string>();
+  const kevCves = new Set<string>();
+  const deviceIds = new Set<string>();
+  const patchReadyDevices = new Set<string>();
+  const versions = new Set<string>();
+  const ticketIds = new Set<string>();
+  let worst: string | null = null;
+  let maxRisk: number | null = null;
+  let maxEpss: number | null = null;
+  let patchReadyFindingCount = 0;
+
+  for (const r of bucket) {
+    cveIds.add(r.cveId);
+    if (r.knownExploited) kevCves.add(r.cveId);
+    deviceIds.add(r.deviceId);
+    if (r.softwareVersion) versions.add(r.softwareVersion);
+    if (r.ticketId) ticketIds.add(r.ticketId);
+    if (r.patchAvailable && r.status === 'open') {
+      patchReadyFindingCount += 1;
+      patchReadyDevices.add(r.deviceId);
+    }
+    const sev = (r.severity ?? '').toLowerCase();
+    if ((SEVERITY_RANK[sev] ?? 0) > (worst ? (SEVERITY_RANK[worst] ?? 0) : 0)) worst = sev;
+    if (r.riskScore !== null && (maxRisk === null || r.riskScore > maxRisk)) maxRisk = r.riskScore;
+    if (r.epssScore !== null && (maxEpss === null || r.epssScore > maxEpss)) maxEpss = r.epssScore;
+  }
+
+  return {
+    groupKey,
+    kind,
+    name: kind === 'os' ? OS_GROUP_NAMES[first.deviceOsType] : ((first.softwareName ?? '').trim() || 'Unknown software'),
+    vendor: kind === 'os' ? null : (first.softwareVendor?.trim() || null),
+    versions: [...versions].sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+    deviceCount: deviceIds.size,
+    cveCount: cveIds.size,
+    cveIds: [...cveIds].sort(),
+    worstSeverity: worst,
+    maxRiskScore: maxRisk,
+    kevCveCount: kevCves.size,
+    maxEpss,
+    patchReadyFindingCount,
+    patchReadyDeviceCount: patchReadyDevices.size,
+    ticketIds: [...ticketIds],
+  };
+}
+
+export function groupFindings(rows: FleetFindingRow[], opts: { search?: string } = {}): SoftwareGroup[] {
+  const buckets = new Map<string, FleetFindingRow[]>();
+  for (const row of rows) {
+    const key = buildGroupKey(row);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(row);
+    else buckets.set(key, [row]);
+  }
+
+  let groups = [...buckets.entries()].map(([key, bucket]) => summarizeGroup(key, bucket));
+
+  const search = opts.search?.trim().toLowerCase();
+  if (search) {
+    groups = groups.filter(
+      (g) =>
+        g.name.toLowerCase().includes(search) ||
+        (g.vendor ?? '').toLowerCase().includes(search) ||
+        g.cveIds.some((id) => id.toLowerCase().includes(search)),
+    );
+  }
+
+  return groups.sort((a, b) => {
+    const riskA = a.maxRiskScore ?? -1;
+    const riskB = b.maxRiskScore ?? -1;
+    if (riskB !== riskA) return riskB - riskA;
+    if (b.deviceCount !== a.deviceCount) return b.deviceCount - a.deviceCount;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function computeStats(rows: FleetFindingRow[], now: Date): FleetVulnStats {
+  const kevCves = new Set<string>();
+  const kevDevices = new Set<string>();
+  let criticalOpen = 0;
+  let patchReadyFindingCount = 0;
+  let acceptedExpiringSoon = 0;
+  const nowMs = now.getTime();
+  const soonMs = nowMs + ACCEPTED_EXPIRING_WINDOW_MS;
+
+  for (const r of rows) {
+    if (r.status === 'open') {
+      if ((r.severity ?? '').toLowerCase() === 'critical') criticalOpen += 1;
+      if (r.knownExploited) {
+        kevCves.add(r.cveId);
+        kevDevices.add(r.deviceId);
+      }
+      if (r.patchAvailable) patchReadyFindingCount += 1;
+    } else if (r.status === 'accepted' && r.acceptedUntil) {
+      const t = new Date(r.acceptedUntil).getTime();
+      if (t > nowMs && t <= soonMs) acceptedExpiringSoon += 1;
+    }
+  }
+
+  return {
+    criticalOpen,
+    kevCveCount: kevCves.size,
+    kevDeviceCount: kevDevices.size,
+    patchReadyFindingCount,
+    acceptedExpiringSoon,
+  };
+}
+
+export function toGroupFinding(r: FleetFindingRow): GroupFinding {
+  return {
+    deviceVulnerabilityId: r.deviceVulnerabilityId,
+    deviceId: r.deviceId,
+    deviceName: r.deviceName,
+    orgId: r.orgId,
+    orgName: r.orgName,
+    cveId: r.cveId,
+    status: r.status,
+    patchAvailable: r.patchAvailable,
+    riskScore: r.riskScore,
+    detectedAt: r.detectedAt,
+    ticketId: r.ticketId,
+  };
+}
+
+export function buildGroupDetail(groupKey: string, rows: FleetFindingRow[]): SoftwareGroupDetail | null {
+  const bucket = rows.filter((r) => buildGroupKey(r) === groupKey);
+  if (bucket.length === 0) return null;
+
+  const cveMap = new Map<string, GroupCve>();
+  for (const r of bucket) {
+    const existing = cveMap.get(r.cveId);
+    if (!existing) {
+      cveMap.set(r.cveId, {
+        cveId: r.cveId,
+        vulnerabilityId: r.vulnerabilityId,
+        severity: r.severity,
+        cvssScore: r.cvssScore,
+        epssScore: r.epssScore,
+        knownExploited: r.knownExploited,
+        patchAvailable: r.patchAvailable,
+        maxRiskScore: r.riskScore,
+      });
+    } else if (r.riskScore !== null && (existing.maxRiskScore === null || r.riskScore > existing.maxRiskScore)) {
+      existing.maxRiskScore = r.riskScore;
+    }
+  }
+
+  const cves = [...cveMap.values()].sort((a, b) => (b.maxRiskScore ?? -1) - (a.maxRiskScore ?? -1));
+  const findings = bucket
+    .map(toGroupFinding)
+    .sort((a, b) => a.deviceName.localeCompare(b.deviceName) || a.cveId.localeCompare(b.cveId));
+
+  return { group: summarizeGroup(groupKey, bucket), cves, findings };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm vitest run src/services/vulnerabilityFleetAggregation.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/vulnerabilityFleetAggregation.ts apps/api/src/services/vulnerabilityFleetAggregation.test.ts
+git commit -m "feat(api): pure fleet vulnerability aggregation service"
+```
+
+---
+
+### Task 3: Fleet finding fetcher + `GET /vulnerabilities/software` + `GET /vulnerabilities/stats`
+
+**Files:**
+- Create: `apps/api/src/services/vulnerabilityFleetQueries.ts`
+- Modify: `apps/api/src/routes/vulnerabilities.ts` (add imports; register the two GET routes after the existing `GET /` handler at ~line 353)
+- Test: `apps/api/src/routes/vulnerabilities.test.ts` (extend existing file)
+
+**Interfaces:**
+- Consumes: Task 2's `FleetFindingRow`, `filterFindings`, `groupFindings`, `computeStats`; Task 1's `ticketId` column.
+- Produces:
+  - `fetchFleetFindingRows(filters: { status: string; allowedSiteIds?: string[] }): Promise<FleetFindingRow[]>` (used by Tasks 4).
+  - `fetchCveCatalogRecord(cveId: string): Promise<CveCatalogRecord | null>` (used by Task 4) where `CveCatalogRecord = { cveId, description, references: unknown, cvssVersion, cvssVector, cvssScore, epssScore, knownExploited, patchAvailable, severity, publishedAt, modifiedAt }` (scores as `number | null`, dates as ISO strings or null).
+  - `GET /vulnerabilities/software?status&severity&search&kevOnly&patchAvailable` → `{ items: SoftwareGroup[], hasMore: boolean }`.
+  - `GET /vulnerabilities/stats` → `FleetVulnStats`.
+  - Route-file helper `boolQuerySchema` (reused by Task 5).
+
+- [ ] **Step 1: Write the failing route tests**
+
+In `apps/api/src/routes/vulnerabilities.test.ts`, add to the mock block (next to the existing `vi.mock('../services/vulnerabilityRemediation', ...)` call):
+
+```ts
+vi.mock('../services/vulnerabilityFleetQueries', () => ({
+  fetchFleetFindingRows: vi.fn(async () => []),
+  fetchCveCatalogRecord: vi.fn(async () => null),
+}));
+```
+
+Import next to the other post-mock imports:
+
+```ts
+import { fetchFleetFindingRows, fetchCveCatalogRecord } from '../services/vulnerabilityFleetQueries';
+import type { FleetFindingRow } from '../services/vulnerabilityFleetAggregation';
+```
+
+Add a shared fixture helper near the top-level helpers (after the `post` helper):
+
+```ts
+function fleetRow(overrides: Partial<FleetFindingRow> = {}): FleetFindingRow {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    orgId: 'org-1',
+    status: 'open',
+    riskScore: 75,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    acceptedUntil: null,
+    ticketId: null,
+    softwareInventoryId: 'sw-1',
+    softwareName: 'Google Chrome',
+    softwareVendor: 'Google LLC',
+    softwareVersion: '126.0.1',
+    deviceName: 'WS-01',
+    deviceOsType: 'windows',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    vulnerabilityId: 'v-1',
+    severity: 'critical',
+    cvssScore: 9.1,
+    epssScore: 0.4,
+    knownExploited: true,
+    patchAvailable: true,
+    ...overrides,
+  };
+}
+```
+
+Then add the describe blocks:
+
+```ts
+describe('GET /vulnerabilities/software (fleet work queue)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('403s without devices:read', async () => {
+    granted.clear();
+    const res = await app().request('/vulnerabilities/software');
+    expect(res.status).toBe(403);
+  });
+
+  it('groups findings and returns items + hasMore', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', softwareName: 'google chrome ' }),
+    ]);
+    const res = await app().request('/vulnerabilities/software');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasMore).toBe(false);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toMatchObject({
+      groupKey: 'sw:google chrome|google llc',
+      kind: 'software',
+      deviceCount: 2,
+    });
+  });
+
+  it('passes status through and forwards allowedSiteIds from the permissions context', async () => {
+    permissionsState.allowedSiteIds = ['site-1'];
+    const res = await app().request('/vulnerabilities/software?status=accepted');
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith({
+      status: 'accepted',
+      allowedSiteIds: ['site-1'],
+    });
+  });
+
+  it('applies severity/kevOnly/patchAvailable/search filters', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', softwareName: 'Zoom', softwareVendor: 'Zoom', severity: 'low', knownExploited: false, patchAvailable: false, cveId: 'CVE-2026-2' }),
+    ]);
+    const res = await app().request('/vulnerabilities/software?severity=critical&kevOnly=true&patchAvailable=true&search=chrome');
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].name).toBe('Google Chrome');
+  });
+
+  it('400s on an invalid boolean param', async () => {
+    const res = await app().request('/vulnerabilities/software?kevOnly=yes');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /vulnerabilities/stats', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('403s without devices:read', async () => {
+    granted.clear();
+    const res = await app().request('/vulnerabilities/stats');
+    expect(res.status).toBe(403);
+  });
+
+  it('fetches ALL statuses and returns the four stat numbers', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(), // open critical KEV patch-ready
+      fleetRow({ deviceVulnerabilityId: 'dv-2', status: 'accepted', acceptedUntil: new Date(Date.now() + 5 * 864e5).toISOString() }),
+    ]);
+    const res = await app().request('/vulnerabilities/stats');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all' }),
+    );
+    expect(body).toEqual({
+      criticalOpen: 1,
+      kevCveCount: 1,
+      kevDeviceCount: 1,
+      patchReadyFindingCount: 1,
+      acceptedExpiringSoon: 1,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: FAIL — the new describes 404 (routes not registered) / cannot resolve `vulnerabilityFleetQueries`. Existing tests must still pass.
+
+- [ ] **Step 3: Write the fetcher service**
+
+Create `apps/api/src/services/vulnerabilityFleetQueries.ts`:
+
+```ts
+/**
+ * DB fetch layer for the fleet vulnerabilities triage UI.
+ *
+ * Org isolation: RLS on the request's db context (same as the existing fleet
+ * list in routes/vulnerabilities.ts). Site axis: app-layer narrowing via
+ * allowedSiteIds -> devices.siteId (RLS does NOT cover sites). The global
+ * `vulnerabilities` catalog is system-scoped reference data and is read under
+ * a system context, mirroring readCatalogRows in routes/vulnerabilities.ts.
+ */
+import { and, eq, ilike, inArray, type SQL } from 'drizzle-orm';
+
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { deviceVulnerabilities, devices, organizations, softwareInventory, vulnerabilities } from '../db/schema';
+import type { FleetFindingRow } from './vulnerabilityFleetAggregation';
+
+export interface CveCatalogRecord {
+  cveId: string;
+  description: string;
+  references: unknown;
+  cvssVersion: string | null;
+  cvssVector: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  severity: string | null;
+  publishedAt: string | null;
+  modifiedAt: string | null;
+}
+
+function toNumber(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function fetchFleetFindingRows(filters: {
+  status: string;
+  /** Site-axis narrowing; empty array = fail closed (return nothing). */
+  allowedSiteIds?: string[];
+}): Promise<FleetFindingRow[]> {
+  const conditions: SQL[] = [];
+  if (filters.status !== 'all') {
+    conditions.push(eq(deviceVulnerabilities.status, filters.status));
+  }
+  if (filters.allowedSiteIds !== undefined) {
+    if (filters.allowedSiteIds.length === 0) return [];
+    const allowedDeviceRows = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .where(inArray(devices.siteId, filters.allowedSiteIds));
+    const allowedDeviceIds = allowedDeviceRows.map((r) => r.id);
+    if (allowedDeviceIds.length === 0) return [];
+    conditions.push(inArray(deviceVulnerabilities.deviceId, allowedDeviceIds));
+  }
+
+  const findingRows = await db
+    .select({
+      id: deviceVulnerabilities.id,
+      orgId: deviceVulnerabilities.orgId,
+      deviceId: deviceVulnerabilities.deviceId,
+      vulnerabilityId: deviceVulnerabilities.vulnerabilityId,
+      softwareInventoryId: deviceVulnerabilities.softwareInventoryId,
+      status: deviceVulnerabilities.status,
+      riskScore: deviceVulnerabilities.riskScore,
+      detectedAt: deviceVulnerabilities.detectedAt,
+      acceptedUntil: deviceVulnerabilities.acceptedUntil,
+      ticketId: deviceVulnerabilities.ticketId,
+    })
+    .from(deviceVulnerabilities)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+
+  if (findingRows.length === 0) return [];
+
+  const deviceIds = [...new Set(findingRows.map((r) => r.deviceId))];
+  const deviceRows = await db
+    .select({
+      id: devices.id,
+      hostname: devices.hostname,
+      displayName: devices.displayName,
+      osType: devices.osType,
+    })
+    .from(devices)
+    .where(inArray(devices.id, deviceIds));
+  const deviceById = new Map(deviceRows.map((d) => [d.id, d]));
+
+  const orgIds = [...new Set(findingRows.map((r) => r.orgId))];
+  const orgRows = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+  const orgById = new Map(orgRows.map((o) => [o.id, o]));
+
+  const swIds = [...new Set(findingRows.map((r) => r.softwareInventoryId).filter((v): v is string => v !== null))];
+  const swRows =
+    swIds.length > 0
+      ? await db
+          .select({
+            id: softwareInventory.id,
+            name: softwareInventory.name,
+            vendor: softwareInventory.vendor,
+            version: softwareInventory.version,
+          })
+          .from(softwareInventory)
+          .where(inArray(softwareInventory.id, swIds))
+      : [];
+  const swById = new Map(swRows.map((s) => [s.id, s]));
+
+  const vulnIds = [...new Set(findingRows.map((r) => r.vulnerabilityId))];
+  const catalogRows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          id: vulnerabilities.id,
+          cveId: vulnerabilities.cveId,
+          severity: vulnerabilities.severity,
+          cvssScore: vulnerabilities.cvssScore,
+          epssScore: vulnerabilities.epssScore,
+          knownExploited: vulnerabilities.knownExploited,
+          patchAvailable: vulnerabilities.patchAvailable,
+        })
+        .from(vulnerabilities)
+        .where(inArray(vulnerabilities.id, vulnIds)),
+    ),
+  );
+  const catalogById = new Map(catalogRows.map((v) => [v.id, v]));
+
+  const rows: FleetFindingRow[] = [];
+  for (const f of findingRows) {
+    const device = deviceById.get(f.deviceId);
+    const catalog = catalogById.get(f.vulnerabilityId);
+    // Orphaned rows (device deleted mid-request, catalog purge) — skip rather
+    // than crash the whole queue.
+    if (!device || !catalog) continue;
+    const sw = f.softwareInventoryId ? swById.get(f.softwareInventoryId) : undefined;
+    rows.push({
+      deviceVulnerabilityId: f.id,
+      deviceId: f.deviceId,
+      orgId: f.orgId,
+      status: f.status,
+      riskScore: toNumber(f.riskScore),
+      detectedAt: f.detectedAt.toISOString(),
+      acceptedUntil: f.acceptedUntil ? f.acceptedUntil.toISOString() : null,
+      ticketId: f.ticketId ?? null,
+      softwareInventoryId: f.softwareInventoryId,
+      // Inventory row can vanish between correlation and read; keep the finding
+      // in the queue under a recognizable name instead of dropping it.
+      softwareName: f.softwareInventoryId ? (sw?.name ?? 'Unknown software') : null,
+      softwareVendor: sw?.vendor ?? null,
+      softwareVersion: sw?.version ?? null,
+      deviceName: device.displayName ?? device.hostname,
+      deviceOsType: device.osType,
+      orgName: orgById.get(f.orgId)?.name ?? null,
+      cveId: catalog.cveId,
+      vulnerabilityId: f.vulnerabilityId,
+      severity: catalog.severity,
+      cvssScore: toNumber(catalog.cvssScore),
+      epssScore: toNumber(catalog.epssScore),
+      knownExploited: catalog.knownExploited ?? false,
+      patchAvailable: catalog.patchAvailable ?? false,
+    });
+  }
+  return rows;
+}
+
+export async function fetchCveCatalogRecord(cveId: string): Promise<CveCatalogRecord | null> {
+  const [row] = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          cveId: vulnerabilities.cveId,
+          description: vulnerabilities.description,
+          references: vulnerabilities.references,
+          cvssVersion: vulnerabilities.cvssVersion,
+          cvssVector: vulnerabilities.cvssVector,
+          cvssScore: vulnerabilities.cvssScore,
+          epssScore: vulnerabilities.epssScore,
+          knownExploited: vulnerabilities.knownExploited,
+          patchAvailable: vulnerabilities.patchAvailable,
+          severity: vulnerabilities.severity,
+          publishedAt: vulnerabilities.publishedAt,
+          modifiedAt: vulnerabilities.modifiedAt,
+        })
+        .from(vulnerabilities)
+        .where(ilike(vulnerabilities.cveId, cveId))
+        .limit(1),
+    ),
+  );
+  if (!row) return null;
+  return {
+    ...row,
+    cvssScore: toNumber(row.cvssScore),
+    epssScore: toNumber(row.epssScore),
+    knownExploited: row.knownExploited ?? false,
+    patchAvailable: row.patchAvailable ?? false,
+    publishedAt: row.publishedAt ? row.publishedAt.toISOString() : null,
+    modifiedAt: row.modifiedAt ? row.modifiedAt.toISOString() : null,
+  };
+}
+```
+
+- [ ] **Step 4: Register the routes**
+
+In `apps/api/src/routes/vulnerabilities.ts`, add to the imports:
+
+```ts
+import { computeStats, filterFindings, groupFindings } from '../services/vulnerabilityFleetAggregation';
+import { fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
+```
+
+Add next to the existing inline zod schemas (after `mitigateSchema`, ~line 60):
+
+```ts
+// Query-string boolean: accepts "true"/"false" (any case), rejects everything else.
+const boolQuerySchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toLowerCase())
+  .pipe(z.enum(['true', 'false']))
+  .transform((value) => value === 'true');
+
+const softwareQuerySchema = z.object({
+  status: statusSchema.default('open'),
+  severity: severitySchema.optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  kevOnly: boolQuerySchema.optional(),
+  patchAvailable: boolQuerySchema.optional(),
+});
+
+const SOFTWARE_GROUP_CAP = 500;
+```
+
+Register the routes immediately AFTER the existing `vulnerabilityRoutes.get('/', ...)` handler (~line 353) — static paths must be registered before the `/:cveId/devices` param route added in Task 4:
+
+```ts
+// Fleet work queue: one row per remediation unit (software product or OS
+// pseudo-group). Group cardinality is fleet-bounded; hard cap + hasMore
+// instead of pagination.
+vulnerabilityRoutes.get('/software', zValidator('query', softwareQuerySchema), async (c) => {
+  const query = c.req.valid('query');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({
+    status: query.status,
+    allowedSiteIds: perms?.allowedSiteIds,
+  });
+  const filtered = filterFindings(rows, {
+    status: query.status,
+    severity: query.severity,
+    kevOnly: query.kevOnly,
+    patchAvailable: query.patchAvailable,
+  });
+  const groups = groupFindings(filtered, { search: query.search });
+  return c.json({
+    items: groups.slice(0, SOFTWARE_GROUP_CAP),
+    hasMore: groups.length > SOFTWARE_GROUP_CAP,
+  });
+});
+
+// The four stat-card numbers in one call. Needs every status: open findings
+// feed three cards, accepted findings feed the expiring-soon card.
+vulnerabilityRoutes.get('/stats', async (c) => {
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({
+    status: 'all',
+    allowedSiteIds: perms?.allowedSiteIds,
+  });
+  return c.json(computeStats(rows, new Date()));
+});
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS — new describes green, all pre-existing tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/vulnerabilityFleetQueries.ts apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): fleet software-group and stats endpoints"
+```
+
+---
+
+### Task 4: `GET /vulnerabilities/software/:groupKey` + `GET /vulnerabilities/:cveId/devices`
+
+**Files:**
+- Modify: `apps/api/src/routes/vulnerabilities.ts`
+- Test: `apps/api/src/routes/vulnerabilities.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2's `buildGroupDetail`, `toGroupFinding`; Task 3's `fetchFleetFindingRows`, `fetchCveCatalogRecord`.
+- Produces:
+  - `GET /vulnerabilities/software/:groupKey` → `SoftwareGroupDetail` (`{ group, cves, findings }`) or 404 `{ error: 'Group not found' }`.
+  - `GET /vulnerabilities/:cveId/devices` → `{ cve: CveCatalogRecord, findings: GroupFinding[] }` or 404 `{ error: 'CVE not found' }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/vulnerabilities.test.ts` (uses `fleetRow` from Task 3):
+
+```ts
+describe('GET /vulnerabilities/software/:groupKey (drawer payload)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+  });
+
+  it('404s for an unknown group', async () => {
+    const res = await app().request(`/vulnerabilities/software/${encodeURIComponent('sw:nope|')}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('400s on a key without the sw:/os: prefix', async () => {
+    const res = await app().request('/vulnerabilities/software/garbage');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns group + cves + findings for a URL-encoded key, across ALL statuses', async () => {
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', status: 'accepted', cveId: 'CVE-2026-0002', vulnerabilityId: 'v-2' }),
+    ]);
+    const res = await app().request(`/vulnerabilities/software/${encodeURIComponent('sw:google chrome|google llc')}`);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetchFleetFindingRows)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'all' }),
+    );
+    const body = await res.json();
+    expect(body.group.groupKey).toBe('sw:google chrome|google llc');
+    expect(body.cves).toHaveLength(2);
+    expect(body.findings).toHaveLength(2);
+    expect(body.findings[0]).toMatchObject({ deviceVulnerabilityId: expect.any(String), deviceName: expect.any(String) });
+  });
+});
+
+describe('GET /vulnerabilities/:cveId/devices (CVE drawer payload)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchFleetFindingRows).mockReset().mockResolvedValue([]);
+    vi.mocked(fetchCveCatalogRecord).mockReset().mockResolvedValue(null);
+  });
+
+  it('400s on a non-CVE-shaped id', async () => {
+    const res = await app().request('/vulnerabilities/not-a-cve/devices');
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the CVE is not in the catalog', async () => {
+    const res = await app().request('/vulnerabilities/CVE-2026-0001/devices');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the catalog record + fleet findings for the CVE (case-insensitive match)', async () => {
+    vi.mocked(fetchCveCatalogRecord).mockResolvedValue({
+      cveId: 'CVE-2026-0001',
+      description: 'Bad bug',
+      references: ['https://example.test/advisory'],
+      cvssVersion: '3.1',
+      cvssVector: 'CVSS:3.1/AV:N',
+      cvssScore: 9.1,
+      epssScore: 0.4,
+      knownExploited: true,
+      patchAvailable: true,
+      severity: 'critical',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: null,
+    });
+    vi.mocked(fetchFleetFindingRows).mockResolvedValue([
+      fleetRow(),
+      fleetRow({ deviceVulnerabilityId: 'dv-2', cveId: 'CVE-2026-9999', vulnerabilityId: 'v-9' }), // other CVE — excluded
+    ]);
+    const res = await app().request('/vulnerabilities/cve-2026-0001/devices');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cve.cveId).toBe('CVE-2026-0001');
+    expect(body.findings).toHaveLength(1);
+    expect(body.findings[0].deviceVulnerabilityId).toBe('dv-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: FAIL — new endpoints 404/miss.
+
+- [ ] **Step 3: Implement the routes**
+
+In `apps/api/src/routes/vulnerabilities.ts`, extend the aggregation import:
+
+```ts
+import { buildGroupDetail, computeStats, filterFindings, groupFindings, toGroupFinding } from '../services/vulnerabilityFleetAggregation';
+import { fetchCveCatalogRecord, fetchFleetFindingRows } from '../services/vulnerabilityFleetQueries';
+```
+
+Add schemas next to `softwareQuerySchema`:
+
+```ts
+const groupKeyParamSchema = z.object({
+  // Opaque group key: sw:<name>|<vendor> or os:<platform>. Hono decodes the
+  // URL-encoded segment before validation.
+  groupKey: z.string().min(4).max(600).regex(/^(sw:|os:)/),
+});
+
+const cveIdParamSchema = z.object({
+  // Real-world CVE ids are CVE-YYYY-NNNN+, but seeded/e2e ids use letters too.
+  cveId: z.string().trim().regex(/^CVE-\d{4}-[A-Za-z0-9-]{1,32}$/i),
+});
+```
+
+Register `GET /software/:groupKey` directly after the `GET /software` handler:
+
+```ts
+vulnerabilityRoutes.get('/software/:groupKey', zValidator('param', groupKeyParamSchema), async (c) => {
+  const { groupKey } = c.req.valid('param');
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  // status 'all' so the drawer can show accepted/mitigated findings alongside
+  // open ones (reopen lives in the drawers).
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const detail = buildGroupDetail(groupKey, rows);
+  if (!detail) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  return c.json(detail);
+});
+```
+
+Register `GET /:cveId/devices` LAST among the GET routes in this file (after `/software/:groupKey`, `/stats`, and the existing `/device/:deviceId` if present — a param in the first segment must not shadow static paths):
+
+```ts
+vulnerabilityRoutes.get('/:cveId/devices', zValidator('param', cveIdParamSchema), async (c) => {
+  const { cveId } = c.req.valid('param');
+  const cve = await fetchCveCatalogRecord(cveId);
+  if (!cve) {
+    return c.json({ error: 'CVE not found' }, 404);
+  }
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const rows = await fetchFleetFindingRows({ status: 'all', allowedSiteIds: perms?.allowedSiteIds });
+  const target = cveId.toLowerCase();
+  const findings = rows
+    .filter((r) => r.cveId.toLowerCase() === target)
+    .map(toGroupFinding)
+    .sort((a, b) => a.deviceName.localeCompare(b.deviceName));
+  return c.json({ cve, findings });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): software-group detail and CVE devices drawer endpoints"
+```
+
+---
+
+### Task 5: Extend fleet `GET /vulnerabilities` with `kevOnly` / `patchAvailable` + richer aggregate rows
+
+**Files:**
+- Modify: `apps/api/src/routes/vulnerabilities.ts` (`listQuerySchema` ~line 35, `readCatalogRows` ~lines 194–226, `FleetRow` type ~lines 288–297, `aggregateFleet`/`mergeRows` ~lines 159–336)
+- Test: `apps/api/src/routes/vulnerabilities.test.ts`
+
+**Interfaces:**
+- Consumes: Task 3's `boolQuerySchema`.
+- Produces: `GET /vulnerabilities?status&severity&cve&kevOnly&patchAvailable` where the aggregated `FleetRow` gains `patchAvailable: boolean` and `statuses: string[]` (distinct finding statuses in the aggregate). The `cve` filter becomes a substring match. Web Task 11 consumes these fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/vulnerabilities.test.ts`:
+
+```ts
+describe('GET /vulnerabilities — kevOnly/patchAvailable params', () => {
+  beforeEach(() => {
+    granted.clear();
+    delete permissionsState.allowedSiteIds;
+    granted.add('devices:read');
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('accepts kevOnly/patchAvailable and still 200s', async () => {
+    // db.select falls back to the default mock chain (resolves []), so an
+    // empty fleet is fine — this asserts schema acceptance, not data flow.
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    } as never);
+    const res = await app().request('/vulnerabilities?kevOnly=true&patchAvailable=false');
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual([]);
+  });
+
+  it('400s on malformed boolean params', async () => {
+    const res = await app().request('/vulnerabilities?kevOnly=1');
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: FAIL — `kevOnly=true` currently 200s but `kevOnly=1` also 200s (unknown query keys ignored), so the 400 assertion fails.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/vulnerabilities.ts`:
+
+1. Extend `listQuerySchema`:
+
+```ts
+const listQuerySchema = z.object({
+  status: statusSchema.default('open'),
+  severity: severitySchema.optional(),
+  cve: z.string().trim().min(1).max(32).optional(),
+  kevOnly: boolQuerySchema.optional(),
+  patchAvailable: boolQuerySchema.optional(),
+});
+```
+
+(If `boolQuerySchema` is declared below `listQuerySchema`, move it above.)
+
+2. Thread the new filters through `listVulnerabilities` → `readCatalogRows`. In `readCatalogRows`'s filter-building block, add:
+
+```ts
+if (filters.kevOnly) {
+  catalogConditions.push(eq(vulnerabilities.knownExploited, true));
+}
+if (filters.patchAvailable) {
+  catalogConditions.push(eq(vulnerabilities.patchAvailable, true));
+}
+```
+
+(Adapt the array name to the file's actual local — the function already collects `severity`/`cve` conditions; extend its `filters` parameter type with `kevOnly?: boolean; patchAvailable?: boolean`.)
+
+3. Make the `cve` filter a substring match — change the existing `ilike(vulnerabilities.cveId, filters.cve)` to:
+
+```ts
+ilike(vulnerabilities.cveId, `%${filters.cve}%`)
+```
+
+so the shared filter-bar text search matches partial CVE ids on the `#cves` tab.
+
+4. Extend the `FleetRow` type with:
+
+```ts
+  patchAvailable: boolean;
+  statuses: string[];
+```
+
+and in `aggregateFleet` (which folds merged finding+catalog rows into one row per `vulnerabilityId`), carry `patchAvailable` from the catalog side and collect the distinct finding `status` values per aggregate into `statuses` (sorted, e.g. `[...new Set(statusesForThisCve)].sort()`). `mergeRows` already carries `status` on each merged item and `patchAvailable` is already projected by `readCatalogRows` — wire them through to the aggregate.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS (including all pre-existing fleet GET tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): kevOnly/patchAvailable filters and richer fleet CVE rows"
+```
+
+---
+
+### Task 6: Bulk accept-risk + bulk mitigate endpoints
+
+**Files:**
+- Modify: `apps/api/src/routes/vulnerabilities.ts`
+- Test: `apps/api/src/routes/vulnerabilities.test.ts`
+
+**Interfaces:**
+- Consumes: existing `loadFindingForWrite` pattern (`routes/vulnerabilities.ts:78-124`), `writeRouteAudit`, `PERMISSIONS.VULN_RISK_ACCEPT`, `requireVulnerabilityWrite`.
+- Produces:
+  - `POST /vulnerabilities/bulk/accept-risk` `{ deviceVulnerabilityIds, reason, acceptedUntil }` → `{ success, succeeded, skipped }`; permission `vulnerabilities:accept_risk`; per-item audit `vulnerability.accept_risk`.
+  - `POST /vulnerabilities/bulk/mitigate` `{ deviceVulnerabilityIds, note }` → same shape; permission `devices:write`; per-item audit `vulnerability.mitigate`.
+  - Route-file helper `loadFindingsForBulkWrite(ids, auth)` (reused by Task 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/vulnerabilities.test.ts`. The db mock needs scripted chains for: findings select (`.from().where()` resolving rows), devices select (same), and the update (`.set().where()`); the top-of-file `db` mock already supports `update`. Use `mockReturnValueOnce` chains like the existing site-narrowing tests:
+
+```ts
+function mockBulkSelects(findingRows: unknown[], deviceRows: unknown[]) {
+  const selectMock = vi.mocked(db.select);
+  selectMock.mockReset();
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(findingRows) }),
+  } as never);
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(deviceRows) }),
+  } as never);
+}
+
+const DV1 = '11111111-1111-1111-8111-111111111111';
+const DV2 = '22222222-2222-2222-8222-222222222222';
+
+describe('POST /vulnerabilities/bulk/accept-risk', () => {
+  beforeEach(() => {
+    vi.mocked(writeRouteAudit).mockClear();
+  });
+
+  it('403s without vulnerabilities:accept_risk', async () => {
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1], reason: 'x', acceptedUntil: future });
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on validation failures (empty ids, >200 ids, past acceptedUntil)', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    expect((await post('/bulk/accept-risk', { deviceVulnerabilityIds: [], reason: 'x', acceptedUntil: future })).status).toBe(400);
+    expect((await post('/bulk/accept-risk', {
+      deviceVulnerabilityIds: Array.from({ length: 201 }, () => DV1),
+      reason: 'x',
+      acceptedUntil: future,
+    })).status).toBe(400);
+    expect((await post('/bulk/accept-risk', {
+      deviceVulnerabilityIds: [DV1],
+      reason: 'x',
+      acceptedUntil: new Date(Date.now() - 864e5).toISOString(),
+    })).status).toBe(400);
+  });
+
+  it('updates valid findings, skips unknown ids per-item, audits each success', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1, DV2], reason: 'compensating control', acceptedUntil: future });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      succeeded: 1,
+      skipped: [{ id: DV2, reason: 'finding not found' }],
+    });
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.accept_risk', resourceId: DV1 }),
+    );
+  });
+
+  it('reports success:false when every item is skipped', async () => {
+    granted.add('vulnerabilities:accept_risk');
+    mockBulkSelects([], []);
+    const res = await post('/bulk/accept-risk', { deviceVulnerabilityIds: [DV1], reason: 'x', acceptedUntil: future });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.skipped).toHaveLength(1);
+  });
+});
+
+describe('POST /vulnerabilities/bulk/mitigate', () => {
+  it('403s for a caller without devices:write', async () => {
+    const res = await post('/bulk/mitigate', { deviceVulnerabilityIds: [DV1], note: 'firewalled' });
+    expect(res.status).toBe(403);
+  });
+
+  it('mitigates valid findings with per-item audit', async () => {
+    granted.add('devices:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    vi.mocked(writeRouteAudit).mockClear();
+    const res = await post('/bulk/mitigate', { deviceVulnerabilityIds: [DV1], note: 'firewalled' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, succeeded: 1, skipped: [] });
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.mitigate', resourceId: DV1 }),
+    );
+  });
+});
+```
+
+Note: the auth mock in this file sets `canAccessSite: () => true`; the per-item "site access denied" branch is covered indirectly by the helper's device-row filtering (a device the org/site narrowing removed → `finding not found`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: FAIL — bulk routes 404.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/vulnerabilities.ts`, add schemas next to the existing ones:
+
+```ts
+const bulkAcceptRiskSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  reason: z.string().trim().min(1).max(2000),
+  acceptedUntil: z.string().datetime(),
+});
+
+const bulkMitigateSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  note: z.string().trim().min(1).max(2000),
+});
+```
+
+Add the bulk loader helper next to `loadFindingForWrite`:
+
+```ts
+type BulkFindingRow = { id: string; orgId: string; deviceId: string; status: string };
+type BulkAccess = { valid: BulkFindingRow[]; skipped: Array<{ id: string; reason: string }> };
+
+/**
+ * Batch analogue of loadFindingForWrite: resolves each id to a finding the
+ * caller may write (org via RLS + orgCondition on the device row, site via
+ * canAccessSite), collecting per-item skip reasons instead of failing the
+ * batch. Duplicate ids are collapsed.
+ */
+async function loadFindingsForBulkWrite(ids: string[], auth: AuthContext): Promise<BulkAccess> {
+  const unique = [...new Set(ids)];
+  const rows = await db
+    .select({
+      id: deviceVulnerabilities.id,
+      orgId: deviceVulnerabilities.orgId,
+      deviceId: deviceVulnerabilities.deviceId,
+      status: deviceVulnerabilities.status,
+    })
+    .from(deviceVulnerabilities)
+    .where(inArray(deviceVulnerabilities.id, unique));
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const deviceIds = [...new Set(rows.map((r) => r.deviceId))];
+  const orgCond = auth.orgCondition(devices.orgId);
+  const deviceRows =
+    deviceIds.length > 0
+      ? await db
+          .select({ id: devices.id, siteId: devices.siteId })
+          .from(devices)
+          .where(orgCond ? and(inArray(devices.id, deviceIds), orgCond) : inArray(devices.id, deviceIds))
+      : [];
+  const deviceById = new Map(deviceRows.map((d) => [d.id, d]));
+
+  const valid: BulkFindingRow[] = [];
+  const skipped: Array<{ id: string; reason: string }> = [];
+  for (const id of unique) {
+    const row = byId.get(id);
+    if (!row) {
+      skipped.push({ id, reason: 'finding not found' });
+      continue;
+    }
+    const device = deviceById.get(row.deviceId);
+    if (!device) {
+      // Device outside the caller's org scope reads as not-found (no existence leak).
+      skipped.push({ id, reason: 'finding not found' });
+      continue;
+    }
+    if (auth.canAccessSite && !auth.canAccessSite(device.siteId)) {
+      skipped.push({ id, reason: 'site access denied' });
+      continue;
+    }
+    valid.push(row);
+  }
+  return { valid, skipped };
+}
+```
+
+Register the routes next to the existing per-finding `POST /:id/accept-risk` (bulk routes have a static first segment, so they never collide with `/:id/*`):
+
+```ts
+vulnerabilityRoutes.post(
+  '/bulk/accept-risk',
+  requirePermission(PERMISSIONS.VULN_RISK_ACCEPT.resource, PERMISSIONS.VULN_RISK_ACCEPT.action),
+  zValidator('json', bulkAcceptRiskSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, reason, acceptedUntil } = c.req.valid('json');
+
+    if (new Date(acceptedUntil).getTime() <= Date.now()) {
+      return c.json({ success: false, error: 'acceptedUntil must be in the future' }, 400);
+    }
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+    if (valid.length > 0) {
+      await db
+        .update(deviceVulnerabilities)
+        .set({
+          status: 'accepted',
+          acceptedBy: auth.user.id,
+          acceptedUntil: new Date(acceptedUntil),
+          // Acceptance rationale reuses mitigation_note — same as the
+          // per-finding accept-risk endpoint (no dedicated reason column).
+          mitigationNote: reason,
+          updatedAt: new Date(),
+        })
+        .where(inArray(deviceVulnerabilities.id, valid.map((v) => v.id)));
+      for (const row of valid) {
+        writeRouteAudit(c, {
+          orgId: row.orgId,
+          action: 'vulnerability.accept_risk',
+          resourceType: 'device_vulnerability',
+          resourceId: row.id,
+          details: { acceptedUntil, reason, bulk: true },
+        });
+      }
+    }
+    return c.json({ success: valid.length > 0, succeeded: valid.length, skipped });
+  },
+);
+
+vulnerabilityRoutes.post(
+  '/bulk/mitigate',
+  requireVulnerabilityWrite,
+  zValidator('json', bulkMitigateSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, note } = c.req.valid('json');
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+    if (valid.length > 0) {
+      await db
+        .update(deviceVulnerabilities)
+        .set({ status: 'mitigated', mitigationNote: note, resolvedAt: new Date(), updatedAt: new Date() })
+        .where(inArray(deviceVulnerabilities.id, valid.map((v) => v.id)));
+      for (const row of valid) {
+        writeRouteAudit(c, {
+          orgId: row.orgId,
+          action: 'vulnerability.mitigate',
+          resourceType: 'device_vulnerability',
+          resourceId: row.id,
+          details: { note, bulk: true },
+        });
+      }
+    }
+    return c.json({ success: valid.length > 0, succeeded: valid.length, skipped });
+  },
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): bulk accept-risk and mitigate endpoints with per-item skips"
+```
+
+---
+
+### Task 7: `POST /vulnerabilities/tickets` — create ticket(s) from findings
+
+**Files:**
+- Modify: `apps/api/src/routes/vulnerabilities.ts`
+- Test: `apps/api/src/routes/vulnerabilities.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `ticketId` column; Task 6's `loadFindingsForBulkWrite`; `createTicket(input, actor)` + `TicketServiceError` from `apps/api/src/services/ticketService.ts`; `PERMISSIONS.TICKETS_WRITE`.
+- Produces: `POST /vulnerabilities/tickets` `{ deviceVulnerabilityIds (1–200), title (1–255), description? (≤50000), priority ('low'|'normal'|'high'|'urgent', default 'normal') }` → `{ success, tickets: [{ ticketId, orgId, findingCount }], skipped }`. Cross-org selections create one ticket per org. Audit `vulnerability.ticket_create` per ticket.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/src/routes/vulnerabilities.test.ts`. New mock in the mock block (keep the real error class via `importActual` so `instanceof` works):
+
+```ts
+vi.mock('../services/ticketService', async () => {
+  const actual = await vi.importActual<typeof import('../services/ticketService')>('../services/ticketService');
+  return { ...actual, createTicket: vi.fn() };
+});
+```
+
+Post-mock import: `import { createTicket, TicketServiceError } from '../services/ticketService';`
+
+The auth mock needs `canAccessOrg`; extend the mocked `authMiddleware`'s auth object with `canAccessOrg: (id: string) => id !== 'org-denied'` (adjust the existing `c.set('auth', {...})` literal).
+
+```ts
+describe('POST /vulnerabilities/tickets', () => {
+  const DV_ORG2 = '33333333-3333-3333-8333-333333333333';
+
+  beforeEach(() => {
+    vi.mocked(createTicket).mockReset();
+    vi.mocked(writeRouteAudit).mockClear();
+  });
+
+  it('403s without tickets:write', async () => {
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'Patch Chrome' });
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on validation failures (missing title, >200 ids)', async () => {
+    granted.add('tickets:write');
+    expect((await post('/tickets', { deviceVulnerabilityIds: [DV1] })).status).toBe(400);
+    expect((await post('/tickets', {
+      deviceVulnerabilityIds: Array.from({ length: 201 }, () => DV1),
+      title: 'x',
+    })).status).toBe(400);
+  });
+
+  it('splits a cross-org selection into one ticket per org and stamps ticket_id', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [
+        { id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
+        { id: DV2, orgId: 'org-1', deviceId: 'dev-1', status: 'open' },
+        { id: DV_ORG2, orgId: 'org-2', deviceId: 'dev-2', status: 'open' },
+      ],
+      [
+        { id: 'dev-1', siteId: 'site-1' },
+        { id: 'dev-2', siteId: 'site-2' },
+      ],
+    );
+    vi.mocked(createTicket)
+      .mockResolvedValueOnce({ id: 't-1' } as never)
+      .mockResolvedValueOnce({ id: 't-2' } as never);
+
+    const res = await post('/tickets', {
+      deviceVulnerabilityIds: [DV1, DV2, DV_ORG2],
+      title: 'Patch Chrome fleet-wide',
+      description: 'CVE-2026-0001',
+      priority: 'high',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.tickets).toEqual([
+      { ticketId: 't-1', orgId: 'org-1', findingCount: 2 },
+      { ticketId: 't-2', orgId: 'org-2', findingCount: 1 },
+    ]);
+    expect(vi.mocked(createTicket)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(createTicket)).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-1', subject: 'Patch Chrome fleet-wide', priority: 'high', source: 'manual' }),
+      expect.objectContaining({ userId: 'u1' }),
+    );
+    expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'vulnerability.ticket_create', resourceType: 'ticket', resourceId: 't-1' }),
+    );
+  });
+
+  it('skips findings in an org the caller cannot access', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-denied', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.tickets).toEqual([]);
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'access to organization denied' }]);
+    expect(vi.mocked(createTicket)).not.toHaveBeenCalled();
+  });
+
+  it('maps a TicketServiceError into per-item skips without failing the batch', async () => {
+    granted.add('tickets:write');
+    mockBulkSelects(
+      [{ id: DV1, orgId: 'org-1', deviceId: 'dev-1', status: 'open' }],
+      [{ id: 'dev-1', siteId: 'site-1' }],
+    );
+    vi.mocked(createTicket).mockRejectedValue(new TicketServiceError('Organization not found', 404));
+    const res = await post('/tickets', { deviceVulnerabilityIds: [DV1], title: 'x' });
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.skipped).toEqual([{ id: DV1, reason: 'Organization not found' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: FAIL — `/tickets` route 404s (reads as a failing status assertion).
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/vulnerabilities.ts`, add imports:
+
+```ts
+import { createTicket, TicketServiceError } from '../services/ticketService';
+```
+
+Add the schema:
+
+```ts
+const bulkTicketSchema = z.object({
+  deviceVulnerabilityIds: z.array(z.string().uuid()).min(1).max(200),
+  title: z.string().trim().min(1).max(255),
+  description: z.string().max(50_000).optional(),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+});
+```
+
+Register the route (static path — before `/:id/*` POST routes or after, either is safe since `tickets` is a static segment; put it next to the bulk routes for cohesion):
+
+```ts
+vulnerabilityRoutes.post(
+  '/tickets',
+  requirePermission(PERMISSIONS.TICKETS_WRITE.resource, PERMISSIONS.TICKETS_WRITE.action),
+  zValidator('json', bulkTicketSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { deviceVulnerabilityIds, title, description, priority } = c.req.valid('json');
+
+    const { valid, skipped } = await loadFindingsForBulkWrite(deviceVulnerabilityIds, auth);
+
+    // One ticket per org: a ticket is org-owned, so a cross-org selection
+    // splits along org lines rather than leaking device names across tenants.
+    const byOrg = new Map<string, BulkFindingRow[]>();
+    for (const row of valid) {
+      const bucket = byOrg.get(row.orgId);
+      if (bucket) bucket.push(row);
+      else byOrg.set(row.orgId, [row]);
+    }
+
+    const tickets: Array<{ ticketId: string; orgId: string; findingCount: number }> = [];
+    for (const [orgId, rows] of byOrg) {
+      if (!auth.canAccessOrg(orgId)) {
+        for (const r of rows) skipped.push({ id: r.id, reason: 'access to organization denied' });
+        continue;
+      }
+      try {
+        const ticket = await createTicket(
+          { orgId, subject: title, description, priority, source: 'manual' },
+          { userId: auth.user.id, name: auth.user.name, email: auth.user.email },
+        );
+        await db
+          .update(deviceVulnerabilities)
+          .set({ ticketId: ticket.id, updatedAt: new Date() })
+          .where(inArray(deviceVulnerabilities.id, rows.map((r) => r.id)));
+        writeRouteAudit(c, {
+          orgId,
+          action: 'vulnerability.ticket_create',
+          resourceType: 'ticket',
+          resourceId: ticket.id,
+          details: { deviceVulnerabilityIds: rows.map((r) => r.id), title },
+        });
+        tickets.push({ ticketId: ticket.id, orgId, findingCount: rows.length });
+      } catch (err) {
+        const reason = err instanceof TicketServiceError ? err.message : 'failed to create ticket';
+        for (const r of rows) skipped.push({ id: r.id, reason });
+      }
+    }
+
+    return c.json({ success: tickets.length > 0, tickets, skipped });
+  },
+);
+```
+
+If `auth.user.name` doesn't exist on `AuthContext['user']` (typecheck error), pass only `{ userId: auth.user.id, email: auth.user.email }` — `TicketActor.name` is optional.
+
+- [ ] **Step 4: Run tests to verify they pass, then run the whole API suite**
+
+Run: `cd apps/api && pnpm vitest run src/routes/vulnerabilities.test.ts`
+Expected: PASS.
+
+Run: `cd apps/api && pnpm vitest run src/routes/ src/services/ 2>&1 | tail -20`
+Expected: no regressions in other route/service tests (the tickets route test mocks its own modules and is unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/vulnerabilities.ts apps/api/src/routes/vulnerabilities.test.ts
+git commit -m "feat(api): create native tickets from vulnerability findings with cross-org split"
+```
+
+---
+
+## Final verification for Part 1 (after Task 7)
+
+- [ ] `cd apps/api && pnpm vitest run` — full API unit suite green.
+- [ ] `pnpm db:check-drift` with a migrated local DB — no drift.
+- [ ] Smoke against the worktree stack: `GET /api/v1/vulnerabilities/software`, `/stats`, `/software/<key>`, `/<cveId>/devices` return sane payloads for the seeded fixtures.
+
+Then continue with Part 2: `2026-07-05-vulnerabilities-triage-web.md`.

--- a/docs/superpowers/plans/2026-07-05-vulnerabilities-triage-web.md
+++ b/docs/superpowers/plans/2026-07-05-vulnerabilities-triage-web.md
@@ -1,0 +1,2783 @@
+# Vulnerabilities Fleet Triage UI Implementation Plan — Part 2: Web (Tasks 8–17)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The frontend of the fleet vulnerabilities triage UI: shared Drawer primitive, API client, software-grouped work queue + CVE tab, stat cards + filter bar + hash-routed page shell, action drawers (remediate / accept-risk / mitigate / reopen / create-ticket), and e2e coverage.
+
+**Prerequisite:** Part 1 — `2026-07-05-vulnerabilities-triage-api.md` (Tasks 1–7) must be implemented first; every endpoint and payload shape consumed here is produced there. Task numbering continues from Part 1 so cross-references like "Task 9's `fetchSoftwareGroups`" stay unambiguous across both documents.
+
+**Architecture:** A hash-routed page island (`#software` default / `#cves`) owns shared filter state and a `refreshKey`; tables and drawers are leaf components that fetch through `lib/api/vulnerabilities.ts`. Drawers are built on `shared/Drawer.tsx`, extracted verbatim from the catalog editor drawer chrome.
+
+**Tech Stack:** Astro + React islands + Tailwind, Vitest + jsdom + Testing Library, Playwright e2e.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md` (approved).
+
+## Global Constraints
+
+- **Web mutations:** always via `runAction` (`apps/web/src/lib/runAction.ts`); catch with `handleActionError(err, fallback)`. New mutating/action components are added to `TARGET_GLOBS` in `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` with the count constant bumped in the same commit (current value **58**; this plan ends at **63**: +`VulnerabilityFleetPage` Task 12, +`SoftwareGroupDrawer`/`VulnBulkActionModal` Task 13, +`CveDrawer` Task 14, +`CreateVulnTicketModal` Task 15).
+- **URL state:** hash only (`#software`, `#cves`, `#software/<encodeURIComponent(groupKey)>`, `#cves/<cveId>`). Filters are transient React state — NOT query params.
+- **Group key format (opaque, produced by the API):** `sw:<lower(trim(name))>|<lower(trim(coalesce(vendor,'')))>` or `os:<windows|macos|linux>`. The web treats it as an opaque string; always `encodeURIComponent` when placing it in a hash or URL path.
+- **Permissions (exact strings, via `usePermissions().can(resource, action)`):** remediate = `('devices','execute')`; accept-risk & reopen = `('vulnerabilities','accept_risk')`; mitigate = `('devices','write')`; create-ticket = `('tickets','write')`. Buttons are HIDDEN when unpermitted (device-tab convention); the server re-checks.
+- **E2E:** `data-testid` attributes only, never text/role/CSS selectors.
+- **Component tests:** scope table assertions to `within(screen.getByTestId('responsive-table-desktop'))` (the mobile card duplicate renders in jsdom too); mock the typed API module (`../../lib/api/vulnerabilities`), not `fetch`.
+- **Test commands:** `cd apps/web && pnpm vitest run <file>`; e2e: `cd e2e-tests && pnpm test -- tests/vulnerabilities.spec.ts` (needs a running seeded stack — `worktree-stack` skill).
+
+---
+
+### Task 8: Shared `Drawer.tsx` primitive (extracted from the catalog editor drawer)
+
+**Files:**
+- Create: `apps/web/src/components/shared/Drawer.tsx`
+- Test: `apps/web/src/components/shared/Drawer.test.tsx`
+
+**Interfaces:**
+- Consumes: chrome + a11y code extracted VERBATIM from `apps/web/src/components/settings/CatalogItemEditorDrawer.tsx` (a11y block lines 177–207, portal/backdrop/panel JSX lines 437–474, `FOCUSABLE` constant lines 27–28). Class strings, inline animation styles, and behavior must be byte-identical — the CSS animations `dialog-backdrop-in` and `slide-in-from-right` are defined in the web app's global CSS and must keep matching.
+- Produces: `Drawer` component with props `{ open: boolean; onClose: () => void; title: ReactNode; width?: string; dataTestId?: string; closeDisabled?: boolean; children: ReactNode }` — used by Tasks 13, 14, 17.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/shared/Drawer.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Drawer } from './Drawer';
+
+describe('Drawer', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Drawer open={false} onClose={() => {}} title="Details">
+        <p>body</p>
+      </Drawer>,
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders title, children, and dialog semantics when open', () => {
+    render(
+      <Drawer open onClose={() => {}} title="Details" dataTestId="my-drawer">
+        <p>body</p>
+      </Drawer>,
+    );
+    const panel = screen.getByTestId('my-drawer');
+    expect(panel).toHaveAttribute('role', 'dialog');
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+  });
+
+  it('calls onClose on Escape and on backdrop click, but not on panel click', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" dataTestId="my-drawer">
+        <button type="button">inner</button>
+      </Drawer>,
+    );
+    fireEvent.click(screen.getByText('inner'));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('my-drawer-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(screen.getByTestId('my-drawer'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppresses backdrop close when closeDisabled', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" dataTestId="my-drawer" closeDisabled>
+        <p>body</p>
+      </Drawer>,
+    );
+    fireEvent.click(screen.getByTestId('my-drawer-backdrop'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('applies a custom width class and the close button works', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} title="T" width="max-w-xl" dataTestId="my-drawer">
+        <p>body</p>
+      </Drawer>,
+    );
+    expect(screen.getByTestId('my-drawer').className).toContain('max-w-xl');
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/shared/Drawer.test.tsx`
+Expected: FAIL — cannot resolve `./Drawer`.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/web/src/components/shared/Drawer.tsx`. Before writing, open `apps/web/src/components/settings/CatalogItemEditorDrawer.tsx` and copy the referenced blocks verbatim (do not retype from this plan — the plan reproduces them, but the source file is the source of truth for class strings):
+
+```tsx
+import { useCallback, useEffect, useId, useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// Extracted verbatim from settings/CatalogItemEditorDrawer.tsx so both drawers
+// keep identical chrome, animations, and a11y behavior.
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  /** Tailwind max-width class for the panel. */
+  width?: string;
+  dataTestId?: string;
+  /** Blocks backdrop-click close (e.g. while a mutation is in flight). */
+  closeDisabled?: boolean;
+  children: ReactNode;
+}
+
+export function Drawer({
+  open,
+  onClose,
+  title,
+  width = 'max-w-md',
+  dataTestId = 'drawer',
+  closeDisabled = false,
+  children,
+}: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  // ---- a11y: focus, scroll-lock, escape, focus-trap -----------------------
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = document.activeElement;
+    const raf = requestAnimationFrame(() => {
+      const first = panelRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+      (first ?? panelRef.current)?.focus();
+    });
+    document.body.style.overflow = 'hidden';
+    return () => {
+      cancelAnimationFrame(raf);
+      document.body.style.overflow = '';
+      if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
+    };
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && panelRef.current) {
+        const nodes = Array.from(panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE));
+        if (nodes.length === 0) return;
+        const first = nodes[0];
+        const last = nodes[nodes.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last!.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first!.focus();
+        }
+      }
+    },
+    [onClose],
+  );
+
+  const handleBackdropClick = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget && !closeDisabled) onClose();
+    },
+    [onClose, closeDisabled],
+  );
+
+  if (!open || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="dialog-backdrop fixed inset-0 z-50 flex justify-end bg-background/80"
+      style={{ animation: 'dialog-backdrop-in 150ms ease-out' }}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      data-testid={`${dataTestId}-backdrop`}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={`drawer-panel flex h-full w-full ${width} flex-col border-l bg-card shadow-xl focus:outline-hidden`}
+        style={{ animation: 'slide-in-from-right 220ms cubic-bezier(0.22, 1, 0.36, 1)' }}
+        data-testid={dataTestId}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-5 py-4">
+          <h2 id={titleId} className="min-w-0 text-base font-semibold">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close"
+            data-testid={`${dataTestId}-close`}
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6 6 18M6 6l12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default Drawer;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/shared/Drawer.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/shared/Drawer.tsx apps/web/src/components/shared/Drawer.test.tsx
+git commit -m "feat(web): shared slide-over Drawer primitive extracted from catalog editor"
+```
+
+---
+
+### Task 9: Web API client — new fetchers, bulk mutations, richer remediate toast
+
+**Files:**
+- Modify: `apps/web/src/lib/api/vulnerabilities.ts`
+- Test: `apps/web/src/lib/api/vulnerabilities.helpers.test.ts` (new)
+
+**Interfaces:**
+- Consumes: API shapes from Tasks 3–7; existing `runAction`, `fetchWithAuth`, `JSON_HEADERS` already used in this file.
+- Produces (all exported; consumed by Tasks 10–15):
+  - Types: `VulnFleetFilters`, `SoftwareGroup`, `SoftwareGroupDetail`, `GroupCve`, `GroupFinding`, `FleetVulnStats`, `CveCatalogRecord`, `CveDevicesPayload`, `BulkActionResult`, `VulnTicketResult`; `FleetVulnerability` gains `epssScore: number | null`, `patchAvailable: boolean`, `statuses: string[]`; `VulnerabilityFilters` gains `kevOnly?: boolean; patchAvailable?: boolean`.
+  - Reads: `fetchSoftwareGroups(filters: VulnFleetFilters): Promise<{ items: SoftwareGroup[]; hasMore: boolean }>`, `fetchSoftwareGroupDetail(groupKey: string): Promise<SoftwareGroupDetail>`, `fetchVulnStats(): Promise<FleetVulnStats>`, `fetchCveDevices(cveId: string): Promise<CveDevicesPayload>`.
+  - Mutations: `bulkAcceptVulnRisk(ids: string[], payload: { reason: string; acceptedUntil: string }): Promise<BulkActionResult>`, `bulkMitigateVulns(ids: string[], payload: { note: string }): Promise<BulkActionResult>`, `createVulnTicket(ids: string[], payload: { title: string; description?: string; priority: 'low' | 'normal' | 'high' | 'urgent' }): Promise<VulnTicketResult>`.
+  - Pure helpers (exported for tests): `buildVulnQuery(params: Record<string, string | boolean | undefined>): string`, `bulkSummary(verb: string, succeeded: number, skipped: Array<{ id: string; reason: string }>): string`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/lib/api/vulnerabilities.helpers.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildVulnQuery, bulkSummary } from './vulnerabilities';
+
+describe('buildVulnQuery', () => {
+  it('serializes set params, drops empty/false/undefined, and URL-encodes', () => {
+    expect(
+      buildVulnQuery({ status: 'open', severity: '', search: 'google chrome', kevOnly: true, patchAvailable: false }),
+    ).toBe('?status=open&search=google+chrome&kevOnly=true');
+  });
+
+  it('returns empty string when nothing is set', () => {
+    expect(buildVulnQuery({ severity: undefined, kevOnly: false })).toBe('');
+  });
+});
+
+describe('bulkSummary', () => {
+  it('reports plain success', () => {
+    expect(bulkSummary('accepted', 12, [])).toBe('12 accepted');
+  });
+
+  it('appends skip count and first skip reason (partial success)', () => {
+    expect(
+      bulkSummary('scheduled', 12, [
+        { id: 'a', reason: 'no approved patch' },
+        { id: 'b', reason: 'no approved patch' },
+      ]),
+    ).toBe('12 scheduled, 2 skipped — no approved patch');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/lib/api/vulnerabilities.helpers.test.ts`
+Expected: FAIL — `buildVulnQuery`/`bulkSummary` not exported.
+
+- [ ] **Step 3: Implement**
+
+In `apps/web/src/lib/api/vulnerabilities.ts` (read the file first; mirror its existing `fetchVulnerabilities` read helper and `remediateVuln` mutation idioms exactly — imports, `fetchWithAuth`, `JSON_HEADERS`, error handling on `!res.ok`):
+
+1. Add the shared filter/type block:
+
+```ts
+export interface VulnFleetFilters {
+  search: string;
+  severity: string;   // '' = all
+  status: string;     // 'open' default
+  kevOnly: boolean;
+  patchAvailable: boolean;
+}
+
+export interface SoftwareGroup {
+  groupKey: string;
+  kind: 'software' | 'os';
+  name: string;
+  vendor: string | null;
+  versions: string[];
+  deviceCount: number;
+  cveCount: number;
+  cveIds: string[];
+  worstSeverity: string | null;
+  maxRiskScore: number | null;
+  kevCveCount: number;
+  maxEpss: number | null;
+  patchReadyFindingCount: number;
+  patchReadyDeviceCount: number;
+  ticketIds: string[];
+}
+
+export interface GroupCve {
+  cveId: string;
+  vulnerabilityId: string;
+  severity: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  maxRiskScore: number | null;
+}
+
+export interface GroupFinding {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  deviceName: string;
+  orgId: string;
+  orgName: string | null;
+  cveId: string;
+  status: string;
+  patchAvailable: boolean;
+  riskScore: number | null;
+  detectedAt: string;
+  ticketId: string | null;
+}
+
+export interface SoftwareGroupDetail {
+  group: SoftwareGroup;
+  cves: GroupCve[];
+  findings: GroupFinding[];
+}
+
+export interface FleetVulnStats {
+  criticalOpen: number;
+  kevCveCount: number;
+  kevDeviceCount: number;
+  patchReadyFindingCount: number;
+  acceptedExpiringSoon: number;
+}
+
+export interface CveCatalogRecord {
+  cveId: string;
+  description: string;
+  references: unknown;
+  cvssVersion: string | null;
+  cvssVector: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  knownExploited: boolean;
+  patchAvailable: boolean;
+  severity: string | null;
+  publishedAt: string | null;
+  modifiedAt: string | null;
+}
+
+export interface CveDevicesPayload {
+  cve: CveCatalogRecord;
+  findings: GroupFinding[];
+}
+
+export interface BulkActionResult {
+  success: boolean;
+  succeeded: number;
+  skipped: Array<{ id: string; reason: string }>;
+}
+
+export interface VulnTicketResult {
+  success: boolean;
+  tickets: Array<{ ticketId: string; orgId: string; findingCount: number }>;
+  skipped: Array<{ id: string; reason: string }>;
+}
+```
+
+2. Extend the existing `FleetVulnerability` interface with `epssScore: number | null; patchAvailable: boolean; statuses: string[];` (keep existing fields) and `VulnerabilityFilters` with `kevOnly?: boolean; patchAvailable?: boolean;`. Thread the two new params through `fetchVulnerabilities`'s query-string building (use `buildVulnQuery` below — refactor the existing helper if one exists, keeping behavior).
+
+3. Add the pure helpers:
+
+```ts
+export function buildVulnQuery(params: Record<string, string | boolean | undefined>): string {
+  const q = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === '' || value === false) continue;
+    q.set(key, String(value));
+  }
+  const s = q.toString();
+  return s ? `?${s}` : '';
+}
+
+export function bulkSummary(verb: string, succeeded: number, skipped: Array<{ id: string; reason: string }>): string {
+  const base = `${succeeded} ${verb}`;
+  if (skipped.length === 0) return base;
+  return `${base}, ${skipped.length} skipped — ${skipped[0]!.reason}`;
+}
+```
+
+4. Add the read fetchers (mirror `fetchVulnerabilities`'s exact fetch/throw idiom):
+
+```ts
+export async function fetchSoftwareGroups(filters: VulnFleetFilters): Promise<{ items: SoftwareGroup[]; hasMore: boolean }> {
+  const res = await fetchWithAuth(
+    `/vulnerabilities/software${buildVulnQuery({
+      status: filters.status,
+      severity: filters.severity,
+      search: filters.search,
+      kevOnly: filters.kevOnly,
+      patchAvailable: filters.patchAvailable,
+    })}`,
+  );
+  if (!res.ok) throw new Error('Failed to load software groups');
+  return res.json() as Promise<{ items: SoftwareGroup[]; hasMore: boolean }>;
+}
+
+export async function fetchSoftwareGroupDetail(groupKey: string): Promise<SoftwareGroupDetail> {
+  const res = await fetchWithAuth(`/vulnerabilities/software/${encodeURIComponent(groupKey)}`);
+  if (!res.ok) throw new Error('Failed to load software group');
+  return res.json() as Promise<SoftwareGroupDetail>;
+}
+
+export async function fetchVulnStats(): Promise<FleetVulnStats> {
+  const res = await fetchWithAuth('/vulnerabilities/stats');
+  if (!res.ok) throw new Error('Failed to load vulnerability stats');
+  return res.json() as Promise<FleetVulnStats>;
+}
+
+export async function fetchCveDevices(cveId: string): Promise<CveDevicesPayload> {
+  const res = await fetchWithAuth(`/vulnerabilities/${encodeURIComponent(cveId)}/devices`);
+  if (!res.ok) throw new Error('Failed to load CVE details');
+  return res.json() as Promise<CveDevicesPayload>;
+}
+```
+
+5. Add the mutations (all `runAction`-wrapped; this file is already in the `no-silent-mutations` targeted set):
+
+```ts
+function parseBulk(data: unknown): BulkActionResult {
+  const d = data as Partial<BulkActionResult>;
+  return { success: d.success ?? false, succeeded: d.succeeded ?? 0, skipped: d.skipped ?? [] };
+}
+
+export async function bulkAcceptVulnRisk(
+  deviceVulnerabilityIds: string[],
+  payload: { reason: string; acceptedUntil: string },
+): Promise<BulkActionResult> {
+  return runAction<BulkActionResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/bulk/accept-risk', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to accept risk',
+    successMessage: (d) => bulkSummary('accepted', d.succeeded, d.skipped),
+    parseSuccess: parseBulk,
+  });
+}
+
+export async function bulkMitigateVulns(
+  deviceVulnerabilityIds: string[],
+  payload: { note: string },
+): Promise<BulkActionResult> {
+  return runAction<BulkActionResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/bulk/mitigate', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to mitigate',
+    successMessage: (d) => bulkSummary('mitigated', d.succeeded, d.skipped),
+    parseSuccess: parseBulk,
+  });
+}
+
+export async function createVulnTicket(
+  deviceVulnerabilityIds: string[],
+  payload: { title: string; description?: string; priority: 'low' | 'normal' | 'high' | 'urgent' },
+): Promise<VulnTicketResult> {
+  return runAction<VulnTicketResult>({
+    request: () =>
+      fetchWithAuth('/vulnerabilities/tickets', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+      }),
+    errorFallback: 'Failed to create ticket',
+    successMessage: (d) =>
+      d.tickets.length === 1 ? 'Ticket created' : `${d.tickets.length} tickets created (one per organization)`,
+    parseSuccess: (data) => {
+      const d = data as Partial<VulnTicketResult>;
+      return { success: d.success ?? false, tickets: d.tickets ?? [], skipped: d.skipped ?? [] };
+    },
+  });
+}
+```
+
+6. Upgrade `remediateVuln`'s `successMessage` to surface partial success (spec: "12 scheduled, 2 skipped — no approved patch"):
+
+```ts
+    successMessage: (d) => bulkSummary(`remediation${d.scheduled === 1 ? '' : 's'} scheduled`, d.scheduled, d.skipped),
+```
+
+Wait — that reads "12 remediations scheduled, 2 skipped — no approved patch" only if `bulkSummary` puts the verb after the count; with the helper as defined it renders `12 remediations scheduled, 2 skipped — no approved patch`. That is the desired copy; keep it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/lib/api/vulnerabilities.helpers.test.ts src/lib/__tests__/no-silent-mutations.test.ts src/components/devices/DeviceVulnerabilitiesTab.test.tsx`
+Expected: PASS — helpers green; no-silent-mutations still green (this file was already targeted and all new mutations are `runAction`-wrapped); the device tab tests still pass (its mocked API module gained functions it doesn't use).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/vulnerabilities.ts apps/web/src/lib/api/vulnerabilities.helpers.test.ts
+git commit -m "feat(web): fleet vulnerability API client — groups, stats, bulk actions, tickets"
+```
+
+---
+
+### Task 10: `SeverityBadge` extraction + `SoftwareGroupTable` (work-queue tab)
+
+**Files:**
+- Create: `apps/web/src/components/vulnerabilities/SeverityBadge.tsx`
+- Create: `apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx`
+- Modify: `apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx` (delete its inline `SEVERITY_BADGES`/`SeverityBadge`, import from the new file)
+- Test: `apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 9's `fetchSoftwareGroups`, `SoftwareGroup`, `VulnFleetFilters`; `ResponsiveTable`/`DataCard`/`CardField` from `../shared/ResponsiveTable`.
+- Produces:
+  - `SeverityBadge({ severity }: { severity: string | null })` (named + default export).
+  - `SoftwareGroupTable({ filters, refreshKey, onSelectGroup, onClearFilters }: { filters: VulnFleetFilters; refreshKey: number; onSelectGroup: (groupKey: string) => void; onClearFilters: () => void })`.
+  - Testids: `software-group-row-<groupKey>` (desktop rows), `software-group-table-empty`, `software-group-table-error`, `software-group-clear-filters`, `software-group-has-more`.
+
+- [ ] **Step 1: Extract `SeverityBadge`**
+
+Create `apps/web/src/components/vulnerabilities/SeverityBadge.tsx` by MOVING (cut, not copy) the `SEVERITY_BADGES` map and `SeverityBadge` function from `VulnerabilityTable.tsx` lines 10–28 verbatim, adding exports:
+
+```tsx
+const SEVERITY_BADGES: Record<string, { label: string; className: string }> = {
+  critical: { label: 'Critical', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
+  high: { label: 'High', className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300' },
+  medium: { label: 'Medium', className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' },
+  low: { label: 'Low', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
+};
+
+export function SeverityBadge({ severity }: { severity: string | null }) {
+  const key = severity?.toLowerCase() ?? '';
+  const badge = SEVERITY_BADGES[key] ?? {
+    label: severity ?? 'Unknown',
+    className: 'bg-slate-100 text-slate-700 dark:bg-slate-900/30 dark:text-slate-300',
+  };
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${badge.className}`}>
+      {badge.label}
+    </span>
+  );
+}
+
+export default SeverityBadge;
+```
+
+In `VulnerabilityTable.tsx`, replace the removed block with `import { SeverityBadge } from './SeverityBadge';`.
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/`
+Expected: existing `VulnerabilityTable.test.tsx` still PASSES.
+
+- [ ] **Step 2: Write the failing `SoftwareGroupTable` tests**
+
+Create `apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx` (copy the auth/API mock idioms from `DeviceVulnerabilitiesTab.test.tsx`; scope assertions to the desktop surface):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchSoftwareGroups: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { SoftwareGroupTable } from './SoftwareGroupTable';
+import type { SoftwareGroup, VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const FILTERS: VulnFleetFilters = { search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false };
+
+function group(overrides: Partial<SoftwareGroup> = {}): SoftwareGroup {
+  return {
+    groupKey: 'sw:google chrome|google llc',
+    kind: 'software',
+    name: 'Google Chrome',
+    vendor: 'Google LLC',
+    versions: ['125.0', '126.0'],
+    deviceCount: 14,
+    cveCount: 6,
+    cveIds: ['CVE-2026-0001'],
+    worstSeverity: 'critical',
+    maxRiskScore: 95,
+    kevCveCount: 1,
+    maxEpss: 0.9,
+    patchReadyFindingCount: 12,
+    patchReadyDeviceCount: 12,
+    ticketIds: [],
+    ...overrides,
+  };
+}
+
+describe('SoftwareGroupTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [group()], hasMore: false });
+  });
+
+  it('renders one row per group with patch readiness and KEV flag', async () => {
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    const row = desktop.getByTestId('software-group-row-sw:google chrome|google llc');
+    expect(row).toHaveTextContent('Google Chrome');
+    expect(row).toHaveTextContent('Google LLC');
+    expect(row).toHaveTextContent('Ready · 12/14 devices');
+    expect(row).toHaveTextContent('KEV');
+  });
+
+  it('invokes onSelectGroup with the groupKey on row click', async () => {
+    const onSelect = vi.fn();
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={onSelect} onClearFilters={() => {}} />);
+    const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+    fireEvent.click(desktop.getByTestId('software-group-row-sw:google chrome|google llc'));
+    expect(onSelect).toHaveBeenCalledWith('sw:google chrome|google llc');
+  });
+
+  it('refetches when filters or refreshKey change', async () => {
+    const { rerender } = render(
+      <SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+    );
+    await screen.findByTestId('responsive-table-desktop');
+    rerender(
+      <SoftwareGroupTable filters={{ ...FILTERS, severity: 'critical' }} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />,
+    );
+    await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalledTimes(2));
+    expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'critical' }));
+  });
+
+  it('shows the filtered-empty state with a clear-filters link', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
+    const onClear = vi.fn();
+    render(
+      <SoftwareGroupTable
+        filters={{ ...FILTERS, severity: 'low' }}
+        refreshKey={0}
+        onSelectGroup={() => {}}
+        onClearFilters={onClear}
+      />,
+    );
+    fireEvent.click(await screen.findByTestId('software-group-clear-filters'));
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('shows the error state on fetch failure', async () => {
+    vi.mocked(api.fetchSoftwareGroups).mockRejectedValue(new Error('boom'));
+    render(<SoftwareGroupTable filters={FILTERS} refreshKey={0} onSelectGroup={() => {}} onClearFilters={() => {}} />);
+    expect(await screen.findByTestId('software-group-table-error')).toHaveTextContent('boom');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/SoftwareGroupTable.test.tsx`
+Expected: FAIL — cannot resolve `./SoftwareGroupTable`.
+
+- [ ] **Step 4: Implement**
+
+Create `apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx` (follow `VulnerabilityTable.tsx`'s structure: `useEffect` fetch with `cancelled` flag, `useMemo` table + cards, `ResponsiveTable`):
+
+```tsx
+import { useEffect, useMemo, useState } from 'react';
+
+import { ResponsiveTable, DataCard, CardField } from '../shared/ResponsiveTable';
+import { SeverityBadge } from './SeverityBadge';
+import {
+  fetchSoftwareGroups,
+  type SoftwareGroup,
+  type VulnFleetFilters,
+} from '../../lib/api/vulnerabilities';
+
+function fmtRisk(value: number | null): string {
+  return value === null ? '—' : String(Math.round(value));
+}
+
+function versionRange(versions: string[]): string {
+  if (versions.length === 0) return '';
+  if (versions.length === 1) return versions[0]!;
+  return `${versions[0]} – ${versions[versions.length - 1]}`;
+}
+
+function patchLabel(g: SoftwareGroup): string {
+  return g.patchReadyFindingCount > 0 ? `Ready · ${g.patchReadyDeviceCount}/${g.deviceCount} devices` : '—';
+}
+
+const KEV_BADGE = (
+  <span className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+    KEV
+  </span>
+);
+
+export function SoftwareGroupTable({
+  filters,
+  refreshKey,
+  onSelectGroup,
+  onClearFilters,
+}: {
+  filters: VulnFleetFilters;
+  refreshKey: number;
+  onSelectGroup: (groupKey: string) => void;
+  onClearFilters: () => void;
+}) {
+  const [items, setItems] = useState<SoftwareGroup[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchSoftwareGroups(filters)
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.items);
+        setHasMore(res.hasMore);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load software groups');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, refreshKey]);
+
+  const table = useMemo(
+    () => (
+      <table className="min-w-full divide-y">
+        <thead className="bg-muted/40">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <th className="px-4 py-3">Software</th>
+            <th className="px-4 py-3">Severity</th>
+            <th className="px-4 py-3">Risk</th>
+            <th className="px-4 py-3">CVEs</th>
+            <th className="px-4 py-3">Devices</th>
+            <th className="px-4 py-3">Patch</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {items.map((g) => (
+            <tr
+              key={g.groupKey}
+              data-testid={`software-group-row-${g.groupKey}`}
+              className="cursor-pointer transition hover:bg-muted/40"
+              onClick={() => onSelectGroup(g.groupKey)}
+            >
+              <td className="px-4 py-3 text-sm">
+                <div className="font-medium">{g.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {[g.vendor, versionRange(g.versions)].filter(Boolean).join(' · ')}
+                </div>
+              </td>
+              <td className="px-4 py-3 text-sm">
+                <span className="inline-flex items-center gap-1.5">
+                  <SeverityBadge severity={g.worstSeverity} />
+                  {g.kevCveCount > 0 && KEV_BADGE}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</td>
+              <td className="px-4 py-3 text-sm tabular-nums">{g.cveCount}</td>
+              <td className="px-4 py-3 text-sm tabular-nums">{g.deviceCount}</td>
+              <td className="px-4 py-3 text-sm">{patchLabel(g)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ),
+    [items, onSelectGroup],
+  );
+
+  const cards = useMemo(
+    () =>
+      items.map((g) => (
+        <DataCard key={g.groupKey} onClick={() => onSelectGroup(g.groupKey)}>
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-sm font-semibold">{g.name}</span>
+            <span className="inline-flex shrink-0 items-center gap-1.5">
+              <SeverityBadge severity={g.worstSeverity} />
+              {g.kevCveCount > 0 && KEV_BADGE}
+            </span>
+          </div>
+          <div className="mt-3 space-y-2 border-t pt-3">
+            <CardField label="Risk"><span className="text-sm tabular-nums">{fmtRisk(g.maxRiskScore)}</span></CardField>
+            <CardField label="CVEs"><span className="text-sm tabular-nums">{g.cveCount}</span></CardField>
+            <CardField label="Devices"><span className="text-sm tabular-nums">{g.deviceCount}</span></CardField>
+            <CardField label="Patch"><span className="text-sm">{patchLabel(g)}</span></CardField>
+          </div>
+        </DataCard>
+      )),
+    [items, onSelectGroup],
+  );
+
+  if (error) {
+    return (
+      <div
+        data-testid="software-group-table-error"
+        className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return (
+      <div
+        data-testid="software-group-table-empty"
+        className="rounded-md border border-dashed px-4 py-12 text-center text-sm text-muted-foreground"
+      >
+        <p>No vulnerabilities match the current filters.</p>
+        <button
+          type="button"
+          data-testid="software-group-clear-filters"
+          className="mt-2 text-sm font-medium text-primary hover:underline"
+          onClick={onClearFilters}
+        >
+          Clear filters
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <ResponsiveTable table={table} cards={cards} />
+      {hasMore && (
+        <p data-testid="software-group-has-more" className="text-xs text-muted-foreground">
+          Showing the top 500 groups by risk — narrow the filters to see the rest.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default SoftwareGroupTable;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/`
+Expected: PASS — new tests green, existing `VulnerabilityTable.test.tsx` green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/SeverityBadge.tsx apps/web/src/components/vulnerabilities/SoftwareGroupTable.tsx apps/web/src/components/vulnerabilities/SoftwareGroupTable.test.tsx apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx
+git commit -m "feat(web): software-grouped vulnerability work-queue table"
+```
+
+---
+
+### Task 11: Extend `VulnerabilityTable` for the `#cves` tab (shared filters, EPSS/Patch/Status columns, row click)
+
+**Files:**
+- Modify: `apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx`
+- Test: `apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx` (existing — update)
+
+**Interfaces:**
+- Consumes: Task 9's extended `FleetVulnerability` (`epssScore`, `patchAvailable`, `statuses`) and `VulnerabilityFilters` (`kevOnly`, `patchAvailable`); Task 10's `SeverityBadge` import (already done).
+- Produces: `VulnerabilityTable({ filters, refreshKey, onSelectCve, onClearFilters }: { filters: VulnFleetFilters; refreshKey: number; onSelectCve: (cveId: string) => void; onClearFilters: () => void })`. The component's own severity `<select>` is REMOVED (the page-level filter bar owns filtering now). Testids kept: `vulnerability-row-<id>`, `vulnerability-table-empty`, `vulnerability-table-error`; new: `vulnerability-clear-filters`.
+
+- [ ] **Step 1: Update the tests to the new contract (failing first)**
+
+Rewrite `apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx` to render with the new props. Keep its existing mock of `fetchVulnerabilities` and fixtures, extend fixture objects with `epssScore: 0.42, patchAvailable: true, statuses: ['open']`, and replace filter-select interactions with prop-driven assertions:
+
+```tsx
+const FILTERS: VulnFleetFilters = { search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false };
+
+it('maps the shared filter bar onto API filters (search -> cve substring)', async () => {
+  render(<VulnerabilityTable filters={{ ...FILTERS, search: '0001', severity: 'critical', kevOnly: true }} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+  await vi.waitFor(() =>
+    expect(api.fetchVulnerabilities).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'open', severity: 'critical', cve: '0001', kevOnly: true }),
+    ),
+  );
+});
+
+it('renders EPSS and Patch columns and fires onSelectCve on row click', async () => {
+  const onSelect = vi.fn();
+  render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={onSelect} onClearFilters={() => {}} />);
+  const desktop = within(await screen.findByTestId('responsive-table-desktop'));
+  const row = desktop.getByTestId('vulnerability-row-v-1'); // adjust id to the existing fixture's id
+  expect(row).toHaveTextContent('42.0%');  // EPSS 0.42
+  expect(row).toHaveTextContent('Yes');    // patchAvailable
+  fireEvent.click(row);
+  expect(onSelect).toHaveBeenCalledWith('CVE-2026-0001'); // fixture's cveId
+});
+
+it('shows the Status column only when the status filter is not open', async () => {
+  const { rerender } = render(<VulnerabilityTable filters={FILTERS} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+  await screen.findByTestId('responsive-table-desktop');
+  expect(screen.queryByText('Status')).toBeNull();
+  rerender(<VulnerabilityTable filters={{ ...FILTERS, status: 'accepted' }} refreshKey={0} onSelectCve={() => {}} onClearFilters={() => {}} />);
+  await vi.waitFor(() => expect(screen.getByText('Status')).toBeInTheDocument());
+});
+```
+
+Keep/adapt the existing empty-state and error-state tests (empty state now also asserts the `vulnerability-clear-filters` button calls `onClearFilters`). Delete the old severity-select test.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/VulnerabilityTable.test.tsx`
+Expected: FAIL — component still has the old zero-prop signature.
+
+- [ ] **Step 3: Implement**
+
+Modify `VulnerabilityTable.tsx`:
+
+1. New signature and fetch effect (replaces the `severity` state + old effect):
+
+```tsx
+export function VulnerabilityTable({
+  filters,
+  refreshKey,
+  onSelectCve,
+  onClearFilters,
+}: {
+  filters: VulnFleetFilters;
+  refreshKey: number;
+  onSelectCve: (cveId: string) => void;
+  onClearFilters: () => void;
+}) {
+  const [items, setItems] = useState<FleetVulnerability[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const showStatusColumn = filters.status !== 'open';
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const apiFilters: VulnerabilityFilters = { status: filters.status };
+    if (filters.severity) apiFilters.severity = filters.severity;
+    if (filters.search) apiFilters.cve = filters.search;
+    if (filters.kevOnly) apiFilters.kevOnly = true;
+    if (filters.patchAvailable) apiFilters.patchAvailable = true;
+    fetchVulnerabilities(apiFilters)
+      .then((res) => {
+        if (!cancelled) setItems(res.items);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load vulnerabilities');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, refreshKey]);
+```
+
+2. Remove the `SEVERITY_OPTIONS` constant and the whole filter `<label>` block from the JSX (the page-level filter bar replaces it).
+
+3. Add a formatting helper and extend both the desktop table and mobile cards:
+
+```tsx
+function fmtEpss(value: number | null): string {
+  return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
+```
+
+Desktop `<thead>` gains `<th className="px-4 py-3">EPSS</th>` and `<th className="px-4 py-3">Patch</th>` after the Risk column, and — only when `showStatusColumn` — `<th className="px-4 py-3">Status</th>` last. Rows become clickable:
+
+```tsx
+<tr
+  key={v.id}
+  data-testid={`vulnerability-row-${v.id}`}
+  className="cursor-pointer transition hover:bg-muted/40"
+  onClick={() => onSelectCve(v.cveId)}
+>
+```
+
+with the matching new cells:
+
+```tsx
+<td className="px-4 py-3 text-sm tabular-nums">{fmtEpss(v.epssScore)}</td>
+<td className="px-4 py-3 text-sm">{v.patchAvailable ? 'Yes' : '—'}</td>
+{showStatusColumn && <td className="px-4 py-3 text-sm capitalize">{v.statuses.join(', ')}</td>}
+```
+
+Cards gain matching `CardField`s (`EPSS`, `Patch`, and `Status` when shown) and `DataCard` gets `onClick={() => onSelectCve(v.cveId)}`. The empty state adds the clear-filters button (same pattern as `SoftwareGroupTable`, testid `vulnerability-clear-filters`). Remember the `table`/`cards` `useMemo` deps must include `onSelectCve` and `showStatusColumn`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/VulnerabilityTable.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx apps/web/src/components/vulnerabilities/VulnerabilityTable.test.tsx
+git commit -m "feat(web): CVE tab — shared filters, EPSS/patch/status columns, row selection"
+```
+
+---
+
+### Task 12: Page shell — stat cards, filter bar, hash tabs, Astro wiring
+
+**Files:**
+- Create: `apps/web/src/components/vulnerabilities/VulnFilterBar.tsx`
+- Create: `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx`
+- Modify: `apps/web/src/pages/vulnerabilities.astro`
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (add page to `TARGET_GLOBS`, bump count 58 → 59)
+- Test: `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 9's `fetchVulnStats`, `FleetVulnStats`, `VulnFleetFilters`; Task 10's `SoftwareGroupTable`; Task 11's `VulnerabilityTable`; `SecurityStatCard` from `../security/SecurityStatCard`; lucide icons.
+- Produces:
+  - `VulnFilterBar({ filters, onChange }: { filters: VulnFleetFilters; onChange: (f: VulnFleetFilters) => void })` — testids `vuln-filter-search`, `vuln-filter-severity`, `vuln-filter-status`, `vuln-filter-kev`, `vuln-filter-patch`.
+  - `VulnerabilityFleetPage()` — default export, the page island. Hash contract: `#software` (default) / `#cves` tabs; `#software/<encodeURIComponent(groupKey)>` and `#cves/<cveId>` select a drawer item (selection state is created HERE; the drawers render in Tasks 13–14). Exposes `refresh()` internally via a `refreshKey` counter.
+  - `DEFAULT_FILTERS` export: `{ search: '', severity: '', status: 'open', kevOnly: false, patchAvailable: false }`.
+  - Testids: `vuln-stat-critical`, `vuln-stat-kev`, `vuln-stat-patch-ready`, `vuln-stat-accepted-expiring`, `vuln-tab-software`, `vuln-tab-cves`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchVulnStats: vi.fn(),
+  fetchSoftwareGroups: vi.fn(),
+  fetchVulnerabilities: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import VulnerabilityFleetPage from './VulnerabilityFleetPage';
+
+describe('VulnerabilityFleetPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    vi.mocked(api.fetchVulnStats).mockResolvedValue({
+      criticalOpen: 3,
+      kevCveCount: 2,
+      kevDeviceCount: 5,
+      patchReadyFindingCount: 12,
+      acceptedExpiringSoon: 1,
+    });
+    vi.mocked(api.fetchSoftwareGroups).mockResolvedValue({ items: [], hasMore: false });
+    vi.mocked(api.fetchVulnerabilities).mockResolvedValue({ items: [] });
+  });
+
+  it('defaults to the software tab and renders the four stat cards', async () => {
+    render(<VulnerabilityFleetPage />);
+    expect(await screen.findByTestId('vuln-stat-critical')).toHaveTextContent('3');
+    expect(screen.getByTestId('vuln-stat-kev')).toHaveTextContent('2');
+    expect(screen.getByTestId('vuln-stat-patch-ready')).toHaveTextContent('12');
+    expect(screen.getByTestId('vuln-stat-accepted-expiring')).toHaveTextContent('1');
+    await vi.waitFor(() => expect(api.fetchSoftwareGroups).toHaveBeenCalled());
+    expect(api.fetchVulnerabilities).not.toHaveBeenCalled();
+  });
+
+  it('switches tabs via click and writes the hash', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-tab-cves'));
+    expect(window.location.hash).toBe('#cves');
+    await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
+  });
+
+  it('honors a #cves deep link on mount', async () => {
+    window.location.hash = '#cves';
+    render(<VulnerabilityFleetPage />);
+    await vi.waitFor(() => expect(api.fetchVulnerabilities).toHaveBeenCalled());
+  });
+
+  it('applies the matching filter when a stat card is clicked', async () => {
+    render(<VulnerabilityFleetPage />);
+    fireEvent.click(await screen.findByTestId('vuln-stat-critical'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(
+        expect.objectContaining({ severity: 'critical', status: 'open' }),
+      ),
+    );
+    fireEvent.click(screen.getByTestId('vuln-stat-kev'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ kevOnly: true })),
+    );
+    fireEvent.click(screen.getByTestId('vuln-stat-accepted-expiring'));
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'accepted' })),
+    );
+  });
+
+  it('changes filters through the filter bar', async () => {
+    render(<VulnerabilityFleetPage />);
+    await screen.findByTestId('vuln-filter-severity');
+    fireEvent.change(screen.getByTestId('vuln-filter-severity'), { target: { value: 'high' } });
+    await vi.waitFor(() =>
+      expect(api.fetchSoftwareGroups).toHaveBeenLastCalledWith(expect.objectContaining({ severity: 'high' })),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx`
+Expected: FAIL — cannot resolve `./VulnerabilityFleetPage`.
+
+- [ ] **Step 3: Implement the filter bar**
+
+Create `apps/web/src/components/vulnerabilities/VulnFilterBar.tsx`:
+
+```tsx
+import type { VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'mitigated', label: 'Mitigated' },
+  { value: 'patched', label: 'Patched' },
+  { value: 'all', label: 'All statuses' },
+] as const;
+
+const selectCls = 'rounded-md border bg-background px-2 py-1 text-sm';
+
+export function VulnFilterBar({
+  filters,
+  onChange,
+}: {
+  filters: VulnFleetFilters;
+  onChange: (f: VulnFleetFilters) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <input
+        type="search"
+        data-testid="vuln-filter-search"
+        value={filters.search}
+        onChange={(e) => onChange({ ...filters, search: e.target.value })}
+        placeholder="Search software or CVE…"
+        className="w-56 rounded-md border bg-background px-2 py-1 text-sm"
+      />
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Severity</span>
+        <select
+          data-testid="vuln-filter-severity"
+          value={filters.severity}
+          onChange={(e) => onChange({ ...filters, severity: e.target.value })}
+          className={selectCls}
+        >
+          <option value="">All</option>
+          {SEVERITY_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s[0]!.toUpperCase() + s.slice(1)}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Status</span>
+        <select
+          data-testid="vuln-filter-status"
+          value={filters.status}
+          onChange={(e) => onChange({ ...filters, status: e.target.value })}
+          className={selectCls}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          data-testid="vuln-filter-kev"
+          checked={filters.kevOnly}
+          onChange={(e) => onChange({ ...filters, kevOnly: e.target.checked })}
+          className="h-4 w-4 rounded border"
+        />
+        <span>KEV only</span>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          data-testid="vuln-filter-patch"
+          checked={filters.patchAvailable}
+          onChange={(e) => onChange({ ...filters, patchAvailable: e.target.checked })}
+          className="h-4 w-4 rounded border"
+        />
+        <span>Patch available</span>
+      </label>
+    </div>
+  );
+}
+
+export default VulnFilterBar;
+```
+
+- [ ] **Step 4: Implement the page shell**
+
+Create `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx` (hash pattern copied from `DeviceDetails.tsx:144-178`):
+
+```tsx
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Clock, ShieldAlert, Wrench } from 'lucide-react';
+
+import SecurityStatCard from '../security/SecurityStatCard';
+import { VulnFilterBar } from './VulnFilterBar';
+import { SoftwareGroupTable } from './SoftwareGroupTable';
+import { VulnerabilityTable } from './VulnerabilityTable';
+import { fetchVulnStats, type FleetVulnStats, type VulnFleetFilters } from '../../lib/api/vulnerabilities';
+
+type Tab = 'software' | 'cves';
+const VALID_TABS: Tab[] = ['software', 'cves'];
+
+export const DEFAULT_FILTERS: VulnFleetFilters = {
+  search: '',
+  severity: '',
+  status: 'open',
+  kevOnly: false,
+  patchAvailable: false,
+};
+
+function getTabFromHash(): Tab {
+  if (typeof window === 'undefined') return 'software';
+  const hash = window.location.hash.replace('#', '').split('/')[0] ?? '';
+  if (VALID_TABS.includes(hash as Tab)) return hash as Tab;
+  return 'software';
+}
+
+function getSelectionFromHash(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const [tab, ...rest] = window.location.hash.replace('#', '').split('/');
+  if (!VALID_TABS.includes(tab as Tab) || rest.length === 0) return undefined;
+  // groupKey segments may themselves contain encoded slashes — rejoin.
+  const raw = rest.join('/');
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export function VulnerabilityFleetPage() {
+  const [activeTab, setActiveTab] = useState<Tab>(getTabFromHash);
+  const [selection, setSelection] = useState<string | undefined>(getSelectionFromHash);
+  const [filters, setFilters] = useState<VulnFleetFilters>(DEFAULT_FILTERS);
+  const [stats, setStats] = useState<FleetVulnStats | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const onHashChange = () => {
+      setActiveTab(getTabFromHash());
+      setSelection(getSelectionFromHash());
+    };
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchVulnStats()
+      .then((s) => {
+        if (!cancelled) setStats(s);
+      })
+      .catch(() => {
+        /* stat cards are non-blocking; tables surface their own errors */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const switchTab = (tab: Tab) => {
+    window.location.hash = tab;
+    setActiveTab(tab);
+    setSelection(undefined);
+  };
+
+  const select = (tab: Tab, id: string) => {
+    window.location.hash = `${tab}/${encodeURIComponent(id)}`;
+    setActiveTab(tab);
+    setSelection(id);
+  };
+
+  const closeSelection = () => {
+    window.location.hash = activeTab;
+    setSelection(undefined);
+  };
+
+  const refresh = () => setRefreshKey((k) => k + 1);
+  const clearFilters = () => setFilters(DEFAULT_FILTERS);
+
+  const tabCls = (tab: Tab) =>
+    `border-b-2 px-3 py-2 text-sm font-medium transition ${
+      activeTab === tab
+        ? 'border-primary text-foreground'
+        : 'border-transparent text-muted-foreground hover:text-foreground'
+    }`;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-4">
+        <button type="button" data-testid="vuln-stat-critical" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, severity: 'critical' })}>
+          <SecurityStatCard icon={AlertTriangle} label="Critical open" value={stats?.criticalOpen ?? '—'} variant="danger" />
+        </button>
+        <button type="button" data-testid="vuln-stat-kev" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, kevOnly: true })}>
+          <SecurityStatCard
+            icon={ShieldAlert}
+            label="KEV exposure"
+            value={stats?.kevCveCount ?? '—'}
+            variant="warning"
+            detail={stats ? `${stats.kevDeviceCount} devices affected` : undefined}
+          />
+        </button>
+        <button type="button" data-testid="vuln-stat-patch-ready" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, patchAvailable: true })}>
+          <SecurityStatCard icon={Wrench} label="Patch ready" value={stats?.patchReadyFindingCount ?? '—'} variant="success" detail="fixable right now" />
+        </button>
+        <button type="button" data-testid="vuln-stat-accepted-expiring" className="text-left" onClick={() => setFilters({ ...DEFAULT_FILTERS, status: 'accepted' })}>
+          <SecurityStatCard icon={Clock} label="Accepted, expiring soon" value={stats?.acceptedExpiringSoon ?? '—'} detail="within 14 days" />
+        </button>
+      </div>
+
+      <div className="flex items-center gap-1 border-b">
+        <button type="button" data-testid="vuln-tab-software" className={tabCls('software')} onClick={() => switchTab('software')}>
+          By software
+        </button>
+        <button type="button" data-testid="vuln-tab-cves" className={tabCls('cves')} onClick={() => switchTab('cves')}>
+          By CVE
+        </button>
+      </div>
+
+      <VulnFilterBar filters={filters} onChange={setFilters} />
+
+      {activeTab === 'software' ? (
+        <SoftwareGroupTable
+          filters={filters}
+          refreshKey={refreshKey}
+          onSelectGroup={(groupKey) => select('software', groupKey)}
+          onClearFilters={clearFilters}
+        />
+      ) : (
+        <VulnerabilityTable
+          filters={filters}
+          refreshKey={refreshKey}
+          onSelectCve={(cveId) => select('cves', cveId)}
+          onClearFilters={clearFilters}
+        />
+      )}
+      {/* Drawers mount here (Tasks 13–14): selection + activeTab decide which. */}
+    </div>
+  );
+}
+
+export default VulnerabilityFleetPage;
+```
+
+Note for Tasks 13–14: `selection`, `closeSelection`, and `refresh` are defined here but only consumed once the drawers mount at the marked spot. If `astro check`/tsc flags them as unused in this task's commit, add `void selection;\n  void closeSelection;` immediately above the `return` and delete those two lines in Task 13 when the drawer wiring starts using them.
+
+- [ ] **Step 5: Update the Astro page**
+
+Replace the island in `apps/web/src/pages/vulnerabilities.astro`:
+
+```astro
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import VulnerabilityFleetPage from '../components/vulnerabilities/VulnerabilityFleetPage';
+---
+
+<DashboardLayout title="Vulnerabilities">
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-2xl font-semibold">Vulnerabilities</h1>
+      <p class="text-sm text-muted-foreground">
+        Fleet-wide CVE exposure grouped into remediation actions — triage, remediate, accept, or ticket from here.
+      </p>
+    </div>
+    <VulnerabilityFleetPage client:load />
+  </div>
+</DashboardLayout>
+```
+
+- [ ] **Step 6: Register in the no-silent-mutations targeted set**
+
+In `apps/web/src/lib/__tests__/no-silent-mutations.test.ts`: add `'src/components/vulnerabilities/VulnerabilityFleetPage.tsx',` to `TARGET_GLOBS` (keep the array's ordering convention) and change the count assertion `expect(absoluteFiles.length).toBe(58)` → `.toBe(59)`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/ src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/VulnFilterBar.tsx apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.test.tsx apps/web/src/pages/vulnerabilities.astro apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(web): vulnerabilities fleet page shell — stat cards, filter bar, hash tabs"
+```
+
+---
+
+### Task 13: Bulk action modal + software-group drawer (remediate / accept / mitigate)
+
+**Files:**
+- Create: `apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx`
+- Create: `apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx`
+- Modify: `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx` (mount the drawer)
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (add 2 files, 59 → 61)
+- Test: `apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 8's `Drawer`; Task 9's `fetchSoftwareGroupDetail`, `remediateVuln`, `bulkAcceptVulnRisk`, `bulkMitigateVulns`, `SoftwareGroupDetail`; `usePermissions` from `../../lib/permissions`; `handleActionError` from `../../lib/runAction`; `SeverityBadge`.
+- Produces:
+  - `VulnBulkActionModal({ kind, count, busy, onCancel, onSubmit }: { kind: 'accept' | 'mitigate'; count: number; busy: boolean; onCancel: () => void; onSubmit: (payload: { reason?: string; acceptedUntil?: string; note?: string }) => void })` — testids `vuln-bulk-modal`, `vuln-bulk-text`, `vuln-bulk-until`, `vuln-bulk-submit` (reused by Task 14).
+  - `SoftwareGroupDrawer({ groupKey, onClose, onActionComplete, onSelectCve }: { groupKey: string; onClose: () => void; onActionComplete: () => void; onSelectCve: (cveId: string) => void })` — testids `vuln-software-drawer`, `vuln-drawer-error`, `vuln-drawer-retry`, `vuln-finding-check-<deviceVulnerabilityId>`, `vuln-drawer-cve-<cveId>`, `vuln-action-remediate`, `vuln-action-accept`, `vuln-action-mitigate`, `vuln-ticket-chip-<ticketId>`. (The `vuln-action-ticket` button is added in Task 15.)
+
+- [ ] **Step 1: Write the `VulnBulkActionModal` component**
+
+Create `apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx` — same structure/classes as the device tab's `VulnActionModal` (`DeviceVulnerabilitiesTab.tsx:378-448`) with a count in the title and new testids:
+
+```tsx
+import { useState } from 'react';
+
+const BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+
+export function VulnBulkActionModal({
+  kind,
+  count,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  kind: 'accept' | 'mitigate';
+  count: number;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: { reason?: string; acceptedUntil?: string; note?: string }) => void;
+}) {
+  const [text, setText] = useState('');
+  const [until, setUntil] = useState('');
+  const isAccept = kind === 'accept';
+  const canSubmit = isAccept ? text.trim().length > 0 && until.length > 0 : text.trim().length > 0;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-bulk-modal">
+        <h3 className="text-base font-semibold">
+          {isAccept ? 'Accept risk' : 'Mark mitigated'} — {count} finding{count === 1 ? '' : 's'}
+        </h3>
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">{isAccept ? 'Reason' : 'Mitigation note'}</span>
+            <textarea
+              data-testid="vuln-bulk-text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          {isAccept && (
+            <label className="block text-sm">
+              <span className="text-muted-foreground">Accepted until</span>
+              <input
+                type="date"
+                data-testid="vuln-bulk-until"
+                value={until}
+                min={(() => {
+                  const d = new Date();
+                  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+                })()}
+                onChange={(e) => setUntil(e.target.value)}
+                className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+              />
+            </label>
+          )}
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="vuln-bulk-submit"
+            className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+            disabled={!canSubmit || busy}
+            onClick={() =>
+              onSubmit(
+                isAccept
+                  ? { reason: text.trim(), acceptedUntil: new Date(`${until}T00:00:00Z`).toISOString() }
+                  : { note: text.trim() },
+              )
+            }
+          >
+            {isAccept ? 'Accept risk' : 'Mark mitigated'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VulnBulkActionModal;
+```
+
+Note the `z-[60]` — the modal must stack above the drawer's `z-50`.
+
+- [ ] **Step 2: Write the failing drawer tests**
+
+Create `apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchSoftwareGroupDetail: vi.fn(),
+  remediateVuln: vi.fn(),
+  bulkAcceptVulnRisk: vi.fn(),
+  bulkMitigateVulns: vi.fn(),
+  createVulnTicket: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { SoftwareGroupDrawer } from './SoftwareGroupDrawer';
+import type { SoftwareGroupDetail } from '../../lib/api/vulnerabilities';
+
+const DETAIL: SoftwareGroupDetail = {
+  group: {
+    groupKey: 'sw:google chrome|google llc',
+    kind: 'software',
+    name: 'Google Chrome',
+    vendor: 'Google LLC',
+    versions: ['126.0'],
+    deviceCount: 2,
+    cveCount: 1,
+    cveIds: ['CVE-2026-0001'],
+    worstSeverity: 'critical',
+    maxRiskScore: 95,
+    kevCveCount: 1,
+    maxEpss: 0.9,
+    patchReadyFindingCount: 1,
+    patchReadyDeviceCount: 1,
+    ticketIds: [],
+  },
+  cves: [
+    {
+      cveId: 'CVE-2026-0001',
+      vulnerabilityId: 'v-1',
+      severity: 'critical',
+      cvssScore: 9.1,
+      epssScore: 0.9,
+      knownExploited: true,
+      patchAvailable: true,
+      maxRiskScore: 95,
+    },
+  ],
+  findings: [
+    {
+      deviceVulnerabilityId: 'dv-1',
+      deviceId: 'dev-1',
+      deviceName: 'WS-01',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'open',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+    {
+      deviceVulnerabilityId: 'dv-2',
+      deviceId: 'dev-2',
+      deviceName: 'WS-02',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'accepted',
+      patchAvailable: false,
+      riskScore: 90,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: 't-9',
+    },
+  ],
+};
+
+describe('SoftwareGroupDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    vi.mocked(api.fetchSoftwareGroupDetail).mockResolvedValue(DETAIL);
+  });
+
+  it('renders header, CVE list, and device findings with open findings pre-selected', async () => {
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-software-drawer')).toHaveTextContent('Google Chrome');
+    expect(screen.getByTestId('vuln-drawer-cve-CVE-2026-0001')).toBeInTheDocument();
+    expect(screen.getByTestId('vuln-finding-check-dv-1')).toBeChecked();       // open — pre-selected
+    expect(screen.getByTestId('vuln-finding-check-dv-2')).not.toBeChecked();   // accepted — not pre-selected
+    expect(screen.getByTestId('vuln-ticket-chip-t-9')).toBeInTheDocument();
+  });
+
+  it('accept-risk flow: opens modal, submits selected ids, reloads and notifies', async () => {
+    vi.mocked(api.bulkAcceptVulnRisk).mockResolvedValue({ success: true, succeeded: 1, skipped: [] });
+    const onActionComplete = vi.fn();
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={onActionComplete} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'compensating control' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() =>
+      expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], {
+        reason: 'compensating control',
+        acceptedUntil: new Date('2030-01-01T00:00:00Z').toISOString(),
+      }),
+    );
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+    expect(api.fetchSoftwareGroupDetail).toHaveBeenCalledTimes(2); // initial + reload
+  });
+
+  it('remediate acts on the selected findings', async () => {
+    vi.mocked(api.remediateVuln).mockResolvedValue({ scheduled: 1, skipped: [] });
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    fireEvent.click(await screen.findByTestId('vuln-action-remediate'));
+    await waitFor(() => expect(api.remediateVuln).toHaveBeenCalledWith(['dv-1']));
+  });
+
+  it('hides permission-gated actions', async () => {
+    authState.permissions = [{ resource: 'devices', action: 'read' }];
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    await screen.findByTestId('vuln-software-drawer');
+    expect(screen.queryByTestId('vuln-action-remediate')).toBeNull();
+    expect(screen.queryByTestId('vuln-action-accept')).toBeNull();
+    expect(screen.queryByTestId('vuln-action-mitigate')).toBeNull();
+  });
+
+  it('shows an inline retry on fetch failure', async () => {
+    vi.mocked(api.fetchSoftwareGroupDetail).mockRejectedValueOnce(new Error('boom'));
+    render(
+      <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+    );
+    expect(await screen.findByTestId('vuln-drawer-error')).toHaveTextContent('boom');
+    fireEvent.click(screen.getByTestId('vuln-drawer-retry'));
+    expect(await screen.findByTestId('vuln-finding-check-dv-1')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx`
+Expected: FAIL — cannot resolve `./SoftwareGroupDrawer`.
+
+- [ ] **Step 4: Implement the drawer**
+
+Create `apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+
+import { Drawer } from '../shared/Drawer';
+import { SeverityBadge } from './SeverityBadge';
+import { VulnBulkActionModal } from './VulnBulkActionModal';
+import { usePermissions } from '../../lib/permissions';
+import { handleActionError } from '../../lib/runAction';
+import {
+  bulkAcceptVulnRisk,
+  bulkMitigateVulns,
+  fetchSoftwareGroupDetail,
+  remediateVuln,
+  type SoftwareGroupDetail,
+} from '../../lib/api/vulnerabilities';
+
+const ACTION_BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50';
+
+function fmtEpss(value: number | null): string {
+  return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
+
+export function SoftwareGroupDrawer({
+  groupKey,
+  onClose,
+  onActionComplete,
+  onSelectCve,
+}: {
+  groupKey: string;
+  onClose: () => void;
+  onActionComplete: () => void;
+  onSelectCve: (cveId: string) => void;
+}) {
+  const [detail, setDetail] = useState<SoftwareGroupDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState<'remediate' | 'accept' | 'mitigate' | 'ticket' | null>(null);
+  const [modal, setModal] = useState<'accept' | 'mitigate' | null>(null);
+
+  const { can } = usePermissions();
+  const canRemediate = can('devices', 'execute');
+  const canAcceptRisk = can('vulnerabilities', 'accept_risk');
+  const canMitigate = can('devices', 'write');
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const d = await fetchSoftwareGroupDetail(groupKey);
+      setDetail(d);
+      // Open findings are the actionable ones — pre-select them (spec: all selected by default).
+      setSelected(new Set(d.findings.filter((f) => f.status === 'open').map((f) => f.deviceVulnerabilityId)));
+    } catch (err) {
+      setDetail(null);
+      setError(err instanceof Error ? err.message : 'Failed to load software group');
+    }
+  }, [groupKey]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectedIds = [...selected];
+
+  const runBulk = useCallback(
+    async (kind: 'remediate' | 'accept' | 'mitigate' | 'ticket', action: () => Promise<unknown>, fallback: string) => {
+      if (busy || selectedIds.length === 0) return;
+      setBusy(kind);
+      try {
+        await action();
+        setModal(null);
+        await load();
+        onActionComplete();
+      } catch (err) {
+        handleActionError(err, fallback);
+      } finally {
+        setBusy(null);
+      }
+    },
+    // selectedIds is derived from `selected`; depend on the source set.
+    [busy, selected, load, onActionComplete],
+  );
+
+  const title = detail ? (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{detail.group.name}</span>
+      <SeverityBadge severity={detail.group.worstSeverity} />
+      {detail.group.kevCveCount > 0 && (
+        <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+          KEV
+        </span>
+      )}
+    </span>
+  ) : (
+    'Software group'
+  );
+
+  return (
+    <Drawer open onClose={onClose} title={title} width="max-w-xl" dataTestId="vuln-software-drawer" closeDisabled={busy !== null}>
+      <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+        {error && (
+          <div
+            data-testid="vuln-drawer-error"
+            className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+          >
+            <p>{error}</p>
+            <button type="button" data-testid="vuln-drawer-retry" className="mt-2 text-sm font-medium underline" onClick={() => void load()}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {detail && (
+          <>
+            <div className="text-sm text-muted-foreground">
+              {[detail.group.vendor, `${detail.group.deviceCount} devices`, `max risk ${detail.group.maxRiskScore ?? '—'}`]
+                .filter(Boolean)
+                .join(' · ')}
+            </div>
+
+            {detail.group.ticketIds.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {detail.group.ticketIds.map((tid) => (
+                  <a
+                    key={tid}
+                    href={`/tickets#${tid}`}
+                    data-testid={`vuln-ticket-chip-${tid}`}
+                    className="inline-flex items-center rounded-full border bg-muted/40 px-2.5 py-1 text-xs font-medium hover:bg-muted"
+                  >
+                    Ticket · {tid.slice(0, 8)}
+                  </a>
+                ))}
+              </div>
+            )}
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">CVEs ({detail.cves.length})</h3>
+              <ul className="mt-2 divide-y rounded-md border">
+                {detail.cves.map((cve) => (
+                  <li key={cve.cveId}>
+                    <button
+                      type="button"
+                      data-testid={`vuln-drawer-cve-${cve.cveId}`}
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-muted/40"
+                      onClick={() => onSelectCve(cve.cveId)}
+                    >
+                      <span className="font-medium">{cve.cveId}</span>
+                      <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <SeverityBadge severity={cve.severity} />
+                        <span className="tabular-nums">CVSS {cve.cvssScore ?? '—'}</span>
+                        <span className="tabular-nums">EPSS {fmtEpss(cve.epssScore)}</span>
+                        {cve.knownExploited && <span className="font-semibold text-red-600">KEV</span>}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Devices ({detail.findings.length} findings)
+              </h3>
+              <ul className="mt-2 divide-y rounded-md border">
+                {detail.findings.map((f) => (
+                  <li key={f.deviceVulnerabilityId} className="flex items-center gap-3 px-3 py-2 text-sm">
+                    <input
+                      type="checkbox"
+                      data-testid={`vuln-finding-check-${f.deviceVulnerabilityId}`}
+                      checked={selected.has(f.deviceVulnerabilityId)}
+                      onChange={() => toggle(f.deviceVulnerabilityId)}
+                      className="h-4 w-4 rounded border"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium">{f.deviceName}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {[f.orgName, f.cveId].filter(Boolean).join(' · ')}
+                      </span>
+                    </span>
+                    <span className="text-xs capitalize text-muted-foreground">{f.status}</span>
+                    <span className="text-xs">{f.patchAvailable ? 'Patch' : '—'}</span>
+                    {f.ticketId && (
+                      <a href={`/tickets#${f.ticketId}`} data-testid={`vuln-ticket-chip-${f.ticketId}`} className="text-xs underline">
+                        Ticket
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </>
+        )}
+      </div>
+
+      {detail && (
+        <div className="flex flex-wrap items-center gap-2 border-t px-5 py-3">
+          <span className="mr-auto text-xs text-muted-foreground">{selectedIds.length} selected</span>
+          {canRemediate && (
+            <button
+              type="button"
+              data-testid="vuln-action-remediate"
+              className={`${ACTION_BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => void runBulk('remediate', () => remediateVuln(selectedIds), 'Failed to schedule remediation')}
+            >
+              Remediate
+            </button>
+          )}
+          {canAcceptRisk && (
+            <button
+              type="button"
+              data-testid="vuln-action-accept"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('accept')}
+            >
+              Accept risk
+            </button>
+          )}
+          {canMitigate && (
+            <button
+              type="button"
+              data-testid="vuln-action-mitigate"
+              className={ACTION_BTN}
+              disabled={busy !== null || selectedIds.length === 0}
+              onClick={() => setModal('mitigate')}
+            >
+              Mitigate
+            </button>
+          )}
+        </div>
+      )}
+
+      {modal && (
+        <VulnBulkActionModal
+          kind={modal}
+          count={selectedIds.length}
+          busy={busy !== null}
+          onCancel={() => setModal(null)}
+          onSubmit={(payload) => {
+            if (modal === 'accept') {
+              void runBulk(
+                'accept',
+                () => bulkAcceptVulnRisk(selectedIds, { reason: payload.reason ?? '', acceptedUntil: payload.acceptedUntil ?? '' }),
+                'Failed to accept risk',
+              );
+            } else {
+              void runBulk('mitigate', () => bulkMitigateVulns(selectedIds, { note: payload.note ?? '' }), 'Failed to mitigate');
+            }
+          }}
+        />
+      )}
+    </Drawer>
+  );
+}
+
+export default SoftwareGroupDrawer;
+```
+
+- [ ] **Step 5: Mount the drawer in the page**
+
+In `VulnerabilityFleetPage.tsx`, add the import and replace the `{/* Drawers mount here ... */}` comment with:
+
+```tsx
+      {selection && activeTab === 'software' && (
+        <SoftwareGroupDrawer
+          groupKey={selection}
+          onClose={closeSelection}
+          onActionComplete={refresh}
+          onSelectCve={(cveId) => select('cves', cveId)}
+        />
+      )}
+```
+
+- [ ] **Step 6: Register in the no-silent-mutations targeted set**
+
+Add `'src/components/vulnerabilities/SoftwareGroupDrawer.tsx',` and `'src/components/vulnerabilities/VulnBulkActionModal.tsx',` to `TARGET_GLOBS`; bump the count 59 → 61.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/ src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/VulnBulkActionModal.tsx apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(web): software-group drawer with bulk remediate/accept/mitigate"
+```
+
+---
+
+### Task 14: CVE drawer (details, affected devices, actions, reopen)
+
+**Files:**
+- Create: `apps/web/src/components/vulnerabilities/CveDrawer.tsx`
+- Modify: `apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx` (mount it)
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (61 → 62)
+- Test: `apps/web/src/components/vulnerabilities/CveDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 8's `Drawer`; Task 9's `fetchCveDevices`, `CveDevicesPayload`, `remediateVuln`, `bulkAcceptVulnRisk`, `bulkMitigateVulns`, `reopenVuln` (existing); Task 13's `VulnBulkActionModal`; `usePermissions`, `handleActionError`, `SeverityBadge`.
+- Produces: `CveDrawer({ cveId, onClose, onActionComplete }: { cveId: string; onClose: () => void; onActionComplete: () => void })` — testids `vuln-cve-drawer`, `vuln-cve-meta`, `vuln-cve-reference-<index>`, `vuln-finding-check-<id>`, `vuln-action-remediate`, `vuln-action-accept`, `vuln-action-mitigate`, `vuln-reopen-<deviceVulnerabilityId>`, `vuln-drawer-error`, `vuln-drawer-retry`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/components/vulnerabilities/CveDrawer.test.tsx` (same auth/API mock scaffold as Task 13's test — mock `fetchCveDevices`, `remediateVuln`, `bulkAcceptVulnRisk`, `bulkMitigateVulns`, `reopenVuln`):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+type Perm = { resource: string; action: string };
+const authState = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+
+vi.mock('../../lib/api/vulnerabilities', () => ({
+  fetchCveDevices: vi.fn(),
+  remediateVuln: vi.fn(),
+  bulkAcceptVulnRisk: vi.fn(),
+  bulkMitigateVulns: vi.fn(),
+  reopenVuln: vi.fn(),
+  createVulnTicket: vi.fn(),
+}));
+
+import * as api from '../../lib/api/vulnerabilities';
+import { CveDrawer } from './CveDrawer';
+import type { CveDevicesPayload } from '../../lib/api/vulnerabilities';
+
+const PAYLOAD: CveDevicesPayload = {
+  cve: {
+    cveId: 'CVE-2026-0001',
+    description: 'Heap overflow in the render pipeline.',
+    references: ['https://example.test/advisory'],
+    cvssVersion: '3.1',
+    cvssVector: 'CVSS:3.1/AV:N/AC:L',
+    cvssScore: 9.1,
+    epssScore: 0.42,
+    knownExploited: true,
+    patchAvailable: true,
+    severity: 'critical',
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-02-01T00:00:00.000Z',
+  },
+  findings: [
+    {
+      deviceVulnerabilityId: 'dv-1',
+      deviceId: 'dev-1',
+      deviceName: 'WS-01',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'open',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+    {
+      deviceVulnerabilityId: 'dv-2',
+      deviceId: 'dev-2',
+      deviceName: 'WS-02',
+      orgId: 'org-1',
+      orgName: 'Acme',
+      cveId: 'CVE-2026-0001',
+      status: 'accepted',
+      patchAvailable: true,
+      riskScore: 95,
+      detectedAt: '2026-06-01T00:00:00.000Z',
+      ticketId: null,
+    },
+  ],
+};
+
+describe('CveDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    vi.mocked(api.fetchCveDevices).mockResolvedValue(PAYLOAD);
+  });
+
+  it('renders CVE metadata, vector, EPSS, KEV, and reference links', async () => {
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    const meta = await screen.findByTestId('vuln-cve-meta');
+    expect(meta).toHaveTextContent('Heap overflow');
+    expect(meta).toHaveTextContent('CVSS:3.1/AV:N/AC:L');
+    expect(meta).toHaveTextContent('42.0%');
+    expect(meta).toHaveTextContent('KEV');
+    expect(screen.getByTestId('vuln-cve-reference-0')).toHaveAttribute('href', 'https://example.test/advisory');
+  });
+
+  it('shows Reopen only on accepted/mitigated findings and calls the API', async () => {
+    vi.mocked(api.reopenVuln).mockResolvedValue(undefined as never);
+    const onActionComplete = vi.fn();
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={onActionComplete} />);
+    await screen.findByTestId('vuln-cve-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-1')).toBeNull();      // open finding
+    fireEvent.click(screen.getByTestId('vuln-reopen-dv-2'));          // accepted finding
+    await waitFor(() => expect(api.reopenVuln).toHaveBeenCalledWith('dv-2'));
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+  });
+
+  it('hides Reopen without vulnerabilities:accept_risk', async () => {
+    authState.permissions = [{ resource: 'devices', action: 'read' }];
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    await screen.findByTestId('vuln-cve-drawer');
+    expect(screen.queryByTestId('vuln-reopen-dv-2')).toBeNull();
+  });
+
+  it('runs bulk accept-risk against the selected findings scoped to this CVE', async () => {
+    vi.mocked(api.bulkAcceptVulnRisk).mockResolvedValue({ success: true, succeeded: 1, skipped: [] });
+    render(<CveDrawer cveId="CVE-2026-0001" onClose={() => {}} onActionComplete={() => {}} />);
+    fireEvent.click(await screen.findByTestId('vuln-action-accept'));
+    fireEvent.change(screen.getByTestId('vuln-bulk-text'), { target: { value: 'ok' } });
+    fireEvent.change(screen.getByTestId('vuln-bulk-until'), { target: { value: '2030-01-01' } });
+    fireEvent.click(screen.getByTestId('vuln-bulk-submit'));
+    await waitFor(() => expect(api.bulkAcceptVulnRisk).toHaveBeenCalledWith(['dv-1'], expect.anything()));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/CveDrawer.test.tsx`
+Expected: FAIL — cannot resolve `./CveDrawer`.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/web/src/components/vulnerabilities/CveDrawer.tsx` by COPYING `SoftwareGroupDrawer.tsx` (Task 13, same directory) as the starting point — keep its load/retry state machine, open-findings-preselected `selected` set, `runBulk` helper, action bar, and `VulnBulkActionModal` wiring intact — then apply these differences:
+
+- Fetch: `fetchCveDevices(cveId)`; state `payload: CveDevicesPayload | null`.
+- Title: `<span className="flex items-center gap-2"><span>{cveId}</span>{payload && <SeverityBadge severity={payload.cve.severity} />}</span>`.
+- Metadata section (before the devices list):
+
+```tsx
+{payload && (
+  <section data-testid="vuln-cve-meta" className="space-y-2 text-sm">
+    <p>{payload.cve.description}</p>
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+      <dt className="text-muted-foreground">CVSS {payload.cve.cvssVersion ?? ''}</dt>
+      <dd className="tabular-nums">{payload.cve.cvssScore ?? '—'}</dd>
+      <dt className="text-muted-foreground">Vector</dt>
+      <dd className="break-all">{payload.cve.cvssVector ?? '—'}</dd>
+      <dt className="text-muted-foreground">EPSS</dt>
+      <dd className="tabular-nums">{fmtEpss(payload.cve.epssScore)}</dd>
+      <dt className="text-muted-foreground">Known exploited</dt>
+      <dd>{payload.cve.knownExploited ? 'KEV' : 'No'}</dd>
+      <dt className="text-muted-foreground">Published</dt>
+      <dd>{payload.cve.publishedAt ? new Date(payload.cve.publishedAt).toLocaleDateString() : '—'}</dd>
+      <dt className="text-muted-foreground">Modified</dt>
+      <dd>{payload.cve.modifiedAt ? new Date(payload.cve.modifiedAt).toLocaleDateString() : '—'}</dd>
+    </dl>
+    {referenceUrls(payload.cve.references).length > 0 && (
+      <ul className="space-y-1 text-xs">
+        {referenceUrls(payload.cve.references).map((url, i) => (
+          <li key={url}>
+            <a data-testid={`vuln-cve-reference-${i}`} href={url} target="_blank" rel="noreferrer" className="break-all text-primary hover:underline">
+              {url}
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+)}
+```
+
+with the defensive reference normalizer (the catalog stores `references` as source-dependent jsonb):
+
+```tsx
+function referenceUrls(references: unknown): string[] {
+  if (!Array.isArray(references)) return [];
+  return references
+    .map((r) => (typeof r === 'string' ? r : typeof r === 'object' && r !== null && 'url' in r ? String((r as { url: unknown }).url) : null))
+    .filter((u): u is string => typeof u === 'string' && u.startsWith('http'))
+    .slice(0, 10);
+}
+```
+
+- Devices list: same row markup as the group drawer minus the CVE id line, PLUS a per-finding Reopen button:
+
+```tsx
+{canAcceptRisk && (f.status === 'accepted' || f.status === 'mitigated') && (
+  <button
+    type="button"
+    data-testid={`vuln-reopen-${f.deviceVulnerabilityId}`}
+    className="text-xs font-medium text-primary hover:underline disabled:opacity-50"
+    disabled={busy !== null}
+    onClick={() => void onReopen(f.deviceVulnerabilityId)}
+  >
+    Reopen
+  </button>
+)}
+```
+
+with the handler:
+
+```tsx
+const onReopen = useCallback(
+  async (id: string) => {
+    if (busy) return;
+    setBusy('reopen');
+    try {
+      await reopenVuln(id);
+      await load();
+      onActionComplete();
+    } catch (err) {
+      handleActionError(err, 'Failed to reopen finding');
+    } finally {
+      setBusy(null);
+    }
+  },
+  [busy, load, onActionComplete],
+);
+```
+
+(`busy` union gains `'reopen'`.) Action bar identical to the group drawer (`vuln-action-remediate` / `vuln-action-accept` / `vuln-action-mitigate`, same permission gates), acting on the drawer's selected finding ids. `dataTestId="vuln-cve-drawer"`, `width="max-w-xl"`.
+
+- [ ] **Step 4: Mount in the page + targeted set**
+
+In `VulnerabilityFleetPage.tsx`, next to the software drawer:
+
+```tsx
+      {selection && activeTab === 'cves' && (
+        <CveDrawer cveId={selection} onClose={closeSelection} onActionComplete={refresh} />
+      )}
+```
+
+Add `'src/components/vulnerabilities/CveDrawer.tsx',` to `TARGET_GLOBS`; bump 61 → 62.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/ src/lib/__tests__/no-silent-mutations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/CveDrawer.tsx apps/web/src/components/vulnerabilities/CveDrawer.test.tsx apps/web/src/components/vulnerabilities/VulnerabilityFleetPage.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(web): CVE drawer with metadata, device selection, actions, and reopen"
+```
+
+---
+
+### Task 15: Create-ticket modal + wiring into both drawers
+
+**Files:**
+- Create: `apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx`
+- Modify: `apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx`, `apps/web/src/components/vulnerabilities/CveDrawer.tsx`
+- Modify: `apps/web/src/lib/__tests__/no-silent-mutations.test.ts` (62 → 63)
+- Test: `apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx` + extend `SoftwareGroupDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 9's `createVulnTicket`, `GroupFinding`; `usePermissions` (`can('tickets', 'write')`).
+- Produces: `CreateVulnTicketModal({ findings, defaultTitle, busy, onCancel, onSubmit }: { findings: GroupFinding[]; defaultTitle: string; busy: boolean; onCancel: () => void; onSubmit: (payload: { title: string; description: string; priority: 'low' | 'normal' | 'high' | 'urgent' }) => void })` — testids `vuln-ticket-modal`, `vuln-ticket-title`, `vuln-ticket-description`, `vuln-ticket-priority`, `vuln-ticket-submit`, `vuln-ticket-cross-org-note`. Both drawers gain a `vuln-action-ticket` button (visible with `tickets:write`).
+
+- [ ] **Step 1: Write the failing modal tests**
+
+Create `apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CreateVulnTicketModal } from './CreateVulnTicketModal';
+import type { GroupFinding } from '../../lib/api/vulnerabilities';
+
+function finding(overrides: Partial<GroupFinding> = {}): GroupFinding {
+  return {
+    deviceVulnerabilityId: 'dv-1',
+    deviceId: 'dev-1',
+    deviceName: 'WS-01',
+    orgId: 'org-1',
+    orgName: 'Acme',
+    cveId: 'CVE-2026-0001',
+    status: 'open',
+    patchAvailable: true,
+    riskScore: 95,
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    ticketId: null,
+    ...overrides,
+  };
+}
+
+describe('CreateVulnTicketModal', () => {
+  it('pre-fills the title and a description listing CVEs and devices', () => {
+    render(
+      <CreateVulnTicketModal
+        findings={[finding(), finding({ deviceVulnerabilityId: 'dv-2', deviceId: 'dev-2', deviceName: 'WS-02', cveId: 'CVE-2026-0002' })]}
+        defaultTitle="Remediate Google Chrome"
+        busy={false}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('vuln-ticket-title')).toHaveValue('Remediate Google Chrome');
+    const description = screen.getByTestId('vuln-ticket-description');
+    expect(description).toHaveValue(expect.stringContaining('CVE-2026-0001') as unknown as string);
+    expect((description as HTMLTextAreaElement).value).toContain('WS-02');
+  });
+
+  it('warns when the selection spans multiple organizations', () => {
+    render(
+      <CreateVulnTicketModal
+        findings={[finding(), finding({ deviceVulnerabilityId: 'dv-2', orgId: 'org-2', orgName: 'Beta' })]}
+        defaultTitle="T"
+        busy={false}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('vuln-ticket-cross-org-note')).toHaveTextContent('2 organizations');
+  });
+
+  it('submits title/description/priority and blocks empty titles', () => {
+    const onSubmit = vi.fn();
+    render(<CreateVulnTicketModal findings={[finding()]} defaultTitle="T" busy={false} onCancel={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: '' } });
+    expect(screen.getByTestId('vuln-ticket-submit')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('vuln-ticket-title'), { target: { value: 'Patch it' } });
+    fireEvent.change(screen.getByTestId('vuln-ticket-priority'), { target: { value: 'high' } });
+    fireEvent.click(screen.getByTestId('vuln-ticket-submit'));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ title: 'Patch it', priority: 'high' }));
+  });
+});
+```
+
+(If the `toHaveValue(expect.stringContaining(...))` matcher combination is rejected by jest-dom, assert via `(el as HTMLTextAreaElement).value).toContain('CVE-2026-0001')` as done for WS-02.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/vulnerabilities/CreateVulnTicketModal.test.tsx`
+Expected: FAIL — cannot resolve `./CreateVulnTicketModal`.
+
+- [ ] **Step 3: Implement the modal**
+
+Create `apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx`:
+
+```tsx
+import { useMemo, useState } from 'react';
+
+import type { GroupFinding } from '../../lib/api/vulnerabilities';
+
+const BTN =
+  'inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50';
+
+const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
+type Priority = (typeof PRIORITIES)[number];
+
+function buildDescription(findings: GroupFinding[]): string {
+  const cves = [...new Set(findings.map((f) => f.cveId))].sort();
+  const devices = [...new Set(findings.map((f) => f.deviceName))].sort();
+  return [
+    `CVEs (${cves.length}): ${cves.join(', ')}`,
+    `Devices (${devices.length}): ${devices.join(', ')}`,
+    '',
+    'Created from the Breeze vulnerabilities triage queue.',
+  ].join('\n');
+}
+
+export function CreateVulnTicketModal({
+  findings,
+  defaultTitle,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  findings: GroupFinding[];
+  defaultTitle: string;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: { title: string; description: string; priority: Priority }) => void;
+}) {
+  const [title, setTitle] = useState(defaultTitle);
+  const [description, setDescription] = useState(() => buildDescription(findings));
+  const [priority, setPriority] = useState<Priority>('normal');
+
+  const orgCount = useMemo(() => new Set(findings.map((f) => f.orgId)).size, [findings]);
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-lg" data-testid="vuln-ticket-modal">
+        <h3 className="text-base font-semibold">Create ticket — {findings.length} finding{findings.length === 1 ? '' : 's'}</h3>
+        {orgCount > 1 && (
+          <p data-testid="vuln-ticket-cross-org-note" className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+            Selection spans {orgCount} organizations — one ticket per organization will be created.
+          </p>
+        )}
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Title</span>
+            <input
+              data-testid="vuln-ticket-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={255}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Description</span>
+            <textarea
+              data-testid="vuln-ticket-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-muted-foreground">Priority</span>
+            <select
+              data-testid="vuln-ticket-priority"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as Priority)}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>{p[0]!.toUpperCase() + p.slice(1)}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" className={BTN} onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="vuln-ticket-submit"
+            className={`${BTN} bg-primary text-primary-foreground hover:bg-primary/90`}
+            disabled={busy || title.trim().length === 0}
+            onClick={() => onSubmit({ title: title.trim(), description, priority })}
+          >
+            Create ticket
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CreateVulnTicketModal;
+```
+
+- [ ] **Step 4: Wire into both drawers**
+
+In `SoftwareGroupDrawer.tsx`:
+- `const canCreateTicket = can('tickets', 'write');`
+- state: `const [ticketModal, setTicketModal] = useState(false);`
+- Action bar gains (after Mitigate):
+
+```tsx
+{canCreateTicket && (
+  <button
+    type="button"
+    data-testid="vuln-action-ticket"
+    className={ACTION_BTN}
+    disabled={busy !== null || selectedIds.length === 0}
+    onClick={() => setTicketModal(true)}
+  >
+    Create ticket
+  </button>
+)}
+```
+
+- Modal rendering (after `VulnBulkActionModal`):
+
+```tsx
+{ticketModal && detail && (
+  <CreateVulnTicketModal
+    findings={detail.findings.filter((f) => selected.has(f.deviceVulnerabilityId))}
+    defaultTitle={`Remediate ${detail.group.name}`}
+    busy={busy !== null}
+    onCancel={() => setTicketModal(false)}
+    onSubmit={(payload) => {
+      setTicketModal(false);
+      void runBulk('ticket', () => createVulnTicket(selectedIds, payload), 'Failed to create ticket');
+    }}
+  />
+)}
+```
+
+(`runBulk`'s union already includes `'ticket'` from Task 13; import `createVulnTicket`.) After success, `load()` re-renders the ticket chips from the refreshed `ticketId`s.
+
+In `CveDrawer.tsx`: identical wiring with `defaultTitle={\`Remediate ${cveId}\`}` and `findings={payload.findings.filter((f) => selected.has(f.deviceVulnerabilityId))}`.
+
+- [ ] **Step 5: Extend the drawer test for the ticket flow**
+
+Add to `SoftwareGroupDrawer.test.tsx`:
+
+```tsx
+it('create-ticket flow: opens prefilled modal, submits, refreshes chips', async () => {
+  vi.mocked(api.createVulnTicket).mockResolvedValue({ success: true, tickets: [{ ticketId: 't-1', orgId: 'org-1', findingCount: 1 }], skipped: [] });
+  const onActionComplete = vi.fn();
+  render(
+    <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={onActionComplete} onSelectCve={() => {}} />,
+  );
+  fireEvent.click(await screen.findByTestId('vuln-action-ticket'));
+  expect(screen.getByTestId('vuln-ticket-title')).toHaveValue('Remediate Google Chrome');
+  fireEvent.click(screen.getByTestId('vuln-ticket-submit'));
+  await waitFor(() =>
+    expect(api.createVulnTicket).toHaveBeenCalledWith(['dv-1'], expect.objectContaining({ title: 'Remediate Google Chrome', priority: 'normal' })),
+  );
+  await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+});
+
+it('hides Create ticket without tickets:write', async () => {
+  authState.permissions = [
+    { resource: 'devices', action: 'execute' },
+    { resource: 'vulnerabilities', action: 'accept_risk' },
+    { resource: 'devices', action: 'write' },
+  ];
+  render(
+    <SoftwareGroupDrawer groupKey="sw:google chrome|google llc" onClose={() => {}} onActionComplete={() => {}} onSelectCve={() => {}} />,
+  );
+  await screen.findByTestId('vuln-software-drawer');
+  expect(screen.queryByTestId('vuln-action-ticket')).toBeNull();
+});
+```
+
+(Task 13's mock of the API module already stubs `createVulnTicket`.)
+
+- [ ] **Step 6: Targeted set + run all web tests**
+
+Add `'src/components/vulnerabilities/CreateVulnTicketModal.tsx',` to `TARGET_GLOBS`; bump 62 → 63.
+
+Run: `cd apps/web && pnpm vitest run`
+Expected: full web suite PASS (catches any cross-component fallout).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/vulnerabilities/CreateVulnTicketModal.tsx apps/web/src/components/vulnerabilities/CreateVulnTicketModal.test.tsx apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.tsx apps/web/src/components/vulnerabilities/SoftwareGroupDrawer.test.tsx apps/web/src/components/vulnerabilities/CveDrawer.tsx apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+git commit -m "feat(web): create-ticket modal with cross-org split warning in vuln drawers"
+```
+
+---
+
+### Task 16: E2E — page object, updated fleet spec, triage happy path
+
+**Files:**
+- Create: `e2e-tests/pages/VulnerabilitiesPage.ts`
+- Modify: `e2e-tests/tests/vulnerabilities.spec.ts`
+
+**Interfaces:**
+- Consumes: testids from Tasks 10–15; existing fixtures (`authedPage`), seeded device `e65460f3-413c-4599-a9a6-90ee71bbc4ff` + `CVE-2025-E2E-0001` from `seed-fixtures.sql`.
+- Produces: `VulnerabilitiesPage` page object; a full accept→reopen loop spec that leaves seed data as it found it.
+
+**Prerequisite:** a running seeded stack (`worktree-stack` skill) — these tests run in the `e2e-tests` harness, not vitest.
+
+- [ ] **Step 1: Write the page object**
+
+Create `e2e-tests/pages/VulnerabilitiesPage.ts` (modeled on `PamPage.ts` — testid getters only):
+
+```ts
+import type { Page, Locator } from '@playwright/test';
+
+export class VulnerabilitiesPage {
+  constructor(private page: Page) {}
+
+  goto = (hash = '') => this.page.goto(`/vulnerabilities${hash}`);
+
+  // Stat cards
+  statCritical = () => this.page.getByTestId('vuln-stat-critical');
+  statKev = () => this.page.getByTestId('vuln-stat-kev');
+  statPatchReady = () => this.page.getByTestId('vuln-stat-patch-ready');
+  statAcceptedExpiring = () => this.page.getByTestId('vuln-stat-accepted-expiring');
+
+  // Tabs + filters
+  tabSoftware = () => this.page.getByTestId('vuln-tab-software');
+  tabCves = () => this.page.getByTestId('vuln-tab-cves');
+  filterStatus = () => this.page.getByTestId('vuln-filter-status');
+
+  // Tables
+  groupRows = (): Locator => this.page.locator('[data-testid^="software-group-row-"]');
+  cveRows = (): Locator => this.page.locator('[data-testid^="vulnerability-row-"]');
+
+  // Software drawer
+  softwareDrawer = () => this.page.getByTestId('vuln-software-drawer');
+  actionAccept = () => this.page.getByTestId('vuln-action-accept');
+  actionRemediate = () => this.page.getByTestId('vuln-action-remediate');
+
+  // Bulk modal
+  bulkModal = () => this.page.getByTestId('vuln-bulk-modal');
+  bulkText = () => this.page.getByTestId('vuln-bulk-text');
+  bulkUntil = () => this.page.getByTestId('vuln-bulk-until');
+  bulkSubmit = () => this.page.getByTestId('vuln-bulk-submit');
+
+  // CVE drawer
+  cveDrawer = () => this.page.getByTestId('vuln-cve-drawer');
+  reopenButtons = (): Locator => this.page.locator('[data-testid^="vuln-reopen-"]');
+
+  drawerClose = (drawer: 'vuln-software-drawer' | 'vuln-cve-drawer') => this.page.getByTestId(`${drawer}-close`);
+}
+```
+
+- [ ] **Step 2: Update the fleet spec**
+
+In `e2e-tests/tests/vulnerabilities.spec.ts`:
+
+1. The existing `'fleet dashboard lists CVE rows'` test navigates to `/vulnerabilities` and asserts `[data-testid^="vulnerability-row-"]` — CVE rows now live on the `#cves` tab. Change its navigation line to:
+
+```ts
+    await authedPage.goto('/vulnerabilities#cves');
+```
+
+(Leave the rest of that test and the per-device test untouched.)
+
+2. Add the triage loop test (accept from the software drawer, then reopen from the CVE drawer so seed state is restored for the per-device test):
+
+```ts
+  test('fleet triage: accept risk from software drawer, reopen from CVE drawer', async ({ authedPage }) => {
+    const vulnPage = new VulnerabilitiesPage(authedPage);
+    await vulnPage.goto();
+
+    // Stat cards render.
+    await expect(vulnPage.statCritical()).toBeVisible({ timeout: 15_000 });
+
+    // Software work queue is the default tab; open the first group's drawer.
+    await expect(vulnPage.groupRows().first()).toBeVisible({ timeout: 15_000 });
+    const groupsBefore = await vulnPage.groupRows().count();
+    await vulnPage.groupRows().first().click();
+    await expect(vulnPage.softwareDrawer()).toBeVisible();
+
+    // Accept risk for the pre-selected open findings.
+    await vulnPage.actionAccept().click();
+    await expect(vulnPage.bulkModal()).toBeVisible();
+    await vulnPage.bulkText().fill('Compensating control in place (fleet e2e)');
+    await vulnPage.bulkUntil().fill('2030-01-01');
+    await vulnPage.bulkSubmit().click();
+
+    // Drawer reloads; close it. The open queue shrinks (group had only open findings).
+    await expect(vulnPage.bulkModal()).toBeHidden({ timeout: 15_000 });
+    await vulnPage.drawerClose('vuln-software-drawer').click();
+    await expect(vulnPage.groupRows()).toHaveCount(groupsBefore - 1, { timeout: 15_000 });
+
+    // Restore: find the accepted finding on the CVE tab and reopen it.
+    await vulnPage.tabCves().click();
+    await vulnPage.filterStatus().selectOption('accepted');
+    await expect(vulnPage.cveRows().first()).toBeVisible({ timeout: 15_000 });
+    await vulnPage.cveRows().first().click();
+    await expect(vulnPage.cveDrawer()).toBeVisible();
+    const reopenCount = await vulnPage.reopenButtons().count();
+    expect(reopenCount).toBeGreaterThan(0);
+    // Reopen every accepted finding this e2e created.
+    for (let i = 0; i < reopenCount; i += 1) {
+      await vulnPage.reopenButtons().first().click();
+      await expect(vulnPage.reopenButtons()).toHaveCount(reopenCount - i - 1, { timeout: 15_000 });
+    }
+  });
+```
+
+Add the import at the top: `import { VulnerabilitiesPage } from '../pages/VulnerabilitiesPage';`
+
+**Ordering caveat:** this test mutates then restores the seeded finding. Keep it AFTER the existing `'fleet dashboard lists CVE rows'` test in the file and note that Playwright runs tests within a file serially, so the per-device accept-risk test (which itself consumes one finding) still sees its expected state.
+
+- [ ] **Step 3: Run the e2e suite against a live stack**
+
+Run (with the worktree stack up): `cd e2e-tests && pnpm test -- tests/vulnerabilities.spec.ts`
+Expected: PASS (3 tests). If no stack is available locally, verify via CI's e2e job and say so in the commit message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-tests/pages/VulnerabilitiesPage.ts e2e-tests/tests/vulnerabilities.spec.ts
+git commit -m "test(e2e): fleet vulnerability triage flow with page object"
+```
+
+---
+
+### Task 17 (OPTIONAL cleanup): Refactor `CatalogItemEditorDrawer` onto shared `Drawer`
+
+Low-risk, behavior-preserving. Skip if the schedule is tight — the spec marks it optional.
+
+**Files:**
+- Modify: `apps/web/src/components/settings/CatalogItemEditorDrawer.tsx`
+
+**Interfaces:**
+- Consumes: Task 8's `Drawer` (`closeDisabled` maps to the drawer's `saving` state).
+
+- [ ] **Step 1: Refactor**
+
+Replace the drawer's own chrome with the shared primitive:
+- Delete its local `FOCUSABLE` constant, the a11y `useEffect`, `handleKeyDown`, `handleBackdropClick`, `panelRef`/`triggerRef`/`titleId`, the `createPortal(...)` wrapper, backdrop `<div>`, panel `<div>`, and header block.
+- Wrap the remaining body in:
+
+```tsx
+<Drawer
+  open={open}
+  onClose={onClose}
+  title={editId ? 'Edit item' : 'New item'}
+  dataTestId="catalog-item-editor"
+  closeDisabled={saving}
+>
+  {/* existing form body + footer, unchanged */}
+</Drawer>
+```
+
+**Testid compatibility:** the original uses `data-testid="catalog-editor-backdrop"` and `data-testid="catalog-form-close"`, while the shared Drawer derives `catalog-item-editor-backdrop` / `catalog-item-editor-close`. Grep the web tests and e2e specs for `catalog-editor-backdrop` and `catalog-form-close`:
+
+```bash
+grep -rn "catalog-editor-backdrop\|catalog-form-close" apps/web/src e2e-tests/
+```
+
+Update every hit to the derived names in the same commit (or, if e2e churn is unwanted, extend `Drawer` with optional `backdropTestId`/`closeTestId` overrides — prefer updating the tests).
+
+- [ ] **Step 2: Run the catalog tests**
+
+Run: `cd apps/web && pnpm vitest run src/components/settings/`
+Expected: PASS after testid updates.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/settings/CatalogItemEditorDrawer.tsx apps/web/src
+git commit -m "refactor(web): CatalogItemEditorDrawer consumes shared Drawer primitive"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `cd apps/api && pnpm vitest run` — full API unit suite green.
+- [ ] `cd apps/web && pnpm vitest run` — full web suite green (including `no-silent-mutations` at 63 and `astro check` if part of the suite).
+- [ ] `pnpm db:check-drift` with a migrated local DB — no drift.
+- [ ] `cd apps/web && pnpm build` — the Astro page builds (catches island/import errors `tsc` misses).
+- [ ] Manual smoke via the worktree stack: `/vulnerabilities` renders stat cards + software queue; drawer opens from a row and from a `#software/<key>` deep link; accept-risk round-trips.
+
+## Deferred / out of scope (from the spec)
+
+- Dual-control co-sign for critical/KEV waivers; PSA ticket sync; network-device vulnerabilities (BE-16 phase 5); any change to `/security/vulnerabilities` (EDR threats page).
+- MFA step-up UX for remediate: `runAction` already toasts the server's 403 message; a dedicated `friendly`-mapped step-up prompt is a follow-up if the raw message proves confusing.
+
+
+

--- a/docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md
+++ b/docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md
@@ -1,0 +1,109 @@
+# Vulnerabilities Fleet Page — Triage UI Enhancement (Design)
+
+**Date:** 2026-07-04
+**Status:** Approved design, pending implementation plan
+**Route:** `/vulnerabilities` (top-level fleet page — NOT `/security/vulnerabilities`, which is the EDR threats list)
+
+## Problem
+
+The fleet `/vulnerabilities` page (`apps/web/src/components/vulnerabilities/VulnerabilityTable.tsx`, 148 lines) is a read-only 6-column per-CVE table with a single severity filter. The backend (BE-16 phases 1–3) is far richer: triage statuses (open/patched/mitigated/accepted), accept-risk with reason+expiry, mitigate, reopen, bulk remediate wired to approved patches, EPSS/KEV/risk scoring, per-finding patch availability — all surfaced only on the per-device tab (`DeviceVulnerabilitiesTab.tsx`). Technicians cannot triage from the fleet view, and the per-CVE grain means one Chrome update shows as ~30 identical Critical rows.
+
+## Decisions (user-approved)
+
+- **Workflow:** fix-first remediation queue (not risk-review dashboard).
+- **Primary grain:** software/product — one row ≈ one remediation action. Per-CVE view retained as a second tab.
+- **Scope:** full-stack — new aggregation/bulk endpoints, one migration (ticket linkage).
+- **Actions:** remediate, accept-risk, mitigate, reopen (all existing server-side) **plus** create-ticket (net-new linkage to native ticketing).
+- **Detail view:** right-side slide-over drawer, hash-selected. Extracted from the existing catalog drawer chrome, not invented new.
+
+## UX Design
+
+### Page structure
+
+1. **Header + stat cards** (reuse `SecurityStatCard` pattern from the security page). Four clickable cards that apply the matching filter:
+   - **Critical open** — open findings with severity critical.
+   - **KEV exposure** — known-exploited CVEs present, with affected-device count.
+   - **Patch ready** — open findings with an approved patch pending ("fixable right now").
+   - **Accepted, expiring soon** — acceptances with `acceptedUntil` within 14 days.
+2. **Tabs** (hash-based, app convention): `#software` (default work queue) and `#cves` (report view). Drawer sub-selection: `#software/<groupKey>`, `#cves/<cveId>`.
+3. **Filter bar** shared across tabs: text search (software name or CVE id), severity select, status select (default **Open**), KEV-only toggle, patch-available toggle.
+
+### By-software table (default tab)
+
+One row per remediation unit, sorted by max risk score desc:
+
+| Software (name, vendor, affected version range) | Worst severity (+KEV flag) | Risk (max) | CVEs | Devices | Patch ("Ready · 12/14 devices" / "—") |
+
+OS-level CVEs (from `os_vulnerabilities`; findings without a software product) roll into per-platform pseudo-groups ("Windows OS updates", "macOS updates") so nothing falls out of the queue.
+
+### By-CVE table
+
+Today's table plus: EPSS column, patch-available column, status column (when the status filter ≠ open), row click opens the CVE drawer. The existing fleet endpoint `GET /vulnerabilities` already supports `status`/`severity`/`cve`; it gains `kevOnly` and `patchAvailable` params so the shared filter bar works identically on both tabs.
+
+Mobile: both tabs keep the `ResponsiveTable`/`DataCard` pattern.
+
+### Drawer
+
+**Shared primitive** `apps/web/src/components/shared/Drawer.tsx`, extracted verbatim from the chrome of `settings/CatalogItemEditorDrawer.tsx:441-458` (portal, `dialog-backdrop` backdrop + `justify-end`, `drawer-panel` with `slide-in-from-right` animation from `globals.css`, header with close button) and its a11y block (`:177-207`: focus-first, scroll-lock, Escape, Tab focus-trap, focus restore). Props: `open`, `onClose`, `title` (node), `width` (default `max-w-md`; vuln page uses `max-w-xl`), `data-testid`, children. Optional low-risk cleanup task: refactor `CatalogItemEditorDrawer` to consume it (markup identical).
+
+**Software-group drawer** (`#software/<groupKey>`):
+- Header: name + vendor, worst-severity badge, KEV flag, max risk.
+- CVE section: compact list (CVE id, severity, CVSS, EPSS, KEV), each linking to `#cves/<id>`.
+- Devices section: affected devices with per-device finding status, patch availability, checkboxes (all selected by default).
+- Action bar (permission-gated, all `runAction`):
+  - **Remediate** (`devices:execute` + MFA) — existing bulk endpoint; surfaces per-item skip reasons.
+  - **Accept risk** (`vulnerabilities:accept_risk`) — reason + future expiry modal (same as device tab), new bulk endpoint.
+  - **Mitigate** (`devices:write`) — note modal, new bulk endpoint.
+  - **Create ticket** — pre-filled ticket modal; on create, findings link to the ticket; drawer shows a ticket chip thereafter.
+
+**CVE drawer** (`#cves/<cveId>`): description, published/modified, reference links, CVSS vector, EPSS, KEV; affected-device list with same selection + action bar scoped to the CVE. **Reopen** shown on accepted/mitigated findings (`vulnerabilities:accept_risk`).
+
+Actions refresh table + stat cards; partial success → summary toast ("12 scheduled, 2 skipped — no approved patch").
+
+## Backend Design
+
+All new routes live in `apps/api/src/routes/vulnerabilities.ts` under the existing middleware stack (`authMiddleware`, `requireScope`, `requirePermission(devices:read)`, site-axis filtering; org isolation via RLS). Aggregation logic goes in a new unit-testable service `apps/api/src/services/vulnerabilityFleetAggregation.ts`.
+
+### Read endpoints
+
+1. `GET /vulnerabilities/software` — groups `device_vulnerabilities` by remediation unit. **Group key (opaque, URL-safe):** `sw:<normalized name>|<normalized vendor>` (URL-encoded; derived from the finding's `software_inventory` row, normalized the same way the correlation pipeline normalizes to `software_products`) for software findings, or `os:<platform>` (`os:windows`, `os:macos`, …) for OS findings (`softwareInventoryId` null). The key must be stable across requests so `#software/<groupKey>` deep links work. Query params: `status` (default open), `severity`, `search` (software name or CVE), `kevOnly`, `patchAvailable`. Returns per group: `groupKey, kind ('software'|'os'), name, vendor, deviceCount, cveCount, worstSeverity, maxRiskScore, kevCveCount, maxEpss, patchReadyFindingCount, ticketIds`. Sorted maxRiskScore desc. No pagination — group cardinality is fleet-bounded; hard cap (500) + `hasMore` flag.
+2. `GET /vulnerabilities/software/:groupKey` — drawer payload: group's CVEs (id, severity, cvssScore, epssScore, knownExploited, riskScore) + per-device findings (deviceVulnerabilityId, deviceId, deviceName, orgId/orgName, status, patchAvailable, detectedAt, ticketId).
+3. `GET /vulnerabilities/stats` — the four stat-card numbers in one call.
+4. `GET /vulnerabilities/:cveId/devices` — CVE drawer payload: fleet-wide affected devices + findings for one CVE (same finding shape as above) + the CVE catalog record (description, references, vector, dates).
+
+### Mutation endpoints
+
+- `POST /vulnerabilities/bulk/accept-risk` `{ deviceVulnerabilityIds (1–200), reason (1–2000), acceptedUntil (future ISO) }` — `vulnerabilities:accept_risk`; per-item audit (`vulnerability.accept_risk`).
+- `POST /vulnerabilities/bulk/mitigate` `{ deviceVulnerabilityIds (1–200), note (1–2000) }` — `devices:write`; per-item audit.
+- Bulk remediate: existing `POST /vulnerabilities/remediate` unchanged. Reopen: existing per-finding `POST /:id/reopen` unchanged.
+- `POST /vulnerabilities/tickets` `{ deviceVulnerabilityIds (1–200), title, description, priority }` — gated on ticketing write permission; creates ticket(s) via the existing ticketing service. Ticket org = findings' org; a cross-org selection creates one ticket per org. Stamps `ticket_id` on the findings; audited.
+
+Bulk endpoints are per-item fault-tolerant: `{ success, succeeded, skipped: [{id, reason}] }` — never fail the whole batch on one bad id (matches remediate's contract).
+
+### Schema / migration
+
+`apps/api/migrations/2026-07-04-device-vulnerabilities-ticket-link.sql` (idempotent, no inner BEGIN/COMMIT):
+- `ALTER TABLE device_vulnerabilities ADD COLUMN IF NOT EXISTS ticket_id uuid REFERENCES tickets(id) ON DELETE SET NULL;`
+- Partial index on `ticket_id WHERE ticket_id IS NOT NULL`.
+- Existing tenant table with RLS already forced — no policy changes, no allowlist changes. Drizzle schema updated in `apps/api/src/db/schema/vulnerabilityManagement.ts`; `pnpm db:check-drift` must pass.
+
+## Permissions & Error Handling
+
+- Web buttons gated via `usePermissions().can(...)`; hidden when unpermitted (device-tab convention). Remediate surfaces the MFA-required 403 cleanly.
+- All mutations wrapped in `runAction`; new components added to the `no-silent-mutations` targeted set (bump the count constant in the same PR).
+- Drawer fetch failure → inline retry; filtered-empty state → clear-filters link.
+
+## Testing
+
+- **API route tests** (Vitest + Drizzle mocks): auth/RBAC per endpoint, validation bounds, 200-id caps, per-item skip paths, cross-org ticket split, `ticket_id` stamping.
+- **Aggregation unit tests** (`vulnerabilityFleetAggregation`): grouping key resolution, OS pseudo-groups, worst-severity/max-risk/patch-ready math, filter application.
+- **Web component tests**: software table render, drawer open/close via hash, action flows with mocked fetch, permission-hiding, stat-card filter application.
+- **E2E** (Playwright, `data-testid` only): open queue → open drawer → accept risk happy path.
+- No RLS coverage changes (no new tables).
+
+## Out of Scope
+
+- Dual-control co-sign for critical/KEV waivers (explicitly deferred in the RBAC spec).
+- PSA (external) ticket sync — native ticketing only.
+- Network-device vulnerabilities (BE-16 phase 5).
+- Changes to `/security/vulnerabilities` (EDR threats page).

--- a/e2e-tests/pages/VulnerabilitiesPage.ts
+++ b/e2e-tests/pages/VulnerabilitiesPage.ts
@@ -1,0 +1,39 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class VulnerabilitiesPage {
+  constructor(private page: Page) {}
+
+  goto = (hash = '') => this.page.goto(`/vulnerabilities${hash}`);
+
+  // Stat cards
+  statCritical = () => this.page.getByTestId('vuln-stat-critical');
+  statKev = () => this.page.getByTestId('vuln-stat-kev');
+  statPatchReady = () => this.page.getByTestId('vuln-stat-patch-ready');
+  statAcceptedExpiring = () => this.page.getByTestId('vuln-stat-accepted-expiring');
+
+  // Tabs + filters
+  tabSoftware = () => this.page.getByTestId('vuln-tab-software');
+  tabCves = () => this.page.getByTestId('vuln-tab-cves');
+  filterStatus = () => this.page.getByTestId('vuln-filter-status');
+
+  // Tables
+  groupRows = (): Locator => this.page.locator('[data-testid^="software-group-row-"]');
+  cveRows = (): Locator => this.page.locator('[data-testid^="vulnerability-row-"]');
+
+  // Software drawer
+  softwareDrawer = () => this.page.getByTestId('vuln-software-drawer');
+  actionAccept = () => this.page.getByTestId('vuln-action-accept');
+  actionRemediate = () => this.page.getByTestId('vuln-action-remediate');
+
+  // Bulk modal
+  bulkModal = () => this.page.getByTestId('vuln-bulk-modal');
+  bulkText = () => this.page.getByTestId('vuln-bulk-text');
+  bulkUntil = () => this.page.getByTestId('vuln-bulk-until');
+  bulkSubmit = () => this.page.getByTestId('vuln-bulk-submit');
+
+  // CVE drawer
+  cveDrawer = () => this.page.getByTestId('vuln-cve-drawer');
+  reopenButtons = (): Locator => this.page.locator('[data-testid^="vuln-reopen-"]');
+
+  drawerClose = (drawer: 'vuln-software-drawer' | 'vuln-cve-drawer') => this.page.getByTestId(`${drawer}-close`);
+}

--- a/e2e-tests/pages/VulnerabilitiesPage.ts
+++ b/e2e-tests/pages/VulnerabilitiesPage.ts
@@ -20,16 +20,23 @@ export class VulnerabilitiesPage {
   groupRows = (): Locator => this.page.locator('[data-testid^="software-group-row-"]');
   cveRows = (): Locator => this.page.locator('[data-testid^="vulnerability-row-"]');
 
+  // Zero-row states (same testids on both tabs; only one table renders at a time)
+  emptyFiltered = () => this.page.getByTestId('vuln-empty-filtered');
+  emptyClean = () => this.page.getByTestId('vuln-empty-clean');
+  emptyUnscanned = () => this.page.getByTestId('vuln-empty-unscanned');
+
   // Software drawer
   softwareDrawer = () => this.page.getByTestId('vuln-software-drawer');
   actionAccept = () => this.page.getByTestId('vuln-action-accept');
   actionRemediate = () => this.page.getByTestId('vuln-action-remediate');
 
-  // Bulk modal
+  // Bulk modal (accept / mitigate / remediate confirmation)
   bulkModal = () => this.page.getByTestId('vuln-bulk-modal');
   bulkText = () => this.page.getByTestId('vuln-bulk-text');
   bulkUntil = () => this.page.getByTestId('vuln-bulk-until');
   bulkSubmit = () => this.page.getByTestId('vuln-bulk-submit');
+  bulkCancel = () => this.page.getByTestId('vuln-bulk-cancel');
+  remediateSummary = () => this.page.getByTestId('vuln-bulk-remediate-summary');
 
   // CVE drawer
   cveDrawer = () => this.page.getByTestId('vuln-cve-drawer');

--- a/e2e-tests/pages/VulnerabilitiesPage.ts
+++ b/e2e-tests/pages/VulnerabilitiesPage.ts
@@ -36,11 +36,15 @@ export class VulnerabilitiesPage {
   bulkUntil = () => this.page.getByTestId('vuln-bulk-until');
   bulkSubmit = () => this.page.getByTestId('vuln-bulk-submit');
   bulkCancel = () => this.page.getByTestId('vuln-bulk-cancel');
-  remediateSummary = () => this.page.getByTestId('vuln-bulk-remediate-summary');
+  // Per-action consequence line (all kinds; formerly vuln-bulk-remediate-summary).
+  remediateSummary = () => this.page.getByTestId('vuln-bulk-consequence');
+  bulkSelection = () => this.page.getByTestId('vuln-bulk-selection');
 
   // CVE drawer
   cveDrawer = () => this.page.getByTestId('vuln-cve-drawer');
+  // Present in BOTH drawers (only one renders at a time).
   reopenButtons = (): Locator => this.page.locator('[data-testid^="vuln-reopen-"]');
+  selectAllFindings = () => this.page.getByTestId('vuln-select-all');
 
   drawerClose = (drawer: 'vuln-software-drawer' | 'vuln-cve-drawer') => this.page.getByTestId(`${drawer}-close`);
 }

--- a/e2e-tests/tests/vulnerabilities.spec.ts
+++ b/e2e-tests/tests/vulnerabilities.spec.ts
@@ -7,6 +7,11 @@ const SEEDED_CVE = 'CVE-2025-E2E-0001';
 
 const rowSelector = '[data-testid^="vulnerability-row-"]';
 
+// These tests mutate the SAME seeded finding (accept/reopen/remediate on the
+// one open CVE), so they must not run concurrently — under fullyParallel the
+// accept-risk test removes the row the remediate test is about to open.
+test.describe.configure({ mode: 'default' });
+
 test.describe('Vulnerabilities', () => {
   test('fleet dashboard lists CVE rows', async ({ authedPage }) => {
     await authedPage.goto('/vulnerabilities#cves');
@@ -34,6 +39,26 @@ test.describe('Vulnerabilities', () => {
 
     // The tab re-fetches status=open findings, so the accepted one disappears.
     await expect(authedPage.locator(rowSelector)).toHaveCount(before - 1, { timeout: 15_000 });
+  });
+
+  test('remediate shows a confirmation with counts and cancel leaves state untouched', async ({ authedPage }) => {
+    const vulnPage = new VulnerabilitiesPage(authedPage);
+    await vulnPage.goto();
+
+    await expect(vulnPage.groupRows().first()).toBeVisible({ timeout: 15_000 });
+    await vulnPage.groupRows().first().click();
+    await expect(vulnPage.softwareDrawer()).toBeVisible();
+
+    // Remediate no longer fires immediately — a confirmation stands in between.
+    await vulnPage.actionRemediate().click();
+    await expect(vulnPage.bulkModal()).toBeVisible();
+    await expect(vulnPage.remediateSummary()).toContainText('finding');
+    await expect(vulnPage.remediateSummary()).toContainText('device');
+
+    // Cancel: no mutation, drawer still open and usable.
+    await vulnPage.bulkCancel().click();
+    await expect(vulnPage.bulkModal()).toBeHidden();
+    await expect(vulnPage.softwareDrawer()).toBeVisible();
   });
 
   test('fleet triage: accept risk from software drawer, reopen from CVE drawer', async ({ authedPage }) => {

--- a/e2e-tests/tests/vulnerabilities.spec.ts
+++ b/e2e-tests/tests/vulnerabilities.spec.ts
@@ -61,21 +61,35 @@ test.describe('Vulnerabilities', () => {
     await vulnPage.drawerClose('vuln-software-drawer').click();
     await expect(vulnPage.groupRows()).toHaveCount(groupsBefore - 1, { timeout: 15_000 });
 
-    // Restore: find the accepted finding on the CVE tab and reopen it.
+    // Restore: the accepted software group can span MULTIPLE CVEs, so drain
+    // every accepted CVE row on the CVE tab, not just the first, or seed state
+    // is only partially restored and poisons subsequent runs.
     await vulnPage.tabCves().click();
     await vulnPage.filterStatus().selectOption('accepted');
-    await expect(vulnPage.cveRows().first()).toBeVisible({ timeout: 15_000 });
-    await vulnPage.cveRows().first().click();
-    await expect(vulnPage.cveDrawer()).toBeVisible();
-    // The drawer container renders before its findings fetch resolves, so wait
-    // for a reopen button rather than counting immediately (avoids a 0-count race).
-    await expect(vulnPage.reopenButtons().first()).toBeVisible({ timeout: 15_000 });
-    const reopenCount = await vulnPage.reopenButtons().count();
-    expect(reopenCount).toBeGreaterThan(0);
-    // Reopen every accepted finding this e2e created.
-    for (let i = 0; i < reopenCount; i += 1) {
-      await vulnPage.reopenButtons().first().click();
-      await expect(vulnPage.reopenButtons()).toHaveCount(reopenCount - i - 1, { timeout: 15_000 });
+
+    const MAX_CVE_RESTORE_ITERATIONS = 20;
+    for (let iteration = 0; iteration < MAX_CVE_RESTORE_ITERATIONS; iteration += 1) {
+      const remainingCveRows = await vulnPage.cveRows().count();
+      if (remainingCveRows === 0) break;
+
+      await vulnPage.cveRows().first().click();
+      await expect(vulnPage.cveDrawer()).toBeVisible();
+      // The drawer container renders before its findings fetch resolves, so wait
+      // for a reopen button rather than counting immediately (avoids a 0-count race).
+      await expect(vulnPage.reopenButtons().first()).toBeVisible({ timeout: 15_000 });
+      const reopenCount = await vulnPage.reopenButtons().count();
+      expect(reopenCount).toBeGreaterThan(0);
+      // Reopen every accepted finding in this CVE.
+      for (let i = 0; i < reopenCount; i += 1) {
+        await vulnPage.reopenButtons().first().click();
+        await expect(vulnPage.reopenButtons()).toHaveCount(reopenCount - i - 1, { timeout: 15_000 });
+      }
+      await vulnPage.drawerClose('vuln-cve-drawer').click();
+      await expect(vulnPage.cveDrawer()).toBeHidden({ timeout: 15_000 });
     }
+
+    // Self-verify: under the still-applied accepted filter, no CVE rows remain.
+    // If this fails, restoration was incomplete and seed state is poisoned for reruns.
+    await expect(vulnPage.cveRows()).toHaveCount(0, { timeout: 15_000 });
   });
 });

--- a/e2e-tests/tests/vulnerabilities.spec.ts
+++ b/e2e-tests/tests/vulnerabilities.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures';
+import { VulnerabilitiesPage } from '../pages/VulnerabilitiesPage';
 
 // Fixed Windows device id from seed-fixtures.sql (carries the seeded open CVE).
 const WINDOWS_DEVICE_ID = 'e65460f3-413c-4599-a9a6-90ee71bbc4ff';
@@ -8,9 +9,12 @@ const rowSelector = '[data-testid^="vulnerability-row-"]';
 
 test.describe('Vulnerabilities', () => {
   test('fleet dashboard lists CVE rows', async ({ authedPage }) => {
-    await authedPage.goto('/vulnerabilities');
+    await authedPage.goto('/vulnerabilities#cves');
     await expect(authedPage.locator(rowSelector).first()).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByText(SEEDED_CVE)).toBeVisible();
+    // ResponsiveTable renders both the desktop row and the mobile card for the
+    // same CVE (CSS-toggled, not conditionally rendered), so this now needs
+    // .first() to avoid a strict-mode violation once it targets the #cves tab.
+    await expect(authedPage.getByText(SEEDED_CVE).first()).toBeVisible();
   });
 
   test('per-device tab accept-risk drops a finding out of the open list', async ({ authedPage }) => {
@@ -30,5 +34,48 @@ test.describe('Vulnerabilities', () => {
 
     // The tab re-fetches status=open findings, so the accepted one disappears.
     await expect(authedPage.locator(rowSelector)).toHaveCount(before - 1, { timeout: 15_000 });
+  });
+
+  test('fleet triage: accept risk from software drawer, reopen from CVE drawer', async ({ authedPage }) => {
+    const vulnPage = new VulnerabilitiesPage(authedPage);
+    await vulnPage.goto();
+
+    // Stat cards render.
+    await expect(vulnPage.statCritical()).toBeVisible({ timeout: 15_000 });
+
+    // Software work queue is the default tab; open the first group's drawer.
+    await expect(vulnPage.groupRows().first()).toBeVisible({ timeout: 15_000 });
+    const groupsBefore = await vulnPage.groupRows().count();
+    await vulnPage.groupRows().first().click();
+    await expect(vulnPage.softwareDrawer()).toBeVisible();
+
+    // Accept risk for the pre-selected open findings.
+    await vulnPage.actionAccept().click();
+    await expect(vulnPage.bulkModal()).toBeVisible();
+    await vulnPage.bulkText().fill('Compensating control in place (fleet e2e)');
+    await vulnPage.bulkUntil().fill('2030-01-01');
+    await vulnPage.bulkSubmit().click();
+
+    // Drawer reloads; close it. The open queue shrinks (group had only open findings).
+    await expect(vulnPage.bulkModal()).toBeHidden({ timeout: 15_000 });
+    await vulnPage.drawerClose('vuln-software-drawer').click();
+    await expect(vulnPage.groupRows()).toHaveCount(groupsBefore - 1, { timeout: 15_000 });
+
+    // Restore: find the accepted finding on the CVE tab and reopen it.
+    await vulnPage.tabCves().click();
+    await vulnPage.filterStatus().selectOption('accepted');
+    await expect(vulnPage.cveRows().first()).toBeVisible({ timeout: 15_000 });
+    await vulnPage.cveRows().first().click();
+    await expect(vulnPage.cveDrawer()).toBeVisible();
+    // The drawer container renders before its findings fetch resolves, so wait
+    // for a reopen button rather than counting immediately (avoids a 0-count race).
+    await expect(vulnPage.reopenButtons().first()).toBeVisible({ timeout: 15_000 });
+    const reopenCount = await vulnPage.reopenButtons().count();
+    expect(reopenCount).toBeGreaterThan(0);
+    // Reopen every accepted finding this e2e created.
+    for (let i = 0; i < reopenCount; i += 1) {
+      await vulnPage.reopenButtons().first().click();
+      await expect(vulnPage.reopenButtons()).toHaveCount(reopenCount - i - 1, { timeout: 15_000 });
+    }
   });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -762,6 +762,12 @@ export * from './ai';
 export * from './billing-enums';
 
 // ============================================
+// Vulnerability fleet-triage SSOT
+// ============================================
+
+export * from './vulnerability';
+
+// ============================================
 // Security & Compliance Posture Report
 // ============================================
 

--- a/packages/shared/src/types/vulnerability.ts
+++ b/packages/shared/src/types/vulnerability.ts
@@ -1,0 +1,282 @@
+/**
+ * Single source of truth for the vulnerability fleet-triage domain types.
+ *
+ * These shapes were previously DUPLICATED across three files, drifting apart
+ * over time:
+ *   - apps/api/src/services/vulnerabilityFleetAggregation.ts
+ *   - apps/api/src/services/vulnerabilityFleetQueries.ts
+ *   - apps/web/src/lib/api/vulnerabilities.ts
+ * Both `apps/api` and `apps/web` MUST import these from `@breeze/shared` so the
+ * wire contract is defined once. This mirrors the billing-enum precedent in
+ * `./billing-enums.ts` (const tuple -> derived union type): the tuple is the
+ * authority, every layer derives from it.
+ *
+ * SCOPE NOTE (compile-time strengthening only): the field names and JSON shapes
+ * here are byte-for-byte the current wire contract. The only changes vs. the old
+ * duplicated interfaces are `string` -> closed unions and added doc comments.
+ * No runtime/wire behavior changes.
+ */
+
+// ============================================
+// Enum tuples (const tuple -> derived union, billing-enums pattern)
+// ============================================
+
+/**
+ * Stored finding statuses (the `device_vulnerabilities.status` lifecycle).
+ * 'all' is NOT here — it is a filter-only sentinel (see VULN_STATUS_FILTERS).
+ * The Zod enum in routes/vulnerabilities.ts is `[...open,patched,mitigated,accepted, all]`.
+ */
+export const VULN_STATUSES = ['open', 'patched', 'mitigated', 'accepted'] as const;
+export type VulnStatus = (typeof VULN_STATUSES)[number];
+
+/**
+ * Status values accepted as a FILTER. 'all' means "no status filter — return
+ * every status"; it is never persisted. Keeping it separate from VULN_STATUSES
+ * prevents a caller from accidentally storing 'all' as a finding status.
+ */
+export const VULN_STATUS_FILTERS = [...VULN_STATUSES, 'all'] as const;
+export type VulnStatusFilter = (typeof VULN_STATUS_FILTERS)[number];
+
+/** Catalog severity buckets (`vulnerabilities.severity`). */
+export const VULN_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+export type VulnSeverity = (typeof VULN_SEVERITIES)[number];
+
+/** Priority for a ticket created from findings (POST /vulnerabilities/tickets). */
+export const VULN_TICKET_PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
+export type VulnTicketPriority = (typeof VULN_TICKET_PRIORITIES)[number];
+
+// ============================================
+// Skip-reason model (closed vocabulary + human labels)
+// ============================================
+
+/**
+ * Stable per-item skip CODES for the bulk endpoints. The API routes/services
+ * currently emit human prose strings directly (see
+ * loadFindingsForBulkWrite / the /tickets route in routes/vulnerabilities.ts and
+ * services/vulnerabilityRemediation.ts). This closed code set is the canonical
+ * vocabulary those prose strings map onto; VULN_SKIP_REASON_LABELS below holds
+ * the current prose for each code. 'unknown' is the graceful fallback for any
+ * reason not in the closed set (e.g. a dynamic TicketServiceError message or a
+ * queue-driver error string).
+ */
+export const VULN_SKIP_REASONS = [
+  'not_found', // bulk write: 'finding not found'
+  'device_not_found', // remediation: 'device not found'
+  'site_access_denied', // 'site access denied'
+  'org_access_denied', // tickets: 'access to organization denied'
+  'not_open', // remediation: 'not an open vulnerability'
+  'no_available_patch', // remediation: 'no available patch'
+  'patch_not_approved', // remediation: 'patch not approved'
+  'queue_failed', // remediation: 'failed to queue install command'
+  'ticket_create_failed', // tickets: 'failed to create ticket'
+  'unknown', // fallback for unmapped / dynamic reasons
+] as const;
+export type VulnSkipReason = (typeof VULN_SKIP_REASONS)[number];
+
+/** Canonical human prose for each skip code (the strings the API emits today). */
+export const VULN_SKIP_REASON_LABELS: Record<VulnSkipReason, string> = {
+  not_found: 'finding not found',
+  device_not_found: 'device not found',
+  site_access_denied: 'site access denied',
+  org_access_denied: 'access to organization denied',
+  not_open: 'not an open vulnerability',
+  no_available_patch: 'no available patch',
+  patch_not_approved: 'patch not approved',
+  queue_failed: 'failed to queue install command',
+  ticket_create_failed: 'failed to create ticket',
+  unknown: 'unknown',
+};
+
+/** A single skipped item in a bulk outcome. */
+export interface SkippedItem {
+  id: string;
+  reason: VulnSkipReason;
+}
+
+// ============================================
+// Bulk outcomes
+// ============================================
+
+/**
+ * Shared base for every bulk-outcome shape: the one field they all carry is
+ * `skipped`. The three concrete outcomes below `extends` this so they SHARE the
+ * skip model while keeping their existing, wire-load-bearing count fields
+ * (`succeeded` / `scheduled` / `tickets`) intact — renaming any of those would
+ * be a breaking wire change. A generic BulkOutcome<T> is also provided for
+ * future callers that want a single parameterized shape.
+ */
+export interface BulkOutcomeBase {
+  skipped: SkippedItem[];
+}
+
+/**
+ * Generic unified bulk outcome. `items` is the domain payload (e.g. created
+ * tickets). Prefer the concrete interfaces below when matching an existing
+ * endpoint's wire shape; use this generic for new bulk endpoints.
+ */
+export interface BulkOutcome<T = never> extends BulkOutcomeBase {
+  success: boolean;
+  /** Count of items that succeeded (accept/mitigate semantics). */
+  succeeded: number;
+  items?: T[];
+}
+
+/** POST /vulnerabilities/bulk/accept-risk and /bulk/mitigate. */
+export interface BulkActionResult extends BulkOutcomeBase {
+  success: boolean;
+  succeeded: number;
+}
+
+/** POST /vulnerabilities/remediate. `scheduled` is the domain count (no `success`/`succeeded`). */
+export interface RemediateResult extends BulkOutcomeBase {
+  scheduled: number;
+}
+
+/** POST /vulnerabilities/tickets. One ticket per org; `tickets` is the domain payload. */
+export interface VulnTicketResult extends BulkOutcomeBase {
+  success: boolean;
+  tickets: Array<{ ticketId: string; orgId: string; findingCount: number }>;
+}
+
+// ============================================
+// Fleet-triage DTOs (canonical wire shapes)
+// ============================================
+
+/**
+ * A per-(device, CVE) finding row as fetched by the fleet-triage query layer
+ * (services/vulnerabilityFleetQueries.ts) and fed to the pure aggregation
+ * functions (services/vulnerabilityFleetAggregation.ts). Not a direct HTTP
+ * payload — an internal DTO shared so the aggregation input type is single-sourced.
+ */
+export interface FleetFindingRow {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  orgId: string;
+  status: VulnStatus;
+  riskScore: number | null;
+  detectedAt: string; // ISO
+  acceptedUntil: string | null; // ISO
+  ticketId: string | null;
+  /** Human ticket number (tickets.internal_number) for display; null when the
+   *  ticket predates numbering or is outside the caller's read scope. */
+  ticketNumber: string | null;
+  softwareInventoryId: string | null;
+  softwareName: string | null;
+  softwareVendor: string | null;
+  softwareVersion: string | null;
+  deviceName: string;
+  deviceOsType: 'windows' | 'macos' | 'linux';
+  orgName: string | null;
+  cveId: string;
+  vulnerabilityId: string;
+  severity: VulnSeverity | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  knownExploited: boolean;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  patchAvailable: boolean;
+}
+
+/** A remediation-unit row for the fleet work queue: one software product or OS pseudo-group. */
+export interface SoftwareGroup {
+  groupKey: string;
+  kind: 'software' | 'os';
+  name: string;
+  vendor: string | null;
+  versions: string[];
+  deviceCount: number;
+  cveCount: number;
+  cveIds: string[];
+  worstSeverity: VulnSeverity | null;
+  maxRiskScore: number | null;
+  kevCveCount: number;
+  maxEpss: number | null;
+  /** Open findings whose CVE has a patch available ("fixable right now"). */
+  patchReadyFindingCount: number;
+  /** Distinct devices with at least one patch-ready open finding. */
+  patchReadyDeviceCount: number;
+  /** Distinct linked tickets; `number` is the human ticket number (null for legacy tickets). */
+  tickets: Array<{ id: string; number: string | null }>;
+}
+
+/** A CVE rollup within a software group (drawer per-CVE table). */
+export interface GroupCve {
+  cveId: string;
+  vulnerabilityId: string;
+  severity: VulnSeverity | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  knownExploited: boolean;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  patchAvailable: boolean;
+  maxRiskScore: number | null;
+}
+
+/** A single finding row inside a group/CVE drawer. */
+export interface GroupFinding {
+  deviceVulnerabilityId: string;
+  deviceId: string;
+  deviceName: string;
+  orgId: string;
+  orgName: string | null;
+  cveId: string;
+  status: VulnStatus;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  patchAvailable: boolean;
+  riskScore: number | null;
+  detectedAt: string;
+  /** ISO expiry of an accepted-risk window. Non-null only when status === 'accepted'. */
+  acceptedUntil: string | null;
+  ticketId: string | null;
+  ticketNumber: string | null;
+}
+
+/** GET /vulnerabilities/software/:groupKey payload. */
+export interface SoftwareGroupDetail {
+  group: SoftwareGroup;
+  cves: GroupCve[];
+  findings: GroupFinding[];
+}
+
+/** GET /vulnerabilities/stats — the fleet stat-card numbers. */
+export interface FleetVulnStats {
+  criticalOpen: number;
+  kevCveCount: number;
+  kevDeviceCount: number;
+  patchReadyFindingCount: number;
+  acceptedExpiringSoon: number;
+  /** Findings across ALL statuses — the UI's "has scanning ever produced data"
+   *  signal, distinguishing a clean fleet from never-scanned. */
+  totalFindings: number;
+  /** Most recent detectedAt across all findings (ISO), null when none exist. */
+  lastDetectedAt: string | null;
+}
+
+/**
+ * A single reference from the CVE catalog. The `vulnerabilities.references`
+ * jsonb column is source-dependent: some feeds store bare URL strings, others
+ * store `{ url, source? }` objects. CveDrawer.tsx normalizes both shapes, so the
+ * type is the union of what the DB actually stores.
+ */
+export type CveReference = string | { url: string; source?: string };
+
+/** GET /vulnerabilities/:cveId/devices — the catalog record half of the payload. */
+export interface CveCatalogRecord {
+  cveId: string;
+  description: string;
+  /** Source-dependent jsonb; see CveReference. Callers must normalize defensively. */
+  references: CveReference[];
+  cvssVersion: string | null;
+  cvssVector: string | null;
+  cvssScore: number | null;
+  epssScore: number | null;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  knownExploited: boolean;
+  /** false OR unknown — the DB column is nullable and NULL is coalesced to false at read. */
+  patchAvailable: boolean;
+  severity: VulnSeverity | null;
+  publishedAt: string | null;
+  modifiedAt: string | null;
+}


### PR DESCRIPTION
## Vulnerabilities Fleet Triage UI

Turns the read-only `/vulnerabilities` fleet page into a fix-first triage work queue. Technicians can now triage from the fleet view (previously only possible per-device), and findings are grouped by remediation unit so one Chrome update is one row instead of ~30 identical Critical CVE rows.

Spec: `docs/superpowers/specs/2026-07-04-vulnerabilities-triage-ui-design.md`
Plans: `docs/superpowers/plans/2026-07-05-vulnerabilities-triage-api.md` · `-web.md`

### What's new

**UX**
- Four clickable stat cards (Critical open · KEV exposure · Patch ready · Accepted expiring) that apply the matching filter.
- Hash-based tabs: `#software` (default work queue, one row per remediation unit) and `#cves` (per-CVE report view), with a shared filter bar (search · severity · status · KEV-only · patch-available).
- Right-side slide-over drawers (hash-selected) for both grains, with permission-gated **remediate / accept-risk / mitigate / reopen / create-ticket** actions and per-item skip summaries.
- OS-level CVEs roll into per-platform pseudo-groups (`Windows OS updates`, `macOS updates`, …) so nothing falls out of the queue.

**Backend** (`apps/api/src/routes/vulnerabilities.ts` + new services)
- Pure aggregation service (`vulnerabilityFleetAggregation.ts`, zero DB, exhaustively unit-tested) + fetch layer (`vulnerabilityFleetQueries.ts`).
- 4 read endpoints: `/software`, `/software/:groupKey`, `/stats`, `/:cveId/devices`; `kevOnly`/`patchAvailable` added to the existing fleet `GET /`.
- 2 bulk mutation endpoints (`/bulk/accept-risk`, `/bulk/mitigate`) — per-item fault-tolerant `{ success, succeeded, skipped }`.
- `/tickets` — creates native tickets from findings, splitting one ticket per org on a cross-org selection and stamping `ticket_id` on the right org's findings only.
- One idempotent migration adding `device_vulnerabilities.ticket_id` (FK `ON DELETE SET NULL` + partial index). No new tables → no RLS allowlist changes.

**Frontend**
- Shared `Drawer.tsx` primitive extracted verbatim from the catalog editor chrome (a11y, animations, focus-trap).
- Software-grouped work-queue table, reworked CVE tab, hash-routed page shell, two action drawers + create-ticket modal.

### Tenancy / safety
- Org isolation via RLS; site axis narrowed app-layer via `allowedSiteIds`; catalog read under system context. Cross-org ticket split verified to stamp `ticketId` only on each org's own findings. Final whole-branch review confirmed isolation holds across all new endpoints.

### Testing
- API: aggregation unit tests + route tests (auth/RBAC, validation bounds, 200-id caps, per-item skips, cross-org split, `ticket_id` stamping).
- Web: component tests for tables, drawers, action flows, permission-hiding, stat-card filters; all mutations wrapped in `runAction` (`no-silent-mutations` count 58→63).
- E2E: Playwright triage happy path (open queue → drawer → accept-risk → reopen), self-restoring seed state. The 3 vuln specs pass individually against a live stack; full-suite + drift check run in CI.

### Deferred (non-blocking, from review)
- `/stats` could move to a SQL `GROUP BY`/`COUNT` for very large fleets (currently in-memory, RLS-scoped, matches existing `GET /`).
- A real-Postgres integration test for tenant isolation on `/tickets` + the bulk site-skip branch would close the one gap the unit mocks can't reach.
- Task 17 (optional refactor of `CatalogItemEditorDrawer` onto the shared `Drawer`) intentionally deferred to a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
