### PR TITLE
feat(portal): customer portal onboarding + invite flow + Portal Users management UI

### DIFF
--- a/apps/api/migrations/2026-07-07-portal-user-invites.sql
+++ b/apps/api/migrations/2026-07-07-portal-user-invites.sql
@@ -1,0 +1,6 @@
+-- Portal customer-onboarding: invite provenance columns on portal_users.
+-- Idempotent. portal_users already has org-scoped RLS (shape 1, direct org_id);
+-- new nullable columns need no new policy. Timestamps are WITHOUT time zone to
+-- match the existing last_login_at/created_at columns (drizzle drift).
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS invited_by uuid REFERENCES users(id);
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS invited_at timestamp;

--- a/apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Real-driver integration coverage for the customer-portal invite→accept
+ * lifecycle (MSP-facing invite routes + public portal accept-invite/login),
+ * plus cross-tenant (RLS) isolation on the MSP-facing invite endpoints.
+ *
+ * Runs under vitest.integration.config.ts — connects as the unprivileged
+ * `breeze_app` role (rolbypassrls=f), so RLS is genuinely enforced. If
+ * .env.test is missing the symlink, these tests pass vacuously on a
+ * BYPASSRLS admin connection (see memory: worktree_env_test_rls_vacuous).
+ *
+ * Harness mirrored from:
+ *   apps/api/src/__tests__/integration/portal-routes-rls.integration.test.ts
+ *     (public portal app: `app.route('/portal', portalRoutes)`,
+ *      `getTestDb()` superuser seeding, real login round-trip)
+ *   apps/api/src/__tests__/integration/update-rings-partner-scope.integration.test.ts
+ *     (MSP-facing route app built directly from a route-registration
+ *      function + `authMiddleware`, `createAccessToken` mfa:true tokens for
+ *      requireMfa()-gated writes, cross-partner 404 assertions)
+ *
+ * Coverage:
+ *   1. Partner-scoped tech invites a new email → `portal_users` row with
+ *      status='invited', invited_by set (Task 6/7 route).
+ *   2. The same tech cannot list/invite portal users for an org outside
+ *      their partner — RLS hides the org row so the route 404s before any
+ *      write is attempted (no existence-oracle leak).
+ *   3. Consuming the stored invite token via POST /portal/auth/accept-invite
+ *      flips the row to status='active' with a non-null password_hash, and
+ *      a subsequent POST /portal/auth/login with that password succeeds.
+ *      The raw token is captured by calling `storePortalInviteToken()`
+ *      directly (the invite route never echoes it back — it only reaches
+ *      the invitee via `sendPortalInvite` email, which integration tests
+ *      don't have a mailbox to intercept).
+ *   4. bulk-invite must not re-invite a `status='disabled'` row (closes a
+ *      gap not covered by the mocked unit test — `bulkWhere` excludes
+ *      `disabled` rows at the SQL predicate level, which a mocked
+ *      `db.select` can't exercise).
+ */
+import './setup';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { portalUsers } from '../../db/schema';
+import { authMiddleware } from '../../middleware/auth';
+import { registerOrgPortalUsersRoutes } from '../../routes/orgPortalUsers';
+import { portalRoutes } from '../../routes/portal';
+import { storePortalInviteToken } from '../../routes/portal/helpers';
+import { createAccessToken } from '../../services/jwt';
+import { createPartner, createOrganization, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const NEW_PORTAL_PASSWORD = 'NewPortalPass456!';
+
+function buildMspApp(): Hono {
+  const app = new Hono();
+  app.use('*', authMiddleware);
+  registerOrgPortalUsersRoutes(app);
+  return app;
+}
+
+function buildPortalApp(): Hono {
+  const app = new Hono();
+  app.route('/portal', portalRoutes);
+  return app;
+}
+
+/** Mint an mfa:true token for a `setupTestEnvironment({ scope: 'partner' })`
+ *  env — the invite/bulk-invite/resend/delete/patch routes all gate on
+ *  requireMfa(). */
+async function mfaTokenFor(env: Awaited<ReturnType<typeof setupTestEnvironment>>): Promise<string> {
+  return createAccessToken({
+    sub: env.user.id,
+    email: env.user.email,
+    roleId: env.role.id,
+    orgId: null,
+    partnerId: env.partner.id,
+    scope: 'partner',
+    mfa: true,
+  });
+}
+
+async function fetchPortalUser(userId: string) {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        status: portalUsers.status,
+        passwordHash: portalUsers.passwordHash,
+        invitedBy: portalUsers.invitedBy,
+        invitedAt: portalUsers.invitedAt,
+      })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, userId))
+  );
+  return row ?? null;
+}
+
+describe('portal user invite→accept — end-to-end + tenant isolation', () => {
+  it('partner-scoped tech invites a new email → portal_users row is invited with invited_by set', async () => {
+    const envA = await setupTestEnvironment({ scope: 'partner' });
+    const mfaToken = await mfaTokenFor(envA);
+    const app = buildMspApp();
+
+    const res = await app.request(`/organizations/${envA.organization.id}/portal-users/invite`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${mfaToken}`, ...JSON_HEADERS },
+      body: JSON.stringify({ email: 'new@acme.example' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.status).toBe('invited');
+    expect(body.data.email).toBe('new@acme.example');
+
+    // The write ran through the breeze_app pool under the tech's partner-scope
+    // DB access context — read it back under system scope to prove it's a real
+    // row, not just an echoed response.
+    const row = await fetchPortalUser(body.data.id);
+    expect(row).not.toBeNull();
+    expect(row!.orgId).toBe(envA.organization.id);
+    expect(row!.status).toBe('invited');
+    expect(row!.invitedBy).toBe(envA.user.id);
+    expect(row!.invitedAt).not.toBeNull();
+    expect(row!.passwordHash).toBeNull();
+  });
+
+  it('a partner-scoped tech cannot list or invite portal users for an org outside their partner (404, RLS-hidden)', async () => {
+    const envA = await setupTestEnvironment({ scope: 'partner' });
+    const mfaToken = await mfaTokenFor(envA);
+
+    // Unrelated partner + org — envA has no membership/access to either.
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+
+    const app = buildMspApp();
+
+    const listRes = await app.request(`/organizations/${orgB.id}/portal-users`, {
+      headers: { Authorization: `Bearer ${envA.token}` },
+    });
+    expect(listRes.status).toBe(404);
+
+    const inviteRes = await app.request(`/organizations/${orgB.id}/portal-users/invite`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${mfaToken}`, ...JSON_HEADERS },
+      body: JSON.stringify({ email: 'cross-tenant@evil.example' }),
+    });
+    expect(inviteRes.status).toBe(404);
+
+    // No row was ever created for org B — the write never happened, it
+    // wasn't just hidden from the response.
+    const leaked = await withSystemDbAccessContext(() =>
+      db.select({ id: portalUsers.id }).from(portalUsers).where(eq(portalUsers.orgId, orgB.id))
+    );
+    expect(leaked).toHaveLength(0);
+  });
+
+  it('accept-invite activates the row (status=active, password_hash set) and the new password logs in', async () => {
+    const envA = await setupTestEnvironment({ scope: 'partner' });
+    const mfaToken = await mfaTokenFor(envA);
+    const mspApp = buildMspApp();
+
+    const inviteRes = await mspApp.request(`/organizations/${envA.organization.id}/portal-users/invite`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${mfaToken}`, ...JSON_HEADERS },
+      body: JSON.stringify({ email: 'accept-me@acme.example' }),
+    });
+    expect(inviteRes.status).toBe(200);
+    const invited = await inviteRes.json();
+    const portalUserId = invited.data.id as string;
+
+    // The invite route never echoes the raw token (it's only delivered via
+    // sendPortalInvite email, which this harness has no mailbox to
+    // intercept). Mint a fresh one directly against the same in-memory
+    // token store the route itself uses (PORTAL_USE_REDIS is false under
+    // NODE_ENV=test) — this is the sanctioned escape hatch for exercising
+    // accept-invite without a real email transport.
+    const rawToken = await storePortalInviteToken(portalUserId);
+    expect(rawToken).toBeTruthy();
+
+    const portalApp = buildPortalApp();
+    const acceptRes = await portalApp.request('/portal/auth/accept-invite', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ token: rawToken, password: NEW_PORTAL_PASSWORD }),
+    });
+    expect(acceptRes.status).toBe(200);
+    const acceptBody = await acceptRes.json();
+    expect(acceptBody.accessToken).toBeTruthy();
+    expect(acceptBody.user.email).toBe('accept-me@acme.example');
+
+    const row = await fetchPortalUser(portalUserId);
+    expect(row!.status).toBe('active');
+    expect(row!.passwordHash).not.toBeNull();
+
+    const loginRes = await portalApp.request('/portal/auth/login', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ email: 'accept-me@acme.example', password: NEW_PORTAL_PASSWORD, orgId: envA.organization.id }),
+    });
+    expect(loginRes.status).toBe(200);
+    const loginBody = await loginRes.json();
+    expect(loginBody.accessToken).toBeTruthy();
+  });
+
+  it('bulk-invite skips a disabled portal_users row but re-invites a pending one', async () => {
+    const envA = await setupTestEnvironment({ scope: 'partner' });
+    const mfaToken = await mfaTokenFor(envA);
+    const admin = getTestDb();
+
+    // Disabled, password-less row — must NOT be flipped back to 'invited'.
+    const [disabledUser] = await admin
+      .insert(portalUsers)
+      .values({
+        orgId: envA.organization.id,
+        email: 'disabled@acme.example',
+        passwordHash: null,
+        status: 'disabled',
+      })
+      .returning();
+
+    // Already-pending row with no password — bulk-invite's candidate set,
+    // should get re-invited (invitedBy/invitedAt refreshed).
+    const [pendingUser] = await admin
+      .insert(portalUsers)
+      .values({
+        orgId: envA.organization.id,
+        email: 'pending@acme.example',
+        passwordHash: null,
+        status: 'invited',
+      })
+      .returning();
+
+    const app = buildMspApp();
+    const res = await app.request(`/organizations/${envA.organization.id}/portal-users/bulk-invite`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${mfaToken}`, ...JSON_HEADERS },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const invitedIds = body.data.map((r: { id: string }) => r.id);
+    expect(invitedIds).toContain(pendingUser!.id);
+    expect(invitedIds).not.toContain(disabledUser!.id);
+
+    const disabledRow = await fetchPortalUser(disabledUser!.id);
+    expect(disabledRow!.status).toBe('disabled');
+    expect(disabledRow!.invitedBy).toBeNull();
+
+    const pendingRow = await fetchPortalUser(pendingUser!.id);
+    expect(pendingRow!.status).toBe('invited');
+    expect(pendingRow!.invitedBy).toBe(envA.user.id);
+    expect(pendingRow!.invitedAt).not.toBeNull();
+  });
+});

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -49,6 +49,8 @@ export const portalUsers = pgTable('portal_users', {
   receiveNotifications: boolean('receive_notifications').notNull().default(true),
   lastLoginAt: timestamp('last_login_at'),
   status: varchar('status', { length: 20 }).notNull().default('active'),
+  invitedBy: uuid('invited_by').references(() => users.id),
+  invitedAt: timestamp('invited_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });

--- a/apps/api/src/routes/orgPortalUsers.test.ts
+++ b/apps/api/src/routes/orgPortalUsers.test.ts
@@ -99,6 +99,15 @@ describe('POST /organizations/:id/portal-users/invite', () => {
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();
   });
+
+  it('409s when the existing row is disabled — disable is terminal, must not resurrect via invite', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'disabled@acme.example', passwordHash: 'h', status: 'disabled' }]);
+    const res = await invite({ email: 'disabled@acme.example' });
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
 });
 
 describe('PATCH /organizations/:id/portal-users/:userId', () => {
@@ -131,6 +140,15 @@ describe('POST /organizations/:id/portal-users/:userId/resend-invite', () => {
     selectResult
       .mockResolvedValueOnce([{ id: ORG_ID }]) // org
       .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'live@acme.example', name: null, passwordHash: 'h', status: 'active' }]); // target
+    const res = await resend('pu-1');
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+
+  it('409s when the target is disabled — disable is terminal, must not resurrect via resend', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'disabled@acme.example', name: null, passwordHash: 'h', status: 'disabled' }]); // target
     const res = await resend('pu-1');
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();

--- a/apps/api/src/routes/orgPortalUsers.test.ts
+++ b/apps/api/src/routes/orgPortalUsers.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectResult, insertReturning, sendInvite } = vi.hoisted(() => ({
+  authRef: { current: { scope: 'partner' as string, user: { id: 'u-1', name: 'Tess', email: 'tess@msp.example' }, partnerId: 'p-1' as string | null, canAccessOrg: (_id: string) => true } },
+  selectResult: vi.fn(),
+  insertReturning: vi.fn(),
+  sendInvite: vi.fn()
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => { c.set('auth', authRef.current); await next(); }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next()
+}));
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => selectResult()), orderBy: vi.fn(() => selectResult()) })) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })) }))
+  }
+}));
+vi.mock('../db/schema', () => ({
+  portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status', invitedBy: 'invitedBy', invitedAt: 'invitedAt', lastLoginAt: 'lastLoginAt', createdAt: 'createdAt' },
+  organizations: { id: 'id', name: 'name', deletedAt: 'deletedAt' }
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../routes/portal/helpers', () => ({ storePortalInviteToken: vi.fn(async () => 'raw-token'), buildPortalUrl: (p: string) => `https://x/portal${p}` }));
+vi.mock('../services/email', () => ({ getEmailService: () => ({ sendPortalInvite: sendInvite }) }));
+
+import { authMiddleware } from '../middleware/auth';
+import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const makeApp = () => { const app = new Hono(); app.use('*', authMiddleware as any); registerOrgPortalUsersRoutes(app); return app; };
+beforeEach(() => { vi.clearAllMocks(); authRef.current = { scope: 'partner', user: { id: 'u-1', name: 'Tess', email: 'tess@msp.example' }, partnerId: 'p-1', canAccessOrg: () => true }; });
+
+describe('GET /organizations/:id/portal-users', () => {
+  it('lists users with an effective status', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org existence
+      .mockResolvedValueOnce([
+        { id: 'pu-1', email: 'a@acme.example', name: 'A', passwordHash: 'h', status: 'active', receiveNotifications: true, lastLoginAt: null, invitedAt: null },
+        { id: 'pu-2', email: 'b@acme.example', name: null, passwordHash: null, status: 'active', receiveNotifications: true, lastLoginAt: null, invitedAt: null }
+      ]);
+    const res = await makeApp().request(`/organizations/${ORG_ID}/portal-users`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((u: any) => u.effectiveStatus)).toEqual(['active', 'pending_setup']);
+    expect(JSON.stringify(body)).not.toContain('passwordHash');
+  });
+});
+
+describe('POST /organizations/:id/portal-users/invite', () => {
+  const invite = (body: unknown) => makeApp().request(`/organizations/${ORG_ID}/portal-users/invite`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+
+  it('creates an invited user and emails a link', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org existence
+      .mockResolvedValueOnce([])               // no existing portal user
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    insertReturning.mockResolvedValueOnce([{ id: 'pu-new', email: 'new@acme.example', status: 'invited' }]);
+    const res = await invite({ email: 'new@acme.example', name: 'New Cust' });
+    expect(res.status).toBe(200);
+    expect(sendInvite).toHaveBeenCalledWith(expect.objectContaining({ to: 'new@acme.example', inviteUrl: expect.stringContaining('/portal/accept-invite?token=raw-token') }));
+  });
+
+  it('409s when the email is already an active account with a password', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'live@acme.example', passwordHash: 'h', status: 'active' }]);
+    const res = await invite({ email: 'live@acme.example' });
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/orgPortalUsers.test.ts
+++ b/apps/api/src/routes/orgPortalUsers.test.ts
@@ -16,9 +16,30 @@ vi.mock('../middleware/auth', () => ({
 }));
 vi.mock('../db', () => ({
   db: {
-    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => selectResult()), orderBy: vi.fn(() => selectResult()) })) })) })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => selectResult()),
+          orderBy: vi.fn(() => selectResult()),
+          // bulk-invite's candidates query awaits `.where()` directly with no
+          // `.limit()`/`.orderBy()` leaf — make the where-result thenable so
+          // `await ...where(x)` also resolves via selectResult().
+          then: (resolve: any, reject: any) => selectResult().then(resolve, reject)
+        }))
+      }))
+    })),
     insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })),
-    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => insertReturning()),
+          // bulk-invite's per-user update has no `.returning()` leaf —
+          // make the where-result thenable so a bare `await ...where(x)`
+          // also resolves via insertReturning().
+          then: (resolve: any, reject: any) => insertReturning().then(resolve, reject)
+        }))
+      }))
+    })),
     delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) }))
   }
 }));
