### PR TITLE
feat(quotes): deposits — percent or selected-line, deposit-first invoicing

### DIFF
--- a/apps/api/migrations/2026-07-06-quote-deposits.sql
+++ b/apps/api/migrations/2026-07-06-quote-deposits.sql
@@ -1,0 +1,15 @@
+-- Quote deposits (spec: docs/superpowers/specs/2026-07-05-quote-deposits-design.md).
+-- Columns only — no new tables, RLS untouched.
+
+DO $$ BEGIN
+  CREATE TYPE quote_deposit_type AS ENUM ('none', 'percent', 'selected_lines');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS deposit_type quote_deposit_type NOT NULL DEFAULT 'none';
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS deposit_percent numeric(5,2);
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS deposit_amount numeric(12,2);
+
+ALTER TABLE quote_lines ADD COLUMN IF NOT EXISTS deposit_eligible boolean NOT NULL DEFAULT false;
+ALTER TABLE quote_lines ADD COLUMN IF NOT EXISTS item_type catalog_item_type;
+
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS deposit_due numeric(12,2);

--- a/apps/api/migrations/2026-07-06-z-quote-deposit-constraints.sql
+++ b/apps/api/migrations/2026-07-06-z-quote-deposit-constraints.sql
@@ -1,0 +1,33 @@
+-- Defense-in-depth CHECK constraints for the deposit columns added in
+-- 2026-07-06-quote-deposits.sql. The 0<percent<100 range and the
+-- non-percent-type-carries-no-percent invariant are enforced in the app layer
+-- (validateQuoteDeposit + updateQuoteSchema.refine), but any future write path
+-- that bypasses updateQuote (a new route, a backfill, an AI tool, direct SQL)
+-- could otherwise persist an out-of-range percent or a percent on a non-percent
+-- deposit. Enforce it at the lowest layer too.
+--
+-- Deliberately NOT a strict `(deposit_type='percent') = (deposit_percent IS NOT
+-- NULL)` biconditional: a draft may legitimately hold deposit_type='percent'
+-- before the user has entered the percentage (recompute stores NULL; the
+-- send-time gate blocks the quote from going out). We only forbid the always-false
+-- combination — a NON-percent type carrying a percent value.
+
+DO $$ BEGIN
+  ALTER TABLE quotes ADD CONSTRAINT quotes_deposit_percent_range_chk
+    CHECK (deposit_percent IS NULL OR (deposit_percent > 0 AND deposit_percent < 100));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE quotes ADD CONSTRAINT quotes_deposit_percent_type_chk
+    CHECK (deposit_type = 'percent' OR deposit_percent IS NULL);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE quotes ADD CONSTRAINT quotes_deposit_amount_nonneg_chk
+    CHECK (deposit_amount IS NULL OR deposit_amount >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE invoices ADD CONSTRAINT invoices_deposit_due_nonneg_chk
+    CHECK (deposit_due IS NULL OR deposit_due >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/api/src/__tests__/integration/quoteDeposit.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteDeposit.integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * End-to-end real-Postgres happy path for the quote-deposits feature (Task 14).
+ * Exercises the full lifecycle in one sequential flow — draft → deposit config →
+ * send → accept (invoice + contract) → chargeNow → deposit payment → chargeNow
+ * again → due-date update → final payment → content-hash binding — against a
+ * real DB, not mocks. Mirrors the harness of quoteAccept.integration.test.ts and
+ * quotePay.integration.test.ts (org-scope ctx/actor helpers, `runDb` gate,
+ * withSystemDbAccessContext for tenant seeding + read-back assertions).
+ *
+ * Money trail (asserted at every step so a regression in quoteMath/invoiceMath/
+ * depositMath surfaces here immediately):
+ *   catalog line (hardware, taxable):      6200.00
+ *   manual labor line (taxable):           2400.00
+ *   monthly recurring line:                 300.00 (excluded from one-time math)
+ *   tax rate:                                 10%
+ *   dueOnAcceptance = (6200+2400) + 10% tax = 8600 + 860 = 9460.00
+ *   deposit (selected_lines, catalog line only) = 6200 + 10% = 6820.00
+ *   balance after deposit payment = 9460 − 6820 = 2640.00
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { quotes, quoteBlocks, quoteLines, quoteAcceptances } from '../../db/schema/quotes';
+import { invoices } from '../../db/schema/invoices';
+import { contracts } from '../../db/schema/contracts';
+import { catalogItems } from '../../db/schema/catalog';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote, addManualLine, addCatalogLine, updateQuote, getQuote } from '../../services/quoteService';
+import { sendQuote } from '../../services/quoteLifecycle';
+import { acceptQuote } from '../../services/quoteAcceptService';
+import { recordPayment, updateIssuedDueDate, getInvoice } from '../../services/invoiceService';
+import { computeQuoteSha256 } from '../../services/quoteContentHash';
+import { computeChargeNow } from '@breeze/shared';
+import type { QuoteActor } from '../../services/quoteTypes';
+import type { InvoiceActor } from '../../services/invoiceTypes';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function ctxFor(orgId: string, partnerId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null };
+}
+function qActor(orgId: string, partnerId: string): QuoteActor {
+  return { userId: null, partnerId, accessibleOrgIds: [orgId] };
+}
+function iActor(orgId: string, partnerId: string): InvoiceActor {
+  return { userId: null, partnerId, accessibleOrgIds: [orgId] };
+}
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    return { partner, org };
+  });
+}
+
+/** Seed a taxable hardware catalog item (system scope bypasses RLS for the seed). */
+async function seedHardwareCatalogItem(partnerId: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.insert(catalogItems).values({
+      partnerId,
+      itemType: 'hardware',
+      name: 'Managed switch',
+      unitPrice: '6200.00',
+      billingType: 'one_time',
+      taxable: true,
+      isBundle: false,
+    }).returning({ id: catalogItems.id });
+    return { id: row!.id };
+  });
+}
+
+describe('quote deposits: accept → deposit → balance (breeze_app, real DB)', () => {
+  runDb('full deposit lifecycle: draft → selected_lines deposit → send → accept → chargeNow → deposit payment → chargeNow → due-date update → final payment → content-hash binding', async () => {
+    const { partner, org } = await seed();
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = qActor(org.id, partner.id);
+    const invActor = iActor(org.id, partner.id);
+
+    // --- Step 1: draft quote with a hardware catalog line, a manual labor line,
+    // and a monthly recurring line; both one-time lines are taxable. ---
+    const item = await seedHardwareCatalogItem(partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+
+    const catalogLine = await withDbAccessContext(ctx, () =>
+      addCatalogLine(created.id, item.id, 1, undefined, actor)
+    );
+    expect(catalogLine.unitPrice).toBe('6200.00');
+    expect(catalogLine.taxable).toBe(true);
+    // Hardware auto-defaults to deposit-eligible (addCatalogLine snapshot rule).
+    expect(catalogLine.depositEligible).toBe(true);
+    expect(catalogLine.itemType).toBe('hardware');
+
+    await withDbAccessContext(ctx, () =>
+      addManualLine(created.id, {
+        sourceType: 'manual', description: 'Installation labor', quantity: 1, unitPrice: 2400,
+        taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false,
+      }, actor)
+    );
+    await withDbAccessContext(ctx, () =>
+      addManualLine(created.id, {
+        sourceType: 'manual', description: 'Managed services', quantity: 1, unitPrice: 300,
+        taxable: false, customerVisible: true, recurrence: 'monthly', depositEligible: false,
+      }, actor)
+    );
+
+    // 10% tax.
+    await withDbAccessContext(ctx, () => updateQuote(created.id, { taxRate: 0.10 }, actor));
+
+    // --- Step 2: configure a selected_lines deposit — only the (deposit-eligible)
+    // hardware line counts: 6200 + 10% tax = 6820.00. ---
+    const withDeposit = await withDbAccessContext(ctx, () =>
+      updateQuote(created.id, { depositType: 'selected_lines' }, actor)
+    );
+    expect(withDeposit.depositAmount).toBe('6820.00');
+
+    const fetched = await withDbAccessContext(ctx, () => getQuote(created.id, actor));
+    expect(fetched.quote.dueOnAcceptanceTotal).toBe('9460.00'); // (6200+2400) + 10% tax
+    expect(fetched.quote.depositDueTotal).toBe('6820.00');
+    const fetchedCatalogLine = fetched.lines.find((l) => l.id === catalogLine.id)!;
+    expect(fetchedCatalogLine.depositEligible).toBe(true);
+    expect(fetchedCatalogLine.itemType).toBe('hardware');
+
+    // --- Step 3: send → accept. Invoice issued for the one-time total, deposit
+    // due carried over from the quote; monthly line spins off a draft contract. ---
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+    const res = await withDbAccessContext(ctx, () =>
+      acceptQuote({ quoteId: created.id, signerName: 'Jane Buyer', signerEmail: 'jane@org.example' })
+    );
+    expect(res.invoiceIssued).toBe(true);
+
+    const [invoiceRow] = await withSystemDbAccessContext(() =>
+      db.select().from(invoices).where(eq(invoices.id, res.invoiceId))
+    );
+    expect(invoiceRow!.status).toBe('sent');
+    expect(invoiceRow!.total).toBe('9460.00'); // 8600 + 860 tax
+    expect(invoiceRow!.balance).toBe('9460.00');
+    expect(invoiceRow!.depositDue).toBe('6820.00');
+
+    const [quoteAfterAccept] = await withSystemDbAccessContext(() =>
+      db.select().from(quotes).where(eq(quotes.id, created.id))
+    );
+    expect(quoteAfterAccept!.status).toBe('converted');
+    expect(quoteAfterAccept!.convertedInvoiceId).toBe(res.invoiceId);
+
+    expect(res.contractIds).toHaveLength(1);
+    const [contract] = await withSystemDbAccessContext(() =>
+      db.select().from(contracts).where(eq(contracts.id, res.contractIds[0]!))
+    );
+    expect(contract!.status).toBe('draft');
+    expect(contract!.intervalMonths).toBe(1); // the monthly line's cadence
+
+    // --- Step 4: chargeNow on the freshly-issued invoice targets the deposit. ---
+    let chargeNow = computeChargeNow({
+      depositDue: invoiceRow!.depositDue, amountPaid: invoiceRow!.amountPaid, balance: invoiceRow!.balance,
+    });
+    expect(chargeNow).toEqual({ amount: '6820.00', isDeposit: true });
+
+    // --- Step 5: record the deposit payment. Status flips to partially_paid;
+    // balance is the remainder; chargeNow now targets the full remaining balance. ---
+    await withDbAccessContext(ctx, () =>
+      recordPayment(res.invoiceId, { amount: 6820.00, method: 'bank_transfer', receivedAt: new Date().toISOString().slice(0, 10) }, invActor)
+    );
+    const afterDeposit = await withDbAccessContext(ctx, () => getInvoice(res.invoiceId, invActor));
+    expect(afterDeposit.invoice.status).toBe('partially_paid');
+    expect(afterDeposit.invoice.balance).toBe('2640.00');
+    expect(afterDeposit.invoice.amountPaid).toBe('6820.00');
+
+    chargeNow = computeChargeNow({
+      depositDue: afterDeposit.invoice.depositDue, amountPaid: afterDeposit.invoice.amountPaid, balance: afterDeposit.invoice.balance,
+    });
+    expect(chargeNow).toEqual({ amount: '2640.00', isDeposit: false });
+
+    // --- Step 6: due-date update succeeds on the still-open (partially_paid)
+    // invoice and is reflected on read-back. ---
+    const futureDueDate = new Date(Date.now() + 45 * 86400000).toISOString().slice(0, 10);
+    const dueDateResult = await withDbAccessContext(ctx, () =>
+      updateIssuedDueDate(res.invoiceId, futureDueDate, invActor)
+    );
+    expect(dueDateResult.invoice.dueDate).toBe(futureDueDate);
+    const afterDueDateUpdate = await withDbAccessContext(ctx, () => getInvoice(res.invoiceId, invActor));
+    expect(afterDueDateUpdate.invoice.dueDate).toBe(futureDueDate);
+
+    // --- Step 7: pay off the remaining balance → invoice fully paid. ---
+    await withDbAccessContext(ctx, () =>
+      recordPayment(res.invoiceId, { amount: 2640.00, method: 'bank_transfer', receivedAt: new Date().toISOString().slice(0, 10) }, invActor)
+    );
+    const afterFinalPayment = await withDbAccessContext(ctx, () => getInvoice(res.invoiceId, invActor));
+    expect(afterFinalPayment.invoice.status).toBe('paid');
+    expect(afterFinalPayment.invoice.balance).toBe('0.00');
+
+    // --- Step 8: the signed content hash binds the deposit terms — hashing the
+    // same quote content with the deposit stripped must NOT reproduce the stored
+    // hash (the customer signed the deposit terms as part of the acceptance). ---
+    const [acceptance] = await withSystemDbAccessContext(() =>
+      db.select().from(quoteAcceptances).where(eq(quoteAcceptances.quoteId, created.id))
+    );
+    expect(acceptance!.quoteSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    const blocksForHash = await withSystemDbAccessContext(() =>
+      db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, created.id))
+    );
+    const linesForHash = await withSystemDbAccessContext(() =>
+      db.select().from(quoteLines).where(eq(quoteLines.quoteId, created.id))
+    );
+    // Sanity: recomputing the hash from the (unchanged) persisted quote/lines
+    // reproduces the exact hash stored at accept time.
+    const recomputedHash = computeQuoteSha256(quoteAfterAccept as any, blocksForHash as any, linesForHash as any);
+    expect(recomputedHash).toBe(acceptance!.quoteSha256);
+
+    // Now strip the deposit terms and hash again — must differ.
+    const strippedHash = computeQuoteSha256(
+      { ...(quoteAfterAccept as any), depositType: 'none', depositPercent: null, depositAmount: null },
+      blocksForHash as any,
+      linesForHash as any,
+    );
+    expect(strippedHash).not.toBe(acceptance!.quoteSha256);
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteService.integration.test.ts
@@ -142,6 +142,7 @@ describe('quoteService (breeze_app, real DB)', () => {
         taxable: false,
         customerVisible: true,
         recurrence: 'one_time',
+        depositEligible: false,
       }, fx.actorA)
     );
     expect(line.lineTotal).toBe('300.00'); // 3 * 100.00 via computeLineTotal
@@ -197,7 +198,7 @@ describe('quoteService (breeze_app, real DB)', () => {
     const line = await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Widget', quantity: 2, unitPrice: 50,
-        taxable: false, customerVisible: true, recurrence: 'one_time',
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
       }, fx.actorA)
     );
     let fetched = await withDbAccessContext(fx.ctxA, () => getQuote(quote.id, fx.actorA));
@@ -252,7 +253,7 @@ describe('quoteService (breeze_app, real DB)', () => {
     await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Doomed line', quantity: 1, unitPrice: 10,
-        taxable: false, customerVisible: true, recurrence: 'one_time',
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
       }, fx.actorA)
     );
 
@@ -279,19 +280,19 @@ describe('quoteService (breeze_app, real DB)', () => {
     await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Sub-cent unit price', quantity: 3, unitPrice: 0.34,
-        taxable: false, customerVisible: true, recurrence: 'one_time',
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false,
       }, fx.actorA)
     );
     await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Monthly seat', quantity: 7, unitPrice: 12.50,
-        taxable: false, customerVisible: true, recurrence: 'monthly',
+        taxable: false, customerVisible: true, recurrence: 'monthly', depositEligible: false,
       }, fx.actorA)
     );
     await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Internal cost (hidden)', quantity: 1, unitPrice: 999.99,
-        taxable: false, customerVisible: false, recurrence: 'one_time',
+        taxable: false, customerVisible: false, recurrence: 'one_time', depositEligible: false,
       }, fx.actorA)
     );
 
@@ -337,13 +338,13 @@ describe('quoteService (breeze_app, real DB)', () => {
     const oneTime = await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Setup fee', quantity: 2, unitPrice: 75,
-        taxable: false, customerVisible: true, recurrence: 'one_time', blockId: block.id,
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, blockId: block.id,
       }, fx.actorA)
     );
     const monthly = await withDbAccessContext(fx.ctxA, () =>
       addManualLine(quote.id, {
         sourceType: 'manual', description: 'Monthly support', quantity: 4, unitPrice: 25,
-        taxable: false, customerVisible: true, recurrence: 'monthly', blockId: block.id,
+        taxable: false, customerVisible: true, recurrence: 'monthly', depositEligible: false, blockId: block.id,
       }, fx.actorA)
     );
 
