### PR TITLE
fix(api): stop decommissioned devices resurrecting via live agent WebSocket (#2230)

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
+import { and, eq, notInArray } from 'drizzle-orm';
 
 const updateRestoreJobFromResultMock = vi.fn().mockResolvedValue(true);
 
@@ -155,6 +156,7 @@ vi.mock('../services/tenantStatus', () => ({
 }));
 
 import { db } from '../db';
+import { devices } from '../db/schema';
 import {
   createAgentWsHandlers,
   createAgentWsRoutes,
@@ -172,6 +174,7 @@ import { processBackupVerificationResult } from './backup/verificationService';
 import { updateRestoreJobFromResult } from '../services/restoreResultPersistence';
 import { rateLimiter } from '../services/rate-limit';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
+import { publishEvent } from '../services/eventBus';
 
 function wsMock() {
   return {
@@ -318,6 +321,71 @@ describe('agent websocket handshake', () => {
     } as any, ws as any);
 
     expect(vi.mocked(handleTerminalOutput)).toHaveBeenCalledWith(sessionId, 'café\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2230: WS lifecycle status writes must never overwrite terminal statuses.
+// Decommission/quarantine only gate the WS handshake — an agent whose socket
+// was already open when the device was decommissioned keeps sending heartbeats,
+// and an unguarded `UPDATE devices SET status='online' WHERE agent_id=?` flips
+// the row back to 'online', resurrecting the device in the dashboard. The
+// disconnect path has the same hole ('decommissioned' → 'offline' becomes
+// visible again). These tests pin the notInArray guard in updateDeviceStatus.
+// ---------------------------------------------------------------------------
+describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const TERMINAL_GUARD = notInArray(devices.status, ['decommissioned', 'quarantined']);
+
+  function rigStatusUpdateCapture() {
+    const whereMock = vi.fn().mockResolvedValue([]);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+    return { whereMock, setMock };
+  }
+
+  it('excludes decommissioned/quarantined rows when flipping a device online on connect', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const { whereMock, setMock } = rigStatusUpdateCapture();
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    await handlers.onOpen({}, wsMock() as any);
+
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'online' }));
+    expect(whereMock).toHaveBeenCalledWith(
+      and(eq(devices.agentId, 'agent-123'), TERMINAL_GUARD)
+    );
+  });
+
+  it('excludes decommissioned/quarantined rows when flipping a device offline on disconnect', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    // Connect first so onClose sees this ws as the active connection.
+    vi.mocked(db.update).mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) } as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+    await handlers.onOpen({}, ws as any);
+
+    vi.clearAllMocks();
+    vi.mocked(publishEvent).mockResolvedValue('event-id');
+    const { whereMock, setMock } = rigStatusUpdateCapture();
+    // onClose status pre-check select — return a live row so the offline write runs.
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([
+      { id: 'device-123', siteId: 'site-1', status: 'online', hostname: 'host-1' },
+    ]) as any);
+
+    await handlers.onClose({}, ws as any);
+
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'offline' }));
+    expect(whereMock).toHaveBeenCalledWith(
+      and(eq(devices.agentId, 'agent-123'), TERMINAL_GUARD)
+    );
   });
 });
 

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -324,15 +324,10 @@ describe('agent websocket handshake', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// #2230: WS lifecycle status writes must never overwrite terminal statuses.
-// Decommission/quarantine only gate the WS handshake — an agent whose socket
-// was already open when the device was decommissioned keeps sending heartbeats,
-// and an unguarded `UPDATE devices SET status='online' WHERE agent_id=?` flips
-// the row back to 'online', resurrecting the device in the dashboard. The
-// disconnect path has the same hole ('decommissioned' → 'offline' becomes
-// visible again). These tests pin the notInArray guard in updateDeviceStatus.
-// ---------------------------------------------------------------------------
+// Regression coverage for #2230 — see the updateDeviceStatus() doc comment in
+// agentWs.ts for the full incident writeup. These tests pin the terminal-status
+// guard on every agent-driven status write: connect, WS heartbeat (the actual
+// resurrection vector), disconnect, and the update_status self-update message.
 describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -383,6 +378,42 @@ describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
     await handlers.onClose({}, ws as any);
 
     expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'offline' }));
