### PR TITLE
feat(software): single-step package creation, installer URL variables, and ready-to-deploy EDR listings

### DIFF
--- a/apps/api/src/services/installerVariables.test.ts
+++ b/apps/api/src/services/installerVariables.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  substituteInstallerVariables,
+  resolveInstallerVariables,
+  type InstallerVariableContext,
+} from './installerVariables';
+
+const ctx: InstallerVariableContext = {
+  org: { id: 'org-123', name: 'Acme Corp' },
+  site: { id: 'site-9', name: 'HQ' },
+  device: {
+    hostname: 'WKS-014',
+    customFields: { license_key: 'ABC-999', region: 'us-east', blank: '' },
+  },
+};
+
+describe('substituteInstallerVariables', () => {
+  it('returns the template untouched when it has no variables', () => {
+    const r = substituteInstallerVariables('https://example.com/app.msi', ctx);
+    expect(r.value).toBe('https://example.com/app.msi');
+    expect(r.unresolved).toEqual([]);
+  });
+
+  it('passes null through', () => {
+    expect(substituteInstallerVariables(null, ctx)).toEqual({ value: null, unresolved: [] });
+  });
+
+  it.each([
+    ['{{org.name}}', 'Acme Corp'],
+    ['{{org.id}}', 'org-123'],
+    ['{{site.name}}', 'HQ'],
+    ['{{site.id}}', 'site-9'],
+    ['{{device.hostname}}', 'WKS-014'],
+    ['{{device.customField.license_key}}', 'ABC-999'],
+  ])('resolves built-in / custom token %s', (token, expected) => {
+    const r = substituteInstallerVariables(`x-${token}-y`, ctx);
+    expect(r.value).toBe(`x-${expected}-y`);
+    expect(r.unresolved).toEqual([]);
+  });
+
+  it('tolerates inner whitespace', () => {
+    expect(substituteInstallerVariables('{{ org.name }}', ctx).value).toBe('Acme Corp');
+  });
+
+  it('resolves multiple variables in one string', () => {
+    const r = substituteInstallerVariables(
+      'https://dl/{{org.id}}/{{device.customField.region}}/app.msi',
+      ctx,
+    );
+    expect(r.value).toBe('https://dl/org-123/us-east/app.msi');
+    expect(r.unresolved).toEqual([]);
+  });
+
+  it('leaves the single-brace {file} agent token alone', () => {
+    const r = substituteInstallerVariables('msiexec /i "{file}" /qn {{org.id}}', ctx);
+    expect(r.value).toBe('msiexec /i "{file}" /qn org-123');
+    expect(r.unresolved).toEqual([]);
+  });
+
+  it('flags an unknown token and leaves it verbatim', () => {
+    const r = substituteInstallerVariables('https://dl/{{org.licence}}/app.msi', ctx);
+    expect(r.value).toBe('https://dl/{{org.licence}}/app.msi');
+    expect(r.unresolved).toEqual(['{{org.licence}}']);
+  });
+
+  it('treats a missing or empty custom field as unresolved (fail loudly)', () => {
+    const missing = substituteInstallerVariables('{{device.customField.absent}}', ctx);
+    expect(missing.unresolved).toEqual(['{{device.customField.absent}}']);
+    const blank = substituteInstallerVariables('{{device.customField.blank}}', ctx);
+    expect(blank.unresolved).toEqual(['{{device.customField.blank}}']);
+  });
+
+  it('handles a null customFields bag', () => {
+    const r = substituteInstallerVariables('{{device.customField.license_key}}', {
+      ...ctx,
+      device: { hostname: 'H', customFields: null },
+    });
+    expect(r.unresolved).toEqual(['{{device.customField.license_key}}']);
+  });
+});
+
+describe('resolveInstallerVariables', () => {
+  it('resolves both fields and de-duplicates unresolved tokens', () => {
+    const r = resolveInstallerVariables(
+      'https://dl/{{org.bogus}}/app.msi',
+      'run {{org.bogus}} now',
+      ctx,
+    );
+    expect(r.downloadUrl).toBe('https://dl/{{org.bogus}}/app.msi');
+    expect(r.silentInstallArgs).toBe('run {{org.bogus}} now');
+    expect(r.unresolved).toEqual(['{{org.bogus}}']); // de-duped across both fields
+  });
+
+  it('returns clean values when everything resolves', () => {
+    const r = resolveInstallerVariables(
+      'https://dl/{{org.id}}/app.msi',
+      'msiexec /i "{file}" /qn KEY={{device.customField.license_key}}',
+      ctx,
+    );
+    expect(r.downloadUrl).toBe('https://dl/org-123/app.msi');
+    expect(r.silentInstallArgs).toBe('msiexec /i "{file}" /qn KEY=ABC-999');
+    expect(r.unresolved).toEqual([]);
+  });
+});

--- a/apps/api/src/services/installerVariables.test.ts
+++ b/apps/api/src/services/installerVariables.test.ts
@@ -70,6 +70,19 @@ describe('substituteInstallerVariables', () => {
     expect(blank.unresolved).toEqual(['{{device.customField.blank}}']);
   });
 
+  it('treats an empty built-in value (e.g. blank hostname) as unresolved', () => {
+    const blankHost = substituteInstallerVariables('https://dl/{{device.hostname}}/app.msi', {
+      ...ctx,
+      device: { hostname: '', customFields: {} },
+    });
+    expect(blankHost.unresolved).toEqual(['{{device.hostname}}']);
+    const blankSite = substituteInstallerVariables('https://dl/{{site.name}}/app.msi', {
+      ...ctx,
+      site: { id: 'site-9', name: '' },
+    });
+    expect(blankSite.unresolved).toEqual(['{{site.name}}']);
+  });
+
   it('handles a null customFields bag', () => {
     const r = substituteInstallerVariables('{{device.customField.license_key}}', {
       ...ctx,

--- a/apps/api/src/services/installerVariables.ts
+++ b/apps/api/src/services/installerVariables.ts
@@ -30,30 +30,34 @@ const TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g;
 const CUSTOM_FIELD_KEY = /^device\.customField\.([a-z][a-z0-9_]*)$/;
 
 function resolveKey(key: string, ctx: InstallerVariableContext): string | null {
+  let raw: unknown;
   switch (key) {
     case 'org.name':
-      return ctx.org.name;
-    case 'org.id':
-      return ctx.org.id;
-    case 'site.name':
-      return ctx.site.name;
-    case 'site.id':
-      return ctx.site.id;
-    case 'device.hostname':
-      return ctx.device.hostname;
-    default:
+      raw = ctx.org.name;
       break;
+    case 'org.id':
+      raw = ctx.org.id;
+      break;
+    case 'site.name':
+      raw = ctx.site.name;
+      break;
+    case 'site.id':
+      raw = ctx.site.id;
+      break;
+    case 'device.hostname':
+      raw = ctx.device.hostname;
+      break;
+    default: {
+      const fieldKey = CUSTOM_FIELD_KEY.exec(key)?.[1];
+      if (!fieldKey) return null; // unknown token — not in the vocabulary
+      raw = ctx.device.customFields?.[fieldKey];
+    }
   }
-  const custom = CUSTOM_FIELD_KEY.exec(key);
-  const fieldKey = custom?.[1];
-  if (fieldKey) {
-    const raw = ctx.device.customFields?.[fieldKey];
-    // A missing/empty custom field is unresolved on purpose — fail the device
-    // loudly rather than ship an installer URL with a blank segment.
-    if (raw == null || raw === '') return null;
-    return String(raw);
-  }
-  return null;
+  // Uniform fail-loudly: a missing OR blank resolution — built-in (e.g. a device
+  // with an empty hostname) or custom field — is treated as unresolved so a
+  // device never ships an installer URL/args with a blank segment.
+  if (raw == null || raw === '') return null;
+  return String(raw);
 }
 
 export interface SubstitutionResult {

--- a/apps/api/src/services/installerVariables.ts
+++ b/apps/api/src/services/installerVariables.ts
@@ -1,0 +1,105 @@
+/**
+ * Deploy-time substitution of `{{...}}` variables in a software version's
+ * download URL and silent install/uninstall args.
+ *
+ * This is the generic sibling of `edrInstallerResolver.ts`: where that resolves
+ * a fixed set of single-brace EDR secrets (`{huntress_org_key}`, …) for built-in
+ * packages, this resolves double-brace tenant variables (`{{org.name}}`,
+ * `{{device.customField.licenseKey}}`) for ANY package, per target device.
+ *
+ * Double braces are deliberate — they never collide with the single-brace
+ * `{file}` token the agent substitutes with the downloaded installer path.
+ *
+ * The web-side vocabulary/validation lives in
+ * `apps/web/src/lib/installerVariables.ts`; keep the two key sets in sync.
+ *
+ * Contract: an unrecognized or unfillable token (typo, or a custom field the
+ * device doesn't have) is returned in `unresolved` and left verbatim in the
+ * string. Callers MUST fail that device rather than dispatch a literal `{{...}}`
+ * to an agent.
+ */
+
+export interface InstallerVariableContext {
+  org: { id: string; name: string };
+  site: { id: string; name: string };
+  device: { hostname: string; customFields: Record<string, unknown> | null };
+}
+
+// Matches `{{ key }}` with optional inner whitespace; the key itself excludes braces.
+const TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g;
+const CUSTOM_FIELD_KEY = /^device\.customField\.([a-z][a-z0-9_]*)$/;
+
+function resolveKey(key: string, ctx: InstallerVariableContext): string | null {
+  switch (key) {
+    case 'org.name':
+      return ctx.org.name;
+    case 'org.id':
+      return ctx.org.id;
+    case 'site.name':
+      return ctx.site.name;
+    case 'site.id':
+      return ctx.site.id;
+    case 'device.hostname':
+      return ctx.device.hostname;
+    default:
+      break;
+  }
+  const custom = CUSTOM_FIELD_KEY.exec(key);
+  const fieldKey = custom?.[1];
+  if (fieldKey) {
+    const raw = ctx.device.customFields?.[fieldKey];
+    // A missing/empty custom field is unresolved on purpose — fail the device
+    // loudly rather than ship an installer URL with a blank segment.
+    if (raw == null || raw === '') return null;
+    return String(raw);
+  }
+  return null;
+}
+
+export interface SubstitutionResult {
+  value: string | null;
+  /** Full token strings (e.g. `["{{device.customField.licenseKey}}"]`) left unresolved. */
+  unresolved: string[];
+}
+
+/** Substitute one template string against a device context. Pure + DB-free. */
+export function substituteInstallerVariables(
+  template: string | null | undefined,
+  ctx: InstallerVariableContext,
+): SubstitutionResult {
+  if (template == null) return { value: null, unresolved: [] };
+  if (!template.includes('{{')) return { value: template, unresolved: [] };
+
+  const unresolved: string[] = [];
+  const value = template.replace(TOKEN, (match, rawKey: string) => {
+    const resolved = resolveKey(rawKey.trim(), ctx);
+    if (resolved == null) {
+      unresolved.push(match);
+      return match;
+    }
+    return resolved;
+  });
+  return { value, unresolved };
+}
+
+export interface ResolvedInstallerVariables {
+  downloadUrl: string | null;
+  silentInstallArgs: string | null;
+  /** De-duplicated unresolved tokens across both fields; non-empty ⇒ fail the device. */
+  unresolved: string[];
+}
+
+/** Substitute both installer fields for one device and collect all unresolved tokens. */
+export function resolveInstallerVariables(
+  downloadUrl: string | null,
+  silentInstallArgs: string | null,
+  ctx: InstallerVariableContext,
+): ResolvedInstallerVariables {
+  const url = substituteInstallerVariables(downloadUrl, ctx);
+  const args = substituteInstallerVariables(silentInstallArgs, ctx);
+  return {
+    downloadUrl: url.value,
+    silentInstallArgs: args.value,
+    unresolved: [...new Set([...url.unresolved, ...args.unresolved])],
+  };
+}

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -60,6 +60,9 @@ vi.mock('../db/schema', () => ({
 }));
 
 import { createSoftwareDeployment } from './softwareDeployment';
+import { resolveEdrInstaller } from './edrInstallerResolver';
+
+const resolveEdrMock = vi.mocked(resolveEdrInstaller);
 
 // ---------------------------------------------------------------------------
 // Mock builder helpers
@@ -206,6 +209,131 @@ describe('createSoftwareDeployment', () => {
     expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
       'https://dl/org-1/KEY-1/app.msi',
     );
+  });
+
+  it('dispatches a built-in EDR install using the resolver-provided URL/args', async () => {
+    resolveEdrMock.mockResolvedValueOnce({
+      downloadUrl: 'https://edr.example/agent.exe',
+      silentInstallArgs: '/SILENT /TOKEN=abc',
+    });
+    const versionRecord = {
+      id: 'ver-edr',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: '{huntress_org_key}', // template; resolver replaces it
+      checksum: null,
+      originalFileName: 'agent.exe',
+      fileType: 'exe',
+      silentInstallArgs: '/TOKEN={huntress_org_key}',
+      version: '3.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'Huntress', integrationProvider: 'huntress' };
+    const deployment = { id: 'dep-edr', orgId: 'org-1' };
+    const targetDevices = [{ id: 'dev-1', agentId: 'agent-1' }];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-edr',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('pending');
+    const payload = sendCommandMock.mock.calls[0]![1].payload;
+    expect(payload.downloadUrl).toBe('https://edr.example/agent.exe');
+    expect(payload.silentInstallArgs).toBe('/SILENT /TOKEN=abc');
+  });
+
+  it('fails the whole EDR deployment (no dispatch) when the resolver returns an error', async () => {
+    resolveEdrMock.mockResolvedValueOnce({ error: 'Organization not mapped to Huntress' });
+    const versionRecord = {
+      id: 'ver-edr2',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: '{huntress_org_key}',
+      checksum: null,
+      originalFileName: 'agent.exe',
+      fileType: 'exe',
+      silentInstallArgs: null,
+      version: '3.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'Huntress', integrationProvider: 'huntress' };
+    const deployment = { id: 'dep-edr2', orgId: 'org-1' };
+
+    selectMock.mockReturnValueOnce(sel([versionRecord])).mockReturnValueOnce(sel([catalogItem]));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+    const failWhere = vi.fn().mockResolvedValue(undefined);
+    updateMock.mockReturnValue({ set: vi.fn().mockReturnValue({ where: failWhere }) });
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-edr2',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toMatch(/not mapped to Huntress/);
+    expect(result.dispatchedDeviceIds).toEqual([]);
+    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(failWhere).toHaveBeenCalledTimes(1); // all result rows marked failed
+  });
+
+  it('dispatches resolved devices and fails only the unresolvable ones on a mixed batch', async () => {
+    const versionRecord = {
+      id: 'ver-mix',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{device.customField.license_key}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-mix', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: { license_key: 'KEY-1' } },
+      { id: 'dev-2', agentId: 'agent-2', siteId: 'site-1', hostname: 'WKS-2', customFields: {} },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }]))
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+    const failWhere = vi.fn().mockResolvedValue(undefined);
+    updateMock.mockReturnValue({ set: vi.fn().mockReturnValue({ where: failWhere }) });
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-mix',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    // Partial failure: overall pending, only the resolvable device dispatched,
+    // the unresolvable one marked failed — never shipped a literal {{...}}.
+    expect(result.status).toBe('pending');
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe('https://dl/KEY-1/app.msi');
+    expect(failWhere).toHaveBeenCalledTimes(1); // dev-2 only
   });
 
   it('fails a device (and never dispatches) when an installer variable cannot be resolved', async () => {

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -47,7 +47,16 @@ vi.mock('../db/schema', () => ({
     deviceId: 'dr.deviceId',
     status: 'dr.status',
   },
-  devices: { id: 'd.id', orgId: 'd.orgId', agentId: 'd.agentId' },
+  devices: {
+    id: 'd.id',
+    orgId: 'd.orgId',
+    agentId: 'd.agentId',
+    siteId: 'd.siteId',
+    hostname: 'd.hostname',
+    customFields: 'd.customFields',
+  },
+  organizations: { id: 'o.id', name: 'o.name' },
+  sites: { id: 's.id', name: 's.name', orgId: 's.orgId' },
 }));
 
 import { createSoftwareDeployment } from './softwareDeployment';
@@ -61,6 +70,17 @@ function sel(rows: unknown[]) {
   return {
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+/** Chainable select ending in .limit(): db.select().from().where().limit() → Promise<rows> */
+function selLimit(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
     }),
   };
 }
@@ -144,6 +164,93 @@ describe('createSoftwareDeployment', () => {
     expect(result.dispatchedDeviceIds).toEqual(['dev-1', 'dev-2']);
     expect(sendCommandMock).toHaveBeenCalledTimes(2);
     expect(sendCommandMock.mock.calls[0]![1].type).toBe('software_install');
+  });
+
+  it('substitutes {{...}} installer variables per device from org/site/device context', async () => {
+    const versionRecord = {
+      id: 'ver-var',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{org.id}}/{{device.customField.license_key}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-var', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: { license_key: 'KEY-1' } },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }])) // organizations
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])); // sites
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-var',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
+    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
+      'https://dl/org-1/KEY-1/app.msi',
+    );
+  });
+
+  it('fails a device (and never dispatches) when an installer variable cannot be resolved', async () => {
+    const versionRecord = {
+      id: 'ver-bad',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{device.customField.missing}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-bad', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: {} },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }]))
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]));
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+    const failWhere = vi.fn().mockResolvedValue(undefined);
+    updateMock.mockReturnValue({ set: vi.fn().mockReturnValue({ where: failWhere }) });
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-bad',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    // Every target failed resolution → overall failure, nothing dispatched, the
+    // device's result row was marked failed instead of shipping a literal token.
+    expect(result.status).toBe('failed');
+    expect(result.dispatchedDeviceIds).toEqual([]);
+    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(failWhere).toHaveBeenCalledTimes(1);
   });
 
   it('threads detection rules and forceReinstall into the dispatched install payload', async () => {

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -249,6 +249,7 @@ export async function createSoftwareDeployment(
     const forceReinstall = options?.forceReinstall === true;
 
     const dispatchedDeviceIds: string[] = [];
+    let variableFailureCount = 0;
     for (const device of targetDevices) {
       // Resolve `{{...}}` variables against this device's org/site/device context.
       // A no-op when the templates contain no variables (fast path inside the
@@ -280,6 +281,7 @@ export async function createSoftwareDeployment(
                 eq(deploymentResults.deviceId, device.id),
               ),
             );
+          variableFailureCount++;
           continue;
         }
         // Substituting a non-null template yields a non-null string; the ?? keeps
@@ -307,6 +309,19 @@ export async function createSoftwareDeployment(
       };
       sendCommandToAgent(device.agentId, command);
       dispatchedDeviceIds.push(device.id);
+    }
+
+    // If installer variables were in play and NOTHING dispatched because every
+    // target failed resolution, report failure — mirrors the EDR/no-installer
+    // paths rather than reporting a false 'pending' success to the caller.
+    if (variableFailureCount > 0 && dispatchedDeviceIds.length === 0) {
+      return {
+        deploymentId: deployment.id,
+        deployment,
+        status: 'failed',
+        message: 'All target devices failed installer variable resolution',
+        dispatchedDeviceIds: [],
+      };
     }
     return { deploymentId: deployment.id, deployment, status: 'pending', dispatchedDeviceIds };
   }

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -3,11 +3,14 @@ import { db } from '../db';
 import {
   deploymentResults,
   devices,
+  organizations,
+  sites,
   softwareCatalog,
   softwareDeployments,
   softwareVersions,
 } from '../db/schema';
 import { resolveEdrInstaller, type ResolvedInstaller } from './edrInstallerResolver';
+import { resolveInstallerVariables, type InstallerVariableContext } from './installerVariables';
 import { getPresignedUrl, isS3Configured, isS3NotFound } from './s3Storage';
 import { sendCommandToAgent, type AgentCommand } from '../routes/agentWs';
 
@@ -195,9 +198,16 @@ export async function createSoftwareDeployment(
       };
     }
 
-    // Get agentIds for target devices
+    // Get agentIds + variable context for target devices. hostname/siteId/
+    // customFields feed deploy-time `{{...}}` variable substitution below.
     const targetDevices = await db