@@ -89,6 +110,84 @@ describe('PATCH /organizations/:id/portal-users/:userId', () => {
     insertReturning.mockResolvedValueOnce([{ id: 'pu-1', status: 'disabled' }]); // update .returning
     const res = await patch('pu-1', { status: 'disabled' });
     expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /organizations/:id/portal-users/:userId/resend-invite', () => {
+  const resend = (uid: string) => makeApp().request(`/organizations/${ORG_ID}/portal-users/${uid}/resend-invite`, { method: 'POST' });
+
+  it('resends the invite to a pending (no-password) user', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'pending@acme.example', name: null, passwordHash: null, status: 'invited' }]) // target
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    const res = await resend('pu-1');
+    expect(res.status).toBe(200);
+    expect(sendInvite).toHaveBeenCalledTimes(1);
+    expect(sendInvite).toHaveBeenCalledWith(expect.objectContaining({ to: 'pending@acme.example' }));
+  });
+
+  it('409s when the target already has an active password-set account', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID, email: 'live@acme.example', name: null, passwordHash: 'h', status: 'active' }]); // target
+    const res = await resend('pu-1');
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /organizations/:id/portal-users/bulk-invite', () => {
+  const bulkInvite = (body: unknown) => makeApp().request(`/organizations/${ORG_ID}/portal-users/bulk-invite`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  const PU_1 = 'aaaaaaaa-1111-4222-8333-444455556666';
+  const PU_2 = 'bbbbbbbb-1111-4222-8333-444455556666';
+  const PU_DISABLED = 'cccccccc-1111-4222-8333-444455556666';
+
+  it('invites all candidates returned by the pending-setup query when no userIds are given', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([
+        { id: PU_1, email: 'a@acme.example' },
+        { id: PU_2, email: 'b@acme.example' }
+      ]) // candidates — the handler's baseWhere (org + no password + status != disabled) already filtered these
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    insertReturning.mockResolvedValue([]); // per-user update
+    const res = await bulkInvite({});
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((r: any) => r.id)).toEqual([PU_1, PU_2]);
+    expect(sendInvite).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a requested userId that is not in the candidate set (e.g. a disabled account)', async () => {
+    // Candidates mock simulates the DB-side ne(status,'disabled') filter already having
+    // excluded PU_DISABLED — the handler's userIds-intersection then can only invite PU_1.
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([{ id: PU_1, email: 'a@acme.example' }]) // candidates
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    insertReturning.mockResolvedValue([]);
+    const res = await bulkInvite({ userIds: [PU_1, PU_DISABLED] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((r: any) => r.id)).toEqual([PU_1]);
+    expect(sendInvite).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects userIds — only invites the requested subset of candidates', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org
+      .mockResolvedValueOnce([
+        { id: PU_1, email: 'a@acme.example' },
+        { id: PU_2, email: 'b@acme.example' }
+      ]) // candidates
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    insertReturning.mockResolvedValue([]);
+    const res = await bulkInvite({ userIds: [PU_1] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((r: any) => r.id)).toEqual([PU_1]);
+    expect(sendInvite).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/routes/orgPortalUsers.test.ts
+++ b/apps/api/src/routes/orgPortalUsers.test.ts
@@ -18,12 +18,16 @@ vi.mock('../db', () => ({
   db: {
     select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => selectResult()), orderBy: vi.fn(() => selectResult()) })) })) })),
     insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })),
