### PR TITLE
fix(quotes): revert deposit type select when the deposit PATCH is rejected

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.deposit.test.tsx
@@ -114,6 +114,36 @@ describe('QuoteEditor deposit controls', () => {
     await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'l-1', { depositEligible: true }));
   });
 
+  it('reverts the type select to the persisted value when the deposit PATCH is rejected', async () => {
+    // The deposit PATCH 400s (e.g. selecting Selected lines when the deposit would
+    // equal the full due-on-acceptance total); every other request still succeeds.
+    fetchMock.mockImplementation(async (path, init) => {
+      const isDepositPatch = path === '/quotes/q-1'
+        && (init as RequestInit | undefined)?.method === 'PATCH'
+        && String((init as RequestInit).body).includes('deposit');
+      if (isDepositPatch) {
+        return json(
+          { error: 'Deposit must be less than the amount due on acceptance — remove the deposit instead', code: 'DEPOSIT_NOT_BELOW_TOTAL' },
+          false,
+          400,
+        );
+      }
+      return json({ data: {} });
+    });
+
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-deposit-controls')).toBeInTheDocument());
+
+    const select = screen.getByTestId('quote-deposit-type') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'selected_lines' } });
+
+    // The optimistic switch fires one PATCH, which is rejected...
+    await waitFor(() => expect(depositPatchCalls()).toHaveLength(1));
+    // ...so the select snaps back to the persisted 'none' instead of lying as
+    // 'selected_lines' — a mode that never saved and would vanish on reload.
+    await waitFor(() => expect(select.value).toBe('none'));
+  });
+
   it('renders no deposit controls figure when deposit is none', async () => {
     render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('quote-deposit-controls')).toBeInTheDocument());

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -352,6 +352,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     }, 'Could not update the deposit.'),
   [quote.id, refresh, runScoped]);
 
+  // Snap the local mirrors back to the server-persisted deposit config. Used when
+  // a deposit PATCH is rejected (e.g. 400 DEPOSIT_NOT_BELOW_TOTAL or
+  // DEPOSIT_NO_ELIGIBLE_LINES): runAction already toasts the API's reason, but the
+  // optimistic type select / percent draft would otherwise keep showing a mode that
+  // never saved — a dropdown that lies about persisted state until the next reload.
+  const revertDepositMirrors = useCallback(() => {
+    setDepositType(quote.depositType ?? 'none');
+    setDepositPercentDraft(quote.depositPercent ?? '');
+  }, [quote.depositType, quote.depositPercent]);
+
   const onDepositTypeChange = useCallback((next: QuoteDepositType) => {
     setDepositType(next);
     if (next === 'percent') {
@@ -359,11 +369,13 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
       // so defer the PATCH until a percent exists — persist immediately only when one
       // is already entered (the percent input's onBlur handles the first entry).
       const pct = depositPercentDraft.trim() === '' ? null : Number(depositPercentDraft);
-      if (pct != null && Number.isFinite(pct)) void saveDeposit({ depositType: 'percent', depositPercent: pct });
+      if (pct != null && Number.isFinite(pct)) {
+        void saveDeposit({ depositType: 'percent', depositPercent: pct }).then((ok) => { if (!ok) revertDepositMirrors(); });
+      }
     } else {
-      void saveDeposit({ depositType: next });
+      void saveDeposit({ depositType: next }).then((ok) => { if (!ok) revertDepositMirrors(); });
     }
-  }, [depositPercentDraft, saveDeposit]);
+  }, [depositPercentDraft, saveDeposit, revertDepositMirrors]);
 
   const onDepositPercentBlur = useCallback(() => {
     if (depositType !== 'percent') return;
@@ -372,8 +384,8 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange }:
     // Only fire when it actually differs from the persisted value (avoids a
     // redundant PATCH on a focus-through).
     if (quote.depositType === 'percent' && quote.depositPercent != null && Number(quote.depositPercent) === pct) return;
-    void saveDeposit({ depositType: 'percent', depositPercent: pct });
-  }, [depositType, depositPercentDraft, quote.depositType, quote.depositPercent, saveDeposit]);
+    void saveDeposit({ depositType: 'percent', depositPercent: pct }).then((ok) => { if (!ok) revertDepositMirrors(); });
+  }, [depositType, depositPercentDraft, quote.depositType, quote.depositPercent, saveDeposit, revertDepositMirrors]);
 
   const loadCatalog = useCallback(async () => {
     const res = await listCatalog({ isActive: true, limit: 200 });


### PR DESCRIPTION
## Problem

Found during manual e2e of the quote deposits feature (#2245). In the quote editor, selecting a deposit mode optimistically updates the local type/percent state but **never rolls it back when the autosave `PATCH /quotes/:id` fails**. The two backend validations are correct —

- `DEPOSIT_NO_ELIGIBLE_LINES` — "Selected lines" picked before any one-time line is flagged deposit-eligible (the natural order: pick mode → then flag lines).
- `DEPOSIT_NOT_BELOW_TOTAL` — the selected lines sum to the full due-on-acceptance total (deposit would be 100%).

`runAction` already toasts the API's reason, but the deposit `<select>` keeps showing a mode that never persisted — a control that lies until the next reload (where the choice silently vanishes).

## Fix

- Add `revertDepositMirrors()` which snaps `depositType` / `depositPercentDraft` back to the server-persisted `quote.depositType` / `quote.depositPercent`.
- Consume the `runScoped` success boolean the two `saveDeposit` callers were already discarding: `saveDeposit(...).then((ok) => { if (!ok) revertDepositMirrors(); })`.

No backend change — the validations are right; this only stops the UI from misrepresenting unpersisted state.

## Testing

- New regression test in `QuoteEditor.deposit.test.tsx` (deposit PATCH 400 → select reverts to persisted value).
- All 23 quote component test files / 112 tests pass; web `tsc --noEmit` clean.
- Verified live in the worktree stack via Playwright: selecting "Selected lines" with no eligible line → toast *"Flag at least one one-time line as deposit-eligible"* + the dropdown snaps back to "No deposit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)