+    expect(whereMock).toHaveBeenCalledWith(
+      and(eq(devices.agentId, 'agent-123'), TERMINAL_GUARD)
+    );
+  });
+
+  it('excludes decommissioned/quarantined rows when a WS heartbeat flips a device online', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const { whereMock, setMock } = rigStatusUpdateCapture();
+    // getPendingCommands device lookup — no row, so no command claim follows.
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+    const ws = wsMock();
+
+    await handlers.onMessage({
+      data: JSON.stringify({ type: 'heartbeat', timestamp: 1234567890 }),
+    } as any, ws as any);
+
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'online' }));
+    expect(whereMock).toHaveBeenCalledWith(
+      and(eq(devices.agentId, 'agent-123'), TERMINAL_GUARD)
+    );
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"heartbeat_ack"'));
+  });
+
+  it('excludes decommissioned/quarantined rows when update_status flips a device to updating', async () => {
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const { whereMock, setMock } = rigStatusUpdateCapture();
+
+    const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
+
+    await handlers.onMessage({
+      data: JSON.stringify({ type: 'update_status', targetVersion: '1.2.3' }),
+    } as any, wsMock() as any);
+
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'updating' }));
     expect(whereMock).toHaveBeenCalledWith(
       and(eq(devices.agentId, 'agent-123'), TERMINAL_GUARD)
     );

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -839,6 +839,10 @@ export async function validateAgentToken(agentId: string, token: string): Promis
   };
 }
 
+// Statuses that agent-driven writes must never overwrite. Mirrored inline in
+// routes/agents/heartbeat.ts (the REST polling counterpart).
+const TERMINAL_DEVICE_STATUSES = ['decommissioned', 'quarantined'] as const;
+
 /**
  * Update device status when WebSocket connects/disconnects.
  *
@@ -849,8 +853,6 @@ export async function validateAgentToken(agentId: string, token: string): Promis
  * the dashboard (#2230). The disconnect path has the same hole
  * ('decommissioned' → 'offline' makes the row visible again).
  */