-      .select({ id: devices.id, agentId: devices.agentId })
+      .select({
+        id: devices.id,
+        agentId: devices.agentId,
+        siteId: devices.siteId,
+        hostname: devices.hostname,
+        customFields: devices.customFields,
+      })
       .from(devices)
       .where(
         and(
@@ -205,6 +215,29 @@ export async function createSoftwareDeployment(
           inArray(devices.id, deviceIds),
         ),
       );
+
+    // Load org + site names once so per-device `{{org.name}}` / `{{site.name}}`
+    // resolve without an N+1. Only needed when a template actually references
+    // variables, but the two lookups are cheap and keep the loop simple.
+    const templatesUseVariables =
+      (finalDownloadUrl?.includes('{{') ?? false) ||
+      (finalSilentInstallArgs?.includes('{{') ?? false);
+
+    let orgName = '';
+    const siteNames = new Map<string, string>();
+    if (templatesUseVariables) {
+      const [org] = await db
+        .select({ name: organizations.name })
+        .from(organizations)
+        .where(eq(organizations.id, orgId))
+        .limit(1);
+      orgName = org?.name ?? '';
+      const siteRows = await db
+        .select({ id: sites.id, name: sites.name })
+        .from(sites)
+        .where(eq(sites.orgId, orgId));
+      for (const s of siteRows) siteNames.set(s.id, s.name);
+    }
 
     // Detection rules (#2022) and the force-reinstall toggle ride along with the
     // install command so the agent can skip-if-already-present and verify the
@@ -217,17 +250,55 @@ export async function createSoftwareDeployment(
 
     const dispatchedDeviceIds: string[] = [];
     for (const device of targetDevices) {
+      // Resolve `{{...}}` variables against this device's org/site/device context.
+      // A no-op when the templates contain no variables (fast path inside the
+      // resolver). An unresolvable token fails THIS device rather than shipping a
+      // literal `{{...}}` to the agent.
+      let deviceDownloadUrl = finalDownloadUrl;
+      let deviceSilentInstallArgs = finalSilentInstallArgs;
+      if (templatesUseVariables) {
+        const ctx: InstallerVariableContext = {
+          org: { id: orgId, name: orgName },
+          site: { id: device.siteId, name: siteNames.get(device.siteId) ?? '' },
+          device: {
+            hostname: device.hostname,
+            customFields: (device.customFields as Record<string, unknown> | null) ?? {},
+          },
+        };
+        const resolved = resolveInstallerVariables(finalDownloadUrl, finalSilentInstallArgs, ctx);
+        if (resolved.unresolved.length > 0) {
+          await db
+            .update(deploymentResults)
+            .set({
+              status: 'failed',
+              errorMessage: `Could not resolve installer variable(s): ${resolved.unresolved.join(', ')}`,
+              completedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(deploymentResults.deploymentId, deployment.id),
+                eq(deploymentResults.deviceId, device.id),
+              ),
+            );
+          continue;
+        }
+        // Substituting a non-null template yields a non-null string; the ?? keeps
+        // the type as string (finalDownloadUrl is non-null past the guard above).
+        deviceDownloadUrl = resolved.downloadUrl ?? finalDownloadUrl;
+        deviceSilentInstallArgs = resolved.silentInstallArgs;
+      }
+
       const command: AgentCommand = {
         id: `sw-install-${deployment.id}-${device.id}`,
         type: 'software_install',
         payload: {
           deploymentId: deployment.id,
-          downloadUrl: finalDownloadUrl,
+          downloadUrl: deviceDownloadUrl,
           checksum: versionRecord.checksum,
           fileName:
             versionRecord.originalFileName ?? `package.${versionRecord.fileType ?? 'exe'}`,
           fileType: versionRecord.fileType ?? 'exe',
-          silentInstallArgs: finalSilentInstallArgs,
+          silentInstallArgs: deviceSilentInstallArgs,
           softwareName: catalogItem.name,
           version: versionRecord.version,
           ...(detectionRules ? { detectionRules } : {}),

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -216,9 +216,9 @@ export async function createSoftwareDeployment(
         ),
       );
 
-    // Load org + site names once so per-device `{{org.name}}` / `{{site.name}}`
-    // resolve without an N+1. Only needed when a template actually references
-    // variables, but the two lookups are cheap and keep the loop simple.
+    // When a template references variables, load the org name + ALL of the org's
+    // site names once here (gated below) rather than per-device inside the loop —
+    // avoids an N+1 across the dispatch fan-out.
     const templatesUseVariables =
       (finalDownloadUrl?.includes('{{') ?? false) ||
       (finalSilentInstallArgs?.includes('{{') ?? false);
@@ -252,9 +252,9 @@ export async function createSoftwareDeployment(
     let variableFailureCount = 0;
     for (const device of targetDevices) {
       // Resolve `{{...}}` variables against this device's org/site/device context.
-      // A no-op when the templates contain no variables (fast path inside the
-      // resolver). An unresolvable token fails THIS device rather than shipping a
-      // literal `{{...}}` to the agent.
+      // Skipped entirely unless `templatesUseVariables` (computed once above); the
+      // resolver also fast-paths internally. An unresolvable token fails THIS
+      // device rather than shipping a literal `{{...}}` to the agent.
       let deviceDownloadUrl = finalDownloadUrl;
       let deviceSilentInstallArgs = finalSilentInstallArgs;
       if (templatesUseVariables) {

--- a/apps/web/src/components/software/AddPackageModal.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.test.tsx
@@ -136,4 +136,25 @@ describe('AddPackageModal', () => {
     expect(catalogPosts).toHaveLength(1);
     expect(versionAttempts).toBe(2);
   });
+
+  it('surfaces the created package (0 versions) if the user cancels after a version-write failure', async () => {
+    const onCreated = vi.fn();
+    routeMock({ createVersion: () => jsonResponse({ error: 'boom' }, false, 500) });
+    render(<AddPackageModal open onClose={() => {}} onCreated={onCreated} />);
+
+    fillMinimum();
+    fireEvent.click(await screen.findByRole('button', { name: 'Create package' }));
+
+    // Version write failed → button flips to retry, catalog id retained.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Retry adding version' })).toBeInTheDocument(),
+    );
+
+    // Cancelling now must NOT leave an invisible orphan — the created package is
+    // surfaced with versionCount 0 so it appears in the catalog.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cat-1', name: 'Google Chrome', versionCount: 0 }),
+    );
+  });
 });

--- a/apps/web/src/components/software/AddPackageModal.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AddPackageModal from './AddPackageModal';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// DetectionRulesEditor is exercised elsewhere; it lives behind the Advanced
+// disclosure and isn't needed for the create-flow assertions here.
+vi.mock('./DetectionRulesEditor', () => ({ default: () => null }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+/** Route mock keyed by URL + method so effect-order doesn't matter. */
+function routeMock(handlers: {
+  customFields?: unknown;
+  createCatalog?: () => Response;
+  createVersion?: () => Response;
+}) {
+  fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+    if (url.startsWith('/custom-fields')) {
+      return Promise.resolve(jsonResponse({ data: handlers.customFields ?? [] }));
+    }
+    if (url === '/software/catalog' && opts?.method === 'POST') {
+      return Promise.resolve((handlers.createCatalog ?? (() => jsonResponse({ data: { id: 'cat-1' } })))());
+    }
+    if (/\/software\/catalog\/.+\/versions$/.test(url) && opts?.method === 'POST') {
+      return Promise.resolve((handlers.createVersion ?? (() => jsonResponse({ data: { id: 'ver-1' } })))());
+    }
+    return Promise.resolve(jsonResponse({}, false, 404));
+  });
+}
+
+const fillMinimum = () => {
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Google Chrome' } });
+  fireEvent.change(screen.getByLabelText('Version'), { target: { value: '1.0.0' } });
+  fireEvent.change(screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'), {
+    target: { value: 'https://dl.example.com/chrome.msi' },
+  });
+};
+
+describe('AddPackageModal', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    showToast.mockReset();
+  });
+
+  it('keeps Create disabled until name, version and a source are present', async () => {
+    routeMock({});
+    render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+
+    const submit = screen.getByRole('button', { name: 'Create package' });
+    expect(submit).toBeDisabled();
+
+    fillMinimum();
+    await waitFor(() => expect(submit).toBeEnabled());
+  });
+
+  it('creates the catalog item then its first version and reports the new package', async () => {
+    const onCreated = vi.fn();
+    routeMock({});
+    render(<AddPackageModal open onClose={() => {}} onCreated={onCreated} />);
+
+    fillMinimum();
+    fireEvent.click(await screen.findByRole('button', { name: 'Create package' }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+
+    const catalogCall = fetchMock.mock.calls.find(([u, o]) => u === '/software/catalog' && o?.method === 'POST');
+    const versionCall = fetchMock.mock.calls.find(([u, o]) => /\/versions$/.test(u as string) && o?.method === 'POST');
+    expect(catalogCall).toBeTruthy();
+    expect(versionCall).toBeTruthy();
+
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cat-1', name: 'Google Chrome', versionCount: 1 }),
+    );
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('blocks submit when the URL contains an unknown variable', async () => {
+    routeMock({});
+    render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'App' } });
+    fireEvent.change(screen.getByLabelText('Version'), { target: { value: '2.0' } });
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'), {
+      target: { value: 'https://dl/{{org.bogus}}/app.msi' },
+    });
+
+    expect(await screen.findByText(/Unknown variable/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create package' })).toBeDisabled();
+  });
+
+  it('on version-write failure keeps the created catalog id and retries only the version step', async () => {
+    const onCreated = vi.fn();
+    let versionAttempts = 0;
+    routeMock({
+      createVersion: () => {
+        versionAttempts += 1;
+        return versionAttempts === 1
+          ? jsonResponse({ error: 'boom' }, false, 500)
+          : jsonResponse({ data: { id: 'ver-1' } });
+      },
+    });
+    render(<AddPackageModal open onClose={() => {}} onCreated={onCreated} />);
+
+    fillMinimum();
+    fireEvent.click(await screen.findByRole('button', { name: 'Create package' }));
+
+    // First attempt fails on the version write; onCreated must NOT fire and the
+    // button flips to a retry label.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Retry adding version' })).toBeInTheDocument(),
+    );
+    expect(onCreated).not.toHaveBeenCalled();
+
+    // Retry: succeeds, and the catalog item is NOT created a second time.
+    fireEvent.click(screen.getByRole('button', { name: 'Retry adding version' }));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+
+    const catalogPosts = fetchMock.mock.calls.filter(
+      ([u, o]) => u === '/software/catalog' && o?.method === 'POST',
+    );
+    expect(catalogPosts).toHaveLength(1);
+    expect(versionAttempts).toBe(2);
+  });
+});

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -1,0 +1,525 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Loader2, Upload, Link2, HardDriveUpload } from 'lucide-react';
+import type { DetectionRule } from '@breeze/shared';
+import { cn } from '@/lib/utils';
+import { Dialog } from '../shared/Dialog';
+import { showToast } from '../shared/Toast';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { findUnknownTokens } from '@/lib/installerVariables';
+import DetectionRulesEditor from './DetectionRulesEditor';
+import VariableInput, { type DeviceCustomField } from './VariableInput';
+
+type Architecture = 'x64' | 'arm64' | 'x86';
+type Source = 'url' | 'file';
+
+export interface CreatedPackage {
+  id: string;
+  name: string;
+  vendor: string;
+  category: string;
+  description: string;
+  createdAt: string;
+  versionCount: number;
+}
+
+interface AddPackageModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called once the package AND its first version are persisted. */
+  onCreated: (pkg: CreatedPackage) => void;
+}
+
+const CATEGORIES = [
+  'browser', 'utility', 'compression', 'productivity',
+  'communication', 'developer', 'media', 'security',
+] as const;
+
+const OS_OPTIONS = ['Windows', 'macOS', 'Linux'] as const;
+
+const blankForm = {
+  name: '',
+  vendor: '',
+  category: 'utility',
+  description: '',
+  version: '',
+  architecture: 'x64' as Architecture,
+  source: 'url' as Source,
+  downloadUrl: '',
+  supportedOs: [] as string[],
+  silentInstallArgs: '',
+  silentUninstallArgs: '',
+  detectionRules: [] as DetectionRule[],
+  notes: '',
+  file: null as File | null,
+  fileName: '',
+};
+
+export default function AddPackageModal({ open, onClose, onCreated }: AddPackageModalProps) {
+  const [form, setForm] = useState(blankForm);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // If the catalog item was created but the version write failed, keep its id so
+  // a retry continues from the version step instead of creating a duplicate.
+  const createdCatalogId = useRef<string | null>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(blankForm);
+    setAdvancedOpen(false);
+    createdCatalogId.current = null;
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth('/custom-fields?limit=200');
+        if (!res.ok || cancelled) return;
+        const payload = await res.json();
+        const rows = payload.data ?? payload ?? [];
+        if (Array.isArray(rows)) {
+          setCustomFields(
+            rows
+              .map((r: Record<string, unknown>) => ({
+                fieldKey: String(r.fieldKey ?? ''),
+                name: String(r.name ?? r.fieldKey ?? ''),
+              }))
+              .filter((f: DeviceCustomField) => f.fieldKey),
+          );
+        }
+      } catch {
+        /* custom fields are optional for the variable picker */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const update = <K extends keyof typeof blankForm>(key: K, value: (typeof blankForm)[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    setForm((prev) => ({
+      ...prev,
+      file,
+      fileName: file.name,
+      silentInstallArgs:
+        ext === 'msi' && !prev.silentInstallArgs
+          ? 'msiexec /i "{file}" /qn /norestart'
+          : prev.silentInstallArgs,
+      silentUninstallArgs:
+        ext === 'msi' && !prev.silentUninstallArgs
+          ? 'msiexec /x "{file}" /qn /norestart'
+          : prev.silentUninstallArgs,
+    }));
+  };
+
+  const knownKeys = useMemo(() => new Set(customFields.map((f) => f.fieldKey)), [customFields]);
+  const tokenErrors = useMemo(() => {
+    const opts = { requireKnownCustomKeys: knownKeys.size > 0 };
+    return [form.downloadUrl, form.silentInstallArgs, form.silentUninstallArgs].flatMap((s) =>
+      findUnknownTokens(s, knownKeys, opts),
+    );
+  }, [form.downloadUrl, form.silentInstallArgs, form.silentUninstallArgs, knownKeys]);
+
+  const hasSource = form.source === 'url' ? form.downloadUrl.trim() !== '' : form.file != null;
+  const canSubmit =
+    form.name.trim() !== '' &&
+    form.version.trim() !== '' &&
+    hasSource &&
+    tokenErrors.length === 0 &&
+    !saving;
+
+  const buildVersionRequest = (catalogId: string): (() => Promise<Response>) => {
+    const shared = {
+      version: form.version.trim(),
+      architecture: form.architecture,
+      releaseNotes: form.notes || undefined,
+      silentInstallArgs: form.silentInstallArgs || undefined,
+      silentUninstallArgs: form.silentUninstallArgs || undefined,
+      supportedOs: form.supportedOs.length > 0 ? form.supportedOs : undefined,
+      detectionRules: form.detectionRules.length > 0 ? form.detectionRules : undefined,
+    };
+
+    if (form.source === 'file' && form.file) {
+      const fd = new FormData();
+      fd.append('file', form.file);
+      fd.append('version', shared.version);
+      fd.append('architecture', shared.architecture);
+      if (shared.releaseNotes) fd.append('releaseNotes', shared.releaseNotes);
+      if (shared.silentInstallArgs) fd.append('silentInstallArgs', shared.silentInstallArgs);
+      if (shared.silentUninstallArgs) fd.append('silentUninstallArgs', shared.silentUninstallArgs);
+      if (shared.supportedOs) fd.append('supportedOs', JSON.stringify(shared.supportedOs));
+      if (shared.detectionRules) fd.append('detectionRules', JSON.stringify(shared.detectionRules));
+      if (form.downloadUrl.trim()) fd.append('downloadUrl', form.downloadUrl.trim());
+      return () =>
+        fetchWithAuth(`/software/catalog/${catalogId}/versions/upload`, {
+          method: 'POST',
+          body: fd,
+          headers: {},
+        });
+    }
+
+    return () =>
+      fetchWithAuth(`/software/catalog/${catalogId}/versions`, {
+        method: 'POST',
+        body: JSON.stringify({ ...shared, downloadUrl: form.downloadUrl.trim() || undefined }),
+      });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setSaving(true);
+    try {
+      // Step 1 — create the catalog item (skip if a prior attempt already did).
+      if (!createdCatalogId.current) {
+        const item = await runAction<{ id: string }>({
+          request: () =>
+            fetchWithAuth('/software/catalog', {
+              method: 'POST',
+              body: JSON.stringify({
+                name: form.name.trim(),
+                vendor: form.vendor.trim() || undefined,
+                category: form.category,
+                description: form.description.trim() || undefined,
+              }),
+            }),
+          parseSuccess: (d) => {
+            const data = (d as { data?: { id?: unknown } }).data ?? (d as { id?: unknown });
+            return { id: String((data as { id?: unknown }).id ?? '') };
+          },
+          errorFallback: 'Failed to create package',
+        });
+        createdCatalogId.current = item.id;
+      }
+
+      const catalogId = createdCatalogId.current;
+      if (!catalogId) throw new Error('Missing package id');
+
+      // Step 2 — add the first version. Success toast lands here so the user is
+      // only told "added" once the package is actually deployable.
+      await runAction({
+        request: buildVersionRequest(catalogId),
+        errorFallback: 'Package created, but adding the first version failed',
+        successMessage: `Added ${form.name.trim()} — v${form.version.trim()}`,
+      });
+
+      onCreated({
+        id: catalogId,
+        name: form.name.trim(),
+        vendor: form.vendor.trim(),
+        category: form.category,
+        description: form.description.trim(),
+        createdAt: new Date().toISOString(),
+        versionCount: 1,
+      });
+      onClose();
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return; // auth redirect handles it
+      if (!(err instanceof ActionError)) {
+        showToast({ type: 'error', message: err instanceof Error ? err.message : 'Failed to add package' });
+      }
+      // Non-401 ActionError already toasted by runAction. Modal stays open; if the
+      // catalog item was created, createdCatalogId retries from the version step.
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const labelCls = 'text-xs font-semibold uppercase text-muted-foreground';
+  const inputCls =
+    'mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring';
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? () => {} : onClose}
+      title="Add software package"
+      labelledBy={titleId}
+      maxWidth="2xl"
+      alignTop
+      className="flex max-h-[90vh] flex-col"
+    >
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <div>
+          <h2 id={titleId} className="text-lg font-semibold">Add software package</h2>
+          <p className="text-sm text-muted-foreground">
+            Create the package and its first deployable version in one step.
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
+          {/* Package identity */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">Package</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelCls} htmlFor="pkg-name">Name</label>
+                <input
+                  id="pkg-name"
+                  autoFocus
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => update('name', e.target.value)}
+                  placeholder="e.g. Google Chrome"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls} htmlFor="pkg-vendor">Vendor</label>
+                <input
+                  id="pkg-vendor"
+                  type="text"
+                  value={form.vendor}
+                  onChange={(e) => update('vendor', e.target.value)}
+                  placeholder="e.g. Google"
+                  className={inputCls}
+                />
+              </div>
+            </div>
+            <div>
+              <label className={labelCls} htmlFor="pkg-category">Category</label>
+              <select
+                id="pkg-category"
+                value={form.category}
+                onChange={(e) => update('category', e.target.value)}
+                className={inputCls}
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>
+                ))}
+              </select>
+            </div>
+          </section>
+
+          {/* First version */}
+          <section className="space-y-4 border-t pt-5">
+            <h3 className="text-sm font-semibold text-foreground">First version</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelCls} htmlFor="pkg-version">Version</label>
+                <input
+                  id="pkg-version"
+                  type="text"
+                  value={form.version}
+                  onChange={(e) => update('version', e.target.value)}
+                  placeholder="e.g. 1.0.0"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls} htmlFor="pkg-arch">Architecture</label>
+                <select
+                  id="pkg-arch"
+                  value={form.architecture}
+                  onChange={(e) => update('architecture', e.target.value as Architecture)}
+                  className={inputCls}
+                >
+                  <option value="x64">x64</option>
+                  <option value="arm64">arm64</option>
+                  <option value="x86">x86</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Source: URL or file, one control */}
+            <div>
+              <span className={labelCls}>Source</span>
+              <div className="mt-2 inline-flex rounded-md border bg-muted/40 p-0.5" role="tablist" aria-label="Installer source">
+                {([['url', 'Download URL', Link2], ['file', 'Upload file', HardDriveUpload]] as const).map(
+                  ([val, label, Icon]) => (
+                    <button
+                      key={val}
+                      type="button"
+                      role="tab"
+                      aria-selected={form.source === val}
+                      onClick={() => update('source', val)}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition-colors',
+                        form.source === val
+                          ? 'bg-background text-foreground shadow-xs'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <Icon className="h-4 w-4" />
+                      {label}
+                    </button>
+                  ),
+                )}
+              </div>
+
+              {form.source === 'url' ? (
+                <div className="mt-3">
+                  <VariableInput
+                    id="pkg-url"
+                    value={form.downloadUrl}
+                    onChange={(v) => update('downloadUrl', v)}
+                    placeholder="https://example.com/package-v1.0.0.msi"
+                    customFields={customFields}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Use variables like <code className="font-mono">{'{{org.name}}'}</code> — resolved per organization at deploy time.
+                  </p>
+                </div>
+              ) : (
+                <div className="mt-3 flex items-center gap-3">
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".msi,.exe,.dmg,.deb,.pkg"
+                    onChange={handleFile}
+                    className="hidden"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
+                  >
+                    <Upload className="h-4 w-4" />
+                    Choose file
+                  </button>
+                  <span className="truncate text-sm text-muted-foreground">
+                    {form.fileName || 'No file selected (.msi, .exe, .dmg, .deb, .pkg)'}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <span className={labelCls}>Supported OS</span>
+              <div className="mt-2 flex flex-wrap items-center gap-4">
+                {OS_OPTIONS.map((os) => {
+                  const val = os.toLowerCase();
+                  return (
+                    <label key={os} className="inline-flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={form.supportedOs.includes(val)}
+                        onChange={(e) =>
+                          update(
+                            'supportedOs',
+                            e.target.checked
+                              ? [...form.supportedOs, val]
+                              : form.supportedOs.filter((o) => o !== val),
+                          )
+                        }
+                        className="h-4 w-4 rounded border"
+                      />
+                      {os}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <label className={labelCls} htmlFor="pkg-install">Silent install args</label>
+              <div className="mt-2">
+                <VariableInput
+                  id="pkg-install"
+                  value={form.silentInstallArgs}
+                  onChange={(v) => update('silentInstallArgs', v)}
+                  placeholder={'e.g. msiexec /i "{file}" /qn /norestart'}
+                  customFields={customFields}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Advanced */}
+          <section className="border-t pt-3">
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((o) => !o)}
+              aria-expanded={advancedOpen}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+            >
+              <ChevronDown className={cn('h-4 w-4 transition-transform', advancedOpen && 'rotate-180')} />
+              Advanced options
+            </button>
+
+            {advancedOpen && (
+              <div className="mt-4 space-y-4">
+                <div>
+                  <label className={labelCls} htmlFor="pkg-uninstall">Silent uninstall args</label>
+                  <div className="mt-2">
+                    <VariableInput
+                      id="pkg-uninstall"
+                      value={form.silentUninstallArgs}
+                      onChange={(v) => update('silentUninstallArgs', v)}
+                      placeholder={'e.g. msiexec /x "{file}" /qn /norestart'}
+                      customFields={customFields}
+                    />
+                  </div>
+                </div>
+
+                <DetectionRulesEditor
+                  rules={form.detectionRules}
+                  onChange={(detectionRules) => update('detectionRules', detectionRules)}
+                />
+
+                <div>
+                  <label className={labelCls} htmlFor="pkg-notes">Release notes</label>
+                  <textarea
+                    id="pkg-notes"
+                    value={form.notes}
+                    onChange={(e) => update('notes', e.target.value)}
+                    placeholder="One item per line"
+                    className="mt-2 min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+
+                <div>
+                  <label className={labelCls} htmlFor="pkg-desc">Description</label>
+                  <textarea
+                    id="pkg-desc"
+                    value={form.description}
+                    onChange={(e) => update('description', e.target.value)}
+                    placeholder="Brief description of the software"
+                    className="mt-2 min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Sticky footer */}
+        <div className="flex items-center justify-end gap-2 border-t px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+            {saving
+              ? form.source === 'file'
+                ? 'Uploading…'
+                : 'Creating…'
+              : createdCatalogId.current
+                ? 'Retry adding version'
+                : 'Create package'}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -86,7 +86,9 @@ export default function AddPackageModal({ open, onClose, onCreated }: AddPackage
                 fieldKey: String(r.fieldKey ?? ''),
                 name: String(r.name ?? r.fieldKey ?? ''),
               }))
-              .filter((f: DeviceCustomField) => f.fieldKey),
+              // Only offer keys that match the token grammar the resolver accepts,
+              // so the picker never presents a token it would then flag as unknown.
+              .filter((f: DeviceCustomField) => /^[a-z][a-z0-9_]*$/.test(f.fieldKey)),
           );
         }
       } catch {
@@ -234,6 +236,24 @@ export default function AddPackageModal({ open, onClose, onCreated }: AddPackage
     }
   };
 