-    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })) }))
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })) })),
+    delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) }))
   }
 }));
 vi.mock('../db/schema', () => ({
   portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status', invitedBy: 'invitedBy', invitedAt: 'invitedAt', lastLoginAt: 'lastLoginAt', createdAt: 'createdAt' },
-  organizations: { id: 'id', name: 'name', deletedAt: 'deletedAt' }
+  organizations: { id: 'id', name: 'name', deletedAt: 'deletedAt' },
+  tickets: { id: 'id', submittedBy: 'submittedBy' },
+  ticketComments: { id: 'id', portalUserId: 'portalUserId' },
+  assetCheckouts: { id: 'id', checkedOutTo: 'checkedOutTo' }
 }));
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../routes/portal/helpers', () => ({ storePortalInviteToken: vi.fn(async () => 'raw-token'), buildPortalUrl: (p: string) => `https://x/portal${p}` }));
@@ -73,5 +77,40 @@ describe('POST /organizations/:id/portal-users/invite', () => {
     const res = await invite({ email: 'live@acme.example' });
     expect(res.status).toBe(409);
     expect(sendInvite).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /organizations/:id/portal-users/:userId', () => {
+  const patch = (uid: string, body: unknown) => makeApp().request(`/organizations/${ORG_ID}/portal-users/${uid}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  it('disables a user', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])                         // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }]);          // target exists in org
+    insertReturning.mockResolvedValueOnce([{ id: 'pu-1', status: 'disabled' }]); // update .returning
+    const res = await patch('pu-1', { status: 'disabled' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('DELETE /organizations/:id/portal-users/:userId', () => {
+  const del = (uid: string) => makeApp().request(`/organizations/${ORG_ID}/portal-users/${uid}`, { method: 'DELETE' });
+  it('409s when the user has ticket references', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])            // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }]) // target
+      .mockResolvedValueOnce([{ id: 't-1' }]);            // reference exists (tickets)
+    const res = await del('pu-1');
+    expect(res.status).toBe(409);
+  });
+  it('hard-deletes an unreferenced user', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }])
+      .mockResolvedValueOnce([]) // tickets ref
+      .mockResolvedValueOnce([]) // comments ref
+      .mockResolvedValueOnce([]); // checkouts ref
+    // delete().where() resolves (mock deleteChain below)
+    const res = await del('pu-1');
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -2,16 +2,16 @@ import type { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq, isNull, desc } from 'drizzle-orm';
 import { db } from '../db';
-import { organizations, portalUsers } from '../db/schema';
+import { organizations, portalUsers, tickets, ticketComments, assetCheckouts } from '../db/schema';
 import { requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
 import { getEmailService } from '../services/email';
 import { storePortalInviteToken, buildPortalUrl } from './portal/helpers';
-import { invitePortalUserSchema } from '@breeze/shared';
+import { invitePortalUserSchema, bulkInvitePortalUsersSchema, updatePortalUserSchema } from '@breeze/shared';
 
-// MSP-facing customer-portal user management (portal_users). List + invite
-// only — bulk-invite/update/disable ship in Task 7 on this same file.
+// MSP-facing customer-portal user management (portal_users): list, invite,
+// patch (disable/reactivate), resend-invite, bulk-invite, and delete.
 // Mirrors routes/orgPortalSettings.ts for gating: partner|system scope,
 // ORGS_READ/ORGS_WRITE permission, requireMfa() on the write, and a
 // module-local resolveAccessibleOrg (duplicated rather than shared, per
@@ -63,6 +63,36 @@ async function resolveAccessibleOrg(c: any): Promise<{ id: string } | Response> 
   return { id };
 }
 
+async function getOrgScopedPortalUser(orgId: string, userId: string) {
+  const [row] = await db.select({ id: portalUsers.id, orgId: portalUsers.orgId, email: portalUsers.email, name: portalUsers.name, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
+    .from(portalUsers).where(and(eq(portalUsers.id, userId), eq(portalUsers.orgId, orgId))).limit(1);
+  return row ?? null;
+}
+
+async function hasPortalUserReferences(userId: string): Promise<boolean> {
+  const [t] = await db.select({ id: tickets.id }).from(tickets).where(eq(tickets.submittedBy, userId)).limit(1);
+  if (t) return true;
+  const [cm] = await db.select({ id: ticketComments.id }).from(ticketComments).where(eq(ticketComments.portalUserId, userId)).limit(1);
+  if (cm) return true;
+  const [ck] = await db.select({ id: assetCheckouts.id }).from(assetCheckouts).where(eq(assetCheckouts.checkedOutTo, userId)).limit(1);
+  return Boolean(ck);
+}
+
+async function issueAndSendInvite(c: any, orgId: string, user: { id: string; email: string }, orgName: string | null, inviterName: string | null | undefined, message?: string): Promise<boolean> {
+  const rawToken = await storePortalInviteToken(user.id);
+  if (!rawToken) return false; // redis unavailable — do not email a dead invite link
+  const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
+  const emailService = getEmailService();
+  if (!emailService) return false;
+  try {
+    await emailService.sendPortalInvite({ to: user.email, inviteUrl, orgName: orgName ?? undefined, inviterName: inviterName ?? undefined, message });
+    return true;
+  } catch (err) {
+    console.error('[orgPortalUsers] invite email failed:', err);
+    return false;
+  }
+}
+
 export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
   const requireOrgRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
   const requireOrgWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
@@ -108,22 +138,68 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     }
 
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
-    const rawToken = await storePortalInviteToken(userId);
-    if (!rawToken) return c.json({ error: 'Service temporarily unavailable' }, 503);
-    const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
-
-    let emailSent = false;
-    const emailService = getEmailService();
-    if (emailService) {
-      try {
-        await emailService.sendPortalInvite({ to: normalizedEmail, inviteUrl, orgName: orgRow?.name ?? undefined, inviterName: auth.user.name ?? undefined, message });
-        emailSent = true;
-      } catch (err) {
-        console.error('[orgPortalUsers] invite email failed:', err);
-      }
-    }
+    const emailSent = await issueAndSendInvite(c, org.id, { id: userId, email: normalizedEmail }, orgRow?.name ?? null, auth.user.name, message);
 
     writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.invite', resourceType: 'portal_user', resourceId: userId, details: { email: normalizedEmail, emailSent } });
     return c.json({ data: { id: userId, email: normalizedEmail, status: 'invited' }, emailSent });
+  });
+
+  orgRoutes.patch('/organizations/:id/portal-users/:userId', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', updatePortalUserSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const body = c.req.valid('json');
+    if (Object.keys(body).length === 0) return c.json({ error: 'No updates provided' }, 400);
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    const [updated] = await db.update(portalUsers).set({ ...body, updatedAt: new Date() }).where(eq(portalUsers.id, target.id)).returning({ id: portalUsers.id, status: portalUsers.status });
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.update', resourceType: 'portal_user', resourceId: target.id, details: { changedFields: Object.keys(body) } });
+    return c.json({ data: { id: updated!.id, status: updated!.status } });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/:userId/resend-invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (target.passwordHash && target.status === 'active') return c.json({ error: 'This account is already set up.' }, 409);
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const emailSent = await issueAndSendInvite(c, org.id, { id: target.id, email: target.email }, orgRow?.name ?? null, auth.user.name);
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.resend_invite', resourceType: 'portal_user', resourceId: target.id, details: { emailSent } });
+    return c.json({ data: { id: target.id }, emailSent });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/bulk-invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', bulkInvitePortalUsersSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const { userIds } = c.req.valid('json');
+    // "Pending setup" = no password. Invite selected, or all pending in the org.
+    const baseWhere = and(eq(portalUsers.orgId, org.id), isNull(portalUsers.passwordHash));
+    const candidates = await db.select({ id: portalUsers.id, email: portalUsers.email }).from(portalUsers).where(baseWhere);
+    const targets = userIds && userIds.length > 0 ? candidates.filter((u) => userIds.includes(u.id)) : candidates;
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const now = new Date();
+    const results: Array<{ id: string; emailSent: boolean }> = [];
+    for (const t of targets) {
+      await db.update(portalUsers).set({ status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, t.id));
+      const emailSent = await issueAndSendInvite(c, org.id, t, orgRow?.name ?? null, auth.user.name);
+      results.push({ id: t.id, emailSent });
+    }
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.bulk_invite', resourceType: 'organization', resourceId: org.id, details: { invited: results.length } });
+    return c.json({ data: results });
+  });
+
+  orgRoutes.delete('/organizations/:id/portal-users/:userId', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (await hasPortalUserReferences(target.id)) {
+      return c.json({ error: 'This user has ticket or asset history. Disable them instead of deleting.' }, 409);
+    }
+    await db.delete(portalUsers).where(eq(portalUsers.id, target.id));
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.delete', resourceType: 'portal_user', resourceId: target.id, details: { email: target.email } });
+    return c.json({ data: { id: target.id, deleted: true } });
   });
 }

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -123,6 +123,10 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const [existing] = await db.select({ id: portalUsers.id, email: portalUsers.email, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
       .from(portalUsers).where(and(eq(portalUsers.orgId, org.id), eq(portalUsers.email, normalizedEmail))).limit(1);
 
+    if (existing && existing.status === 'disabled') {
+      return c.json({ error: 'This user is disabled. Reactivate them before inviting.' }, 409);
+    }
+
     if (existing && existing.passwordHash && existing.status === 'active') {
       return c.json({ error: 'This email already has an active portal account.' }, 409);
     }
@@ -162,6 +166,7 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const auth = c.get('auth') as AuthContext;
     const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
     if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (target.status === 'disabled') return c.json({ error: 'This user is disabled. Reactivate them first.' }, 409);
     if (target.passwordHash && target.status === 'active') return c.json({ error: 'This account is already set up.' }, 409);
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
     const emailSent = await issueAndSendInvite(c, org.id, { id: target.id, email: target.email }, orgRow?.name ?? null, auth.user.name);

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -1,6 +1,6 @@
 import type { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, isNull, desc } from 'drizzle-orm';
+import { and, eq, isNull, desc, ne } from 'drizzle-orm';
 import { db } from '../db';
 import { organizations, portalUsers, tickets, ticketComments, assetCheckouts } from '../db/schema';
 import { requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
@@ -175,7 +175,7 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
     const auth = c.get('auth') as AuthContext;
     const { userIds } = c.req.valid('json');
     // "Pending setup" = no password. Invite selected, or all pending in the org.
-    const baseWhere = and(eq(portalUsers.orgId, org.id), isNull(portalUsers.passwordHash));
+    const baseWhere = and(eq(portalUsers.orgId, org.id), isNull(portalUsers.passwordHash), ne(portalUsers.status, 'disabled'));
     const candidates = await db.select({ id: portalUsers.id, email: portalUsers.email }).from(portalUsers).where(baseWhere);
     const targets = userIds && userIds.length > 0 ? candidates.filter((u) => userIds.includes(u.id)) : candidates;
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -1,0 +1,129 @@
+import type { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, isNull, desc } from 'drizzle-orm';
+import { db } from '../db';
+import { organizations, portalUsers } from '../db/schema';
+import { requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { PERMISSIONS } from '../services/permissions';
+import { writeRouteAudit } from '../services/auditEvents';
+import { getEmailService } from '../services/email';
+import { storePortalInviteToken, buildPortalUrl } from './portal/helpers';
+import { invitePortalUserSchema } from '@breeze/shared';
+
+// MSP-facing customer-portal user management (portal_users). List + invite
+// only — bulk-invite/update/disable ship in Task 7 on this same file.
+// Mirrors routes/orgPortalSettings.ts for gating: partner|system scope,
+// ORGS_READ/ORGS_WRITE permission, requireMfa() on the write, and a
+// module-local resolveAccessibleOrg (duplicated rather than shared, per
+// the pattern established there).
+
+type PortalUserListRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  passwordHash: string | null;
+  status: string;
+  receiveNotifications: boolean;
+  lastLoginAt: Date | null;
+  invitedAt: Date | null;
+};
+
+// A portal user is 'active' only once they've actually set a password
+// (accepted their invite) AND aren't administratively disabled. Rows
+// created by an invite sit in DB status 'invited' with passwordHash
+// null — those must read back as 'pending_setup', not 'active'.
+export function effectivePortalStatus(row: { status: string; passwordHash: string | null }): 'active' | 'disabled' | 'pending_setup' {
+  if (row.status === 'disabled') return 'disabled';
+  if (!row.passwordHash) return 'pending_setup';
+  return 'active';
+}
+
+function toListItem(row: PortalUserListRow) {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    status: row.status,
+    effectiveStatus: effectivePortalStatus(row),
+    receiveNotifications: row.receiveNotifications,
+    lastLoginAt: row.lastLoginAt,
+    invitedAt: row.invitedAt
+  };
+}
+
+async function resolveAccessibleOrg(c: any): Promise<{ id: string } | Response> {
+  const auth = c.get('auth') as AuthContext;
+  const id = c.req.param('id')!;
+  if (auth.scope === 'partner' && !auth.canAccessOrg(id)) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+  const rows = await db.select({ id: organizations.id }).from(organizations)
+    .where(and(eq(organizations.id, id), isNull(organizations.deletedAt))).limit(1);
+  if (!rows[0]) return c.json({ error: 'Organization not found' }, 404);
+  return { id };
+}
+
+export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
+  const requireOrgRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
+  const requireOrgWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+
+  orgRoutes.get('/organizations/:id/portal-users', requireScope('partner', 'system'), requireOrgRead, async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const rows = await db.select({
+      id: portalUsers.id,
+      email: portalUsers.email,
+      name: portalUsers.name,
+      passwordHash: portalUsers.passwordHash,
+      status: portalUsers.status,
+      receiveNotifications: portalUsers.receiveNotifications,
+      lastLoginAt: portalUsers.lastLoginAt,
+      invitedAt: portalUsers.invitedAt
+    }).from(portalUsers).where(eq(portalUsers.orgId, org.id)).orderBy(desc(portalUsers.createdAt));
+    return c.json({ data: rows.map(toListItem) });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', invitePortalUserSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const { email, name, message } = c.req.valid('json');
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const [existing] = await db.select({ id: portalUsers.id, email: portalUsers.email, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
+      .from(portalUsers).where(and(eq(portalUsers.orgId, org.id), eq(portalUsers.email, normalizedEmail))).limit(1);
+
+    if (existing && existing.passwordHash && existing.status === 'active') {
+      return c.json({ error: 'This email already has an active portal account.' }, 409);
+    }
+
+    const now = new Date();
+    let userId: string;
+    if (existing) {
+      await db.update(portalUsers).set({ name: name ?? undefined, status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, existing.id)).returning({ id: portalUsers.id });
+      userId = existing.id;
+    } else {
+      const [created] = await db.insert(portalUsers).values({ orgId: org.id, email: normalizedEmail, name: name ?? null, passwordHash: null, authMethod: 'password', status: 'invited', invitedBy: auth.user.id, invitedAt: now }).returning({ id: portalUsers.id });
+      userId = created!.id;
+    }
+
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const rawToken = await storePortalInviteToken(userId);
+    if (!rawToken) return c.json({ error: 'Service temporarily unavailable' }, 503);
+    const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
+
+    let emailSent = false;
+    const emailService = getEmailService();
+    if (emailService) {
+      try {
+        await emailService.sendPortalInvite({ to: normalizedEmail, inviteUrl, orgName: orgRow?.name ?? undefined, inviterName: auth.user.name ?? undefined, message });
+        emailSent = true;
+      } catch (err) {
+        console.error('[orgPortalUsers] invite email failed:', err);
+      }
+    }
+
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.invite', resourceType: 'portal_user', resourceId: userId, details: { email: normalizedEmail, emailSent } });
+    return c.json({ data: { id: userId, email: normalizedEmail, status: 'invited' }, emailSent });
+  });
+}

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -27,6 +27,7 @@ import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { clearPartnerAllowlistCache, ipAllowlistMode, readPartnerAllowlist } from '../services/ipAllowlist';
 import { registerOrgPortalSettingsRoutes } from './orgPortalSettings';
+import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
 import { registerOrgTicketSettingsRoutes } from './orgTicketSettings';
 
 export const orgRoutes = new Hono();
@@ -1330,6 +1331,8 @@ orgRoutes.put('/organizations/:id', ...updateOrgHandler);
 
 // Customer-portal settings (portal_branding) — see routes/orgPortalSettings.ts
 registerOrgPortalSettingsRoutes(orgRoutes);
+// Customer-portal users (portal_users invite/manage) — see routes/orgPortalUsers.ts
+registerOrgPortalUsersRoutes(orgRoutes);
 // Org ticketing overrides (org_ticket_settings) — see routes/orgTicketSettings.ts
 registerOrgTicketSettingsRoutes(orgRoutes);
 

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -304,7 +304,7 @@ describe('portal routes', () => {
       expect(sendPasswordResetMock).toHaveBeenCalledTimes(1);
       expect(sendPasswordResetMock).toHaveBeenCalledWith({
         to: 'portal@example.com',
-        resetUrl: 'http://localhost:4321/reset-password?token=nanoid-token&orgId=f1b0c8a6-45d1-4f84-8b8b-0ad0ce620001'
+        resetUrl: 'http://localhost:4321/portal/reset-password?token=nanoid-token&orgId=f1b0c8a6-45d1-4f84-8b8b-0ad0ce620001'
       });
     });
   });

--- a/apps/api/src/routes/portal/acceptInvite.test.ts
+++ b/apps/api/src/routes/portal/acceptInvite.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { userRow, updateSpy } = vi.hoisted(() => ({
+  userRow: { current: null as any },
+  updateSpy: vi.fn()
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve(userRow.current ? [userRow.current] : []) }) }) }),
+    update: () => ({ set: (v: any) => ({ where: () => { updateSpy(v); return Promise.resolve(); } }) })
+  },
+  withDbAccessContext: (_ctx: any, fn: any) => fn(),
+  withSystemDbAccessContext: (fn: any) => fn()
+}));
+vi.mock('../../db/schema', () => ({ portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status' } }));
+vi.mock('../../services/email', () => ({ getEmailService: () => null }));
+
+import { authRoutes } from './auth';
+import { storePortalInviteToken } from './helpers';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const USER_ID = '11111111-2222-4333-8444-555566667777';
+const makeApp = () => { const app = new Hono(); app.route('/', authRoutes); return app; };
+const post = (body: unknown) => makeApp().request('/auth/accept-invite', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+
+beforeEach(() => { vi.clearAllMocks(); userRow.current = null; });
+
+describe('POST /auth/accept-invite', () => {
+  it('activates an invited user and issues a session', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!', name: 'Cust Omer' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.id).toBe(USER_ID);
+    expect(body.accessToken).toBeTruthy();
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'active', name: 'Cust Omer' }));
+  });
+
+  it('rejects an invalid/expired token', async () => {
+    const res = await post({ token: 'nope', password: 'Str0ngPass!' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when the account is already active with a password', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: 'X', passwordHash: 'existing-hash', receiveNotifications: true, status: 'active' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!' });
+    expect(res.status).toBe(400);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a weak password', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'c@a.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'short' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/portal/acceptInvite.test.ts
+++ b/apps/api/src/routes/portal/acceptInvite.test.ts
@@ -44,6 +44,14 @@ describe('POST /auth/accept-invite', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a disabled account, even with a valid consumed invite token', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, receiveNotifications: true, status: 'disabled' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!' });
+    expect(res.status).toBe(403);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
   it('rejects when the account is already active with a password', async () => {
     userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: 'X', passwordHash: 'existing-hash', receiveNotifications: true, status: 'active' };
     const token = await storePortalInviteToken(USER_ID);

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -13,6 +13,7 @@ import {
   loginSchema,
   forgotPasswordSchema,
   resetPasswordSchema,
+  acceptInviteSchema,
   SESSION_TTL_MS,
   SESSION_TTL_SECONDS,
   RESET_TTL_MS,
@@ -40,6 +41,8 @@ import {
   clearRateLimitKeys,
   buildPortalUserPayload,
   validatePortalCookieCsrfRequest,
+  consumePortalInviteToken,
+  buildPortalUrl,
 } from './helpers';
 import { isSelfManagedDbContextRoute } from '../../middleware/selfManagedDbContextRoutes';
 
@@ -389,9 +392,8 @@ authRoutes.post('/auth/forgot-password', zValidator('json', forgotPasswordSchema
       capMapByOldest(portalResetTokens, PORTAL_RESET_TOKEN_CAP, (token) => token.createdAt.getTime());
     }
 
-    const appBaseUrl = (process.env.DASHBOARD_URL || process.env.PUBLIC_APP_URL || 'http://localhost:4321').replace(/\/$/, '');
     const orgQuery = orgId ? `&orgId=${encodeURIComponent(orgId)}` : '';
-    const resetUrl = `${appBaseUrl}/reset-password?token=${encodeURIComponent(resetToken)}${orgQuery}`;
+    const resetUrl = buildPortalUrl(`/reset-password?token=${encodeURIComponent(resetToken)}${orgQuery}`);
     const emailService = getEmailService();
 
     if (emailService) {
@@ -500,6 +502,98 @@ authRoutes.post('/auth/reset-password', zValidator('json', resetPasswordSchema),
   }
 
   return c.json({ success: true, message: 'Password reset successfully' });
+});
+
+authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), async (c) => {
+  sweepPortalState();
+
+  const { token, password, name } = c.req.valid('json');
+  const clientIp = getClientIp(c);
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+
+  for (const rateKey of [`portal:accept:ip:${clientIp}`, `portal:accept:token:${tokenHash}`]) {
+    const rate = await checkRateLimit(rateKey, RESET_PASSWORD_RATE_LIMIT);
+    if (!rate.allowed) {
+      c.header('Retry-After', String(rate.retryAfterSeconds));
+      return c.json({ error: 'Too many attempts. Please try again later.' }, 429);
+    }
+  }
+
+  const strength = isPasswordStrong(password);
+  if (!strength.valid) {
+    return c.json({ error: strength.errors[0] }, 400);
+  }
+
+  if (PORTAL_USE_REDIS && !getRedis()) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const portalUserId = await consumePortalInviteToken(token);
+  if (!portalUserId) {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        name: portalUsers.name,
+        passwordHash: portalUsers.passwordHash,
+        receiveNotifications: portalUsers.receiveNotifications,
+        status: portalUsers.status
+      })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, portalUserId))
+      .limit(1)
+  );
+
+  if (!user) {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+  // An invite must never hijack a live account.
+  if (user.passwordHash && user.status === 'active') {
+    return c.json({ error: 'This account is already set up. Use the login page.' }, 400);
+  }
+
+  const now = new Date();
+  const passwordHash = await hashPassword(password);
+  const resolvedName = user.name ?? (name ?? null);
+
+  await withSystemDbAccessContext(() =>
+    db
+      .update(portalUsers)
+      .set({ passwordHash, name: resolvedName, status: 'active', lastLoginAt: now, updatedAt: now })
+      .where(eq(portalUsers.id, user.id))
+  );
+
+  const sessionToken = nanoid(48);
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (redis) {
+      await redis
+        .multi()
+        .setex(PORTAL_REDIS_KEYS.session(sessionToken), SESSION_TTL_SECONDS, JSON.stringify({ portalUserId: user.id, orgId: user.orgId, createdAt: now.toISOString() }))
+        .sadd(PORTAL_REDIS_KEYS.userSessions(user.id), sessionToken)
+        .expire(PORTAL_REDIS_KEYS.userSessions(user.id), SESSION_TTL_SECONDS * 2)
+        .exec();
+    }
+  } else {
+    portalSessions.set(sessionToken, { token: sessionToken, portalUserId: user.id, orgId: user.orgId, createdAt: now, expiresAt });
+    capMapByOldest(portalSessions, PORTAL_SESSION_CAP, (s) => s.createdAt.getTime());
+  }
+
+  setPortalSessionCookies(c, sessionToken);
+
+  return c.json({
+    user: buildPortalUserPayload({ ...user, name: resolvedName, status: 'active' }),
+    accessToken: sessionToken,
+    expiresAt,
+    tokens: { accessToken: sessionToken, expiresInSeconds: Math.floor(SESSION_TTL_MS / 1000) }
+  });
 });
 
 authRoutes.post('/auth/logout', portalAuthMiddleware, async (c) => {

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -552,6 +552,12 @@ authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), a
   if (!user) {
     return c.json({ error: 'Invalid or expired invite' }, 400);
   }
+  // Disable is terminal — a disabled account may not be resurrected via an
+  // accept-invite flow. The invite token is already consumed at this point;
+  // that's fine, it just burns the token.
+  if (user.status === 'disabled') {
+    return c.json({ error: 'This account has been disabled.' }, 403);
+  }
   // An invite must never hijack a live account.
   if (user.passwordHash && user.status === 'active') {
     return c.json({ error: 'This account is already set up. Use the login page.' }, 400);

--- a/apps/api/src/routes/portal/helpers.test.ts
+++ b/apps/api/src/routes/portal/helpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildPortalUrl } from './helpers';
+
+const ENV_KEYS = ['PUBLIC_PORTAL_URL', 'DASHBOARD_URL', 'PUBLIC_APP_URL'] as const;
+const saved: Record<string, string | undefined> = {};
+function setEnv(vals: Partial<Record<(typeof ENV_KEYS)[number], string>>) {
+  for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+  for (const [k, v] of Object.entries(vals)) process.env[k] = v;
+}
+afterEach(() => { for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+describe('buildPortalUrl', () => {
+  it('uses PUBLIC_PORTAL_URL when set', () => {
+    setEnv({ PUBLIC_PORTAL_URL: 'https://us.2breeze.app/portal' });
+    expect(buildPortalUrl('/accept-invite?token=abc')).toBe('https://us.2breeze.app/portal/accept-invite?token=abc');
+  });
+  it('falls back to DASHBOARD_URL + /portal', () => {
+    setEnv({ DASHBOARD_URL: 'https://us.2breeze.app' });
+    expect(buildPortalUrl('/reset-password?token=x')).toBe('https://us.2breeze.app/portal/reset-password?token=x');
+  });
+  it('does not double the /portal segment', () => {
+    setEnv({ PUBLIC_PORTAL_URL: 'https://us.2breeze.app/portal/' });
+    expect(buildPortalUrl('/reset-password')).toBe('https://us.2breeze.app/portal/reset-password');
+  });
+});

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import { nanoid } from 'nanoid';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { DEFAULT_ALLOWED_ORIGINS } from '../../services/corsOrigins';
@@ -19,6 +20,9 @@ import {
   RATE_LIMIT_SWEEP_INTERVAL_MS,
   PORTAL_USE_REDIS,
   PORTAL_REDIS_KEYS,
+  INVITE_TTL_MS,
+  INVITE_TTL_SECONDS,
+  PORTAL_INVITE_TOKEN_CAP,
 } from './schemas';
 
 // ============================================
@@ -27,6 +31,7 @@ import {
 
 export const portalSessions = new Map<string, PortalSession>();
 export const portalResetTokens = new Map<string, { userId: string; expiresAt: Date; createdAt: Date }>();
+export const portalInviteTokens = new Map<string, { portalUserId: string; expiresAt: Date; createdAt: Date }>();
 export const portalRateLimitBuckets = new Map<string, {
   count: number;
   resetAtMs: number;
@@ -230,8 +235,15 @@ export function sweepPortalState(nowMs: number = Date.now()) {
     }
   }
 
+  for (const [tokenHash, invite] of portalInviteTokens.entries()) {
+    if (invite.expiresAt.getTime() <= nowMs) {
+      portalInviteTokens.delete(tokenHash);
+    }
+  }
+
   capMapByOldest(portalSessions, PORTAL_SESSION_CAP, (session) => session.createdAt.getTime());
   capMapByOldest(portalResetTokens, PORTAL_RESET_TOKEN_CAP, (token) => token.createdAt.getTime());
+  capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (token) => token.createdAt.getTime());
 }
 
 function sweepRateLimitBuckets(nowMs: number = Date.now()) {
@@ -462,4 +474,52 @@ function safeCompareTokens(headerToken: string, cookieToken: string): boolean {
     return false;
   }
   return timingSafeEqual(headerBuffer, cookieBuffer);
+}
+
+// ============================================
+// Portal URL + invite tokens
+// ============================================
+
+/**
+ * Absolute base for portal-hosted pages in outbound emails (reset, invite).
+ * The portal is served under /portal on the main domain, so links MUST include
+ * that segment — DASHBOARD_URL/PUBLIC_APP_URL point at the MSP app root.
+ */
+export function buildPortalUrl(path: string): string {
+  const explicit = process.env.PUBLIC_PORTAL_URL?.trim();
+  const appRoot = (process.env.DASHBOARD_URL || process.env.PUBLIC_APP_URL || 'http://localhost:4321').trim();
+  const base = (explicit && explicit.length > 0 ? explicit : `${appRoot.replace(/\/$/, '')}/portal`).replace(/\/$/, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+export async function storePortalInviteToken(portalUserId: string): Promise<string> {
+  const rawToken = nanoid(48);
+  const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (redis) {
+      await redis.setex(PORTAL_REDIS_KEYS.inviteToken(tokenHash), INVITE_TTL_SECONDS, JSON.stringify({ portalUserId }));
+    }
+  } else {
+    portalInviteTokens.set(tokenHash, { portalUserId, expiresAt: new Date(Date.now() + INVITE_TTL_MS), createdAt: new Date() });
+    capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (t) => t.createdAt.getTime());
+  }
+  return rawToken;
+}
+
+export async function consumePortalInviteToken(rawToken: string): Promise<string | null> {
+  const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (!redis) return null;
+    const raw = await redis.get(PORTAL_REDIS_KEYS.inviteToken(tokenHash));
+    if (!raw) return null;
+    await redis.del(PORTAL_REDIS_KEYS.inviteToken(tokenHash));
+    try { return JSON.parse(raw).portalUserId ?? null; } catch { return null; }
+  }
+  const stored = portalInviteTokens.get(tokenHash);
+  portalInviteTokens.delete(tokenHash);
+  if (stored && stored.expiresAt.getTime() > Date.now()) return stored.portalUserId;
+  return null;
 }

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -493,14 +493,13 @@ export function buildPortalUrl(path: string): string {
   return `${base}${suffix}`;
 }
 
-export async function storePortalInviteToken(portalUserId: string): Promise<string> {
+export async function storePortalInviteToken(portalUserId: string): Promise<string | null> {
   const rawToken = nanoid(48);
   const tokenHash = createHash('sha256').update(rawToken).digest('hex');
   if (PORTAL_USE_REDIS) {
     const redis = getRedis();
-    if (redis) {
-      await redis.setex(PORTAL_REDIS_KEYS.inviteToken(tokenHash), INVITE_TTL_SECONDS, JSON.stringify({ portalUserId }));
-    }
+    if (!redis) return null; // redis required but unavailable — don't mint an unredeemable token
+    await redis.setex(PORTAL_REDIS_KEYS.inviteToken(tokenHash), INVITE_TTL_SECONDS, JSON.stringify({ portalUserId }));
   } else {
     portalInviteTokens.set(tokenHash, { portalUserId, expiresAt: new Date(Date.now() + INVITE_TTL_MS), createdAt: new Date() });
     capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (t) => t.createdAt.getTime());

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -50,6 +50,9 @@ export const CSRF_HEADER_NAME = 'x-breeze-csrf';
 export const PORTAL_CSRF_COOKIE_NAME = 'breeze_portal_csrf_token';
 export const PORTAL_CSRF_COOKIE_PATH = '/';
 export const RESET_TTL_SECONDS = Math.floor(RESET_TTL_MS / 1000);
+export const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+export const INVITE_TTL_SECONDS = Math.floor(INVITE_TTL_MS / 1000);
+export const PORTAL_INVITE_TOKEN_CAP = 20000;
 
 export const PORTAL_USE_REDIS =
   process.env.PORTAL_STATE_BACKEND === 'redis' || process.env.NODE_ENV === 'production';
@@ -58,6 +61,7 @@ export const PORTAL_REDIS_KEYS = {
   session: (token: string) => `portal:session:${token}`,
   userSessions: (userId: string) => `portal:user-sessions:${userId}`,
   resetToken: (hash: string) => `portal:reset:${hash}`,
+  inviteToken: (hash: string) => `portal:invite:${hash}`,
   rlAttempts: (key: string) => `portal:rl:attempts:${key}`,
   rlBlock: (key: string) => `portal:rl:block:${key}`,
 };
@@ -102,6 +106,12 @@ export const forgotPasswordSchema = z.object({
 export const resetPasswordSchema = z.object({
   token: z.string().min(1),
   password: z.string().min(8)
+});
+
+export const acceptInviteSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8),
+  name: z.string().min(1).max(255).optional()
 });
 
 export const listSchema = z.object({

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -48,6 +48,15 @@ export interface PasswordResetEmailParams {
   supportEmail?: string;
 }
 
+export interface PortalInviteEmailParams {
+  to: string | string[];
+  inviteUrl: string;
+  orgName?: string;
+  inviterName?: string;
+  message?: string;
+  supportEmail?: string;
+}
+
 export interface VerificationEmailParams {
   to: string | string[];
   name?: string;
@@ -299,6 +308,16 @@ export class EmailService {
 
   async sendEmailChanged(params: EmailChangedEmailParams): Promise<void> {
     const template = buildEmailChangedTemplate(params);
+    await this.sendEmail({
+      to: params.to,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+  }
+
+  async sendPortalInvite(params: PortalInviteEmailParams): Promise<void> {
+    const template = buildPortalInviteTemplate(params);
     await this.sendEmail({
       to: params.to,
       subject: template.subject,
@@ -656,6 +675,32 @@ function buildPasswordResetTemplate(params: PasswordResetEmailParams): EmailTemp
     .filter(Boolean)
     .join('\n');
 
+  return { subject, html, text };
+}
+
+export function buildPortalInviteTemplate(params: PortalInviteEmailParams): EmailTemplate {
+  const orgName = params.orgName?.trim();
+  const inviter = params.inviterName?.trim();
+  const customMessage = params.message?.trim();
+  const subject = orgName ? `You're invited to the ${orgName} support portal` : `You're invited to your support portal`;
+  const preheader = 'Set your password to access your support portal.';
+  const heading = orgName ? `Join the ${orgName} portal` : 'Join your support portal';
+  const invitedBy = inviter ? `${escapeHtml(inviter)} invited you` : 'You have been invited';
+  const body = `
+      <p style="${BODY_PARA}">${invitedBy} to the${orgName ? ` ${escapeHtml(orgName)}` : ''} support portal, where you can open tickets, view invoices, and track your devices.</p>
+      ${customMessage ? `<p style="${BODY_PARA}">${escapeHtml(customMessage)}</p>` : ''}
+      ${renderButton('Set your password', params.inviteUrl)}
+      <p style="${MUTED_PARA}">This invite link expires in 7 days. If you didn't expect this, you can ignore this email.</p>
+  `;
+  const html = renderLayout({ title: subject, preheader, heading, body, footer: supportFooter(params.supportEmail, 'Need help? Contact') });
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    orgName ? `You're invited to the ${orgName} support portal.` : `You're invited to your support portal.`,
+    customMessage || null,
+    `Set your password: ${params.inviteUrl}`,
+    'This invite link expires in 7 days.',
+    support ? `Need help? Contact ${support}.` : null
+  ].filter(Boolean).join('\n');
   return { subject, html, text };
 }
 

--- a/apps/api/src/services/portalInviteEmail.test.ts
+++ b/apps/api/src/services/portalInviteEmail.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { buildPortalInviteTemplate } from './email';
+
+describe('buildPortalInviteTemplate', () => {
+  it('includes the invite URL and org name', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://us.2breeze.app/portal/accept-invite?token=abc', orgName: 'Acme Co', inviterName: 'Tess' });
+    expect(t.subject).toContain('Acme Co');
+    expect(t.html).toContain('https://us.2breeze.app/portal/accept-invite?token=abc');
+    expect(t.text).toContain('https://us.2breeze.app/portal/accept-invite?token=abc');
+  });
+  it('renders a generic subject without an org name', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://x/portal/accept-invite?token=1' });
+    expect(t.subject.length).toBeGreaterThan(0);
+  });
+  it('includes an optional custom message', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://x/p?t=1', message: 'Welcome aboard!' });
+    expect(t.html).toContain('Welcome aboard!');
+  });
+});

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+import OrgPortalUsersEditor from './OrgPortalUsersEditor';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const ok = (data: unknown) => ({ ok: true, status: 200, json: async () => (data) });
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('OrgPortalUsersEditor', () => {
+  it('renders portal users with status badges', async () => {
+    fetchWithAuth.mockResolvedValueOnce(ok({ data: [
+      { id: 'pu-1', email: 'a@acme.example', name: 'A', status: 'active', effectiveStatus: 'active', lastLoginAt: null, invitedAt: null },
+      { id: 'pu-2', email: 'b@acme.example', name: null, status: 'active', effectiveStatus: 'pending_setup', lastLoginAt: null, invitedAt: null }
+    ] }));
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByText('a@acme.example')).toBeInTheDocument());
+    expect(screen.getByText('b@acme.example')).toBeInTheDocument();
+    expect(screen.getByText(/pending setup/i)).toBeInTheDocument();
+  });
+
+  it('invites a user through the API', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(ok({ data: [] }))                                  // initial list
+      .mockResolvedValueOnce(ok({ data: { id: 'pu-new', status: 'invited' }, emailSent: true })) // invite
+      .mockResolvedValueOnce(ok({ data: [] }));                                 // reload
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('portal-users-invite-open'));
+    fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'new@acme.example' } });
+    fireEvent.click(screen.getByTestId('portal-users-invite-submit'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG_ID}/portal-users/invite`,
+      expect.objectContaining({ method: 'POST' })
+    ));
+  });
+});

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
@@ -24,6 +24,19 @@ describe('OrgPortalUsersEditor', () => {
     expect(screen.getByText(/pending setup/i)).toBeInTheDocument();
   });
 
