### PR TITLE
fix(deps): repair broken pnpm-lock.yaml (duplicate hono key) blocking all CI (#2246)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6792,14 +6792,6 @@ packages:
     resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.28:
-    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.28:
-    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -17220,10 +17212,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.12.28: {}
-
-  hono@4.12.28: {}
 
   hono@4.12.28: {}
 


### PR DESCRIPTION
Fixes #2246 — **main CI is fully red; this unblocks it.**

## Cause
The Dependabot merge storm (hono-group bump #2240 landing amid #2237/#2242) left `pnpm-lock.yaml` with `hono@4.12.28` **triplicated** in both the `packages:` and `snapshots:` sections (byte-identical stanzas), producing:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken: duplicated mapping key (6795:3)
```

Every JS/TS job (Lint, Type Check, all `test-*`, all add-in jobs, Security Audit) dies at `pnpm install --frozen-lockfile` before running anything. Go (`test-agent`) and Rust are unaffected — the classic "all-JS-down, Go/Rust-up" install-failure signature.

## Fix
Surgical: collapse each triplicated `hono@4.12.28` entry back to a single occurrence. **12 line deletions, 0 insertions, 0 version drift.**

A full `pnpm install` regen was deliberately **rejected** — it re-resolved ~50 transitive packages (eslint plugins, sentry, aws-sdk, pg, react-email, …), which is unreviewed dependency churn well beyond the dup-key repair. This keeps the lockfile byte-identical to the intended post-bump state minus the duplicate keys.

## Verification (local, pnpm 10.33.4, node 22.20.0)
- Before: `pnpm install --frozen-lockfile` → `ERR_PNPM_BROKEN_LOCKFILE`.
- After: `pnpm install --frozen-lockfile` → **clean** (Done in 9.8s), proving the lockfile is valid and consistent with `package.json` (no drift).
- `grep -c '^  hono@4.12.28:'` = 2 (one per section, matching a canonical regen).

Lockfile-only change; the JS jobs were failing solely at the install step, so a clean frozen install is the complete proof.