@@ -627,7 +628,7 @@ describe('quoteService (breeze_app, real DB)', () => {
       const mk = (name: string, blockId: string) =>
         addManualLine(quote.id, {
           sourceType: 'manual', name, description: null, quantity: 1, unitPrice: 10,
-          taxable: false, customerVisible: true, recurrence: 'one_time', blockId,
+          taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, blockId,
         }, fx.actorA);
       const lineA1 = await mk('A1', blockA.id);
       const lineA2 = await mk('A2', blockA.id);

--- a/apps/api/src/__tests__/integration/quoteService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteService.integration.test.ts
@@ -759,7 +759,7 @@ describe('quoteService (breeze_app, real DB)', () => {
       const b2 = await addBlock(q2.id, { blockType: 'line_items', content: {} }, fx.actorA);
       return addManualLine(q2.id, {
         sourceType: 'manual', name: 'foreign', description: null, quantity: 1, unitPrice: 10,
-        taxable: false, customerVisible: true, recurrence: 'one_time', blockId: b2.id,
+        taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, blockId: b2.id,
       }, fx.actorA);
     });
     await expect(withDbAccessContext(fx.ctxA, () =>

--- a/apps/api/src/db/schema/invoices.ts
+++ b/apps/api/src/db/schema/invoices.ts
@@ -40,6 +40,8 @@ export const invoices = pgTable('invoices', {
   total: numeric('total', { precision: 12, scale: 2 }).notNull().default('0'),
   amountPaid: numeric('amount_paid', { precision: 12, scale: 2 }).notNull().default('0'),
   balance: numeric('balance', { precision: 12, scale: 2 }).notNull().default('0'),
+  // Deposit due at acceptance, snapshotted from the quote. NULL = ordinary invoice.
+  depositDue: numeric('deposit_due', { precision: 12, scale: 2 }),
   billToName: varchar('bill_to_name', { length: 255 }),
   billToAddress: jsonb('bill_to_address'),
   billToTaxId: varchar('bill_to_tax_id', { length: 100 }),

--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -43,8 +43,11 @@ export const quotes = pgTable('quotes', {
   annualRecurringTotal: numeric('annual_recurring_total', { precision: 12, scale: 2 }).notNull().default('0'),
   depositType: quoteDepositTypeEnum('deposit_type').notNull().default('none'),
   // Whole-percent scale (30.00 = 30%), only meaningful for deposit_type='percent'.
+  // CHECK quotes_deposit_percent_range_chk (0<pct<100) + quotes_deposit_percent_type_chk
+  // (non-percent types carry no percent), migration 2026-07-06-z, enforce it at the DB.
   depositPercent: numeric('deposit_percent', { precision: 5, scale: 2 }),
   // Stored snapshot of the computed deposit due; recomputed on every draft edit.
+  // CHECK quotes_deposit_amount_nonneg_chk (migration 2026-07-06-z) forbids negatives.
   depositAmount: numeric('deposit_amount', { precision: 12, scale: 2 }),
   billToName: varchar('bill_to_name', { length: 255 }),
   billToAddress: jsonb('bill_to_address'),

--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -7,6 +7,7 @@ import { partners, organizations } from './orgs';
 // Reuse the exported `bytea` custom type (Buffer-mapped) from users.ts instead
 // of redefining it locally — same pattern as users.avatarData.
 import { users, bytea } from './users';
+import { catalogItemTypeEnum } from './catalog';
 
 export const quoteStatusEnum = pgEnum('quote_status', [
   'draft', 'sent', 'viewed', 'accepted', 'declined', 'expired', 'converted'
@@ -14,6 +15,7 @@ export const quoteStatusEnum = pgEnum('quote_status', [
 export const quoteLineSourceTypeEnum = pgEnum('quote_line_source_type', ['catalog', 'bundle', 'manual']);
 export const quoteLineRecurrenceEnum = pgEnum('quote_line_recurrence', ['one_time', 'monthly', 'annual']);
 export const quoteBlockTypeEnum = pgEnum('quote_block_type', ['heading', 'rich_text', 'image', 'line_items']);
+export const quoteDepositTypeEnum = pgEnum('quote_deposit_type', ['none', 'percent', 'selected_lines']);
 
 function sqlNumberPresent(t: { quoteNumber: unknown }): SQL { return sql`${t.quoteNumber} IS NOT NULL`; }
 function sqlOpenForExpiry(t: { status: unknown }): SQL { return sql`${t.status} IN ('sent','viewed')`; }
@@ -39,6 +41,11 @@ export const quotes = pgTable('quotes', {
   oneTimeTotal: numeric('one_time_total', { precision: 12, scale: 2 }).notNull().default('0'),
   monthlyRecurringTotal: numeric('monthly_recurring_total', { precision: 12, scale: 2 }).notNull().default('0'),
   annualRecurringTotal: numeric('annual_recurring_total', { precision: 12, scale: 2 }).notNull().default('0'),
+  depositType: quoteDepositTypeEnum('deposit_type').notNull().default('none'),
+  // Whole-percent scale (30.00 = 30%), only meaningful for deposit_type='percent'.
+  depositPercent: numeric('deposit_percent', { precision: 5, scale: 2 }),
+  // Stored snapshot of the computed deposit due; recomputed on every draft edit.
+  depositAmount: numeric('deposit_amount', { precision: 12, scale: 2 }),
   billToName: varchar('bill_to_name', { length: 255 }),
   billToAddress: jsonb('bill_to_address'),
   billToTaxId: varchar('bill_to_tax_id', { length: 100 }),
@@ -101,6 +108,11 @@ export const quoteLines = pgTable('quote_lines', {
   billingFrequency: varchar('billing_frequency', { length: 20 }),
   // Internal builder economics — never serialized to the customer document.
   unitCost: numeric('unit_cost', { precision: 12, scale: 2 }),
+  // Counts toward a 'selected_lines' deposit. Catalog hardware defaults it on.
+  depositEligible: boolean('deposit_eligible').notNull().default(false),
+  // Catalog item type snapshotted at add-time (null for manual lines) — drives
+  // the per-category subtotal breakdown without a portal-invisible catalog join.
+  itemType: catalogItemTypeEnum('item_type'),
   sku: varchar('sku', { length: 100 }),
   partNumber: varchar('part_number', { length: 100 }),
   // Optional per-line product image (quote_images row on the SAME quote; the

--- a/apps/api/src/routes/invoices/invoices.test.ts
+++ b/apps/api/src/routes/invoices/invoices.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../services/invoiceService', () => ({
   removeLine: vi.fn(),
   deleteDraftInvoice: vi.fn(),
   updateInvoice: vi.fn(),
+  updateIssuedDueDate: vi.fn(),
   issueInvoice: vi.fn(),
   voidInvoice: vi.fn(),
   recordPayment: vi.fn(),
@@ -62,6 +63,7 @@ import { invoiceAssemblyRoutes } from './assembly';
 import * as svc from '../../services/invoiceService';
 import * as pdfSvc from '../../services/invoicePdf';
 import * as brandingSvc from '../../services/quoteBranding';
+import { writeRouteAudit } from '../../services/auditEvents';
 import { InvoiceServiceError } from '../../services/invoiceTypes';
 
 function app() {
@@ -191,6 +193,59 @@ describe('invoice crud + lines routes', () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.code).toBe('NOTHING_TO_INVOICE');
+  });
+});
+
+describe('invoice due-date route', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('PATCH /:id/due-date rejects a malformed date (400, no service call)', async () => {
+    const res = await app().request(`/${INV_ID}/due-date`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ dueDate: '09/01/2026' })
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateIssuedDueDate).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /:id/due-date updates the due date and writes invoice.due_date.updated to the audit chain', async () => {
+    (svc.updateIssuedDueDate as any).mockResolvedValue({
+      invoice: { id: INV_ID, dueDate: '2026-09-01', status: 'sent' },
+      audit: { orgId: ORG_ID, invoiceId: INV_ID, oldDueDate: '2026-06-01', newDueDate: '2026-09-01' }
+    });
+    const res = await app().request(`/${INV_ID}/due-date`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ dueDate: '2026-09-01' })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.dueDate).toBe('2026-09-01');
+    expect(svc.updateIssuedDueDate).toHaveBeenCalledWith(INV_ID, '2026-09-01', expect.anything());
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), {
+      orgId: ORG_ID,
+      action: 'invoice.due_date.updated',
+      resourceType: 'invoice',
+      resourceId: INV_ID,
+      details: { oldDueDate: '2026-06-01', newDueDate: '2026-09-01' }
+    });
+  });
+
+  it('maps an INVALID_STATE InvoiceServiceError from updateIssuedDueDate to 409', async () => {
+    (svc.updateIssuedDueDate as any).mockRejectedValue(
+      new InvoiceServiceError('Due date can only be changed on an open issued invoice', 409, 'INVALID_STATE')
+    );
+    const res = await app().request(`/${INV_ID}/due-date`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ dueDate: '2026-09-01' })
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe('INVALID_STATE');
+    expect(writeRouteAudit).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/invoices/invoices.test.ts
+++ b/apps/api/src/routes/invoices/invoices.test.ts
@@ -209,6 +209,20 @@ describe('invoice due-date route', () => {
     expect(svc.updateIssuedDueDate).not.toHaveBeenCalled();
   });
 
+  it('PATCH /:id/due-date rejects a non-calendar date that passes the regex (400, no service call)', async () => {
+    // 2026-13-40 matches \d{4}-\d{2}-\d{2} but is not a real date — Date would
+    // silently roll it over to a later valid date instead of erroring, and
+    // without the round-trip refine this used to reach the service and 500 at
+    // the Postgres DATE column.
+    const res = await app().request(`/${INV_ID}/due-date`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ dueDate: '2026-13-40' })
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateIssuedDueDate).not.toHaveBeenCalled();
+  });
+
   it('PATCH /:id/due-date updates the due date and writes invoice.due_date.updated to the audit chain', async () => {
     (svc.updateIssuedDueDate as any).mockResolvedValue({
       invoice: { id: INV_ID, dueDate: '2026-09-01', status: 'sent' },

--- a/apps/api/src/routes/invoices/invoices.ts
+++ b/apps/api/src/routes/invoices/invoices.ts
@@ -9,8 +9,9 @@ import {
 } from '@breeze/shared';
 import {
   createManualInvoice, getInvoice, listInvoices, addManualLine, addCatalogLine, addBundleLine,
-  updateLine, removeLine, deleteDraftInvoice, updateInvoice
+  updateLine, removeLine, deleteDraftInvoice, updateInvoice, updateIssuedDueDate
 } from '../../services/invoiceService';
+import { writeRouteAudit } from '../../services/auditEvents';
 import { InvoiceServiceError, type InvoiceActor } from '../../services/invoiceTypes';
 import { resolveQuoteBranding } from '../../services/quoteBranding';
 
@@ -20,6 +21,7 @@ const readPerm = requirePermission(PERMISSIONS.INVOICES_READ.resource, PERMISSIO
 const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
 const idParam = z.object({ id: z.string().guid() });
 const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
+const dueDateSchema = z.object({ dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD') });
 
 export function invoiceActorFrom(c: { get: (k: string) => unknown }): InvoiceActor {
   const auth = c.get('auth') as AuthContext;
@@ -67,6 +69,19 @@ invoiceCrudRoutes.post('/:id/lines/catalog', scopes, writePerm, zValidator('para
 invoiceCrudRoutes.post('/:id/lines/bundle', scopes, writePerm, zValidator('param', idParam), zValidator('json', bundleLineSchema), async (c) => {
   try { const b = c.req.valid('json'); return c.json({ data: await addBundleLine(c.req.valid('param').id, b.bundleId, b.quantity, invoiceActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
+});
+invoiceCrudRoutes.patch('/:id/due-date', scopes, writePerm, zValidator('param', idParam), zValidator('json', dueDateSchema), async (c) => {
+  try {
+    const { invoice, audit } = await updateIssuedDueDate(c.req.valid('param').id, c.req.valid('json').dueDate, invoiceActorFrom(c));
+    writeRouteAudit(c, {
+      orgId: audit.orgId,
+      action: 'invoice.due_date.updated',
+      resourceType: 'invoice',
+      resourceId: audit.invoiceId,
+      details: { oldDueDate: audit.oldDueDate, newDueDate: audit.newDueDate },
+    });
+    return c.json({ data: invoice });
+  } catch (err) { return handleServiceError(c, err); }
 });
 invoiceCrudRoutes.patch('/:id/lines/:lineId', scopes, writePerm, zValidator('param', lineParam), zValidator('json', updateLineSchema), async (c) => {
   try { const p = c.req.valid('param'); return c.json({ data: await updateLine(p.id, p.lineId, c.req.valid('json'), invoiceActorFrom(c)) }); }

--- a/apps/api/src/routes/invoices/invoices.ts
+++ b/apps/api/src/routes/invoices/invoices.ts
@@ -21,7 +21,19 @@ const readPerm = requirePermission(PERMISSIONS.INVOICES_READ.resource, PERMISSIO
 const writePerm = requirePermission(PERMISSIONS.INVOICES_WRITE.resource, PERMISSIONS.INVOICES_WRITE.action);
 const idParam = z.object({ id: z.string().guid() });
 const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
-const dueDateSchema = z.object({ dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD') });
+const dueDateSchema = z.object({
+  dueDate: z.string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD')
+    .refine((s) => {
+      // The regex alone accepts non-calendar dates like 2026-13-40 — Date parses
+      // those by rolling over into the next month/year, so round-trip the parsed
+      // date back to a YYYY-MM-DD string and require it to match verbatim. A
+      // rolled-over date silently reaches the invoiceService update and 500s at
+      // the Postgres DATE column instead of failing validation here.
+      const d = new Date(`${s}T00:00:00Z`);
+      return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+    }, 'invalid calendar date'),
+});
 
 export function invoiceActorFrom(c: { get: (k: string) => unknown }): InvoiceActor {
   const auth = c.get('auth') as AuthContext;

--- a/apps/api/src/routes/portal/invoices.test.ts
+++ b/apps/api/src/routes/portal/invoices.test.ts
@@ -213,6 +213,58 @@ describe('portal invoices routes', () => {
     }));
   });
 
+  it('POST /invoices/:id/pay charges the deposit-remaining amount while the deposit is unmet', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '10000.00', depositDue: '3000.00', amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-DEP',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient('acct_9'));
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_dep', url: 'https://checkout.stripe.com/c/cs_dep', payment_intent: 'pi_dep' });
+
+    const res = await app().request(`/invoices/${INV_ID}/pay`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(sessionsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [expect.objectContaining({
+          price_data: expect.objectContaining({
+            unit_amount: 300000,
+            product_data: { name: 'Deposit — Invoice INV-DEP' },
+          }),
+        })],
+        metadata: expect.objectContaining({ invoice_balance_cents: '300000' }),
+      }),
+      { idempotencyKey: `inv_${INV_ID}_300000` },
+    );
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '3000.00' }));
+  });
+
+  it('POST /invoices/:id/pay charges the remaining balance (plain name) once the deposit is satisfied', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'partially_paid',
+      balance: '7000.00', depositDue: '3000.00', amountPaid: '3000.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-DEP',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient('acct_9'));
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_dep2', url: 'https://checkout.stripe.com/c/cs_dep2', payment_intent: 'pi_dep2' });
+
+    const res = await app().request(`/invoices/${INV_ID}/pay`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(sessionsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [expect.objectContaining({
+          price_data: expect.objectContaining({
+            unit_amount: 700000,
+            product_data: { name: 'Invoice INV-DEP' },
+          }),
+        })],
+        metadata: expect.objectContaining({ invoice_balance_cents: '700000' }),
+      }),
+      { idempotencyKey: `inv_${INV_ID}_700000` },
+    );
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '7000.00' }));
+  });
+
   it('POST /invoices/:id/pay returns 409 when the partner has no Stripe key configured', async () => {
     dbResults.push([{
       id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',

--- a/apps/api/src/routes/portal/invoices.test.ts
+++ b/apps/api/src/routes/portal/invoices.test.ts
@@ -178,8 +178,9 @@ describe('portal invoices routes', () => {
         success_url: expect.stringContaining('session_id={CHECKOUT_SESSION_ID}'),
       }),
       // No Connect stripeAccount option — the client is already the partner's. Only an
-      // idempotency key keyed on (invoice, balance) so a double-click reuses the session.
-      { idempotencyKey: `inv_${INV_ID}_10000` },
+      // idempotency key keyed on (invoice, balance, phase) so a double-click reuses
+      // the session.
+      { idempotencyKey: `inv_${INV_ID}_10000_bal` },
     );
     // the Stripe object → payment mapping row is recorded
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -206,7 +207,7 @@ describe('portal invoices routes', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '1000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_1000` },
+      { idempotencyKey: `inv_${INV_ID}_1000_bal` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
       stripeObjectId: 'cs_jpy', amount: '1000.00', currency: 'JPY',
@@ -234,7 +235,7 @@ describe('portal invoices routes', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '300000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_300000` },
+      { idempotencyKey: `inv_${INV_ID}_300000_dep` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '3000.00' }));
   });
@@ -260,9 +261,39 @@ describe('portal invoices routes', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '700000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_700000` },
+      { idempotencyKey: `inv_${INV_ID}_700000_bal` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '7000.00' }));
+  });
+
+  it('POST /invoices/:id/pay deposit-phase and balance-phase idempotency keys differ for the SAME charge amount', async () => {
+    // Mirrors the equivalent invoiceCheckout.test.ts case: a 50%-deposit invoice
+    // where depositDue equals the eventual balance charge, so chargeMinor is
+    // identical across the two sessions — only the dep/bal suffix disambiguates.
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '10000.00', depositDue: '5000.00', amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-EQ',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient('acct_9'));
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_dep_eq', url: 'https://checkout.stripe.com/c/cs_dep_eq', payment_intent: 'pi_dep_eq' });
+    await app().request(`/invoices/${INV_ID}/pay`, { method: 'POST' });
+    const depositKey = (sessionsCreateMock.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    expect(depositKey).toBe(`inv_${INV_ID}_500000_dep`);
+
+    vi.clearAllMocks();
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'partially_paid',
+      balance: '5000.00', depositDue: '5000.00', amountPaid: '5000.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-EQ',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient('acct_9'));
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_bal_eq', url: 'https://checkout.stripe.com/c/cs_bal_eq', payment_intent: 'pi_bal_eq' });
+    await app().request(`/invoices/${INV_ID}/pay`, { method: 'POST' });
+    const balanceKey = (sessionsCreateMock.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    expect(balanceKey).toBe(`inv_${INV_ID}_500000_bal`);
+
+    expect(depositKey).not.toBe(balanceKey);
   });
 
   it('POST /invoices/:id/pay returns 409 Nothing to pay when the charge-now amount is zero', async () => {

--- a/apps/api/src/routes/portal/invoices.test.ts
+++ b/apps/api/src/routes/portal/invoices.test.ts
@@ -265,6 +265,24 @@ describe('portal invoices routes', () => {
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '7000.00' }));
   });
 
+  it('POST /invoices/:id/pay returns 409 Nothing to pay when the charge-now amount is zero', async () => {
+    // A payable-status invoice whose charge-now amount computes to zero must be
+    // rejected BEFORE any Stripe work (the guard now fires on chargeMinor, the
+    // computeChargeNow output, not the raw balance).
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '0.00', depositDue: null, amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-ZERO',
+    }]);
+
+    const res = await app().request(`/invoices/${INV_ID}/pay`, { method: 'POST' });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: 'Nothing to pay' });
+    expect(getPartnerStripeClientMock).not.toHaveBeenCalled();
+    expect(sessionsCreateMock).not.toHaveBeenCalled();
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
   it('POST /invoices/:id/pay returns 409 when the partner has no Stripe key configured', async () => {
     dbResults.push([{
       id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -51,6 +51,7 @@ invoiceRoutes.get('/invoices', zValidator('query', listSchema), async (c) => {
       total: invoices.total,
       amountPaid: invoices.amountPaid,
       balance: invoices.balance,
+      depositDue: invoices.depositDue,
     })
     .from(invoices)
     .where(conditions)

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -18,6 +18,7 @@ import { InvoiceServiceError } from '../../services/invoiceTypes';
 import { getPartnerStripeClient, PartnerStripeError } from '../../services/partnerStripe';
 import { settleCheckoutSession } from '../../services/stripeSettle';
 import { toMinorUnits } from '../../services/stripeMoney';
+import { computeChargeNow } from '@breeze/shared';
 
 // The Checkout session id Stripe substitutes into success_url ({CHECKOUT_SESSION_ID}).
 const settleSchema = z.object({ sessionId: z.string().trim().min(1).max(255) });
@@ -159,10 +160,16 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
   if (!inv) return c.json({ error: 'Invoice not found' }, 404);
   if (!PAYABLE.has(inv.status)) return c.json({ error: 'Invoice is not payable' }, 409);
 
+  // Deposit-first: charge the deposit remaining while unmet, else the full
+  // balance. computeChargeNow clamps to balance and handles every state (no
+  // deposit, deposit partially/fully paid) — never reimplement that logic here.
+  const chargeNow = computeChargeNow({
+    depositDue: inv.depositDue, amountPaid: inv.amountPaid, balance: inv.balance,
+  });
   // Currency-aware minor units: zero-decimal currencies (JPY, KRW, …) must NOT be
   // multiplied by 100, or the customer is over-charged 100x (see stripeMoney.ts).
-  const balanceMinor = toMinorUnits(inv.balance, inv.currencyCode);
-  if (balanceMinor <= 0) return c.json({ error: 'Nothing to pay' }, 409);
+  const chargeMinor = toMinorUnits(chargeNow.amount, inv.currencyCode);
+  if (chargeMinor <= 0) return c.json({ error: 'Nothing to pay' }, 409);
 
   // stripe_connect_accounts is a partner-axis table (reused by the #1610 API-key
   // model). This handler runs with NO ambient DB context (#1448 opt-out), and even
@@ -206,8 +213,12 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
     line_items: [{
       price_data: {
         currency: inv.currencyCode.toLowerCase(),
-        unit_amount: balanceMinor,
-        product_data: { name: `Invoice ${inv.invoiceNumber ?? inv.id}` },
+        unit_amount: chargeMinor,
+        product_data: {
+          name: chargeNow.isDeposit
+            ? `Deposit — Invoice ${inv.invoiceNumber ?? inv.id}`
+            : `Invoice ${inv.invoiceNumber ?? inv.id}`,
+        },
       },
       quantity: 1,
     }],
@@ -219,12 +230,16 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
       invoice_id: inv.id,
       org_id: inv.orgId,
       partner_id: inv.partnerId,
-      invoice_balance_cents: String(balanceMinor),
+      // Historically the full balance; now the amount actually charged in THIS
+      // session (deposit or balance). Write-only — the settle path (stripeSettle.ts)
+      // records what Stripe reports paid via session.amount_total, never this field.
+      invoice_balance_cents: String(chargeMinor),
     },
   }, {
-    // Dedupe double-click / retry: identical (invoice, balance) reuses the same
-    // Checkout session instead of creating a second pending mapping row.
-    idempotencyKey: `inv_${inv.id}_${balanceMinor}`,
+    // Dedupe double-click / retry: identical (invoice, charge-now amount) reuses the
+    // same Checkout session instead of creating a second pending mapping row. Amount-
+    // sensitive so a deposit session and a later full-balance session never collide.
+    idempotencyKey: `inv_${inv.id}_${chargeMinor}`,
   }));
 
   // Fresh short context so the pending-mapping write isn't a contextless 0-row
@@ -237,7 +252,7 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
       stripeObjectType: 'checkout_session',
       stripeObjectId: session.id,
       stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-      amount: Number(inv.balance).toFixed(2),
+      amount: chargeNow.amount,
       currency: inv.currencyCode,
       status: 'pending',
     })

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -237,10 +237,12 @@ invoiceRoutes.post('/invoices/:id/pay', zValidator('param', ticketParamSchema), 
       invoice_balance_cents: String(chargeMinor),
     },
   }, {
-    // Dedupe double-click / retry: identical (invoice, charge-now amount) reuses the
-    // same Checkout session instead of creating a second pending mapping row. Amount-
-    // sensitive so a deposit session and a later full-balance session never collide.
-    idempotencyKey: `inv_${inv.id}_${chargeMinor}`,
+    // Dedupe double-click / retry: identical (invoice, charge-now amount, phase) reuses
+    // the same Checkout session instead of creating a second pending mapping row. A
+    // 50%-deposit invoice has the SAME chargeMinor for the deposit and the later
+    // balance charge (different product name but equal amount), so the amount alone
+    // can't disambiguate — the explicit dep/bal discriminator does.
+    idempotencyKey: `inv_${inv.id}_${chargeMinor}_${chargeNow.isDeposit ? 'dep' : 'bal'}`,
   }));
 
   // Fresh short context so the pending-mapping write isn't a contextless 0-row

--- a/apps/api/src/routes/portal/quotes.test.ts
+++ b/apps/api/src/routes/portal/quotes.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// DB mock: select().from().where().limit()/orderBy() resolves to the next queued
+// row set, consumed FIFO in call order. Mirrors the pattern in
+// routes/portal/invoices.test.ts and services/invoiceCheckout.test.ts.
+const { dbResults } = vi.hoisted(() => ({ dbResults: [] as unknown[][] }));
+vi.mock('../../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const m of ['select', 'from', 'where', 'orderBy', 'limit']) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = dbResults.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  return {
+    db: makeChain(),
+    runOutsideDbContext: <T>(fn: () => T): T => fn(),
+    withSystemDbAccessContext: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  };
+});
+
+// The route dynamically imports renderQuotePdf — vi.mock still intercepts it
+// regardless of the static/dynamic import site. Spying (not exercising pdfkit)
+// lets the test assert on exactly what the route computed and handed over.
+const { renderQuotePdfMock } = vi.hoisted(() => ({ renderQuotePdfMock: vi.fn() }));
+vi.mock('../../services/quotePdf', () => ({ renderQuotePdf: renderQuotePdfMock }));
+
+import { quoteRoutes as portalQuoteRoutes } from './quotes';
+
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const QUOTE_ID = '11111111-1111-1111-1111-111111111111';
+const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
+
+function app(orgId = ORG_ID) {
+  const a = new Hono();
+  a.use('*', async (c, next) => {
+    c.set('portalAuth', {
+      user: { id: 'pu1', orgId, email: 'c@example.test', name: 'Cust', receiveNotifications: true, status: 'active' },
+      token: 't', authMethod: 'bearer',
+    });
+    await next();
+  });
+  a.route('/', portalQuoteRoutes);
+  return a;
+}
+
+describe('portal quotes /:id/pdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbResults.length = 0;
+    renderQuotePdfMock.mockResolvedValue(Buffer.from('%PDF-test'));
+  });
+
+  it('feeds renderQuotePdf the same totals sweep as GET /quotes/:id (dueOnAcceptanceTotal + categoryBreakdown), not the raw tax-exclusive fallback', async () => {
+    // One-time $6200 taxable hardware line (deposit-eligible) + $2400 taxable
+    // labor line, 10% tax, selected_lines deposit on the hardware line only.
+    // Reference numbers: dueOnAcceptanceTotal '9460.00', deposit '6820.00',
+    // remaining balance '2640.00' (9460.00 - 6820.00).
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      quoteNumber: 'Q-1', currencyCode: 'USD', taxRate: '0.10',
+      depositType: 'selected_lines', depositPercent: null, depositAmount: '6820.00',
+      sellerSnapshot: null, terms: null,
+    }]); // quote SELECT
+    dbResults.push([]); // quoteBlocks SELECT
+    dbResults.push([
+      {
+        id: 'l1', quoteId: QUOTE_ID, quantity: '1', unitPrice: '6200.00', unitCost: '4000.00',
+        taxable: true, customerVisible: true, recurrence: 'one_time',
+        depositEligible: true, itemType: 'hardware',
+      },
+      {
+        id: 'l2', quoteId: QUOTE_ID, quantity: '1', unitPrice: '2400.00', unitCost: '1200.00',
+        taxable: true, customerVisible: true, recurrence: 'one_time',
+        depositEligible: false, itemType: 'service',
+      },
+    ]); // quoteLines SELECT
+    dbResults.push([{ name: 'Lantern IT', billingCompanyName: null, billingEmail: null, billingPhone: null, billingWebsite: null, billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null, invoiceFooter: null, currencyCode: 'USD' }]); // partners SELECT (system ctx)
+    dbResults.push([]); // portalBranding SELECT
+
+    const res = await app().request(`/quotes/${QUOTE_ID}/pdf`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+
+    expect(renderQuotePdfMock).toHaveBeenCalledOnce();
+    const [quoteArg] = renderQuotePdfMock.mock.calls[0] as [Record<string, unknown>, unknown, unknown, unknown, unknown];
+    expect(quoteArg.dueOnAcceptanceTotal).toBe('9460.00');
+    expect(quoteArg.categoryBreakdown).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: 'hardware', oneTimeTotal: '6200.00' }),
+        expect.objectContaining({ category: 'service', oneTimeTotal: '2400.00' }),
+      ]),
+    );
+    // Deposit (frozen depositAmount, unrelated to the totals sweep) + the derived
+    // due-on-acceptance together let the PDF renderer compute the correct
+    // tax-inclusive remaining balance (9460.00 - 6820.00 = 2640.00), instead of
+    // silently falling back to the tax-exclusive oneTimeTotal.
+    expect(quoteArg.depositAmount).toBe('6820.00');
+  });
+
+  it('404s for a quote outside the customer org (no PDF render)', async () => {
+    dbResults.push([]); // quote SELECT → none
+    const res = await app().request(`/quotes/${QUOTE_ID}/pdf`, { method: 'GET' });
+    expect(res.status).toBe(404);
+    expect(renderQuotePdfMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -55,7 +55,13 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, id), eq(quotes.orgId, auth.user.orgId))).limit(1);
   if (!quote || quote.status === 'draft') return c.json({ error: 'Quote not found' }, 404);
   const blocks = await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, id)).orderBy(quoteBlocks.sortOrder);
-  const lines = toCustomerLines(await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder));
+  const lines = toCustomerLines((await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible));
+  // Same totals sweep as GET /quotes/:id: derive the amount due on acceptance
+  // (one-time only, tax-inclusive) + per-category subtotals so the PDF's
+  // "Remaining balance" line matches the portal detail view instead of falling
+  // back to renderQuotePdf's oneTimeTotal default (tax-exclusive on taxed
+  // deposit quotes).
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
   // partners is a partner-axis RLS table — the portal request runs in ORG scope,
   // where breeze_has_partner_access is false. A bare read returns 0 rows with NO
   // error (the #1375 class), causing buildSellerSnapshot(undefined) to produce an
@@ -83,7 +89,12 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   const { renderQuotePdf } = await import('../../services/quotePdf');
   // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
   // the From block still renders (issued docs use the frozen column).
-  const quoteForRender = { ...quote, sellerSnapshot: quote.sellerSnapshot ?? (partner ? buildSellerSnapshot(partner) : null) };
+  const quoteForRender = {
+    ...quote,
+    sellerSnapshot: quote.sellerSnapshot ?? (partner ? buildSellerSnapshot(partner) : null),
+    dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal,
+    categoryBreakdown: totals.categoryBreakdown,
+  };
   const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, {
     partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
     footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -43,9 +43,10 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
   const lines = toCustomerLines((await db.select().from(quoteLines).where(eq(quoteLines.quoteId, id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible));
   try { await markQuoteViewed(id, auth.user.orgId); } catch (err) { console.error('[portal] quote markViewed failed', { id, err }); }
   // Derive the amount accept actually invoices (one-time only) so the customer
-  // sees an accurate "due on acceptance" instead of the recurring-inclusive total.
-  const dueOnAcceptanceTotal = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null).dueOnAcceptanceTotal;
-  return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal }, blocks, lines } });
+  // sees an accurate "due on acceptance" instead of the recurring-inclusive total,
+  // plus the deposit due + per-category subtotals for the summary panel.
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
+  return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines } });
 });
 
 // GET /quotes/:id/pdf

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -56,9 +56,10 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
     const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
     await markQuoteViewed(quote.id, quote.orgId);
     // Derive the amount accept actually invoices (one-time only) so the prospect
-    // sees an accurate "due on acceptance" instead of the recurring-inclusive total.
-    const dueOnAcceptanceTotal = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null).dueOnAcceptanceTotal;
-    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
+    // sees an accurate "due on acceptance" instead of the recurring-inclusive total,
+    // plus the deposit due + per-category subtotals for the summary panel.
+    const totals = computeQuoteTotals(lines as QuoteLineForMath[], quote.taxRate ? parseFloat(quote.taxRate) : null, { type: quote.depositType, percent: quote.depositPercent });
+    return { quote: { ...quote, status: quote.status === 'sent' ? 'viewed' : quote.status, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines, branding: { partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null } };
   }));
   if (!data) return c.json({ error: 'Quote not found' }, 404);
   return c.json({ data });

--- a/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
+++ b/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
@@ -97,6 +97,14 @@ function getTool(): AiTool {
   return t;
 }
 
+function getReadTool(name: 'get_invoice' | 'list_invoices'): AiTool {
+  const map = new Map<string, AiTool>();
+  registerBillingTools(map);
+  const t = map.get(name);
+  if (!t) throw new Error(`${name} not registered`);
+  return t;
+}
+
 describe('manage_invoices', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -267,5 +275,61 @@ describe('manage_invoices', () => {
     const out = await getTool().handler({ action: 'nope' }, auth);
 
     expect(JSON.parse(out)).toHaveProperty('error');
+  });
+});
+
+describe('get_invoice / list_invoices deposit fields', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get_invoice adds depositPaid=true when amountPaid covers depositDue', async () => {
+    vi.mocked(invoiceService.getInvoice).mockResolvedValueOnce({
+      invoice: { id: 'inv-1', depositDue: '100.00', amountPaid: '100.00' },
+      lines: [],
+      stripeConnected: false,
+    } as any);
+
+    const out = await getReadTool('get_invoice').handler({ invoiceId: 'inv-1' }, auth);
+
+    expect(JSON.parse(out).invoice).toMatchObject({ depositDue: '100.00', depositPaid: true });
+  });
+
+  it('get_invoice adds depositPaid=false when amountPaid is short of depositDue', async () => {
+    vi.mocked(invoiceService.getInvoice).mockResolvedValueOnce({
+      invoice: { id: 'inv-1', depositDue: '100.00', amountPaid: '40.00' },
+      lines: [],
+      stripeConnected: false,
+    } as any);
+
+    const out = await getReadTool('get_invoice').handler({ invoiceId: 'inv-1' }, auth);
+
+    expect(JSON.parse(out).invoice).toMatchObject({ depositDue: '100.00', depositPaid: false });
+  });
+
+  it('get_invoice omits depositPaid when no deposit is configured', async () => {
+    vi.mocked(invoiceService.getInvoice).mockResolvedValueOnce({
+      invoice: { id: 'inv-1', depositDue: null, amountPaid: '0.00' },
+      lines: [],
+      stripeConnected: false,
+    } as any);
+
+    const out = await getReadTool('get_invoice').handler({ invoiceId: 'inv-1' }, auth);
+
+    expect(JSON.parse(out).invoice).toEqual({ id: 'inv-1', depositDue: null, amountPaid: '0.00' });
+    expect(JSON.parse(out).invoice).not.toHaveProperty('depositPaid');
+  });
+
+  it('list_invoices adds depositPaid per row using integer-cents comparison', async () => {
+    vi.mocked(invoiceService.listInvoices).mockResolvedValueOnce([
+      { id: 'inv-1', depositDue: '68.20', amountPaid: '68.20' },
+      { id: 'inv-2', depositDue: '100.00', amountPaid: '99.99' },
+      { id: 'inv-3', depositDue: null, amountPaid: '0.00' },
+    ] as any);
+
+    const out = await getReadTool('list_invoices').handler({}, auth);
+    const { invoices } = JSON.parse(out);
+
+    expect(invoices[0]).toMatchObject({ depositPaid: true });
+    expect(invoices[1]).toMatchObject({ depositPaid: false });
+    expect(invoices[2]).not.toHaveProperty('depositPaid');
   });
 });

--- a/apps/api/src/services/aiToolsBilling.ts
+++ b/apps/api/src/services/aiToolsBilling.ts
@@ -44,6 +44,7 @@ import {
 import { createInvoicePayLink } from './invoiceCheckout';
 import { InvoiceServiceError, type InvoiceActor } from './invoiceTypes';
 import { computeContractEstimate, getContract } from './contractService';
+import { toCents } from './invoiceMath';
 
 type UpdateInvoiceLinePatch = Parameters<typeof updateLine>[2];
 type UpdateInvoiceHeaderPatch = Parameters<typeof updateInvoice>[1];
@@ -63,6 +64,20 @@ function serviceErrorToJson(err: unknown): string | null {
   return null;
 }
 
+/**
+ * Adds a derived `depositPaid` boolean (amountPaid >= depositDue, compared in
+ * integer cents to avoid float/string drift) to a read-only invoice payload.
+ * When no deposit is configured (`depositDue` null/undefined), `depositPaid`
+ * is omitted entirely rather than emitted as `false` — there's no deposit
+ * state to report, and `false` would misleadingly read as "deposit unpaid".
+ */
+function withDepositPaid<T extends { depositDue?: string | null; amountPaid: string }>(
+  inv: T
+): T & { depositPaid?: boolean } {
+  if (inv.depositDue == null) return inv;
+  return { ...inv, depositPaid: toCents(inv.amountPaid) >= toCents(inv.depositDue) };
+}
+
 export function registerBillingTools(aiTools: Map<string, AiTool>): void {
   aiTools.set('list_invoices', {
     tier: 2 as AiToolTier,
@@ -70,7 +85,8 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'list_invoices',
       description:
-        'List invoices for the orgs the caller can access, newest first. Optionally filter by org or status. Read-only.',
+        'List invoices for the orgs the caller can access, newest first. Optionally filter by org or status. ' +
+        'Each invoice includes depositDue and, when a deposit is configured, a derived depositPaid boolean. Read-only.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -96,7 +112,7 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
           },
           actorFromAuth(auth)
         );
-        return JSON.stringify({ invoices: rows, showing: rows.length });
+        return JSON.stringify({ invoices: rows.map(withDepositPaid), showing: rows.length });
       } catch (err) {
         const json = serviceErrorToJson(err);
         if (json) return json;
@@ -111,7 +127,8 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'get_invoice',
       description:
-        'Get the full accounting view of one invoice (header plus all lines) by id. Read-only.',
+        'Get the full accounting view of one invoice (header plus all lines) by id. Includes depositDue and, ' +
+        'when a deposit is configured, a derived depositPaid boolean. Read-only.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -123,7 +140,7 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
     handler: async (input, auth) => {
       try {
         const result = await getInvoice(String(input.invoiceId), actorFromAuth(auth));
-        return JSON.stringify(result);
+        return JSON.stringify({ ...result, invoice: withDepositPaid(result.invoice) });
       } catch (err) {
         const json = serviceErrorToJson(err);
         if (json) return json;

--- a/apps/api/src/services/aiToolsQuotes.test.ts
+++ b/apps/api/src/services/aiToolsQuotes.test.ts
@@ -3,6 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('./quoteService', () => ({
   createQuote: vi.fn().mockResolvedValue({ id: 'quote-1', status: 'draft' }),
   updateQuote: vi.fn().mockResolvedValue({ id: 'quote-1', introNotes: 'Updated' }),
+  getQuote: vi.fn().mockResolvedValue({
+    quote: {
+      id: 'quote-1',
+      introNotes: 'Updated',
+      depositType: 'percent',
+      depositPercent: '30.00',
+      depositAmount: '150.00',
+      depositDueTotal: '150.00',
+      categoryBreakdown: { hardware: '150.00' },
+    },
+    blocks: [],
+    lines: [],
+  }),
   deleteDraftQuote: vi.fn().mockResolvedValue(undefined),
   addBlock: vi.fn().mockResolvedValue({ id: 'block-1', quoteId: 'quote-1' }),
   updateBlock: vi.fn().mockResolvedValue({ id: 'block-1', content: { text: 'Updated' } }),
@@ -80,6 +93,39 @@ describe('manage_quotes', () => {
 
     expect(quoteService.createQuote).toHaveBeenCalledWith(input, actor);
     expect(JSON.parse(out)).toEqual({ id: 'quote-1', status: 'draft' });
+  });
+
+  it('update passes depositType/depositPercent through to updateQuote and re-reads the quote', async () => {
+    const patch = { depositType: 'percent', depositPercent: 30 };
+
+    const out = await getTool().handler(
+      { action: 'update', quoteId: 'quote-1', patch },
+      auth,
+    );
+
+    expect(quoteService.updateQuote).toHaveBeenCalledWith('quote-1', patch, actor);
+    expect(quoteService.getQuote).toHaveBeenCalledWith('quote-1', actor);
+    expect(JSON.parse(out)).toEqual({
+      id: 'quote-1',
+      introNotes: 'Updated',
+      depositType: 'percent',
+      depositPercent: '30.00',
+      depositAmount: '150.00',
+      depositDueTotal: '150.00',
+      categoryBreakdown: { hardware: '150.00' },
+    });
+  });
+
+  it('update_line passes depositEligible through to updateLine', async () => {
+    const patch = { depositEligible: true };
+
+    const out = await getTool().handler(
+      { action: 'update_line', quoteId: 'quote-1', lineId: 'line-1', patch },
+      auth,
+    );
+
+    expect(quoteService.updateLine).toHaveBeenCalledWith('quote-1', 'line-1', patch, actor);
+    expect(JSON.parse(out)).toEqual({ id: 'line-1', quantity: '2' });
   });
 
   it('send calls sendQuote with quoteId and actor', async () => {

--- a/apps/api/src/services/aiToolsQuotes.ts
+++ b/apps/api/src/services/aiToolsQuotes.ts
@@ -23,6 +23,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
   createQuote,
+  getQuote,
   updateQuote,
   deleteDraftQuote,
   addBlock,
@@ -96,7 +97,19 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
           partNumber: { type: 'string' },
           reason: { type: 'string', description: 'Decline reason' },
           input: { type: 'object', description: 'Full create-quote payload including orgId and siteId' },
-          patch: { type: 'object', description: 'Quote header or line patch fields' },
+          patch: {
+            type: 'object',
+            description:
+              'Quote header or line patch fields. Header (update): depositType (\'none\'|\'percent\'|\'selected_lines\', ' +
+              'omit to leave unchanged), depositPercent (0-100 exclusive, 2dp; null clears — only used when depositType ' +
+              'is \'percent\'). Line (update_line): depositEligible (boolean; whether this line counts toward the ' +
+              'deposit-due calculation when depositType is \'selected_lines\').',
+            properties: {
+              depositType: { type: 'string', enum: ['none', 'percent', 'selected_lines'] },
+              depositPercent: { type: ['number', 'null'] },
+              depositEligible: { type: 'boolean' },
+            },
+          },
           block: { type: 'object', description: 'Quote block input fields' },
           line: { type: 'object', description: 'Manual quote line fields' },
           blockIds: { type: 'array', items: { type: 'string' }, description: 'Ordered block UUIDs' },
@@ -113,12 +126,17 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
         switch (input.action) {
           case 'create_draft':
             return JSON.stringify(await createQuote(input.input as CreateQuoteInput, actor));
-          case 'update':
-            return JSON.stringify(await updateQuote(
-              String(input.quoteId),
-              input.patch as UpdateQuoteInput,
-              actor
-            ));
+          case 'update': {
+            const quoteId = String(input.quoteId);
+            await updateQuote(quoteId, input.patch as UpdateQuoteInput, actor);
+            // Re-read rather than return updateQuote's raw row: the raw row carries
+            // depositType/depositPercent/depositAmount but not the derived
+            // depositDueTotal/categoryBreakdown (computed from current lines in
+            // getQuote) — there's no separate read tool for the AI to fetch those,
+            // so the update response has to surface them itself.
+            const { quote } = await getQuote(quoteId, actor);
+            return JSON.stringify(quote);
+          }
           case 'delete_draft':
             await deleteDraftQuote(String(input.quoteId), actor);
             return JSON.stringify({ ok: true });

--- a/apps/api/src/services/email.test.ts
+++ b/apps/api/src/services/email.test.ts
@@ -275,3 +275,39 @@ describe('email service', () => {
     expect(createTransportMock).not.toHaveBeenCalled();
   });
 });
+
+describe('buildInvoiceTemplate', () => {
+  const base = {
+    invoiceNumber: 'INV-0001',
+    partnerName: 'Acme MSP',
+    total: '$10,000.00',
+    dueDate: '2026-09-01',
+    portalUrl: 'https://portal.example.com/invoices/i1',
+  };
+
+  it('renders "Amount due now" equal to the total when there is no deposit', async () => {
+    const { buildInvoiceTemplate } = await import('./email');
+    const t = buildInvoiceTemplate(base);
+    expect(t.html).toContain('Amount due now');
+    expect(t.html).toContain('$10,000.00');
+    expect(t.text).toContain('Amount due now: $10,000.00 by 2026-09-01.');
+  });
+
+  it('renders "Amount due now" + "Paid to date" when deposit params are present', async () => {
+    const { buildInvoiceTemplate } = await import('./email');
+    const t = buildInvoiceTemplate({ ...base, amountDueNow: '$7,000.00', amountPaid: '$3,000.00' });
+    expect(t.html).toContain('Amount due now');
+    expect(t.html).toContain('$7,000.00');
+    expect(t.html).toContain('Paid to date');
+    expect(t.html).toContain('$3,000.00');
+    expect(t.text).toContain('Amount due now: $7,000.00 by 2026-09-01.');
+    expect(t.text).toContain('Paid to date: $3,000.00 of $10,000.00.');
+  });
+
+  it('omits the "Paid to date" line when amountPaid is not supplied', async () => {
+    const { buildInvoiceTemplate } = await import('./email');
+    const t = buildInvoiceTemplate({ ...base, amountDueNow: '$10,000.00' });
+    expect(t.html).not.toContain('Paid to date');
+    expect(t.text).not.toContain('Paid to date');
+  });
+});

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -34,6 +34,11 @@ export interface InvoiceEmailParams {
   dueDate: string;
   portalUrl: string;
   supportEmail?: string;
+  // Deposit-aware payment-request fields (optional — omitted for pre-deposit
+  // callers, in which case "Amount due now" just equals the total). Wording is
+  // intentionally the same for ALL invoices; there's no behavioral copy fork.
+  amountDueNow?: string;
+  amountPaid?: string;
 }
 
 export interface PasswordResetEmailParams {
@@ -731,13 +736,18 @@ export function buildInvoiceTemplate(params: InvoiceEmailParams): EmailTemplate 
   const number = params.invoiceNumber.trim();
   const subject = `Invoice ${number} from ${params.partnerName}`;
   const preheader = `Invoice ${number} — ${params.total}${params.dueDate ? `, due ${params.dueDate}` : ''}.`;
+  const dueNow = params.amountDueNow ?? params.total;
   const dueLine = params.dueDate
-    ? `<p style="${BODY_PARA}">Amount due: <strong>${escapeHtml(params.total)}</strong> by <strong>${escapeHtml(params.dueDate)}</strong>.</p>`
-    : `<p style="${BODY_PARA}">Amount due: <strong>${escapeHtml(params.total)}</strong>.</p>`;
+    ? `<p style="${BODY_PARA}">Amount due now: <strong>${escapeHtml(dueNow)}</strong> by <strong>${escapeHtml(params.dueDate)}</strong>.</p>`
+    : `<p style="${BODY_PARA}">Amount due now: <strong>${escapeHtml(dueNow)}</strong>.</p>`;
+  const paidLine = params.amountPaid
+    ? `<p style="${MUTED_PARA}">Paid to date: ${escapeHtml(params.amountPaid)} of ${escapeHtml(params.total)}.</p>`
+    : '';
   const body = `
       <p style="${BODY_PARA}">Hi there,</p>
       <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you invoice <strong>${escapeHtml(number)}</strong>. A PDF copy is attached to this email.</p>
       ${dueLine}
+      ${paidLine}
       ${renderButton('View invoice', params.portalUrl)}
       <p style="${MUTED_PARA}">You can view this invoice and download a copy any time from your customer portal.</p>
   `;
@@ -753,7 +763,8 @@ export function buildInvoiceTemplate(params: InvoiceEmailParams): EmailTemplate 
   const text = [
     'Hi there,',
     `${params.partnerName} has sent you invoice ${number}. A PDF copy is attached.`,
-    params.dueDate ? `Amount due: ${params.total} by ${params.dueDate}.` : `Amount due: ${params.total}.`,
+    params.dueDate ? `Amount due now: ${dueNow} by ${params.dueDate}.` : `Amount due now: ${dueNow}.`,
+    params.amountPaid ? `Paid to date: ${params.amountPaid} of ${params.total}.` : null,
     `View invoice: ${params.portalUrl}`,
     support ? `Questions about this invoice? Contact ${support}.` : null,
   ]

--- a/apps/api/src/services/invoiceCheckout.test.ts
+++ b/apps/api/src/services/invoiceCheckout.test.ts
@@ -85,7 +85,7 @@ describe('createInvoicePayLink', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '300000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_300000` },
+      { idempotencyKey: `inv_${INV_ID}_300000_dep` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '3000.00' }));
   });
@@ -111,7 +111,7 @@ describe('createInvoicePayLink', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '700000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_700000` },
+      { idempotencyKey: `inv_${INV_ID}_700000_bal` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '7000.00' }));
   });
@@ -137,9 +137,43 @@ describe('createInvoicePayLink', () => {
         })],
         metadata: expect.objectContaining({ invoice_balance_cents: '10000' }),
       }),
