### PR TITLE
feat(quotes): add a line-item image from a URL (parity with image blocks)

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
-import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
-import { addBlock, addQuoteImageFromUrl } from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock, QuoteLine } from './quoteTypes';
+import { addBlock, addQuoteImageFromUrl, updateLine } from '../../../lib/api/quotes';
 
 vi.mock('../../../stores/auth', () => ({
   fetchWithAuth: vi.fn().mockResolvedValue(
@@ -62,6 +62,21 @@ const detail: QuoteDetailData = {
 
 const addBlockMock = vi.mocked(addBlock);
 const fromUrlMock = vi.mocked(addQuoteImageFromUrl);
+const updateLineMock = vi.mocked(updateLine);
+
+// A pricing table + one manual line, so the per-line image controls render.
+const lineBlock: QuoteBlock = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const manualLine: QuoteLine = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, imageId: null, parentLineId: null, unitCost: null, sku: null,
+  partNumber: null, name: 'Widget', description: null, quantity: '1', unitPrice: '10.00',
+  taxable: true, customerVisible: true, lineTotal: '10.00', recurrence: 'one_time',
+  termMonths: null, billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+const detailWithLine: QuoteDetailData = { ...detail, blocks: [lineBlock], lines: [manualLine] };
 
 async function openImageUrlPanel() {
   render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
@@ -117,5 +132,67 @@ describe('QuoteEditor — add image from URL', () => {
 
     expect(screen.queryByTestId('quote-block-image-url')).not.toBeInTheDocument();
     expect(screen.getByTestId('quote-block-image-file')).toBeInTheDocument();
+  });
+});
+
+describe('QuoteEditor — add line image from URL', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  async function renderWithLine() {
+    render(<QuoteEditor detail={detailWithLine} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-line-line-1')).toBeInTheDocument());
+  }
+
+  it('the URL field is hidden until "From URL" is clicked', async () => {
+    await renderWithLine();
+    expect(screen.queryByTestId('quote-line-image-url-input-line-1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    expect(screen.getByTestId('quote-line-image-url-input-line-1')).toBeInTheDocument();
+  });
+
+  it('fetching a URL copies the image then PATCHes the line with the returned id', async () => {
+    fromUrlMock.mockResolvedValue(okRes({ imageId: 'img-9' }));
+    updateLineMock.mockResolvedValue(okRes({}));
+    await renderWithLine();
+
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    fireEvent.change(screen.getByTestId('quote-line-image-url-input-line-1'), { target: { value: 'https://cdn.example.com/w.png' } });
+    fireEvent.click(screen.getByTestId('quote-line-image-url-fetch-line-1'));
+
+    await waitFor(() => expect(fromUrlMock).toHaveBeenCalledWith('q-1', 'https://cdn.example.com/w.png'));
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { imageId: 'img-9' }));
+    // Success collapses the disclosure back to hidden.
+    await waitFor(() => expect(screen.queryByTestId('quote-line-image-url-input-line-1')).not.toBeInTheDocument());
+  });
+
+  it('Fetch is disabled until a URL is entered', async () => {
+    await renderWithLine();
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    expect(screen.getByTestId('quote-line-image-url-fetch-line-1')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('quote-line-image-url-input-line-1'), { target: { value: 'https://x/y.png' } });
+    expect(screen.getByTestId('quote-line-image-url-fetch-line-1')).toBeEnabled();
+  });
+
+  it('a failed fetch shows an error toast and does not PATCH the line', async () => {
+    fromUrlMock.mockResolvedValue(errRes());
+    await renderWithLine();
+
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    fireEvent.change(screen.getByTestId('quote-line-image-url-input-line-1'), { target: { value: 'https://internal/w.png' } });
+    fireEvent.click(screen.getByTestId('quote-line-image-url-fetch-line-1'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ message: 'x', type: 'error' })));
+    expect(updateLineMock).not.toHaveBeenCalled();
+  });
+
+  it('Cancel closes the disclosure and clears the draft', async () => {
+    await renderWithLine();
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    fireEvent.change(screen.getByTestId('quote-line-image-url-input-line-1'), { target: { value: 'https://x/y.png' } });
+    fireEvent.click(screen.getByTestId('quote-line-image-url-cancel-line-1'));
+    expect(screen.queryByTestId('quote-line-image-url-input-line-1')).not.toBeInTheDocument();
+    // Reopening shows an empty field, not the abandoned draft.
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    expect(screen.getByTestId('quote-line-image-url-input-line-1')).toHaveValue('');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.imageurl.test.tsx
@@ -173,7 +173,7 @@ describe('QuoteEditor — add line image from URL', () => {
     expect(screen.getByTestId('quote-line-image-url-fetch-line-1')).toBeEnabled();
   });
 
-  it('a failed fetch shows an error toast and does not PATCH the line', async () => {
+  it('a failed fetch toasts, does not PATCH, and keeps the URL open for retry', async () => {
     fromUrlMock.mockResolvedValue(errRes());
     await renderWithLine();
 
@@ -183,6 +183,25 @@ describe('QuoteEditor — add line image from URL', () => {
 
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ message: 'x', type: 'error' })));
     expect(updateLineMock).not.toHaveBeenCalled();
+    // Retry affordance: the disclosure stays open with the URL intact.
+    expect(screen.getByTestId('quote-line-image-url-input-line-1')).toHaveValue('https://internal/w.png');
+  });
+
+  it('a fetch that succeeds but a failed line PATCH keeps the URL open for retry', async () => {
+    // The remote copy lands an imageId, but the follow-up line PATCH fails: the
+    // error toast must NOT be contradicted by the panel collapsing as if saved.
+    fromUrlMock.mockResolvedValue(okRes({ imageId: 'img-9' }));
+    updateLineMock.mockResolvedValue(errRes());
+    await renderWithLine();
+
+    fireEvent.click(screen.getByTestId('quote-line-image-url-toggle-line-1'));
+    fireEvent.change(screen.getByTestId('quote-line-image-url-input-line-1'), { target: { value: 'https://cdn.example.com/w.png' } });
+    fireEvent.click(screen.getByTestId('quote-line-image-url-fetch-line-1'));
+
+    await waitFor(() => expect(updateLineMock).toHaveBeenCalledWith('q-1', 'line-1', { imageId: 'img-9' }));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    // Disclosure stays open with the URL intact so the user can retry the save.
+    expect(screen.getByTestId('quote-line-image-url-input-line-1')).toHaveValue('https://cdn.example.com/w.png');
   });
 
   it('Cancel closes the disclosure and clears the draft', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -2296,11 +2296,24 @@ function EditableLineRow({
     return ok;
   }, [onEdit, line.id, flashSaved]);
 
-  // Per-line product image: upload to quote_images, then PATCH the line's
+  // Per-line product image: resolve an imageId from an uploaded file OR a pasted
+  // URL (the server copies the bytes in — not a hotlink), then PATCH the line's
   // imageId. Local busy (not the pending map) because the upload itself runs
-  // before any line mutation exists to scope.
+  // before any line mutation exists to scope. The URL path is a disclosure — a
+  // "From URL" button reveals `imageUrlOpen`'s inline field — rather than a
+  // per-row tab toggle, which would bloat every line; the add-block form (which
+  // has room) uses tabs instead.
   const imageInputRef = useRef<HTMLInputElement>(null);
   const [imageBusy, setImageBusy] = useState(false);
+  const [imageUrlOpen, setImageUrlOpen] = useState(false);
+  const [imageUrlDraft, setImageUrlDraft] = useState('');
+  // Attach `uploaded.imageId` to the line and reset the URL disclosure. Shared by
+  // both the file and URL paths so success behaves identically.
+  const applyImageId = useCallback(async (imageId: string) => {
+    await edit({ imageId }, 'image');
+    setImageUrlDraft('');
+    setImageUrlOpen(false);
+  }, [edit]);
   const attachImage = useCallback((file: File) => {
     if (file.size > 5 * 1024 * 1024) {
       handleActionError(new Error('image too large'), 'Image must be 5MB or smaller.');
@@ -2315,14 +2328,37 @@ function EditableLineRow({
           onUnauthorized: UNAUTHORIZED,
           parseSuccess: (d) => (d as { data: { imageId: string } }).data,
         });
-        await edit({ imageId: uploaded.imageId }, 'image');
+        await applyImageId(uploaded.imageId);
       } catch {
         // runAction already surfaced the failure (toast/redirect).
       } finally {
         setImageBusy(false);
       }
     })();
-  }, [quoteId, edit]);
+  }, [quoteId, applyImageId]);
+  // URL path: the server fetches + copies the remote bytes (SSRF-guarded, 5 MB
+  // cap enforced server-side — unlike the file path there's no local size check
+  // because the bytes aren't in hand here). Mirrors the image block's URL flow.
+  const attachImageFromUrl = useCallback(() => {
+    const url = imageUrlDraft.trim();
+    if (!url) return;
+    void (async () => {
+      setImageBusy(true);
+      try {
+        const uploaded = await runAction<{ imageId: string }>({
+          request: () => addQuoteImageFromUrl(quoteId, url),
+          errorFallback: 'Could not fetch the image from that URL.',
+          onUnauthorized: UNAUTHORIZED,
+          parseSuccess: (d) => (d as { data: { imageId: string } }).data,
+        });
+        await applyImageId(uploaded.imageId);
+      } catch {
+        // runAction already surfaced the failure (toast/redirect).
+      } finally {
+        setImageBusy(false);
+      }
+    })();
+  }, [quoteId, imageUrlDraft, applyImageId]);
   // Per-field dirty cue (mirrors the terms/tax ring) so every editable surface
   // signals unsaved state the same way.
   const nameDirty = name.trim() !== (line.name ?? '');
@@ -2695,6 +2731,16 @@ function EditableLineRow({
             {imageBusy && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
             {imageBusy ? 'Uploading…' : line.imageId ? 'Replace image' : 'Add image'}
           </button>
+          <button
+            type="button"
+            onClick={() => setImageUrlOpen((v) => !v)}
+            disabled={imageBusy || fieldBusy('image')}
+            aria-expanded={imageUrlOpen}
+            data-testid={`quote-line-image-url-toggle-${line.id}`}
+            className="inline-flex h-8 items-center rounded-md border px-2 text-xs font-medium hover:bg-muted disabled:opacity-50"
+          >
+            From URL
+          </button>
           {line.imageId && !imageBusy && (
             <button
               type="button"
@@ -2705,6 +2751,41 @@ function EditableLineRow({
             >
               Remove image
             </button>
+          )}
+          {/* URL disclosure: wraps to its own row (basis-full) so the input has
+              room. Server copies the bytes in (SSRF-guarded); Fetch is disabled
+              until a URL is entered, matching the image block's submit gate. */}
+          {imageUrlOpen && (
+            <div className="flex w-full items-center gap-2">
+              <input
+                type="url"
+                value={imageUrlDraft}
+                onChange={(e) => setImageUrlDraft(e.target.value)}
+                placeholder="https://example.com/photo.png"
+                disabled={imageBusy}
+                aria-label="Image URL"
+                data-testid={`quote-line-image-url-input-${line.id}`}
+                className="h-8 min-w-0 flex-1 rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+              />
+              <button
+                type="button"
+                onClick={attachImageFromUrl}
+                disabled={imageBusy || fieldBusy('image') || !imageUrlDraft.trim()}
+                data-testid={`quote-line-image-url-fetch-${line.id}`}
+                className="inline-flex h-8 items-center rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                Fetch
+              </button>
+              <button
+                type="button"
+                onClick={() => { setImageUrlOpen(false); setImageUrlDraft(''); }}
+                disabled={imageBusy}
+                data-testid={`quote-line-image-url-cancel-${line.id}`}
+                className="inline-flex h-8 items-center rounded-md border px-2 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
           )}
         </div>
       </td>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -2307,16 +2307,21 @@ function EditableLineRow({
   const [imageBusy, setImageBusy] = useState(false);
   const [imageUrlOpen, setImageUrlOpen] = useState(false);
   const [imageUrlDraft, setImageUrlDraft] = useState('');
-  // Attach `uploaded.imageId` to the line and reset the URL disclosure. Shared by
-  // both the file and URL paths so success behaves identically.
+  // Attach `uploaded.imageId` to the line, and only on a successful PATCH reset the
+  // URL disclosure. Shared by both the file and URL paths so success behaves
+  // identically. `edit` swallows a failed PATCH inside runScoped (toasts, returns
+  // false, never throws), so gating the reset on its result keeps the disclosure
+  // open with the URL intact on failure — otherwise the panel would collapse and
+  // wipe the URL exactly as if it had saved, contradicting the error toast.
   const applyImageId = useCallback(async (imageId: string) => {
-    await edit({ imageId }, 'image');
-    setImageUrlDraft('');
-    setImageUrlOpen(false);
+    if (await edit({ imageId }, 'image')) {
+      setImageUrlDraft('');
+      setImageUrlOpen(false);
+    }
   }, [edit]);
   const attachImage = useCallback((file: File) => {
     if (file.size > 5 * 1024 * 1024) {
-      handleActionError(new Error('image too large'), 'Image must be 5MB or smaller.');
+      handleActionError(new Error('image too large'), 'Image must be 5 MB or smaller.');
       return;
     }
     void (async () => {
@@ -2752,9 +2757,10 @@ function EditableLineRow({
               Remove image
             </button>
           )}
-          {/* URL disclosure: wraps to its own row (basis-full) so the input has
-              room. Server copies the bytes in (SSRF-guarded); Fetch is disabled
-              until a URL is entered, matching the image block's submit gate. */}
+          {/* URL disclosure: w-full forces it onto its own row under the parent's
+              flex-wrap so the input has room. Server copies the bytes in
+              (SSRF-guarded); Fetch is disabled until a URL is entered, matching
+              the image block's submit gate. */}
           {imageUrlOpen && (
             <div className="flex w-full items-center gap-2">
               <input

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.test.tsx
@@ -18,6 +18,9 @@ vi.mock('../../lib/api/catalog', async (importActual) => {
     createCatalogItem: vi.fn(),
     updateCatalogItem: vi.fn(),
     setBundleComponents: vi.fn(),
+    uploadCatalogItemImage: vi.fn(),
+    importCatalogItemImageFromUrl: vi.fn(),
+    deleteCatalogItemImageRequest: vi.fn(),
   };
 });
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
@@ -201,5 +204,60 @@ describe('CatalogItemEditorDrawer — detail load failure (#1944)', () => {
     expect(bundleMock).toHaveBeenCalledWith('item-1', [
       { componentItemId: 'c-1', quantity: 2, showOnInvoice: false },
     ]);
+  });
+});
+
+// Product image "Import from URL" — the server downloads + validates the remote
+// bytes (SSRF-guarded, 5 MB cap), so the client just posts the URL. Mirrors the
+// quote line/image-block URL source.
+describe('CatalogItemEditorDrawer — product image from URL', () => {
+  const importUrlMock = vi.mocked(catalogApi.importCatalogItemImageFromUrl);
+  const toastMock = vi.mocked(showToast);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    claimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    getMock.mockResolvedValue(json({ data: { item: item(), components: [], overrides: [] } }));
+  });
+
+  const renderDrawer = () =>
+    render(<CatalogItemEditorDrawer open item={item()} allItems={[]} onClose={vi.fn()} onSaved={vi.fn()} />);
+
+  it('posts the URL to the import endpoint and reports success', async () => {
+    importUrlMock.mockResolvedValue(json({ data: { imageId: 'img-1' } }));
+    renderDrawer();
+    await screen.findByTestId('catalog-form-image-url');
+
+    fireEvent.change(screen.getByTestId('catalog-form-image-url'), { target: { value: 'https://cdn.example.com/p.png' } });
+    fireEvent.click(screen.getByTestId('catalog-form-image-url-btn'));
+
+    await waitFor(() => expect(importUrlMock).toHaveBeenCalledWith('item-1', 'https://cdn.example.com/p.png'));
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ message: 'Image imported' })));
+  });
+
+  it('disables Import from URL until a URL is entered', async () => {
+    renderDrawer();
+    await screen.findByTestId('catalog-form-image-url-btn');
+    expect(screen.getByTestId('catalog-form-image-url-btn')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('catalog-form-image-url'), { target: { value: 'https://x/y.png' } });
+    expect(screen.getByTestId('catalog-form-image-url-btn')).toBeEnabled();
+  });
+
+  it('a failed import toasts an error', async () => {
+    importUrlMock.mockResolvedValue(json(null, false));
+    renderDrawer();
+    await screen.findByTestId('catalog-form-image-url');
+
+    fireEvent.change(screen.getByTestId('catalog-form-image-url'), { target: { value: 'https://internal/p.png' } });
+    fireEvent.click(screen.getByTestId('catalog-form-image-url-btn'));
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+  });
+
+  it('hides the image controls for a new (unsaved) item until it is saved', async () => {
+    render(<CatalogItemEditorDrawer open item={null} allItems={[]} onClose={vi.fn()} onSaved={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('catalog-item-editor')).toBeInTheDocument());
+    expect(screen.queryByTestId('catalog-form-image-url')).not.toBeInTheDocument();
+    expect(screen.getByTestId('catalog-form-image-hint')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

The URL image source shipped in #2264 for quote **image blocks** (the add-block form got a "Upload file / From URL" tab toggle), but the **per-line item image** control in `EditableLineRow` was still file-upload only. This adds a URL path there too, and backfills test coverage for the equivalent catalog-item feature.

## Changes

- **Quote line items** (`QuoteEditor.tsx`): added a **"From URL"** disclosure next to "Add image / Replace image" — a toggle reveals an inline URL field with **Fetch** / **Cancel**. It reuses `addQuoteImageFromUrl` (server copies the remote bytes — SSRF-guarded, 5 MB cap enforced server-side) and PATCHes the line's `imageId`. Both the file and URL paths funnel through a shared `applyImageId` helper.
  - A disclosure (not a per-row tab strip like the add-block form) keeps the compact line row uncluttered — only the add-block form, which has room, uses tabs.
- **Catalog items**: the item editor **already** supports "Import from URL" (`importCatalogItemImageFromUrl`), but it had no test coverage. Added tests for the happy path, the empty-URL disabled gate, the error toast, and the unsaved-item hint. No production change here.

## Review fixes folded in

A PR-review pass (silent-failure + test agents) caught that `applyImageId` reset the URL panel unconditionally — so when the remote copy succeeded but the follow-up line PATCH failed, the panel collapsed as if it had saved, contradicting the error toast and wiping the typed URL. The reset is now gated on the PATCH's success boolean; on failure the disclosure stays open with the URL intact for a one-click retry. Covered by a regression test.

## Tests

- `QuoteEditor.imageurl.test.tsx`: +6 line-item URL tests (happy path, disabled gate, fetch-failure retry, PATCH-failure retry, hidden-until-toggled, Cancel clears).
- `CatalogItemEditorDrawer.test.tsx`: +4 catalog URL-import tests.
- 26/26 pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)