-const TERMINAL_DEVICE_STATUSES = ['decommissioned', 'quarantined'] as const;
-
 async function updateDeviceStatus(agentId: string, status: 'online' | 'offline'): Promise<void> {
   try {
     await db
@@ -1740,6 +1742,9 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
           if (agentDb) {
             await runWithAgentDbAccess(async () => {
               try {
+                // Same terminal-status guard as updateDeviceStatus (#2230):
+                // this write must not resurrect a decommissioned/quarantined
+                // row to 'updating'.
                 await db
                   .update(devices)
                   .set({
@@ -1747,7 +1752,10 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
                     lastSeenAt: new Date(),
                     updatedAt: new Date()
                   })
-                  .where(eq(devices.agentId, agentId));
+                  .where(and(
+                    eq(devices.agentId, agentId),
+                    notInArray(devices.status, [...TERMINAL_DEVICE_STATUSES])
+                  ));
                 console.log(`[AgentWs] Agent ${agentId} entering update to ${message.targetVersion}`);
               } catch (error) {
                 console.error(`[AgentWs] Failed to set updating status for ${agentId}:`, error);
@@ -2542,28 +2550,34 @@ export function sendCommandToAgent(agentId: string, command: AgentCommand): bool
   }
 }
 
+export type AgentWsDisconnectResult = 'closed' | 'close-failed' | 'not-connected';
+
 /**
  * Force-close an agent's active WS connection so it reconnects with a fresh
  * handshake (and re-resolves its orgId/siteId via agentAuth). Use this after
  * any server-side change that invalidates the orgId baked into the live
  * connection — e.g. a cross-org move where every per-message
  * runWithAgentDbAccess call would otherwise keep using the stale orgId for
- * RLS (see preValidatedAgent closure capture in createAgentWsHandlers).
+ * RLS (see preValidatedAgent closure capture in createAgentWsHandlers), or a
+ * decommission that must sever the live command channel (#2230).
  *
- * Returns true if a connection was found and close() was called.
- * Returns false if no active connection exists for this agentId.
+ * Callers that record the outcome (audit trails) must not collapse
+ * 'close-failed' into success: a throwing close() plausibly leaves the
+ * channel live, which is exactly what e.g. a decommission needs to know.
  */
-export function disconnectAgent(agentId: string, code: number = 4040, reason: string = 'orgId changed, reconnect required'): boolean {
+export function disconnectAgent(agentId: string, code: number = 4040, reason: string = 'orgId changed, reconnect required'): AgentWsDisconnectResult {
   const ws = activeConnections.get(agentId);
-  if (!ws) return false;
+  if (!ws) return 'not-connected';
   try {
     ws.close(code, reason);
   } catch (error) {
     console.error(`disconnectAgent(${agentId.slice(0,12)}) close threw:`, error);
+    captureException(error instanceof Error ? error : new Error(String(error)));
+    return 'close-failed';
   }
   // Don't delete from map here — the WS onClose handler does that itself
   // (lines ~1905-1907) and we don't want to race with reconnect logic.
-  return true;
+  return 'closed';
 }
 
 /**

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
 import { z } from 'zod';
-import { eq, and, inArray, sql } from 'drizzle-orm';
+import { eq, and, inArray, notInArray, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { devices, deviceCommands, discoveryJobs, scriptExecutions, scriptExecutionBatches, remoteSessions, backupJobs, restoreJobs, tunnelSessions } from '../db/schema';
@@ -840,8 +840,17 @@ export async function validateAgentToken(agentId: string, token: string): Promis
 }
 
 /**
- * Update device status when WebSocket connects/disconnects
+ * Update device status when WebSocket connects/disconnects.
+ *
+ * Never overwrites terminal lifecycle statuses: decommission/quarantine are
+ * only enforced at WS connect time, so an agent whose socket was already open
+ * when the device was decommissioned keeps sending heartbeats — an unguarded
+ * write here flipped the row back to 'online' and resurrected the device in
+ * the dashboard (#2230). The disconnect path has the same hole
+ * ('decommissioned' → 'offline' makes the row visible again).
  */
+const TERMINAL_DEVICE_STATUSES = ['decommissioned', 'quarantined'] as const;
+
 async function updateDeviceStatus(agentId: string, status: 'online' | 'offline'): Promise<void> {
   try {
     await db
@@ -851,7 +860,10 @@ async function updateDeviceStatus(agentId: string, status: 'online' | 'offline')
         lastSeenAt: new Date(),
         updatedAt: new Date()
       })
-      .where(eq(devices.agentId, agentId));
+      .where(and(
+        eq(devices.agentId, agentId),
+        notInArray(devices.status, [...TERMINAL_DEVICE_STATUSES])
+      ));
   } catch (error) {
     console.error(`Failed to update device status for ${agentId}:`, error);
   }

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../db', () => ({
 vi.mock('../../db/schema', () => ({
   devices: {
     id: 'devices.id',
+    status: 'devices.status',
     orgId: 'devices.org_id',
     siteId: 'devices.site_id',
     hostname: 'devices.hostname',
@@ -163,7 +164,9 @@ vi.mock('../../services/manifestSigning', () => ({
   },
 }));
 
+import { and, eq, notInArray } from 'drizzle-orm';
 import { heartbeatRoutes } from './heartbeat';
+import { devices } from '../../db/schema';
 
 // Builds a thenable mock-chain so any `.from().where().limit()` access
 // resolves to the given value.
@@ -1846,5 +1849,59 @@ describe('POST /agents/:id/heartbeat — version-pin threading (#2124)', () => {
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as { watchdogUpgradeTo?: string | null };
     expect(body.watchdogUpgradeTo).toBeFalsy();
+  });
+});
+
+// Regression coverage for #2230 — see the updateDeviceStatus() doc comment in
+// routes/agentWs.ts for the full incident writeup. The REST heartbeat is the
+// polling counterpart: agentAuthMiddleware 403s terminal-status devices up
+// front, but a decommission landing mid-request must not be flipped back to
+// 'online' by the devices write at the end of the handler.
+describe('POST /agents/:id/heartbeat — terminal-status guard (#2230)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    runOutsideDbContextMock.mockClear();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+  });
+
+  it('the devices status write excludes decommissioned/quarantined rows', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host',
+          osType: 'windows',
+          architecture: 'amd64',
+          agentVersion: '0.65.15',
+          deviceRoleSource: 'auto',
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    const whereSpy = vi.fn().mockResolvedValue(undefined);
+    const setSpy = vi.fn(() => ({ where: whereSpy }));
+    updateMock.mockReturnValue({ set: setSpy });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    selectMock.mockReturnValue(selectChainResolving([]));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+    expect(resp.status).toBe(200);
+
+    // The first devices update is the deviceUpdates write.
+    const firstSet = (setSpy.mock.calls as any[])[0]?.[0] as Record<string, unknown>;
+    expect(firstSet.status).toBe('online');
+    expect(whereSpy.mock.calls[0]?.[0]).toEqual(
+      and(eq(devices.id, 'device-1'), notInArray(devices.status, ['decommissioned', 'quarantined'])),
+    );
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, notInArray } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import {
   devices,
@@ -466,10 +466,17 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     deviceUpdates.batteryStatus = battery;
   }
 
+  // agentAuthMiddleware already 403s decommissioned/quarantined devices, but
+  // a decommission landing mid-request (between the auth fetch and this
+  // write) would be silently flipped back to 'online' (#2230). Mirrors
+  // TERMINAL_DEVICE_STATUSES in routes/agentWs.ts.
   await db
     .update(devices)
     .set(deviceUpdates)
-    .where(eq(devices.id, device.id));
+    .where(and(
+      eq(devices.id, device.id),
+      notInArray(devices.status, ['decommissioned', 'quarantined'])
+    ));
 
   // Publish event when agent version changes (for real-time UI updates)
   if (data.agentVersion && data.agentVersion !== device.agentVersion) {

--- a/apps/api/src/routes/devices/core.decommission.test.ts
+++ b/apps/api/src/routes/devices/core.decommission.test.ts
@@ -77,7 +77,7 @@ vi.mock('../../services/remoteAccessLauncher', () => ({
 vi.mock('../agentWs', () => ({
   sendCommandToAgent: vi.fn(),
   isAgentConnected: vi.fn().mockReturnValue(false),
-  disconnectAgent: vi.fn().mockReturnValue(true),
+  disconnectAgent: vi.fn().mockReturnValue('closed'),
 }));
 
 vi.mock('../../services/commandQueue', () => ({
@@ -101,6 +101,7 @@ import { coreRoutes } from './core';
 import { db } from '../../db';
 import { terminateDeviceRemoteSessions } from '../../services/remoteSessionTeardown';
 import { disconnectAgent } from '../agentWs';
+import { writeRouteAudit } from '../../services/auditEvents';
 
 const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -168,12 +169,11 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
     expect(disconnectAgent).not.toHaveBeenCalled();
   });
 
-  // #2230: the status flip is only enforced at WS connect time, so a live
-  // agent socket would keep full command/control after decommission (and its
-  // heartbeats used to flip the row back to 'online'). The endpoint must
-  // force-close the agent's WS control channel; the handshake gate then
-  // rejects the reconnect.
-  it('force-closes the agent WS control channel when the device has an agent', async () => {
+  // Regression coverage for #2230 — see the updateDeviceStatus() doc comment
+  // in routes/agentWs.ts for the full incident writeup. The endpoint must
+  // force-close the agent's live WS control channel; the handshake gate then
+  // rejects the reconnect, and the outcome lands in the audit trail.
+  it('force-closes the agent WS control channel and audits the outcome', async () => {
     rigDecommission({ ...ONLINE_DEVICE, agentId: 'agent-abc-123' });
 
     const res = await app.request(`/devices/${DEVICE_ID}`, {
@@ -182,7 +182,26 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
     });
 
     expect(res.status).toBe(200);
-    expect(disconnectAgent).toHaveBeenCalledWith('agent-abc-123', 4001, 'Device decommissioned');
+    expect(disconnectAgent).toHaveBeenCalledWith('agent-abc-123', 4041, 'Device decommissioned');
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'device.decommission',
+      details: expect.objectContaining({ agentWsDisconnect: 'closed' }),
+    }));
+  });
+
+  it('audits a close failure instead of collapsing it into success', async () => {
+    rigDecommission({ ...ONLINE_DEVICE, agentId: 'agent-abc-123' });
+    vi.mocked(disconnectAgent).mockReturnValueOnce('close-failed');
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      details: expect.objectContaining({ agentWsDisconnect: 'close-failed' }),
+    }));
   });
 
   it('skips the WS disconnect when the device has no agentId', async () => {
@@ -195,5 +214,8 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
 
     expect(res.status).toBe(200);
     expect(disconnectAgent).not.toHaveBeenCalled();
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      details: expect.objectContaining({ agentWsDisconnect: 'not-connected' }),
+    }));
   });
 });

--- a/apps/api/src/routes/devices/core.decommission.test.ts
+++ b/apps/api/src/routes/devices/core.decommission.test.ts
@@ -77,6 +77,7 @@ vi.mock('../../services/remoteAccessLauncher', () => ({
 vi.mock('../agentWs', () => ({
   sendCommandToAgent: vi.fn(),
   isAgentConnected: vi.fn().mockReturnValue(false),
+  disconnectAgent: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('../../services/commandQueue', () => ({
@@ -99,6 +100,7 @@ vi.mock('../../services/remoteSessionTeardown', () => ({
 import { coreRoutes } from './core';
 import { db } from '../../db';
 import { terminateDeviceRemoteSessions } from '../../services/remoteSessionTeardown';
+import { disconnectAgent } from '../agentWs';
 
 const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -163,5 +165,35 @@ describe('DELETE /devices/:id (decommission) — remote-session teardown wiring'
 
     expect(res.status).toBe(400);
     expect(terminateDeviceRemoteSessions).not.toHaveBeenCalled();
+    expect(disconnectAgent).not.toHaveBeenCalled();
+  });
+
+  // #2230: the status flip is only enforced at WS connect time, so a live
+  // agent socket would keep full command/control after decommission (and its
+  // heartbeats used to flip the row back to 'online'). The endpoint must
+  // force-close the agent's WS control channel; the handshake gate then
+  // rejects the reconnect.
+  it('force-closes the agent WS control channel when the device has an agent', async () => {
+    rigDecommission({ ...ONLINE_DEVICE, agentId: 'agent-abc-123' });
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(disconnectAgent).toHaveBeenCalledWith('agent-abc-123', 4001, 'Device decommissioned');
+  });
+
+  it('skips the WS disconnect when the device has no agentId', async () => {
+    rigDecommission(ONLINE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(disconnectAgent).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1223,10 +1223,12 @@ coreRoutes.delete(
     // channel (#2230): a connected agent would keep its full command channel
     // after decommission. Force-close it; the handshake gate
     // (validateAgentToken) rejects the reconnect for decommissioned devices.
-    let agentWsDisconnected = false;
-    if (device.agentId) {
-      agentWsDisconnected = disconnectAgent(device.agentId, 4001, 'Device decommissioned');
-    }
+    // ('close-failed' means the channel may still be live — recorded in the
+    // audit trail below. Quarantine flows don't force-close the socket; they
+    // rely on the terminal-status write guard in agentWs.updateDeviceStatus.)
+    const agentWsDisconnect = device.agentId
+      ? disconnectAgent(device.agentId, 4041, 'Device decommissioned')
+      : 'not-connected';
 
     writeRouteAudit(c, {
       orgId: device.orgId,
@@ -1236,7 +1238,7 @@ coreRoutes.delete(
       resourceName: updated?.hostname ?? updated?.displayName ?? device.hostname,
       details: {
         remoteSessionTeardown: teardownResult === TEARDOWN_FAILED ? 'failed' : 'ok',
-        agentWsDisconnected,
+        agentWsDisconnect,
       },
     });
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -48,7 +48,7 @@ import {
 import { captureException } from '../../services/sentry';
 import type { InheritableRemoteAccessSettings, PartnerSettings } from '@breeze/shared';
 import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
-import { sendCommandToAgent, isAgentConnected } from '../agentWs';
+import { sendCommandToAgent, isAgentConnected, disconnectAgent } from '../agentWs';
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { CommandTypes } from '../../services/commandQueue';
 import { getGlobalEnrollmentSecret } from '../agents/enrollment';
@@ -1219,13 +1219,25 @@ coreRoutes.delete(
     // recorded in the audit trail so there's a record live control may persist.
     const teardownResult = await terminateDeviceRemoteSessions(deviceId);
 
+    // Same connect-time-only gap applies to the agent's own WS control
+    // channel (#2230): a connected agent would keep its full command channel
+    // after decommission. Force-close it; the handshake gate
+    // (validateAgentToken) rejects the reconnect for decommissioned devices.
+    let agentWsDisconnected = false;
+    if (device.agentId) {
+      agentWsDisconnected = disconnectAgent(device.agentId, 4001, 'Device decommissioned');
+    }
+
     writeRouteAudit(c, {
       orgId: device.orgId,
       action: 'device.decommission',
       resourceType: 'device',
       resourceId: updated?.id ?? deviceId,
       resourceName: updated?.hostname ?? updated?.displayName ?? device.hostname,
-      details: { remoteSessionTeardown: teardownResult === TEARDOWN_FAILED ? 'failed' : 'ok' },
+      details: {
+        remoteSessionTeardown: teardownResult === TEARDOWN_FAILED ? 'failed' : 'ok',
+        agentWsDisconnected,
+      },
     });
 
     return c.json({ success: true, device: updated ? stripSensitiveDeviceFields(updated) : updated });


### PR DESCRIPTION
## Summary

Fixes the "decommissioned devices re-appear in the portal with full control" bug (#2230).

**Root cause.** Decommission (`DELETE /devices/:id`) is a soft delete — it flips `status='decommissioned'`, which is enforced **only at WS connect time** (`validateAgentToken`). An agent whose WebSocket was already open at decommission time kept its full command/control channel, and every WS `heartbeat` message ran an unguarded `UPDATE devices SET status='online' WHERE agent_id=?` (`updateDeviceStatus`), flipping the row back to `'online'`. The dashboard hides devices by status, so the device "reappeared", fully controllable. Devices that happened to be offline at decommission time stayed gone — exactly matching the reported *"some devices re-appear"* and the retry loop.

## Changes

- **`agentWs.ts` — terminal-status guard on every agent-driven status write.** `updateDeviceStatus` (WS connect / heartbeat / disconnect / error paths) and the `update_status` self-update handler now exclude `decommissioned` and `quarantined` rows via `notInArray(devices.status, TERMINAL_DEVICE_STATUSES)`. The disconnect path had the same hole in the other direction (`decommissioned` → `'offline'` would make the row visible again); quarantine shares the guard because it has the identical connect-time-only latent hole.
- **`agents/heartbeat.ts` — same guard on the REST polling heartbeat.** `agentAuthMiddleware` 403s terminal-status devices up front, but a decommission landing mid-request (between the auth fetch and the final devices write) was silently flipped back to `'online'`. The write now carries the same `notInArray` guard.
- **`devices/core.ts` — cut the live control channel on decommission.** The decommission endpoint force-closes the agent's active WS via `disconnectAgent` (close code 4041 — 4001 already means "token suspended"). On reconnect the handshake gate already rejects decommissioned devices, so the agent goes auth-dead immediately instead of retaining control.
- **`disconnectAgent` — honest outcome reporting.** Now returns `'closed' | 'close-failed' | 'not-connected'` and reports `ws.close()` throws to Sentry; the decommission audit record stores the tri-state (`agentWsDisconnect`) instead of collapsing "close threw, channel may still be live" into success.

## Tests

- `agentWs.test.ts`: guard pinned on all four write paths — connect (`onOpen`), WS `heartbeat` message (the actual #2230 field vector), disconnect (`onClose`), and `update_status`. Verified red before the fix, green after.
- `core.decommission.test.ts`: `disconnectAgent` wiring (agentId + 4041), audit tri-state outcomes (`closed` / `close-failed` / `not-connected`), no-agent and already-decommissioned negative paths.
- `heartbeat.test.ts`: REST heartbeat devices write asserts the guarded `where` clause.
- Full `src/routes/devices/` + `src/routes/agents/` suites: 811 passed. Independent re-review ran the full API suite: 11,684 passed. `tsc --noEmit` clean.

## Notes / non-goals

- **No uninstall on decommission.** The reporter expected the agent to be removed; decommission is deliberately reversible (`POST /devices/:id/restore`), and remote uninstall belongs to `DELETE /devices/:id/permanent`. That path's best-effort `SELF_UNINSTALL` only ever reached *connected* agents; after this fix a decommissioned agent is cut off immediately, so remote uninstall of an already-decommissioned device is (and was) unreliable — the endpoint already tells the operator manual removal may be needed. If "decommission + uninstall agent" is wanted as a first-class flow, that's a product decision for a follow-up issue.
- Quarantine flows don't force-close the live socket (quarantine is set by the mTLS pipeline, not an admin route); they rely on the status-write guard added here. Noted in-code.
- Re-enrollment of a decommissioned hostname with the org enrollment key remains allowed by design (#896/#914) — a deliberate path for rebuilt machines, unchanged here.

Closes #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)