### PR TITLE
fix(software): custom-field variables never load — clamp picker fetch to limit=100 (#2276)

### DIFF
--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -75,7 +75,7 @@ export default function AddPackageModal({ open, onClose, onCreated }: AddPackage
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetchWithAuth('/custom-fields?limit=200');
+        const res = await fetchWithAuth('/custom-fields?limit=100');
         if (!res.ok || cancelled) return;
         const payload = await res.json();
         const rows = payload.data ?? payload ?? [];

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -146,7 +146,7 @@ export default function SoftwareVersionManager({ timezone, catalogId: propCatalo
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetchWithAuth('/custom-fields?limit=200');
+        const res = await fetchWithAuth('/custom-fields?limit=100');
         if (!res.ok || cancelled) return;
         const payload = await res.json();
         const rows = payload.data ?? payload ?? [];


### PR DESCRIPTION
## Summary

Found during the pre-release UI QA sweep of the post-`v0.92.0` delta (feature #2260, single-step Add Package + installer URL variables).

The Software **"Insert variable"** picker never loaded partner/org **custom-field** variables. Both callers fetched `/custom-fields?limit=200`, but the route caps `limit` at `100` (`apps/api/src/routes/customFields.ts:51` → `z.coerce.number().int().positive().max(100)`), so every request returned **400**. The fetch is `try/catch`-guarded, so it failed **silently**: built-in tokens (`{{org.name}}`, `{{site.name}}`, `{{device.hostname}}`) still populated, but custom fields never appeared — despite the modal advertising deploy-time variable substitution — and a `400` logged to console on every modal open / version-manager mount.

## Fix

Clamp both callers to the route's max (`limit=100`):
- `apps/web/src/components/software/AddPackageModal.tsx`
- `apps/web/src/components/software/SoftwareVersionManager.tsx`

Contained, matches the existing route contract, no API/schema change.

## Verification

- ✅ Live (wt-stack): opening Add Package now issues `GET /custom-fields?limit=100 → 200 OK`; **0 console errors** (previously a `400`).
- ✅ `AddPackageModal.test.tsx` passes (mock is prefix-matched on `/custom-fields`, so no test change needed).

Closes #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)