### PR TITLE
fix(deps): dedup broken pnpm-lock (hono duplicated by #2236 merge)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6792,10 +6792,6 @@ packages:
     resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.28:
-    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -17216,8 +17212,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.12.28: {}
 
   hono@4.12.28: {}
 


### PR DESCRIPTION
Fix-forward for red main. Admin-merging dependabot #2236 3-way-merged the root `pnpm-lock.yaml` and duplicated the `hono@4.12.28` block in both the `packages:` and `snapshots:` sections, so `pnpm install --frozen-lockfile` failed with `ERR_PNPM_BROKEN_LOCKFILE` (duplicated mapping key 6795:3) — reddening every JS CI job at the Install step (Lint, Test API/Web/Portal, all Office add-ins, Type Check, Check Migrations, Security Audit).

Surgically removed the two duplicate blocks. Verified locally: `pnpm install --frozen-lockfile` exits 0 and leaves the lockfile byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)