+  it('shows Reactivate (not Resend) for a disabled row, and Resend only for pending_setup', async () => {
+    fetchWithAuth.mockResolvedValueOnce(ok({ data: [
+      { id: 'pu-1', email: 'disabled@acme.example', name: 'D', status: 'disabled', effectiveStatus: 'disabled', lastLoginAt: null, invitedAt: null },
+      { id: 'pu-2', email: 'pending@acme.example', name: null, status: 'invited', effectiveStatus: 'pending_setup', lastLoginAt: null, invitedAt: null }
+    ] }));
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByText('disabled@acme.example')).toBeInTheDocument());
+
+    expect(screen.getByTestId('portal-user-enable-pu-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('portal-user-resend-pu-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('portal-user-resend-pu-2')).toBeInTheDocument();
+  });
+
   it('invites a user through the API', async () => {
     fetchWithAuth
       .mockResolvedValueOnce(ok({ data: [] }))                                  // initial list

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
@@ -163,7 +163,7 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
                 <td className="py-2">{u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString() : '—'}</td>
                 <td className="py-2">
                   <div className="flex justify-end gap-2">
-                    {u.effectiveStatus !== 'active' && (
+                    {u.effectiveStatus === 'pending_setup' && (
                       <button
                         type="button"
                         data-testid={`portal-user-resend-${u.id}`}

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, ActionError } from '@/lib/runAction';
+
+type PortalUser = {
+  id: string; email: string; name: string | null; status: string;
+  effectiveStatus: 'active' | 'disabled' | 'pending_setup';
+  receiveNotifications?: boolean;
+  lastLoginAt: string | null; invitedAt: string | null;
+};
+
+const STATUS_LABEL: Record<PortalUser['effectiveStatus'], string> = {
+  active: 'Active', disabled: 'Disabled', pending_setup: 'Pending setup'
+};
+
+const STATUS_BADGE_CLASS: Record<PortalUser['effectiveStatus'], string> = {
+  active: 'bg-emerald-500/10 text-emerald-600',
+  disabled: 'bg-muted text-muted-foreground',
+  pending_setup: 'bg-amber-500/10 text-amber-600'
+};
+
+const base = (orgId: string) => `/orgs/organizations/${orgId}/portal-users`;
+
+export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
+  const [users, setUsers] = useState<PortalUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const res = await fetchWithAuth(base(orgId));
+      if (res.status === 401) { void navigateTo('/login', { replace: true }); return; }
+      if (!res.ok) throw new Error(`portal users load failed: ${res.status}`);
+      setUsers((await res.json()).data ?? []);
+    } catch (err) {
+      console.warn('[OrgPortalUsersEditor] load failed', err);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const invite = async () => {
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`${base(orgId)}/invite`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, name: name || undefined, message: message || undefined })
+        }),
+        errorFallback: 'Failed to send invite',
+        successMessage: 'Invite sent',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      setInviteOpen(false); setEmail(''); setName(''); setMessage('');
+      await load();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    }
+  };
+
+  const mutate = async (userId: string | null, path: string, method: string, body?: unknown, successMessage?: string) => {
+    setBusyId(userId);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`${base(orgId)}${path}`, {
+          method,
+          headers: body ? { 'Content-Type': 'application/json' } : undefined,
+          body: body ? JSON.stringify(body) : undefined
+        }),
+        errorFallback: 'Action failed',
+        successMessage,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      await load();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const pendingCount = users.filter((u) => u.effectiveStatus === 'pending_setup').length;
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading portal users…</p>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground" data-testid="portal-users-load-error">
+        Portal users failed to load.{' '}
+        <button type="button" onClick={() => void load()} className="underline hover:text-foreground">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border bg-card p-6 shadow-xs space-y-4" data-testid="portal-users-editor">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Portal users</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Customer contacts with access to this organization's portal.</p>
+        </div>
+        <div className="flex gap-2">
+          {pendingCount > 0 && (
+            <button
+              type="button"
+              data-testid="portal-users-bulk-invite"
+              onClick={() => void mutate(null, '/bulk-invite', 'POST', {}, `Invited ${pendingCount} pending user(s)`)}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted/50"
+            >
+              Invite pending ({pendingCount})
+            </button>
+          )}
+          <button
+            type="button"
+            data-testid="portal-users-invite-open"
+            onClick={() => setInviteOpen(true)}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Invite user
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs text-muted-foreground">
+              <th className="py-2 font-medium">Email</th>
+              <th className="py-2 font-medium">Name</th>
+              <th className="py-2 font-medium">Status</th>
+              <th className="py-2 font-medium">Last login</th>
+              <th className="py-2 font-medium"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} data-testid={`portal-user-row-${u.id}`} className="border-b last:border-0">
+                <td className="py-2">{u.email}</td>
+                <td className="py-2">{u.name ?? '—'}</td>
+                <td className="py-2">
+                  <span
+                    data-testid={`portal-user-status-${u.id}`}
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE_CLASS[u.effectiveStatus]}`}
+                  >
+                    {STATUS_LABEL[u.effectiveStatus]}
+                  </span>
+                </td>
+                <td className="py-2">{u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString() : '—'}</td>
+                <td className="py-2">
+                  <div className="flex justify-end gap-2">
+                    {u.effectiveStatus !== 'active' && (
+                      <button
+                        type="button"
+                        data-testid={`portal-user-resend-${u.id}`}
+                        disabled={busyId === u.id}
+                        onClick={() => void mutate(u.id, `/${u.id}/resend-invite`, 'POST', undefined, 'Invite resent')}
+                        className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted/50 disabled:opacity-50"
+                      >
+                        Resend
+                      </button>
+                    )}
+                    {u.effectiveStatus === 'disabled' ? (
+                      <button
+                        type="button"
+                        data-testid={`portal-user-enable-${u.id}`}
+                        disabled={busyId === u.id}
+                        onClick={() => void mutate(u.id, `/${u.id}`, 'PATCH', { status: 'active' }, 'User reactivated')}
+                        className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted/50 disabled:opacity-50"
+                      >
+                        Reactivate
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        data-testid={`portal-user-disable-${u.id}`}
+                        disabled={busyId === u.id}
+                        onClick={() => void mutate(u.id, `/${u.id}`, 'PATCH', { status: 'disabled' }, 'User disabled')}
+                        className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted/50 disabled:opacity-50"
+                      >
+                        Disable
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      data-testid={`portal-user-delete-${u.id}`}
+                      disabled={busyId === u.id}
+                      onClick={() => void mutate(u.id, `/${u.id}`, 'DELETE', undefined, 'User removed')}
+                      className="rounded-md border px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={5} className="py-4 text-center text-muted-foreground">No portal users yet.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {inviteOpen && (
+        <div data-testid="portal-users-invite-modal" className="space-y-3 rounded-md border bg-muted/30 p-4">
+          <div>
+            <label className="text-sm font-medium" htmlFor="portal-users-invite-email">Email</label>
+            <input
+              id="portal-users-invite-email"
+              data-testid="portal-users-invite-email"
+              type="email"
+              placeholder="customer@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="portal-users-invite-name">Name (optional)</label>
+            <input
+              id="portal-users-invite-name"
+              data-testid="portal-users-invite-name"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="portal-users-invite-message">Message (optional)</label>
+            <textarea
+              id="portal-users-invite-message"
+              data-testid="portal-users-invite-message"
+              rows={3}
+              placeholder="Personal note for the invite email"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setInviteOpen(false)}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted/50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              data-testid="portal-users-invite-submit"
+              disabled={!email}
+              onClick={() => void invite()}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              Send invite
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -22,6 +22,7 @@ import OrgBillingSettings from '../billing/OrgBillingSettings';
 import SettingsSectionNav, { type SettingsNavGroup } from './SettingsSectionNav';
 import OrgBrandingEditor from './OrgBrandingEditor';
 import OrgPortalSettingsEditor from './OrgPortalSettingsEditor';
+import OrgPortalUsersEditor from './OrgPortalUsersEditor';
 import OrgTicketSettingsEditor from './OrgTicketSettingsEditor';
 import OrgDefaultsEditor from './OrgDefaultsEditor';
 import type { PinnableVersions, AgentVersionPinsValue } from './AgentVersionPinSelectors';
@@ -486,11 +487,14 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         );
       case 'portal':
         return effectiveOrgId ? (
-          <OrgPortalSettingsEditor
-            orgId={effectiveOrgId}
-            onDirty={handleDirty}
-            onSave={() => handleSave()}
-          />
+          <>
+            <OrgPortalSettingsEditor
+              orgId={effectiveOrgId}
+              onDirty={handleDirty}
+              onSave={() => handleSave()}
+            />
+            <OrgPortalUsersEditor orgId={effectiveOrgId} />
+          </>
         ) : null;
       case 'notifications':
         return (

--- a/docs/superpowers/plans/2026-07-07-portal-customer-onboarding.md
+++ b/docs/superpowers/plans/2026-07-07-portal-customer-onboarding.md
@@ -1,0 +1,1427 @@
+# Customer Portal Onboarding & Invite Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make logged-in customer onboarding work end-to-end — a customer can accept an invite and set a password, a tech can invite/manage portal users from the dashboard, and portal emails link to `/portal/*`.
+
+**Architecture:** Reuse the portal's existing redis+in-memory token pattern for a new invite token (7-day TTL). Add a customer-facing `POST /portal/auth/accept-invite` and fix the forgot-password link base via a new `buildPortalUrl` helper. Add an MSP-facing `orgPortalUsers.ts` route module (registered on `orgRoutes`, mirroring `orgPortalSettings.ts` gating) and an `OrgPortalUsersEditor.tsx` in the Org Settings → Portal tab.
+
+**Tech Stack:** Hono + Drizzle + Zod (API), Astro/React + `fetchWithAuth`/`runAction` (web), Vitest.
+
+## Global Constraints
+
+- Zod idioms: email = `z.string().email()`, UUID = `z.string().guid()` (NOT `.uuid()` — repo migrated Zod 3→4).
+- New tenant table columns on `portal_users` need no new RLS policy — it already has org-scoped RLS (shape 1, direct `org_id`).
+- Migrations: filename `YYYY-MM-DD-<slug>.sql`, idempotent (`IF NOT EXISTS`), **no** inner `BEGIN;/COMMIT;`, never edit a shipped migration.
+- `portal_users` timestamp columns use `timestamp` WITHOUT timezone (match `last_login_at`) — do NOT use `timestamptz` (drift).
+- Web mutations MUST go through `runAction` (`apps/web/src/lib/runAction.ts`); reads use `fetchWithAuth` directly. Web paths are relative and `/orgs`-prefixed (e.g. `/orgs/organizations/${orgId}/portal-users`).
+- MSP route gating (mirror `orgPortalSettings.ts`): `requireScope('partner','system')`, reads `requirePermission(PERMISSIONS.ORGS_READ...)`, writes add `requireMfa()`, all mutations call `writeRouteAudit`.
+- Portal auth rejects any `status !== 'active'` (login + middleware already enforce this) — so `invited`/`disabled` block login for free.
+- Commit after each task. Do NOT commit `docs/testing/FEATURE_TEST_LOG.md` (unrelated pre-existing WIP).
+
+---
+
+## Task 1: Migration + schema columns (`invited_by`, `invited_at`)
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-07-portal-user-invites.sql`
+- Modify: `apps/api/src/db/schema/portal.ts:51-53` (add two columns to `portalUsers`)
+
+**Interfaces:**
+- Produces: `portalUsers.invitedBy` (uuid, nullable), `portalUsers.invitedAt` (timestamp, nullable).
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-07-07-portal-user-invites.sql`:
+
+```sql
+-- Portal customer-onboarding: invite provenance columns on portal_users.
+-- Idempotent. portal_users already has org-scoped RLS (shape 1, direct org_id);
+-- new nullable columns need no new policy. Timestamps are WITHOUT time zone to
+-- match the existing last_login_at/created_at columns (drizzle drift).
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS invited_by uuid REFERENCES users(id);
+ALTER TABLE portal_users ADD COLUMN IF NOT EXISTS invited_at timestamp;
+```
+
+- [ ] **Step 2: Add the columns to the Drizzle schema**
+
+In `apps/api/src/db/schema/portal.ts`, inside `portalUsers`, immediately after the `status` column (line 51), add:
+
+```ts
+  invitedBy: uuid('invited_by').references(() => users.id),
+  invitedAt: timestamp('invited_at'),
+```
+
+(`uuid`, `timestamp`, and `users` are already imported in this file.)
+
+- [ ] **Step 3: Verify no schema drift**
+
+Run: `export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift`
+Expected: no drift reported (schema matches migrations).
+
+- [ ] **Step 4: Verify migration auto-ordering test still passes**
+
+Run: `pnpm test --filter=@breeze/api -- autoMigrate`
+Expected: PASS (new dated migration sorts correctly).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-07-07-portal-user-invites.sql apps/api/src/db/schema/portal.ts
+git commit -m "feat(portal): add invited_by/invited_at to portal_users"
+```
+
+---
+
+## Task 2: Invite-token infra + `buildPortalUrl` helper
+
+**Files:**
+- Modify: `apps/api/src/routes/portal/schemas.ts` (constants, redis key, `acceptInviteSchema`)
+- Modify: `apps/api/src/routes/portal/helpers.ts` (in-memory map, sweep, `buildPortalUrl`, store/consume helpers)
+- Test: `apps/api/src/routes/portal/helpers.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces:
+  - `INVITE_TTL_MS`, `INVITE_TTL_SECONDS`, `PORTAL_INVITE_TOKEN_CAP` (schemas.ts)
+  - `PORTAL_REDIS_KEYS.inviteToken(hash: string): string`
+  - `acceptInviteSchema` = `z.object({ token: string(min1), password: string(min8), name?: string(min1,max255) })`
+  - `buildPortalUrl(path: string): string` (helpers.ts)
+  - `storePortalInviteToken(portalUserId: string): Promise<string>` → raw token
+  - `consumePortalInviteToken(rawToken: string): Promise<string | null>` → portalUserId or null
+
+- [ ] **Step 1: Add constants + schema + redis key to `schemas.ts`**
+
+In `apps/api/src/routes/portal/schemas.ts`, add after `RESET_TTL_SECONDS` (line 52):
+
+```ts
+export const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+export const INVITE_TTL_SECONDS = Math.floor(INVITE_TTL_MS / 1000);
+export const PORTAL_INVITE_TOKEN_CAP = 20000;
+```
+
+Add `inviteToken` to `PORTAL_REDIS_KEYS` (after the `resetToken` line, line 60):
+
+```ts
+  inviteToken: (hash: string) => `portal:invite:${hash}`,
+```
+
+Add `acceptInviteSchema` after `resetPasswordSchema` (line 105):
+
+```ts
+export const acceptInviteSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8),
+  name: z.string().min(1).max(255).optional()
+});
+```
+
+- [ ] **Step 2: Write the failing test for `buildPortalUrl`**
+
+Create `apps/api/src/routes/portal/helpers.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildPortalUrl } from './helpers';
+
+const ENV_KEYS = ['PUBLIC_PORTAL_URL', 'DASHBOARD_URL', 'PUBLIC_APP_URL'] as const;
+const saved: Record<string, string | undefined> = {};
+function setEnv(vals: Partial<Record<(typeof ENV_KEYS)[number], string>>) {
+  for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+  for (const [k, v] of Object.entries(vals)) process.env[k] = v;
+}
+afterEach(() => { for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+describe('buildPortalUrl', () => {
+  it('uses PUBLIC_PORTAL_URL when set', () => {
+    setEnv({ PUBLIC_PORTAL_URL: 'https://us.2breeze.app/portal' });
+    expect(buildPortalUrl('/accept-invite?token=abc')).toBe('https://us.2breeze.app/portal/accept-invite?token=abc');
+  });
+  it('falls back to DASHBOARD_URL + /portal', () => {
+    setEnv({ DASHBOARD_URL: 'https://us.2breeze.app' });
+    expect(buildPortalUrl('/reset-password?token=x')).toBe('https://us.2breeze.app/portal/reset-password?token=x');
+  });
+  it('does not double the /portal segment', () => {
+    setEnv({ PUBLIC_PORTAL_URL: 'https://us.2breeze.app/portal/' });
+    expect(buildPortalUrl('/reset-password')).toBe('https://us.2breeze.app/portal/reset-password');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test --filter=@breeze/api -- portal/helpers.test`
+Expected: FAIL — `buildPortalUrl` is not exported.
+
+- [ ] **Step 4: Implement the helper infra in `helpers.ts`**
+
+In `apps/api/src/routes/portal/helpers.ts`:
+
+Add `nanoid` to the imports at the top:
+
+```ts
+import { nanoid } from 'nanoid';
+```
+
+Add the invite constants to the existing `./schemas` import block (lines 8-22):
+
+```ts
+  INVITE_TTL_MS,
+  INVITE_TTL_SECONDS,
+  PORTAL_INVITE_TOKEN_CAP,
+```
+
+Add the in-memory map after `portalResetTokens` (line 29):
+
+```ts
+export const portalInviteTokens = new Map<string, { portalUserId: string; expiresAt: Date; createdAt: Date }>();
+```
+
+Add invite-token sweeping inside `sweepPortalState`, after the reset-token loop (line 231), and its cap after line 234:
+
+```ts
+  for (const [tokenHash, invite] of portalInviteTokens.entries()) {
+    if (invite.expiresAt.getTime() <= nowMs) {
+      portalInviteTokens.delete(tokenHash);
+    }
+  }
+```
+```ts
+  capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (token) => token.createdAt.getTime());
+```
+
+Append the new exported functions at the end of the file:
+
+```ts
+// ============================================
+// Portal URL + invite tokens
+// ============================================
+
+/**
+ * Absolute base for portal-hosted pages in outbound emails (reset, invite).
+ * The portal is served under /portal on the main domain, so links MUST include
+ * that segment — DASHBOARD_URL/PUBLIC_APP_URL point at the MSP app root.
+ */
+export function buildPortalUrl(path: string): string {
+  const explicit = process.env.PUBLIC_PORTAL_URL?.trim();
+  const appRoot = (process.env.DASHBOARD_URL || process.env.PUBLIC_APP_URL || 'http://localhost:4321').trim();
+  const base = (explicit && explicit.length > 0 ? explicit : `${appRoot.replace(/\/$/, '')}/portal`).replace(/\/$/, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+export async function storePortalInviteToken(portalUserId: string): Promise<string> {
+  const rawToken = nanoid(48);
+  const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (redis) {
+      await redis.setex(PORTAL_REDIS_KEYS.inviteToken(tokenHash), INVITE_TTL_SECONDS, JSON.stringify({ portalUserId }));
+    }
+  } else {
+    portalInviteTokens.set(tokenHash, { portalUserId, expiresAt: new Date(Date.now() + INVITE_TTL_MS), createdAt: new Date() });
+    capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (t) => t.createdAt.getTime());
+  }
+  return rawToken;
+}
+
+export async function consumePortalInviteToken(rawToken: string): Promise<string | null> {
+  const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (!redis) return null;
+    const raw = await redis.get(PORTAL_REDIS_KEYS.inviteToken(tokenHash));
+    if (!raw) return null;
+    await redis.del(PORTAL_REDIS_KEYS.inviteToken(tokenHash));
+    try { return JSON.parse(raw).portalUserId ?? null; } catch { return null; }
+  }
+  const stored = portalInviteTokens.get(tokenHash);
+  portalInviteTokens.delete(tokenHash);
+  if (stored && stored.expiresAt.getTime() > Date.now()) return stored.portalUserId;
+  return null;
+}
+```
+
+`createHash`, `getRedis`, `PORTAL_USE_REDIS`, `PORTAL_REDIS_KEYS`, `capMapByOldest` are already imported/in-scope in this file.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test --filter=@breeze/api -- portal/helpers.test`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/portal/schemas.ts apps/api/src/routes/portal/helpers.ts apps/api/src/routes/portal/helpers.test.ts
+git commit -m "feat(portal): invite-token store + buildPortalUrl helper"
+```
+
+---
+
+## Task 3: `accept-invite` endpoint + forgot-password link fix
+
+**Files:**
+- Modify: `apps/api/src/routes/portal/auth.ts` (new route; fix `forgot-password` URL)
+- Test: `apps/api/src/routes/portal/acceptInvite.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `consumePortalInviteToken`, `storePortalInviteToken`, `buildPortalUrl` (Task 2); `acceptInviteSchema`, `INVITE_TTL_*` (Task 2).
+- Produces: `POST /portal/auth/accept-invite` → `{ user, accessToken, expiresAt, tokens }` (same shape as `/auth/login`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/portal/acceptInvite.test.ts`. It exercises the real handler with the in-memory token store (NODE_ENV=test ⇒ `PORTAL_USE_REDIS=false`), mocking only the DB layer:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { userRow, updateSpy } = vi.hoisted(() => ({
+  userRow: { current: null as any },
+  updateSpy: vi.fn()
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve(userRow.current ? [userRow.current] : []) }) }) }),
+    update: () => ({ set: (v: any) => ({ where: () => { updateSpy(v); return Promise.resolve(); } }) })
+  },
+  withDbAccessContext: (_ctx: any, fn: any) => fn(),
+  withSystemDbAccessContext: (fn: any) => fn()
+}));
+vi.mock('../../db/schema', () => ({ portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status' } }));
+vi.mock('../../services/email', () => ({ getEmailService: () => null }));
+
+import { authRoutes } from './auth';
+import { storePortalInviteToken } from './helpers';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const USER_ID = '11111111-2222-4333-8444-555566667777';
+const makeApp = () => { const app = new Hono(); app.route('/', authRoutes); return app; };
+const post = (body: unknown) => makeApp().request('/auth/accept-invite', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+
+beforeEach(() => { vi.clearAllMocks(); userRow.current = null; });
+
+describe('POST /auth/accept-invite', () => {
+  it('activates an invited user and issues a session', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!', name: 'Cust Omer' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.id).toBe(USER_ID);
+    expect(body.accessToken).toBeTruthy();
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'active', name: 'Cust Omer' }));
+  });
+
+  it('rejects an invalid/expired token', async () => {
+    const res = await post({ token: 'nope', password: 'Str0ngPass!' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when the account is already active with a password', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'cust@acme.example', name: 'X', passwordHash: 'existing-hash', receiveNotifications: true, status: 'active' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'Str0ngPass!' });
+    expect(res.status).toBe(400);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a weak password', async () => {
+    userRow.current = { id: USER_ID, orgId: ORG_ID, email: 'c@a.example', name: null, passwordHash: null, receiveNotifications: true, status: 'invited' };
+    const token = await storePortalInviteToken(USER_ID);
+    const res = await post({ token, password: 'short' });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter=@breeze/api -- portal/acceptInvite.test`
+Expected: FAIL — route returns 404 (not implemented).
+
+- [ ] **Step 3: Implement the endpoint + fix forgot-password**
+
+In `apps/api/src/routes/portal/auth.ts`:
+
+Add to the `./schemas` import (lines 12-28): `acceptInviteSchema`.
+Add to the `./helpers` import (lines 29-43): `consumePortalInviteToken`, `buildPortalUrl`.
+
+Fix the forgot-password reset URL — replace lines 392-394 (`const appBaseUrl = ...` through the `resetUrl` assignment) with:
+
+```ts
+    const orgQuery = orgId ? `&orgId=${encodeURIComponent(orgId)}` : '';
+    const resetUrl = buildPortalUrl(`/reset-password?token=${encodeURIComponent(resetToken)}${orgQuery}`);
+```
+
+Add the new route immediately after the `reset-password` handler (after line 503):
+
+```ts
+authRoutes.post('/auth/accept-invite', zValidator('json', acceptInviteSchema), async (c) => {
+  sweepPortalState();
+
+  const { token, password, name } = c.req.valid('json');
+  const clientIp = getClientIp(c);
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+
+  for (const rateKey of [`portal:accept:ip:${clientIp}`, `portal:accept:token:${tokenHash}`]) {
+    const rate = await checkRateLimit(rateKey, RESET_PASSWORD_RATE_LIMIT);
+    if (!rate.allowed) {
+      c.header('Retry-After', String(rate.retryAfterSeconds));
+      return c.json({ error: 'Too many attempts. Please try again later.' }, 429);
+    }
+  }
+
+  const strength = isPasswordStrong(password);
+  if (!strength.valid) {
+    return c.json({ error: strength.errors[0] }, 400);
+  }
+
+  if (PORTAL_USE_REDIS && !getRedis()) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const portalUserId = await consumePortalInviteToken(token);
+  if (!portalUserId) {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+
+  const [user] = await withSystemDbAccessContext(() =>
+    db
+      .select({
+        id: portalUsers.id,
+        orgId: portalUsers.orgId,
+        email: portalUsers.email,
+        name: portalUsers.name,
+        passwordHash: portalUsers.passwordHash,
+        receiveNotifications: portalUsers.receiveNotifications,
+        status: portalUsers.status
+      })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, portalUserId))
+      .limit(1)
+  );
+
+  if (!user) {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+  // An invite must never hijack a live account.
+  if (user.passwordHash && user.status === 'active') {
+    return c.json({ error: 'This account is already set up. Use the login page.' }, 400);
+  }
+
+  const now = new Date();
+  const passwordHash = await hashPassword(password);
+  const resolvedName = user.name ?? (name ?? null);
+
+  await withSystemDbAccessContext(() =>
+    db
+      .update(portalUsers)
+      .set({ passwordHash, name: resolvedName, status: 'active', lastLoginAt: now, updatedAt: now })
+      .where(eq(portalUsers.id, user.id))
+  );
+
+  const sessionToken = nanoid(48);
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (redis) {
+      await redis
+        .multi()
+        .setex(PORTAL_REDIS_KEYS.session(sessionToken), SESSION_TTL_SECONDS, JSON.stringify({ portalUserId: user.id, orgId: user.orgId, createdAt: now.toISOString() }))
+        .sadd(PORTAL_REDIS_KEYS.userSessions(user.id), sessionToken)
+        .expire(PORTAL_REDIS_KEYS.userSessions(user.id), SESSION_TTL_SECONDS * 2)
+        .exec();
+    }
+  } else {
+    portalSessions.set(sessionToken, { token: sessionToken, portalUserId: user.id, orgId: user.orgId, createdAt: now, expiresAt });
+    capMapByOldest(portalSessions, PORTAL_SESSION_CAP, (s) => s.createdAt.getTime());
+  }
+
+  setPortalSessionCookies(c, sessionToken);
+
+  return c.json({
+    user: buildPortalUserPayload({ ...user, name: resolvedName, status: 'active' }),
+    accessToken: sessionToken,
+    expiresAt,
+    tokens: { accessToken: sessionToken, expiresInSeconds: Math.floor(SESSION_TTL_MS / 1000) }
+  });
+});
+```
+
+Add any not-yet-imported names to the existing `./schemas` import: `SESSION_TTL_MS`, `SESSION_TTL_SECONDS`, `PORTAL_SESSION_CAP`, `PORTAL_REDIS_KEYS`, `PORTAL_USE_REDIS`, `RESET_PASSWORD_RATE_LIMIT` (most already imported — add only the missing ones), and to `./helpers`: `portalSessions`, `capMapByOldest`, `setPortalSessionCookies`, `buildPortalUserPayload` (add only missing). `hashPassword`, `isPasswordStrong`, `getRedis`, `createHash`, `nanoid`, `eq`, `db`, `portalUsers`, `withSystemDbAccessContext` are already imported at the top of `auth.ts`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test --filter=@breeze/api -- portal/acceptInvite.test`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Verify the existing portal auth tests still pass**
+
+Run: `pnpm test --filter=@breeze/api -- portal`
+Expected: PASS (existing `portal.test.ts` / `portal.compat.test.ts` unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/portal/auth.ts apps/api/src/routes/portal/acceptInvite.test.ts
+git commit -m "feat(portal): accept-invite endpoint + fix forgot-password link base"
+```
+
+---
+
+## Task 4: Shared validators (MSP-facing)
+
+**Files:**
+- Modify: `packages/shared/src/validators/portal.ts` (3 schemas)
+- Modify: `packages/shared/src/validators/index.ts` (ensure `export * from './portal';` present)
+- Test: `packages/shared/src/validators/portal.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces (all importable from `@breeze/shared`):
+  - `invitePortalUserSchema` = `{ email: email, name?: string(max255), message?: string(max1000) }`
+  - `bulkInvitePortalUsersSchema` = `{ userIds?: string(guid)[] }`
+  - `updatePortalUserSchema` = `{ name?: string(max255), receiveNotifications?: boolean, status?: 'active'|'disabled' }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/shared/src/validators/portal.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { invitePortalUserSchema, bulkInvitePortalUsersSchema, updatePortalUserSchema } from './portal';
+
+describe('invitePortalUserSchema', () => {
+  it('accepts a valid invite', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'a@b.example', name: 'A', message: 'hi' }).success).toBe(true);
+  });
+  it('rejects a bad email', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'nope' }).success).toBe(false);
+  });
+  it('rejects an over-long message', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'a@b.example', message: 'x'.repeat(1001) }).success).toBe(false);
+  });
+});
+
+describe('updatePortalUserSchema', () => {
+  it('accepts active/disabled status', () => {
+    expect(updatePortalUserSchema.safeParse({ status: 'disabled' }).success).toBe(true);
+  });
+  it('rejects an invited status (not settable here)', () => {
+    expect(updatePortalUserSchema.safeParse({ status: 'invited' }).success).toBe(false);
+  });
+});
+
+describe('bulkInvitePortalUsersSchema', () => {
+  it('accepts an optional userIds array of GUIDs', () => {
+    expect(bulkInvitePortalUsersSchema.safeParse({ userIds: ['7c0a1f7e-1111-4222-8333-444455556666'] }).success).toBe(true);
+    expect(bulkInvitePortalUsersSchema.safeParse({}).success).toBe(true);
+  });
+  it('rejects non-GUID ids', () => {
+    expect(bulkInvitePortalUsersSchema.safeParse({ userIds: ['not-a-guid'] }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter=@breeze/shared -- validators/portal.test`
+Expected: FAIL — schemas not exported.
+
+- [ ] **Step 3: Add the schemas**
+
+Append to `packages/shared/src/validators/portal.ts`:
+
+```ts
+export const invitePortalUserSchema = z.object({
+  email: z.string().email().max(255),
+  name: z.string().min(1).max(255).optional(),
+  message: z.string().max(1000).optional()
+}).strict();
+export type InvitePortalUserInput = z.infer<typeof invitePortalUserSchema>;
+
+export const bulkInvitePortalUsersSchema = z.object({
+  userIds: z.array(z.string().guid()).optional()
+}).strict();
+export type BulkInvitePortalUsersInput = z.infer<typeof bulkInvitePortalUsersSchema>;
+
+export const updatePortalUserSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  receiveNotifications: z.boolean().optional(),
+  status: z.enum(['active', 'disabled']).optional()
+}).strict();
+export type UpdatePortalUserInput = z.infer<typeof updatePortalUserSchema>;
+```
+
+- [ ] **Step 4: Ensure the barrel re-exports `./portal`**
+
+Check `packages/shared/src/validators/index.ts`. If it does not already contain `export * from './portal';`, add it to the export list (top of file, alongside the other `export * from './...'` lines).
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm test --filter=@breeze/shared -- validators/portal.test`
+Expected: PASS (7 assertions across 3 describes).
+Run: `pnpm --filter=@breeze/shared build` (or the repo's shared typecheck) to confirm the new `@breeze/shared` exports compile.
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/validators/portal.ts packages/shared/src/validators/portal.test.ts packages/shared/src/validators/index.ts
+git commit -m "feat(portal): shared validators for portal-user invite/manage"
+```
+
+---
+
+## Task 5: Email — `sendPortalInvite`
+
+**Files:**
+- Modify: `apps/api/src/services/email.ts` (interface, method, template builder)
+- Test: `apps/api/src/services/portalInviteEmail.test.ts` (create)
+
+**Interfaces:**
+- Produces: `EmailService.sendPortalInvite(params: PortalInviteEmailParams): Promise<void>`; `PortalInviteEmailParams = { to: string|string[]; inviteUrl: string; orgName?: string; inviterName?: string; message?: string; supportEmail?: string }`; and exported `buildPortalInviteTemplate(params): EmailTemplate` for testing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/services/portalInviteEmail.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildPortalInviteTemplate } from './email';
+
+describe('buildPortalInviteTemplate', () => {
+  it('includes the invite URL and org name', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://us.2breeze.app/portal/accept-invite?token=abc', orgName: 'Acme Co', inviterName: 'Tess' });
+    expect(t.subject).toContain('Acme Co');
+    expect(t.html).toContain('https://us.2breeze.app/portal/accept-invite?token=abc');
+    expect(t.text).toContain('https://us.2breeze.app/portal/accept-invite?token=abc');
+  });
+  it('renders a generic subject without an org name', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://x/portal/accept-invite?token=1' });
+    expect(t.subject.length).toBeGreaterThan(0);
+  });
+  it('includes an optional custom message', () => {
+    const t = buildPortalInviteTemplate({ to: 'c@a.example', inviteUrl: 'https://x/p?t=1', message: 'Welcome aboard!' });
+    expect(t.html).toContain('Welcome aboard!');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter=@breeze/api -- portalInviteEmail.test`
+Expected: FAIL — `buildPortalInviteTemplate` not exported.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/services/email.ts`, add the params interface near `PasswordResetEmailParams` (~line 44):
+
+```ts
+export interface PortalInviteEmailParams {
+  to: string | string[];
+  inviteUrl: string;
+  orgName?: string;
+  inviterName?: string;
+  message?: string;
+  supportEmail?: string;
+}
+```
+
+Add the method inside `class EmailService` (before it closes at line 309), mirroring `sendPasswordReset`:
+
+```ts
+  async sendPortalInvite(params: PortalInviteEmailParams): Promise<void> {
+    const template = buildPortalInviteTemplate(params);
+    await this.sendEmail({ to: params.to, subject: template.subject, html: template.html, text: template.text });
+  }
+```
+
+Add the exported template builder near `buildPasswordResetTemplate` (~line 630):
+
+```ts
+export function buildPortalInviteTemplate(params: PortalInviteEmailParams): EmailTemplate {
+  const orgName = params.orgName?.trim();
+  const inviter = params.inviterName?.trim();
+  const customMessage = params.message?.trim();
+  const subject = orgName ? `You're invited to the ${orgName} support portal` : `You're invited to your support portal`;
+  const preheader = 'Set your password to access your support portal.';
+  const heading = orgName ? `Join the ${orgName} portal` : 'Join your support portal';
+  const invitedBy = inviter ? `${escapeHtml(inviter)} invited you` : 'You have been invited';
+  const body = `
+      <p style="${BODY_PARA}">${invitedBy} to the${orgName ? ` ${escapeHtml(orgName)}` : ''} support portal, where you can open tickets, view invoices, and track your devices.</p>
+      ${customMessage ? `<p style="${BODY_PARA}">${escapeHtml(customMessage)}</p>` : ''}
+      ${renderButton('Set your password', params.inviteUrl)}
+      <p style="${MUTED_PARA}">This invite link expires in 7 days. If you didn't expect this, you can ignore this email.</p>
+  `;
+  const html = renderLayout({ title: subject, preheader, heading, body, footer: supportFooter(params.supportEmail, 'Need help? Contact') });
+  const support = getSupportEmail(params.supportEmail);
+  const text = [
+    orgName ? `You're invited to the ${orgName} support portal.` : `You're invited to your support portal.`,
+    customMessage || null,
+    `Set your password: ${params.inviteUrl}`,
+    'This invite link expires in 7 days.',
+    support ? `Need help? Contact ${support}.` : null
+  ].filter(Boolean).join('\n');
+  return { subject, html, text };
+}
+```
+
+`escapeHtml`, `renderButton`, `renderLayout`, `getSupportEmail` are already imported from `./emailLayout`; `BODY_PARA`, `MUTED_PARA`, `supportFooter`, `EmailTemplate` are already in this file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter=@breeze/api -- portalInviteEmail.test`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/email.ts apps/api/src/services/portalInviteEmail.test.ts
+git commit -m "feat(portal): sendPortalInvite email template"
+```
+
+---
+
+## Task 6: MSP API — `orgPortalUsers.ts` (list + invite)
+
+**Files:**
+- Create: `apps/api/src/routes/orgPortalUsers.ts`
+- Modify: `apps/api/src/routes/orgs.ts:29` (import) and `:1331-1334` (register)
+- Test: `apps/api/src/routes/orgPortalUsers.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `storePortalInviteToken`, `buildPortalUrl` (Task 2); `getEmailService().sendPortalInvite` (Task 5); `invitePortalUserSchema` (Task 4).
+- Produces: `registerOrgPortalUsersRoutes(orgRoutes: Hono): void`; `effectivePortalStatus(row): 'active'|'disabled'|'pending_setup'` (module-local); routes `GET /organizations/:id/portal-users`, `POST /organizations/:id/portal-users/invite`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/orgPortalUsers.test.ts` (mirrors `orgPortalSettings.test.ts` mock skeleton):
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectResult, insertReturning, sendInvite } = vi.hoisted(() => ({
+  authRef: { current: { scope: 'partner' as string, user: { id: 'u-1', name: 'Tess', email: 'tess@msp.example' }, partnerId: 'p-1' as string | null, canAccessOrg: (_id: string) => true } },
+  selectResult: vi.fn(),
+  insertReturning: vi.fn(),
+  sendInvite: vi.fn()
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => { c.set('auth', authRef.current); await next(); }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next()
+}));
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => selectResult()), orderBy: vi.fn(() => selectResult()) })) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(() => insertReturning()) })) })) }))
+  }
+}));
+vi.mock('../db/schema', () => ({
+  portalUsers: { id: 'id', orgId: 'orgId', email: 'email', name: 'name', passwordHash: 'passwordHash', receiveNotifications: 'receiveNotifications', status: 'status', invitedBy: 'invitedBy', invitedAt: 'invitedAt', lastLoginAt: 'lastLoginAt', createdAt: 'createdAt' },
+  organizations: { id: 'id', name: 'name', deletedAt: 'deletedAt' }
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../routes/portal/helpers', () => ({ storePortalInviteToken: vi.fn(async () => 'raw-token'), buildPortalUrl: (p: string) => `https://x/portal${p}` }));
+vi.mock('../services/email', () => ({ getEmailService: () => ({ sendPortalInvite: sendInvite }) }));
+
+import { authMiddleware } from '../middleware/auth';
+import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const makeApp = () => { const app = new Hono(); app.use('*', authMiddleware as any); registerOrgPortalUsersRoutes(app); return app; };
+beforeEach(() => { vi.clearAllMocks(); authRef.current = { scope: 'partner', user: { id: 'u-1', name: 'Tess', email: 'tess@msp.example' }, partnerId: 'p-1', canAccessOrg: () => true }; });
+
+describe('GET /organizations/:id/portal-users', () => {
+  it('lists users with an effective status', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org existence
+      .mockResolvedValueOnce([
+        { id: 'pu-1', email: 'a@acme.example', name: 'A', passwordHash: 'h', status: 'active', receiveNotifications: true, lastLoginAt: null, invitedAt: null },
+        { id: 'pu-2', email: 'b@acme.example', name: null, passwordHash: null, status: 'active', receiveNotifications: true, lastLoginAt: null, invitedAt: null }
+      ]);
+    const res = await makeApp().request(`/organizations/${ORG_ID}/portal-users`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.map((u: any) => u.effectiveStatus)).toEqual(['active', 'pending_setup']);
+    expect(JSON.stringify(body)).not.toContain('passwordHash');
+  });
+});
+
+describe('POST /organizations/:id/portal-users/invite', () => {
+  const invite = (body: unknown) => makeApp().request(`/organizations/${ORG_ID}/portal-users/invite`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+
+  it('creates an invited user and emails a link', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }]) // org existence
+      .mockResolvedValueOnce([])               // no existing portal user
+      .mockResolvedValueOnce([{ name: 'Acme Co' }]); // org name
+    insertReturning.mockResolvedValueOnce([{ id: 'pu-new', email: 'new@acme.example', status: 'invited' }]);
+    const res = await invite({ email: 'new@acme.example', name: 'New Cust' });
+    expect(res.status).toBe(200);
+    expect(sendInvite).toHaveBeenCalledWith(expect.objectContaining({ to: 'new@acme.example', inviteUrl: expect.stringContaining('/portal/accept-invite?token=raw-token') }));
+  });
+
+  it('409s when the email is already an active account with a password', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', email: 'live@acme.example', passwordHash: 'h', status: 'active' }]);
+    const res = await invite({ email: 'live@acme.example' });
+    expect(res.status).toBe(409);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter=@breeze/api -- orgPortalUsers.test`
+Expected: FAIL — module `./orgPortalUsers` does not exist.
+
+- [ ] **Step 3: Implement the route module**
+
+Create `apps/api/src/routes/orgPortalUsers.ts`:
+
+```ts
+import type { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq, isNull, desc } from 'drizzle-orm';
+import { db } from '../db';
+import { organizations, portalUsers } from '../db/schema';
+import { requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
+import { PERMISSIONS } from '../services/permissions';
+import { writeRouteAudit } from '../services/auditEvents';
+import { getEmailService } from '../services/email';
+import { storePortalInviteToken, buildPortalUrl } from './portal/helpers';
+import { invitePortalUserSchema } from '@breeze/shared';
+
+type PortalUserListRow = {
+  id: string; email: string; name: string | null; passwordHash: string | null;
+  status: string; receiveNotifications: boolean; lastLoginAt: Date | null; invitedAt: Date | null;
+};
+
+export function effectivePortalStatus(row: { status: string; passwordHash: string | null }): 'active' | 'disabled' | 'pending_setup' {
+  if (row.status === 'disabled') return 'disabled';
+  if (!row.passwordHash) return 'pending_setup';
+  return 'active';
+}
+
+function toListItem(row: PortalUserListRow) {
+  return {
+    id: row.id, email: row.email, name: row.name, status: row.status,
+    effectiveStatus: effectivePortalStatus(row), receiveNotifications: row.receiveNotifications,
+    lastLoginAt: row.lastLoginAt, invitedAt: row.invitedAt
+  };
+}
+
+async function resolveAccessibleOrg(c: any): Promise<{ id: string } | Response> {
+  const auth = c.get('auth') as AuthContext;
+  const id = c.req.param('id')!;
+  if (auth.scope === 'partner' && !auth.canAccessOrg(id)) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+  const rows = await db.select({ id: organizations.id }).from(organizations)
+    .where(and(eq(organizations.id, id), isNull(organizations.deletedAt))).limit(1);
+  if (!rows[0]) return c.json({ error: 'Organization not found' }, 404);
+  return { id };
+}
+
+export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
+  const requireOrgRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
+  const requireOrgWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+
+  orgRoutes.get('/organizations/:id/portal-users', requireScope('partner', 'system'), requireOrgRead, async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const rows = await db.select({
+      id: portalUsers.id, email: portalUsers.email, name: portalUsers.name, passwordHash: portalUsers.passwordHash,
+      status: portalUsers.status, receiveNotifications: portalUsers.receiveNotifications,
+      lastLoginAt: portalUsers.lastLoginAt, invitedAt: portalUsers.invitedAt
+    }).from(portalUsers).where(eq(portalUsers.orgId, org.id)).orderBy(desc(portalUsers.createdAt));
+    return c.json({ data: rows.map(toListItem) });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', invitePortalUserSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const { email, name, message } = c.req.valid('json');
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const [existing] = await db.select({ id: portalUsers.id, email: portalUsers.email, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
+      .from(portalUsers).where(and(eq(portalUsers.orgId, org.id), eq(portalUsers.email, normalizedEmail))).limit(1);
+
+    if (existing && existing.passwordHash && existing.status === 'active') {
+      return c.json({ error: 'This email already has an active portal account.' }, 409);
+    }
+
+    const now = new Date();
+    let userId: string;
+    if (existing) {
+      await db.update(portalUsers).set({ name: name ?? undefined, status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, existing.id)).returning({ id: portalUsers.id });
+      userId = existing.id;
+    } else {
+      const [created] = await db.insert(portalUsers).values({ orgId: org.id, email: normalizedEmail, name: name ?? null, passwordHash: null, authMethod: 'password', status: 'invited', invitedBy: auth.user.id, invitedAt: now }).returning({ id: portalUsers.id });
+      userId = created!.id;
+    }
+
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const rawToken = await storePortalInviteToken(userId);
+    const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
+
+    let emailSent = false;
+    const emailService = getEmailService();
+    if (emailService) {
+      try {
+        await emailService.sendPortalInvite({ to: normalizedEmail, inviteUrl, orgName: orgRow?.name ?? undefined, inviterName: auth.user.name ?? undefined, message });
+        emailSent = true;
+      } catch (err) {
+        console.error('[orgPortalUsers] invite email failed:', err);
+      }
+    }
+
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.invite', resourceType: 'portal_user', resourceId: userId, details: { email: normalizedEmail, emailSent } });
+    return c.json({ data: { id: userId, email: normalizedEmail, status: 'invited' }, emailSent });
+  });
+}
+```
+
+- [ ] **Step 4: Register the routes in `orgs.ts`**
+
+In `apps/api/src/routes/orgs.ts`, add next to line 29:
+
+```ts
+import { registerOrgPortalUsersRoutes } from './orgPortalUsers';
+```
+
+And next to the `registerOrgPortalSettingsRoutes(orgRoutes);` call (line ~1332):
+
+```ts
+// Customer-portal users (portal_users invite/manage) — see routes/orgPortalUsers.ts
+registerOrgPortalUsersRoutes(orgRoutes);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test --filter=@breeze/api -- orgPortalUsers.test`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/orgPortalUsers.ts apps/api/src/routes/orgPortalUsers.test.ts apps/api/src/routes/orgs.ts
+git commit -m "feat(portal): MSP org-portal-users list + invite endpoints"
+```
+
+---
+
+## Task 7: MSP API — patch, resend, bulk-invite, delete
+
+**Files:**
+- Modify: `apps/api/src/routes/orgPortalUsers.ts`
+- Modify: `apps/api/src/routes/orgPortalUsers.test.ts`
+
+**Interfaces:**
+- Consumes: `bulkInvitePortalUsersSchema`, `updatePortalUserSchema` (Task 4); `ticketComments`, `tickets`, `assetCheckouts` schema tables.
+- Produces: `PATCH`, `POST .../resend-invite`, `POST .../bulk-invite`, `DELETE` routes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/routes/orgPortalUsers.test.ts`:
+
+```ts
+describe('PATCH /organizations/:id/portal-users/:userId', () => {
+  const patch = (uid: string, body: unknown) => makeApp().request(`/organizations/${ORG_ID}/portal-users/${uid}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  it('disables a user', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])                         // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }]);          // target exists in org
+    insertReturning.mockResolvedValueOnce([{ id: 'pu-1', status: 'disabled' }]); // update .returning
+    const res = await patch('pu-1', { status: 'disabled' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('DELETE /organizations/:id/portal-users/:userId', () => {
+  const del = (uid: string) => makeApp().request(`/organizations/${ORG_ID}/portal-users/${uid}`, { method: 'DELETE' });
+  it('409s when the user has ticket references', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])            // org
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }]) // target
+      .mockResolvedValueOnce([{ id: 't-1' }]);            // reference exists (tickets)
+    const res = await del('pu-1');
+    expect(res.status).toBe(409);
+  });
+  it('hard-deletes an unreferenced user', async () => {
+    selectResult
+      .mockResolvedValueOnce([{ id: ORG_ID }])
+      .mockResolvedValueOnce([{ id: 'pu-1', orgId: ORG_ID }])
+      .mockResolvedValueOnce([]) // tickets ref
+      .mockResolvedValueOnce([]) // comments ref
+      .mockResolvedValueOnce([]); // checkouts ref
+    // delete().where() resolves (mock deleteChain below)
+    const res = await del('pu-1');
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+Extend the `../db` mock in the hoisted block to add a `delete` chain — update the `vi.mock('../db', ...)` `db` object to include:
+
+```ts
+    delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test --filter=@breeze/api -- orgPortalUsers.test`
+Expected: FAIL — new routes not implemented.
+
+- [ ] **Step 3: Implement the remaining routes**
+
+In `apps/api/src/routes/orgPortalUsers.ts`, extend the schema import:
+
+```ts
+import { invitePortalUserSchema, bulkInvitePortalUsersSchema, updatePortalUserSchema } from '@breeze/shared';
+```
+Add table imports for the reference check:
+```ts
+import { tickets, ticketComments, assetCheckouts } from '../db/schema';
+```
+
+Add a shared helper inside the module (above `registerOrgPortalUsersRoutes`):
+
+```ts
+async function getOrgScopedPortalUser(orgId: string, userId: string) {
+  const [row] = await db.select({ id: portalUsers.id, orgId: portalUsers.orgId, email: portalUsers.email, name: portalUsers.name, passwordHash: portalUsers.passwordHash, status: portalUsers.status })
+    .from(portalUsers).where(and(eq(portalUsers.id, userId), eq(portalUsers.orgId, orgId))).limit(1);
+  return row ?? null;
+}
+
+async function hasPortalUserReferences(userId: string): Promise<boolean> {
+  const [t] = await db.select({ id: tickets.id }).from(tickets).where(eq(tickets.submittedBy, userId)).limit(1);
+  if (t) return true;
+  const [cm] = await db.select({ id: ticketComments.id }).from(ticketComments).where(eq(ticketComments.portalUserId, userId)).limit(1);
+  if (cm) return true;
+  const [ck] = await db.select({ id: assetCheckouts.id }).from(assetCheckouts).where(eq(assetCheckouts.checkedOutTo, userId)).limit(1);
+  return Boolean(ck);
+}
+
+async function issueAndSendInvite(c: any, orgId: string, user: { id: string; email: string }, orgName: string | null, inviterName: string | null | undefined, message?: string): Promise<boolean> {
+  const rawToken = await storePortalInviteToken(user.id);
+  const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
+  const emailService = getEmailService();
+  if (!emailService) return false;
+  try {
+    await emailService.sendPortalInvite({ to: user.email, inviteUrl, orgName: orgName ?? undefined, inviterName: inviterName ?? undefined, message });
+    return true;
+  } catch (err) {
+    console.error('[orgPortalUsers] invite email failed:', err);
+    return false;
+  }
+}
+```
+
+Refactor the existing invite handler's token+email block to call `issueAndSendInvite` (DRY) — replace the inline `storePortalInviteToken`/`getEmailService` block with:
+
+```ts
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const emailSent = await issueAndSendInvite(c, org.id, { id: userId, email: normalizedEmail }, orgRow?.name ?? null, auth.user.name, message);
+```
+
+Add these routes inside `registerOrgPortalUsersRoutes` (after the invite route):
+
+```ts
+  orgRoutes.patch('/organizations/:id/portal-users/:userId', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', updatePortalUserSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const body = c.req.valid('json');
+    if (Object.keys(body).length === 0) return c.json({ error: 'No updates provided' }, 400);
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    const [updated] = await db.update(portalUsers).set({ ...body, updatedAt: new Date() }).where(eq(portalUsers.id, target.id)).returning({ id: portalUsers.id, status: portalUsers.status });
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.update', resourceType: 'portal_user', resourceId: target.id, details: { changedFields: Object.keys(body) } });
+    return c.json({ data: { id: updated!.id, status: updated!.status } });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/:userId/resend-invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (target.passwordHash && target.status === 'active') return c.json({ error: 'This account is already set up.' }, 409);
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const emailSent = await issueAndSendInvite(c, org.id, { id: target.id, email: target.email }, orgRow?.name ?? null, auth.user.name);
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.resend_invite', resourceType: 'portal_user', resourceId: target.id, details: { emailSent } });
+    return c.json({ data: { id: target.id }, emailSent });
+  });
+
+  orgRoutes.post('/organizations/:id/portal-users/bulk-invite', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', bulkInvitePortalUsersSchema), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const auth = c.get('auth') as AuthContext;
+    const { userIds } = c.req.valid('json');
+    // "Pending setup" = no password. Invite selected, or all pending in the org.
+    const baseWhere = and(eq(portalUsers.orgId, org.id), isNull(portalUsers.passwordHash));
+    const candidates = await db.select({ id: portalUsers.id, email: portalUsers.email }).from(portalUsers).where(baseWhere);
+    const targets = userIds && userIds.length > 0 ? candidates.filter((u) => userIds.includes(u.id)) : candidates;
+    const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
+    const now = new Date();
+    const results: Array<{ id: string; emailSent: boolean }> = [];
+    for (const t of targets) {
+      await db.update(portalUsers).set({ status: 'invited', invitedBy: auth.user.id, invitedAt: now, updatedAt: now }).where(eq(portalUsers.id, t.id));
+      const emailSent = await issueAndSendInvite(c, org.id, t, orgRow?.name ?? null, auth.user.name);
+      results.push({ id: t.id, emailSent });
+    }
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.bulk_invite', resourceType: 'organization', resourceId: org.id, details: { invited: results.length } });
+    return c.json({ data: results });
+  });
+
+  orgRoutes.delete('/organizations/:id/portal-users/:userId', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), async (c) => {
+    const org = await resolveAccessibleOrg(c);
+    if (org instanceof Response) return org;
+    const target = await getOrgScopedPortalUser(org.id, c.req.param('userId')!);
+    if (!target) return c.json({ error: 'Portal user not found' }, 404);
+    if (await hasPortalUserReferences(target.id)) {
+      return c.json({ error: 'This user has ticket or asset history. Disable them instead of deleting.' }, 409);
+    }
+    await db.delete(portalUsers).where(eq(portalUsers.id, target.id));
+    writeRouteAudit(c, { orgId: org.id, action: 'organization.portal_user.delete', resourceType: 'portal_user', resourceId: target.id, details: { email: target.email } });
+    return c.json({ data: { id: target.id, deleted: true } });
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test --filter=@breeze/api -- orgPortalUsers.test`
+Expected: PASS (all tests across Tasks 6 + 7).
+
+- [ ] **Step 5: Typecheck the API**
+
+Run: `pnpm --filter=@breeze/api typecheck` (or the repo's API type-check script)
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/orgPortalUsers.ts apps/api/src/routes/orgPortalUsers.test.ts
+git commit -m "feat(portal): org-portal-users patch/resend/bulk-invite/delete"
+```
+
+---
+
+## Task 8: Web UI — `OrgPortalUsersEditor.tsx`
+
+**Files:**
+- Create: `apps/web/src/components/settings/OrgPortalUsersEditor.tsx`
+- Modify: `apps/web/src/components/settings/OrgSettingsPage.tsx:24` (import) and the `case 'portal'` block (~line 485)
+- Test: `apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `fetchWithAuth` (`../../stores/auth`), `runAction`/`ActionError` (`@/lib/runAction`), `navigateTo` (`@/lib/navigation`).
+- API paths (relative, `/orgs`-prefixed): `GET/POST /orgs/organizations/${orgId}/portal-users`, `POST .../invite`, `POST .../bulk-invite`, `PATCH .../:userId`, `POST .../:userId/resend-invite`, `DELETE .../:userId`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+import OrgPortalUsersEditor from './OrgPortalUsersEditor';
+
+const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
+const ok = (data: unknown) => ({ ok: true, status: 200, json: async () => (data) });
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('OrgPortalUsersEditor', () => {
+  it('renders portal users with status badges', async () => {
+    fetchWithAuth.mockResolvedValueOnce(ok({ data: [
+      { id: 'pu-1', email: 'a@acme.example', name: 'A', status: 'active', effectiveStatus: 'active', lastLoginAt: null, invitedAt: null },
+      { id: 'pu-2', email: 'b@acme.example', name: null, status: 'active', effectiveStatus: 'pending_setup', lastLoginAt: null, invitedAt: null }
+    ] }));
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByText('a@acme.example')).toBeInTheDocument());
+    expect(screen.getByText('b@acme.example')).toBeInTheDocument();
+    expect(screen.getByText(/pending setup/i)).toBeInTheDocument();
+  });
+
+  it('invites a user through the API', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(ok({ data: [] }))                                  // initial list
+      .mockResolvedValueOnce(ok({ data: { id: 'pu-new', status: 'invited' }, emailSent: true })) // invite
+      .mockResolvedValueOnce(ok({ data: [] }));                                 // reload
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('portal-users-invite-open'));
+    fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'new@acme.example' } });
+    fireEvent.click(screen.getByTestId('portal-users-invite-submit'));
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG_ID}/portal-users/invite`,
+      expect.objectContaining({ method: 'POST' })
+    ));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm test -- OrgPortalUsersEditor.test`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/web/src/components/settings/OrgPortalUsersEditor.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, ActionError } from '@/lib/runAction';
+
+type PortalUser = {
+  id: string; email: string; name: string | null; status: string;
+  effectiveStatus: 'active' | 'disabled' | 'pending_setup';
+  lastLoginAt: string | null; invitedAt: string | null;
+};
+
+const STATUS_LABEL: Record<PortalUser['effectiveStatus'], string> = {
+  active: 'Active', disabled: 'Disabled', pending_setup: 'Pending setup'
+};
+
+const base = (orgId: string) => `/orgs/organizations/${orgId}/portal-users`;
+
+export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
+  const [users, setUsers] = useState<PortalUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(base(orgId));
+      if (res.status === 401) { void navigateTo('/login', { replace: true }); return; }
+      if (!res.ok) throw new Error(`portal users load failed: ${res.status}`);
+      setUsers((await res.json()).data ?? []);
+    } catch (err) {
+      console.warn('[OrgPortalUsersEditor] load failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const invite = async () => {
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`${base(orgId)}/invite`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, name: name || undefined, message: message || undefined })
+        }),
+        errorFallback: 'Failed to send invite',
+        successMessage: 'Invite sent',
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      setInviteOpen(false); setEmail(''); setName(''); setMessage('');
+      await load();
+    } catch (err) { if (!(err instanceof ActionError)) throw err; }
+  };
+
+  const mutate = async (path: string, method: string, body?: unknown, successMessage?: string) => {
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`${base(orgId)}${path}`, {
+          method,
+          headers: body ? { 'Content-Type': 'application/json' } : undefined,
+          body: body ? JSON.stringify(body) : undefined
+        }),
+        errorFallback: 'Action failed',
+        successMessage,
+        onUnauthorized: () => void navigateTo('/login', { replace: true })
+      });
+      await load();
+    } catch (err) { if (!(err instanceof ActionError)) throw err; }
+  };
+
+  const pendingCount = users.filter((u) => u.effectiveStatus === 'pending_setup').length;
+
+  return (
+    <section data-testid="portal-users-editor" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold">Portal users</h3>
+        <div className="flex gap-2">
+          {pendingCount > 0 && (
+            <button type="button" data-testid="portal-users-bulk-invite"
+              onClick={() => void mutate('/bulk-invite', 'POST', {}, `Invited ${pendingCount} pending user(s)`)}>
+              Invite pending ({pendingCount})
+            </button>
+          )}
+          <button type="button" data-testid="portal-users-invite-open" onClick={() => setInviteOpen(true)}>Invite user</button>
+        </div>
+      </div>
+
+      {loading ? <p>Loading…</p> : (
+        <table className="w-full text-sm">
+          <thead><tr><th>Email</th><th>Name</th><th>Status</th><th>Last login</th><th></th></tr></thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} data-testid={`portal-user-row-${u.id}`}>
+                <td>{u.email}</td>
+                <td>{u.name ?? '—'}</td>
+                <td><span data-testid={`portal-user-status-${u.id}`}>{STATUS_LABEL[u.effectiveStatus]}</span></td>
+                <td>{u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString() : '—'}</td>
+                <td className="flex gap-2">
+                  {u.effectiveStatus !== 'active' && (
+                    <button type="button" data-testid={`portal-user-resend-${u.id}`}
+                      onClick={() => void mutate(`/${u.id}/resend-invite`, 'POST', undefined, 'Invite resent')}>Resend</button>
+                  )}
+                  {u.effectiveStatus === 'disabled' ? (
+                    <button type="button" data-testid={`portal-user-enable-${u.id}`}
+                      onClick={() => void mutate(`/${u.id}`, 'PATCH', { status: 'active' }, 'User reactivated')}>Reactivate</button>
+                  ) : (
+                    <button type="button" data-testid={`portal-user-disable-${u.id}`}
+                      onClick={() => void mutate(`/${u.id}`, 'PATCH', { status: 'disabled' }, 'User disabled')}>Disable</button>
+                  )}
+                  <button type="button" data-testid={`portal-user-delete-${u.id}`}
+                    onClick={() => void mutate(`/${u.id}`, 'DELETE', undefined, 'User removed')}>Remove</button>
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && <tr><td colSpan={5}>No portal users yet.</td></tr>}
+          </tbody>
+        </table>
+      )}
+
+      {inviteOpen && (
+        <div data-testid="portal-users-invite-modal" className="space-y-2">
+          <input data-testid="portal-users-invite-email" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <input data-testid="portal-users-invite-name" placeholder="Name (optional)" value={name} onChange={(e) => setName(e.target.value)} />
+          <textarea data-testid="portal-users-invite-message" placeholder="Message (optional)" value={message} onChange={(e) => setMessage(e.target.value)} />
+          <div className="flex gap-2">
+            <button type="button" data-testid="portal-users-invite-submit" onClick={() => void invite()}>Send invite</button>
+            <button type="button" onClick={() => setInviteOpen(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+(Styling classes are minimal placeholders; match sibling `OrgPortalSettingsEditor` styling conventions when wiring. `data-testid` attributes are required for e2e per the repo convention.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm test -- OrgPortalUsersEditor.test`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Render it in the Portal tab**
+
+In `apps/web/src/components/settings/OrgSettingsPage.tsx`:
+Add next to line 24:
+```tsx
+import OrgPortalUsersEditor from './OrgPortalUsersEditor';
+```
+Replace the `case 'portal':` return (around line 484) with:
+```tsx
+    case 'portal':
+      return effectiveOrgId ? (
+        <>
+          <OrgPortalSettingsEditor orgId={effectiveOrgId} onDirty={handleDirty} onSave={() => handleSave()} />
+          <OrgPortalUsersEditor orgId={effectiveOrgId} />
+        </>
+      ) : null;
+```
+
+- [ ] **Step 6: Typecheck web + run the settings tests**
+
+Run: `cd apps/web && pnpm test -- OrgPortalUsersEditor.test OrgPortalSettingsEditor.test`
+Expected: PASS.
+Run: `cd apps/web && pnpm astro check` (or the repo web typecheck)
+Expected: no new type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/settings/OrgPortalUsersEditor.tsx apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx apps/web/src/components/settings/OrgSettingsPage.tsx
+git commit -m "feat(portal): Portal Users management UI in Org Settings"
+```
+
+---
+
+## Task 9: Integration test — RLS + end-to-end invite→accept (real Postgres)
+
+**Files:**
+- Test: `apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts` (create)
+
+**Interfaces:**
+- Consumes: everything above, against a real DB (see `vitest.integration.config.ts`, port 5433).
+
+- [ ] **Step 1: Write the integration test**
+
+Create `apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts` following the existing integration harness (see a sibling `*.integration.test.ts` for the DB bootstrap/seed + `withSystemDbAccessContext` helpers). Cover:
+  - A partner-scoped tech invites `new@acme.example` → a `portal_users` row exists with `status='invited'`, `invited_by` set.
+  - The same tech CANNOT list/invite for an org outside their partner (cross-tenant → 404 / RLS blocks the write).
+  - Consuming the stored invite token via `POST /portal/auth/accept-invite` flips the row to `status='active'` with a non-null `password_hash`, and a subsequent `POST /portal/auth/login` with that password succeeds.
+
+Model the DB setup and request harness on the nearest existing integration test in that directory (do not invent a new harness). Assert row state with a `withSystemDbAccessContext` select.
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `pnpm test:integration -- portalUserInvite` (real DB on :5433 must be up per `docs` integration setup)
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/portalUserInvite.integration.test.ts
+git commit -m "test(portal): integration coverage for invite→accept + RLS isolation"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full API unit suite: `pnpm test --filter=@breeze/api`
+- [ ] Run the shared suite: `pnpm test --filter=@breeze/shared`
+- [ ] Run the web suite: `cd apps/web && pnpm test`
+- [ ] `pnpm db:check-drift` — no drift.
+- [ ] Confirm `docs/testing/FEATURE_TEST_LOG.md` is NOT staged in any commit.
+- [ ] Open a PR from `feat/portal-customer-onboarding` → `main`; body notes the deploy tie-in: **setting `PUBLIC_PORTAL_URL` on the API is part of the held portal rollout, tracked separately.**
+
+---
+
+## Spec coverage self-check
+
+| Spec requirement | Task |
+|---|---|
+| `invited_by`/`invited_at`, status model | 1 |
+| Invite token (redis+in-memory, 7d), `buildPortalUrl` | 2 |
+| `accept-invite` endpoint | 3 |
+| forgot-password link fix | 3 |
+| Shared validators (invite/bulk/update) | 4 |
+| `sendPortalInvite` email | 5 |
+| MSP list + invite | 6 |
+| MSP patch/resend/bulk-invite/delete (409-when-referenced) | 7 |
+| Effective "Pending setup" status | 6 (`effectivePortalStatus`) |
+| Web `OrgPortalUsersEditor` in Portal tab, `runAction` | 8 |
+| RLS + e2e invite→accept integration | 9 |
+| `acceptInviteSchema` location | 2 (portal/schemas.ts, co-located with `resetPasswordSchema` — deviates from spec's "shared validators" listing; local is consistent with the sibling reset schema) |

--- a/docs/superpowers/plans/2026-07-07-portal-customer-onboarding.md
+++ b/docs/superpowers/plans/2026-07-07-portal-customer-onboarding.md
@@ -873,6 +873,7 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
 
     const [orgRow] = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, org.id)).limit(1);
     const rawToken = await storePortalInviteToken(userId);
+    if (!rawToken) return c.json({ error: 'Service temporarily unavailable' }, 503);
     const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
 
     let emailSent = false;
@@ -1015,6 +1016,7 @@ async function hasPortalUserReferences(userId: string): Promise<boolean> {
 
 async function issueAndSendInvite(c: any, orgId: string, user: { id: string; email: string }, orgName: string | null, inviterName: string | null | undefined, message?: string): Promise<boolean> {
   const rawToken = await storePortalInviteToken(user.id);
+  if (!rawToken) return false; // redis unavailable — do not email a dead invite link
   const inviteUrl = buildPortalUrl(`/accept-invite?token=${encodeURIComponent(rawToken)}`);
   const emailService = getEmailService();
   if (!emailService) return false;

--- a/docs/superpowers/specs/2026-07-07-portal-customer-onboarding-design.md
+++ b/docs/superpowers/specs/2026-07-07-portal-customer-onboarding-design.md
@@ -1,0 +1,207 @@
+# Customer Portal — Onboarding & Invite Flow
+
+**Date:** 2026-07-07
+**Status:** Design approved, pending spec review
+**Branch:** `feat/portal-customer-onboarding`
+
+## Problem
+
+The customer portal (`apps/portal`, served under `/portal`) is fully built and released
+(image published to GHCR by `release.yml`), but its **logged-in customer onboarding is
+incomplete**, which blocks deploying it to production as a usable feature:
+
+1. **No accept-invite endpoint.** The portal UI ships `AcceptInviteForm.tsx`, which POSTs
+   to `/portal/auth/accept-invite`, but that route is **not mounted** on the API
+   (`apps/api/src/routes/portal/auth.ts` has only `login`, `forgot-password`,
+   `reset-password`, `logout`). The invite page is dead.
+2. **No MSP-side way to invite a portal user.** Portal accounts (`portal_users`) are only
+   ever auto-created via inbound-email→ticket (`services/inboundEmail/resolveOrg.ts`,
+   `status='active'`, `password_hash=NULL`) and Excel add-in SSO (`routes/clientAi/auth.ts`).
+   There is no dashboard action for a tech to invite a customer contact. The existing
+   `OrgPortalSettingsEditor.tsx` only toggles portal *features*, not users.
+3. **Forgot-password link points at the wrong app.** `/portal/auth/forgot-password` builds
+   its reset URL from `DASHBOARD_URL`/`PUBLIC_APP_URL` as `${base}/reset-password`, i.e. the
+   **MSP** dashboard's reset page, not the portal's `/portal/reset-password`. The one
+   self-serve way in is broken.
+
+Net effect: a customer whose email was captured can't actually get into the portal, and
+there is no way to invite one. Public (no-login) surfaces — emailed quote viewing/e-sign and
+invoice pay-online — work; the logged-in experience does not.
+
+## Goals
+
+Make logged-in customer onboarding work end-to-end, with **fuller** MSP-side management:
+- A customer can accept an invite, set a password, and land logged in.
+- A tech can invite customers to the portal from the dashboard, resend invites, edit basic
+  profile fields, disable/reactivate, and remove users; and bulk-invite the pre-existing
+  auto-created "pending setup" contacts.
+- The forgot-password (and invite) links resolve to the portal.
+
+## Non-goals
+
+- Portal custom-domain / visual branding (separate domain-verification project).
+- Portal SSO beyond the existing Entra (AI-for-Office) path.
+- Notification preferences beyond the existing `receive_notifications` toggle.
+- Deploying the portal to production — a separate, already-scoped rollout step (this work
+  makes `PUBLIC_PORTAL_URL` load-bearing, so setting it is part of that rollout).
+
+## Architectural decision: invite token storage
+
+**Chosen: Redis + in-memory fallback**, reusing the exact pattern the portal already uses for
+password-reset tokens (`PORTAL_REDIS_KEYS`, SHA-256-hashed token value, TTL, dev-only
+in-memory `Map`). A new `inviteToken` key namespace with a **7-day TTL**. Revoking an invite
+deletes the key.
+
+Rejected:
+- **DB `portal_invites` table** — durable/queryable but adds schema, RLS, and a cleanup job
+  for no benefit here.
+- **Stateless signed JWT** — no storage, but cannot be revoked before expiry, which defeats
+  the "Revoke invite" requirement.
+
+## Data model
+
+`portal_users.status` (already `varchar(20)`, default `active`) formalizes a 3-value model:
+
+| status | meaning | can log in? |
+|---|---|---|
+| `invited` | invited, no password yet, awaiting acceptance | no (auth rejects non-`active`) |
+| `active` | normal account | yes (if `password_hash` set) |
+| `disabled` | blocked by a tech | no |
+
+No enum migration needed — the column is a varchar, and `portal/auth.ts` already rejects any
+`status !== 'active'` at both login and the auth middleware, so `invited`/`disabled` are
+enforced for free.
+
+**Migration** (`apps/api/migrations/2026-07-07-portal-user-invites.sql`, idempotent):
+- `ADD COLUMN IF NOT EXISTS invited_by uuid REFERENCES users(id)`
+- `ADD COLUMN IF NOT EXISTS invited_at timestamptz`
+
+`portal_users` already has org-scoped RLS (shape 1, direct `org_id`); adding columns needs no
+new policy. No RLS-coverage allowlist change.
+
+**Effective display status.** The pre-existing auto-created contacts are `status='active'`
+with `password_hash=NULL` and cannot actually log in. The list endpoint computes an effective
+state so these read as **"Pending setup"** rather than a misleading "Active":
+
+```
+disabled                       -> "Disabled"
+password_hash IS NULL          -> "Pending setup"   (covers invited + auto-created no-pw)
+else                           -> "Active"
+```
+
+## Customer-facing portal API (`apps/api/src/routes/portal/`)
+
+### New: `POST /portal/auth/accept-invite`
+Body `{ token, password, name? }` (new `acceptInviteSchema` in `portal/schemas.ts`).
+Flow, mirroring `reset-password` + `login`:
+1. Rate-limit by IP + token (reuse `checkRateLimit`).
+2. `isPasswordStrong(password)` gate.
+3. Look up + consume the invite token (Redis `inviteToken(hash)` / in-memory), yielding
+   `portalUserId`. Invalid/expired → 400.
+4. Under `withSystemDbAccessContext`: set `password_hash`, `name` (if provided and not already
+   set), `status='active'`, `updated_at`. Guard: if the row is already `active` **with** a
+   password, treat the token as spent (400) — an invite can't hijack a live account.
+5. Mint a session exactly like `/login` (Redis session + cookies + `lastLoginAt`), return
+   `{ user, accessToken, expiresAt, tokens }`.
+
+This activates the existing `AcceptInviteForm.tsx` (already wired to this path).
+
+### Fix: portal link base
+New helper `buildPortalUrl(path: string): string` (in `portal/helpers.ts`):
+`(PUBLIC_PORTAL_URL || `${DASHBOARD_URL || PUBLIC_APP_URL}/portal`)` normalized, no double
+slash. Used by:
+- `forgot-password` → `buildPortalUrl('/reset-password?token=...')`
+- new invite email → `buildPortalUrl('/accept-invite?token=...')`
+
+Add `PORTAL_REDIS_KEYS.inviteToken(hash)` and `INVITE_TTL_MS`/`INVITE_TTL_SECONDS`
+(7 days) + a dev `portalInviteTokens` map with cap, mirroring `portalResetTokens`.
+
+## MSP-facing API — new `orgPortalUsers.ts`
+
+A new route module registered on `orgRoutes` (inherits `authMiddleware`), mirroring
+`orgPortalSettings.ts` gating precisely: `requireScope('partner','system')`, reads
+`requirePermission(ORGS_READ)`, writes `requirePermission(ORGS_WRITE)` + `requireMfa()`,
+`resolveAccessibleOrg(c)` for org access + existence (404 on cross-tenant), `writeRouteAudit`
+on every mutation. Writes run under the request's RLS context; `portal_users` org RLS admits
+partner-scoped techs for their accessible orgs.
+
+| Method + path | Body | Behavior |
+|---|---|---|
+| `GET /organizations/:id/portal-users` | — | List: id, email, name, effective status, lastLoginAt, receiveNotifications, invitedAt. |
+| `POST /organizations/:id/portal-users/invite` | `{email, name?, message?}` | Find-or-create row (`invited` if new; existing pending/no-pw reused). Mint invite token, email link. Sets `invited_by`/`invited_at`. Re-invite = re-issue. 409 if the email is already an active account with a password. |
+| `POST /organizations/:id/portal-users/bulk-invite` | `{userIds?: string[]}` | Invite selected (or all) "Pending setup" contacts. Returns per-user results. |
+| `PATCH /organizations/:id/portal-users/:userId` | `{name?, receiveNotifications?, status?}` | Edit profile + `disabled`⇄`active` transitions. `status` limited to `active`/`disabled` here (not `invited`). |
+| `POST /organizations/:id/portal-users/:userId/resend-invite` | — | Re-mint + re-send. 409 if already an active account with a password. |
+| `DELETE /organizations/:id/portal-users/:userId` | — | Hard-delete **only if** the user has no `tickets.submitted_by` / `ticket_comments.portal_user_id` / `asset_checkouts.checked_out_to` references; otherwise **409 "disable instead"** (preserves audit history). |
+
+New email method `emailService.sendPortalInvite({ to, inviteUrl, orgName, inviterName?, message? })`
+in `services/email.ts`, following the existing `sendPasswordReset` shape and `renderButton`.
+
+## Web UI — new `OrgPortalUsersEditor.tsx`
+
+Rendered in Org Settings → Portal tab (`OrgSettingsPage.tsx`), alongside
+`OrgPortalSettingsEditor`. A table (email, name, status badge, last login) with:
+- **Invite** modal: email, name (optional), optional message.
+- Row actions: **Resend**, **Disable/Reactivate**, **Revoke/Remove**.
+- Bulk **"Invite pending contacts"** action over the "Pending setup" rows.
+
+Every mutation wrapped in `runAction` (`apps/web/src/lib/runAction.ts`) per the repo rule, so
+success/failure always surfaces; 401 defers to the auth redirect. New client methods in the
+web API client for the endpoints above.
+
+## Validators (`packages/shared`)
+
+- `acceptInviteSchema` — `{ token: string, password: string (min per policy), name?: string }`
+- `invitePortalUserSchema` — `{ email: email, name?: string, message?: string (max ~1000) }`
+- `bulkInvitePortalUsersSchema` — `{ userIds?: string[] }`
+- `updatePortalUserSchema` — `{ name?, receiveNotifications?, status?: 'active'|'disabled' }`
+
+## Error handling
+
+- Invalid/expired/reused invite token → 400 (generic message; no account enumeration).
+- Invite for an already-active-with-password email → 409 with a clear message.
+- Cross-tenant org access → 404 (matches `orgPortalSettings`).
+- `DELETE` on a referenced user → 409 "disable instead".
+- Email-send failure on invite → the invite row + token still persist; endpoint returns a
+  soft warning so the tech can Resend (don't 500 the whole action). Logged.
+- `PUBLIC_PORTAL_URL` unset → `buildPortalUrl` falls back to `${DASHBOARD_URL}/portal`;
+  if no host is derivable, log a warning (mirrors `quoteLifecycle` guard) rather than emit a
+  hostless link.
+
+## Testing (per `breeze-testing`)
+
+**API (Vitest + Drizzle mocks / integration where RLS matters):**
+- `accept-invite`: valid token → active + session issued; expired token → 400; reused token →
+  400; already-active-with-password → 400; weak password → 400.
+- `forgot-password`: reset link uses the portal base (`/portal/reset-password`), not the MSP app.
+- `orgPortalUsers`: invite creates `invited` row + token + email; list returns effective
+  status; PATCH disable blocks login; resend re-issues; bulk-invite covers pending only;
+  DELETE 409 when referenced, 200 when clean; auth gating (missing perm 403, cross-org 404).
+- One integration test proving RLS: a partner-scoped tech can invite/list only within
+  accessible orgs.
+
+**Web (Vitest + jsdom):**
+- `OrgPortalUsersEditor`: list renders with status badges; Invite calls the endpoint via
+  `runAction`; failure surfaces a toast; disable/revoke call through.
+
+**Shared:** zod schema coverage for the four new schemas (valid + boundary + reject cases).
+
+## Rollout / deployment tie-in
+
+This makes `PUBLIC_PORTAL_URL` load-bearing for portal emails. The held production rollout
+(add the `portal` service + `/portal` Caddy block on both droplets) must also set
+`PUBLIC_PORTAL_URL=https://us.2breeze.app/portal` (and `eu.`) in the API env. Tracked with the
+deploy step, not this PR.
+
+## Files touched (summary)
+
+- `apps/api/migrations/2026-07-07-portal-user-invites.sql` (new)
+- `apps/api/src/routes/portal/auth.ts` (accept-invite, forgot-password link fix)
+- `apps/api/src/routes/portal/schemas.ts` (invite token keys/TTL, acceptInviteSchema)
+- `apps/api/src/routes/portal/helpers.ts` (`buildPortalUrl`, invite token map)
+- `apps/api/src/routes/orgPortalUsers.ts` (new) + registration next to `orgPortalSettings`
+- `apps/api/src/services/email.ts` (`sendPortalInvite`)
+- `packages/shared/src/validators/*` (four schemas)
+- `apps/web/src/components/settings/OrgPortalUsersEditor.tsx` (new) + `OrgSettingsPage.tsx`
+- Web API client method additions
+- Co-located test files for each of the above

--- a/packages/shared/src/validators/portal.test.ts
+++ b/packages/shared/src/validators/portal.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { updatePortalSettingsSchema } from './portal';
+import {
+  updatePortalSettingsSchema,
+  invitePortalUserSchema,
+  bulkInvitePortalUsersSchema,
+  updatePortalUserSchema
+} from './portal';
 
 describe('updatePortalSettingsSchema', () => {
   it('accepts a full valid payload', () => {
@@ -60,5 +65,36 @@ describe('updatePortalSettingsSchema', () => {
     expect(updatePortalSettingsSchema.safeParse({ supportEmail: `${'a'.repeat(250)}@b.example` }).success).toBe(false);
     expect(updatePortalSettingsSchema.safeParse({ welcomeMessage: 'x'.repeat(2001) }).success).toBe(false);
     expect(updatePortalSettingsSchema.safeParse({ footerText: 'x'.repeat(2001) }).success).toBe(false);
+  });
+});
+
+describe('invitePortalUserSchema', () => {
+  it('accepts a valid invite', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'a@b.example', name: 'A', message: 'hi' }).success).toBe(true);
+  });
+  it('rejects a bad email', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'nope' }).success).toBe(false);
+  });
+  it('rejects an over-long message', () => {
+    expect(invitePortalUserSchema.safeParse({ email: 'a@b.example', message: 'x'.repeat(1001) }).success).toBe(false);
+  });
+});
+
+describe('updatePortalUserSchema', () => {
+  it('accepts active/disabled status', () => {
+    expect(updatePortalUserSchema.safeParse({ status: 'disabled' }).success).toBe(true);
+  });
+  it('rejects an invited status (not settable here)', () => {
+    expect(updatePortalUserSchema.safeParse({ status: 'invited' }).success).toBe(false);
+  });
+});
+
+describe('bulkInvitePortalUsersSchema', () => {
+  it('accepts an optional userIds array of GUIDs', () => {
+    expect(bulkInvitePortalUsersSchema.safeParse({ userIds: ['7c0a1f7e-1111-4222-8333-444455556666'] }).success).toBe(true);
+    expect(bulkInvitePortalUsersSchema.safeParse({}).success).toBe(true);
+  });
+  it('rejects non-GUID ids', () => {
+    expect(bulkInvitePortalUsersSchema.safeParse({ userIds: ['not-a-guid'] }).success).toBe(false);
   });
 });

