### PR TITLE
fix(agent): UniFi collector missing /api/v1 prefix leaves deep telemetry stuck on pending

### DIFF
--- a/agent/internal/unifi/collector.go
+++ b/agent/internal/unifi/collector.go
@@ -18,17 +18,21 @@ type CollectorConfig struct {
 }
 
 type CollectorDeps struct {
-	APIBaseURL string
-	AgentID    string       // this agent's id; agent telemetry endpoints live under /agents/<AgentID>/
+	APIBaseURL string       // the Breeze server root (cfg.ServerURL), e.g. https://breeze.example.com — NOT including /api/v1
+	AgentID    string       // this agent's id; agent telemetry endpoints live under /api/v1/agents/<AgentID>/
 	HTTP       *http.Client // authed transport to the Breeze API (agent token attached)
 	Logf       func(format string, args ...any)
 }
 
 // agentBase builds the per-agent endpoint prefix the API mounts under
-// (agentAuthMiddleware runs on /agents/:id/*). The device is resolved from the
-// agent token server-side; the :id in the path matches the existing agent routes.
+// (agentAuthMiddleware runs on /api/v1/agents/:id/*). The /api/v1 prefix is
+// mandatory — every other agent call (heartbeat, monitoring, commands, logs)
+// builds ServerURL + "/api/v1/agents/...", and the collector must match or the
+// API 404s the request and the collector never leaves status=pending (#2263).
+// The device is resolved from the agent token server-side; the :id in the path
+// matches the existing agent routes.
 func (d CollectorDeps) agentBase() string {
-	return d.APIBaseURL + "/agents/" + d.AgentID
+	return d.APIBaseURL + "/api/v1/agents/" + d.AgentID
 }
 
 func (d CollectorDeps) logf(format string, args ...any) {
@@ -156,7 +160,7 @@ func RunOnce(ctx context.Context, deps CollectorDeps, cfg CollectorConfig, contr
 }
 
 // StartCollectorLoop periodically fetches this agent's collector configs from
-// GET /agents/:id/unifi-collectors and runs each due collector. It spawns its
+// GET /api/v1/agents/:id/unifi-collectors and runs each due collector. It spawns its
 // own goroutine and returns a channel that closes once the loop has exited
 // (after ctx is cancelled), so shutdownAgent can wait for a clean teardown
 // instead of leaking the loop across in-process restarts.

--- a/agent/internal/unifi/collector_test.go
+++ b/agent/internal/unifi/collector_test.go
@@ -28,8 +28,10 @@ func TestRunOnceUploadsTelemetry(t *testing.T) {
 	var got map[string]any
 	var gotPath string
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Agent telemetry endpoints are mounted under /agents/<agentId>/.
-		if r.URL.Path == "/agents/agent-1/unifi-telemetry" {
+		// Agent telemetry endpoints are mounted under /api/v1/agents/<agentId>/ —
+		// the /api/v1 prefix is mandatory (matches heartbeat & every other agent
+		// call); dropping it 404s and pins the collector at status=pending.
+		if r.URL.Path == "/api/v1/agents/agent-1/unifi-telemetry" {
 			mu.Lock()
 			defer mu.Unlock()
 			gotPath = r.URL.Path
@@ -48,7 +50,7 @@ func TestRunOnceUploadsTelemetry(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if gotPath != "/agents/agent-1/unifi-telemetry" {
+	if gotPath != "/api/v1/agents/agent-1/unifi-telemetry" {
 		t.Fatalf("telemetry posted to unexpected path: %q", gotPath)
 	}
 	if got["collectorId"] != "c1" || got["firmwareOk"] != true {
@@ -79,7 +81,7 @@ func TestRunOnceUploadsSites(t *testing.T) {
 	var mu sync.Mutex
 	var got map[string]any
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/agents/agent-1/unifi-telemetry" {
+		if r.URL.Path == "/api/v1/agents/agent-1/unifi-telemetry" {
 			mu.Lock()
 			defer mu.Unlock()
 			_ = json.NewDecoder(r.Body).Decode(&got)
@@ -107,13 +109,14 @@ func TestRunOnceUploadsSites(t *testing.T) {
 	}
 }
 
-// fetchConfigs must GET the agent-scoped path /agents/<id>/unifi-collectors, not
-// the bare /agent/unifi-collectors (which 404s and never returns configs — C3).
+// fetchConfigs must GET the agent-scoped path /api/v1/agents/<id>/unifi-collectors.
+// Dropping the /api/v1 prefix (as the loop did before the fix) 404s and never
+// returns configs, so the collector stays status=pending forever — C3.
 func TestFetchConfigsHitsAgentScopedPath(t *testing.T) {
 	var gotPath string
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		if r.URL.Path == "/agents/agent-1/unifi-collectors" {
+		if r.URL.Path == "/api/v1/agents/agent-1/unifi-collectors" {
 			w.Write([]byte(`{"collectors":[{"collectorId":"c1","controllerUrl":"https://10.0.0.1","apiKey":"k","pollIntervalSeconds":60}]}`))
 			return
 		}
@@ -125,7 +128,7 @@ func TestFetchConfigsHitsAgentScopedPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetchConfigs: %v", err)
 	}
-	if gotPath != "/agents/agent-1/unifi-collectors" {
+	if gotPath != "/api/v1/agents/agent-1/unifi-collectors" {
 		t.Fatalf("fetchConfigs hit unexpected path: %q", gotPath)
 	}
 	if len(configs) != 1 || configs[0].CollectorID != "c1" {


### PR DESCRIPTION
## Problem

Reported by **SemoTech** on self-hosted v0.92.0: UniFi deep telemetry collector saves fine (`unifi_collectors` row created, `status=pending`, `is_enabled=true`, `last_poll_at` null) but never transitions `pending → connected`. Agent log repeats every ~30s:

```
[unifi] fetch configs: fetch configs: status 404
```

## Root cause

`agent/internal/unifi/collector.go` built agent API URLs without the `/api/v1` prefix:

```go
func (d CollectorDeps) agentBase() string {
    return d.APIBaseURL + "/agents/" + d.AgentID   // ← missing /api/v1
}
```

`main.go` passes `APIBaseURL: cfg.ServerURL`, so both collector calls hit `{server}/agents/{id}/unifi-collectors` and `.../unifi-telemetry` → **404**. Heartbeat and *every* other agent call build `ServerURL + "/api/v1/agents/%s/..."` (e.g. `heartbeat.go`), and the server mounts the route at `/api/v1/agents/:id/unifi-collectors`. The collector was the lone exception.

Impact: collector never leaves `pending`, no telemetry upload, no `last_poll_at`. Cloud inventory/sync unaffected.

## Fix

Centralize the prefix in `agentBase()` so it builds `ServerURL + "/api/v1/agents/<id>"`, matching heartbeat. `main.go` keeps passing `cfg.ServerURL` (symmetric with every other subsystem).

## Why it shipped: tests were vacuously green

The existing `collector_test.go` pointed `APIBaseURL` at a bare `httptest` root and asserted `/agents/...`, so it never exercised the `/api/v1` prefix. Hardened all three tests to assert the real `/api/v1/agents/...` path. They now **fail with the reported `status 404`** against the old code and pass with the fix — a genuine regression guard.

## Verification

- `go test -race ./internal/unifi/` — pass
- Reverted `collector.go`, reran tests → fail with `telemetry upload: status 404` / `fetch configs: status 404` (reproduces the field symptom)
- `go vet ./internal/unifi/` clean, `go build ./...` clean

Agent-only change; no API / DB / RLS surface.

Refs SemoTech report (self-hosted v0.92.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)