-      { idempotencyKey: `inv_${INV_ID}_10000` },
+      { idempotencyKey: `inv_${INV_ID}_10000_bal` },
     );
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '100.00' }));
+  });
+
+  it('deposit-phase and balance-phase idempotency keys differ for the SAME charge amount (#idempotency-collision)', async () => {
+    // A 50%-deposit invoice: depositDue exactly equals the eventual balance
+    // charge amount, so chargeMinor is IDENTICAL for the deposit session and the
+    // later full-balance session. Without a phase discriminator the two Stripe
+    // idempotencyKeys would collide and the second session creation would be
+    // rejected with idempotency_error for ~24h.
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '10000.00', depositDue: '5000.00', amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-EQ',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient());
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_dep_eq', url: 'https://checkout.stripe.com/c/cs_dep_eq', payment_intent: 'pi_dep_eq' });
+    await createInvoicePayLink(INV_ID, actor);
+    const depositKey = (sessionsCreateMock.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    expect(depositKey).toBe(`inv_${INV_ID}_500000_dep`);
+
+    vi.clearAllMocks();
+    // Deposit now fully paid: the balance charge is ALSO 5000.00 (equal minor
+    // amount to the deposit above) — simulating the exact collision scenario.
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'partially_paid',
+      balance: '5000.00', depositDue: '5000.00', amountPaid: '5000.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-EQ',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient());
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_bal_eq', url: 'https://checkout.stripe.com/c/cs_bal_eq', payment_intent: 'pi_bal_eq' });
+    await createInvoicePayLink(INV_ID, actor);
+    const balanceKey = (sessionsCreateMock.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    expect(balanceKey).toBe(`inv_${INV_ID}_500000_bal`);
+
+    expect(depositKey).not.toBe(balanceKey);
   });
 
   it('throws NOTHING_TO_PAY when the charge-now amount is zero', async () => {

--- a/apps/api/src/services/invoiceCheckout.test.ts
+++ b/apps/api/src/services/invoiceCheckout.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// DB mock: select().from().where().limit() resolves to the next queued row set;
+// insert().values() is a thenable so the mapping-row write awaits cleanly.
+// Mirrors the pattern in routes/portal/invoices.test.ts.
+const { dbResults, insertValuesMock } = vi.hoisted(() => ({
+  dbResults: [] as unknown[][],
+  insertValuesMock: vi.fn(),
+}));
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const m of ['select', 'from', 'where', 'limit']) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = dbResults.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    (chain as { insert: unknown }).insert = vi.fn(() => ({
+      values: (v: unknown) => { insertValuesMock(v); return Promise.resolve(undefined); },
+    }));
+    return chain;
+  };
+  return {
+    db: makeChain(),
+    runOutsideDbContext: <T>(fn: () => T): T => fn(),
+    withSystemDbAccessContext: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  };
+});
+
+// Partner Stripe-key mocks (API-key model — no Connect).
+const { sessionsCreateMock, getPartnerStripeClientMock } = vi.hoisted(() => ({
+  sessionsCreateMock: vi.fn(),
+  getPartnerStripeClientMock: vi.fn(),
+}));
+vi.mock('./partnerStripe', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./partnerStripe')>();
+  return {
+    PartnerStripeError: actual.PartnerStripeError,
+    getPartnerStripeClient: getPartnerStripeClientMock,
+  };
+});
+
+// requireOrgAccess only — the rest of invoiceService is irrelevant here and
+// pulls in unrelated schema imports, so keep the mock minimal (no-op by default).
+const { requireOrgAccessMock } = vi.hoisted(() => ({ requireOrgAccessMock: vi.fn() }));
+vi.mock('./invoiceService', () => ({ requireOrgAccess: requireOrgAccessMock }));
+
+import { createInvoicePayLink } from './invoiceCheckout';
+
+const partnerClient = (stripeAccountId = 'acct_9') => ({
+  stripe: { checkout: { sessions: { create: sessionsCreateMock } } },
+  stripeAccountId,
+});
+
+const INV_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+
+describe('createInvoicePayLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbResults.length = 0;
+    insertValuesMock.mockReset();
+  });
+
+  it('deposit unpaid: charges the deposit-remaining amount, not the full balance', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '10000.00', depositDue: '3000.00', amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-1',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient());
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_1', url: 'https://checkout.stripe.com/c/cs_1', payment_intent: 'pi_1' });
+
+    const result = await createInvoicePayLink(INV_ID, actor);
+    expect(result).toEqual({ url: 'https://checkout.stripe.com/c/cs_1' });
+
+    expect(sessionsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [expect.objectContaining({
+          price_data: expect.objectContaining({
+            unit_amount: 300000,
+            product_data: { name: 'Deposit — Invoice INV-1' },
+          }),
+        })],
+        metadata: expect.objectContaining({ invoice_balance_cents: '300000' }),
+      }),
+      { idempotencyKey: `inv_${INV_ID}_300000` },
+    );
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '3000.00' }));
+  });
+
+  it('deposit already satisfied: charges the remaining balance with a plain product name', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'partially_paid',
+      balance: '7000.00', depositDue: '3000.00', amountPaid: '3000.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-1',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient());
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_2', url: 'https://checkout.stripe.com/c/cs_2', payment_intent: 'pi_2' });
+
+    await createInvoicePayLink(INV_ID, actor);
+
+    expect(sessionsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [expect.objectContaining({
+          price_data: expect.objectContaining({
+            unit_amount: 700000,
+            product_data: { name: 'Invoice INV-1' },
+          }),
+        })],
+        metadata: expect.objectContaining({ invoice_balance_cents: '700000' }),
+      }),
+      { idempotencyKey: `inv_${INV_ID}_700000` },
+    );
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '7000.00' }));
+  });
+
+  it('no-deposit invoice: unchanged full-balance charge (byte-identical to pre-deposit behavior)', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '100.00', depositDue: null, amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-3',
+    }]);
+    getPartnerStripeClientMock.mockResolvedValue(partnerClient());
+    sessionsCreateMock.mockResolvedValue({ id: 'cs_3', url: 'https://checkout.stripe.com/c/cs_3', payment_intent: 'pi_3' });
+
+    await createInvoicePayLink(INV_ID, actor);
+
+    expect(sessionsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [expect.objectContaining({
+          price_data: expect.objectContaining({
+            unit_amount: 10000,
+            product_data: { name: 'Invoice INV-3' },
+          }),
+        })],
+        metadata: expect.objectContaining({ invoice_balance_cents: '10000' }),
+      }),
+      { idempotencyKey: `inv_${INV_ID}_10000` },
+    );
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({ amount: '100.00' }));
+  });
+
+  it('throws NOTHING_TO_PAY when the charge-now amount is zero', async () => {
+    dbResults.push([{
+      id: INV_ID, orgId: ORG_ID, partnerId: 'p1', status: 'sent',
+      balance: '0.00', depositDue: null, amountPaid: '0.00',
+      currencyCode: 'USD', invoiceNumber: 'INV-4',
+    }]);
+
+    await expect(createInvoicePayLink(INV_ID, actor)).rejects.toMatchObject({ code: 'NOTHING_TO_PAY' });
+    expect(sessionsCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import { computeChargeNow } from '@breeze/shared';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { invoices, invoiceStripePayments } from '../db/schema';
 import { getPartnerStripeClient, PartnerStripeError } from './partnerStripe';
@@ -38,9 +39,15 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
   requireOrgAccess(actor, inv.orgId);
   if (!PAYABLE.has(inv.status)) throw new InvoiceServiceError('Invoice is not payable', 409, 'NOT_PAYABLE');
 
+  // Deposit-first: charge the deposit remaining while unmet, else the full
+  // balance. computeChargeNow clamps to balance and handles every state (no
+  // deposit, deposit partially/fully paid) — never reimplement that logic here.
+  const chargeNow = computeChargeNow({
+    depositDue: inv.depositDue, amountPaid: inv.amountPaid, balance: inv.balance,
+  });
   // Currency-aware minor units (zero-decimal currencies must not be ×100).
-  const balanceMinor = toMinorUnits(inv.balance, inv.currencyCode);
-  if (balanceMinor <= 0) throw new InvoiceServiceError('Nothing to pay', 409, 'NOTHING_TO_PAY');
+  const chargeMinor = toMinorUnits(chargeNow.amount, inv.currencyCode);
+  if (chargeMinor <= 0) throw new InvoiceServiceError('Nothing to pay', 409, 'NOTHING_TO_PAY');
 
   // The partner charges on their OWN Stripe account using their stored key (no
   // platform/Connect). stripe_connect_accounts is a partner-axis table (reused by
@@ -75,8 +82,12 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
     line_items: [{
       price_data: {
         currency: inv.currencyCode.toLowerCase(),
-        unit_amount: balanceMinor,
-        product_data: { name: `Invoice ${inv.invoiceNumber ?? inv.id}` },
+        unit_amount: chargeMinor,
+        product_data: {
+          name: chargeNow.isDeposit
+            ? `Deposit — Invoice ${inv.invoiceNumber ?? inv.id}`
+            : `Invoice ${inv.invoiceNumber ?? inv.id}`,
+        },
       },
       quantity: 1,
     }],
@@ -89,12 +100,16 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
       invoice_id: inv.id,
       org_id: inv.orgId,
       partner_id: inv.partnerId,
-      invoice_balance_cents: String(balanceMinor),
+      // Historically the full balance; now the amount actually charged in THIS
+      // session (deposit or balance). Write-only — the settle path (stripeSettle.ts)
+      // records what Stripe reports paid via session.amount_total, never this field.
+      invoice_balance_cents: String(chargeMinor),
     },
   }, {
-    // Identical (invoice, balance) reuses the session instead of creating a
-    // second pending mapping — safe for repeated "send link" clicks.
-    idempotencyKey: `inv_${inv.id}_${balanceMinor}`,
+    // Identical (invoice, charge-now amount) reuses the session instead of creating
+    // a second pending mapping — safe for repeated "send link" clicks. Amount-sensitive
+    // so a deposit session and a later full-balance session never collide.
+    idempotencyKey: `inv_${inv.id}_${chargeMinor}`,
   }));
 
   if (!session.url) throw new InvoiceServiceError('Stripe did not return a checkout URL', 500, 'STRIPE_NO_URL');
@@ -109,7 +124,7 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
       stripeObjectType: 'checkout_session',
       stripeObjectId: session.id,
       stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-      amount: Number(inv.balance).toFixed(2),
+      amount: chargeNow.amount,
       currency: inv.currencyCode,
       status: 'pending',
     })

--- a/apps/api/src/services/invoiceCheckout.ts
+++ b/apps/api/src/services/invoiceCheckout.ts
@@ -106,10 +106,12 @@ export async function createInvoicePayLink(invoiceId: string, actor: InvoiceActo
       invoice_balance_cents: String(chargeMinor),
     },
   }, {
-    // Identical (invoice, charge-now amount) reuses the session instead of creating
-    // a second pending mapping — safe for repeated "send link" clicks. Amount-sensitive
-    // so a deposit session and a later full-balance session never collide.
-    idempotencyKey: `inv_${inv.id}_${chargeMinor}`,
+    // Identical (invoice, charge-now amount, phase) reuses the session instead of
+    // creating a second pending mapping — safe for repeated "send link" clicks. A
+    // 50%-deposit invoice has the SAME chargeMinor for the deposit and the later
+    // balance charge (different product name but equal amount), so the amount
+    // alone can't disambiguate — the explicit dep/bal discriminator does.
+    idempotencyKey: `inv_${inv.id}_${chargeMinor}_${chargeNow.isDeposit ? 'dep' : 'bal'}`,
   }));
 
   if (!session.url) throw new InvoiceServiceError('Stripe did not return a checkout URL', 500, 'STRIPE_NO_URL');

--- a/apps/api/src/services/invoicePdf.test.ts
+++ b/apps/api/src/services/invoicePdf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
-import { renderInvoiceHtml, renderInvoicePdfBuffer, type InvoiceBranding } from './invoicePdf';
+import { renderInvoiceHtml, renderInvoicePdfBuffer, buildInvoiceEmailAmounts, type InvoiceBranding } from './invoicePdf';
 import { invoices, invoiceLines } from '../db/schema';
 
 type InvoiceRow = typeof invoices.$inferSelect;
@@ -169,3 +169,34 @@ it('renderInvoicePdfBuffer emits a %PDF with a seller snapshot present', async (
   );
   expect(buf.subarray(0, 4).toString()).toBe('%PDF');
 });
+
+describe('buildInvoiceEmailAmounts (deposit-vs-balance split for the email)', () => {
+  const base = { total: '1000.00', currencyCode: 'USD' as string | null };
+
+  it('a deposit invoice with nothing paid asks for the DEPOSIT, not the total', () => {
+    const a = buildInvoiceEmailAmounts({ ...base, depositDue: '300.00', amountPaid: '0.00', balance: '1000.00' });
+    expect(a.amountDueNow).toBe('$300.00');
+    // The regression this test exists for: amountDueNow must NOT be the total, or a
+    // customer would be emailed to pay the full amount before any deposit is applied.
+    expect(a.amountDueNow).not.toBe(a.total);
+    expect(a.total).toBe('$1,000.00');
+    expect(a.amountPaid).toBeUndefined();
+  });
+
+  it('once the deposit is paid, it asks for the remaining balance and shows amountPaid', () => {
+    const a = buildInvoiceEmailAmounts({ ...base, depositDue: '300.00', amountPaid: '300.00', balance: '700.00' });
+    expect(a.amountDueNow).toBe('$700.00');
+    expect(a.amountPaid).toBe('$300.00');
+  });
+
+  it('a non-deposit invoice asks for the full balance', () => {
+    const a = buildInvoiceEmailAmounts({ ...base, depositDue: null, amountPaid: '0.00', balance: '1000.00' });
+    expect(a.amountDueNow).toBe('$1,000.00');
+    expect(a.amountPaid).toBeUndefined();
+  });
+
+  it('clamps the charge to the balance when a manual payment shrank it below the deposit', () => {
+    const a = buildInvoiceEmailAmounts({ ...base, depositDue: '300.00', amountPaid: '900.00', balance: '100.00' });
+    expect(a.amountDueNow).toBe('$100.00'); // never advertises more than is owed
+  });
+})

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -457,6 +457,30 @@ export interface SendInvoiceResult {
 }
 
 /**
+ * The money fields of the invoice email, isolated so the deposit-vs-balance split
+ * is unit-testable without standing up the whole send path. `amountDueNow` is what
+ * is owed NOW — the remaining deposit (via computeChargeNow) or the full balance —
+ * NOT the invoice total, so a customer who has already paid the deposit is never
+ * asked to pay the total again. `amountPaid` is omitted (undefined) when nothing
+ * has been paid, so the template can suppress the "already paid" line.
+ */
+export function buildInvoiceEmailAmounts(inv: {
+  total: string;
+  depositDue: string | null;
+  amountPaid: string;
+  balance: string;
+  currencyCode: string | null;
+}): { total: string; amountDueNow: string; amountPaid: string | undefined } {
+  const currency = inv.currencyCode ?? 'USD';
+  const chargeNow = computeChargeNow({ depositDue: inv.depositDue, amountPaid: inv.amountPaid, balance: inv.balance });
+  return {
+    total: formatMoney(inv.total, currency),
+    amountDueNow: formatMoney(chargeNow.amount, currency),
+    amountPaid: Number(inv.amountPaid) > 0 ? formatMoney(inv.amountPaid, currency) : undefined,
+  };
+}
+
+/**
  * Issue the invoice if it is still a draft, ensure a PDF artifact exists
  * (rendered synchronously — the email path must NOT depend on the async worker),
  * email it to the org billing contact with the PDF attached, and stamp sent_at.
@@ -512,18 +536,18 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
       'http://localhost:4321'
     ).replace(/\/$/, '');
     const portalLink = `${portalBase}/invoices/${invoiceId}`;
-    // This IS the "Request balance payment" action for deposit invoices: chargeNow
-    // reflects the deposit-vs-balance split so the email states what's owed NOW,
-    // not just the invoice total (which may already be partially covered).
-    const chargeNow = computeChargeNow({ depositDue: invoice.depositDue, amountPaid: invoice.amountPaid, balance: invoice.balance });
+    // This IS the "Request balance payment" action for deposit invoices: the money
+    // fields reflect the deposit-vs-balance split so the email states what's owed
+    // NOW, not just the invoice total (which may already be partially covered).
+    const amounts = buildInvoiceEmailAmounts(invoice);
     const template = buildInvoiceTemplate({
       invoiceNumber: invoice.invoiceNumber ?? '',
       partnerName: partner?.name ?? 'your provider',
-      total: formatMoney(invoice.total, invoice.currencyCode ?? 'USD'),
+      total: amounts.total,
       dueDate: formatDate(invoice.dueDate),
       portalUrl: portalLink,
-      amountDueNow: formatMoney(chargeNow.amount, invoice.currencyCode ?? 'USD'),
-      amountPaid: Number(invoice.amountPaid) > 0 ? formatMoney(invoice.amountPaid, invoice.currencyCode ?? 'USD') : undefined,
+      amountDueNow: amounts.amountDueNow,
+      amountPaid: amounts.amountPaid,
     });
     await emailService.sendEmail({
       to: recipient,

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -25,6 +25,7 @@ import { emitInvoiceEvent } from './invoiceEvents';
 import { InvoiceServiceError } from './invoiceTypes';
 import type { InvoiceActor } from './invoiceTypes';
 import { buildSellerSnapshot, sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
+import { computeChargeNow } from '@breeze/shared';
 
 type InvoiceRow = typeof invoices.$inferSelect;
 type InvoiceLineRow = typeof invoiceLines.$inferSelect;
@@ -511,12 +512,18 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
       'http://localhost:4321'
     ).replace(/\/$/, '');
     const portalLink = `${portalBase}/invoices/${invoiceId}`;
+    // This IS the "Request balance payment" action for deposit invoices: chargeNow
+    // reflects the deposit-vs-balance split so the email states what's owed NOW,
+    // not just the invoice total (which may already be partially covered).
+    const chargeNow = computeChargeNow({ depositDue: invoice.depositDue, amountPaid: invoice.amountPaid, balance: invoice.balance });
     const template = buildInvoiceTemplate({
       invoiceNumber: invoice.invoiceNumber ?? '',
       partnerName: partner?.name ?? 'your provider',
       total: formatMoney(invoice.total, invoice.currencyCode ?? 'USD'),
       dueDate: formatDate(invoice.dueDate),
       portalUrl: portalLink,
+      amountDueNow: formatMoney(chargeNow.amount, invoice.currencyCode ?? 'USD'),
+      amountPaid: Number(invoice.amountPaid) > 0 ? formatMoney(invoice.amountPaid, invoice.currencyCode ?? 'USD') : undefined,
     });
     await emailService.sendEmail({
       to: recipient,

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -202,6 +202,56 @@ describe('invoiceService guards', () => {
   });
 });
 
+describe('updateIssuedDueDate', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('updates dueDate on a sent invoice and returns old/new in the audit payload', async () => {
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', dueDate: '2026-06-01' }]); // getOwnedInvoiceOr404
+    queueResult([]); // db.update dueDate
+    // recomputeInvoiceStatus internals:
+    queueResult([{ id: 'i1', orgId: 'org1', invoiceNumber: 'INV-0001', total: '100.00', dueDate: '2026-09-01', voidedAt: null, paidAt: null, markedOverdueAt: null }]); // getOwnedInvoiceOr404
+    queueResult([{ amount: '0.00' }]); // paidRows
+    queueResult([]); // db.update status patch
+    // final getOwnedInvoiceOr404
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', dueDate: '2026-09-01' }]);
+
+    const result = await svc.updateIssuedDueDate('i1', '2026-09-01', actor);
+    expect(result.audit).toEqual({ orgId: 'org1', invoiceId: 'i1', oldDueDate: '2026-06-01', newDueDate: '2026-09-01' });
+    expect(result.invoice.dueDate).toBe('2026-09-01');
+  });
+
+  it('re-derives status: an overdue invoice moved to a future due date flips back to partially_paid', async () => {
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+    queueResult([{ id: 'i1', status: 'overdue', orgId: 'org1', partnerId: 'p1', dueDate: '2026-01-01' }]); // getOwnedInvoiceOr404
+    queueResult([]); // db.update dueDate
+    // recomputeInvoiceStatus internals: total 100, paid 40 -> balance 60 > 0, dueDate now future -> partially_paid
+    queueResult([{ id: 'i1', orgId: 'org1', invoiceNumber: 'INV-0002', total: '100.00', dueDate: '2026-12-01', voidedAt: null, paidAt: null, markedOverdueAt: '2026-02-01' }]);
+    queueResult([{ amount: '40.00' }]); // paidRows
+    queueResult([]); // db.update status patch
+    queueResult([{ id: 'i1', status: 'partially_paid', orgId: 'org1', partnerId: 'p1', dueDate: '2026-12-01' }]); // final getOwnedInvoiceOr404
+
+    const result = await svc.updateIssuedDueDate('i1', '2026-12-01', actor);
+    expect(result.invoice.status).toBe('partially_paid');
+  });
+
+  it.each(['draft', 'paid', 'void'])('409s (INVALID_STATE) when invoice status is %s', async (status) => {
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+    queueResult([{ id: 'i1', status, orgId: 'org1', partnerId: 'p1', dueDate: '2026-06-01' }]);
+    await expect(
+      svc.updateIssuedDueDate('i1', '2026-09-01', actor)
+    ).rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it('denies an actor without access to the invoice org (ORG_DENIED 403)', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', dueDate: '2026-06-01' }]);
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['other-org'] };
+    await expect(
+      svc.updateIssuedDueDate('i1', '2026-09-01', actor)
+    ).rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+  });
+});
+
 describe('addContractLine', () => {
   beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
 

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -259,6 +259,25 @@ export async function updateInvoice(
   return getOwnedInvoiceOr404(invoiceId);
 }
 
+/**
+ * Due-date carve-out (deposit spec): the ONE field editable on an ISSUED invoice.
+ * Due date is scheduling metadata, not signed financial content — the immutability
+ * rule (billing-v1.1 roadmap) covers money/lines, which stay locked. Status is
+ * re-derived so pushing the date out un-flags a premature 'overdue'.
+ */
+export async function updateIssuedDueDate(invoiceId: string, dueDate: string, actor: InvoiceActor) {
+  const inv = await getOwnedInvoiceOr404(invoiceId);
+  requireOrgAccess(actor, inv.orgId);
+  if (!['sent', 'partially_paid', 'overdue'].includes(inv.status)) {
+    throw new InvoiceServiceError('Due date can only be changed on an open issued invoice', 409, 'INVALID_STATE');
+  }
+  const oldDueDate = inv.dueDate;
+  await db.update(invoices).set({ dueDate, updatedAt: new Date() }).where(eq(invoices.id, invoiceId));
+  await recomputeInvoiceStatus(invoiceId); // overdue ↔ partially_paid/sent keys off due date
+  const updated = await getOwnedInvoiceOr404(invoiceId);
+  return { invoice: updated, audit: { orgId: inv.orgId, invoiceId, oldDueDate, newDueDate: dueDate } };
+}
+
 export async function getInvoice(invoiceId: string, actor: InvoiceActor) {
   const inv = await getOwnedInvoiceOr404(invoiceId); requireOrgAccess(actor, inv.orgId);
   const lines = await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId)).orderBy(invoiceLines.sortOrder);

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Controllable Drizzle chain mock (same pattern as quoteService.test.ts /
+// invoiceService.test.ts): every builder method returns the same chain; a
+// query resolves when awaited (the chain is a thenable that yields the next
+// queued result). Tests queue the rows each db call should resolve to, in
+// call order.
+//
+// acceptQuote has no dedicated org/RLS layer to stub around (it runs inside
+// the caller's already-scoped transaction), so this harness drives the
+// function's own literal db call sequence directly rather than mocking a
+// sibling service. See the per-test comment blocks for the exact call order.
+const results: unknown[][] = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute', 'transaction'];
+    for (const m of methods) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = results.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+import { acceptQuote } from './quoteAcceptService';
+import { db } from '../db';
+
+type Chain = { set: { mock: { calls: unknown[][] } } };
+
+const baseParams = {
+  quoteId: 'q1',
+  signerName: 'Jane Doe',
+  signerEmail: 'jane@example.com',
+  ipAddress: '1.2.3.4',
+  userAgent: 'test-agent',
+  acceptanceTokenJti: null,
+  actorUserId: null,
+};
+
+/**
+ * Queues the full db call sequence acceptQuote makes for a quote with exactly
+ * one one-time, customer-visible line (so the invoice auto-issues) and NO
+ * recurring lines (so buildContractSpecsFromQuote yields zero contract specs
+ * and the contract-creation loop never touches the db — keeping this harness
+ * to acceptQuote's own calls):
+ *   1. select quotes ... for('update')      -> [quote]
+ *   2. select quoteBlocks                    -> []
+ *   3. select quoteLines                     -> [line]
+ *   4. insert quoteAcceptances .returning()  -> [{id}]
+ *   5. insert invoices .returning()          -> [{id}]
+ *   6. insert invoiceLines (1x, unused)      -> []
+ *   7. select partners (prefix/termsDays)    -> [{...}]
+ *   8. execute (counter upsert)              -> [{counter}]
+ *   9. update invoices .set(issueFields)     -> [] (unused)
+ *  10. update quotes .set(converted)         -> [] (unused)
+ *  11. select quotes (final re-select)       -> [updated quote]
+ */
+function queueAcceptHappyPath(quoteOverrides: Record<string, unknown> = {}) {
+  const quote = {
+    id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
+    expiryDate: null, quoteNumber: 'Q-2026-0001', taxRate: null,
+    currencyCode: 'USD', siteId: null,
+    billToName: null, billToAddress: null, billToTaxId: null,
+    sellerSnapshot: null, termsAndConditions: null, terms: null,
+    depositType: 'none', depositPercent: null, depositAmount: null,
+    ...quoteOverrides,
+  };
+  const line = {
+    id: 'l1', quoteId: 'q1', recurrence: 'one_time', customerVisible: true,
+    taxable: true, quantity: '1', unitPrice: '1000.00', catalogItemId: null,
+    description: 'Widget', name: 'Widget', termMonths: null, sortOrder: 0,
+  };
+
+  queueResult([quote]);                              // 1
+  queueResult([]);                                    // 2 blocks
+  queueResult([line]);                                // 3 lines
+  queueResult([{ id: 'acc1' }]);                       // 4 quote_acceptances insert
+  queueResult([{ id: 'inv1' }]);                       // 5 invoices insert
+  queueResult([]);                                    // 6 invoiceLines insert
+  queueResult([{ prefix: 'INV', termsDays: 30 }]);     // 7 partners select
+  queueResult([{ counter: 1 }]);                       // 8 counter upsert
+  queueResult([]);                                    // 9 invoices update
+  queueResult([]);                                    // 10 quotes update
+  queueResult([{ ...quote, status: 'converted' }]);    // 11 final re-select
+
+  return { quote, line };
+}
+
+describe('acceptQuote deposit snapshot', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('snapshots quote.depositAmount onto the issued invoice as depositDue when a deposit is configured', async () => {
+    queueAcceptHappyPath({ depositType: 'percent', depositPercent: '30.00', depositAmount: '300.00' });
+
+    await acceptQuote(baseParams);
+
+    const setMock = (db as unknown as Chain).set;
+    // calls[0] is the invoices update (issueFields); calls[1] is the quotes
+    // status->converted update. See queueAcceptHappyPath's call-order doc above.
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ depositDue: '300.00' });
+  });
+
+  it('leaves depositDue unset on the invoice when the quote has no deposit configured', async () => {
+    queueAcceptHappyPath(); // depositType: 'none', depositAmount: null (defaults)
+
+    await acceptQuote(baseParams);
+
+    const setMock = (db as unknown as Chain).set;
+    expect(setMock.mock.calls[0]![0]).not.toHaveProperty('depositDue');
+  });
+});

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -192,6 +192,12 @@ export async function acceptQuote(
     issueFields.sellerSnapshot = quote.sellerSnapshot ?? null;
     issueFields.termsAndConditions = quote.termsAndConditions ?? null;
     issueFields.terms = quote.terms ?? null;
+    // Deposit terms travel from the signed quote onto the issued invoice.
+    // depositAmount was validated < dueOnAcceptanceTotal at send and the quote
+    // is locked since, so it is safe to snapshot verbatim.
+    if (quote.depositType !== 'none' && quote.depositAmount !== null) {
+      issueFields.depositDue = quote.depositAmount;
+    }
   }
   await db.update(invoices).set(issueFields).where(eq(invoices.id, invoice!.id));
 

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -194,8 +194,11 @@ export async function acceptQuote(
     issueFields.terms = quote.terms ?? null;
     // Deposit terms travel from the signed quote onto the issued invoice.
     // depositAmount was validated < dueOnAcceptanceTotal at send and the quote
-    // is locked since, so it is safe to snapshot verbatim.
-    if (quote.depositType !== 'none' && quote.depositAmount !== null) {
+    // is locked since, so it is safe to snapshot verbatim. Guard on a POSITIVE
+    // amount, not just non-null: a $0.00 deposit is "no deposit" and must never
+    // be snapshotted. (computeQuoteTotals now persists null for a zero deposit;
+    // this is belt-and-suspenders against any legacy/foreign write that stored "0.00".)
+    if (quote.depositType !== 'none' && Number(quote.depositAmount) > 0) {
       issueFields.depositDue = quote.depositAmount;
     }
   }

--- a/apps/api/src/services/quoteContentHash.test.ts
+++ b/apps/api/src/services/quoteContentHash.test.ts
@@ -26,4 +26,23 @@ describe('computeQuoteSha256', () => {
     const evolved = { ...quote, status: 'converted', quoteNumber: 'Q-9999-9999' };
     expect(computeQuoteSha256(evolved, blocks, lines)).toBe(computeQuoteSha256(quote, blocks, lines));
   });
+  it('hash is UNCHANGED for quotes without a deposit (backward compat with stored acceptances)', () => {
+    const quote = { id: 'q1', currencyCode: 'USD', subtotal: '10.00', taxTotal: '0.00', total: '10.00',
+      oneTimeTotal: '10.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00' };
+    const legacy = computeQuoteSha256(quote as any, [], []);
+    const withNone = computeQuoteSha256({ ...quote, depositType: 'none', depositPercent: null, depositAmount: null } as any, [], []);
+    expect(withNone).toBe(legacy);
+  });
+  it('deposit config and line eligibility change the hash', () => {
+    const quote = { id: 'q1', currencyCode: 'USD', subtotal: '10.00', taxTotal: '0.00', total: '10.00',
+      oneTimeTotal: '10.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00' };
+    const line = { id: 'l1', description: 'x', quantity: '1', unitPrice: '10.00', lineTotal: '10.00',
+      recurrence: 'one_time', taxable: false, customerVisible: true, sortOrder: 0 };
+    const base = computeQuoteSha256(quote as any, [], [line as any]);
+    const withDeposit = computeQuoteSha256(
+      { ...quote, depositType: 'percent', depositPercent: '30.00', depositAmount: '3.00' } as any, [], [line as any]);
+    const withFlag = computeQuoteSha256(quote as any, [], [{ ...line, depositEligible: true } as any]);
+    expect(withDeposit).not.toBe(base);
+    expect(withFlag).not.toBe(base);
+  });
 });

