### PR TITLE
test(invoices): fix stale idempotency-key assertion breaking main after #2245 (#2252)

### DIFF
--- a/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/invoiceCheckout.integration.test.ts
@@ -88,7 +88,9 @@ describe('createInvoicePayLink (breeze_app, real DB)', () => {
     // currency-aware minor units: $100.00 → 10000
     const call = sessionsCreateMock.mock.calls[0]!;
     expect(call[0].line_items[0].price_data.unit_amount).toBe(10000);
-    expect(call[1].idempotencyKey).toBe(`inv_${inv.id}_10000`);
+    // #2245 deposit invoicing: the idempotency key now carries a _dep/_bal
+    // suffix. A plain payable (non-deposit) invoice charges the balance → `_bal`.
+    expect(call[1].idempotencyKey).toBe(`inv_${inv.id}_10000_bal`);
 
     const mappings = await withSystemDbAccessContext(() =>
       db.select().from(invoiceStripePayments).where(eq(invoiceStripePayments.invoiceId, inv.id)));


### PR DESCRIPTION
Fixes #2252 (main CI red).

## Cause
#2245 (deposit invoicing) changed the Stripe idempotency key in `invoiceCheckout.ts` / `portal/invoices.ts` to carry a deposit-vs-balance suffix:

```ts
idempotencyKey: `inv_${inv.id}_${chargeMinor}_${chargeNow.isDeposit ? 'dep' : 'bal'}`
```

Every **co-located unit** test was updated to the new `_dep`/`_bal` format (`portal/invoices.test.ts`, `services/invoiceCheckout.test.ts` — the latter asserts exactly `inv_${INV_ID}_10000_bal` for the same $100 balance case). But the **integration** test `invoiceCheckout.integration.test.ts:91` — which lives in a separate CI glob/job (`Integration Tests`, not the unit `test-api` job Todd runs locally) — still asserted the old suffix-less `inv_${inv.id}_10000`. It runs a plain payable (non-deposit → balance → `_bal`) invoice, so it fails:

```
Expected: "inv_<id>_10000"
Received: "inv_<id>_10000_bal"
```

The ~38-min integration suite surfaced this only after #2245 had already merged.

## Fix
Update the one stale assertion to `inv_${inv.id}_10000_bal`, matching the already-merged code's intended format and the sibling unit test. Test-only; no production change.

## Verification (local, pnpm 10.33.4, node 22.20.0, OrbStack test DB)
- `vitest run --config vitest.integration.config.ts src/__tests__/integration/invoiceCheckout.integration.test.ts` → **5 passed** (was 1 failed).
- `tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `eslint` on the file — clean.
