### PR TITLE
fix(software): scope catalog package delete to the item's own org

### DIFF
--- a/apps/web/src/components/software/SoftwareCatalog.test.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.test.tsx
@@ -33,6 +33,7 @@ const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Res
 
 const ITEM = {
   id: 'cat-1',
+  orgId: 'org-1',
   name: 'TestApp',
   vendor: 'Acme',
   category: 'utility',
@@ -66,13 +67,43 @@ describe('SoftwareCatalog delete', () => {
     const confirmButtons = screen.getAllByRole('button', { name: /^Delete$/ });
     fireEvent.click(confirmButtons[confirmButtons.length - 1]);
 
+    // The item's own orgId must ride on the DELETE so a partner/system user in
+    // "All organizations" mode (no ambient orgId injected by fetchWithAuth) can
+    // still resolve which org's package to remove — otherwise the API answers
+    // "orgId is required for this scope" (resolveScopedOrgId).
     await waitFor(() =>
-      expect(fetchMock).toHaveBeenLastCalledWith('/software/catalog/cat-1', { method: 'DELETE' })
+      expect(fetchMock).toHaveBeenLastCalledWith('/software/catalog/cat-1?orgId=org-1', { method: 'DELETE' })
     );
 
     // Success toast + item removed from the grid.
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
     await waitFor(() => expect(screen.queryByText('TestApp')).not.toBeInTheDocument());
+  });
+
+  it('deletes an org-less (partner-scoped) package with no orgId query param', async () => {
+    // A package the loader mapped with no orgId (DB org_id NULL) must DELETE to
+    // the bare URL — appending ?orgId=undefined would break the request. Guards
+    // against collapsing the conditional into an unconditional template.
+    const { orgId, ...orgLessItem } = ITEM;
+    void orgId;
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: [orgLessItem] })) // GET /software/catalog
+      .mockResolvedValueOnce(jsonResponse({ success: true, id: ITEM.id })); // DELETE
+
+    render(<SoftwareCatalog />);
+    await waitFor(() => expect(screen.getByText('TestApp')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('TestApp'));
+    const deleteButtons = await screen.findAllByRole('button', { name: /Delete/ });
+    fireEvent.click(deleteButtons[0]);
+    expect(await screen.findByText('Delete package?')).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole('button', { name: /^Delete$/ });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenLastCalledWith('/software/catalog/cat-1', { method: 'DELETE' })
+    );
   });
 
   it('does not call the API when the delete is cancelled', async () => {

--- a/apps/web/src/components/software/SoftwareCatalog.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.tsx
@@ -21,6 +21,8 @@ import BuiltinPackageDetail from './BuiltinPackageDetail';
 
 type SoftwareItem = {
   id: string;
+  /** Owning org for an org-scoped (non-built-in) package; unset for partner-scoped built-ins. */
+  orgId?: string;
   name: string;
   vendor: string;
   category: string;
@@ -100,6 +102,7 @@ export default function SoftwareCatalog() {
       if (Array.isArray(data)) {
         setCatalogItems(data.map((item: Record<string, unknown>) => ({
           id: String(item.id),
+          orgId: item.orgId ? String(item.orgId) : undefined,
           name: String(item.name ?? ''),
           vendor: String(item.vendor ?? ''),
           category: String(item.category ?? 'utility'),
@@ -171,8 +174,15 @@ export default function SoftwareCatalog() {
   const handleDeletePackage = async (item: SoftwareItem) => {
     try {
       setDeleting(true);
+      // Scope the DELETE to the package's own org. fetchWithAuth only auto-injects
+      // an orgId when one is actively selected in the org switcher, so a
+      // partner/system user in "All organizations" mode would otherwise send no
+      // orgId and hit "orgId is required for this scope" (resolveScopedOrgId).
+      const deleteUrl = item.orgId
+        ? `/software/catalog/${item.id}?orgId=${item.orgId}`
+        : `/software/catalog/${item.id}`;
       await runAction({
-        request: () => fetchWithAuth(`/software/catalog/${item.id}`, { method: 'DELETE' }),
+        request: () => fetchWithAuth(deleteUrl, { method: 'DELETE' }),
         errorFallback: 'Failed to delete package',
         successMessage: `Deleted "${item.name}"`,
       });


### PR DESCRIPTION
## Problem

Deleting a software package from **Software → Catalog** returned `400 "orgId is required for this scope"` for partner/system users operating in **"All organizations"** mode.

## Root cause

- `SoftwareCatalog.tsx` issued `DELETE /software/catalog/:id` with **no `orgId`**.
- `fetchWithAuth` (`apps/web/src/stores/auth.ts:463-470`) only auto-injects an `orgId` when one is actively selected in the org switcher — in "All orgs" mode nothing is injected.
- The API's `DELETE /catalog/:id` calls `resolveScopedOrgId` (`apps/api/src/routes/software.ts:621`), which for a partner token with >1 accessible org and no `orgId` returns `400 "orgId is required for this scope"`.
- Listing worked because `GET /catalog` uses a different helper (`resolveCatalogListScope`) with a partner-wide branch. The GET response already includes each item's `orgId`, but the frontend was dropping it.

## Fix (frontend only)

1. Add `orgId?: string` to the `SoftwareItem` type.
2. Capture `orgId` from the catalog GET response.
3. Scope the DELETE to the package's own org: `/software/catalog/:id?orgId=<item.orgId>`. Because the URL already contains `orgId=`, `fetchWithAuth`'s auto-inject correctly leaves it alone.

Partner-scoped built-in integration packages (org_id NULL) have no delete control, so they fall through to the bare URL harmlessly.

## Tests

`SoftwareCatalog.test.tsx` — updated the existing delete test to assert `?orgId=org-1` (would have failed on old code), and added a fallback-branch test proving an org-less package deletes to the bare URL (guards against a regression to `?orgId=undefined`). Full software suite green (9/9 in this file, 50+ in the folder).

## Follow-up (not in this PR)

`SoftwareVersionManager.tsx` and `AddPackageModal.tsx` have the same latent bug (POST version upload/promote/create without `orgId`) and would fail identically in "All orgs" mode. Worth a separate tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)