--- a/apps/api/src/services/quoteContentHash.ts
+++ b/apps/api/src/services/quoteContentHash.ts
@@ -4,11 +4,13 @@ type HashableQuote = {
   id: string; currencyCode: string;
   subtotal: string; taxTotal: string; total: string;
   oneTimeTotal: string; monthlyRecurringTotal: string; annualRecurringTotal: string;
+  depositType?: string | null; depositPercent?: string | null; depositAmount?: string | null;
 };
 type HashableBlock = { id: string; blockType: string; content: unknown; sortOrder: number };
 type HashableLine = {
   id: string; description: string; quantity: string; unitPrice: string; lineTotal: string;
   recurrence: string; taxable: boolean; customerVisible: boolean; sortOrder: number;
+  depositEligible?: boolean;
 };
 
 /**
@@ -29,7 +31,7 @@ export function computeQuoteSha256(
   blocks: HashableBlock[],
   lines: HashableLine[]
 ): string {
-  const canonical = {
+  const canonical: { quote: Record<string, unknown>; blocks: unknown[]; lines: unknown[] } = {
     quote: {
       id: quote.id, currency: quote.currencyCode,
       subtotal: quote.subtotal, taxTotal: quote.taxTotal, total: quote.total,
@@ -44,7 +46,17 @@ export function computeQuoteSha256(
         id: l.id, description: l.description, quantity: l.quantity, unitPrice: l.unitPrice,
         lineTotal: l.lineTotal, recurrence: l.recurrence, taxable: l.taxable,
         customerVisible: l.customerVisible, sortOrder: l.sortOrder,
+        ...(l.depositEligible ? { depositEligible: true } : {}),
       })),
   };
+  // Deposit terms are part of what the customer signs. Included ONLY when a
+  // deposit is configured so every pre-deposit acceptance hash stays verifiable.
+  if (quote.depositType && quote.depositType !== 'none') {
+    canonical.quote.deposit = {
+      type: quote.depositType,
+      percent: quote.depositPercent ?? null,
+      amount: quote.depositAmount ?? null,
+    };
+  }
   return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
 }

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -26,6 +26,24 @@ vi.mock('../db', () => {
   };
 });
 
+// Capture the args renderQuotePdf is invoked with, and stub the email service —
+// so the customer-facing send path (sendQuote's email attachment) can run to
+// completion without a real PDF renderer or SMTP transport.
+let capturedPdfArgs: unknown[] | null = null;
+const sendEmailMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./quotePdf', () => ({
+  renderQuotePdf: vi.fn((...args: unknown[]) => {
+    capturedPdfArgs = args;
+    return Promise.resolve(Buffer.from('%PDF-fake'));
+  }),
+}));
+
+vi.mock('./email', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./email')>();
+  return { ...actual, getEmailService: vi.fn(() => ({ sendEmail: sendEmailMock })) };
+});
+
 import { buildPublicQuoteAcceptUrl, portalBase, sendQuote } from './quoteLifecycle';
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
@@ -176,5 +194,71 @@ describe('sendQuote deposit validation', () => {
     // Proves the deposit gate is skipped for depositType 'none' — the failure
     // that surfaces is the pre-existing status guard, never DEPOSIT_INVALID.
     await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+  });
+});
+
+/**
+ * Data-exposure regression: `sendQuote` emails the quote PDF to the customer.
+ * Internal-only lines (`customerVisible: false` — e.g. cost-basis/markup lines
+ * a tech added for their own bookkeeping) must NEVER reach that PDF, mirroring
+ * the portal-download route (apps/api/src/routes/portal/quotes.ts) which
+ * already filters via `toCustomerLines(lines.filter(l => l.customerVisible))`.
+ * The deposit send-gate upstream still validates over ALL lines — this test
+ * exercises the full send-to-email path, not the gate.
+ */
+describe('sendQuote customer-facing PDF', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+    capturedPdfArgs = null;
+    sendEmailMock.mockResolvedValue(undefined);
+  });
+
+  it('excludes customerVisible=false lines from the emailed PDF while keeping visible lines', async () => {
+    const visibleLine = {
+      id: 'line-visible', quoteId: 'q1', sortOrder: 0, name: 'Managed Firewall', description: null,
+      quantity: '1', unitPrice: '100.00', unitCost: '10.00', lineTotal: '100.00',
+      recurrence: 'one_time', taxable: false, customerVisible: true, depositEligible: false,
+    };
+    const internalLine = {
+      id: 'line-internal', quoteId: 'q1', sortOrder: 1, name: 'Internal markup buffer', description: null,
+      quantity: '1', unitPrice: '50.00', unitCost: '5.00', lineTotal: '50.00',
+      recurrence: 'one_time', taxable: false, customerVisible: false, depositEligible: false,
+    };
+
+    // getQuote: select quote, select blocks, select lines (unfiltered — matches prod).
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft',
+      taxRate: null, depositType: 'none', depositPercent: null,
+      quoteNumber: 'Q-2026-0001', issueDate: '2026-01-01', expiryDate: null,
+      total: '100.00', currencyCode: 'USD', terms: null, termsAndConditions: null,
+      sellerSnapshot: null,
+    }]);
+    queueResult([]); // blocks
+    queueResult([visibleLine, internalLine]); // lines
+
+    queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow
+    queueResult([{ id: 'q1' }]); // update ... returning (claimed)
+    queueResult([{ billingContact: { email: 'billing@customer.example' } }]); // org billingContact
+    queueResult([{ name: 'Acme MSP' }]); // partner name
+    queueResult([]); // portalBranding — none configured
+    queueResult([{ // final re-select
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
+      taxRate: null, depositType: 'none', depositPercent: null,
+      quoteNumber: 'Q-2026-0001', total: '100.00', currencyCode: 'USD',
+    }]);
+
+    const result = await sendQuote('q1', actor);
+
+    expect(result.emailed).toBe(true);
+    expect(capturedPdfArgs).not.toBeNull();
+    // renderQuotePdf(quote, blocks, lines, loadImage, branding, loadCatalogImage) — lines is arg index 2.
+    const renderedLines = capturedPdfArgs![2] as Array<Record<string, unknown>>;
+    expect(renderedLines).toHaveLength(1);
+    expect(renderedLines[0]?.id).toBe('line-visible');
+    expect(renderedLines.some((l) => l.id === 'line-internal')).toBe(false);
+    expect(renderedLines.some((l) => l.name === 'Internal markup buffer')).toBe(false);
+    // toCustomerLines also strips the cost-basis field, same as the portal route.
+    expect(renderedLines[0]).not.toHaveProperty('unitCost');
   });
 });

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -1,5 +1,34 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildPublicQuoteAcceptUrl, portalBase } from './quoteLifecycle';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable Drizzle chain mock (same pattern as quoteService.test.ts): every
+// builder method returns the same chain; a query resolves when awaited (the
+// chain is a thenable that yields the next queued result). Tests queue the rows
+// each db call should resolve to, in call order.
+const results: unknown[][] = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute', 'transaction'];
+    for (const m of methods) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = results.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+import { buildPublicQuoteAcceptUrl, portalBase, sendQuote } from './quoteLifecycle';
+
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
 
 /**
  * Regression coverage for the malformed public quote accept link
@@ -101,5 +130,51 @@ describe('quoteLifecycle portal URL', () => {
     const url = buildPublicQuoteAcceptUrl('a/b?c#d');
     expect(url).toBe('https://example.com/portal/quote/a%2Fb%3Fc%23d');
     expect(new URL(url).pathname).toBe('/portal/quote/a%2Fb%3Fc%23d');
+  });
+});
+
+/**
+ * Send-time deposit gate (Task 7): a deposit config can silently become
+ * unsatisfiable while drafting (recomputeAndPersist stores NULL deposit_amount
+ * in that case, per quoteService). sendQuote is the hard stop that keeps a
+ * quote with broken deposit terms from ever reaching the customer.
+ */
+describe('sendQuote deposit validation', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('throws 409 DEPOSIT_INVALID when a deposit is configured but there are zero one-time lines', async () => {
+    // getQuote (called internally): select quote, select blocks, select lines.
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft',
+      taxRate: null, depositType: 'percent', depositPercent: '30.00',
+    }]);
+    queueResult([]); // blocks
+    queueResult([]); // lines — none at all, so dueOnAcceptanceTotal is $0
+
+    await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'DEPOSIT_INVALID' });
+  });
+
+  it('throws 409 DEPOSIT_INVALID when the deposit config is otherwise unsatisfiable (e.g. percent >= 100)', async () => {
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft',
+      taxRate: null, depositType: 'percent', depositPercent: '100.00',
+    }]);
+    queueResult([]); // blocks
+    queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
+
+    await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'DEPOSIT_INVALID' });
+  });
+
+  it('does NOT gate a quote with no deposit configured (depositType none)', async () => {
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent', // non-draft -> INVALID_STATE, not DEPOSIT_INVALID
+      taxRate: null, depositType: 'none', depositPercent: null,
+    }]);
+    queueResult([]); // blocks
+    queueResult([]); // lines
+
+    // Proves the deposit gate is skipped for depositType 'none' — the failure
+    // that surfaces is the pre-existing status guard, never DEPOSIT_INVALID.
+    await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
   });
 });

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -183,6 +183,22 @@ describe('sendQuote deposit validation', () => {
     await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'DEPOSIT_INVALID' });
   });
 