--- a/packages/shared/src/validators/portal.ts
+++ b/packages/shared/src/validators/portal.ts
@@ -16,3 +16,27 @@ export const updatePortalSettingsSchema = z.object({
 }).strict();
 
 export type UpdatePortalSettingsInput = z.infer<typeof updatePortalSettingsSchema>;
+
+// MSP-facing portal-user management (customer-portal onboarding). Invite a
+// single portal user by email; bulk-invite a set of existing (pre-created)
+// portal users by id; update a portal user's editable fields. `status` here
+// is deliberately limited to active/disabled — 'invited' is a system-set
+// state, not something an MSP can set directly via this endpoint.
+export const invitePortalUserSchema = z.object({
+  email: z.string().email().max(255),
+  name: z.string().min(1).max(255).optional(),
+  message: z.string().max(1000).optional()
+}).strict();
+export type InvitePortalUserInput = z.infer<typeof invitePortalUserSchema>;
+
+export const bulkInvitePortalUsersSchema = z.object({
+  userIds: z.array(z.string().guid()).optional()
+}).strict();
+export type BulkInvitePortalUsersInput = z.infer<typeof bulkInvitePortalUsersSchema>;
+
+export const updatePortalUserSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  receiveNotifications: z.boolean().optional(),
+  status: z.enum(['active', 'disabled']).optional()
+}).strict();
+export type UpdatePortalUserInput = z.infer<typeof updatePortalUserSchema>;


