### PR TITLE
feat(web): add clickable Billing tab to org settings

### DIFF
--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   Copy,
   Check,
+  CreditCard,
   FileSignature,
   Fingerprint,
   Globe,
@@ -17,6 +18,7 @@ import {
   Ticket
 } from 'lucide-react';
 import ContractsList from '../contracts/ContractsList';
+import OrgBillingSettings from '../billing/OrgBillingSettings';
 import SettingsSectionNav, { type SettingsNavGroup } from './SettingsSectionNav';
 import OrgBrandingEditor from './OrgBrandingEditor';
 import OrgPortalSettingsEditor from './OrgPortalSettingsEditor';
@@ -36,7 +38,7 @@ import { formatTime as formatUserTime } from '@/lib/dateTimeFormat';
 
 type TabKey =
   | 'general' | 'branding' | 'portal' | 'notifications' | 'security'
-  | 'approval-security' | 'event-logs' | 'remote-access' | 'ticketing' | 'contracts';
+  | 'approval-security' | 'event-logs' | 'remote-access' | 'ticketing' | 'contracts' | 'billing';
 
 // Grouped sidebar definition — same anatomy as PartnerSettingsPage (shared
 // SettingsSectionNav). Hashes are the section keys (already kebab-case).
@@ -46,6 +48,7 @@ const TAB_GROUPS: (Omit<SettingsNavGroup, 'items'> & { items: (SettingsNavGroup[
     items: [
       { key: 'general', hash: 'general', label: 'General', description: 'Profile and defaults', icon: Building2 },
       { key: 'contracts', hash: 'contracts', label: 'Contracts', description: 'Recurring agreements', icon: FileSignature },
+      { key: 'billing', hash: 'billing', label: 'Billing', description: 'Tax and billing address', icon: CreditCard },
     ],
   },
   {
@@ -536,6 +539,12 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         return effectiveOrgId ? (
           <div data-testid="org-tab-contracts">
             <ContractsList lockedOrgId={effectiveOrgId} />
+          </div>
+        ) : null;
+      case 'billing':
+        return effectiveOrgId ? (
+          <div data-testid="org-tab-billing">
+            <OrgBillingSettings orgId={effectiveOrgId} />
           </div>
         ) : null;
       case 'general':


### PR DESCRIPTION
## What & why

The organization billing settings page — tax identity + billing address used on that customer's invoices — lived only at `/settings/organizations/{id}/billing` and had **no tab or link** pointing to it from the org settings screen. The sidebar nav (General, Contracts, Branding, Portal, Security, …) had no Billing entry, so in practice it was reachable only by typing the URL.

## Change

- Add a **Billing** tab (CreditCard icon, "Tax and billing address") to the **Organization** group in `OrgSettingsPage.tsx`, next to Contracts.
- Render the existing `OrgBillingSettings` component inline. It's fully self-contained (own load/save + Save button), so it drops in with no dirty/save wiring — same pattern already used by the `approval-security` tab.
- Deep-linkable via the `#billing` hash; survives back/forward like the other tabs.

## Notes

- The standalone `billing.astro` page is left in place — nothing links to it (verified via grep), so removing it carries bookmark-breaking risk with no benefit. The tab is now the canonical, discoverable path.
- No existing test enumerated the org settings tabs, so nothing broke. The tab content is tagged `data-testid="org-tab-billing"`, matching the `org-tab-contracts` convention.

## Test plan

- Settings → Organizations → pick an org → **Billing** tab appears in the sidebar and renders the Tax + Billing address form.
- Works both via the org switcher and by direct URL (`effectiveOrgId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)