+  it('throws 409 DEPOSIT_INVALID for a selected_lines deposit that lost all its eligible lines', async () => {
+    // A selected_lines deposit becomes unsatisfiable when the flagged one-time
+    // lines are removed/unflagged after the deposit was set — the send gate must
+    // hard-stop it (DEPOSIT_NO_ELIGIBLE_LINES, surfaced as DEPOSIT_INVALID) rather
+    // than send a quote whose deposit computes to nothing.
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft',
+      taxRate: null, depositType: 'selected_lines', depositPercent: null,
+    }]);
+    queueResult([]); // blocks
+    // A one-time line exists (so dueOnAcceptance > 0) but NONE are depositEligible.
+    queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
+
+    await expect(sendQuote('q1', actor)).rejects.toMatchObject({ status: 409, code: 'DEPOSIT_INVALID' });
+  });
+
   it('does NOT gate a quote with no deposit configured (depositType none)', async () => {
     queueResult([{
       id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent', // non-draft -> INVALID_STATE, not DEPOSIT_INVALID

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -3,7 +3,7 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteImages } from '../db/schema/quotes';
 import { organizations, partners } from '../db/schema/orgs';
 import { portalBranding } from '../db/schema/portal';
-import { getQuote } from './quoteService';
+import { getQuote, toCustomerLines } from './quoteService';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
 import { validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
@@ -164,10 +164,17 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
           .limit(1);
         return img?.data ? { data: img.data } : null;
       };
+      // Customer-emailed PDF: filter to customer-visible lines (mirrors the
+      // portal-download route, apps/api/src/routes/portal/quotes.ts). `lines`
+      // itself stays unfiltered above — the deposit send-gate (and any other
+      // internal computation over `lines`) intentionally covers ALL lines /
+      // applies its own visibility rules internally. Internal-only line names
+      // + prices must never reach the customer's inbox.
+      const customerLines = toCustomerLines(lines.filter((l) => l.customerVisible));
       const { renderQuotePdf } = await import('./quotePdf');
       const pdf = await renderQuotePdf(
         { ...quote, status: 'sent', quoteNumber, sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partnerRow) },
-        blocks, lines, loadImage, {
+        blocks, customerLines, loadImage, {
           partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
           footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
         });

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -5,6 +5,7 @@ import { organizations, partners } from '../db/schema/orgs';
 import { portalBranding } from '../db/schema/portal';
 import { getQuote } from './quoteService';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
+import { validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
 import { createQuoteAcceptToken } from './quoteAcceptToken';
 import { buildQuoteTemplate } from './quoteEmail';
@@ -86,6 +87,20 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
   if (quote.status !== 'draft') {
     // Phase 2 send is issue-once: a non-draft quote (already sent/viewed/etc.) cannot be re-sent.
     throw new QuoteServiceError(`Cannot send a quote in status ${quote.status}`, 409, 'INVALID_STATE');
+  }
+
+  // A deposit config can silently become unsatisfiable while drafting (e.g. the
+  // last one-time line was deleted after the deposit was set) — recompute stores
+  // NULL then, and this hard gate stops the quote going out with broken terms.
+  if (quote.depositType && quote.depositType !== 'none') {
+    const check = validateQuoteDeposit(
+      lines as QuoteLineForMath[],
+      quote.taxRate ? parseFloat(quote.taxRate) : null,
+      { type: quote.depositType, percent: quote.depositPercent },
+    );
+    if (!check.ok) {
+      throw new QuoteServiceError(`Cannot send: ${check.message}`, 409, 'DEPOSIT_INVALID');
+    }
   }
 
   // Quotes are numbered at creation now; keep that number on issue. Only legacy

--- a/apps/api/src/services/quoteMath.ts
+++ b/apps/api/src/services/quoteMath.ts
@@ -4,4 +4,12 @@
 // `./quoteMath` import sites (quoteService, quotesPublic, portal/quotes) stable.
 // The quoteMath.test.ts beside this file exercises the shared implementation and
 // guards parity.
-export { computeQuoteTotals, type QuoteLineForMath, type QuoteTotals } from '@breeze/shared';
+export {
+  computeQuoteTotals,
+  validateQuoteDeposit,
+  type QuoteLineForMath,
+  type QuoteTotals,
+  type QuoteDepositConfig,
+  type QuoteDepositType,
+  type QuoteDepositValidation,
+} from '@breeze/shared';

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import zlib from 'node:zlib';
 import { renderQuotePdf } from './quotePdf';
 
 // A minimal valid 1x1 transparent PNG (the smallest real PNG pdfkit will accept).
@@ -6,6 +7,35 @@ const ONE_BY_ONE_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
   'base64',
 );
+
+// pdfkit flate-compresses its content streams, so the drawn text isn't greppable
+// in the raw bytes. Inflate every stream, then decode the show-text operands.
+// pdfkit emits text as hex strings inside TJ arrays (e.g. `[<5072> 20 <...>] TJ`);
+// with its WinAnsi-encoded Helvetica the hex bytes ARE the character codes, so a
+// straight hex→latin1 decode reconstructs the visible text. Literal `(...)`
+// strings are handled too for robustness.
+function extractPdfText(pdf: Buffer): string {
+  const s = pdf.toString('latin1');
+  const streamRe = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
+  let out = '';
+  let sm: RegExpExecArray | null;
+  while ((sm = streamRe.exec(s))) {
+    let body: string;
+    try { body = zlib.inflateSync(Buffer.from(sm[1]!, 'latin1')).toString('latin1'); } catch { continue; }
+    const tokenRe = /<([0-9a-fA-F]+)>|\(((?:[^()\\]|\\.)*)\)/g;
+    let tm: RegExpExecArray | null;
+    while ((tm = tokenRe.exec(body))) {
+      if (tm[1] !== undefined) {
+        const hex = tm[1].length % 2 ? `${tm[1]}0` : tm[1];
+        out += Buffer.from(hex, 'hex').toString('latin1');
+      } else {
+        out += tm[2]!.replace(/\\([()\\])/g, '$1');
+      }
+    }
+    out += ' ';
+  }
+  return out;
+}
 
 describe('renderQuotePdf', () => {
   it('produces a PDF buffer (heading + line_items block)', async () => {
@@ -155,6 +185,52 @@ describe('renderQuotePdf', () => {
     );
     const pageCount = (buf.toString('latin1').match(/\/Type \/Page[^s]/g) ?? []).length;
     expect(pageCount).toBe(1);
+  });
+
+  it('renders deposit rows + category breakdown when a deposit is configured', async () => {
+    const buf = await renderQuotePdf(
+      {
+        id: 'q1', quoteNumber: 'Q-DEP',
+        oneTimeTotal: '1100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+        dueOnAcceptanceTotal: '1100.00', total: '1100.00', currencyCode: 'USD',
+        depositType: 'percent', depositAmount: '330.00',
+        categoryBreakdown: [
+          { category: 'hardware', oneTimeTotal: '1000.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+          { category: 'other', oneTimeTotal: '100.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+        ],
+      },
+      [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: {} }],
+      [
+        { id: 'l1', blockId: 'b1', description: 'Firewall', quantity: '1', unitPrice: '1000', lineTotal: '1000.00', recurrence: 'one_time' },
+        { id: 'l2', blockId: 'b1', description: 'Cabling', quantity: '1', unitPrice: '100', lineTotal: '100.00', recurrence: 'one_time' },
+      ],
+      async () => null,
+      {},
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+    const text = extractPdfText(buf);
+    expect(text).toContain('Deposit due on acceptance');
+    expect(text).toContain('Remaining balance');
+    // Remainder = dueOnAcceptance 1100.00 − deposit 330.00 = 770.00 (cents math).
+    expect(text).toContain('770.00');
+    // Category rows (>1 category) present.
+    expect(text).toContain('Hardware');
+    expect(text).toContain('Other');
+  });
+
+  it('a no-deposit quote still renders the plain Due on acceptance row (no deposit rows)', async () => {
+    const buf = await renderQuotePdf(
+      { id: 'q1', quoteNumber: 'Q-NODEP', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '500.00', total: '500.00', currencyCode: 'USD' },
+      [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: {} }],
+      [{ id: 'l1', blockId: 'b1', description: 'Setup', quantity: '1', unitPrice: '500', lineTotal: '500.00', recurrence: 'one_time' }],
+      async () => null,
+      {},
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+    const text = extractPdfText(buf);
+    expect(text).toContain('Due on acceptance');
+    expect(text).not.toContain('Deposit due on acceptance');
+    expect(text).not.toContain('Remaining balance');
   });
 
   it('renderQuotePdf includes the From block and T&C', async () => {

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -14,15 +14,16 @@ const ONE_BY_ONE_PNG = Buffer.from(
 // with its WinAnsi-encoded Helvetica the hex bytes ARE the character codes, so a
 // straight hex→latin1 decode reconstructs the visible text. Literal `(...)`
 // strings are handled too for robustness.
-function extractPdfText(pdf: Buffer): string {
+function extractPdfTextByStream(pdf: Buffer): string[] {
   const s = pdf.toString('latin1');
   const streamRe = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
-  let out = '';
+  const streams: string[] = [];
   let sm: RegExpExecArray | null;
   while ((sm = streamRe.exec(s))) {
     let body: string;
     try { body = zlib.inflateSync(Buffer.from(sm[1]!, 'latin1')).toString('latin1'); } catch { continue; }
     const tokenRe = /<([0-9a-fA-F]+)>|\(((?:[^()\\]|\\.)*)\)/g;
+    let out = '';
     let tm: RegExpExecArray | null;
     while ((tm = tokenRe.exec(body))) {
       if (tm[1] !== undefined) {
@@ -32,9 +33,13 @@ function extractPdfText(pdf: Buffer): string {
         out += tm[2]!.replace(/\\([()\\])/g, '$1');
       }
     }
-    out += ' ';
+    streams.push(out);
   }
-  return out;
+  return streams;
+}
+
+function extractPdfText(pdf: Buffer): string {
+  return extractPdfTextByStream(pdf).join(' ');
 }
 
 describe('renderQuotePdf', () => {
@@ -231,6 +236,54 @@ describe('renderQuotePdf', () => {
     expect(text).toContain('Due on acceptance');
     expect(text).not.toContain('Deposit due on acceptance');
     expect(text).not.toContain('Remaining balance');
+  });
+
+  it('page-breaks the summary when deposit + breakdown rows would overflow the bottom margin', async () => {
+    // 25 one-time lines leave the cursor in the 90–160px band above the bottom
+    // margin: the legacy 90px reservation would NOT break the page, so the
+    // deposit (extra 18px row) + 4-category breakdown (4×12+4px, ~160px total)
+    // rows would crowd into the bottom margin / footer band (and pdfkit's
+    // auto-page-add on the overflowing last row spawns a stray page). The sized
+    // reservation must instead move the WHOLE summary to page 2 — asserted by
+    // requiring the deposit row to live in a different content stream (page)
+    // from the line rows. A no-deposit, no-breakdown twin of the same quote
+    // stays single-page — proving the extra rows (not the line table) forced
+    // the break.
+    const mkLines = () => Array.from({ length: 25 }, (_, i) => ({
+      id: `l${i}`, blockId: 'b1', description: `Item ${i + 1}`,
+      quantity: '1', unitPrice: '10', lineTotal: '10.00', recurrence: 'one_time' as const,
+    }));
+    const base = {
+      id: 'q1', quoteNumber: 'Q-BRK',
+      oneTimeTotal: '1000.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+      dueOnAcceptanceTotal: '1000.00', total: '1000.00', currencyCode: 'USD',
+    };
+    const blocks = [{ id: 'b1', blockType: 'line_items' as const, sortOrder: 0, content: {} }];
+    const pageCount = (buf: Buffer) => (buf.toString('latin1').match(/\/Type \/Page[^s]/g) ?? []).length;
+
+    const plain = await renderQuotePdf(base, blocks, mkLines(), async () => null, {});
+    expect(pageCount(plain)).toBe(1);
+
+    const withDeposit = await renderQuotePdf(
+      {
+        ...base,
+        depositType: 'percent', depositAmount: '300.00',
+        categoryBreakdown: [
+          { category: 'hardware', oneTimeTotal: '400.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+          { category: 'software', oneTimeTotal: '300.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+          { category: 'service', oneTimeTotal: '200.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+          { category: 'other', oneTimeTotal: '100.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+        ],
+      },
+      blocks, mkLines(), async () => null, {},
+    );
+    expect(pageCount(withDeposit)).toBe(2);
+    const streams = extractPdfTextByStream(withDeposit);
+    const summaryStream = streams.find((t) => t.includes('Deposit due on acceptance'));
+    expect(summaryStream).toBeDefined();
+    expect(summaryStream).toContain('Remaining balance');
+    // The summary page must be its own page — none of the 25 line rows on it.
+    expect(summaryStream).not.toContain('Item ');
   });
 
   it('renderQuotePdf includes the From block and T&C', async () => {

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -14,6 +14,7 @@
 // route in routes/quotes/quotes.ts supplies the real quote_images loader.
 
 import PDFDocument from 'pdfkit';
+import { toCents, fromCents } from '@breeze/shared';
 import { sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
 import { captureException } from './sentry';
 
@@ -109,6 +110,14 @@ interface QuoteHeader {
   annualRecurringTotal?: string | number | null;
   // Amount invoiced on accept (one-time + one-time tax); derived in getQuote.
   dueOnAcceptanceTotal?: string | number | null;
+  // Deposit config (persisted columns): when set to a non-'none' type with an
+  // amount, the summary shows a bold deposit figure + remaining-balance row in
+  // place of the plain "Due on acceptance" row.
+  depositType?: string | null;
+  depositAmount?: string | null;
+  // Per-category subtotals (one-time / monthly / annual), derived in getQuote.
+  // Rendered as muted rows only when >1 category is present.
+  categoryBreakdown?: { category: string; oneTimeTotal: string; monthlyTotal: string; annualTotal: string }[];
   sellerSnapshot?: unknown;
   termsAndConditions?: string | null;
 }
@@ -325,6 +334,24 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
 
   const labelX = sumX;
   const labelW = c.colAmtX - sumX - 8;
+
+  // Per-category subtotals (muted) — only worth showing when the quote spans more
+  // than one category. Drawn above the One-time/Monthly/Annual roll-up.
+  const breakdown = quote.categoryBreakdown ?? [];
+  if (breakdown.length > 1) {
+    for (const b of breakdown) {
+      const label = b.category === 'other' ? 'Other' : b.category[0]!.toUpperCase() + b.category.slice(1);
+      const parts: string[] = [];
+      if (Number(b.oneTimeTotal) > 0) parts.push(formatMoney(b.oneTimeTotal, currency));
+      if (Number(b.monthlyTotal) > 0) parts.push(`${formatMoney(b.monthlyTotal, currency)}/mo`);
+      if (Number(b.annualTotal) > 0) parts.push(`${formatMoney(b.annualTotal, currency)}/yr`);
+      doc.font('Helvetica').fontSize(9).fillColor('#9ca3af');
+      doc.text(label, labelX, y, { width: labelW, align: 'left' });
+      doc.text(parts.join(' + '), c.colAmtX - 60, y, { width: c.colNumW + 60, align: 'right' });
+      y += 12;
+    }
+    y += 4;
+  }
   const drawRow = (
     label: string,
     amount: string | number | null | undefined,
@@ -347,9 +374,18 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
   }
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
-  // Accent primary figure = what accept invoices now. Fall back to the one-time
-  // total if the derived field is somehow absent.
-  drawRow('Due on acceptance', quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, '', { emphasis: true });
+  // Accent primary figure = what accept invoices now. When a deposit is
+  // configured the emphasised figure becomes the deposit due, with the remaining
+  // balance beneath (remainder = due-on-acceptance − deposit, in cents). Fall
+  // back to the one-time total if the derived field is somehow absent.
+  const hasDeposit = quote.depositType && quote.depositType !== 'none' && quote.depositAmount != null;
+  if (hasDeposit) {
+    drawRow('Deposit due on acceptance', quote.depositAmount, '', { emphasis: true });
+    const remainderCents = toCents(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal) - toCents(quote.depositAmount);
+    drawRow('Remaining balance (due per terms)', fromCents(remainderCents), '', { bold: true });
+  } else {
+    drawRow('Due on acceptance', quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, '', { emphasis: true });
+  }
   if (hasRecurring) {
     drawRow('First-period total', quote.total, '');
   }

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -324,7 +324,17 @@ async function renderLineTable(
 
 function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number, showTax = false): number {
   const c = columnsFor(doc, showTax);
-  let y = ensureSpace(doc, startY + 6, 90);
+  // Hoisted above ensureSpace so the page-break reservation can size itself to
+  // the actual content drawn below.
+  const breakdown = quote.categoryBreakdown ?? [];
+  const hasDeposit = quote.depositType && quote.depositType !== 'none' && quote.depositAmount != null;
+  // 90px covered the legacy footer. Category rows add 12px each (+4px gap) and a
+  // deposit adds the extra bold remainder row (18px) — reserve for them, or
+  // ensureSpace won't break the page and the new rows draw past the bottom
+  // margin (pdfkit doesn't auto-paginate explicit-coordinate text). Stays 90 for
+  // a no-deposit, ≤1-category quote so those render exactly as before.
+  const needed = 90 + (breakdown.length > 1 ? breakdown.length * 12 + 4 : 0) + (hasDeposit ? 18 : 0);
+  let y = ensureSpace(doc, startY + 6, needed);
 
   // Wider label column than the line table's so the emphasised "Due on
   // acceptance" figure (14pt) and the recurring labels never wrap/overlap.
@@ -337,7 +347,6 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
 
   // Per-category subtotals (muted) — only worth showing when the quote spans more
   // than one category. Drawn above the One-time/Monthly/Annual roll-up.
-  const breakdown = quote.categoryBreakdown ?? [];
   if (breakdown.length > 1) {
     for (const b of breakdown) {
       const label = b.category === 'other' ? 'Other' : b.category[0]!.toUpperCase() + b.category.slice(1);
@@ -378,7 +387,6 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
   // configured the emphasised figure becomes the deposit due, with the remaining
   // balance beneath (remainder = due-on-acceptance − deposit, in cents). Fall
   // back to the one-time total if the derived field is somehow absent.
-  const hasDeposit = quote.depositType && quote.depositType !== 'none' && quote.depositAmount != null;
   if (hasDeposit) {
     drawRow('Deposit due on acceptance', quote.depositAmount, '', { emphasis: true });
     const remainderCents = toCents(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal) - toCents(quote.depositAmount);

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Controllable Drizzle chain mock (same pattern as invoiceService.test.ts): every
+// builder method returns the same chain; a query resolves when awaited (the
+// chain is a thenable that yields the next queued result). Tests queue the rows
+// each db call should resolve to, in call order.
+const results: unknown[][] = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute', 'transaction'];
+    for (const m of methods) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = results.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+import * as svc from './quoteService';
+import { db } from '../db';
+
+type Chain = { set: { mock: { calls: unknown[][] } }; values: { mock: { calls: unknown[][] } } };
+
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+
+describe('quoteService deposits', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('updateQuote persists deposit config and recompute stores deposit_amount', async () => {
+    // Every awaited db call consumes one queued result, whether or not the
+    // caller destructures it — the header/recompute `update` calls below are
+    // "unused" results but still need a slot (see the chain mock's `.then`).
+    // loadDraft
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: '0.10000', depositType: 'none', depositPercent: null }]);
+    // deposit-validation lines fetch: a single $1000 one-time taxable line
+    queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
+    queueResult([]); // updateQuote's own header update (unused result)
+    // recomputeAndPersist: header select (now reflecting the just-persisted deposit config)
+    queueResult([{ taxRate: '0.10000', depositType: 'percent', depositPercent: '30.00' }]);
+    // recomputeAndPersist: widened lines select
+    queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false, itemType: 'hardware' }]);
+    queueResult([]); // recomputeAndPersist's own update (unused result)
+    // final re-select
+    queueResult([{ id: 'q1', orgId: 'org1', depositType: 'percent', depositPercent: '30.00', depositAmount: '330.00' }]);
+
+    const updated = await svc.updateQuote('q1', { depositType: 'percent', depositPercent: 30 }, actor);
+
+    expect(updated.depositType).toBe('percent');
+    expect(updated.depositAmount).toBe('330.00');
+
+    const setMock = (db as unknown as Chain).set;
+    // Call 0: updateQuote's own header update — persists the deposit config.
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ depositType: 'percent', depositPercent: '30.00' });
+    // Call 1: recomputeAndPersist's update — persists the recomputed deposit_amount.
+    expect(setMock.mock.calls[1]![0]).toMatchObject({ depositAmount: '330.00' });
+  });
+
+  it('updateQuote throws DEPOSIT_REQUIRES_ONE_TIME_LINES when the quote has no one-time visible lines', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: null, depositType: 'none', depositPercent: null }]);
+    queueResult([]); // no lines at all — dueOnAcceptanceTotal is $0
+    await expect(
+      svc.updateQuote('q1', { depositType: 'percent', depositPercent: 10 }, actor)
+    ).rejects.toMatchObject({ code: 'DEPOSIT_REQUIRES_ONE_TIME_LINES', status: 400 });
+  });
+
+  it('addCatalogLine on a hardware catalog item sets depositEligible true and itemType hardware', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ // catalog item lookup
+      name: 'Server', description: null, unitPrice: '500.00', taxable: true,
+      billingType: 'one_time', billingFrequency: null, commitmentTermMonths: null,
+      costBasis: '300.00', sku: 'SKU1', itemType: 'hardware',
+    }]);
+    queueResult([{ max: -1 }]); // nextLineSortOrder
+    queueResult([{ id: 'l1', depositEligible: true, itemType: 'hardware' }]); // insert returning
+    queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute's own update (unused result)
+
+    await svc.addCatalogLine('q1', 'cat1', 1, undefined, actor);
+
+    const valuesMock = (db as unknown as Chain).values;
+    expect(valuesMock.mock.calls.at(-1)![0]).toMatchObject({ depositEligible: true, itemType: 'hardware' });
+  });
+
+  it('addCatalogLine on a service catalog item sets depositEligible false and itemType service', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ // catalog item lookup
+      name: 'Onboarding', description: null, unitPrice: '250.00', taxable: false,
+      billingType: 'one_time', billingFrequency: null, commitmentTermMonths: null,
+      costBasis: null, sku: null, itemType: 'service',
+    }]);
+    queueResult([{ max: -1 }]); // nextLineSortOrder
+    queueResult([{ id: 'l2', depositEligible: false, itemType: 'service' }]); // insert returning
+    queueResult([{ taxRate: null, depositType: 'none', depositPercent: null }]); // recompute header
+    queueResult([]); // recompute lines
+    queueResult([]); // recompute's own update (unused result)
+
+    await svc.addCatalogLine('q1', 'cat2', 1, undefined, actor);
+
+    const valuesMock = (db as unknown as Chain).values;
+    expect(valuesMock.mock.calls.at(-1)![0]).toMatchObject({ depositEligible: false, itemType: 'service' });
+  });
+
+  it('getQuote returns depositDueTotal and categoryBreakdown', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', taxRate: '0.10000', depositType: 'percent', depositPercent: '30.00' }]); // quote
+    queueResult([]); // blocks
+    queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false, itemType: 'hardware' }]); // lines
+
+    const { quote } = await svc.getQuote('q1', actor);
+
+    expect(quote.depositDueTotal).toBe('330.00');
+    expect(quote.categoryBreakdown).toEqual([
+      { category: 'hardware', oneTimeTotal: '1000.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+    ]);
+  });
+});

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -65,6 +65,32 @@ describe('quoteService deposits', () => {
     expect(setMock.mock.calls[1]![0]).toMatchObject({ depositAmount: '330.00' });
   });
 
+  it('updateQuote validates + totals a deposit against a tax rate changed in the SAME patch', async () => {
+    // Regression guard for the effectiveTaxRate branch: a taxRate and a deposit
+    // arriving in one patch must be coherent — the persisted deposit_amount uses
+    // the NEW rate (25%), not the stale persisted one (0%). A $100 one-time taxable
+    // line at 25% tax → dueOnAcceptance $125; a 50% percent deposit → $62.50.
+    // loadDraft
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: '0.00000', depositType: 'none', depositPercent: null }]);
+    // deposit-validation lines fetch
+    queueResult([{ quantity: '1', unitPrice: '100.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
+    queueResult([]); // updateQuote's own header update
+    // recomputeAndPersist: header select now reflects the just-persisted 25% rate + deposit config
+    queueResult([{ taxRate: '0.25000', depositType: 'percent', depositPercent: '50.00' }]);
+    queueResult([{ quantity: '1', unitPrice: '100.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false, itemType: 'hardware' }]);
+    queueResult([]); // recomputeAndPersist's own update
+    queueResult([{ id: 'q1', orgId: 'org1', taxRate: '0.25000', depositType: 'percent', depositPercent: '50.00', depositAmount: '62.50' }]);
+
+    const updated = await svc.updateQuote('q1', { taxRate: 0.25, depositType: 'percent', depositPercent: 50 }, actor);
+    expect(updated.depositAmount).toBe('62.50');
+
+    const setMock = (db as unknown as Chain).set;
+    // Header update persists both the new rate and the deposit config in one write.
+    expect(setMock.mock.calls[0]![0]).toMatchObject({ taxRate: '0.25000', depositType: 'percent', depositPercent: '50.00' });
+    // Recompute persists the deposit_amount computed on the NEW 25% rate.
+    expect(setMock.mock.calls[1]![0]).toMatchObject({ depositAmount: '62.50' });
+  });
+
   it('updateQuote throws DEPOSIT_REQUIRES_ONE_TIME_LINES when the quote has no one-time visible lines', async () => {
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft', taxRate: null, depositType: 'none', depositPercent: null }]);
     queueResult([]); // no lines at all — dueOnAcceptanceTotal is $0

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -10,7 +10,7 @@ function queueResult(rows: unknown[]) { results.push(rows); }
 vi.mock('../db', () => {
   const makeChain = () => {
     const chain: Record<string, unknown> = {};
-    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute', 'transaction'];
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'leftJoin', 'execute', 'transaction'];
     for (const m of methods) chain[m] = vi.fn(() => chain);
     (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
       const rows = results.shift() ?? [];
@@ -121,6 +121,22 @@ describe('quoteService deposits', () => {
     expect(quote.depositDueTotal).toBe('330.00');
     expect(quote.categoryBreakdown).toEqual([
       { category: 'hardware', oneTimeTotal: '1000.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+    ]);
+  });
+
+  it('listQuotes left-joins the converted invoice and flattens invoiceDepositDue/invoiceAmountPaid onto each row', async () => {
+    // The chain mock yields queued rows regardless of shape; queue the joined
+    // projection shape the real select({ quote, invoiceDepositDue, invoiceAmountPaid }) returns.
+    queueResult([
+      { quote: { id: 'q1', orgId: 'org1', status: 'converted', depositType: 'percent' }, invoiceDepositDue: '300.00', invoiceAmountPaid: '300.00' },
+      { quote: { id: 'q2', orgId: 'org1', status: 'draft', depositType: 'none' }, invoiceDepositDue: null, invoiceAmountPaid: null },
+    ]);
+
+    const rows = await svc.listQuotes({ limit: 50 }, actor);
+
+    expect(rows).toEqual([
+      { id: 'q1', orgId: 'org1', status: 'converted', depositType: 'percent', invoiceDepositDue: '300.00', invoiceAmountPaid: '300.00' },
+      { id: 'q2', orgId: 'org1', status: 'draft', depositType: 'none', invoiceDepositDue: null, invoiceAmountPaid: null },
     ]);
   });
 });

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, lt, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteLines, quoteBlocks, quoteImages } from '../db/schema/quotes';
+import { invoices } from '../db/schema/invoices';
 import { organizations, partners } from '../db/schema/orgs';
 import { catalogItems } from '../db/schema/catalog';
 import { computeLineTotal, resolveEffectiveTaxRate } from './invoiceMath';
@@ -203,11 +204,19 @@ export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
       ) as ReturnType<typeof eq>);
     }
   }
-  const rows = await db.select().from(quotes)
+  // Left-join the converted invoice so the list badge can reflect the invoice's
+  // money state (deposit paid/unpaid). The join is null for unconverted quotes;
+  // the mapped fields then stay null and the UI shows the plain "Deposit" chip.
+  const rows = await db.select({
+    quote: quotes,
+    invoiceDepositDue: invoices.depositDue,
+    invoiceAmountPaid: invoices.amountPaid,
+  }).from(quotes)
+    .leftJoin(invoices, eq(invoices.id, quotes.convertedInvoiceId))
     .where(conds.length ? and(...conds) : undefined)
     .orderBy(desc(quotes.createdAt), desc(quotes.id))
     .limit(query.limit);
-  return rows;
+  return rows.map((r) => ({ ...r.quote, invoiceDepositDue: r.invoiceDepositDue, invoiceAmountPaid: r.invoiceAmountPaid }));
 }
 
 /** Draft-only header edit. Only provided fields are written; nullable fields can be

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -4,7 +4,7 @@ import { quotes, quoteLines, quoteBlocks, quoteImages } from '../db/schema/quote
 import { organizations, partners } from '../db/schema/orgs';
 import { catalogItems } from '../db/schema/catalog';
 import { computeLineTotal, resolveEffectiveTaxRate } from './invoiceMath';
-import { computeQuoteTotals, type QuoteLineForMath } from './quoteMath';
+import { computeQuoteTotals, validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
 import { QuoteServiceError, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
 import type {
@@ -50,15 +50,22 @@ function assertOrg(actor: QuoteActor, orgId: string): void {
  * totals are penny-consistent with the persisted line_total and with invoices.
  */
 async function recomputeAndPersist(quoteId: string): Promise<void> {
-  const [q] = await db.select({ taxRate: quotes.taxRate }).from(quotes).where(eq(quotes.id, quoteId)).limit(1);
+  const [q] = await db.select({
+    taxRate: quotes.taxRate,
+    depositType: quotes.depositType,
+    depositPercent: quotes.depositPercent,
+  }).from(quotes).where(eq(quotes.id, quoteId)).limit(1);
   const lines = await db.select({
     quantity: quoteLines.quantity,
     unitPrice: quoteLines.unitPrice,
     taxable: quoteLines.taxable,
     customerVisible: quoteLines.customerVisible,
     recurrence: quoteLines.recurrence,
+    depositEligible: quoteLines.depositEligible,
+    itemType: quoteLines.itemType,
   }).from(quoteLines).where(eq(quoteLines.quoteId, quoteId));
-  const totals = computeQuoteTotals(lines as QuoteLineForMath[], q?.taxRate ? parseFloat(q.taxRate) : null);
+  const deposit = { type: q?.depositType ?? 'none', percent: q?.depositPercent ?? null } as const;
+  const totals = computeQuoteTotals(lines as QuoteLineForMath[], q?.taxRate ? parseFloat(q.taxRate) : null, deposit);
   await db.update(quotes).set({
     subtotal: totals.subtotal,
     taxTotal: totals.taxTotal,
@@ -66,6 +73,9 @@ async function recomputeAndPersist(quoteId: string): Promise<void> {
     oneTimeTotal: totals.oneTimeTotal,
     monthlyRecurringTotal: totals.monthlyRecurringTotal,
     annualRecurringTotal: totals.annualRecurringTotal,
+    // Null when no deposit configured OR the config is currently unsatisfiable
+    // (e.g. the last one-time line was deleted) — sendQuote re-validates hard.
+    depositAmount: totals.depositDueTotal,
     updatedAt: new Date(),
   }).where(eq(quotes.id, quoteId));
 }
@@ -163,8 +173,20 @@ export async function getQuote(id: string, actor: QuoteActor) {
   // contract). Computed from the canonical quoteMath so it stays penny-consistent
   // with quoteAcceptService's invoice, and so the UI can advertise an accurate
   // "due on acceptance" instead of the recurring-inclusive `total` (see #bug).
-  const totals = computeQuoteTotals(lines as QuoteLineForMath[], q.taxRate ? parseFloat(q.taxRate) : null);
-  return { quote: { ...q, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal }, blocks, lines };
+  const totals = computeQuoteTotals(
+    lines as QuoteLineForMath[],
+    q.taxRate ? parseFloat(q.taxRate) : null,
+    { type: q.depositType, percent: q.depositPercent },
+  );
+  return {
+    quote: {
+      ...q,
+      dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal,
+      depositDueTotal: totals.depositDueTotal,
+      categoryBreakdown: totals.categoryBreakdown,
+    },
+    blocks, lines,
+  };
 }
 
 export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
@@ -191,7 +213,7 @@ export async function listQuotes(query: ListQuotesQuery, actor: QuoteActor) {
 /** Draft-only header edit. Only provided fields are written; nullable fields can be
  *  explicitly cleared with null. A tax-rate change triggers a totals recompute. */
 export async function updateQuote(id: string, input: UpdateQuoteInput, actor: QuoteActor) {
-  await loadDraft(id, actor);
+  const q = await loadDraft(id, actor);
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (input.siteId !== undefined) set.siteId = input.siteId;
   if (input.title !== undefined) set.title = input.title === null ? null : input.title.trim() || null;
@@ -202,6 +224,25 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
   if (input.billToName !== undefined) set.billToName = input.billToName;
   // Numeric tax_rate takes a fixed-string value; null clears it.
   if (input.taxRate !== undefined) set.taxRate = input.taxRate === null ? null : Number(input.taxRate).toFixed(5);
+  if (input.depositType !== undefined || input.depositPercent !== undefined) {
+    const lines = await db.select({
+      quantity: quoteLines.quantity, unitPrice: quoteLines.unitPrice,
+      taxable: quoteLines.taxable, customerVisible: quoteLines.customerVisible,
+      recurrence: quoteLines.recurrence, depositEligible: quoteLines.depositEligible,
+    }).from(quoteLines).where(eq(quoteLines.quoteId, id));
+    const nextType = input.depositType ?? q.depositType;
+    const nextPercent = input.depositPercent !== undefined ? input.depositPercent : q.depositPercent;
+    // Include an in-flight taxRate change from THIS SAME patch — a deposit
+    // validated against the stale persisted rate could pass here and then fail
+    // (or silently mis-total) once the new tax rate lands via recomputeAndPersist.
+    const effectiveTaxRate = (input.taxRate !== undefined ? input.taxRate : (q.taxRate ? parseFloat(q.taxRate) : null));
+    const check = validateQuoteDeposit(lines as QuoteLineForMath[], effectiveTaxRate === null ? null : Number(effectiveTaxRate), {
+      type: nextType, percent: nextPercent,
+    });
+    if (!check.ok) throw new QuoteServiceError(check.message, 400, check.code);
+    set.depositType = nextType;
+    set.depositPercent = nextType === 'percent' && nextPercent != null ? Number(nextPercent).toFixed(2) : null;
+  }
   await db.update(quotes).set(set).where(eq(quotes.id, id));
   await recomputeAndPersist(id);
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
@@ -296,6 +337,8 @@ export async function addManualLine(quoteId: string, input: QuoteLineInput, acto
     unitCost: input.unitCost != null ? Number(input.unitCost).toFixed(2) : null,
     sku: input.sku ?? null,
     partNumber: input.partNumber ?? null,
+    depositEligible: input.depositEligible ?? false,
+    itemType: null,
     sortOrder,
   }).returning();
   await recomputeAndPersist(quoteId);
@@ -359,6 +402,12 @@ export async function addCatalogLine(
     unitCost: item.costBasis ?? null,
     sku: item.sku ?? null,
     partNumber: options?.partNumber ?? null,
+    // Deposit eligibility defaults from the catalog item's type — hardware is the
+    // one category a deposit typically secures (custom order, restocking risk).
+    // itemType is snapshotted at add-time so a later catalog recategorization
+    // never reshuffles an existing quote's category breakdown or deposit math.
+    depositEligible: item.itemType === 'hardware',
+    itemType: item.itemType,
     sortOrder,
   }).returning();
   await recomputeAndPersist(quoteId);
@@ -375,6 +424,7 @@ export async function updateLine(
     termMonths?: number | null; sortOrder?: number;
     unitCost?: number | null; sku?: string | null; partNumber?: string | null;
     imageId?: string | null;
+    depositEligible?: boolean;
   },
   actor: QuoteActor
 ) {
@@ -401,6 +451,7 @@ export async function updateLine(
   if (input.unitCost !== undefined) set.unitCost = input.unitCost != null ? Number(input.unitCost).toFixed(2) : null;
   if (input.sku !== undefined) set.sku = input.sku;
   if (input.partNumber !== undefined) set.partNumber = input.partNumber;
+  if (input.depositEligible !== undefined) set.depositEligible = input.depositEligible;
   if (input.imageId !== undefined) {
     // Ownership check: the image must be a quote_images row on THIS quote, or a
     // caller could point a line at another tenant's image and exfiltrate its

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -33,7 +33,12 @@ export type QuoteServiceErrorCode =
   | 'BLOCK_NOT_LINE_ITEMS'
   // Deposit validation codes, sourced from the shared validateQuoteDeposit contract
   // (Extract keeps this union in lockstep with @breeze/shared without duplicating it).
-  | Extract<QuoteDepositValidation, { ok: false }>['code'];
+  | Extract<QuoteDepositValidation, { ok: false }>['code']
+  // Send-time deposit gate (quoteLifecycle.sendQuote): a deposit config that has
+  // become unsatisfiable since it was set (e.g. the last one-time line was
+  // deleted) blocks the send with this single code, regardless of which
+  // underlying validateQuoteDeposit rule failed.
+  | 'DEPOSIT_INVALID';
 
 export class QuoteServiceError extends Error {
   constructor(

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { quoteStatusSchema } from '@breeze/shared';
+import { quoteStatusSchema, type QuoteDepositValidation } from '@breeze/shared';
 
 // Single source of truth for the quote status union lives in the shared Zod
 // schema (validators/quotes.ts); infer the type here rather than re-declaring it.
@@ -30,7 +30,10 @@ export type QuoteServiceErrorCode =
   // Line-move validation codes (moveLineToBlock): a bundle child can't be moved
   // independently of its parent, and lines can only move into a line-items block.
   | 'LINE_IS_BUNDLE_CHILD'
-  | 'BLOCK_NOT_LINE_ITEMS';
+  | 'BLOCK_NOT_LINE_ITEMS'
+  // Deposit validation codes, sourced from the shared validateQuoteDeposit contract
+  // (Extract keeps this union in lockstep with @breeze/shared without duplicating it).
+  | Extract<QuoteDepositValidation, { ok: false }>['code'];
 
 export class QuoteServiceError extends Error {
   constructor(

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { ArrowLeft, AlertCircle, Download, CreditCard } from 'lucide-react';
 import { type InvoiceDetail, type InvoiceStatus, buildPortalApiUrl, portalApi } from '@/lib/api';
 import { STATUS_LABELS, statusColor } from '@/lib/invoiceStatus';
+import { computeChargeNow } from '@/lib/invoiceDeposit';
 import { cn } from '@/lib/utils';
 import { DocumentPaper, DocumentHeader, DocumentTerms, type DocSeller } from './documentShell';
 
@@ -99,6 +100,17 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
   const { invoice, lines } = detail;
   const currency = invoice.currencyCode;
   const canPay = PAYABLE_STATUSES.has(invoice.status) && Number(invoice.balance) > 0;
+  // Deposit-aware charge amount — matches what the server's pay route charges (Task 8),
+  // so the button label and the deposit strip never diverge from the actual charge.
+  const hasDeposit = invoice.depositDue != null;
+  const chargeNow = computeChargeNow({
+    depositDue: invoice.depositDue ?? null,
+    amountPaid: invoice.amountPaid,
+    balance: invoice.balance,
+  });
+  const payLabel = chargeNow.isDeposit
+    ? `Pay deposit ${money(chargeNow.amount, currency)}`
+    : `Pay ${money(chargeNow.amount, currency)}`;
   // Per-line Tax column only when this invoice carries tax (mirrors the Tax row).
   const taxRate = invoice.taxRate ? Number(invoice.taxRate) : 0;
   const showTax = Number(invoice.taxTotal) > 0;
@@ -175,7 +187,7 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
               className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               <CreditCard className="h-4 w-4" />
-              {paying ? 'Redirecting…' : 'Pay now'}
+              {paying ? 'Redirecting…' : payLabel}
             </button>
           )}
           <button
@@ -266,6 +278,15 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
               <span className="text-sm font-semibold text-foreground">Balance due</span>
               <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }} data-testid="invoice-balance-due">{money(invoice.balance, currency)}</span>
             </div>
+            {hasDeposit && (
+              <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="invoice-deposit-strip">
+                {chargeNow.isDeposit ? (
+                  <>Deposit of <strong className="text-foreground">{money(invoice.depositDue!, currency)}</strong> due — {money(invoice.amountPaid, currency)} of {money(invoice.total, currency)} paid.</>
+                ) : (
+                  <>Deposit paid — remaining balance {money(invoice.balance, currency)}.</>
+                )}
+              </div>
+            )}
           </div>
         </section>
 

--- a/apps/portal/src/components/portal/InvoiceList.tsx
+++ b/apps/portal/src/components/portal/InvoiceList.tsx
@@ -2,6 +2,7 @@ import { withBase } from '@/lib/basePath';
 import { Receipt, AlertCircle } from 'lucide-react';
 import { type InvoiceSummary } from '@/lib/api';
 import { STATUS_LABELS, statusColor } from '@/lib/invoiceStatus';
+import { depositBadgeState } from '@/lib/invoiceDeposit';
 import { cn } from '@/lib/utils';
 
 interface InvoiceListProps {
@@ -76,9 +77,24 @@ export function InvoiceList({ invoices, error }: InvoiceListProps) {
                   <td className="px-4 py-3 text-right text-sm">{money(inv.total, inv.currencyCode)}</td>
                   <td className="px-4 py-3 text-right text-sm">{money(inv.balance, inv.currencyCode)}</td>
                   <td className="px-4 py-3">
-                    <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(inv.status))}>
-                      {STATUS_LABELS[inv.status]}
-                    </span>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className={cn('inline-flex rounded-full px-2 py-1 text-xs font-medium', statusColor(inv.status))}>
+                        {STATUS_LABELS[inv.status]}
+                      </span>
+                      {(() => {
+                        const deposit = depositBadgeState(inv);
+                        if (!deposit) return null;
+                        return deposit === 'unpaid' ? (
+                          <span className="inline-flex rounded-full px-2 py-1 text-xs font-medium bg-warning/10 text-warning" data-testid="deposit-unpaid-badge">
+                            Deposit unpaid
+                          </span>
+                        ) : (
+                          <span className="inline-flex rounded-full px-2 py-1 text-xs font-medium bg-success/10 text-success" data-testid="deposit-paid-badge">
+                            Deposit paid
+                          </span>
+                        );
+                      })()}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -43,6 +43,13 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
   const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
   const showTax = Number(quote.taxTotal ?? 0) > 0;
   const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
+  const categoryBreakdown = quote.categoryBreakdown ?? [];
+  const depositDue = quote.depositDueTotal ?? null;
+  const dueOnAcceptance = quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total;
+  // Remaining balance in integer cents so the subtraction never drifts on floats.
+  const remainderCents = depositDue != null
+    ? Math.round(Number(dueOnAcceptance) * 100) - Math.round(Number(depositDue) * 100)
+    : 0;
 
   const seller = (quote.sellerSnapshot ?? null) as DocSeller | null;
 
@@ -160,12 +167,43 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
                 <span className="tabular-nums text-foreground">{money(quote.annualRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/yr</span></span>
               </div>
             )}
-            <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
-              <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
-              <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
-                {money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}
-              </span>
-            </div>
+            {categoryBreakdown.length > 1 && (
+              <div className="space-y-0.5 text-sm text-muted-foreground" data-testid="public-quote-category-breakdown">
+                {categoryBreakdown.map((b) => (
+                  <div key={b.category} className="flex justify-between">
+                    <span className="capitalize">{b.category}</span>
+                    <span className="tabular-nums">
+                      {[
+                        Number(b.oneTimeTotal) > 0 ? money(b.oneTimeTotal, currency) : null,
+                        Number(b.monthlyTotal) > 0 ? `${money(b.monthlyTotal, currency)}/mo` : null,
+                        Number(b.annualTotal) > 0 ? `${money(b.annualTotal, currency)}/yr` : null,
+                      ].filter(Boolean).join(' + ')}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {depositDue != null ? (
+              <>
+                <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }} data-testid="public-quote-deposit-due">
+                  <span className="text-sm font-semibold text-foreground">Deposit due on acceptance</span>
+                  <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                    {money(depositDue, currency)}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm" data-testid="public-quote-deposit-remainder">
+                  <span className="text-muted-foreground">Remaining balance (due per terms)</span>
+                  <span className="tabular-nums text-foreground">{money(remainderCents / 100, currency)}</span>
+                </div>
+              </>
+            ) : (
+              <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
+                <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+                <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                  {money(dueOnAcceptance, currency)}
+                </span>
+              </div>
+            )}
             {hasRecurring && (
               <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">
                 <div className="flex justify-between">

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -130,6 +130,13 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
   const taxRate = quote.taxRate ? Number(quote.taxRate) : 0;
   const showTax = Number(quote.taxTotal ?? 0) > 0;
   const taxPct = taxRate > 0 ? Number((taxRate * 100).toFixed(3)) : 0;
+  const categoryBreakdown = quote.categoryBreakdown ?? [];
+  const depositDue = quote.depositDueTotal ?? null;
+  const dueOnAcceptance = quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total;
+  // Remaining balance in integer cents so the subtraction never drifts on floats.
+  const remainderCents = depositDue != null
+    ? Math.round(Number(dueOnAcceptance) * 100) - Math.round(Number(depositDue) * 100)
+    : 0;
 
   return (
     <div className="space-y-5" data-testid="quote-detail">
@@ -201,12 +208,43 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
                 <span className="tabular-nums text-foreground">{money(quote.annualRecurringTotal ?? 0, currency)}<span className="text-xs text-muted-foreground">/yr</span></span>
               </div>
             )}
-            <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
-              <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
-              <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
-                {money(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal ?? quote.total, currency)}
-              </span>
-            </div>
+            {categoryBreakdown.length > 1 && (
+              <div className="space-y-0.5 text-sm text-muted-foreground" data-testid="quote-category-breakdown">
+                {categoryBreakdown.map((b) => (
+                  <div key={b.category} className="flex justify-between">
+                    <span className="capitalize">{b.category}</span>
+                    <span className="tabular-nums">
+                      {[
+                        Number(b.oneTimeTotal) > 0 ? money(b.oneTimeTotal, currency) : null,
+                        Number(b.monthlyTotal) > 0 ? `${money(b.monthlyTotal, currency)}/mo` : null,
+                        Number(b.annualTotal) > 0 ? `${money(b.annualTotal, currency)}/yr` : null,
+                      ].filter(Boolean).join(' + ')}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {depositDue != null ? (
+              <>
+                <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }} data-testid="quote-deposit-due">
+                  <span className="text-sm font-semibold text-foreground">Deposit due on acceptance</span>
+                  <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                    {money(depositDue, currency)}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm" data-testid="quote-deposit-remainder">
+                  <span className="text-muted-foreground">Remaining balance (due per terms)</span>
+                  <span className="tabular-nums text-foreground">{money(remainderCents / 100, currency)}</span>
+                </div>
+              </>
+            ) : (
+              <div className="flex items-baseline justify-between border-t pt-3" style={{ borderColor: 'var(--doc-accent)' }}>
+                <span className="text-sm font-semibold text-foreground">{hasRecurring ? 'Due on acceptance' : 'Total'}</span>
+                <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                  {money(dueOnAcceptance, currency)}
+                </span>
+              </div>
+            )}
             {hasRecurring && (
               <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">
                 <div className="flex justify-between">

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -407,6 +407,13 @@ export interface QuoteHeader extends QuoteSummary {
   annualRecurringTotal?: string;
   /** Amount invoiced on accept (one-time + one-time tax); derived server-side. */
   dueOnAcceptanceTotal?: string;
+  /** Deposit config (persisted); type 'none' or a null amount means no deposit. */
+  depositType?: string | null;
+  depositAmount?: string | null;
+  /** Deposit due at acceptance, or null when no valid deposit is configured. */
+  depositDueTotal?: string | null;
+  /** Per-category subtotals over customer-visible lines; empty categories omitted. */
+  categoryBreakdown?: { category: string; oneTimeTotal: string; monthlyTotal: string; annualTotal: string }[];
   billToName?: string | null;
   sellerSnapshot?: SellerSnapshot | null;
   termsAndConditions?: string | null;

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -315,6 +315,9 @@ export interface InvoiceSummary {
   total: string;
   amountPaid: string;
   balance: string;
+  // Snapshotted deposit due at quote acceptance; null when the invoice has no
+  // deposit. Present on both the list select and the detail payload.
+  depositDue: string | null;
 }
 
 // Intentional duplicate of SellerSnapshot in apps/api/src/services/sellerSnapshot.ts

--- a/apps/portal/src/lib/invoiceDeposit.test.ts
+++ b/apps/portal/src/lib/invoiceDeposit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeChargeNow, depositBadgeState, toCents } from './invoiceDeposit';
+
+describe('toCents', () => {
+  it('rounds money strings to integer cents', () => {
+    expect(toCents('30.00')).toBe(3000);
+    expect(toCents('12.34')).toBe(1234);
+    expect(toCents('0.005')).toBe(1); // round-half-up on the ×100 product
+  });
+
+  it('treats null/empty/non-finite as 0', () => {
+    expect(toCents(null)).toBe(0);
+    expect(toCents('')).toBe(0);
+    expect(toCents('abc')).toBe(0);
+  });
+});
+
+describe('computeChargeNow (mirrors @breeze/shared)', () => {
+  it('charges the deposit remaining while the deposit is unmet', () => {
+    const r = computeChargeNow({ depositDue: '3000.00', amountPaid: '0.00', balance: '10000.00' });
+    expect(r).toEqual({ amount: '3000.00', isDeposit: true });
+  });
+
+  it('charges the deposit shortfall after a partial deposit payment', () => {
+    const r = computeChargeNow({ depositDue: '3000.00', amountPaid: '1000.00', balance: '9000.00' });
+    expect(r).toEqual({ amount: '2000.00', isDeposit: true });
+  });
+
+  it('charges the full remaining balance once the deposit is satisfied', () => {
+    const r = computeChargeNow({ depositDue: '3000.00', amountPaid: '3000.00', balance: '7000.00' });
+    expect(r).toEqual({ amount: '7000.00', isDeposit: false });
+  });
+
+  it('charges the balance when there is no deposit', () => {
+    const r = computeChargeNow({ depositDue: null, amountPaid: '0.00', balance: '100.00' });
+    expect(r).toEqual({ amount: '100.00', isDeposit: false });
+  });
+
+  it('clamps the deposit charge to the balance (concurrent manual payment)', () => {
+    // Deposit 3000 unmet, but only 500 balance remains — never charge past what is owed.
+    const r = computeChargeNow({ depositDue: '3000.00', amountPaid: '0.00', balance: '500.00' });
+    expect(r).toEqual({ amount: '500.00', isDeposit: true });
+  });
+});
+
+describe('depositBadgeState', () => {
+  it('is null when the invoice has no deposit', () => {
+    expect(depositBadgeState({ depositDue: null, amountPaid: '0.00' })).toBeNull();
+  });
+
+  it('is unpaid while amountPaid < depositDue', () => {
+    expect(depositBadgeState({ depositDue: '3000.00', amountPaid: '2999.99' })).toBe('unpaid');
+  });
+
+  it('is paid once amountPaid meets or exceeds depositDue (exact cents, no float drift)', () => {
+    expect(depositBadgeState({ depositDue: '3000.00', amountPaid: '3000.00' })).toBe('paid');
+    expect(depositBadgeState({ depositDue: '0.10', amountPaid: '0.30' })).toBe('paid');
+  });
+});

--- a/apps/portal/src/lib/invoiceDeposit.ts
+++ b/apps/portal/src/lib/invoiceDeposit.ts
@@ -1,0 +1,47 @@
+// Deposit presentation helpers, shared by InvoiceList (list badge) and
+// InvoiceDetailView (deposit strip + deposit-aware Pay-button label) — extracted
+// here (mirroring invoiceStatus.ts) so the load-bearing money math has one home
+// and a sibling unit test.
+//
+// The charge-now rule mirrors computeChargeNow (@breeze/shared depositMath.ts —
+// the single source of truth the server charges by, Task 8). The portal browser
+// bundle can't import that runtime package (api/web/portal share types only, never
+// runtime code), so the two-branch rule is re-implemented here with integer-cents
+// math. Keeping it identical to the server rule guarantees the Pay button label can
+// never advertise a different amount than the checkout route actually charges.
+
+/** Money string → integer cents (mirrors quoteMath.toCents). Compare money in cents,
+ *  never as floats. Null/empty/non-finite → 0. */
+export function toCents(v: string | null): number {
+  if (v === null || v === '') return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}
+
+export interface DepositChargeInput {
+  depositDue: string | null;
+  amountPaid: string;
+  balance: string;
+}
+
+/** Deposit-first charge amount: when a deposit is set and still unmet, charge the
+ *  deposit remaining (clamped to the balance so a concurrent manual payment can't
+ *  push the charge past what is owed); otherwise charge the full balance. Identical
+ *  to computeChargeNow(@breeze/shared). */
+export function computeChargeNow(inv: DepositChargeInput): { amount: string; isDeposit: boolean } {
+  const balanceCents = toCents(inv.balance);
+  const depositCents = inv.depositDue !== null ? toCents(inv.depositDue) : 0;
+  const paidCents = toCents(inv.amountPaid);
+  if (depositCents > 0 && paidCents < depositCents) {
+    return { amount: (Math.min(depositCents - paidCents, balanceCents) / 100).toFixed(2), isDeposit: true };
+  }
+  return { amount: inv.balance, isDeposit: false };
+}
+
+/** List-badge state for an invoice: 'unpaid' while amountPaid < depositDue, 'paid'
+ *  once the deposit is met, null when the invoice carries no deposit (null depositDue
+ *  is the no-deposit sentinel — no badge, zero visual change). */
+export function depositBadgeState(inv: { depositDue: string | null; amountPaid: string }): 'unpaid' | 'paid' | null {
+  if (inv.depositDue == null) return null;
+  return toCents(inv.amountPaid) < toCents(inv.depositDue) ? 'unpaid' : 'paid';
+}

--- a/apps/portal/src/lib/invoiceDeposit.ts
+++ b/apps/portal/src/lib/invoiceDeposit.ts
@@ -9,6 +9,12 @@
 // runtime code), so the two-branch rule is re-implemented here with integer-cents
 // math. Keeping it identical to the server rule guarantees the Pay button label can
 // never advertise a different amount than the checkout route actually charges.
+//
+// The input contract is sourced from @breeze/shared (type-only — erased at build,
+// as with InvoiceStatus in invoiceStatus.ts) so this re-implemented copy can never
+// structurally drift from the server's computeChargeNow signature.
+import type { DepositChargeInput } from '@breeze/shared';
+export type { DepositChargeInput };
 
 /** Money string → integer cents (mirrors quoteMath.toCents). Compare money in cents,
  *  never as floats. Null/empty/non-finite → 0. */
@@ -16,12 +22,6 @@ export function toCents(v: string | null): number {
   if (v === null || v === '') return 0;
   const n = Number(v);
   return Number.isFinite(n) ? Math.round(n * 100) : 0;
-}
-
-export interface DepositChargeInput {
-  depositDue: string | null;
-  amountPaid: string;
-  balance: string;
 }
 
 /** Deposit-first charge amount: when a deposit is set and still unmet, charge the

--- a/apps/web/src/components/billing/InvoiceDetail.deposit.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.deposit.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceDetail from './InvoiceDetail';
+import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const line: InvoiceDetailData['lines'][number] = {
+  id: 'l1', invoiceId: 'inv-1', sourceType: 'catalog', parentLineId: null, catalogItemId: 'c1',
+  name: null, description: 'Widget', quantity: '1.00', unitPrice: '1000.00', costBasis: '600.00', revenueAllocation: '1000.00',
+  taxable: false, customerVisible: true, lineTotal: '1000.00', isUnapprovedTime: false, sortOrder: 0,
+};
+
+function detail(inv: Partial<InvoiceDetailData['invoice']> = {}): InvoiceDetailData {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
+      currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30', sentAt: null, subtotal: '1000.00',
+      taxRate: '0.000', taxTotal: '0.00', total: '1000.00', amountPaid: '0.00', balance: '1000.00',
+      depositDue: null, billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null,
+      createdAt: '2026-06-01T00:00:00Z', ...inv,
+    },
+    lines: [line],
+  };
+}
+
+describe('InvoiceDetail deposit + due-date + request payment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.endsWith('/payments')) return json({ data: [] });
+      return json({ data: { emailed: true } });
+    });
+  });
+
+  it('renders no deposit strip when the invoice has no deposit', async () => {
+    render(<InvoiceDetail detail={detail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-deposit-strip')).not.toBeInTheDocument();
+  });
+
+  it('shows a deposit-due strip when a deposit is set and unmet', async () => {
+    render(<InvoiceDetail detail={detail({ depositDue: '300.00' })} onChanged={vi.fn()} />);
+    const strip = await screen.findByTestId('invoice-deposit-strip');
+    expect(strip).toHaveTextContent('Deposit of');
+    expect(strip).toHaveTextContent('$300.00');
+  });
+
+  it('shows "Deposit paid" once the deposit is met', async () => {
+    render(<InvoiceDetail detail={detail({ depositDue: '300.00', amountPaid: '300.00', balance: '700.00' })} onChanged={vi.fn()} />);
+    const strip = await screen.findByTestId('invoice-deposit-strip');
+    expect(strip).toHaveTextContent('Deposit paid');
+  });
+
+  it('inline-edits the due date via PATCH /invoices/:id/due-date', async () => {
+    render(<InvoiceDetail detail={detail()} onChanged={vi.fn()} />);
+    fireEvent.click(await screen.findByTestId('invoice-due-date-edit'));
+    fireEvent.change(screen.getByTestId('invoice-due-date-input'), { target: { value: '2026-07-15' } });
+    fireEvent.click(screen.getByTestId('invoice-due-date-save'));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/invoices/inv-1/due-date');
+      expect(call).toBeTruthy();
+      expect(JSON.parse(String((call![1] as RequestInit).body))).toEqual({ dueDate: '2026-07-15' });
+    });
+  });
+
+  it('labels the re-send action "Request payment" once partially paid; POSTs /send', async () => {
+    render(<InvoiceDetail detail={detail({ status: 'partially_paid', amountPaid: '300.00', balance: '700.00', depositDue: '300.00' })} onChanged={vi.fn()} />);
+    const btn = await screen.findByTestId('invoice-request-payment');
+    expect(btn).toHaveTextContent('Request payment');
+    fireEvent.click(btn);
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/send')).toBe(true));
+  });
+
+  it('labels the re-send action "Send invoice" when nothing is paid yet', async () => {
+    render(<InvoiceDetail detail={detail()} onChanged={vi.fn()} />);
+    const btn = await screen.findByTestId('invoice-request-payment');
+    expect(btn).toHaveTextContent('Send invoice');
+  });
+});

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -26,6 +26,7 @@ import {
 import { StatusPill } from './shared/StatusPill';
 import InvoiceActions from './InvoiceActions';
 import { MarginPanel } from './billingUi';
+import { computeChargeNow } from '@breeze/shared';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -64,6 +65,12 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const [voidOpen, setVoidOpen] = useState(false);
   const [voidReason, setVoidReason] = useState('');
   const [voidReissue, setVoidReissue] = useState(false);
+
+  // Inline due-date editor (issued invoices only). Opens with the current due date;
+  // Save PATCHes /invoices/:id/due-date.
+  const [dueDateEditing, setDueDateEditing] = useState(false);
+  const [dueDateDraft, setDueDateDraft] = useState(invoice.dueDate ?? '');
+  useEffect(() => { setDueDateDraft(invoice.dueDate ?? ''); }, [invoice.dueDate]);
 
   const loadPayments = useCallback(async () => {
     const res = await fetchWithAuth(`/invoices/${invoice.id}/payments`);
@@ -115,6 +122,74 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const canRecordPayment =
     invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' && Number(invoice.balance) > 0;
   const canVoid = invoice.status !== 'void' && invoice.status !== 'draft';
+
+  // Deposit-aware charge amount — matches what the server's pay route charges
+  // (computeChargeNow, the single source of truth), so the deposit strip never
+  // advertises a figure different from the actual charge. `depositDue` null = no deposit.
+  const hasDeposit = invoice.depositDue != null;
+  const chargeNow = computeChargeNow({
+    depositDue: invoice.depositDue ?? null,
+    amountPaid: invoice.amountPaid,
+    balance: invoice.balance,
+  });
+
+  // The due date is editable once the invoice is live (issued/partially paid/overdue);
+  // the /due-date route is gated on invoices:write.
+  const canEditDueDate =
+    can('invoices', 'write') && ['sent', 'partially_paid', 'overdue'].includes(invoice.status);
+
+  // Re-sending an issued, part-paid invoice reads as "request payment" rather than
+  // "send" — same POST /send call. Gate on a live, still-owing invoice + invoices:send.
+  const partiallyPaid = Number(invoice.amountPaid) > 0 && Number(invoice.balance) > 0;
+  const canRequestPayment =
+    can('invoices', 'send') &&
+    invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' &&
+    Number(invoice.balance) > 0;
+
+  const saveDueDate = useCallback(async () => {
+    if (busy || !dueDateDraft) return;
+    setBusy(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/due-date`, {
+          method: 'PATCH', body: JSON.stringify({ dueDate: dueDateDraft }),
+        }),
+        errorFallback: 'Could not update the due date.',
+        successMessage: 'Due date updated',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setDueDateEditing(false);
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not update the due date.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, dueDateDraft, invoice.id, refresh]);
+
+  const requestPayment = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      // /send is honest about whether an email actually went out — only claim it
+      // was sent when the API confirms an email was dispatched.
+      const result = await runAction<{ data: { emailed: boolean } }>({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/send`, { method: 'POST' }),
+        errorFallback: 'Could not send the invoice.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      if (result?.data?.emailed) {
+        showToast({ type: 'success', message: partiallyPaid ? 'Payment request sent' : 'Invoice sent' });
+      } else {
+        showToast({ type: 'warning', message: 'No email was sent (no billing contact / email not configured)' });
+      }
+      refresh();
+    } catch (err) {
+      handleActionError(err, 'Could not send the invoice.');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, invoice.id, partiallyPaid, refresh]);
 
   const recordPayment = useCallback(async () => {
     if (busy || !payAmount) return;
@@ -288,7 +363,46 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
                 className={STATUS_ROLES[invoice.status].className}
                 testId="invoice-detail-status"
               />
-              <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
+              {canEditDueDate ? (
+                dueDateEditing ? (
+                  <span className="flex items-center gap-1">
+                    <input
+                      type="date"
+                      value={dueDateDraft}
+                      onChange={(e) => setDueDateDraft(e.target.value)}
+                      disabled={busy}
+                      aria-label="Due date"
+                      data-testid="invoice-due-date-input"
+                      className="h-7 rounded-md border bg-background px-1.5 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+                    />
+                    <button
+                      type="button" onClick={() => void saveDueDate()} disabled={busy || !dueDateDraft}
+                      data-testid="invoice-due-date-save"
+                      className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button" onClick={() => { setDueDateDraft(invoice.dueDate ?? ''); setDueDateEditing(false); }} disabled={busy}
+                      data-testid="invoice-due-date-cancel"
+                      className="rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      Cancel
+                    </button>
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setDueDateEditing(true)}
+                    data-testid="invoice-due-date-edit"
+                    className="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-foreground"
+                  >
+                    Due {formatDate(invoice.dueDate)}
+                  </button>
+                )
+              ) : (
+                <span className="text-xs text-muted-foreground">Due {formatDate(invoice.dueDate)}</span>
+              )}
             </div>
             <dl className="space-y-1 text-sm tabular-nums">
               <div className="flex justify-between"><dt className="text-muted-foreground">Subtotal</dt><dd>{formatMoney(invoice.subtotal, currency)}</dd></div>
@@ -308,6 +422,17 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
                 {formatMoney(invoice.balance, currency)}
               </span>
             </div>
+            {/* Deposit strip — mirrors the customer portal so the operator sees the
+                same deposit-first framing the customer's Pay button uses. */}
+            {hasDeposit && (
+              <div className="mt-3 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="invoice-deposit-strip">
+                {chargeNow.isDeposit ? (
+                  <>Deposit of <strong className="text-foreground">{formatMoney(invoice.depositDue!, currency)}</strong> due — {formatMoney(invoice.amountPaid, currency)} of {formatMoney(invoice.total, currency)} paid.</>
+                ) : (
+                  <>Deposit paid — remaining balance {formatMoney(invoice.balance, currency)}.</>
+                )}
+              </div>
+            )}
             {/* Internal margin summary — profitability stays visible after the
                 invoice is issued and the Editor tab disappears (same reason
                 QuoteDetail renders it). Never reaches the customer document. */}
@@ -352,6 +477,17 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
               the issued-lifecycle rail, not the header. */}
           <div className="space-y-2">
             {!actionsInHeader && <InvoiceActions detail={detail} onChanged={onChanged} variant="rail" />}
+            {/* Re-send the issued invoice. Reads as "Request payment" once the
+                customer has partially paid (same POST /send call). */}
+            {canRequestPayment && (
+              <button
+                type="button" onClick={() => void requestPayment()} disabled={busy}
+                data-testid="invoice-request-payment"
+                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                {partiallyPaid ? 'Request payment' : 'Send invoice'}
+              </button>
+            )}
             {canVoid && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => { setVoidReason(''); setVoidReissue(false); setVoidOpen(true); }}

--- a/apps/web/src/components/billing/InvoicesPage.deposit.test.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.deposit.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoicesPage from './InvoicesPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload), blob: vi.fn() }) as unknown as Response;
+
+const ORGS = [{ id: 'org-1', name: 'Acme Corp' }];
+function invoice(extra: Record<string, unknown>) {
+  return {
+    id: 'inv', invoiceNumber: 'INV-1', orgId: 'org-1', siteId: null, status: 'sent',
+    currencyCode: 'USD', issueDate: '2026-05-01', dueDate: '2026-05-31', sentAt: null, subtotal: '1000.00',
+    taxRate: '0.000', taxTotal: '0.00', total: '1000.00', amountPaid: '0.00', balance: '1000.00',
+    depositDue: null, billToName: 'Acme', notes: null, termsAndConditions: null, sellerSnapshot: null,
+    createdAt: '2026-05-01T00:00:00Z', ...extra,
+  };
+}
+
+function wire(invoices: unknown[]) {
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+    if (input.startsWith('/invoices')) return json({ data: invoices });
+    if (input.startsWith('/orgs/sites')) return json({ data: [] });
+    return json({}, false, 404);
+  });
+}
+
+describe('InvoicesPage deposit badge', () => {
+  beforeEach(() => { vi.clearAllMocks(); window.location.hash = ''; });
+
+  it('shows no deposit badge when the invoice has no deposit', async () => {
+    wire([invoice({ id: 'nd', depositDue: null })]);
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-row-nd')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoices-deposit-unpaid-nd')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoices-deposit-paid-nd')).not.toBeInTheDocument();
+  });
+
+  it('shows Deposit unpaid while the deposit is unmet and Deposit paid once met', async () => {
+    wire([
+      invoice({ id: 'du', depositDue: '300.00', amountPaid: '0.00', balance: '1000.00' }),
+      invoice({ id: 'dp', depositDue: '300.00', amountPaid: '300.00', balance: '700.00', status: 'partially_paid' }),
+    ]);
+    render(<InvoicesPage />);
+    await waitFor(() => expect(screen.getByTestId('invoices-deposit-unpaid-du')).toBeInTheDocument());
+    expect(screen.getByTestId('invoices-deposit-paid-dp')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/InvoicesPage.tsx
+++ b/apps/web/src/components/billing/InvoicesPage.tsx
@@ -75,7 +75,16 @@ function writeFilters(f: Filters): void {
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
+const cents = (s: string | null | undefined) => Math.round(num(s) * 100);
 const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
+
+// Deposit list-badge state (mirrors the portal invoice list): 'unpaid' while
+// amountPaid < depositDue, 'paid' once met, null when the invoice carries no
+// deposit (no badge, zero visual change). Compared in cents.
+function invoiceDepositBadge(inv: InvoiceSummary): 'unpaid' | 'paid' | null {
+  if (inv.depositDue == null) return null;
+  return cents(inv.amountPaid) < cents(inv.depositDue) ? 'unpaid' : 'paid';
+}
 
 export function InvoicesPage() {
   const { can } = usePermissions();
@@ -569,12 +578,27 @@ export function InvoicesPage() {
                           {formatMoney(inv.balance, inv.currencyCode)}
                         </td>
                         <td className="px-3 py-3">
-                          <StatusPill
-                            role={STATUS_ROLES[inv.status].role}
-                            label={statusLabel(inv)}
-                            className={STATUS_ROLES[inv.status].className}
-                            testId={`invoices-status-${inv.id}`}
-                          />
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            <StatusPill
+                              role={STATUS_ROLES[inv.status].role}
+                              label={statusLabel(inv)}
+                              className={STATUS_ROLES[inv.status].className}
+                              testId={`invoices-status-${inv.id}`}
+                            />
+                            {(() => {
+                              const deposit = invoiceDepositBadge(inv);
+                              if (!deposit) return null;
+                              return deposit === 'unpaid' ? (
+                                <span className="inline-flex rounded-full px-2 py-1 text-xs font-medium bg-warning/10 text-warning" data-testid={`invoices-deposit-unpaid-${inv.id}`}>
+                                  Deposit unpaid
+                                </span>
+                              ) : (
+                                <span className="inline-flex rounded-full px-2 py-1 text-xs font-medium bg-success/10 text-success" data-testid={`invoices-deposit-paid-${inv.id}`}>
+                                  Deposit paid
+                                </span>
+                              );
+                            })()}
+                          </div>
                         </td>
                       </tr>
                     );
@@ -615,12 +639,26 @@ export function InvoicesPage() {
                           {inv.invoiceNumber ?? <span aria-hidden="true" className="text-muted-foreground">—</span>}
                         </a>
                       </div>
-                      <StatusPill
-                        role={STATUS_ROLES[inv.status].role}
-                        label={statusLabel(inv)}
-                        className={['shrink-0', STATUS_ROLES[inv.status].className].filter(Boolean).join(' ')}
-                        testId={`invoices-card-status-${inv.id}`}
-                      />
+                      <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+                        <StatusPill
+                          role={STATUS_ROLES[inv.status].role}
+                          label={statusLabel(inv)}
+                          className={['shrink-0', STATUS_ROLES[inv.status].className].filter(Boolean).join(' ')}
+                          testId={`invoices-card-status-${inv.id}`}
+                        />
+                        {(() => {
+                          const deposit = invoiceDepositBadge(inv);
+                          if (!deposit) return null;
+                          return (
+                            <span
+                              className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${deposit === 'unpaid' ? 'bg-warning/10 text-warning' : 'bg-success/10 text-success'}`}
+                              data-testid={`invoices-card-deposit-${inv.id}`}
+                            >
+                              {deposit === 'unpaid' ? 'Deposit unpaid' : 'Deposit paid'}
+                            </span>
+                          );
+                        })()}
+                      </div>
                     </div>
                     <div className="mt-3 space-y-1.5">
                       <CardField label="Organization">{orgName(inv.orgId)}</CardField>

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -54,6 +54,9 @@ export interface InvoiceSummary {
   total: string;
   amountPaid: string;
   balance: string;
+  /** Deposit due at issue (null = no deposit). Drives the deposit strip + the
+   *  deposit paid/unpaid list badge; compared against `amountPaid` in cents. */
+  depositDue?: string | null;
   billToName: string | null;
   notes: string | null;
   termsAndConditions: string | null;

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -182,6 +182,14 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
   // Only surface the per-line Tax column when this quote actually carries tax —
   // otherwise it's a column of dashes. Mirrors the header Tax row's visibility.
   const showTax = Number(quote.taxTotal) > 0;
+  // Deposit summary — mirrors the customer portal (Task 10) so the in-app Preview
+  // matches the proposal link and PDF. `depositDueTotal` null = no deposit.
+  const categoryBreakdown = quote.categoryBreakdown ?? [];
+  const depositDue = quote.depositDueTotal ?? null;
+  // Remaining balance in integer cents so the subtraction never drifts on floats.
+  const remainderCents = depositDue != null
+    ? Math.round(Number(dueOnAcceptance) * 100) - Math.round(Number(depositDue) * 100)
+    : 0;
 
   return (
     <div
@@ -280,19 +288,54 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
                   <span className="tabular-nums text-foreground">{formatMoney(quote.taxTotal, currency)}</span>
                 </div>
               )}
-              <div
-                className="flex items-baseline justify-between border-t pt-3"
-                style={{ borderColor: 'var(--doc-accent)' }}
-              >
-                <span className="text-sm font-semibold text-foreground">Due on acceptance</span>
-                <span
-                  className="text-2xl font-semibold tabular-nums"
-                  style={{ color: 'var(--doc-accent)' }}
-                  data-testid="quote-document-due"
+              {categoryBreakdown.length > 1 && (
+                <div className="space-y-0.5 text-sm text-muted-foreground" data-testid="quote-document-category-breakdown">
+                  {categoryBreakdown.map((b) => (
+                    <div key={b.category} className="flex justify-between">
+                      <span className="capitalize">{b.category}</span>
+                      <span className="tabular-nums">
+                        {[
+                          Number(b.oneTimeTotal) > 0 ? formatMoney(b.oneTimeTotal, currency) : null,
+                          Number(b.monthlyTotal) > 0 ? `${formatMoney(b.monthlyTotal, currency)}/mo` : null,
+                          Number(b.annualTotal) > 0 ? `${formatMoney(b.annualTotal, currency)}/yr` : null,
+                        ].filter(Boolean).join(' + ')}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {depositDue != null ? (
+                <>
+                  <div
+                    className="flex items-baseline justify-between border-t pt-3"
+                    style={{ borderColor: 'var(--doc-accent)' }}
+                    data-testid="quote-document-deposit-due"
+                  >
+                    <span className="text-sm font-semibold text-foreground">Deposit due on acceptance</span>
+                    <span className="text-2xl font-semibold tabular-nums" style={{ color: 'var(--doc-accent)' }}>
+                      {formatMoney(depositDue, currency)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm" data-testid="quote-document-deposit-remainder">
+                    <span className="text-muted-foreground">Remaining balance (due per terms)</span>
+                    <span className="tabular-nums text-foreground">{formatMoney(remainderCents / 100, currency)}</span>
+                  </div>
+                </>
+              ) : (
+                <div
+                  className="flex items-baseline justify-between border-t pt-3"
+                  style={{ borderColor: 'var(--doc-accent)' }}
                 >
-                  {formatMoney(dueOnAcceptance, currency)}
-                </span>
-              </div>
+                  <span className="text-sm font-semibold text-foreground">Due on acceptance</span>
+                  <span
+                    className="text-2xl font-semibold tabular-nums"
+                    style={{ color: 'var(--doc-accent)' }}
+                    data-testid="quote-document-due"
+                  >
+                    {formatMoney(dueOnAcceptance, currency)}
+                  </span>
+                </div>
+              )}
 
               {hasRecurring && (
                 <div className="space-y-1.5 rounded-lg bg-muted/40 p-3 text-sm">

--- a/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock, QuoteLine } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+import { updateLine } from '../../../lib/api/quotes';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  catalogItemImagePath: vi.fn().mockReturnValue('/catalog/img'),
+}));
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(), deleteBlock: vi.fn(), addManualLine: vi.fn(), addCatalogLine: vi.fn(),
+  updateLine: vi.fn().mockResolvedValue({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ data: {} }) }),
+  removeLine: vi.fn(), moveLine: vi.fn(), reorderBlocks: vi.fn(), reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(), quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+  updateBlock: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const updateLineMock = vi.mocked(updateLine);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function line(extra: Partial<QuoteLine> = {}): QuoteLine {
+  return {
+    id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual',
+    catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: 'Server', description: null, quantity: '1', unitPrice: '1000.00', taxable: false,
+    customerVisible: true, lineTotal: '1000.00', recurrence: 'one_time', termMonths: null,
+    billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    depositEligible: false, itemType: 'hardware', ...extra,
+  };
+}
+const block: QuoteBlock = {
+  id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {},
+  sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+function detail(quoteExtra: Partial<QuoteDetailData['quote']> = {}, lines: QuoteLine[] = [line()]): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '1000.00', taxRate: null,
+      taxTotal: '0.00', total: '1000.00', oneTimeTotal: '1000.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '1000.00', depositType: 'none', depositPercent: null,
+      billToName: null, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null,
+      sentAt: null, viewedAt: null, createdBy: null,
+      createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z', ...quoteExtra,
+    },
+    blocks: [block],
+    lines,
+  };
+}
+
+const depositPatchCalls = () =>
+  fetchMock.mock.calls.filter((c) => c[0] === '/quotes/q-1' && (c[1] as RequestInit | undefined)?.method === 'PATCH'
+    && String((c[1] as RequestInit).body).includes('deposit'));
+
+describe('QuoteEditor deposit controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async () => json({ data: {} }));
+  });
+
+  it('selecting Percent defers the PATCH until a percent is entered, then blur-saves both fields', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-deposit-controls')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-deposit-type'), { target: { value: 'percent' } });
+    // No percent yet → no deposit PATCH.
+    expect(depositPatchCalls()).toHaveLength(0);
+
+    const input = await screen.findByTestId('deposit-percent-input');
+    fireEvent.change(input, { target: { value: '30' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(depositPatchCalls()).toHaveLength(1));
+    const body = JSON.parse(String((depositPatchCalls()[0][1] as RequestInit).body));
+    expect(body).toEqual({ depositType: 'percent', depositPercent: 30 });
+  });
+
+  it('shows the live Deposit due figure for a configured percent deposit', async () => {
+    render(<QuoteEditor detail={detail({ depositType: 'percent', depositPercent: '30.00' })} onChanged={vi.fn()} />);
+    const figure = await screen.findByTestId('deposit-due-figure');
+    expect(figure).toHaveTextContent('$300.00');
+  });
+
+  it('Selected lines mode saves the type and reveals a per-line deposit checkbox that PATCHes the line', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-deposit-controls')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-deposit-type'), { target: { value: 'selected_lines' } });
+    await waitFor(() => expect(depositPatchCalls()).toHaveLength(1));
+    expect(JSON.parse(String((depositPatchCalls()[0][1] as RequestInit).body))).toEqual({ depositType: 'selected_lines' });
+
+    const checkbox = await screen.findByTestId('line-deposit-eligible-l-1');
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'l-1', { depositEligible: true }));
+  });
+
+  it('renders no deposit controls figure when deposit is none', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-deposit-controls')).toBeInTheDocument());
+    expect(screen.queryByTestId('deposit-due-figure')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('line-deposit-eligible-l-1')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -862,6 +862,9 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
           taxable: form.taxable,
           customerVisible: true,
           recurrence: form.recurrence,
+          // Manual lines are never deposit-eligible by default (no catalog itemType
+          // to infer hardware from); the user flags it later in the line editor.
+          depositEligible: false,
         }),
         errorFallback: 'Could not add the line.',
         successMessage: 'Line added',

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -19,7 +19,7 @@ import {
   quoteImageUrl,
 } from '../../../lib/api/quotes';
 import type { QuoteBlockInput } from '@breeze/shared';
-import { computeQuoteTotals, computeQuoteProfit, computeLineTotal, markupPct, priceFromMarkup, toCents, fromCents, type QuoteLineForMath, type QuoteProfit, type QuoteTotals } from '@breeze/shared';
+import { computeQuoteTotals, computeQuoteProfit, computeLineTotal, markupPct, priceFromMarkup, toCents, fromCents, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
 import { listCatalog, createCatalogItem, catalogItemImagePath, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import CatalogItemPicker from '../../catalog/CatalogItemPicker';
@@ -79,6 +79,7 @@ type LineUpdate = Partial<{
   sku: string | null;
   partNumber: string | null;
   imageId: string | null;
+  depositEligible: boolean;
 }>;
 
 interface Props {
@@ -261,6 +262,15 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
   useEffect(() => { setTitle(quote.title ?? ''); setTitleDirty(false); }, [quote.title]);
 
+  // ---- deposit controls ----------------------------------------------------
+  // Local mirrors of the persisted deposit config so the type select + percent
+  // input update instantly and the rail's live deposit figure recomputes
+  // mid-edit; both resync from the server after each blur-save's refresh().
+  const [depositType, setDepositType] = useState<QuoteDepositType>(quote.depositType ?? 'none');
+  const [depositPercentDraft, setDepositPercentDraft] = useState<string>(quote.depositPercent ?? '');
+  useEffect(() => { setDepositType(quote.depositType ?? 'none'); }, [quote.depositType]);
+  useEffect(() => { setDepositPercentDraft(quote.depositPercent ?? ''); }, [quote.depositPercent]);
+
   // Coalesce re-pulls: each mutation calls refresh(), but tab-through editing
   // would otherwise fire one full GET /quotes/:id per field. This is a LEADING +
   // trailing throttle, not a pure trailing debounce: the first edit of a burst
@@ -323,6 +333,47 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     }, 'Could not save the title.');
     if (ok) flashTitleSaved();
   }, [titleDirty, title, quote.id, refresh, runScoped, flashTitleSaved]);
+
+  // Persist a deposit-config change via the quote-header PATCH. runAction surfaces
+  // the API's 400 DEPOSIT_* validation message (e.g. "Deposit must be less than the
+  // amount due on acceptance") as the standard failure toast; runScoped clears the
+  // pending key. refresh() re-pulls so the server-recomputed deposit_amount and the
+  // authoritative depositDueTotal land in the rail.
+  const saveDeposit = useCallback((patch: { depositType?: QuoteDepositType; depositPercent?: number | null }) =>
+    runScoped('deposit', async () => {
+      await runAction({
+        request: () => fetchWithAuth(`/quotes/${quote.id}`, {
+          method: 'PATCH', body: JSON.stringify(patch),
+        }),
+        errorFallback: 'Could not update the deposit.',
+        onUnauthorized: UNAUTHORIZED,
+      });
+      refresh();
+    }, 'Could not update the deposit.'),
+  [quote.id, refresh, runScoped]);
+
+  const onDepositTypeChange = useCallback((next: QuoteDepositType) => {
+    setDepositType(next);
+    if (next === 'percent') {
+      // Saving type='percent' with a null percent would 400 DEPOSIT_PERCENT_INVALID,
+      // so defer the PATCH until a percent exists — persist immediately only when one
+      // is already entered (the percent input's onBlur handles the first entry).
+      const pct = depositPercentDraft.trim() === '' ? null : Number(depositPercentDraft);
+      if (pct != null && Number.isFinite(pct)) void saveDeposit({ depositType: 'percent', depositPercent: pct });
+    } else {
+      void saveDeposit({ depositType: next });
+    }
+  }, [depositPercentDraft, saveDeposit]);
+
+  const onDepositPercentBlur = useCallback(() => {
+    if (depositType !== 'percent') return;
+    const pct = depositPercentDraft.trim() === '' ? null : Number(depositPercentDraft);
+    if (pct == null || !Number.isFinite(pct)) return;
+    // Only fire when it actually differs from the persisted value (avoids a
+    // redundant PATCH on a focus-through).
+    if (quote.depositType === 'percent' && quote.depositPercent != null && Number(quote.depositPercent) === pct) return;
+    void saveDeposit({ depositType: 'percent', depositPercent: pct });
+  }, [depositType, depositPercentDraft, quote.depositType, quote.depositPercent, saveDeposit]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });
@@ -421,7 +472,8 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       const prev = m[id];
       if (prev && prev.quantity === draft.quantity && prev.unitPrice === draft.unitPrice
         && (prev.unitCost ?? null) === (draft.unitCost ?? null)
-        && prev.taxable === draft.taxable && prev.recurrence === draft.recurrence) return m;
+        && prev.taxable === draft.taxable && prev.recurrence === draft.recurrence
+        && (prev.depositEligible ?? false) === (draft.depositEligible ?? false)) return m;
       return { ...m, [id]: draft };
     });
   }, []);
@@ -460,6 +512,45 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
   const railTax = optimisticTotals?.taxTotal ?? quote.taxTotal;
   const railTotal = optimisticTotals?.total ?? quote.total;
   const railDue = optimisticTotals?.dueOnAcceptanceTotal ?? quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal;
+
+  // Live deposit + category breakdown. Unlike the figures above (which fall back
+  // to the server values at rest), these ALWAYS recompute from the current lines
+  // (persisted + in-progress drafts) and the current deposit-control state, so the
+  // "Deposit due" figure tracks a percent edit or a deposit-eligible toggle before
+  // the blur-save round-trips. It uses the SAME shared computeQuoteTotals the server
+  // recomputes with, so it can never settle to a different figure than the next GET
+  // returns. Deposit-eligibility/itemType come from the persisted line unless a row
+  // reported them in its draft (a deposit-eligibility toggle).
+  const mergedLines = useMemo<QuoteLineForMath[]>(
+    () => lines.map((l) => {
+      const d = lineDrafts[l.id];
+      return {
+        quantity: d?.quantity ?? l.quantity,
+        unitPrice: d?.unitPrice ?? l.unitPrice,
+        unitCost: d?.unitCost ?? l.unitCost,
+        taxable: d?.taxable ?? l.taxable,
+        customerVisible: l.customerVisible,
+        recurrence: d?.recurrence ?? l.recurrence,
+        depositEligible: d?.depositEligible ?? l.depositEligible ?? false,
+        itemType: d?.itemType ?? l.itemType ?? null,
+      };
+    }),
+    [lines, lineDrafts],
+  );
+  const depositConfig = useMemo<QuoteDepositConfig>(
+    () => ({
+      type: depositType,
+      percent: depositType === 'percent' && depositPercentDraft.trim() !== '' ? Number(depositPercentDraft) : null,
+    }),
+    [depositType, depositPercentDraft],
+  );
+  const liveDepositTotals = useMemo(
+    () => computeQuoteTotals(mergedLines, effectiveRate, depositConfig),
+    [mergedLines, effectiveRate, depositConfig],
+  );
+  const railDeposit = liveDepositTotals.depositDueTotal;
+  const railBreakdown = liveDepositTotals.categoryBreakdown;
+  const depositSelectMode = depositType === 'selected_lines';
 
   // The full "Live totals" sentence a screen reader would announce. The visible
   // figures above update live (per keystroke), but re-announcing this whole
@@ -1047,6 +1138,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 isPending={isPending}
                 canWrite={canWrite}
                 showInternal={showInternal}
+                depositSelectMode={depositSelectMode}
                 ecActive={ecActive}
                 pax8Active={pax8Active}
                 defaultMarkupPct={defaultMarkupPct}
@@ -1199,6 +1291,25 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 </div>
               )}
             </dl>
+            {/* Per-category subtotals (hardware / software / service / other) — only
+                worth showing once the quote spans more than one category. Mirrors the
+                customer document + PDF breakdown so the builder sees what the customer will. */}
+            {railBreakdown.length > 1 && (
+              <div className="mt-2 space-y-0.5 border-t pt-2 text-sm text-muted-foreground" data-testid="quote-category-breakdown">
+                {railBreakdown.map((b) => (
+                  <div key={b.category} className="flex justify-between gap-2">
+                    <span className="capitalize">{b.category}</span>
+                    <span className="tabular-nums">
+                      {[
+                        Number(b.oneTimeTotal) > 0 ? formatMoney(b.oneTimeTotal, currency) : null,
+                        Number(b.monthlyTotal) > 0 ? `${formatMoney(b.monthlyTotal, currency)}/mo` : null,
+                        Number(b.annualTotal) > 0 ? `${formatMoney(b.annualTotal, currency)}/yr` : null,
+                      ].filter(Boolean).join(' + ')}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
             {canSeeMargin && <MarginPanel profit={profit} currency={currency} />}
             {/* Read-only: the rate is resolved at quote creation (org tax settings,
                 falling back to the partner default) and isn't editable per-quote. */}
@@ -1213,6 +1324,57 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
                 Applies to lines marked taxable. Set in the organization&rsquo;s tax settings.
               </p>
             </div>
+            {/* Deposit controls — writer-only. Selecting a type saves it (the server
+                surfaces DEPOSIT_* validation as a toast); the percent input blur-saves.
+                The live "Deposit due" figure recomputes from the same shared math. */}
+            {canWrite && (
+              <div className="mt-2 space-y-2 border-t pt-2" data-testid="quote-deposit-controls">
+                <div className="flex items-center justify-between gap-2">
+                  <label htmlFor="quote-deposit-type" className="text-sm text-muted-foreground">Deposit</label>
+                  <select
+                    id="quote-deposit-type"
+                    value={depositType}
+                    onChange={(e) => onDepositTypeChange(e.target.value as QuoteDepositType)}
+                    disabled={isPending('deposit')}
+                    data-testid="quote-deposit-type"
+                    className="h-9 min-w-0 rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+                  >
+                    <option value="none">No deposit</option>
+                    <option value="percent">Percent of due-on-acceptance</option>
+                    <option value="selected_lines">Selected lines</option>
+                  </select>
+                </div>
+                {depositType === 'percent' && (
+                  <div className="flex items-center justify-between gap-2">
+                    <label htmlFor="quote-deposit-percent" className="text-sm text-muted-foreground">Percent</label>
+                    <div className="flex items-center gap-1">
+                      <input
+                        id="quote-deposit-percent"
+                        type="number" min={0.01} max={99.99} step={0.01}
+                        value={depositPercentDraft}
+                        onChange={(e) => setDepositPercentDraft(e.target.value)}
+                        onBlur={onDepositPercentBlur}
+                        disabled={isPending('deposit')}
+                        data-testid="deposit-percent-input"
+                        className="h-9 w-24 rounded-md border bg-background px-2 text-right text-sm tabular-nums focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+                      />
+                      <span className="text-sm text-muted-foreground">%</span>
+                    </div>
+                  </div>
+                )}
+                {depositType === 'selected_lines' && (
+                  <p className="text-xs text-muted-foreground">
+                    Check the deposit-eligible one-time lines in each pricing table.
+                  </p>
+                )}
+                {railDeposit != null && Number(railDeposit) > 0 && (
+                  <div className="flex items-baseline justify-between gap-2 text-sm font-medium" data-testid="deposit-due-figure">
+                    <span>Deposit due</span>
+                    <span className="tabular-nums">{formatMoney(railDeposit, currency)}</span>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="mt-3 flex items-end justify-between gap-2 border-t pt-3">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">Due on acceptance</span>
               {/* Visual figure only; the SR-only summary node above announces the
@@ -1317,7 +1479,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 function BlockCard({
-  block, quoteId, lines, currency, taxRate, catalog, catalogLoadFailed, isPending, canWrite, showInternal, ecActive, pax8Active, defaultMarkupPct, isFirst, isLast, onAddCatalog, onImportAddDistributor, onImportAddPax8, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock, onLineDraft,
+  block, quoteId, lines, currency, taxRate, catalog, catalogLoadFailed, isPending, canWrite, showInternal, depositSelectMode, ecActive, pax8Active, defaultMarkupPct, isFirst, isLast, onAddCatalog, onImportAddDistributor, onImportAddPax8, onAddManual, onEditLine, onEditBlock, onMoveBlock, onMoveLine, onRemoveLine, onRemoveBlock, onLineDraft,
   moveTargets, onMoveLineToBlock,
 }: {
   block: QuoteBlock;
@@ -1330,6 +1492,9 @@ function BlockCard({
   isPending: (key: string) => boolean;
   canWrite: boolean;
   showInternal: boolean;
+  /** When true (quote deposit = 'selected_lines'), each editable line row shows a
+   *  deposit-eligible checkbox. */
+  depositSelectMode: boolean;
   ecActive: boolean;
   pax8Active: boolean;
   /** Partner default markup % for pre-pricing AI auto-filled lines; null = unknown. */
@@ -1593,6 +1758,7 @@ function BlockCard({
                         isFirst={idx === 0}
                         isLast={idx === lines.length - 1}
                         showInternal={showInternal}
+                        depositSelectMode={depositSelectMode}
                         onEdit={onEditLine}
                         onMove={onMoveLine}
                         onRemove={onRemoveLine}
@@ -1921,7 +2087,7 @@ function ReadonlyLineRow({ line: l, quoteId, currency, taxRate, isFirst, showInt
 // state to the incoming prop so server-side normalization (e.g. recomputed
 // totals, clamped quantity) wins.
 function EditableLineRow({
-  line, quoteId, currency, taxRate, isPending, isFirst, isLast, showInternal, onEdit, onMove, onRemove, onDraft,
+  line, quoteId, currency, taxRate, isPending, isFirst, isLast, showInternal, depositSelectMode, onEdit, onMove, onRemove, onDraft,
   moveTargets, onMoveTo,
 }: {
   line: QuoteLine;
@@ -1932,6 +2098,8 @@ function EditableLineRow({
   isFirst: boolean;
   isLast: boolean;
   showInternal: boolean;
+  /** Show the deposit-eligible checkbox (quote deposit = 'selected_lines'). */
+  depositSelectMode: boolean;
   onEdit: (lineId: string, body: LineUpdate, scopeKey?: string) => Promise<boolean>;
   onMove: (line: QuoteLine, direction: 'up' | 'down') => void;
   onRemove: (line: QuoteLine) => void;
@@ -1955,6 +2123,9 @@ function EditableLineRow({
   // refresh() round-trip lands, and revert if the save fails.
   const [rec, setRec] = useState(line.recurrence);
   const [taxable, setTaxable] = useState(line.taxable);
+  // Deposit-eligibility is committed on change (like taxable) and reverts on a
+  // failed save; resynced from the server prop after each refresh().
+  const [depositEligible, setDepositEligible] = useState(line.depositEligible ?? false);
   // Internal cost/identity fields (cost drives the markup/net strip below the row).
   const [cost, setCost] = useState(line.unitCost ?? '');
   const [sku, setSku] = useState(line.sku ?? '');
@@ -2015,6 +2186,7 @@ function EditableLineRow({
   // refresh GET fires), so a stale resync can't race them — a plain resync wins.
   useEffect(() => { setRec(line.recurrence); }, [line.recurrence]);
   useEffect(() => { setTaxable(line.taxable); }, [line.taxable]);
+  useEffect(() => { setDepositEligible(line.depositEligible ?? false); }, [line.depositEligible]);
 
   // Quiet "Saved" flash in place of the old per-field success toast. This is a
   // single row-level flag on purpose: committing any one field briefly pulses the
@@ -2111,12 +2283,13 @@ function EditableLineRow({
   // recompute uses the same inputs. Emit null once nothing diverges, so the rail
   // reverts to the authoritative server figures; cleanup on unmount avoids a
   // phantom draft skewing the rail after a delete.
-  const diverged = totalDiverged || taxable !== line.taxable || rec !== line.recurrence || costDirty;
+  const depositEligibleDirty = depositEligible !== (line.depositEligible ?? false);
+  const diverged = totalDiverged || taxable !== line.taxable || rec !== line.recurrence || costDirty || depositEligibleDirty;
   useEffect(() => {
     onDraft(line.id, diverged
-      ? { quantity: String(effQty), unitPrice: String(effPrice), unitCost: cost || null, taxable, customerVisible: line.customerVisible, recurrence: rec }
+      ? { quantity: String(effQty), unitPrice: String(effPrice), unitCost: cost || null, taxable, customerVisible: line.customerVisible, recurrence: rec, depositEligible, itemType: line.itemType ?? null }
       : null);
-  }, [onDraft, line.id, line.customerVisible, diverged, effQty, effPrice, cost, taxable, rec]);
+  }, [onDraft, line.id, line.customerVisible, line.itemType, diverged, effQty, effPrice, cost, taxable, rec, depositEligible]);
   // Clear this row's draft when it unmounts (e.g. removed) so the rail doesn't
   // keep a phantom override.
   useEffect(() => () => onDraft(line.id, null), [onDraft, line.id]);
@@ -2282,6 +2455,26 @@ function EditableLineRow({
           disabled={fieldBusy('taxable')}
           data-testid={`quote-line-taxable-${line.id}`}
         />
+        {/* Deposit-eligible toggle appears only when the quote's deposit is
+            'selected_lines'. It's meaningful for one-time lines only (recurring
+            lines never count toward a deposit), so it's hidden for recurring rows. */}
+        {depositSelectMode && rec === 'one_time' && (
+          <label className="mt-1 flex items-center justify-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={depositEligible}
+              aria-label="Deposit eligible"
+              onChange={(e) => {
+                const next = e.target.checked;
+                setDepositEligible(next); // optimistic — revert if the save fails
+                void edit({ depositEligible: next }, 'deposit').then((ok) => { if (!ok) setDepositEligible(line.depositEligible ?? false); });
+              }}
+              disabled={fieldBusy('deposit')}
+              data-testid={`line-deposit-eligible-${line.id}`}
+            />
+            Deposit
+          </label>
+        )}
       </td>
       <td className="px-2 py-2 text-right tabular-nums text-muted-foreground" data-testid={`quote-line-tax-${line.id}`}>
         {displayTax === null ? '—' : formatMoney(displayTax, currency)}

--- a/apps/web/src/components/billing/quotes/QuotesPage.deposit.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.deposit.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuotesPage from './QuotesPage';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload), blob: vi.fn() }) as unknown as Response;
+
+const ORGS = [{ id: 'org-1', name: 'Acme Corp' }];
+function quote(extra: Record<string, unknown>) {
+  return {
+    id: 'q', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null, taxTotal: '0.00',
+    total: '150.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+    depositType: 'none', billToName: null, introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null,
+    acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    invoiceDepositDue: null, invoiceAmountPaid: null, ...extra,
+  };
+}
+
+function wire(quotes: unknown[]) {
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input.startsWith('/orgs/organizations')) return json({ data: ORGS });
+    if (input.startsWith('/quotes')) return json({ data: quotes });
+    return json({}, false, 404);
+  });
+}
+
+describe('QuotesPage deposit badge', () => {
+  beforeEach(() => { vi.clearAllMocks(); window.location.hash = ''; });
+
+  it('shows no badge for a quote without a deposit', async () => {
+    wire([quote({ id: 'qn', depositType: 'none' })]);
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-row-qn')).toBeInTheDocument());
+    expect(screen.queryByTestId('quotes-deposit-badge-qn')).not.toBeInTheDocument();
+  });
+
+  it('shows a neutral Deposit chip for a draft with a deposit configured', async () => {
+    wire([quote({ id: 'qd', depositType: 'percent' })]);
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-deposit-badge-qd')).toHaveTextContent('Deposit'));
+    expect(screen.getByTestId('quotes-deposit-badge-qd')).not.toHaveTextContent('paid');
+  });
+
+  it('shows Deposit unpaid / paid for converted quotes per the invoice money state', async () => {
+    wire([
+      quote({ id: 'qu', status: 'converted', depositType: 'percent', convertedInvoiceId: 'i1', invoiceDepositDue: '300.00', invoiceAmountPaid: '0.00' }),
+      quote({ id: 'qp', status: 'converted', depositType: 'percent', convertedInvoiceId: 'i2', invoiceDepositDue: '300.00', invoiceAmountPaid: '300.00' }),
+    ]);
+    render(<QuotesPage />);
+    await waitFor(() => expect(screen.getByTestId('quotes-deposit-badge-qu')).toHaveTextContent('Deposit unpaid'));
+    expect(screen.getByTestId('quotes-deposit-badge-qp')).toHaveTextContent('Deposit paid');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -74,7 +74,25 @@ function writeFilters(f: Filters): void {
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 const num = (s: string | null | undefined) => { const n = Number(s); return Number.isFinite(n) ? n : 0; };
+const cents = (s: string | null | undefined) => Math.round(num(s) * 100);
 const ts = (d: string | null) => (d ? new Date(d.length === 10 ? `${d}T00:00:00` : d).getTime() : null);
+
+// Deposit chip for a quote row. `null` = no chip (no deposit configured). A
+// converted quote whose invoice carries a deposit shows the money state
+// (paid/unpaid, compared in cents); an unconverted quote with a deposit shows a
+// neutral "Deposit" marker.
+function quoteDepositBadge(q: Quote): { label: string; className: string } | null {
+  if (q.status === 'converted' && q.invoiceDepositDue != null) {
+    const paid = cents(q.invoiceAmountPaid) >= cents(q.invoiceDepositDue);
+    return paid
+      ? { label: 'Deposit paid', className: 'bg-success/10 text-success' }
+      : { label: 'Deposit unpaid', className: 'bg-warning/10 text-warning' };
+  }
+  if ((q.depositType ?? 'none') !== 'none') {
+    return { label: 'Deposit', className: 'bg-muted text-muted-foreground' };
+  }
+  return null;
+}
 
 export function QuotesPage() {
   const { can } = usePermissions();
@@ -496,12 +514,26 @@ export function QuotesPage() {
                       </td>
                       <td className="px-3 py-3">{orgName(qt.orgId)}</td>
                       <td className="px-3 py-3">
-                        <StatusPill
-                          role={STATUS_ROLES[qt.status].role}
-                          label={statusLabel(qt)}
-                          className={STATUS_ROLES[qt.status].className}
-                          testId={`quotes-status-${qt.id}`}
-                        />
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <StatusPill
+                            role={STATUS_ROLES[qt.status].role}
+                            label={statusLabel(qt)}
+                            className={STATUS_ROLES[qt.status].className}
+                            testId={`quotes-status-${qt.id}`}
+                          />
+                          {(() => {
+                            const badge = quoteDepositBadge(qt);
+                            if (!badge) return null;
+                            return (
+                              <span
+                                className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${badge.className}`}
+                                data-testid={`quotes-deposit-badge-${qt.id}`}
+                              >
+                                {badge.label}
+                              </span>
+                            );
+                          })()}
+                        </div>
                       </td>
                       <td className="px-3 py-3 text-right tabular-nums">{formatMoney(qt.total, qt.currencyCode)}</td>
                       <td className="px-3 py-3 text-muted-foreground">{formatDate(qt.createdAt)}</td>

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -6,11 +6,14 @@ import type { SellerSnapshot } from '../invoiceTypes';
 export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
 import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
+import type { QuoteDepositType, QuoteCategorySubtotal } from '@breeze/shared';
+export type { QuoteDepositType, QuoteCategorySubtotal } from '@breeze/shared';
 
 export type QuoteStatus =
   | 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'expired' | 'converted';
 
 export type QuoteLineRecurrence = 'one_time' | 'monthly' | 'annual';
+export type QuoteItemType = 'hardware' | 'software' | 'service';
 export type QuoteLineSourceType = 'catalog' | 'bundle' | 'manual';
 export type QuoteBlockType = 'heading' | 'rich_text' | 'image' | 'line_items';
 
@@ -42,6 +45,20 @@ export interface Quote {
    * from the list endpoint. The UI shows this as "Due on acceptance"; `total`
    * is the recurring-inclusive first-period figure shown separately. */
   dueOnAcceptanceTotal?: string;
+  /** Deposit config. Persisted on every quote (DB defaults `depositType='none'`),
+   *  but optional here so long-standing test fixtures without the columns stay
+   *  assignable — read with a `?? 'none'` fallback. */
+  depositType?: QuoteDepositType;
+  depositPercent?: string | null;
+  depositAmount?: string | null;
+  /** Deposit due at acceptance + per-category subtotals — derived server-side in
+   *  `getQuote`, so present on `GET /quotes/:id` but absent from the list endpoint. */
+  depositDueTotal?: string | null;
+  categoryBreakdown?: QuoteCategorySubtotal[];
+  /** Money state of the converted invoice, joined onto the LIST endpoint only so
+   *  the quotes table can show a Deposit paid/unpaid badge for converted quotes. */
+  invoiceDepositDue?: string | null;
+  invoiceAmountPaid?: string | null;
   billToName: string | null;
   introNotes: string | null;
   terms: string | null;
@@ -92,6 +109,11 @@ export interface QuoteLine {
   customerVisible: boolean;
   lineTotal: string;
   recurrence: QuoteLineRecurrence;
+  /** Counts toward a `selected_lines` deposit (one-time lines only). Optional so
+   *  pre-column fixtures stay assignable; the API always sends it (default false). */
+  depositEligible?: boolean;
+  /** Catalog item type snapshotted at add-time; null = manual → 'other' category. */
+  itemType?: QuoteItemType | null;
   termMonths: number | null;
   billingFrequency: string | null;
   sortOrder: number;

--- a/packages/shared/src/utils/depositMath.test.ts
+++ b/packages/shared/src/utils/depositMath.test.ts
@@ -1,0 +1,31 @@
+// packages/shared/src/utils/depositMath.test.ts
+import { describe, it, expect } from 'vitest';
+import { computeChargeNow } from './depositMath';
+
+describe('computeChargeNow', () => {
+  it('no deposit → full balance', () => {
+    expect(computeChargeNow({ depositDue: null, amountPaid: '0.00', balance: '10000.00' }))
+      .toEqual({ amount: '10000.00', isDeposit: false });
+  });
+  it('deposit unpaid → deposit amount', () => {
+    expect(computeChargeNow({ depositDue: '3000.00', amountPaid: '0.00', balance: '10000.00' }))
+      .toEqual({ amount: '3000.00', isDeposit: true });
+  });
+  it('deposit partly paid (manual check) → deposit remainder', () => {
+    expect(computeChargeNow({ depositDue: '3000.00', amountPaid: '1000.00', balance: '9000.00' }))
+      .toEqual({ amount: '2000.00', isDeposit: true });
+  });
+  it('deposit satisfied → remaining balance', () => {
+    expect(computeChargeNow({ depositDue: '3000.00', amountPaid: '3000.00', balance: '7000.00' }))
+      .toEqual({ amount: '7000.00', isDeposit: false });
+  });
+  it('overpaid past deposit → remaining balance', () => {
+    expect(computeChargeNow({ depositDue: '3000.00', amountPaid: '5000.00', balance: '5000.00' }))
+      .toEqual({ amount: '5000.00', isDeposit: false });
+  });
+  it('never charges more than the balance (deposit > balance edge)', () => {
+    // total 10000, deposit 3000, but 8000 already paid → balance 2000 < deposit remainder
+    expect(computeChargeNow({ depositDue: '9000.00', amountPaid: '8000.00', balance: '2000.00' }))
+      .toEqual({ amount: '1000.00', isDeposit: true });
+  });
+});

--- a/packages/shared/src/utils/depositMath.ts
+++ b/packages/shared/src/utils/depositMath.ts
@@ -7,11 +7,16 @@ import { toCents, fromCents } from './quoteMath';
  * Stripe charge past what is owed. Pure + browser-safe: shared by the API
  * checkout paths and the portal/web "Pay" button labels.
  */
-export function computeChargeNow(inv: {
+/** Input to the deposit-first charge rule. Exported so the portal's re-implemented
+ *  copy (which can't import runtime code from this package) can import the TYPE and
+ *  cannot structurally drift from the server's contract. */
+export interface DepositChargeInput {
   depositDue: string | null;
   amountPaid: string;
   balance: string;
-}): { amount: string; isDeposit: boolean } {
+}
+
+export function computeChargeNow(inv: DepositChargeInput): { amount: string; isDeposit: boolean } {
   const balanceCents = toCents(inv.balance);
   const depositCents = inv.depositDue !== null ? toCents(inv.depositDue) : 0;
   const paidCents = toCents(inv.amountPaid);

--- a/packages/shared/src/utils/depositMath.ts
+++ b/packages/shared/src/utils/depositMath.ts
@@ -1,0 +1,22 @@
+import { toCents, fromCents } from './quoteMath';
+
+/**
+ * The single pay-amount rule (spec §"Pay-amount rule"):
+ *   chargeNow = deposit set && amountPaid < depositDue ? depositDue − amountPaid : balance
+ * Clamped to the invoice balance so a concurrent manual payment can never push a
+ * Stripe charge past what is owed. Pure + browser-safe: shared by the API
+ * checkout paths and the portal/web "Pay" button labels.
+ */
+export function computeChargeNow(inv: {
+  depositDue: string | null;
+  amountPaid: string;
+  balance: string;
+}): { amount: string; isDeposit: boolean } {
+  const balanceCents = toCents(inv.balance);
+  const depositCents = inv.depositDue !== null ? toCents(inv.depositDue) : 0;
+  const paidCents = toCents(inv.amountPaid);
+  if (depositCents > 0 && paidCents < depositCents) {
+    return { amount: fromCents(Math.min(depositCents - paidCents, balanceCents)), isDeposit: true };
+  }
+  return { amount: inv.balance, isDeposit: false };
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,5 +5,6 @@ export * from './timezone';
 export * from './assuranceLevel';
 export * from './ticketTemplate';
 export * from './quoteMath';
+export * from './depositMath';
 export * from './csvExport';
 export * from './reportSchedule';

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, type QuoteLineForMath } from './quoteMath';
+import { computeQuoteTotals, computeLineTotal, toCents, fromCents, markupPct, priceFromMarkup, computeQuoteProfit, validateQuoteDeposit, type QuoteLineForMath } from './quoteMath';
 
 const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
   quantity: '1', unitPrice: '0', taxable: false, recurrence: 'one_time', customerVisible: true, ...over,
@@ -79,3 +79,93 @@ describe('quoteMath (shared)', () => {
     expect(r.linesMissingCost).toBe(1);
   });
 });
+
+// Block-scoped so this `line` helper (default unitPrice '100.00') doesn't
+// collide with the module-level `line` helper above (default unitPrice '0').
+{
+  const line = (over: Partial<QuoteLineForMath>): QuoteLineForMath => ({
+    quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true,
+    recurrence: 'one_time', ...over,
+  });
+
+  describe('deposit math', () => {
+    it('percent deposit = percent of dueOnAcceptanceTotal (one-time + one-time tax)', () => {
+      const lines = [
+        line({ unitPrice: '1000.00', taxable: true }),
+        line({ unitPrice: '500.00', recurrence: 'monthly' }), // recurring excluded
+      ];
+      // dueOnAcceptance = 1000 + 10% tax = 1100.00; 30% => 330.00
+      const t = computeQuoteTotals(lines, 0.1, { type: 'percent', percent: 30 });
+      expect(t.dueOnAcceptanceTotal).toBe('1100.00');
+      expect(t.depositDueTotal).toBe('330.00');
+    });
+
+    it('percent deposit rounds half-up at the cent boundary', () => {
+      // 33.335 => 33.34 (dueOnAcceptance 100.00, 33.335%)
+      const t = computeQuoteTotals([line({ unitPrice: '100.00' })], null, { type: 'percent', percent: 33.335 });
+      expect(t.depositDueTotal).toBe('33.34');
+    });
+
+    it('selected_lines deposit sums flagged one-time lines + tax on flagged taxable lines', () => {
+      const lines = [
+        line({ unitPrice: '6200.00', taxable: true, depositEligible: true, itemType: 'hardware' }),
+        line({ unitPrice: '1100.00', taxable: false, depositEligible: true, itemType: 'hardware' }),
+        line({ unitPrice: '2400.00', taxable: true, depositEligible: false }),           // not flagged
+        line({ unitPrice: '99.00', depositEligible: true, recurrence: 'monthly' }),      // recurring never counts
+        line({ unitPrice: '50.00', depositEligible: true, customerVisible: false }),     // hidden never counts
+      ];
+      // 6200 + 1100 + 10% of 6200 = 7920.00
+      const t = computeQuoteTotals(lines, 0.1, { type: 'selected_lines' });
+      expect(t.depositDueTotal).toBe('7920.00');
+    });
+
+    it('depositDueTotal is null for type none / missing config', () => {
+      expect(computeQuoteTotals([line({})], null).depositDueTotal).toBeNull();
+      expect(computeQuoteTotals([line({})], null, { type: 'none' }).depositDueTotal).toBeNull();
+    });
+
+    it('categoryBreakdown groups by itemType with manual lines under other, omitting empty categories', () => {
+      const lines = [
+        line({ unitPrice: '6200.00', itemType: 'hardware' }),
+        line({ unitPrice: '1100.00', itemType: 'hardware' }),
+        line({ unitPrice: '300.00', itemType: 'service', recurrence: 'monthly' }),
+        line({ unitPrice: '2400.00' }), // manual, no itemType
+        line({ unitPrice: '10.00', customerVisible: false, itemType: 'software' }), // hidden excluded entirely
+      ];
+      const t = computeQuoteTotals(lines, null);
+      expect(t.categoryBreakdown).toEqual([
+        { category: 'hardware', oneTimeTotal: '7300.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+        { category: 'service', oneTimeTotal: '0.00', monthlyTotal: '300.00', annualTotal: '0.00' },
+        { category: 'other', oneTimeTotal: '2400.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+      ]);
+    });
+  });
+
+  describe('validateQuoteDeposit', () => {
+    it('accepts a valid percent deposit', () => {
+      const r = validateQuoteDeposit([line({ unitPrice: '1000.00' })], null, { type: 'percent', percent: 30 });
+      expect(r).toEqual({ ok: true, depositDueTotal: '300.00' });
+    });
+    it('type none is always ok with null total', () => {
+      expect(validateQuoteDeposit([], null, { type: 'none' })).toEqual({ ok: true, depositDueTotal: null });
+    });
+    it('rejects deposit without one-time customer-visible lines', () => {
+      const r = validateQuoteDeposit([line({ recurrence: 'monthly' })], null, { type: 'percent', percent: 30 });
+      expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_REQUIRES_ONE_TIME_LINES' });
+    });
+    it('rejects percent type without a usable percent', () => {
+      expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: null }))
+        .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
+      expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: 100 }))
+        .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
+    });
+    it('rejects selected_lines with no eligible one-time line', () => {
+      const r = validateQuoteDeposit([line({ depositEligible: false })], null, { type: 'selected_lines' });
+      expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_NO_ELIGIBLE_LINES' });
+    });
+    it('rejects deposit >= dueOnAcceptanceTotal (all lines flagged = "no deposit")', () => {
+      const r = validateQuoteDeposit([line({ depositEligible: true })], null, { type: 'selected_lines' });
+      expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_NOT_BELOW_TOTAL' });
+    });
+  });
+}

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -159,6 +159,11 @@ describe('quoteMath (shared)', () => {
       expect(validateQuoteDeposit([line({})], null, { type: 'percent', percent: 100 }))
         .toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
     });
+    it('rejects a percent that rounds the deposit to zero cents', () => {
+      // dueOnAcceptance 1.00; 0.4% => 0.4 cents => rounds to 0 — a $0.00 deposit is no deposit
+      const r = validateQuoteDeposit([line({ unitPrice: '1.00' })], null, { type: 'percent', percent: 0.4 });
+      expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_PERCENT_INVALID' });
+    });
     it('rejects selected_lines with no eligible one-time line', () => {
       const r = validateQuoteDeposit([line({ depositEligible: false })], null, { type: 'selected_lines' });
       expect(r).toMatchObject({ ok: false, code: 'DEPOSIT_NO_ELIGIBLE_LINES' });

--- a/packages/shared/src/utils/quoteMath.test.ts
+++ b/packages/shared/src/utils/quoteMath.test.ts
@@ -124,6 +124,16 @@ describe('quoteMath (shared)', () => {
       expect(computeQuoteTotals([line({})], null, { type: 'none' }).depositDueTotal).toBeNull();
     });
 
+    it('depositDueTotal is null (not "0.00") when a deposit computes to zero', () => {
+      // A percent so small it rounds to $0.00, and a selected_lines deposit with no
+      // eligible lines, must both collapse to null so the persisted snapshot and the
+      // accept-time guard read them as "no deposit", not a bogus $0.00 deposit.
+      expect(computeQuoteTotals([line({ unitPrice: '1.00' })], null, { type: 'percent', percent: 0.4 }).depositDueTotal).toBeNull();
+      expect(computeQuoteTotals([line({ unitPrice: '100.00', depositEligible: false })], null, { type: 'selected_lines' }).depositDueTotal).toBeNull();
+      // And null when the only one-time line was "deleted" (percent type, no one-time lines left).
+      expect(computeQuoteTotals([line({ recurrence: 'monthly' })], null, { type: 'percent', percent: 30 }).depositDueTotal).toBeNull();
+    });
+
     it('categoryBreakdown groups by itemType with manual lines under other, omitting empty categories', () => {
       const lines = [
         line({ unitPrice: '6200.00', itemType: 'hardware' }),

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -36,6 +36,13 @@ export function computeLineTotal(quantity: string | number, unitPrice: string | 
   return fromCents(roundHalfUp(fractionalCents));
 }
 
+export type QuoteDepositType = 'none' | 'percent' | 'selected_lines';
+export interface QuoteDepositConfig {
+  type: QuoteDepositType;
+  /** Required for type 'percent'. Whole-percent scale (30 = 30%), 2dp. */
+  percent?: number | string | null;
+}
+
 export interface QuoteLineForMath {
   quantity: string;
   unitPrice: string;
@@ -43,6 +50,17 @@ export interface QuoteLineForMath {
   taxable: boolean;
   customerVisible: boolean;
   recurrence: 'one_time' | 'monthly' | 'annual';
+  /** Counts toward a 'selected_lines' deposit (one-time lines only). */
+  depositEligible?: boolean;
+  /** Catalog item type snapshotted at add-time; null/undefined = manual → 'other'. */
+  itemType?: 'hardware' | 'software' | 'service' | null;
+}
+
+export interface QuoteCategorySubtotal {
+  category: 'hardware' | 'software' | 'service' | 'other';
+  oneTimeTotal: string;
+  monthlyTotal: string;
+  annualTotal: string;
 }
 
 export interface QuoteTotals {
@@ -60,10 +78,21 @@ export interface QuoteTotals {
    * period. Must equal quoteAcceptService's invoice math.
    */
   dueOnAcceptanceTotal: string;
+  /** Deposit due at acceptance, or null when no (valid) deposit is configured. */
+  depositDueTotal: string | null;
+  /** Per-category subtotals over customer-visible lines; empty categories omitted. */
+  categoryBreakdown: QuoteCategorySubtotal[];
 }
 
-export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | null): QuoteTotals {
+export function computeQuoteTotals(
+  lines: QuoteLineForMath[],
+  taxRate: number | null,
+  deposit?: QuoteDepositConfig | null,
+): QuoteTotals {
   let oneTime = 0, monthly = 0, annual = 0, taxableBasis = 0, oneTimeTaxableBasis = 0;
+  let eligibleCents = 0, eligibleTaxableCents = 0;
+  const CATEGORY_ORDER = ['hardware', 'software', 'service', 'other'] as const;
+  const cat: Record<string, { oneTime: number; monthly: number; annual: number }> = {};
   for (const l of lines) {
     if (!l.customerVisible) continue;
     // Route per-line cents through computeLineTotal so they equal the persisted
@@ -76,6 +105,15 @@ export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | 
       taxableBasis += lineCents;
       if (l.recurrence === 'one_time') oneTimeTaxableBasis += lineCents;
     }
+    if (l.depositEligible && l.recurrence === 'one_time') {
+      eligibleCents += lineCents;
+      if (l.taxable) eligibleTaxableCents += lineCents;
+    }
+    const key = l.itemType ?? 'other';
+    const bucket = (cat[key] ??= { oneTime: 0, monthly: 0, annual: 0 });
+    if (l.recurrence === 'monthly') bucket.monthly += lineCents;
+    else if (l.recurrence === 'annual') bucket.annual += lineCents;
+    else bucket.oneTime += lineCents;
   }
   // First-period basis: one-time + first monthly period + first annual period.
   const subtotal = oneTime + monthly + annual;
@@ -83,6 +121,18 @@ export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | 
   const taxCents = Math.floor(taxableBasis * rate + 0.5);
   // Tax on ONLY the one-time taxable lines — what accept actually invoices.
   const oneTimeTaxCents = Math.floor(oneTimeTaxableBasis * rate + 0.5);
+  const dueOnAcceptanceCents = oneTime + oneTimeTaxCents;
+
+  let depositCents: number | null = null;
+  if (deposit && deposit.type === 'percent') {
+    const pct = Number(deposit.percent);
+    if (Number.isFinite(pct) && pct > 0) {
+      depositCents = Math.floor(dueOnAcceptanceCents * (pct / 100) + 0.5);
+    }
+  } else if (deposit && deposit.type === 'selected_lines') {
+    depositCents = eligibleCents + Math.floor(eligibleTaxableCents * rate + 0.5);
+  }
+
   return {
     subtotal: fromCents(subtotal),
     taxTotal: fromCents(taxCents),
@@ -90,8 +140,51 @@ export function computeQuoteTotals(lines: QuoteLineForMath[], taxRate: number | 
     oneTimeTotal: fromCents(oneTime),
     monthlyRecurringTotal: fromCents(monthly),
     annualRecurringTotal: fromCents(annual),
-    dueOnAcceptanceTotal: fromCents(oneTime + oneTimeTaxCents),
+    dueOnAcceptanceTotal: fromCents(dueOnAcceptanceCents),
+    depositDueTotal: depositCents !== null ? fromCents(depositCents) : null,
+    categoryBreakdown: CATEGORY_ORDER
+      .filter((k) => cat[k])
+      .map((k) => ({
+        category: k,
+        oneTimeTotal: fromCents(cat[k]!.oneTime),
+        monthlyTotal: fromCents(cat[k]!.monthly),
+        annualTotal: fromCents(cat[k]!.annual),
+      })),
   };
+}
+
+export type QuoteDepositValidation =
+  | { ok: true; depositDueTotal: string | null }
+  | { ok: false; code: 'DEPOSIT_REQUIRES_ONE_TIME_LINES' | 'DEPOSIT_PERCENT_INVALID'
+      | 'DEPOSIT_NO_ELIGIBLE_LINES' | 'DEPOSIT_NOT_BELOW_TOTAL'; message: string };
+
+/** Spec rule: deposit needs ≥1 one-time visible line; 0 < deposit < dueOnAcceptanceTotal. */
+export function validateQuoteDeposit(
+  lines: QuoteLineForMath[],
+  taxRate: number | null,
+  deposit: QuoteDepositConfig,
+): QuoteDepositValidation {
+  if (deposit.type === 'none') return { ok: true, depositDueTotal: null };
+  const totals = computeQuoteTotals(lines, taxRate, deposit);
+  if (toCents(totals.dueOnAcceptanceTotal) <= 0) {
+    return { ok: false, code: 'DEPOSIT_REQUIRES_ONE_TIME_LINES',
+      message: 'A deposit needs at least one one-time, customer-visible line' };
+  }
+  if (deposit.type === 'percent') {
+    const pct = Number(deposit.percent);
+    if (!Number.isFinite(pct) || pct <= 0 || pct >= 100) {
+      return { ok: false, code: 'DEPOSIT_PERCENT_INVALID', message: 'Deposit percent must be between 0 and 100 (exclusive)' };
+    }
+  }
+  const depositCents = totals.depositDueTotal !== null ? toCents(totals.depositDueTotal) : 0;
+  if (deposit.type === 'selected_lines' && depositCents <= 0) {
+    return { ok: false, code: 'DEPOSIT_NO_ELIGIBLE_LINES', message: 'Flag at least one one-time line as deposit-eligible' };
+  }
+  if (depositCents >= toCents(totals.dueOnAcceptanceTotal)) {
+    return { ok: false, code: 'DEPOSIT_NOT_BELOW_TOTAL',
+      message: 'Deposit must be less than the amount due on acceptance — remove the deposit instead' };
+  }
+  return { ok: true, depositDueTotal: totals.depositDueTotal };
 }
 
 /** markup on cost = (price − cost) / cost · 100. Null when cost is absent/≤0. */

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -180,6 +180,10 @@ export function validateQuoteDeposit(
   if (deposit.type === 'selected_lines' && depositCents <= 0) {
     return { ok: false, code: 'DEPOSIT_NO_ELIGIBLE_LINES', message: 'Flag at least one one-time line as deposit-eligible' };
   }
+  // Spec rule 0 < deposit: a percent so small it rounds to $0.00 is no deposit.
+  if (deposit.type === 'percent' && depositCents <= 0) {
+    return { ok: false, code: 'DEPOSIT_PERCENT_INVALID', message: 'Deposit percent is too small for this quote total' };
+  }
   if (depositCents >= toCents(totals.dueOnAcceptanceTotal)) {
     return { ok: false, code: 'DEPOSIT_NOT_BELOW_TOTAL',
       message: 'Deposit must be less than the amount due on acceptance — remove the deposit instead' };

--- a/packages/shared/src/utils/quoteMath.ts
+++ b/packages/shared/src/utils/quoteMath.ts
@@ -132,6 +132,11 @@ export function computeQuoteTotals(
   } else if (deposit && deposit.type === 'selected_lines') {
     depositCents = eligibleCents + Math.floor(eligibleTaxableCents * rate + 0.5);
   }
+  // A deposit that computes to $0.00 or less is "no deposit": collapse to null so
+  // the persisted snapshot (recomputeAndPersist) and the accept-time `!= null`
+  // guard agree with the documented contract, rather than storing a bogus "0.00".
+  // validateQuoteDeposit still hard-blocks these before a quote can be sent.
+  if (depositCents !== null && depositCents <= 0) depositCents = null;
 
   return {
     subtotal: fromCents(subtotal),

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -151,3 +151,23 @@ describe('moveQuoteLineSchema', () => {
     expect(moveQuoteLineSchema.safeParse({ blockId: null }).success).toBe(false);
   });
 });
+
+describe('deposit validator fields', () => {
+  it('accepts deposit config on quote update', () => {
+    expect(updateQuoteSchema.parse({ depositType: 'percent', depositPercent: 30 }))
+      .toMatchObject({ depositType: 'percent', depositPercent: 30 });
+    expect(updateQuoteSchema.parse({ depositType: 'none', depositPercent: null }))
+      .toMatchObject({ depositType: 'none', depositPercent: null });
+  });
+  it('rejects out-of-range percent', () => {
+    expect(updateQuoteSchema.safeParse({ depositPercent: 0 }).success).toBe(false);
+    expect(updateQuoteSchema.safeParse({ depositPercent: 100 }).success).toBe(false);
+    expect(updateQuoteSchema.safeParse({ depositPercent: 12.345 }).success).toBe(false);
+  });
+  it('accepts depositEligible on line create and update', () => {
+    const base = { sourceType: 'manual', name: 'x', quantity: 1, unitPrice: 5, taxable: false };
+    expect(quoteLineInputSchema.parse({ ...base, depositEligible: true })).toMatchObject({ depositEligible: true });
+    expect(quoteLineInputSchema.parse(base)).toMatchObject({ depositEligible: false }); // default
+    expect(updateQuoteLineSchema.parse({ depositEligible: true })).toMatchObject({ depositEligible: true });
+  });
+});

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -164,6 +164,16 @@ describe('deposit validator fields', () => {
     expect(updateQuoteSchema.safeParse({ depositPercent: 100 }).success).toBe(false);
     expect(updateQuoteSchema.safeParse({ depositPercent: 12.345 }).success).toBe(false);
   });
+  it('rejects a percent value paired with a non-percent deposit type', () => {
+    // The contradiction (percent is meaningless for none/selected_lines) is caught
+    // at the boundary rather than silently nulled by the service.
+    expect(updateQuoteSchema.safeParse({ depositType: 'none', depositPercent: 30 }).success).toBe(false);
+    expect(updateQuoteSchema.safeParse({ depositType: 'selected_lines', depositPercent: 30 }).success).toBe(false);
+    // A bare percent patch is still allowed — the service derives the type from the stored quote.
+    expect(updateQuoteSchema.safeParse({ depositPercent: 30 }).success).toBe(true);
+    // Clearing the percent alongside a non-percent type is fine.
+    expect(updateQuoteSchema.safeParse({ depositType: 'selected_lines', depositPercent: null }).success).toBe(true);
+  });
   it('accepts depositEligible on line create and update', () => {
     const base = { sourceType: 'manual', name: 'x', quantity: 1, unitPrice: 5, taxable: false };
     expect(quoteLineInputSchema.parse({ ...base, depositEligible: true })).toMatchObject({ depositEligible: true });

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -98,7 +98,15 @@ export const updateQuoteSchema = z.object({
   billToName: z.string().max(255).nullable().optional(),
   depositType: quoteDepositTypeSchema.optional(),
   depositPercent: depositPercent.nullable().optional(),
-});
+}).refine(
+  // A percent value is only meaningful for a 'percent' deposit. Reject a patch
+  // that pairs a non-percent type with a percent in the same request, so the
+  // contradiction is caught at the boundary instead of being silently nulled by
+  // the service. (A bare { depositPercent } patch is still allowed — the service
+  // derives the type from the stored quote.)
+  (d) => !(d.depositType && d.depositType !== 'percent' && d.depositPercent != null),
+  { message: 'depositPercent is only valid when depositType is "percent"', path: ['depositPercent'] },
+);
 
 // A reorder payload must be a clean permutation of the existing ids, so the id
 // list has to be unique — without this, a duplicated id (e.g. [A, A] for blocks

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -13,6 +13,10 @@ export const quoteStatusSchema = z.enum(['draft', 'sent', 'viewed', 'accepted', 
 export const quoteLineRecurrenceSchema = z.enum(['one_time', 'monthly', 'annual']);
 export const quoteLineSourceTypeSchema = z.enum(['catalog', 'bundle', 'manual']);
 export const quoteBlockTypeSchema = z.enum(['heading', 'rich_text', 'image', 'line_items']);
+export const quoteDepositTypeSchema = z.enum(['none', 'percent', 'selected_lines']);
+
+// Whole-percent, 2dp, exclusive bounds per spec (100% = "no deposit" — rejected).
+const depositPercent = z.number().gt(0).lt(100).multipleOf(0.01);
 
 // Block content shapes, discriminated by blockType.
 const headingContent = z.object({ text: z.string().min(1).max(300), level: z.number().int().min(1).max(3).default(2) });
@@ -45,6 +49,7 @@ export const quoteLineInputSchema = z.object({
   unitCost: money.nullable().optional(),
   sku: z.string().max(100).nullable().optional(),
   partNumber: z.string().max(100).nullable().optional(),
+  depositEligible: z.boolean().default(false),
 }).refine((d) => Boolean(d.name?.trim() || d.description?.trim()), {
   message: 'A line needs a name or a description', path: ['name'],
 });
@@ -68,6 +73,7 @@ export const updateQuoteLineSchema = z.object({
   // Attach/replace (guid) or clear (null) the line's product image. Must be a
   // quote_images row on the same quote — the service enforces ownership.
   imageId: z.string().guid().nullable().optional(),
+  depositEligible: z.boolean().optional(),
 });
 
 export const createQuoteSchema = z.object({
@@ -90,6 +96,8 @@ export const updateQuoteSchema = z.object({
   termsAndConditions: z.string().max(20_000).nullable().optional(),
   taxRate: taxRate.nullable().optional(),
   billToName: z.string().max(255).nullable().optional(),
+  depositType: quoteDepositTypeSchema.optional(),
+  depositPercent: depositPercent.nullable().optional(),
 });
 
 // A reorder payload must be a clean permutation of the existing ids, so the id


### PR DESCRIPTION
Stacked on #2227 (base branch `ToddHebebrand/quotes`). Adds **quote deposits** — customers can be charged an up-front deposit (a percentage of the quote, or the total of specific selected lines) at acceptance, with the balance invoiced afterward.

## What's included
- **Deposit math (`packages/shared`)** — `depositMath` + extended `quoteMath` compute deposit amount (percent or selected-line) and a category breakdown; percent deposits that round to zero cents are rejected. `computeChargeNow` decides the pay-now amount for deposit invoices.
- **Schema** — additive migration `2026-07-06-quote-deposits.sql` adds deposit columns to `quotes`, `quote_lines`, and `invoices`. No new tables; existing tenant RLS applies unchanged.
- **Quote lifecycle (API)** — deposit config on quote edit with `itemType` snapshot and recompute; deposit terms folded into the signed content hash (backward compatible); send-time deposit validation; acceptance snapshots `deposit_due` onto the invoice.
- **Billing / Stripe** — checkout charges deposit-first via `computeChargeNow`; phase-discriminated idempotency keys; due-date edit on issued invoices + deposit-aware payment-request email; calendar-valid due dates.
- **Documents & views** — deposit + category breakdown on the quote PDF (summary reservation sized to fit), portal and public quote views, portal invoice deposit strip / pay button / list badges. Internal-only lines are excluded from the customer-emailed quote PDF.
- **Web UI** — quote deposit controls, invoice deposit strip, due-date edit, deposit badges.
- **AI tools** — deposit fields in `manage_quotes` and the invoice tools.

## Tests
Unit coverage for deposit/quote math and validators, web component tests (QuoteEditor / InvoicesPage / InvoiceDetail deposit), portal `invoiceDeposit`, a portal zero-charge 409 branch, and an accept→deposit→balance integration happy path.

## Notes for review
- Review after #2227 merges; base retargets to `main` automatically on merge.
- 20 commits, ~+3.2k/-131 across shared, API, portal, web, and AI tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