### PR DESCRIPTION
## What

Customer Portal onboarding + invite flow, plus a **Portal Users** management UI in Org Settings.

MSP techs can now invite, resend, bulk-invite, disable, and delete portal (customer) users for an org; invited users accept via a tokenized link and set their password. Disable is now **terminal** — a disabled user can't be resurrected by invite/resend/accept.

## Changes

**API**
- `orgPortalUsers.ts` — new MSP-facing routes: list, invite, bulk-invite, patch (enable/disable/role), resend-invite, delete. Bulk-invite and resend exclude disabled users.
- `portal/auth.ts` — `accept-invite` endpoint (token → set password → activate); disabled users are blocked. Fixed forgot-password link base.
- `portal/helpers.ts` — invite-token store (Redis) with `buildPortalUrl`; `storePortalInviteToken` signals failure when Redis is unavailable so callers don't hand out dead links.
- `services/email.ts` — `sendPortalInvite` email template.
- Migration `2026-07-07-portal-user-invites.sql` — adds nullable `invited_by` / `invited_at` provenance columns to `portal_users`. Idempotent; table already has org-scoped RLS (shape 1, direct `org_id`), so no new policy needed.

**Web**
- `OrgPortalUsersEditor.tsx` — Portal Users management panel in Org Settings (invite / resend / bulk-invite / disable / delete), mutations wrapped in `runAction`.

**Shared**
- `validators/portal.ts` — invite/manage validators.

## Tests
- `orgPortalUsers.test.ts`, `acceptInvite.test.ts`, `helpers.test.ts`, `portalInviteEmail.test.ts`, `OrgPortalUsersEditor.test.tsx`, validator tests.
- `portalUserInvite.integration.test.ts` — invite→accept happy path + cross-org RLS isolation against real Postgres.

Design + implementation plan: `docs/superpowers/specs/2026-07-07-portal-customer-onboarding-design.md`, `docs/superpowers/plans/2026-07-07-portal-customer-onboarding.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