+  const handleClose = () => {
+    // If step 1 (catalog) succeeded but the version write never did, surface the
+    // created package (0 versions) so it isn't an invisible orphan the user would
+    // re-create by adding the same name — they can then add a version or delete it.
+    if (createdCatalogId.current) {
+      onCreated({
+        id: createdCatalogId.current,
+        name: form.name.trim(),
+        vendor: form.vendor.trim(),
+        category: form.category,
+        description: form.description.trim(),
+        createdAt: new Date().toISOString(),
+        versionCount: 0,
+      });
+    }
+    onClose();
+  };
+
   const labelCls = 'text-xs font-semibold uppercase text-muted-foreground';
   const inputCls =
     'mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring';
@@ -241,7 +261,7 @@ export default function AddPackageModal({ open, onClose, onCreated }: AddPackage
   return (
     <Dialog
       open={open}
-      onClose={saving ? () => {} : onClose}
+      onClose={saving ? () => {} : handleClose}
       title="Add software package"
       labelledBy={titleId}
       maxWidth="2xl"
@@ -498,7 +518,7 @@ export default function AddPackageModal({ open, onClose, onCreated }: AddPackage
         <div className="flex items-center justify-end gap-2 border-t px-6 py-4">
           <button
             type="button"
-            onClick={onClose}
+            onClick={handleClose}
             disabled={saving}
             className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
           >

--- a/apps/web/src/components/software/BuiltinPackageDetail.test.tsx
+++ b/apps/web/src/components/software/BuiltinPackageDetail.test.tsx
@@ -26,13 +26,6 @@ const missingKey: EdrReadiness = {
     },
     { key: 'orgsMapped', label: 'Organizations mapped', ok: true, detail: '2 orgs mapped' },
   ],
-  firstGap: {
-    key: 'accountKey',
-    label: 'Account key configured',
-    ok: false,
-    detail: 'Add your Huntress account key in Integrations',
-    fixHref: '/integrations',
-  },
 };
 
 describe('BuiltinPackageDetail', () => {

--- a/apps/web/src/components/software/BuiltinPackageDetail.test.tsx
+++ b/apps/web/src/components/software/BuiltinPackageDetail.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BuiltinPackageDetail from './BuiltinPackageDetail';
+import type { EdrReadiness } from './useEdrReadiness';
+
+const ready: EdrReadiness = {
+  status: 'ready',
+  mappedOrgCount: 2,
+  checks: [
+    { key: 'connected', label: 'Integration connected', ok: true },
+    { key: 'accountKey', label: 'Account key configured', ok: true },
+    { key: 'orgsMapped', label: 'Organizations mapped', ok: true, detail: '2 orgs mapped' },
+  ],
+};
+
+const missingKey: EdrReadiness = {
+  status: 'incomplete',
+  checks: [
+    { key: 'connected', label: 'Integration connected', ok: true },
+    {
+      key: 'accountKey',
+      label: 'Account key configured',
+      ok: false,
+      detail: 'Add your Huntress account key in Integrations',
+      fixHref: '/integrations',
+    },
+    { key: 'orgsMapped', label: 'Organizations mapped', ok: true, detail: '2 orgs mapped' },
+  ],
+  firstGap: {
+    key: 'accountKey',
+    label: 'Account key configured',
+    ok: false,
+    detail: 'Add your Huntress account key in Integrations',
+    fixHref: '/integrations',
+  },
+};
+
+describe('BuiltinPackageDetail', () => {
+  it('shows a confident ready state and fires onDeploy', () => {
+    const onDeploy = vi.fn();
+    render(<BuiltinPackageDetail name="Huntress EDR Agent" provider="huntress" readiness={ready} onDeploy={onDeploy} />);
+    expect(screen.getByText(/Ready to deploy to 2 mapped orgs/i)).toBeInTheDocument();
+    // No prereq warnings when ready.
+    expect(screen.queryByText(/account key in Integrations/i)).not.toBeInTheDocument();
+    const deploy = screen.getByRole('button', { name: /^Deploy$/ });
+    expect(deploy).not.toBeDisabled();
+    fireEvent.click(deploy);
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces exactly the one missing step and disables Deploy', () => {
+    render(<BuiltinPackageDetail name="Huntress EDR Agent" provider="huntress" readiness={missingKey} onDeploy={vi.fn()} />);
+    expect(screen.getByText(/Add your Huntress account key in Integrations/i)).toBeInTheDocument();
+    const deploy = screen.getByRole('button', { name: /^Deploy$/ });
+    expect(deploy).toBeDisabled();
+    expect(deploy).toHaveAttribute('title', expect.stringMatching(/account key/i));
+  });
+
+  it('defers to the server when readiness is unknown (Deploy stays enabled)', () => {
+    render(
+      <BuiltinPackageDetail
+        name="Huntress EDR Agent"
+        provider="huntress"
+        readiness={{ status: 'unknown', checks: [] }}
+        onDeploy={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Couldn.t verify setup/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Deploy$/ })).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/software/BuiltinPackageDetail.tsx
+++ b/apps/web/src/components/software/BuiltinPackageDetail.tsx
@@ -89,7 +89,8 @@ export default function BuiltinPackageDetail({ name, provider, readiness, onDepl
             {gap.detail && <p className="mt-0.5 text-muted-foreground">{gap.detail}</p>}
             {gap.fixHref && (
               <a href={gap.fixHref} className="mt-1 inline-flex items-center gap-1 text-xs font-medium underline">
-                Open Integrations <ExternalLink className="h-3 w-3" />
+                {gap.fixHref === '/integrations' ? 'Open Integrations' : 'Go to setup'}
+                <ExternalLink className="h-3 w-3" />
               </a>
             )}
           </div>

--- a/apps/web/src/components/software/BuiltinPackageDetail.tsx
+++ b/apps/web/src/components/software/BuiltinPackageDetail.tsx
@@ -1,0 +1,112 @@
+import { CheckCircle2, AlertTriangle, ExternalLink, Loader2, HelpCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getProviderBranding, type IntegrationProvider } from './providerBranding';
+import type { EdrReadiness } from './useEdrReadiness';
+
+export interface BuiltinPackageDetailProps {
+  name: string;
+  provider: IntegrationProvider;
+  readiness: EdrReadiness;
+  onDeploy: () => void;
+}
+
+export default function BuiltinPackageDetail({ name, provider, readiness, onDeploy }: BuiltinPackageDetailProps) {
+  const branding = getProviderBranding(provider);
+  const Icon = branding.icon;
+  const ready = readiness.status === 'ready';
+  const gap = readiness.firstGap;
+  const disabled = readiness.status === 'incomplete';
+  const deployTitle = disabled && gap ? `Resolve: ${gap.label}` : 'Deploys to mapped organizations only';
+
+  return (
+    <div className="mt-4 space-y-5">
+      <div className="flex items-start gap-3">
+        <div className={cn('flex h-12 w-12 items-center justify-center rounded-md border', branding.accent)}>
+          <Icon className="h-6 w-6" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold">{name}</h3>
+            <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium', branding.accent)}>
+              Managed built-in
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{branding.blurb}</p>
+          {branding.websiteUrl && (
+            <a
+              href={branding.websiteUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {branding.label} website <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-muted/30 p-4">
+        {readiness.status === 'loading' && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Checking setup…
+          </div>
+        )}
+        {readiness.status === 'unknown' && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <HelpCircle className="h-4 w-4" /> Couldn&apos;t verify setup — deploy will confirm on the server.
+          </div>
+        )}
+        {(ready || readiness.status === 'incomplete') && (
+          <ul className="space-y-2">
+            {readiness.checks.map((c) => (
+              <li key={c.key} className="flex items-center gap-2 text-sm">
+                {c.ok ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                ) : (
+                  <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                )}
+                <span className={cn(!c.ok && 'font-medium')}>{c.label}</span>
+                {/* The first gap's detail is shown in the Next-step box below; don't repeat it here. */}
+                {c.detail && c.key !== gap?.key && (
+                  <span className="text-xs text-muted-foreground">· {c.detail}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {ready && (
+          <p className="mt-3 text-sm font-medium text-emerald-700 dark:text-emerald-400">
+            Ready to deploy
+            {typeof readiness.mappedOrgCount === 'number'
+              ? ` to ${readiness.mappedOrgCount} mapped org${readiness.mappedOrgCount === 1 ? '' : 's'}`
+              : ''}
+            .
+          </p>
+        )}
+        {disabled && gap && (
+          <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+            <p className="font-medium">Next step: {gap.label}</p>
+            {gap.detail && <p className="mt-0.5 text-muted-foreground">{gap.detail}</p>}
+            {gap.fixHref && (
+              <a href={gap.fixHref} className="mt-1 inline-flex items-center gap-1 text-xs font-medium underline">
+                Open Integrations <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          disabled={disabled}
+          title={deployTitle}
+          onClick={onDeploy}
+          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Deploy
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/software/BuiltinPackageDetail.tsx
+++ b/apps/web/src/components/software/BuiltinPackageDetail.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, AlertTriangle, ExternalLink, Loader2, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getProviderBranding, type IntegrationProvider } from './providerBranding';
-import type { EdrReadiness } from './useEdrReadiness';
+import { firstGap, type EdrReadiness } from './useEdrReadiness';
 
 export interface BuiltinPackageDetailProps {
   name: string;
@@ -14,7 +14,7 @@ export default function BuiltinPackageDetail({ name, provider, readiness, onDepl
   const branding = getProviderBranding(provider);
   const Icon = branding.icon;
   const ready = readiness.status === 'ready';
-  const gap = readiness.firstGap;
+  const gap = firstGap(readiness);
   const disabled = readiness.status === 'incomplete';
   const deployTitle = disabled && gap ? `Resolve: ${gap.label}` : 'Deploys to mapped organizations only';
 

--- a/apps/web/src/components/software/DeploymentWizard.preselect.test.tsx
+++ b/apps/web/src/components/software/DeploymentWizard.preselect.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DeploymentWizard from './DeploymentWizard';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../filters/DeviceTargetSelector', () => ({ DeviceTargetSelector: () => null }));
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ok = (payload: unknown): Response =>
+  ({ ok: true, status: 200, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function route(url: string) {
+  if (url === '/software/catalog')
+    return ok({ data: [{ id: 'cat-9', name: 'Huntress EDR Agent', vendor: 'Huntress', category: 'security' }] });
+  if (url === '/software/catalog/cat-9/versions')
+    return ok({ data: [{ id: 'ver-1', version: 'latest', isLatest: true }] });
+  return ok({ data: [] }); // /devices, /orgs/sites, /device-groups
+}
+
+describe('DeploymentWizard preselect (initialCatalogId)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) => Promise.resolve(route(url)));
+  });
+
+  it('starts with the preselected package selected', async () => {
+    render(<DeploymentWizard initialCatalogId="cat-9" />);
+    // Once the catalog loads, the preselected package's name appears in the
+    // step-1 selection UI (invariant: preselect → non-empty selectedSoftwareId).
+    await waitFor(() =>
+      expect(screen.getAllByText('Huntress EDR Agent').length).toBeGreaterThan(0),
+    );
+  });
+});

--- a/apps/web/src/components/software/DeploymentWizard.tsx
+++ b/apps/web/src/components/software/DeploymentWizard.tsx
@@ -125,7 +125,12 @@ function getSelectedTargetSummary(
   };
 }
 
-export default function DeploymentWizard() {
+interface DeploymentWizardProps {
+  /** When launched from a specific package's Deploy button, preselect it. */
+  initialCatalogId?: string;
+}
+
+export default function DeploymentWizard({ initialCatalogId }: DeploymentWizardProps = {}) {
   const [activeStepIndex, setActiveStepIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -285,7 +290,12 @@ export default function DeploymentWizard() {
       setTargetTree(tree);
 
       if (normalizedCatalog.length > 0 && !selectedSoftwareId) {
-        const firstDeployable = normalizedCatalog.find((item) => item.versions.length > 0);
+        // Preselect the package the user launched from (per-card Deploy), falling
+        // back to the first deployable one when none was passed or it has no version.
+        const preferred = initialCatalogId
+          ? normalizedCatalog.find((item) => item.id === initialCatalogId && item.versions.length > 0)
+          : undefined;
+        const firstDeployable = preferred ?? normalizedCatalog.find((item) => item.versions.length > 0);
         if (firstDeployable) {
           setSelectedSoftwareId(firstDeployable.id);
           setSelectedVersionId(firstDeployable.versions.find((version) => version.isLatest)?.id ?? firstDeployable.versions[0]?.id ?? '');
@@ -296,7 +306,7 @@ export default function DeploymentWizard() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [initialCatalogId]);
 
   useEffect(() => {
     fetchData();

--- a/apps/web/src/components/software/SoftwareCatalog.test.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.test.tsx
@@ -13,7 +13,12 @@ vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
 
 // DeploymentWizard / SoftwareVersionManager pull in their own fetches; stub them
 // out so this test exercises only the catalog delete flow.
-vi.mock('./DeploymentWizard', () => ({ default: () => null }));
+// Probe echoes the preselected package id so we can assert per-card deploy preselect.
+vi.mock('./DeploymentWizard', () => ({
+  default: (props: { initialCatalogId?: string }) => (
+    <div data-testid="wizard">wizard:{props.initialCatalogId ?? 'none'}</div>
+  ),
+}));
 vi.mock('./SoftwareVersionManager', () => ({ default: () => null }));
 
 const fetchMock = vi.mocked(fetchWithAuth);
@@ -102,31 +107,66 @@ const BUILTIN_ITEM = {
   partnerId: 'partner-1'
 };
 
+/** Route the catalog + readiness fetches by URL so test order is robust. */
+function routeBuiltin(items: unknown[], huntress?: unknown, s1?: unknown) {
+  fetchMock.mockImplementation((url: string) => {
+    if (url === '/software/catalog') return Promise.resolve(jsonResponse({ data: items }));
+    if (url.startsWith('/huntress/integration')) return Promise.resolve(jsonResponse({ data: huntress ?? null }));
+    if (url.startsWith('/s1/integration')) return Promise.resolve(jsonResponse({ data: s1 ?? null }));
+    return Promise.resolve(jsonResponse({ data: null }));
+  });
+}
+
+const HUNTRESS_READY = { isActive: true, hasAccountKey: true, lastSyncOrgs: 2 };
+
 describe('SoftwareCatalog built-in packages', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     showToast.mockReset();
   });
 
-  it('renders a "Built-in · Huntress" badge for an integration package', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [BUILTIN_ITEM] }));
+  it('renders a branded "Built-in" chip and a Ready pill for a ready Huntress package', async () => {
+    routeBuiltin([BUILTIN_ITEM], HUNTRESS_READY);
 
     render(<SoftwareCatalog />);
 
-    expect(await screen.findByText(/Built-in · Huntress/)).toBeInTheDocument();
+    expect(await screen.findByText(/^Built-in$/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/^Ready$/)).toBeInTheDocument());
+    // The Huntress card no longer shows any installer-upload cue.
+    expect(screen.queryByText(/Upload installer/i)).not.toBeInTheDocument();
   });
 
-  it('hides Delete for a built-in package and shows the managed-by note instead', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [BUILTIN_ITEM] }));
+  it('opens the readiness detail panel (Managed built-in) with no Delete control', async () => {
+    routeBuiltin([BUILTIN_ITEM], HUNTRESS_READY);
 
     render(<SoftwareCatalog />);
     await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
 
     fireEvent.click(screen.getByText('Huntress EDR Agent'));
 
-    // Detail modal open: managed note present, no Delete control.
-    expect(await screen.findByText(/managed by the Huntress integration/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Managed built-in/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Delete$/ })).not.toBeInTheDocument();
+  });
+
+  it('surfaces the account-key next step in the detail panel when Huntress is incomplete', async () => {
+    routeBuiltin([BUILTIN_ITEM], { isActive: true, hasAccountKey: false, lastSyncOrgs: 2 });
+
+    render(<SoftwareCatalog />);
+    await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Huntress EDR Agent'));
+
+    expect(await screen.findByText(/Next step: Account key configured/i)).toBeInTheDocument();
+  });
+
+  it('preselects the package into the deploy wizard when Deploy is clicked', async () => {
+    routeBuiltin([BUILTIN_ITEM], HUNTRESS_READY);
+
+    render(<SoftwareCatalog />);
+    await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /^Deploy$/ }));
+    expect(await screen.findByTestId('wizard')).toHaveTextContent('wizard:builtin-huntress');
   });
 
   it('disables Deploy with an upload hint for a SentinelOne package that has no version', async () => {
@@ -141,7 +181,7 @@ describe('SoftwareCatalog built-in packages', () => {
       partnerId: 'partner-1',
       versionCount: 0
     };
-    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [s1NoVersion] }));
+    routeBuiltin([s1NoVersion], undefined, { isActive: true });
 
     render(<SoftwareCatalog />);
     await waitFor(() => expect(screen.getByText('SentinelOne Agent')).toBeInTheDocument());
@@ -162,7 +202,7 @@ describe('SoftwareCatalog built-in packages', () => {
       partnerId: 'partner-1',
       versionCount: 1
     };
-    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [s1WithVersion] }));
+    routeBuiltin([s1WithVersion], undefined, { isActive: true });
 
     render(<SoftwareCatalog />);
     await waitFor(() => expect(screen.getByText('SentinelOne Agent')).toBeInTheDocument());

--- a/apps/web/src/components/software/SoftwareCatalog.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.tsx
@@ -11,8 +11,10 @@ import {
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { Dialog } from '../shared/Dialog';
 import DeploymentWizard from './DeploymentWizard';
 import SoftwareVersionManager from './SoftwareVersionManager';
+import AddPackageModal, { type CreatedPackage } from './AddPackageModal';
 
 type IntegrationProvider = 'huntress' | 'sentinelone';
 
@@ -62,20 +64,19 @@ export default function SoftwareCatalog() {
   const [category, setCategory] = useState<string>('all');
   const [selectedSoftware, setSelectedSoftware] = useState<SoftwareItem | null>(null);
   const [showDeployWizard, setShowDeployWizard] = useState(false);
-  const [showAddForm, setShowAddForm] = useState(false);
+  const [deployCatalogId, setDeployCatalogId] = useState<string | undefined>();
+  const [showAddModal, setShowAddModal] = useState(false);
   const [detailTab, setDetailTab] = useState<'details' | 'versions'>('details');
   const [catalogItems, setCatalogItems] = useState<SoftwareItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<SoftwareItem | null>(null);
   const [deleting, setDeleting] = useState(false);
-  const [addForm, setAddForm] = useState({
-    name: '',
-    vendor: '',
-    category: 'utility',
-    description: ''
-  });
+
+  const openDeploy = (catalogId?: string) => {
+    setDeployCatalogId(catalogId);
+    setShowDeployWizard(true);
+  };
 
   const fetchCatalog = useCallback(async () => {
     try {
@@ -129,44 +130,20 @@ export default function SoftwareCatalog() {
     });
   }, [query, category, catalogItems]);
 
-  const handleAddPackage = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!addForm.name.trim()) return;
-
-    try {
-      setSaving(true);
-      const response = await fetchWithAuth('/software/catalog', {
-        method: 'POST',
-        body: JSON.stringify({
-          name: addForm.name.trim(),
-          vendor: addForm.vendor.trim() || undefined,
-          category: addForm.category,
-          description: addForm.description.trim() || undefined,
-        })
-      });
-
-      if (!response.ok) {
-        const errData = await response.json().catch(() => ({}));
-        throw new Error(errData.error ?? 'Failed to create package');
-      }
-
-      const result = await response.json();
-      const newItem = result.data ?? result;
-      setCatalogItems(prev => [...prev, {
-        id: String(newItem.id),
-        name: String(newItem.name ?? ''),
-        vendor: String(newItem.vendor ?? ''),
-        category: String(newItem.category ?? 'utility'),
-        description: String(newItem.description ?? ''),
-        createdAt: String(newItem.createdAt ?? ''),
-      }]);
-      setAddForm({ name: '', vendor: '', category: 'utility', description: '' });
-      setShowAddForm(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add package');
-    } finally {
-      setSaving(false);
-    }
+  const handleCreated = (pkg: CreatedPackage) => {
+    setCatalogItems(prev => [
+      {
+        id: pkg.id,
+        name: pkg.name,
+        vendor: pkg.vendor,
+        category: pkg.category,
+        description: pkg.description,
+        createdAt: pkg.createdAt,
+        versionCount: pkg.versionCount,
+      },
+      ...prev,
+    ]);
+    setShowAddModal(false);
   };
 
   const handleDeletePackage = async (item: SoftwareItem) => {
@@ -208,7 +185,7 @@ export default function SoftwareCatalog() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => setShowAddForm(true)}
+            onClick={() => setShowAddModal(true)}
             className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
           >
             <Plus className="h-4 w-4" />
@@ -216,7 +193,7 @@ export default function SoftwareCatalog() {
           </button>
           <button
             type="button"
-            onClick={() => setShowDeployWizard(true)}
+            onClick={() => openDeploy(undefined)}
             className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
           >
             <Rocket className="h-4 w-4" />
@@ -333,7 +310,7 @@ export default function SoftwareCatalog() {
                   }
                   onClick={event => {
                     event.stopPropagation();
-                    setShowDeployWizard(true);
+                    openDeploy(item.id);
                   }}
                   className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
@@ -347,15 +324,24 @@ export default function SoftwareCatalog() {
 
       {/* Detail modal */}
       {selectedSoftware && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 overflow-y-auto">
-          <div className="w-full max-w-5xl rounded-lg border bg-card p-6 shadow-lg my-8">
+        <Dialog
+          open={!!selectedSoftware}
+          onClose={() => setSelectedSoftware(null)}
+          title={selectedSoftware.name}
+          labelledBy="software-detail-title"
+          maxWidth="4xl"
+          alignTop
+          className="flex max-h-[90vh] flex-col"
+        >
+          {/* Sticky header: identity + tabs + close */}
+          <div className="border-b px-6 pt-5">
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center rounded-md bg-muted">
                   <Package className="h-6 w-6 text-muted-foreground" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold">{selectedSoftware.name}</h2>
+                  <h2 id="software-detail-title" className="text-lg font-semibold">{selectedSoftware.name}</h2>
                   <p className="text-sm text-muted-foreground">{selectedSoftware.vendor || 'Unknown vendor'}</p>
                 </div>
                 {selectedSoftware.category && (
@@ -372,13 +358,14 @@ export default function SoftwareCatalog() {
               <button
                 type="button"
                 onClick={() => setSelectedSoftware(null)}
+                aria-label="Close"
                 className="inline-flex h-9 w-9 items-center justify-center rounded-md border bg-background hover:bg-muted"
               >
                 <X className="h-4 w-4" />
               </button>
             </div>
 
-            <div className="mt-4 flex items-center gap-1 border-b">
+            <div className="mt-4 flex items-center gap-1">
               <button
                 type="button"
                 onClick={() => setDetailTab('details')}
@@ -404,9 +391,12 @@ export default function SoftwareCatalog() {
                 Versions
               </button>
             </div>
+          </div>
 
+          {/* Scrollable body */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
             {detailTab === 'details' && (
-              <div className="mt-4">
+              <div>
                 {selectedSoftware.description && (
                   <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
                     {selectedSoftware.description}
@@ -431,8 +421,9 @@ export default function SoftwareCatalog() {
                     type="button"
                     title={selectedSoftware.integrationProvider ? 'Deploys to mapped organizations only' : undefined}
                     onClick={() => {
+                      const id = selectedSoftware.id;
                       setSelectedSoftware(null);
-                      setShowDeployWizard(true);
+                      openDeploy(id);
                     }}
                     className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
                   >
@@ -443,152 +434,90 @@ export default function SoftwareCatalog() {
             )}
 
             {detailTab === 'versions' && (
-              <div className="mt-4">
-                <SoftwareVersionManager catalogId={selectedSoftware.id} />
-              </div>
+              <SoftwareVersionManager catalogId={selectedSoftware.id} embedded />
             )}
           </div>
-        </div>
+        </Dialog>
       )}
 
       {/* Delete confirmation modal */}
       {confirmDelete && (
-        <div className="fixed inset-0 z-60 flex items-center justify-center bg-black/50 p-4">
-          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
-            <div className="flex items-start gap-3">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-destructive/10">
-                <Trash2 className="h-5 w-5 text-destructive" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold">Delete package?</h2>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  This removes <span className="font-medium text-foreground">{confirmDelete.name}</span> from
-                  the software library, along with all of its versions and stored installer references. This
-                  cannot be undone.
-                </p>
-              </div>
+        <Dialog
+          open={!!confirmDelete}
+          onClose={() => (deleting ? undefined : setConfirmDelete(null))}
+          title="Delete package?"
+          labelledBy="delete-package-title"
+          maxWidth="md"
+          className="p-6"
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-destructive/10">
+              <Trash2 className="h-5 w-5 text-destructive" />
             </div>
-            <div className="mt-6 flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setConfirmDelete(null)}
-                disabled={deleting}
-                className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => handleDeletePackage(confirmDelete)}
-                disabled={deleting}
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-4 text-sm font-semibold text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
-              >
-                {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
-                {deleting ? 'Deleting...' : 'Delete'}
-              </button>
+            <div>
+              <h2 id="delete-package-title" className="text-lg font-semibold">Delete package?</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                This removes <span className="font-medium text-foreground">{confirmDelete.name}</span> from
+                the software library, along with all of its versions and stored installer references. This
+                cannot be undone.
+              </p>
             </div>
           </div>
-        </div>
+          <div className="mt-6 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              disabled={deleting}
+              className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => handleDeletePackage(confirmDelete)}
+              disabled={deleting}
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-4 text-sm font-semibold text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+            >
+              {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {deleting ? 'Deleting...' : 'Delete'}
+            </button>
+          </div>
+        </Dialog>
       )}
 
-      {/* Add Package modal */}
-      {showAddForm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-          <div className="w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Add Software Package</h2>
-              <button
-                type="button"
-                onClick={() => setShowAddForm(false)}
-                className="h-8 w-8 rounded-md hover:bg-muted flex items-center justify-center"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <form onSubmit={handleAddPackage} className="space-y-4">
-              <div>
-                <label className="text-xs font-semibold uppercase text-muted-foreground">Name</label>
-                <input
-                  type="text"
-                  value={addForm.name}
-                  onChange={e => setAddForm(prev => ({ ...prev, name: e.target.value }))}
-                  placeholder="e.g. Google Chrome"
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </div>
-              <div>
-                <label className="text-xs font-semibold uppercase text-muted-foreground">Vendor</label>
-                <input
-                  type="text"
-                  value={addForm.vendor}
-                  onChange={e => setAddForm(prev => ({ ...prev, vendor: e.target.value }))}
-                  placeholder="e.g. Google"
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </div>
-              <div>
-                <label className="text-xs font-semibold uppercase text-muted-foreground">Category</label>
-                <select
-                  value={addForm.category}
-                  onChange={e => setAddForm(prev => ({ ...prev, category: e.target.value }))}
-                  className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                >
-                  <option value="browser">Browser</option>
-                  <option value="utility">Utility</option>
-                  <option value="compression">Compression</option>
-                  <option value="productivity">Productivity</option>
-                  <option value="communication">Communication</option>
-                  <option value="developer">Developer</option>
-                  <option value="media">Media</option>
-                  <option value="security">Security</option>
-                </select>
-              </div>
-              <div>
-                <label className="text-xs font-semibold uppercase text-muted-foreground">Description</label>
-                <textarea
-                  value={addForm.description}
-                  onChange={e => setAddForm(prev => ({ ...prev, description: e.target.value }))}
-                  placeholder="Brief description of the software"
-                  className="mt-2 u-min-h-px-80 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-              </div>
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowAddForm(false)}
-                  className="inline-flex h-9 items-center justify-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !addForm.name.trim()}
-                  className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-                >
-                  {saving ? 'Creating...' : 'Create Package'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
+      <AddPackageModal
+        open={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        onCreated={handleCreated}
+      />
 
       {showDeployWizard && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8 overflow-y-auto">
-          <div className="w-full max-w-4xl rounded-lg border bg-card p-6 shadow-xs">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Bulk Software Deployment</h2>
-              <button
-                type="button"
-                onClick={() => setShowDeployWizard(false)}
-                className="h-8 w-8 rounded-md hover:bg-muted flex items-center justify-center"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <DeploymentWizard />
+        <Dialog
+          open={showDeployWizard}
+          onClose={() => setShowDeployWizard(false)}
+          title="Software deployment"
+          labelledBy="deploy-wizard-title"
+          maxWidth="4xl"
+          alignTop
+          className="flex max-h-[90vh] flex-col"
+        >
+          <div className="flex items-center justify-between border-b px-6 py-4">
+            <h2 id="deploy-wizard-title" className="text-lg font-semibold">
+              {deployCatalogId ? 'Deploy Software' : 'Bulk Software Deployment'}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setShowDeployWizard(false)}
+              aria-label="Close"
+              className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+            >
+              <X className="h-4 w-4" />
+            </button>
           </div>
-        </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+            <DeploymentWizard initialCatalogId={deployCatalogId} />
+          </div>
+        </Dialog>
       )}
     </div>
   );

--- a/apps/web/src/components/software/SoftwareCatalog.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.tsx
@@ -15,8 +15,9 @@ import { Dialog } from '../shared/Dialog';
 import DeploymentWizard from './DeploymentWizard';
 import SoftwareVersionManager from './SoftwareVersionManager';
 import AddPackageModal, { type CreatedPackage } from './AddPackageModal';
-
-type IntegrationProvider = 'huntress' | 'sentinelone';
+import { getProviderBranding, isIntegrationProvider, type IntegrationProvider } from './providerBranding';
+import { useEdrReadiness, type EdrReadiness } from './useEdrReadiness';
+import BuiltinPackageDetail from './BuiltinPackageDetail';
 
 type SoftwareItem = {
   id: string;
@@ -30,15 +31,6 @@ type SoftwareItem = {
   partnerId?: string;
   /** Number of uploaded versions; built-in S1 needs >=1 before it can deploy. */
   versionCount?: number;
-};
-
-/** Human label for a built-in package's integration provider, or null if not built-in. */
-const providerLabel = (provider?: IntegrationProvider): string | null => {
-  switch (provider) {
-    case 'huntress': return 'Huntress';
-    case 'sentinelone': return 'SentinelOne';
-    default: return null;
-  }
 };
 
 /**
@@ -58,6 +50,24 @@ const categoryStyles: Record<string, string> = {
   compression: 'bg-orange-500/20 text-orange-700 border-orange-500/40',
   media: 'bg-pink-500/20 text-pink-700 border-pink-500/40',
 };
+
+/** Small at-a-glance readiness chip for a built-in EDR card. */
+function ReadinessPill({ status }: { status: EdrReadiness['status'] }) {
+  if (status === 'ready')
+    return (
+      <span className="inline-flex items-center rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+        Ready
+      </span>
+    );
+  if (status === 'incomplete')
+    return (
+      <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+        Setup needed
+      </span>
+    );
+  if (status === 'loading') return <span className="text-xs text-muted-foreground">Checking…</span>;
+  return null;
+}
 
 export default function SoftwareCatalog() {
   const [query, setQuery] = useState('');
@@ -129,6 +139,18 @@ export default function SoftwareCatalog() {
       return matchesQuery && matchesCategory;
     });
   }, [query, category, catalogItems]);
+
+  // Built-in EDR readiness: one fetch per present provider (there's one
+  // integration per partner), shared by the cards and the detail panel.
+  const builtinProviders = useMemo(
+    () => Array.from(new Set(catalogItems.map(i => i.integrationProvider).filter(isIntegrationProvider))),
+    [catalogItems],
+  );
+  const s1VersionCount = useMemo(
+    () => catalogItems.find(i => i.integrationProvider === 'sentinelone')?.versionCount ?? 0,
+    [catalogItems],
+  );
+  const readinessMap = useEdrReadiness(builtinProviders, { s1VersionCount });
 
   const handleCreated = (pkg: CreatedPackage) => {
     setCatalogItems(prev => [
@@ -261,19 +283,35 @@ export default function SoftwareCatalog() {
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-                    <Package className="h-5 w-5 text-muted-foreground" />
-                  </div>
+                  {isIntegrationProvider(item.integrationProvider) ? (() => {
+                    const branding = getProviderBranding(item.integrationProvider);
+                    const Icon = branding.icon;
+                    return (
+                      <div className={cn('flex h-10 w-10 items-center justify-center rounded-md border', branding.accent)}>
+                        <Icon className="h-5 w-5" />
+                      </div>
+                    );
+                  })() : (
+                    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+                      <Package className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                  )}
                   <div>
                     <p className="text-sm font-semibold">{item.name}</p>
                     <p className="text-xs text-muted-foreground">{item.vendor || 'Unknown vendor'}</p>
                   </div>
                 </div>
                 <div className="flex flex-col items-end gap-1.5">
-                  {providerLabel(item.integrationProvider) && (
-                    <span className="inline-flex items-center rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-700">
-                      Built-in · {providerLabel(item.integrationProvider)}
-                    </span>
+                  {isIntegrationProvider(item.integrationProvider) && (
+                    <div className="flex items-center gap-1.5">
+                      <ReadinessPill status={readinessMap[item.integrationProvider].status} />
+                      <span className={cn(
+                        'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium',
+                        getProviderBranding(item.integrationProvider).accent,
+                      )}>
+                        Built-in
+                      </span>
+                    </div>
                   )}
                   {item.category && (
                     <span
@@ -396,18 +434,25 @@ export default function SoftwareCatalog() {
           {/* Scrollable body */}
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
             {detailTab === 'details' && (
-              <div>
-                {selectedSoftware.description && (
-                  <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
-                    {selectedSoftware.description}
-                  </div>
-                )}
-                <div className="mt-5 flex items-center justify-between">
-                  {selectedSoftware.integrationProvider ? (
-                    <p className="text-xs text-muted-foreground">
-                      Built-in package managed by the {providerLabel(selectedSoftware.integrationProvider)} integration.
-                    </p>
-                  ) : (
+              isIntegrationProvider(selectedSoftware.integrationProvider) ? (
+                <BuiltinPackageDetail
+                  name={selectedSoftware.name}
+                  provider={selectedSoftware.integrationProvider}
+                  readiness={readinessMap[selectedSoftware.integrationProvider]}
+                  onDeploy={() => {
+                    const id = selectedSoftware.id;
+                    setSelectedSoftware(null);
+                    openDeploy(id);
+                  }}
+                />
+              ) : (
+                <div>
+                  {selectedSoftware.description && (
+                    <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+                      {selectedSoftware.description}
+                    </div>
+                  )}
+                  <div className="mt-5 flex items-center justify-between">
                     <button
                       type="button"
                       onClick={() => setConfirmDelete(selectedSoftware)}
@@ -416,21 +461,20 @@ export default function SoftwareCatalog() {
                       <Trash2 className="h-4 w-4" />
                       Delete
                     </button>
-                  )}
-                  <button
-                    type="button"
-                    title={selectedSoftware.integrationProvider ? 'Deploys to mapped organizations only' : undefined}
-                    onClick={() => {
-                      const id = selectedSoftware.id;
-                      setSelectedSoftware(null);
-                      openDeploy(id);
-                    }}
-                    className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-                  >
-                    Deploy
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const id = selectedSoftware.id;
+                        setSelectedSoftware(null);
+                        openDeploy(id);
+                      }}
+                      className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                    >
+                      Deploy
+                    </button>
+                  </div>
                 </div>
-              </div>
+              )
             )}
 
             {detailTab === 'versions' && (

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -3,7 +3,9 @@ import { ChevronDown, ChevronUp, Download, Loader2, Plus, Sparkles, CheckCircle,
 import type { DetectionRule } from '@breeze/shared';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
+import { findUnknownTokens } from '@/lib/installerVariables';
 import DetectionRulesEditor from './DetectionRulesEditor';
+import VariableInput, { type DeviceCustomField } from './VariableInput';
 
 type Architecture = 'x64' | 'arm64' | 'x86';
 
@@ -56,9 +58,12 @@ function normalizeVersion(raw: Record<string, unknown>, index: number): VersionE
 interface SoftwareVersionManagerProps {
   timezone?: string;
   catalogId?: string;
+  /** When rendered inside the package detail modal, drop the page heading and
+   *  the full-page comparison cards — the modal supplies its own chrome. */
+  embedded?: boolean;
 }
 
-export default function SoftwareVersionManager({ timezone, catalogId: propCatalogId }: SoftwareVersionManagerProps) {
+export default function SoftwareVersionManager({ timezone, catalogId: propCatalogId, embedded = false }: SoftwareVersionManagerProps) {
   const [versions, setVersions] = useState<VersionEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -69,6 +74,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
   const [promotingVersionId, setPromotingVersionId] = useState<string>('');
   const [uploadProgress, setUploadProgress] = useState(0);
   const [catalogId, setCatalogId] = useState(propCatalogId ?? '');
+  const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [formState, setFormState] = useState({
@@ -135,6 +141,41 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
   useEffect(() => {
     fetchVersions();
   }, [fetchVersions]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth('/custom-fields?limit=200');
+        if (!res.ok || cancelled) return;
+        const payload = await res.json();
+        const rows = payload.data ?? payload ?? [];
+        if (Array.isArray(rows)) {
+          setCustomFields(
+            rows
+              .map((r: Record<string, unknown>) => ({
+                fieldKey: String(r.fieldKey ?? ''),
+                name: String(r.name ?? r.fieldKey ?? ''),
+              }))
+              .filter((f: DeviceCustomField) => f.fieldKey),
+          );
+        }
+      } catch {
+        /* custom fields are optional for the variable picker */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const knownCustomKeys = useMemo(() => new Set(customFields.map((f) => f.fieldKey)), [customFields]);
+  const tokenErrors = useMemo(() => {
+    const opts = { requireKnownCustomKeys: knownCustomKeys.size > 0 };
+    return [formState.downloadUrl, formState.silentInstallArgs, formState.silentUninstallArgs].flatMap((s) =>
+      findUnknownTokens(s, knownCustomKeys, opts),
+    );
+  }, [formState.downloadUrl, formState.silentInstallArgs, formState.silentUninstallArgs, knownCustomKeys]);
 
   const latestVersion = useMemo(
     () => versions.find(item => item.id === latestId) ?? versions[0],
@@ -300,11 +341,13 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">Software Version Manager</h1>
-          <p className="text-sm text-muted-foreground">Manage version history, latest builds, and release notes.</p>
-        </div>
+      <div className={cn('flex flex-col gap-4 sm:flex-row sm:items-center', embedded ? 'sm:justify-end' : 'sm:justify-between')}>
+        {!embedded && (
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">Software Version Manager</h1>
+            <p className="text-sm text-muted-foreground">Manage version history, latest builds, and release notes.</p>
+          </div>
+        )}
         <button
           type="button"
           onClick={() => setIsFormOpen(open => !open)}
@@ -351,14 +394,18 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
 
           <div className="mt-4">
             <label className="text-xs font-semibold uppercase text-muted-foreground">Download URL</label>
-            <input
-              type="url"
-              value={formState.downloadUrl}
-              onChange={event => setFormState(prev => ({ ...prev, downloadUrl: event.target.value }))}
-              placeholder="https://example.com/package-v1.0.0.msi"
-              className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-            />
-            <p className="mt-1 text-xs text-muted-foreground">Provide a direct download URL or upload a file below</p>
+            <div className="mt-2">
+              <VariableInput
+                value={formState.downloadUrl}
+                onChange={value => setFormState(prev => ({ ...prev, downloadUrl: value }))}
+                placeholder="https://example.com/package-v1.0.0.msi"
+                customFields={customFields}
+              />
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Provide a direct download URL or upload a file below. Variables like{' '}
+              <code className="font-mono">{'{{org.name}}'}</code> resolve per organization at deploy time.
+            </p>
           </div>
 
           <div className="mt-4">
@@ -413,23 +460,25 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
           <div className="mt-4 grid gap-4 sm:grid-cols-2">
             <div>
               <label className="text-xs font-semibold uppercase text-muted-foreground">Silent Install Args</label>
-              <input
-                type="text"
-                value={formState.silentInstallArgs}
-                onChange={event => setFormState(prev => ({ ...prev, silentInstallArgs: event.target.value }))}
-                placeholder='e.g. msiexec /i "{file}" /qn /norestart'
-                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-              />
+              <div className="mt-2">
+                <VariableInput
+                  value={formState.silentInstallArgs}
+                  onChange={value => setFormState(prev => ({ ...prev, silentInstallArgs: value }))}
+                  placeholder='e.g. msiexec /i "{file}" /qn /norestart'
+                  customFields={customFields}
+                />
+              </div>
             </div>
             <div>
               <label className="text-xs font-semibold uppercase text-muted-foreground">Silent Uninstall Args</label>
-              <input
-                type="text"
-                value={formState.silentUninstallArgs}
-                onChange={event => setFormState(prev => ({ ...prev, silentUninstallArgs: event.target.value }))}
-                placeholder='e.g. msiexec /x "{file}" /qn /norestart'
-                className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-              />
+              <div className="mt-2">
+                <VariableInput
+                  value={formState.silentUninstallArgs}
+                  onChange={value => setFormState(prev => ({ ...prev, silentUninstallArgs: value }))}
+                  placeholder='e.g. msiexec /x "{file}" /qn /norestart'
+                  customFields={customFields}
+                />
+              </div>
             </div>
           </div>
 
@@ -470,8 +519,8 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
             </button>
             <button
               type="submit"
-              disabled={saving}
-              className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              disabled={saving || tokenErrors.length > 0}
+              className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {saving ? (formState.file ? 'Uploading...' : 'Saving...') : (formState.file ? 'Upload & Save' : 'Save Version')}
             </button>
@@ -554,7 +603,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
         </div>
       </div>
 
-      {selectedVersion && latestVersion && (
+      {!embedded && selectedVersion && latestVersion && (
         <div className="grid gap-4 lg:grid-cols-2">
           <div className="rounded-lg border bg-card p-6 shadow-xs">
             <div className="flex items-center gap-2">

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -157,7 +157,8 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
                 fieldKey: String(r.fieldKey ?? ''),
                 name: String(r.name ?? r.fieldKey ?? ''),
               }))
-              .filter((f: DeviceCustomField) => f.fieldKey),
+              // Only offer keys matching the resolver's token grammar (see AddPackageModal).
+              .filter((f: DeviceCustomField) => /^[a-z][a-z0-9_]*$/.test(f.fieldKey)),
           );
         }
       } catch {

--- a/apps/web/src/components/software/VariableInput.test.tsx
+++ b/apps/web/src/components/software/VariableInput.test.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import VariableInput, { type DeviceCustomField } from './VariableInput';
+
+function Harness({
+  initial = '',
+  customFields = [],
+}: {
+  initial?: string;
+  customFields?: DeviceCustomField[];
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <div>
+      <VariableInput value={value} onChange={setValue} customFields={customFields} placeholder="url" />
+      <span data-testid="value">{value}</span>
+    </div>
+  );
+}
+
+const openMenu = () => fireEvent.click(screen.getByRole('button', { name: /insert variable/i }));
+
+describe('VariableInput', () => {
+  it('opens the menu and inserts a built-in token at the caret', () => {
+    render(<Harness initial="AB" />);
+    const input = screen.getByPlaceholderText('url') as HTMLInputElement;
+    input.setSelectionRange(1, 1); // caret between A and B
+
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Organization name/i }));
+
+    expect(screen.getByTestId('value')).toHaveTextContent('A{{org.name}}B');
+  });
+
+  it('replaces the current selection when inserting', () => {
+    render(<Harness initial="keep-XXX-keep" />);
+    const input = screen.getByPlaceholderText('url') as HTMLInputElement;
+    input.setSelectionRange(5, 8); // select "XXX"
+
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Device hostname/i }));
+
+    expect(screen.getByTestId('value')).toHaveTextContent('keep-{{device.hostname}}-keep');
+  });
+
+  it('offers device custom fields under their own group', () => {
+    render(<Harness customFields={[{ fieldKey: 'license_key', name: 'License Key' }]} />);
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /License Key/i }));
+    expect(screen.getByTestId('value')).toHaveTextContent('{{device.customField.license_key}}');
+  });
+
+  it('warns and marks the field invalid on an unknown token', () => {
+    render(<Harness initial="https://dl/{{bogus}}/app.msi" />);
+    expect(screen.getByText(/Unknown variable/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('url')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not warn on a clean built-in token', () => {
+    render(<Harness initial="https://dl/{{org.id}}/app.msi" />);
+    expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/software/VariableInput.tsx
+++ b/apps/web/src/components/software/VariableInput.tsx
@@ -21,7 +21,7 @@ interface VariableInputProps {
   placeholder?: string;
   /** Device custom-field definitions, offered under "Custom fields" in the menu. */
   customFields?: DeviceCustomField[];
-  /** Rendered as the input's accessible name via aria-labelledby on the wrapper's label. */
+  /** Applied as the input's `id` so a parent `<label htmlFor>` can associate a visible label. */
   id?: string;
   'aria-describedby'?: string;
   className?: string;

--- a/apps/web/src/components/software/VariableInput.tsx
+++ b/apps/web/src/components/software/VariableInput.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Braces, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  BUILTIN_INSTALLER_VARIABLES,
+  customFieldToken,
+  findUnknownTokens,
+  type InstallerVariable,
+  type InstallerVariableGroup,
+} from '@/lib/installerVariables';
+
+export interface DeviceCustomField {
+  fieldKey: string;
+  name: string;
+}
+
+interface VariableInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Device custom-field definitions, offered under "Custom fields" in the menu. */
+  customFields?: DeviceCustomField[];
+  /** Rendered as the input's accessible name via aria-labelledby on the wrapper's label. */
+  id?: string;
+  'aria-describedby'?: string;
+  className?: string;
+}
+
+const GROUP_ORDER: InstallerVariableGroup[] = ['Organization', 'Site', 'Device', 'Custom fields'];
+
+/**
+ * A single-line text input for installer URLs / silent args that accepts
+ * `{{...}}` deploy-time variables. Adds an "Insert variable" menu (rendered in a
+ * portal with fixed positioning so it never clips inside a scrollable modal) and
+ * a live warning when the string contains a token the resolver won't recognize.
+ */
+export default function VariableInput({
+  value,
+  onChange,
+  placeholder,
+  customFields = [],
+  id,
+  className,
+  'aria-describedby': ariaDescribedBy,
+}: VariableInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number }>();
+  const warnId = useId();
+
+  const knownKeys = useMemo(
+    () => new Set(customFields.map((f) => f.fieldKey)),
+    [customFields],
+  );
+
+  const variables = useMemo<InstallerVariable[]>(() => {
+    const custom: InstallerVariable[] = customFields.map((f) => ({
+      token: customFieldToken(f.fieldKey),
+      label: f.name || f.fieldKey,
+      group: 'Custom fields',
+      example: f.fieldKey,
+    }));
+    return [...BUILTIN_INSTALLER_VARIABLES, ...custom];
+  }, [customFields]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<InstallerVariableGroup, InstallerVariable[]>();
+    for (const v of variables) {
+      const list = map.get(v.group) ?? [];
+      list.push(v);
+      map.set(v.group, list);
+    }
+    return GROUP_ORDER.map((g) => [g, map.get(g) ?? []] as const).filter(([, l]) => l.length > 0);
+  }, [variables]);
+
+  // Custom-field keys load async; until they arrive, accept custom-field tokens
+  // on structure alone so a slow fetch never flags a valid `{{device.customField.x}}`.
+  const unknownTokens = useMemo(
+    () => findUnknownTokens(value, knownKeys, { requireKnownCustomKeys: knownKeys.size > 0 }),
+    [value, knownKeys],
+  );
+
+  const positionMenu = () => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const width = 288;
+    // Right-align the menu to the trigger, clamped to the viewport.
+    const left = Math.max(8, Math.min(rect.right - width, window.innerWidth - width - 8));
+    setCoords({ top: rect.bottom + 4, left, width });
+  };
+
+  useLayoutEffect(() => {
+    if (open) positionMenu();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onScroll = () => positionMenu();
+    const onPointer = (e: PointerEvent) => {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll);
+    document.addEventListener('pointerdown', onPointer, true);
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onScroll);
+      document.removeEventListener('pointerdown', onPointer, true);
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [open]);
+
+  const insert = (token: string) => {
+    const el = inputRef.current;
+    const start = el?.selectionStart ?? value.length;
+    const end = el?.selectionEnd ?? value.length;
+    const next = value.slice(0, start) + token + value.slice(end);
+    onChange(next);
+    setOpen(false);
+    // Restore focus + place caret after the inserted token.
+    requestAnimationFrame(() => {
+      el?.focus();
+      const caret = start + token.length;
+      el?.setSelectionRange(caret, caret);
+    });
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex items-stretch gap-2">
+        <input
+          ref={inputRef}
+          id={id}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          aria-invalid={unknownTokens.length > 0 || undefined}
+          aria-describedby={cn(ariaDescribedBy, unknownTokens.length > 0 && warnId) || undefined}
+          className={cn(
+            'h-10 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring',
+            unknownTokens.length > 0 && 'border-destructive/60 focus:ring-destructive/40',
+            className,
+          )}
+        />
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          title="Insert a deploy-time variable"
+          className="inline-flex h-10 shrink-0 items-center gap-1.5 rounded-md border bg-background px-3 text-xs font-medium text-muted-foreground hover:bg-muted focus:outline-hidden focus:ring-2 focus:ring-ring"
+        >
+          <Braces className="h-4 w-4" />
+          <span className="hidden sm:inline">Insert variable</span>
+        </button>
+      </div>
+
+      {unknownTokens.length > 0 && (
+        <p id={warnId} className="mt-1 flex items-start gap-1.5 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Unknown variable {unknownTokens.join(', ')} — pick one from Insert variable.
+          </span>
+        </p>
+      )}
+
+      {open &&
+        coords &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            className="fixed z-[60] max-h-80 overflow-y-auto rounded-md border bg-card p-1 shadow-lg"
+            style={{ top: coords.top, left: coords.left, width: coords.width }}
+          >
+            {grouped.map(([group, list]) => (
+              <div key={group} className="py-1">
+                <p className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {group}
+                </p>
+                {list.map((v) => (
+                  <button
+                    key={v.token}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => insert(v.token)}
+                    className="flex w-full items-baseline justify-between gap-3 rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden"
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm text-foreground">{v.label}</span>
+                      <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                        {v.token}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/apps/web/src/components/software/providerBranding.test.ts
+++ b/apps/web/src/components/software/providerBranding.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getProviderBranding, isIntegrationProvider } from './providerBranding';
+
+describe('providerBranding', () => {
+  it('returns label, icon, accent, and blurb for huntress', () => {
+    const b = getProviderBranding('huntress');
+    expect(b.label).toBe('Huntress');
+    // lucide icons are forwardRef components (objects in this version), not plain functions
+    expect(b.icon).toBeDefined();
+    expect(['function', 'object']).toContain(typeof b.icon);
+    expect(b.accent).toMatch(/\S/);
+    expect(b.blurb.length).toBeGreaterThan(0);
+  });
+
+  it('returns branding for sentinelone', () => {
+    expect(getProviderBranding('sentinelone').label).toBe('SentinelOne');
+  });
+
+  it('type-guards provider strings', () => {
+    expect(isIntegrationProvider('huntress')).toBe(true);
+    expect(isIntegrationProvider('nope')).toBe(false);
+    expect(isIntegrationProvider(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/components/software/providerBranding.ts
+++ b/apps/web/src/components/software/providerBranding.ts
@@ -1,0 +1,37 @@
+import { ShieldCheck, type LucideIcon } from 'lucide-react';
+
+export type IntegrationProvider = 'huntress' | 'sentinelone';
+
+export interface ProviderBranding {
+  label: string;
+  icon: LucideIcon;
+  /** Tailwind classes for the tinted icon tile + chip (theme-aware). NOT a logo. */
+  accent: string;
+  blurb: string;
+  websiteUrl?: string;
+}
+
+const BRANDING: Record<IntegrationProvider, ProviderBranding> = {
+  huntress: {
+    label: 'Huntress',
+    icon: ShieldCheck,
+    accent: 'bg-orange-500/15 text-orange-600 dark:text-orange-400 border-orange-500/40',
+    blurb: 'Managed endpoint detection & response — installs the latest agent automatically.',
+    websiteUrl: 'https://www.huntress.com',
+  },
+  sentinelone: {
+    label: 'SentinelOne',
+    icon: ShieldCheck,
+    accent: 'bg-purple-500/15 text-purple-600 dark:text-purple-400 border-purple-500/40',
+    blurb: 'Autonomous EDR agent deployed from your uploaded installer.',
+    websiteUrl: 'https://www.sentinelone.com',
+  },
+};
+
+export function getProviderBranding(p: IntegrationProvider): ProviderBranding {
+  return BRANDING[p];
+}
+
+export function isIntegrationProvider(v: unknown): v is IntegrationProvider {
+  return v === 'huntress' || v === 'sentinelone';
+}

--- a/apps/web/src/components/software/providerBranding.ts
+++ b/apps/web/src/components/software/providerBranding.ts
@@ -1,6 +1,10 @@
 import { ShieldCheck, type LucideIcon } from 'lucide-react';
 
-export type IntegrationProvider = 'huntress' | 'sentinelone';
+/** Single source of truth for the provider set — the union and the type guard
+ *  both derive from this, so adding a provider can't leave one of them stale. */
+export const INTEGRATION_PROVIDERS = ['huntress', 'sentinelone'] as const;
+
+export type IntegrationProvider = (typeof INTEGRATION_PROVIDERS)[number];
 
 export interface ProviderBranding {
   label: string;
@@ -33,5 +37,5 @@ export function getProviderBranding(p: IntegrationProvider): ProviderBranding {
 }
 
 export function isIntegrationProvider(v: unknown): v is IntegrationProvider {
-  return v === 'huntress' || v === 'sentinelone';
+  return (INTEGRATION_PROVIDERS as readonly unknown[]).includes(v);
 }

--- a/apps/web/src/components/software/useEdrReadiness.test.tsx
+++ b/apps/web/src/components/software/useEdrReadiness.test.tsx
@@ -53,6 +53,15 @@ describe('useEdrReadiness (huntress)', () => {
     expect(screen.getByTestId('gap')).toHaveTextContent('accountKey');
   });
 
+  it('reports incomplete with the org-mapping gap when connected + key set but no orgs mapped', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ data: { isActive: true, hasAccountKey: true, lastSyncOrgs: 0 } }),
+    );
+    render(<HuntressProbe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('orgsMapped');
+  });
+
   it('reports incomplete/disconnected when data is null', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }));
     render(<HuntressProbe />);

--- a/apps/web/src/components/software/useEdrReadiness.test.tsx
+++ b/apps/web/src/components/software/useEdrReadiness.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useEdrReadiness } from './useEdrReadiness';
+import { useEdrReadiness, firstGap } from './useEdrReadiness';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -15,7 +15,7 @@ function HuntressProbe() {
     <div>
       <span data-testid="status">{r.status}</span>
       <span data-testid="orgs">{r.mappedOrgCount ?? -1}</span>
-      <span data-testid="gap">{r.firstGap?.key ?? 'none'}</span>
+      <span data-testid="gap">{firstGap(r)?.key ?? 'none'}</span>
     </div>
   );
 }
@@ -25,7 +25,7 @@ function S1Probe({ versions }: { versions: number }) {
   return (
     <div>
       <span data-testid="status">{r.status}</span>
-      <span data-testid="gap">{r.firstGap?.key ?? 'none'}</span>
+      <span data-testid="gap">{firstGap(r)?.key ?? 'none'}</span>
       <span data-testid="checks">{r.checks.map((c) => c.key).join(',')}</span>
     </div>
   );
@@ -92,5 +92,32 @@ describe('useEdrReadiness (sentinelone)', () => {
     render(<S1Probe versions={0} />);
     await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
     expect(screen.getByTestId('gap')).toHaveTextContent('installerUploaded');
+  });
+
+  it('adds a third site-token check when the endpoint surfaces hasSiteToken', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: { isActive: true, hasSiteToken: true } }));
+    render(<S1Probe versions={1} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('checks')).toHaveTextContent('connected,installerUploaded,siteToken');
+  });
+
+  it('flags the site-token gap when hasSiteToken is false', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: { isActive: true, hasSiteToken: false } }));
+    render(<S1Probe versions={1} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('siteToken');
+  });
+
+  it('flags the connected gap when the S1 integration is inactive', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: { isActive: false } }));
+    render(<S1Probe versions={1} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('connected');
+  });
+
+  it('degrades to unknown when the status fetch fails but an installer exists', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false));
+    render(<S1Probe versions={1} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('unknown'));
   });
 });

--- a/apps/web/src/components/software/useEdrReadiness.test.tsx
+++ b/apps/web/src/components/software/useEdrReadiness.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEdrReadiness } from './useEdrReadiness';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function HuntressProbe() {
+  const r = useEdrReadiness(['huntress']).huntress;
+  return (
+    <div>
+      <span data-testid="status">{r.status}</span>
+      <span data-testid="orgs">{r.mappedOrgCount ?? -1}</span>
+      <span data-testid="gap">{r.firstGap?.key ?? 'none'}</span>
+    </div>
+  );
+}
+
+function S1Probe({ versions }: { versions: number }) {
+  const r = useEdrReadiness(['sentinelone'], { s1VersionCount: versions }).sentinelone;
+  return (
+    <div>
+      <span data-testid="status">{r.status}</span>
+      <span data-testid="gap">{r.firstGap?.key ?? 'none'}</span>
+      <span data-testid="checks">{r.checks.map((c) => c.key).join(',')}</span>
+    </div>
+  );
+}
+
+describe('useEdrReadiness (huntress)', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('reports ready when connected, account key set, and orgs mapped', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ data: { isActive: true, hasAccountKey: true, lastSyncOrgs: 3 } }),
+    );
+    render(<HuntressProbe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('orgs')).toHaveTextContent('3');
+    expect(screen.getByTestId('gap')).toHaveTextContent('none');
+  });
+
+  it('reports incomplete with the account-key gap first', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ data: { isActive: true, hasAccountKey: false, lastSyncOrgs: 3 } }),
+    );
+    render(<HuntressProbe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('accountKey');
+  });
+
+  it('reports incomplete/disconnected when data is null', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }));
+    render(<HuntressProbe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('connected');
+  });
+
+  it('reports unknown when the fetch fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false));
+    render(<HuntressProbe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('unknown'));
+  });
+});
+
+describe('useEdrReadiness (sentinelone)', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('is ready when connected and the installer is uploaded (no site-token check available)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: { isActive: true } })); // /s1/integration
+    render(<S1Probe versions={1} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('ready'));
+    // Only the two provable checks — no invented site-token check.
+    expect(screen.getByTestId('checks')).toHaveTextContent('connected,installerUploaded');
+  });
+
+  it('flags the installer-upload gap when no version is uploaded', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: { isActive: true } }));
+    render(<S1Probe versions={0} />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('installerUploaded');
+  });
+});

--- a/apps/web/src/components/software/useEdrReadiness.ts
+++ b/apps/web/src/components/software/useEdrReadiness.ts
@@ -14,7 +14,12 @@ export interface EdrReadiness {
   status: 'loading' | 'ready' | 'incomplete' | 'unknown';
   checks: ReadinessCheck[];
   mappedOrgCount?: number;
-  firstGap?: ReadinessCheck;
+}
+
+/** The first failing check, if any. Derived from `checks` rather than stored so
+ *  a 'ready' readiness can never carry a gap (single source of truth). */
+export function firstGap(readiness: EdrReadiness): ReadinessCheck | undefined {
+  return readiness.checks.find((c) => !c.ok);
 }
 
 const LOADING: EdrReadiness = { status: 'loading', checks: [] };
@@ -23,18 +28,21 @@ const INTEGRATIONS_FIX = '/integrations';
 const SOFTWARE_FIX = '/software';
 
 function finalize(checks: ReadinessCheck[], mappedOrgCount?: number): EdrReadiness {
-  const firstGap = checks.find((c) => !c.ok);
   return {
-    status: firstGap ? 'incomplete' : 'ready',
+    status: checks.some((c) => !c.ok) ? 'incomplete' : 'ready',
     checks,
     mappedOrgCount,
-    firstGap,
   };
 }
 
 async function fetchHuntress(): Promise<EdrReadiness> {
   const res = await fetchWithAuth('/huntress/integration');
-  if (!res.ok) return UNKNOWN;
+  if (!res.ok) {
+    // Advisory badge only — degrade to 'unknown', but leave a breadcrumb so a
+    // persistent readiness outage isn't completely silent for maintainers.
+    console.warn(`[edr-readiness] huntress status fetch failed: ${res.status}`);
+    return UNKNOWN;
+  }
   const json = (await res.json()) as {
     data?: { isActive?: boolean; hasAccountKey?: boolean; lastSyncOrgs?: number | null } | null;
   };
@@ -80,7 +88,8 @@ async function fetchSentinelOne(s1VersionCount: number): Promise<EdrReadiness> {
       connected = !!data && data.isActive === true;
       hasSiteToken = typeof data?.hasSiteToken === 'boolean' ? data.hasSiteToken : undefined;
     }
-  } catch {
+  } catch (err) {
+    console.warn('[edr-readiness] sentinelone status fetch failed:', err);
     /* fall through to the version-only readiness below */
   }
 

--- a/apps/web/src/components/software/useEdrReadiness.ts
+++ b/apps/web/src/components/software/useEdrReadiness.ts
@@ -63,15 +63,11 @@ async function fetchHuntress(): Promise<EdrReadiness> {
 }
 
 async function fetchSentinelOne(s1VersionCount: number): Promise<EdrReadiness> {
-  // S1 exposes an integration status endpoint mirroring Huntress. hasSiteToken is
-  // derived server-side (the site token is a per-org secret). When the endpoint or
-  // field is unavailable we degrade to the two checks we can prove client-side
-  // (connected + installer uploaded) rather than inventing a signal.
-  // Route mounts at /s1 (apps/api/src/index.ts). The status endpoint exposes
-  // `isActive` (connected) but NO site-token boolean — the S1 site token is a
-  // per-org secret in s1_org_mappings, not surfaced here. So `hasSiteToken`
-  // stays undefined and the site-token check is omitted (2-check readiness),
-  // per the plan's "don't invent a backend field" fallback.
+  // GET /s1/integration (mounts at /s1) currently returns `isActive` but NOT a
+  // site-token boolean — the S1 site token is a per-org secret in
+  // s1_org_mappings, not surfaced here today. We consume `hasSiteToken` if the
+  // endpoint ever adds it (third check below); while it's absent we degrade to
+  // connected + installer-uploaded rather than inventing a signal.
   let connected: boolean | undefined;
   let hasSiteToken: boolean | undefined;
   try {

--- a/apps/web/src/components/software/useEdrReadiness.ts
+++ b/apps/web/src/components/software/useEdrReadiness.ts
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import type { IntegrationProvider } from './providerBranding';
+
+export interface ReadinessCheck {
+  key: string;
+  label: string;
+  ok: boolean;
+  detail?: string;
+  fixHref?: string;
+}
+
+export interface EdrReadiness {
+  status: 'loading' | 'ready' | 'incomplete' | 'unknown';
+  checks: ReadinessCheck[];
+  mappedOrgCount?: number;
+  firstGap?: ReadinessCheck;
+}
+
+const LOADING: EdrReadiness = { status: 'loading', checks: [] };
+const UNKNOWN: EdrReadiness = { status: 'unknown', checks: [] };
+const INTEGRATIONS_FIX = '/integrations';
+const SOFTWARE_FIX = '/software';
+
+function finalize(checks: ReadinessCheck[], mappedOrgCount?: number): EdrReadiness {
+  const firstGap = checks.find((c) => !c.ok);
+  return {
+    status: firstGap ? 'incomplete' : 'ready',
+    checks,
+    mappedOrgCount,
+    firstGap,
+  };
+}
+
+async function fetchHuntress(): Promise<EdrReadiness> {
+  const res = await fetchWithAuth('/huntress/integration');
+  if (!res.ok) return UNKNOWN;
+  const json = (await res.json()) as {
+    data?: { isActive?: boolean; hasAccountKey?: boolean; lastSyncOrgs?: number | null } | null;
+  };
+  const data = json.data ?? null;
+  const connected = !!data && data.isActive === true;
+  const accountKey = !!data?.hasAccountKey;
+  const mappedOrgCount = data?.lastSyncOrgs ?? 0;
+  const checks: ReadinessCheck[] = [
+    { key: 'connected', label: 'Integration connected', ok: connected, fixHref: INTEGRATIONS_FIX },
+    {
+      key: 'accountKey',
+      label: 'Account key configured',
+      ok: accountKey,
+      detail: accountKey ? undefined : 'Add your Huntress account key in Integrations',
+      fixHref: INTEGRATIONS_FIX,
+    },
+    {
+      key: 'orgsMapped',
+      label: 'Organizations mapped',
+      ok: mappedOrgCount > 0,
+      detail: `${mappedOrgCount} org${mappedOrgCount === 1 ? '' : 's'} mapped`,
+      fixHref: INTEGRATIONS_FIX,
+    },
+  ];
+  return finalize(checks, mappedOrgCount);
+}
+
+async function fetchSentinelOne(s1VersionCount: number): Promise<EdrReadiness> {
+  // S1 exposes an integration status endpoint mirroring Huntress. hasSiteToken is
+  // derived server-side (the site token is a per-org secret). When the endpoint or
+  // field is unavailable we degrade to the two checks we can prove client-side
+  // (connected + installer uploaded) rather than inventing a signal.
+  // Route mounts at /s1 (apps/api/src/index.ts). The status endpoint exposes
+  // `isActive` (connected) but NO site-token boolean — the S1 site token is a
+  // per-org secret in s1_org_mappings, not surfaced here. So `hasSiteToken`
+  // stays undefined and the site-token check is omitted (2-check readiness),
+  // per the plan's "don't invent a backend field" fallback.
+  let connected: boolean | undefined;
+  let hasSiteToken: boolean | undefined;
+  try {
+    const res = await fetchWithAuth('/s1/integration');
+    if (res.ok) {
+      const json = (await res.json()) as {
+        data?: { isActive?: boolean; hasSiteToken?: boolean } | null;
+      };
+      const data = json.data ?? null;
+      connected = !!data && data.isActive === true;
+      hasSiteToken = typeof data?.hasSiteToken === 'boolean' ? data.hasSiteToken : undefined;
+    }
+  } catch {
+    /* fall through to the version-only readiness below */
+  }
+
+  const installerUploaded = s1VersionCount >= 1;
+  const checks: ReadinessCheck[] = [];
+  if (connected !== undefined) {
+    checks.push({ key: 'connected', label: 'Integration connected', ok: connected, fixHref: INTEGRATIONS_FIX });
+  }
+  checks.push({
+    key: 'installerUploaded',
+    label: 'Installer uploaded',
+    ok: installerUploaded,
+    detail: installerUploaded ? undefined : 'Upload the SentinelOne installer (Versions tab)',
+    fixHref: SOFTWARE_FIX,
+  });
+  if (hasSiteToken !== undefined) {
+    checks.push({
+      key: 'siteToken',
+      label: 'Site token configured',
+      ok: hasSiteToken,
+      detail: hasSiteToken ? undefined : 'Connect SentinelOne so the site token syncs',
+      fixHref: INTEGRATIONS_FIX,
+    });
+  }
+  // If we couldn't read the integration at all and the installer is present, we
+  // can't prove readiness — report unknown so Deploy defers to the server.
+  if (connected === undefined && installerUploaded) return UNKNOWN;
+  return finalize(checks);
+}
+
+export function useEdrReadiness(
+  providers: IntegrationProvider[],
+  opts?: { s1VersionCount?: number },
+): Record<IntegrationProvider, EdrReadiness> {
+  const s1VersionCount = opts?.s1VersionCount ?? 0;
+  const key = useMemo(
+    () => `${Array.from(new Set(providers)).sort().join(',')}|${s1VersionCount}`,
+    [providers, s1VersionCount],
+  );
+  const [map, setMap] = useState<Record<IntegrationProvider, EdrReadiness>>({
+    huntress: LOADING,
+    sentinelone: LOADING,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const [provPart] = key.split('|');
+    const wanted = provPart ? (provPart.split(',') as IntegrationProvider[]) : [];
+
+    if (wanted.includes('huntress')) {
+      setMap((m) => ({ ...m, huntress: LOADING }));
+      fetchHuntress()
+        .then((r) => { if (!cancelled) setMap((m) => ({ ...m, huntress: r })); })
+        .catch(() => { if (!cancelled) setMap((m) => ({ ...m, huntress: UNKNOWN })); });
+    }
+    if (wanted.includes('sentinelone')) {
+      setMap((m) => ({ ...m, sentinelone: LOADING }));
+      fetchSentinelOne(s1VersionCount)
+        .then((r) => { if (!cancelled) setMap((m) => ({ ...m, sentinelone: r })); })
+        .catch(() => { if (!cancelled) setMap((m) => ({ ...m, sentinelone: UNKNOWN })); });
+    }
+    return () => { cancelled = true; };
+  }, [key, s1VersionCount]);
+
+  return map;
+}

--- a/apps/web/src/lib/installerVariables.test.ts
+++ b/apps/web/src/lib/installerVariables.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { findTokens, findUnknownTokens, customFieldToken } from './installerVariables';
+
+describe('findTokens', () => {
+  it('extracts every {{...}} token', () => {
+    expect(findTokens('https://dl/{{org.id}}/{{device.hostname}}.msi')).toEqual([
+      '{{org.id}}',
+      '{{device.hostname}}',
+    ]);
+  });
+
+  it('ignores single-brace {file}', () => {
+    expect(findTokens('msiexec /i "{file}" /qn')).toEqual([]);
+  });
+});
+
+describe('customFieldToken', () => {
+  it('builds the device custom-field token', () => {
+    expect(customFieldToken('license_key')).toBe('{{device.customField.license_key}}');
+  });
+});
+
+describe('findUnknownTokens', () => {
+  it('accepts all built-ins', () => {
+    const s = '{{org.name}} {{org.id}} {{site.name}} {{site.id}} {{device.hostname}}';
+    expect(findUnknownTokens(s, new Set())).toEqual([]);
+  });
+
+  it('flags a typo\'d built-in', () => {
+    expect(findUnknownTokens('{{org.nam}}', new Set())).toEqual(['{{org.nam}}']);
+  });
+
+  it('accepts custom-field tokens on structure alone before keys load', () => {
+    // Empty known-key set + default requireKnownCustomKeys=false → structural pass.
+    expect(findUnknownTokens('{{device.customField.license_key}}', new Set())).toEqual([]);
+  });
+
+  it('validates custom-field keys against the known set when required', () => {
+    const known = new Set(['license_key']);
+    expect(
+      findUnknownTokens('{{device.customField.license_key}}', known, { requireKnownCustomKeys: true }),
+    ).toEqual([]);
+    expect(
+      findUnknownTokens('{{device.customField.ghost}}', known, { requireKnownCustomKeys: true }),
+    ).toEqual(['{{device.customField.ghost}}']);
+  });
+
+  it('tolerates inner whitespace', () => {
+    expect(findUnknownTokens('{{ org.name }}', new Set())).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/installerVariables.test.ts
+++ b/apps/web/src/lib/installerVariables.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { findTokens, findUnknownTokens, customFieldToken } from './installerVariables';
+import {
+  findTokens,
+  findUnknownTokens,
+  customFieldToken,
+  BUILTIN_INSTALLER_VARIABLES,
+} from './installerVariables';
+
+describe('BUILTIN_INSTALLER_VARIABLES vocabulary', () => {
+  // Tripwire: this exact set must have a matching arm in the API resolver's
+  // resolveKey switch (apps/api/src/services/installerVariables.ts). Adding a
+  // token here without wiring the API side would ship a UI-offered variable the
+  // resolver fails on at deploy time — update BOTH when this test trips.
+  it('offers exactly the tokens the API resolver supports', () => {
+    expect(BUILTIN_INSTALLER_VARIABLES.map((v) => v.token).sort()).toEqual(
+      ['{{device.hostname}}', '{{org.id}}', '{{org.name}}', '{{site.id}}', '{{site.name}}'].sort(),
+    );
+  });
+});
 
 describe('findTokens', () => {
   it('extracts every {{...}} token', () => {

--- a/apps/web/src/lib/installerVariables.ts
+++ b/apps/web/src/lib/installerVariables.ts
@@ -1,0 +1,86 @@
+/**
+ * Installer-URL / silent-arg variable vocabulary.
+ *
+ * A software version's `downloadUrl` and silent install/uninstall args may
+ * contain `{{...}}` variables that are resolved **per target device** at deploy
+ * time (see the API-side resolver in `services/installerVariables.ts`). This
+ * lets one catalog entry serve many organizations — e.g. a licensed installer
+ * whose URL embeds a per-org key.
+ *
+ * Token syntax is deliberately double-brace (`{{org.name}}`) to avoid colliding
+ * with the single-brace `{file}` token already used in silent-install args
+ * (which the agent substitutes with the downloaded file path, not a tenant
+ * value).
+ *
+ * This module is the single source of truth for the built-in vocabulary and the
+ * token grammar; the API resolver mirrors these keys. Keep them in sync — a
+ * token the UI offers but the resolver can't fill would ship a literal
+ * `{{...}}` to an agent (the resolver guards against that by failing the device
+ * loudly, but the UI should never offer an unresolvable built-in).
+ */
+
+export type InstallerVariableGroup = 'Organization' | 'Site' | 'Device' | 'Custom fields';
+
+export interface InstallerVariable {
+  /** The full token as inserted, e.g. `{{org.name}}`. */
+  token: string;
+  /** Human label for the picker, e.g. "Organization name". */
+  label: string;
+  group: InstallerVariableGroup;
+  /** Example resolved value, shown as a hint in the picker. */
+  example: string;
+}
+
+/** Built-in variables, always resolvable for any target device. */
+export const BUILTIN_INSTALLER_VARIABLES: InstallerVariable[] = [
+  { token: '{{org.name}}', label: 'Organization name', group: 'Organization', example: 'Acme Corp' },
+  { token: '{{org.id}}', label: 'Organization ID', group: 'Organization', example: 'a1b2c3d4' },
+  { token: '{{site.name}}', label: 'Site name', group: 'Site', example: 'Headquarters' },
+  { token: '{{site.id}}', label: 'Site ID', group: 'Site', example: 'e5f6a7b8' },
+  { token: '{{device.hostname}}', label: 'Device hostname', group: 'Device', example: 'WKS-014' },
+];
+
+/** Build the custom-field token for a device custom field key. */
+export const customFieldToken = (fieldKey: string): string => `{{device.customField.${fieldKey}}}`;
+
+const CUSTOM_FIELD_TOKEN = /^\{\{device\.customField\.([a-z][a-z0-9_]*)\}\}$/;
+const TOKEN_SCAN = /\{\{\s*[^{}]*?\s*\}\}/g;
+
+/**
+ * Return the list of syntactically-tokenish substrings in a string, e.g.
+ * `["{{org.name}}", "{{device.customField.licenseKey}}"]`. Used both for
+ * highlighting and for validation.
+ */
+export function findTokens(value: string): string[] {
+  return value.match(TOKEN_SCAN) ?? [];
+}
+
+/**
+ * Validate the variables in a template string against the known vocabulary.
+ * `knownCustomFieldKeys` is the set of device custom-field keys defined for the
+ * partner/org (from `GET /custom-fields`); pass an empty set when they haven't
+ * loaded yet, in which case custom-field tokens are accepted on structure alone
+ * so the field never blocks on a slow fetch.
+ *
+ * Returns the list of tokens that are NOT recognized. An empty array means the
+ * string is clean.
+ */
+export function findUnknownTokens(
+  value: string,
+  knownCustomFieldKeys: ReadonlySet<string>,
+  { requireKnownCustomKeys = false }: { requireKnownCustomKeys?: boolean } = {},
+): string[] {
+  const builtinTokens = new Set(BUILTIN_INSTALLER_VARIABLES.map((v) => v.token));
+  const unknown: string[] = [];
+  for (const raw of findTokens(value)) {
+    const token = raw.replace(/\s+/g, ''); // tolerate `{{ org.name }}`
+    if (builtinTokens.has(token)) continue;
+    const custom = CUSTOM_FIELD_TOKEN.exec(token);
+    if (custom) {
+      const key = custom[1];
+      if (!requireKnownCustomKeys || knownCustomFieldKeys.has(key)) continue;
+    }
+    unknown.push(raw);
+  }
+  return unknown;
+}

--- a/apps/web/src/lib/installerVariables.ts
+++ b/apps/web/src/lib/installerVariables.ts
@@ -31,8 +31,15 @@ export interface InstallerVariable {
   example: string;
 }
 
-/** Built-in variables, always resolvable for any target device. */
-export const BUILTIN_INSTALLER_VARIABLES: InstallerVariable[] = [
+/**
+ * Built-in variables, always resolvable for any target device.
+ *
+ * IMPORTANT: every token here MUST have a matching arm in the API resolver's
+ * `resolveKey` switch (`apps/api/src/services/installerVariables.ts`). The two
+ * key sets are kept in sync by convention; the `BUILTIN_TOKENS` tripwire test in
+ * `installerVariables.test.ts` catches an accidental addition on this side.
+ */
+export const BUILTIN_INSTALLER_VARIABLES: readonly InstallerVariable[] = [
   { token: '{{org.name}}', label: 'Organization name', group: 'Organization', example: 'Acme Corp' },
   { token: '{{org.id}}', label: 'Organization ID', group: 'Organization', example: 'a1b2c3d4' },
   { token: '{{site.name}}', label: 'Site name', group: 'Site', example: 'Headquarters' },

--- a/docs/superpowers/plans/2026-07-06-builtin-edr-listing-ui.md
+++ b/docs/superpowers/plans/2026-07-06-builtin-edr-listing-ui.md
@@ -1,0 +1,885 @@
+# Built-in EDR Listing UI — Ready-to-Deploy Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the built-in EDR package listings (Huntress, SentinelOne) in the Software Library read as first-class and visibly ready-to-deploy, surfacing the exact missing setup step only when one exists.
+
+**Architecture:** Frontend-only (`apps/web`). A provider-branding map + a readiness hook (reusing existing `GET /huntress/integration`) + a presentational `BuiltinPackageDetail`. `SoftwareCatalog` fetches readiness once per present provider and passes it down to cards and the detail body; the Deploy path preselects the clicked package into `DeploymentWizard`. No backend changes.
+
+**Tech Stack:** React (islands), TypeScript, Tailwind v4, lucide-react, Vitest + @testing-library/react (jsdom).
+
+**Spec:** `docs/superpowers/specs/2026-07-06-builtin-edr-listing-ui-design.md`
+
+## Global Constraints
+
+- Frontend only — **no backend/API/migration changes**. If a needed readiness signal is missing, stop and flag it; do not add endpoints silently.
+- Reads go through `fetchWithAuth` (`apps/web/src/stores/auth`). Mutations go through `runAction` (`apps/web/src/lib/runAction`) — repo `no-silent-mutations` rule. This change is read-only except the existing deploy dispatch (already wrapped).
+- **No official brand marks/logos.** Providers use a tinted `ShieldCheck` lucide icon + accent, not a logo.
+- Class-name composition uses `cn` from `@/lib/utils`. Theme-aware (works in light + dark).
+- Test style matches `apps/web/src/components/software/SoftwareCatalog.test.tsx`: `vi.mock('../../stores/auth', ...)`, a `jsonResponse` helper, `render`/`screen`/`waitFor`.
+- `IntegrationProvider = 'huntress' | 'sentinelone'` (today declared inline in `SoftwareCatalog.tsx:17`). Task 1 moves the canonical definition to `providerBranding.ts`; `SoftwareCatalog` imports it.
+- **Worktree hazard:** `SoftwareCatalog.tsx` and `DeploymentWizard.tsx` may carry unrelated uncommitted WIP (installer-variables shaping) on branch `ToddHebebrand/software-deploy-UI`. Before starting, confirm those files are in a known state (committed or stashed) so edits don't collide. See "Pre-flight" below.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+- [ ] Confirm the working tree for `SoftwareCatalog.tsx` / `DeploymentWizard.tsx` is clean or the WIP is committed/stashed:
+
+Run: `git -C . status --short apps/web/src/components/software/`
+Expected: no `M` on `SoftwareCatalog.tsx` / `DeploymentWizard.tsx` you don't own. If there is WIP, coordinate (commit/stash) before proceeding — do not overwrite it.
+
+- [ ] Confirm the web test command runs:
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/SoftwareCatalog.test.tsx`
+Expected: existing suite passes (baseline green).
+
+---
+
+## Task 1: Provider branding map
+
+**Files:**
+- Create: `apps/web/src/components/software/providerBranding.ts`
+- Test: `apps/web/src/components/software/providerBranding.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type IntegrationProvider = 'huntress' | 'sentinelone'`
+  - `interface ProviderBranding { label: string; icon: LucideIcon; accent: string; blurb: string; websiteUrl?: string }`
+  - `function getProviderBranding(p: IntegrationProvider): ProviderBranding`
+  - `function isIntegrationProvider(v: unknown): v is IntegrationProvider`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// providerBranding.test.ts
+import { describe, expect, it } from 'vitest';
+import { getProviderBranding, isIntegrationProvider } from './providerBranding';
+
+describe('providerBranding', () => {
+  it('returns label, icon, accent, and blurb for huntress', () => {
+    const b = getProviderBranding('huntress');
+    expect(b.label).toBe('Huntress');
+    expect(b.icon).toBeTypeOf('function'); // lucide icons are components
+    expect(b.accent).toMatch(/\S/);
+    expect(b.blurb.length).toBeGreaterThan(0);
+  });
+
+  it('returns branding for sentinelone', () => {
+    expect(getProviderBranding('sentinelone').label).toBe('SentinelOne');
+  });
+
+  it('type-guards provider strings', () => {
+    expect(isIntegrationProvider('huntress')).toBe(true);
+    expect(isIntegrationProvider('nope')).toBe(false);
+    expect(isIntegrationProvider(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/providerBranding.test.ts`
+Expected: FAIL — cannot find module `./providerBranding`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// providerBranding.ts
+import { ShieldCheck, type LucideIcon } from 'lucide-react';
+
+export type IntegrationProvider = 'huntress' | 'sentinelone';
+
+export interface ProviderBranding {
+  label: string;
+  icon: LucideIcon;
+  /** Tailwind classes for the tinted icon tile + chip (theme-aware). NOT a logo. */
+  accent: string;
+  blurb: string;
+  websiteUrl?: string;
+}
+
+const BRANDING: Record<IntegrationProvider, ProviderBranding> = {
+  huntress: {
+    label: 'Huntress',
+    icon: ShieldCheck,
+    accent: 'bg-orange-500/15 text-orange-600 dark:text-orange-400 border-orange-500/40',
+    blurb: 'Managed endpoint detection & response — installs the latest agent automatically.',
+    websiteUrl: 'https://www.huntress.com',
+  },
+  sentinelone: {
+    label: 'SentinelOne',
+    icon: ShieldCheck,
+    accent: 'bg-purple-500/15 text-purple-600 dark:text-purple-400 border-purple-500/40',
+    blurb: 'Autonomous EDR agent deployed from your uploaded installer.',
+    websiteUrl: 'https://www.sentinelone.com',
+  },
+};
+
+export function getProviderBranding(p: IntegrationProvider): ProviderBranding {
+  return BRANDING[p];
+}
+
+export function isIntegrationProvider(v: unknown): v is IntegrationProvider {
+  return v === 'huntress' || v === 'sentinelone';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/providerBranding.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/software/providerBranding.ts apps/web/src/components/software/providerBranding.test.ts
+git commit -m "feat(software): provider branding map for built-in EDR listings"
+```
+
+---
+
+## Task 2: Readiness hook (Huntress)
+
+**Files:**
+- Create: `apps/web/src/components/software/useEdrReadiness.ts`
+- Test: `apps/web/src/components/software/useEdrReadiness.test.tsx`
+
+**Interfaces:**
+- Consumes: `IntegrationProvider` from Task 1; `fetchWithAuth`.
+- Produces:
+  - `interface ReadinessCheck { key: string; label: string; ok: boolean; detail?: string; fixHref?: string }`
+  - `interface EdrReadiness { status: 'loading' | 'ready' | 'incomplete' | 'unknown'; checks: ReadinessCheck[]; mappedOrgCount?: number; firstGap?: ReadinessCheck }`
+  - `function useEdrReadiness(providers: IntegrationProvider[]): Record<IntegrationProvider, EdrReadiness>`
+
+Design notes:
+- One fetch per present provider (there is one integration per partner, so the
+  card grid + detail share a single fetch). Empty `providers` → no fetch.
+- Huntress: `GET /huntress/integration` → `{ data: { isActive, hasAccountKey, lastSyncOrgs } | null }`.
+- SentinelOne resolves to `status: 'unknown'` here; Task 6 wires it. (Keeps this
+  task Huntress-only but the map shape final.)
+- `fixHref` points at `/integrations` (the Integrations page hosting the Huntress card).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// useEdrReadiness.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEdrReadiness } from './useEdrReadiness';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// Probe: renders the huntress readiness so we can assert via the DOM.
+function Probe() {
+  const map = useEdrReadiness(['huntress']);
+  const r = map.huntress;
+  return (
+    <div>
+      <span data-testid="status">{r.status}</span>
+      <span data-testid="orgs">{r.mappedOrgCount ?? -1}</span>
+      <span data-testid="gap">{r.firstGap?.key ?? 'none'}</span>
+    </div>
+  );
+}
+
+describe('useEdrReadiness (huntress)', () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it('reports ready when connected, account key set, and orgs mapped', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ data: { isActive: true, hasAccountKey: true, lastSyncOrgs: 3 } }),
+    );
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('orgs')).toHaveTextContent('3');
+    expect(screen.getByTestId('gap')).toHaveTextContent('none');
+  });
+
+  it('reports incomplete with the account-key gap first', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ data: { isActive: true, hasAccountKey: false, lastSyncOrgs: 3 } }),
+    );
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('accountKey');
+  });
+
+  it('reports incomplete/disconnected when data is null', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }));
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('incomplete'));
+    expect(screen.getByTestId('gap')).toHaveTextContent('connected');
+  });
+
+  it('reports unknown when the fetch fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false));
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('unknown'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/useEdrReadiness.test.tsx`
+Expected: FAIL — cannot find module `./useEdrReadiness`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// useEdrReadiness.ts
+import { useEffect, useMemo, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import type { IntegrationProvider } from './providerBranding';
+
+export interface ReadinessCheck {
+  key: string;
+  label: string;
+  ok: boolean;
+  detail?: string;
+  fixHref?: string;
+}
+
+export interface EdrReadiness {
+  status: 'loading' | 'ready' | 'incomplete' | 'unknown';
+  checks: ReadinessCheck[];
+  mappedOrgCount?: number;
+  firstGap?: ReadinessCheck;
+}
+
+const LOADING: EdrReadiness = { status: 'loading', checks: [] };
+const UNKNOWN: EdrReadiness = { status: 'unknown', checks: [] };
+const HUNTRESS_FIX = '/integrations';
+
+function finalize(checks: ReadinessCheck[], mappedOrgCount?: number): EdrReadiness {
+  const firstGap = checks.find((c) => !c.ok);
+  return {
+    status: firstGap ? 'incomplete' : 'ready',
+    checks,
+    mappedOrgCount,
+    firstGap,
+  };
+}
+
+async function fetchHuntress(): Promise<EdrReadiness> {
+  const res = await fetchWithAuth('/huntress/integration');
+  if (!res.ok) return UNKNOWN;
+  const json = (await res.json()) as {
+    data?: { isActive?: boolean; hasAccountKey?: boolean; lastSyncOrgs?: number | null } | null;
+  };
+  const data = json.data ?? null;
+  const connected = !!data && data.isActive === true;
+  const accountKey = !!data?.hasAccountKey;
+  const mappedOrgCount = data?.lastSyncOrgs ?? 0;
+  const checks: ReadinessCheck[] = [
+    { key: 'connected', label: 'Integration connected', ok: connected, fixHref: HUNTRESS_FIX },
+    { key: 'accountKey', label: 'Account key configured', ok: accountKey,
+      detail: accountKey ? undefined : 'Add your Huntress account key in Integrations', fixHref: HUNTRESS_FIX },
+    { key: 'orgsMapped', label: 'Organizations mapped', ok: mappedOrgCount > 0,
+      detail: `${mappedOrgCount} org${mappedOrgCount === 1 ? '' : 's'} mapped`, fixHref: HUNTRESS_FIX },
+  ];
+  return finalize(checks, mappedOrgCount);
+}
+
+export function useEdrReadiness(
+  providers: IntegrationProvider[],
+): Record<IntegrationProvider, EdrReadiness> {
+  const key = useMemo(() => Array.from(new Set(providers)).sort().join(','), [providers]);
+  const [map, setMap] = useState<Record<IntegrationProvider, EdrReadiness>>({
+    huntress: LOADING,
+    sentinelone: LOADING,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const wanted = key ? (key.split(',') as IntegrationProvider[]) : [];
+    if (wanted.includes('huntress')) {
+      setMap((m) => ({ ...m, huntress: LOADING }));
+      fetchHuntress()
+        .then((r) => { if (!cancelled) setMap((m) => ({ ...m, huntress: r })); })
+        .catch(() => { if (!cancelled) setMap((m) => ({ ...m, huntress: UNKNOWN })); });
+    }
+    // sentinelone: wired in Task 6; stays 'unknown' until then.
+    if (wanted.includes('sentinelone')) {
+      setMap((m) => ({ ...m, sentinelone: UNKNOWN }));
+    }
+    return () => { cancelled = true; };
+  }, [key]);
+
+  return map;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/useEdrReadiness.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/software/useEdrReadiness.ts apps/web/src/components/software/useEdrReadiness.test.tsx
+git commit -m "feat(software): EDR readiness hook (Huntress) reusing /huntress/integration"
+```
+
+---
+
+## Task 3: BuiltinPackageDetail component
+
+**Files:**
+- Create: `apps/web/src/components/software/BuiltinPackageDetail.tsx`
+- Test: `apps/web/src/components/software/BuiltinPackageDetail.test.tsx`
+
+**Interfaces:**
+- Consumes: `getProviderBranding`, `IntegrationProvider` (Task 1); `EdrReadiness`, `ReadinessCheck` (Task 2).
+- Produces:
+  - `interface BuiltinPackageDetailProps { name: string; provider: IntegrationProvider; readiness: EdrReadiness; onDeploy: () => void }`
+  - `export default function BuiltinPackageDetail(props): JSX.Element`
+
+Behavior (from spec):
+- Header: tinted provider icon + name + blurb + "Managed built-in" chip.
+- Readiness rows from `readiness.checks` (check icon when ok, alert icon when not).
+- All green (`status==='ready'`): confident line `Ready to deploy to N mapped orgs`; enabled Deploy.
+- Any gap (`status==='incomplete'`): one highlighted next step from `firstGap` (its `detail`, linking to `fixHref`); Deploy disabled with `title` naming the gap.
+- `status==='unknown'`: "Couldn't verify setup" note; Deploy stays enabled (defer to the server's fail-fast) with a neutral title.
+- `status==='loading'`: a spinner row.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// BuiltinPackageDetail.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BuiltinPackageDetail from './BuiltinPackageDetail';
+import type { EdrReadiness } from './useEdrReadiness';
+
+const ready: EdrReadiness = {
+  status: 'ready',
+  mappedOrgCount: 2,
+  checks: [
+    { key: 'connected', label: 'Integration connected', ok: true },
+    { key: 'accountKey', label: 'Account key configured', ok: true },
+    { key: 'orgsMapped', label: 'Organizations mapped', ok: true, detail: '2 orgs mapped' },
+  ],
+};
+
+const missingKey: EdrReadiness = {
+  status: 'incomplete',
+  checks: [
+    { key: 'connected', label: 'Integration connected', ok: true },
+    { key: 'accountKey', label: 'Account key configured', ok: false,
+      detail: 'Add your Huntress account key in Integrations', fixHref: '/integrations' },
+    { key: 'orgsMapped', label: 'Organizations mapped', ok: true, detail: '2 orgs mapped' },
+  ],
+  firstGap: { key: 'accountKey', label: 'Account key configured', ok: false,
+    detail: 'Add your Huntress account key in Integrations', fixHref: '/integrations' },
+};
+
+describe('BuiltinPackageDetail', () => {
+  it('shows a confident ready state and fires onDeploy', () => {
+    const onDeploy = vi.fn();
+    render(<BuiltinPackageDetail name="Huntress EDR Agent" provider="huntress" readiness={ready} onDeploy={onDeploy} />);
+    expect(screen.getByText(/Ready to deploy to 2 mapped orgs/i)).toBeInTheDocument();
+    // No prereq warnings when ready.
+    expect(screen.queryByText(/account key in Integrations/i)).not.toBeInTheDocument();
+    const deploy = screen.getByRole('button', { name: /^Deploy$/ });
+    expect(deploy).not.toBeDisabled();
+    fireEvent.click(deploy);
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces exactly the one missing step and disables Deploy', () => {
+    render(<BuiltinPackageDetail name="Huntress EDR Agent" provider="huntress" readiness={missingKey} onDeploy={vi.fn()} />);
+    expect(screen.getByText(/Add your Huntress account key in Integrations/i)).toBeInTheDocument();
+    const deploy = screen.getByRole('button', { name: /^Deploy$/ });
+    expect(deploy).toBeDisabled();
+    expect(deploy).toHaveAttribute('title', expect.stringMatching(/account key/i));
+  });
+
+  it('defers to the server when readiness is unknown (Deploy stays enabled)', () => {
+    render(<BuiltinPackageDetail name="Huntress EDR Agent" provider="huntress"
+      readiness={{ status: 'unknown', checks: [] }} onDeploy={vi.fn()} />);
+    expect(screen.getByText(/Couldn.t verify setup/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Deploy$/ })).not.toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/BuiltinPackageDetail.test.tsx`
+Expected: FAIL — cannot find module `./BuiltinPackageDetail`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// BuiltinPackageDetail.tsx
+import { shield, CheckCircle2, AlertTriangle, ExternalLink, Loader2, HelpCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getProviderBranding, type IntegrationProvider } from './providerBranding';
+import type { EdrReadiness } from './useEdrReadiness';
+
+export interface BuiltinPackageDetailProps {
+  name: string;
+  provider: IntegrationProvider;
+  readiness: EdrReadiness;
+  onDeploy: () => void;
+}
+
+export default function BuiltinPackageDetail({ name, provider, readiness, onDeploy }: BuiltinPackageDetailProps) {
+  const branding = getProviderBranding(provider);
+  const Icon = branding.icon;
+  const ready = readiness.status === 'ready';
+  const gap = readiness.firstGap;
+  const disabled = readiness.status === 'incomplete';
+  const deployTitle = disabled && gap ? `Resolve: ${gap.label}` : 'Deploys to mapped organizations only';
+
+  return (
+    <div className="mt-4 space-y-5">
+      <div className="flex items-start gap-3">
+        <div className={cn('flex h-12 w-12 items-center justify-center rounded-md border', branding.accent)}>
+          <Icon className="h-6 w-6" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold">{name}</h3>
+            <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium', branding.accent)}>
+              Managed built-in
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{branding.blurb}</p>
+          {branding.websiteUrl && (
+            <a href={branding.websiteUrl} target="_blank" rel="noreferrer"
+              className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+              {branding.label} website <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-muted/30 p-4">
+        {readiness.status === 'loading' && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Checking setup…
+          </div>
+        )}
+        {readiness.status === 'unknown' && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <HelpCircle className="h-4 w-4" /> Couldn&apos;t verify setup — deploy will confirm on the server.
+          </div>
+        )}
+        {(ready || readiness.status === 'incomplete') && (
+          <ul className="space-y-2">
+            {readiness.checks.map((c) => (
+              <li key={c.key} className="flex items-center gap-2 text-sm">
+                {c.ok
+                  ? <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                  : <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />}
+                <span className={cn(!c.ok && 'font-medium')}>{c.label}</span>
+                {c.detail && <span className="text-xs text-muted-foreground">· {c.detail}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+        {ready && (
+          <p className="mt-3 text-sm font-medium text-emerald-700 dark:text-emerald-400">
+            Ready to deploy{typeof readiness.mappedOrgCount === 'number' ? ` to ${readiness.mappedOrgCount} mapped org${readiness.mappedOrgCount === 1 ? '' : 's'}` : ''}.
+          </p>
+        )}
+        {disabled && gap && (
+          <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+            <p className="font-medium">Next step: {gap.label}</p>
+            {gap.detail && <p className="mt-0.5 text-muted-foreground">{gap.detail}</p>}
+            {gap.fixHref && (
+              <a href={gap.fixHref} className="mt-1 inline-flex items-center gap-1 text-xs font-medium underline">
+                Open Integrations <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          disabled={disabled}
+          title={deployTitle}
+          onClick={onDeploy}
+          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Deploy
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+Note: fix the import line — use `ShieldCheck` is provided via branding, so the
+component imports only `CheckCircle2, AlertTriangle, ExternalLink, Loader2, HelpCircle`
+from `lucide-react` (remove the stray `shield`). Correct first line:
+
+```tsx
+import { CheckCircle2, AlertTriangle, ExternalLink, Loader2, HelpCircle } from 'lucide-react';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/BuiltinPackageDetail.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/software/BuiltinPackageDetail.tsx apps/web/src/components/software/BuiltinPackageDetail.test.tsx
+git commit -m "feat(software): BuiltinPackageDetail — readiness panel + guided deploy CTA"
+```
+
+---
+
+## Task 4: Wire SoftwareCatalog (cards, detail delegation, preselect)
+
+**Files:**
+- Modify: `apps/web/src/components/software/SoftwareCatalog.tsx`
+- Modify: `apps/web/src/components/software/SoftwareCatalog.test.tsx`
+
+**Interfaces:**
+- Consumes: `getProviderBranding`, `isIntegrationProvider`, `IntegrationProvider` (Task 1); `useEdrReadiness`, `EdrReadiness` (Task 2); `BuiltinPackageDetail` (Task 3).
+- Produces: a `deployPackageId: string | null` passed to `DeploymentWizard` as `preselectedCatalogId` (Task 5 consumes it).
+
+Changes:
+1. Replace the inline `type IntegrationProvider` (line 17) with an import from `./providerBranding`; keep the local `SoftwareItem` type.
+2. Derive present built-in providers and call the readiness hook:
+   ```tsx
+   const builtinProviders = useMemo(
+     () => Array.from(new Set(catalogItems.map(i => i.integrationProvider).filter(isIntegrationProvider))),
+     [catalogItems],
+   );
+   const readinessMap = useEdrReadiness(builtinProviders);
+   ```
+3. Card icon: when `item.integrationProvider` is set, render the tinted provider icon tile instead of the grey `Package` box.
+4. Card readiness pill: for built-in items show a pill from `readinessMap[provider].status` — `ready`→green "Ready", `incomplete`→amber "Setup needed", `loading`→"Checking…", `unknown`→ nothing (neutral).
+5. Remove the Huntress "upload" cue: keep `needsInstallerUpload` for **SentinelOne only** (it already is), but for Huntress the card must show no upload text and an enabled Deploy.
+6. Deploy preselect: introduce `const [deployPackageId, setDeployPackageId] = useState<string | null>(null)`. Card & detail Deploy buttons call `setDeployPackageId(item.id); setShowDeployWizard(true)`. When the wizard closes, reset to `null`.
+7. Detail modal: when `selectedSoftware.integrationProvider` is set, render `<BuiltinPackageDetail name=... provider=... readiness={readinessMap[provider]} onDeploy={() => { setDeployPackageId(selectedSoftware.id); setSelectedSoftware(null); setShowDeployWizard(true); }} />` in place of the current built-in Details body (the "managed by" note + generic Deploy). Non-built-in items keep the existing Details/Delete/Deploy body.
+8. Pass `preselectedCatalogId={deployPackageId ?? undefined}` to `<DeploymentWizard />`.
+
+- [ ] **Step 1: Add failing tests to `SoftwareCatalog.test.tsx`**
+
+Extend the existing `built-in packages` describe block. The DeploymentWizard is mocked to `null`; change the mock to a probe that echoes its `preselectedCatalogId` so we can assert preselect:
+
+```tsx
+// Replace the existing DeploymentWizard mock with a probe.
+vi.mock('./DeploymentWizard', () => ({
+  default: (props: { preselectedCatalogId?: string }) => (
+    <div data-testid="wizard">wizard:{props.preselectedCatalogId ?? 'none'}</div>
+  ),
+}));
+```
+
+Add tests (huntress readiness fetch now happens — mock it as the 2nd call):
+
+```tsx
+it('shows a Ready pill and no upload cue for a ready Huntress package', async () => {
+  fetchMock
+    .mockResolvedValueOnce(jsonResponse({ data: [BUILTIN_ITEM] }))          // GET /software/catalog
+    .mockResolvedValueOnce(jsonResponse({ data: { isActive: true, hasAccountKey: true, lastSyncOrgs: 2 } })); // GET /huntress/integration
+
+  render(<SoftwareCatalog />);
+  await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText(/^Ready$/)).toBeInTheDocument());
+  expect(screen.queryByText(/Upload installer/i)).not.toBeInTheDocument();
+});
+
+it('preselects the package into the deploy wizard when Deploy is clicked', async () => {
+  fetchMock
+    .mockResolvedValueOnce(jsonResponse({ data: [BUILTIN_ITEM] }))
+    .mockResolvedValueOnce(jsonResponse({ data: { isActive: true, hasAccountKey: true, lastSyncOrgs: 2 } }));
+
+  render(<SoftwareCatalog />);
+  await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
+  fireEvent.click(screen.getByRole('button', { name: /^Deploy$/ }));
+  expect(await screen.findByTestId('wizard')).toHaveTextContent('wizard:builtin-huntress');
+});
+
+it('shows the BuiltinPackageDetail readiness panel when a built-in is opened', async () => {
+  fetchMock
+    .mockResolvedValueOnce(jsonResponse({ data: [BUILTIN_ITEM] }))
+    .mockResolvedValueOnce(jsonResponse({ data: { isActive: true, hasAccountKey: false, lastSyncOrgs: 2 } }));
+
+  render(<SoftwareCatalog />);
+  await waitFor(() => expect(screen.getByText('Huntress EDR Agent')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Huntress EDR Agent'));
+  expect(await screen.findByText(/Next step: Account key configured/i)).toBeInTheDocument();
+});
+```
+
+Also update the existing built-in tests that assumed the old body: the test
+`hides Delete for a built-in package and shows the managed-by note` (lines 119-130)
+now asserts the new panel — change its assertion from `/managed by the Huntress
+integration/i` to `/Managed built-in/i`, and keep the `no Delete button` check.
+The two SentinelOne tests still pass unchanged (S1 keeps the upload cue and, with
+readiness `unknown` in this task, no pill).
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/SoftwareCatalog.test.tsx`
+Expected: FAIL — new assertions (Ready pill, preselect, "Next step") not met; the edited managed-by test fails on old text.
+
+- [ ] **Step 3: Implement the SoftwareCatalog changes**
+
+Apply changes 1-8 above. Key snippets:
+
+Import line (replace inline type at line 17):
+```tsx
+import { getProviderBranding, isIntegrationProvider, type IntegrationProvider } from './providerBranding';
+import { useEdrReadiness } from './useEdrReadiness';
+import BuiltinPackageDetail from './BuiltinPackageDetail';
+```
+
+Readiness pill helper (module scope):
+```tsx
+function ReadinessPill({ status }: { status: 'loading' | 'ready' | 'incomplete' | 'unknown' }) {
+  if (status === 'ready')
+    return <span className="inline-flex items-center rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">Ready</span>;
+  if (status === 'incomplete')
+    return <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">Setup needed</span>;
+  if (status === 'loading')
+    return <span className="text-xs text-muted-foreground">Checking…</span>;
+  return null;
+}
+```
+
+Card icon tile (inside the card, replacing the grey `Package` box when built-in):
+```tsx
+{isIntegrationProvider(item.integrationProvider) ? (() => {
+  const Icon = getProviderBranding(item.integrationProvider).icon;
+  return (
+    <div className={cn('flex h-10 w-10 items-center justify-center rounded-md border', getProviderBranding(item.integrationProvider).accent)}>
+      <Icon className="h-5 w-5" />
+    </div>
+  );
+})() : (
+  <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+    <Package className="h-5 w-5 text-muted-foreground" />
+  </div>
+)}
+```
+
+Card Deploy handler now preselects:
+```tsx
+onClick={event => {
+  event.stopPropagation();
+  setDeployPackageId(item.id);
+  setShowDeployWizard(true);
+}}
+```
+
+Detail modal Details tab, built-in branch:
+```tsx
+{selectedSoftware.integrationProvider ? (
+  <BuiltinPackageDetail
+    name={selectedSoftware.name}
+    provider={selectedSoftware.integrationProvider}
+    readiness={readinessMap[selectedSoftware.integrationProvider]}
+    onDeploy={() => {
+      setDeployPackageId(selectedSoftware.id);
+      setSelectedSoftware(null);
+      setShowDeployWizard(true);
+    }}
+  />
+) : (
+  /* existing non-built-in Details body: description + Delete + Deploy */
+)}
+```
+
+Wizard mount + reset on close:
+```tsx
+<DeploymentWizard preselectedCatalogId={deployPackageId ?? undefined} />
+// in the wizard modal close button and overlay close:
+onClick={() => { setShowDeployWizard(false); setDeployPackageId(null); }}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/SoftwareCatalog.test.tsx`
+Expected: PASS (all built-in + delete tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: no errors.
+
+```bash
+git add apps/web/src/components/software/SoftwareCatalog.tsx apps/web/src/components/software/SoftwareCatalog.test.tsx
+git commit -m "feat(software): branded, readiness-aware built-in EDR cards + preselect deploy"
+```
+
+---
+
+## Task 5: DeploymentWizard preselect prop
+
+**Files:**
+- Modify: `apps/web/src/components/software/DeploymentWizard.tsx`
+- Test: `apps/web/src/components/software/DeploymentWizard.preselect.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `preselectedCatalogId?: string` from Task 4.
+- Produces: on mount, when the catalog loads and contains the preselected id, sets `selectedSoftwareId` to it and `selectedVersionId` to that package's latest (or first) version.
+
+Changes to `DeploymentWizard.tsx`:
+1. Signature: `export default function DeploymentWizard({ preselectedCatalogId }: { preselectedCatalogId?: string } = {})`.
+2. After `setSoftwareOptions(normalizedCatalog)` inside `fetchData`, apply the preselect (only if nothing selected yet):
+   ```tsx
+   if (preselectedCatalogId) {
+     const match = normalizedCatalog.find((s) => s.id === preselectedCatalogId);
+     if (match) {
+       setSelectedSoftwareId(match.id);
+       const latest = match.versions.find((v) => v.isLatest) ?? match.versions[0];
+       if (latest) setSelectedVersionId(latest.id);
+     }
+   }
+   ```
+3. Add `preselectedCatalogId` to the `fetchData` `useCallback` dependency array.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// DeploymentWizard.preselect.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DeploymentWizard from './DeploymentWizard';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../filters/DeviceTargetSelector', () => ({ DeviceTargetSelector: () => null }));
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ok = (payload: unknown): Response =>
+  ({ ok: true, status: 200, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function route(url: string) {
+  if (url === '/software/catalog') return ok({ data: [{ id: 'cat-9', name: 'Huntress EDR Agent', vendor: 'Huntress', category: 'security' }] });
+  if (url === '/software/catalog/cat-9/versions') return ok({ data: [{ id: 'ver-1', version: 'latest', isLatest: true }] });
+  return ok({ data: [] }); // /devices, /orgs/sites, /device-groups
+}
+
+describe('DeploymentWizard preselect', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) => Promise.resolve(route(url)));
+  });
+
+  it('starts with the preselected package selected', async () => {
+    render(<DeploymentWizard preselectedCatalogId="cat-9" />);
+    // The selected package name appears in the wizard's selection UI once loaded.
+    await waitFor(() => expect(screen.getAllByText('Huntress EDR Agent').length).toBeGreaterThan(0));
+    // Its latest version option is present/selected.
+    await waitFor(() => expect(screen.getByText(/latest/i)).toBeInTheDocument());
+  });
+});
+```
+
+Note: if the wizard's step-1 markup doesn't render the version label until the
+package row is expanded, assert instead that the "Select Targets" step is
+reachable (the Next control is enabled) — adjust the assertion to the actual
+DOM after reading the step-1 render. The invariant under test: a preselected id
+results in a non-empty `selectedSoftwareId`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/DeploymentWizard.preselect.test.tsx`
+Expected: FAIL — `preselectedCatalogId` prop ignored; package not selected.
+
+- [ ] **Step 3: Implement the preselect (changes 1-3 above)**
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/DeploymentWizard.preselect.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Expected: no errors.
+
+```bash
+git add apps/web/src/components/software/DeploymentWizard.tsx apps/web/src/components/software/DeploymentWizard.preselect.test.tsx
+git commit -m "feat(software): DeploymentWizard accepts a preselected catalog package"
+```
+
+---
+
+## Task 6: SentinelOne readiness wiring
+
+**Files:**
+- Modify: `apps/web/src/components/software/useEdrReadiness.ts`
+- Modify: `apps/web/src/components/software/useEdrReadiness.test.tsx`
+
+**Interfaces:**
+- Consumes: the S1 integration status endpoint. **Confirm the exact route + site-token field** by reading `apps/api/src/routes/sentinelOne.ts` (mirror of the Huntress status endpoint). If no `hasSiteToken`-style boolean exists, flag it — do not add a backend field silently; fall back to a two-check readiness (connected + installer uploaded) and note the gap.
+- S1 needs the built-in item's `versionCount` for the "installer uploaded" check. Extend the hook signature to accept it:
+  - `useEdrReadiness(providers: IntegrationProvider[], opts?: { s1VersionCount?: number }): Record<IntegrationProvider, EdrReadiness>`
+
+S1 checks:
+- `connected`: S1 integration active.
+- `installerUploaded`: `(opts?.s1VersionCount ?? 0) >= 1`, fixHref = `/software` (Versions tab), detail "Upload the SentinelOne installer".
+- `siteTokenConfigured`: from the S1 status endpoint (if available).
+
+- [ ] **Step 1: Add failing S1 tests** (mirror the Huntress probe with `useEdrReadiness(['sentinelone'], { s1VersionCount })`, asserting `installerUploaded` gap when 0, ready when connected + version + site token). Show the exact route mock once confirmed from `sentinelOne.ts`.
+
+- [ ] **Step 2: Run to verify fail.**
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/useEdrReadiness.test.tsx`
+Expected: FAIL (S1 still `unknown`).
+
+- [ ] **Step 3: Implement `fetchSentinelOne(opts)` and route it in the effect** (replace the `unknown` placeholder for `sentinelone`). Thread `opts.s1VersionCount` through the memo key so a version upload re-derives readiness.
+
+- [ ] **Step 4: Run to verify pass.**
+Run: `pnpm --filter @breeze/web test -- --run src/components/software/useEdrReadiness.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `s1VersionCount` from SoftwareCatalog** — pass the S1 built-in item's `versionCount` into the hook; update the S1 SoftwareCatalog tests so the S1 card shows a Ready/Setup pill instead of only the bare upload cue. Typecheck.
+
+```bash
+git add apps/web/src/components/software/useEdrReadiness.ts apps/web/src/components/software/useEdrReadiness.test.tsx apps/web/src/components/software/SoftwareCatalog.tsx apps/web/src/components/software/SoftwareCatalog.test.tsx
+git commit -m "feat(software): SentinelOne readiness (installer upload + site token)"
+```
+
+---
+
+## Task 7: Harden pass + full suite
+
+**Files:**
+- Modify: any of the above as needed.
+
+- [ ] **Step 1:** Manually verify (dev server) the built-in detail in **dark mode** — accent tiles, amber next-step box, emerald ready line all legible. Fix any contrast issues in `providerBranding.ts` accents / component classes.
+- [ ] **Step 2:** Edge: `lastSyncOrgs: 0` → "Setup needed" pill, org-mapping gap shown as the next step (not account key if the key is set). Confirm `firstGap` ordering (connected → accountKey → orgsMapped) matches the most-blocking-first intent; adjust order if product prefers surfacing account-key before org-mapping.
+- [ ] **Step 3:** Run the full software suite + typecheck + lint:
+
+Run: `pnpm --filter @breeze/web test -- --run src/components/software`
+Run: `pnpm --filter @breeze/web exec tsc --noEmit`
+Run: `pnpm --filter @breeze/web lint`
+Expected: all green.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A apps/web/src/components/software/
+git commit -m "chore(software): harden built-in EDR listing (dark mode, edge cases)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** readiness panel (Tasks 2/3), branded/intentional non-logo treatment (Tasks 1/3/4), guided deploy preselect (Tasks 4/5), hide-prereq-when-ready (Task 3 ready branch + Task 4 removing Huntress upload cue), both providers (Tasks 2/6). Covered.
+- **No backend change:** all readiness from `/huntress/integration` (exists) and `/sentinelone/...` status (confirm field in Task 6; flag if missing).
+- **Type consistency:** `IntegrationProvider` defined once (Task 1), imported everywhere; `EdrReadiness`/`ReadinessCheck` defined in Task 2 and consumed by Tasks 3/4; `preselectedCatalogId` produced in Task 4, consumed in Task 5.
+- **Open confirm (Task 6):** exact SentinelOne status route + site-token boolean field name — read `sentinelOne.ts` before writing that test; do not invent a field.
+- **Open confirm (Task 2/3):** the Integrations page route for `fixHref` is assumed `/integrations`; verify against `apps/web/src/pages` and adjust if it differs.

--- a/docs/superpowers/specs/2026-07-06-builtin-edr-listing-ui-design.md
+++ b/docs/superpowers/specs/2026-07-06-builtin-edr-listing-ui-design.md
@@ -33,7 +33,10 @@ looking uniformly unfinished.
 
 Four confirmed intents (all in scope):
 1. **Show it's ready-to-deploy** — a readiness panel, not silence.
-2. **Make it look branded/intentional** — provider brand mark + product framing.
+2. **Make it look intentional** — product framing (name, blurb, "Managed built-in"
+   chip) and a tinted security icon per provider. **No official brand marks/logos**
+   (avoids trademark/asset concerns) — a `ShieldCheck` tinted with the provider
+   accent replaces the generic grey box.
 3. **Guide the deploy flow** — Deploy preselects this package; clarify it targets mapped orgs.
 4. **Hide the prereq-looking cues** — when ready, no warnings/tooltips; for Huntress nothing is ever uploaded.
 
@@ -86,17 +89,18 @@ All new files under `apps/web/src/components/software/`.
 A static, declarative map keyed by `IntegrationProvider`:
 ```
 provider → {
-  label:        string        // "Huntress"
-  brandMark:    ReactNode      // inline SVG (CSP blocks external logos)
-  blurb:        string         // "Managed endpoint detection & response — installs the latest agent automatically."
-  accent:       string         // tailwind class group for the accent
-  readiness:    ReadinessSpec  // ordered checks + how to read them (see below)
+  label:        string          // "Huntress"
+  icon:         LucideIcon        // ShieldCheck (NOT an official logo)
+  accent:       string           // tailwind class group for the tinted icon + chip
+  blurb:        string           // "Managed endpoint detection & response — installs the latest agent automatically."
+  readiness:    ReadinessSpec    // ordered checks + how to read them (see below)
 }
 ```
-- Brand marks are **bundled inline SVGs** (no external URLs — the app CSP blocks
-  remote hosts, and `ensureBuiltinPackage` currently stores `iconUrl: null`). If
-  a real logo asset isn't available, fall back to a tasteful `ShieldCheck`-style
-  mark tinted with the provider accent rather than the generic grey `Package` box.
+- **No official brand marks/logos** (per decision — avoids trademark/asset
+  concerns, and `ensureBuiltinPackage` stores `iconUrl: null` anyway). Each
+  provider gets a `ShieldCheck` lucide icon tinted with its accent class,
+  replacing the generic grey `Package` box. "Intentional" comes from the accent +
+  product framing (name, blurb, chip), not a logo.
 
 ### `useEdrReadiness.ts`
 A hook that fetches the provider status **once** per mount and returns a
@@ -121,8 +125,8 @@ normalized, provider-agnostic readiness object:
 ### `BuiltinPackageDetail.tsx`
 Rendered as the detail-modal body when `selectedSoftware.integrationProvider` is
 set (replacing the current generic Details tab body for built-ins). Composition:
-- **Branded header:** provider brand mark + name + `blurb`; a "Managed built-in"
-  chip. Website link if present.
+- **Header:** provider tinted `ShieldCheck` icon + name + `blurb`; a "Managed
+  built-in" chip. Website link if present. (No official logo.)
 - **Readiness panel:** the ordered checks from `useEdrReadiness`, each a
   row with a check/alert icon.
   - **All green:** a single confident line ("Ready to deploy to N mapped orgs")
@@ -137,8 +141,8 @@ set (replacing the current generic Details tab body for built-ins). Composition:
 
 ## `SoftwareCatalog.tsx` changes
 
-- **Card (grid):** for built-in EDR items, render the provider brand mark instead
-  of the grey `Package` box, and a subtle readiness **pill** (green "Ready" /
+- **Card (grid):** for built-in EDR items, render the provider tinted `ShieldCheck`
+  icon instead of the grey `Package` box, and a subtle readiness **pill** (green "Ready" /
   amber "Setup needed" / neutral "Checking…") driven by the shared readiness
   fetch. Because there is one integration per partner, fetch readiness **once** at
   the catalog level and pass it down — do not issue one request per card.
@@ -191,7 +195,7 @@ set (replacing the current generic Details tab body for built-ins). Composition:
 
 ## Build order
 
-1. `providerBranding.ts` + bundled brand marks (+ fallback).
+1. `providerBranding.ts` (tinted `ShieldCheck` per provider — no logo assets).
 2. `useEdrReadiness.ts` with Huntress wired; unit tests.
 3. `BuiltinPackageDetail.tsx` (readiness panel + guided CTA); tests.
 4. `SoftwareCatalog.tsx` — brand mark + pill on cards, delegate built-in detail

--- a/docs/superpowers/specs/2026-07-06-builtin-edr-listing-ui-design.md
+++ b/docs/superpowers/specs/2026-07-06-builtin-edr-listing-ui-design.md
@@ -1,0 +1,201 @@
+# Built-in EDR Listing UI — Ready-to-Deploy Redesign
+
+**Date:** 2026-07-06
+**Branch:** `ToddHebebrand/software-deploy-UI`
+**Status:** Design approved — ready for implementation plan
+**Area:** `apps/web/src/components/software/`
+
+## Problem
+
+Built-in EDR packages (Huntress, SentinelOne) are provisioned into the Software
+Library when the corresponding integration is connected (`ensureBuiltinPackage`,
+`apps/api/src/services/builtinDeploymentPackages.ts`). But when a user opens the
+Huntress listing today it looks like a bare, generic package that still needs
+work:
+
+- Generic grey `Package` icon — identical to every other package, no branding.
+- Detail modal says passively: *"Built-in package managed by the Huntress integration."*
+- The Deploy button carries a tooltip *"Deploys to mapped organizations only"* —
+  which reads like an unmet prerequisite.
+- **No readiness signal.** Whether the deployment account key is set and orgs are
+  mapped is invisible until a deploy *fails* with a fail-fast message from
+  `edrInstallerResolver.ts` (e.g. *"Huntress account key not configured"*).
+
+The result: a fully-working, ready-to-go integration *looks* like a chore the
+user still has to finish.
+
+## Goal
+
+When a built-in EDR listing is opened, it should read as a first-class,
+integrated product that is **visibly ready to deploy** — and, when it genuinely
+is not ready, it should say exactly which one thing is missing rather than
+looking uniformly unfinished.
+
+Four confirmed intents (all in scope):
+1. **Show it's ready-to-deploy** — a readiness panel, not silence.
+2. **Make it look branded/intentional** — provider brand mark + product framing.
+3. **Guide the deploy flow** — Deploy preselects this package; clarify it targets mapped orgs.
+4. **Hide the prereq-looking cues** — when ready, no warnings/tooltips; for Huntress nothing is ever uploaded.
+
+**Scope:** both built-in EDR providers (Huntress + SentinelOne), via one
+provider-aware component set. Huntress surfaces account-key + org-mapping
+readiness; SentinelOne surfaces installer-upload + site-token readiness.
+
+## Non-goals / Out of scope
+
+- The custom **"Add Package"** single-step modal and the generic installer-URL
+  variable affordance — that is the sibling shaping's territory
+  (`software_deploy_ui_shape_single_step_package_and_url_vars`; the untracked
+  `apps/web/src/lib/installerVariables.ts` on this branch). Do **not** fold that
+  work into this change.
+- No backend changes. Readiness is derived from existing endpoints. If a needed
+  signal turns out to be missing, that is a flagged deviation to raise, not a
+  silent scope expansion.
+
+## Approach
+
+Approach **B** of three considered:
+
+- **A — Special-case inside `SoftwareCatalog.tsx`.** Rejected: that file is already
+  ~595 lines and mixes generic + built-in concerns; inlining bloats it further.
+- **B — Extract dedicated built-in components + a readiness hook + a branding map (chosen).**
+  Clean isolation, testable, keeps Huntress/S1 consistent, no backend change.
+- **C — Backend-enriched catalog** (embed a `readiness` object per item in
+  `/software/catalog`). Rejected as overkill: there is one integration per
+  partner, so a single readiness fetch already covers every Huntress card; the
+  RLS-scoped counts + tests aren't worth it.
+
+## Backend facts this relies on (no changes required)
+
+- `GET /software/catalog` (`apps/api/src/routes/software.ts`) already returns per
+  item: `integrationProvider`, `isManaged`, `iconUrl`, `websiteUrl`, `versionCount`.
+- `GET /huntress/integration` (`apps/api/src/routes/huntress.ts:286`) returns, at
+  partner scope: `isActive`, `hasAccountKey`, `lastSyncOrgs` (count of orgs synced
+  from Huntress = mapped-org count), `lastSyncAt`, `lastSyncStatus`. At org scope
+  it returns `{ data: null, mapped: false }` when the caller's org is not mapped.
+- SentinelOne readiness comes from the catalog item itself (`versionCount ≥ 1` =
+  installer uploaded) plus the S1 integration status endpoint for the site token
+  (mirror of the Huntress status endpoint; confirm exact field name during build
+  — `apps/api/src/routes/sentinelOne.ts`).
+
+## Components
+
+All new files under `apps/web/src/components/software/`.
+
+### `providerBranding.ts`
+A static, declarative map keyed by `IntegrationProvider`:
+```
+provider → {
+  label:        string        // "Huntress"
+  brandMark:    ReactNode      // inline SVG (CSP blocks external logos)
+  blurb:        string         // "Managed endpoint detection & response — installs the latest agent automatically."
+  accent:       string         // tailwind class group for the accent
+  readiness:    ReadinessSpec  // ordered checks + how to read them (see below)
+}
+```
+- Brand marks are **bundled inline SVGs** (no external URLs — the app CSP blocks
+  remote hosts, and `ensureBuiltinPackage` currently stores `iconUrl: null`). If
+  a real logo asset isn't available, fall back to a tasteful `ShieldCheck`-style
+  mark tinted with the provider accent rather than the generic grey `Package` box.
+
+### `useEdrReadiness.ts`
+A hook that fetches the provider status **once** per mount and returns a
+normalized, provider-agnostic readiness object:
+```
+{ loading, error,
+  checks: Array<{ key, label, ok: boolean, detail?: string, fixHref?: string }>,
+  ready: boolean,          // every check ok
+  firstGap?: check         // the first not-ok check, for the "one next step" UI
+}
+```
+- Huntress: reads `GET /huntress/integration` via `fetchWithAuth`.
+  - `connected` = `data != null && data.isActive`
+  - `accountKeyConfigured` = `data.hasAccountKey`
+  - `orgsMapped` = `data.lastSyncOrgs > 0` (detail: "N orgs mapped")
+- SentinelOne: `installerUploaded` from the catalog item's `versionCount`;
+  `siteTokenConfigured` from the S1 status endpoint; `connected` likewise.
+- Errors surface as a non-blocking readiness-unknown state (never a silent
+  "looks ready"): if the status call fails, show "Couldn't verify setup" rather
+  than a false green.
+
+### `BuiltinPackageDetail.tsx`
+Rendered as the detail-modal body when `selectedSoftware.integrationProvider` is
+set (replacing the current generic Details tab body for built-ins). Composition:
+- **Branded header:** provider brand mark + name + `blurb`; a "Managed built-in"
+  chip. Website link if present.
+- **Readiness panel:** the ordered checks from `useEdrReadiness`, each a
+  row with a check/alert icon.
+  - **All green:** a single confident line ("Ready to deploy to N mapped orgs")
+    and the primary **Deploy** CTA. No warnings, no prereq tooltips.
+  - **Any red:** render only the readiness rows plus **one** highlighted next
+    step derived from `firstGap` (e.g. "Add your Huntress account key in
+    Integrations") with a deep link. Deploy stays visible but is disabled with a
+    title naming the specific gap — not the generic "mapped organizations only".
+- Keep the existing Versions tab reachable for built-ins (S1 uploads its
+  installer there). For Huntress, the Versions tab is informational (a single
+  templated `latest`).
+
+## `SoftwareCatalog.tsx` changes
+
+- **Card (grid):** for built-in EDR items, render the provider brand mark instead
+  of the grey `Package` box, and a subtle readiness **pill** (green "Ready" /
+  amber "Setup needed" / neutral "Checking…") driven by the shared readiness
+  fetch. Because there is one integration per partner, fetch readiness **once** at
+  the catalog level and pass it down — do not issue one request per card.
+- **Remove the misleading generic cue** for Huntress: the current
+  `needsInstallerUpload` text/tooltip must not apply to Huntress (it never
+  uploads). S1's upload need is expressed as a readiness item, not ad-hoc text.
+- **Guided deploy / preselect:** the card and detail Deploy buttons currently call
+  `setShowDeployWizard(true)` with **no package**. They must preselect the clicked
+  package into `DeploymentWizard` (the fix already flagged in the sibling memory).
+- Built-in detail body delegates to `BuiltinPackageDetail`; non-built-in items
+  keep the existing Details/Delete/Deploy body unchanged.
+
+## `DeploymentWizard.tsx` changes
+
+- Accept a `preselectedPackage` (or `preselectedCatalogId`) prop and start on the
+  chosen package rather than an empty selection.
+- For a built-in EDR package, show a short context line that it deploys to mapped
+  orgs only. **Stretch (nice-to-have, not core):** filter the org/device picker to
+  only mapped orgs. Core requirement is the preselect + the context line.
+
+## Error handling
+
+- All reads via `fetchWithAuth`. Any mutation via `runAction` (repo rule
+  `no-silent-mutations`). This change is read-heavy; the only mutation path is the
+  existing deploy dispatch inside the wizard, already wrapped.
+- Readiness fetch failure → explicit "couldn't verify setup" state, never a false
+  ready. The server already fails deploys loudly with specific messages
+  (`edrInstallerResolver.ts`), so the UI's job is to *pre-surface* those gaps, not
+  to re-implement them — the honest fallback is deferring to the server's
+  fail-fast message.
+
+## Testing
+
+- `BuiltinPackageDetail.test.tsx` — all-green ready state; each single-gap state
+  (missing account key, no mapped orgs, disconnected) renders exactly one next
+  step and disables Deploy with the right title; readiness-unknown on fetch error.
+- `useEdrReadiness` — Huntress mapping of `{ isActive, hasAccountKey, lastSyncOrgs }`
+  → checks; org-scope `mapped:false`; error path.
+- Update `SoftwareCatalog.test.tsx` — built-in card renders brand mark + pill;
+  Deploy preselects the package (assert the wizard receives it); Huntress card
+  shows no "upload installer" cue.
+- No backend change → no new integration tests.
+
+## Rollout / flag interplay
+
+- No new flag. The EDR connect UI is already gated by the build-time web flag
+  `PUBLIC_ENABLE_EDR_INTEGRATIONS`; this change only affects how built-in EDR
+  packages render inside the already-reachable Software Library, so it needs no
+  additional gating.
+
+## Build order
+
+1. `providerBranding.ts` + bundled brand marks (+ fallback).
+2. `useEdrReadiness.ts` with Huntress wired; unit tests.
+3. `BuiltinPackageDetail.tsx` (readiness panel + guided CTA); tests.
+4. `SoftwareCatalog.tsx` — brand mark + pill on cards, delegate built-in detail
+   body, preselect deploy; update tests.
+5. `DeploymentWizard.tsx` — accept preselected package + built-in context line.
+6. SentinelOne readiness wiring (installer-upload + site-token) reusing the shell.
+7. Harden pass: readiness-unknown state, empty/zero-org edge, dark theme.

--- a/e2e-tests/tests/software_deploy_ui.spec.ts
+++ b/e2e-tests/tests/software_deploy_ui.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '../fixtures';
+
+// Live verification of the single-step Add Package modal + installer URL
+// variables (PR: ToddHebebrand/software-deploy-UI). Kept as ONE test in a single
+// session — the shared storageState auth rotates, so a second test in the same
+// file would land on /login (known Breeze e2e gotcha). Queries by role/text
+// since the new components predate data-testids.
+test('Software Library: single-step Add Package modal + installer variable validation', async ({
+  authedPage,
+}) => {
+  await authedPage.goto('/software');
+  await expect(authedPage.getByRole('heading', { name: 'Software Library' })).toBeVisible();
+
+  await authedPage.getByRole('button', { name: 'Add Package' }).click();
+
+  const dialog = authedPage.getByRole('dialog');
+  await expect(dialog.getByRole('heading', { name: 'Add software package' })).toBeVisible();
+
+  // Identity + first version live in ONE modal (no create-then-versions-tab).
+  await expect(dialog.getByLabel('Name')).toBeVisible();
+  await expect(dialog.getByLabel('Version')).toBeVisible();
+  await expect(dialog.getByRole('tab', { name: 'Download URL' })).toBeVisible();
+  await expect(dialog.getByRole('tab', { name: 'Upload file' })).toBeVisible();
+  // Required first version: Create is gated until name + version + source.
+  await expect(dialog.getByRole('button', { name: 'Create package' })).toBeDisabled();
+
+  const url = dialog.getByPlaceholder('https://example.com/package-v1.0.0.msi');
+
+  // Unknown variable → warning + Create stays disabled (never ships a bad URL).
+  await dialog.getByLabel('Name').fill('Playwright Test App');
+  await dialog.getByLabel('Version').fill('1.2.3');
+  await url.fill('https://dl/{{org.bogus}}/app.msi');
+  await expect(dialog.getByText(/Unknown variable/i)).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Create package' })).toBeDisabled();
+
+  // Valid built-in variable → warning clears, Create enables.
+  await url.fill('https://dl/{{org.name}}/app.msi');
+  await expect(dialog.getByText(/Unknown variable/i)).toBeHidden();
+  await expect(dialog.getByRole('button', { name: 'Create package' })).toBeEnabled();
+
+  // The Insert-variable affordance is present on the URL field.
+  await expect(dialog.getByRole('button', { name: /Insert variable/i }).first()).toBeVisible();
+});


### PR DESCRIPTION
Two related improvements to the Software Library / deployment UX, plus a full multi-agent review pass.

## 1. Single-step Add Package + deploy-time installer variables
- **Add Package is now one modal** (`AddPackageModal`) that captures package identity **and** a required first version (URL or file upload, arch, OS, install args; advanced fields behind a disclosure). Replaces the old create-a-shell → find-the-card → Versions-tab → Add-Version journey. Both writes route through `runAction`; a partial failure keeps the created catalog id for a version-only retry, and cancelling after a partial failure surfaces the package (0 versions) instead of leaving an invisible orphan.
- **Viewport-safe modals** — detail/delete/deploy modals migrated to the shared `Dialog` (sticky header/footer, height-capped scroll body), fixing the oversized detail modal. `SoftwareVersionManager` gains an `embedded` mode that trims duplicate chrome inside the modal.
- **`{{...}}` installer variables** resolved **per target device** at deploy time (`installerVariables` service, generalizing the EDR resolver): built-ins (`{{org.name}}`, `{{site.name}}`, `{{device.hostname}}`, ids) + device custom fields. Double braces never collide with the agent's single-brace `{file}` token. An unresolved or **blank** value fails that device loudly (recorded in `deploymentResults`) rather than dispatching a literal `{{...}}`; if every device fails, the whole deploy reports `failed`. `VariableInput` provides an insert-variable menu + inline validation.
- Per-card **Deploy preselects** its package in the wizard (`initialCatalogId`).

## 2. Ready-to-deploy built-in EDR listings (Huntress / SentinelOne)
- Branded (non-logo, tinted `ShieldCheck`) cards with a **Ready / Setup-needed pill** driven by a readiness hook (`useEdrReadiness`, reusing `GET /huntress/integration` + `GET /s1/integration`).
- `BuiltinPackageDetail` shows a readiness checklist, **one guided next step**, and a Deploy CTA gated on readiness (or deferred to the server when readiness can't be proven).
- SentinelOne exposes no site-token boolean server-side, so readiness **degrades honestly** to connected + installer-uploaded rather than inventing a signal. Frontend-only; no backend/API changes for this half.

## Review
Executed via the plan in `docs/superpowers/plans/2026-07-06-builtin-edr-listing-ui.md` (TDD, per-task commits) and reviewed by a multi-agent pass (general, tests, error-handling, type-design, comments). Findings addressed: the blank-built-in-variable fail-loudly hole, the all-devices-fail status, dead EDR/partial-failure test branches, the `EdrReadiness.firstGap` redundancy, and several comment/label fixes.

**Verification:** web software+lib **59 tests**, API service/resolver **29 tests** (plus existing suites) green; `eslint` clean; `astro check` + API `tsc` **0 errors**.

Deferred follow-ups: extracting the variable vocabulary to `packages/shared` (a tripwire test guards it for now), and the `AddPackageModal` file-upload test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)