### PR TITLE
fix(quotes): freeze org bill-to address on send + add billing-contact settings

### DIFF
--- a/apps/api/src/__tests__/integration/orgBillingSettings.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgBillingSettings.integration.test.ts
@@ -1,0 +1,64 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { organizations } from '../../db/schema/orgs';
+import { createPartner, createOrganization } from './db-utils';
+import { updateOrgBillingSettings } from '../../services/invoiceService';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seed() {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    return { partner, org };
+  });
+}
+function ctxFor(orgId: string, partnerId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [partnerId], userId: null };
+}
+function actorFor(orgId: string, partnerId: string) {
+  return { userId: null, partnerId, accessibleOrgIds: [orgId] };
+}
+async function readContact(orgId: string) {
+  const [row] = await withSystemDbAccessContext(() =>
+    db.select({ billingContact: organizations.billingContact }).from(organizations).where(eq(organizations.id, orgId)).limit(1));
+  return row!.billingContact as Record<string, unknown> | null;
+}
+
+describe('updateOrgBillingSettings billingContact merge (real DB)', () => {
+  runDb('preserves unmodeled keys (e.g. a QuickBooks import) when setting email/name', async () => {
+    const { partner, org } = await seed();
+    // A prior importer wrote keys this endpoint does not model.
+    await withSystemDbAccessContext(() => db.update(organizations)
+      .set({ billingContact: { email: 'old@x.example', quickbooksId: 'QB-1', phone: '555-0100' } })
+      .where(eq(organizations.id, org.id)));
+
+    await withDbAccessContext(ctxFor(org.id, partner.id), () =>
+      updateOrgBillingSettings(org.id, { billingContactEmail: 'new@x.example', billingContactName: 'AP Dept' }, actorFor(org.id, partner.id)));
+
+    expect(await readContact(org.id)).toEqual({
+      email: 'new@x.example', name: 'AP Dept', // updated/added
+      quickbooksId: 'QB-1', phone: '555-0100', // untouched keys survive the `||` merge
+    });
+  });
+
+  runDb('merges onto a NULL billingContact (fresh org, first contact saved)', async () => {
+    const { partner, org } = await seed(); // billing_contact defaults to NULL
+    await withDbAccessContext(ctxFor(org.id, partner.id), () =>
+      updateOrgBillingSettings(org.id, { billingContactEmail: 'first@x.example', billingContactName: 'AP' }, actorFor(org.id, partner.id)));
+
+    expect(await readContact(org.id)).toEqual({ email: 'first@x.example', name: 'AP' });
+  });
+
+  runDb('clears the recipient by setting billingContact.email to JSON null (key kept, value null)', async () => {
+    const { partner, org } = await seed();
+    await withDbAccessContext(ctxFor(org.id, partner.id), () =>
+      updateOrgBillingSettings(org.id, { billingContactEmail: 'x@x.example' }, actorFor(org.id, partner.id)));
+    await withDbAccessContext(ctxFor(org.id, partner.id), () =>
+      updateOrgBillingSettings(org.id, { billingContactEmail: null }, actorFor(org.id, partner.id)));
+
+    expect(await readContact(org.id)).toEqual({ email: null });
+  });
+});

--- a/apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteLifecycle.integration.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
 import { quotes } from '../../db/schema/quotes';
+import { organizations } from '../../db/schema/orgs';
 import { createPartner, createOrganization } from './db-utils';
 import { createQuote, addManualLine } from '../../services/quoteService';
 import { sendQuote, markQuoteViewed, declineQuoteByActor } from '../../services/quoteLifecycle';
@@ -37,6 +38,32 @@ describe('quote lifecycle', () => {
     expect(result.quote.quoteNumber).toMatch(/^Q-\d{4}-\d{4}$/);
     expect(result.quote.sentAt).toBeTruthy();
     expect(result.acceptUrl).toContain('/quote/');
+  });
+
+  runDb('sendQuote freezes the org billing address into the quote bill-to snapshot', async () => {
+    const { partner, org } = await seed();
+    // Save a Billing address on the org (what the customer/org "Billing address" tab writes).
+    await withSystemDbAccessContext(() => db.update(organizations).set({
+      taxId: 'TAX-777',
+      billingAddressLine1: '500 Congress Ave', billingAddressLine2: 'Floor 9',
+      billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    }).where(eq(organizations.id, org.id)));
+
+    const ctx = ctxFor(org.id, partner.id);
+    const actor = actorFor(org.id, partner.id);
+    const created = await withDbAccessContext(ctx, () => createQuote({ orgId: org.id, currencyCode: 'USD' }, actor));
+    await withDbAccessContext(ctx, () => addManualLine(created.id, { sourceType: 'manual', description: 'Setup', quantity: 1, unitPrice: 100, taxable: false, customerVisible: true, recurrence: 'one_time' } as any, actor));
+
+    await withDbAccessContext(ctx, () => sendQuote(created.id, actor));
+
+    const [row] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, created.id)).limit(1));
+    expect(row!.billToAddress).toEqual({
+      line1: '500 Congress Ave', line2: 'Floor 9', city: 'Austin',
+      region: 'TX', postalCode: '78701', country: 'US',
+    });
+    expect(row!.billToName).toBe(org.name); // no draft override → org name
+    expect(row!.billToTaxId).toBe('TAX-777');
   });
 
   runDb('markQuoteViewed flips sent→viewed and stamps first_viewed_at once', async () => {

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -24,6 +24,7 @@ import { getEmailService, buildInvoiceTemplate } from './email';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { InvoiceServiceError } from './invoiceTypes';
 import type { InvoiceActor } from './invoiceTypes';
+import type { BillToAddress } from './sellerSnapshot';
 import { buildSellerSnapshot, sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
 import { computeChargeNow } from '@breeze/shared';
 
@@ -74,11 +75,6 @@ function lineTitle(l: { name: string | null; description: string | null }): stri
 }
 function lineBlurb(l: { name: string | null; description: string | null }): string {
   return l.name ? (l.description ?? '').trim() : '';
-}
-
-interface BillToAddress {
-  line1?: string | null; line2?: string | null; city?: string | null;
-  region?: string | null; postalCode?: string | null; country?: string | null;
 }
 
 function addressLines(addr: BillToAddress | null | undefined): string[] {

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -31,6 +31,7 @@ vi.mock('../db', () => {
 vi.mock('./catalogService', () => ({ resolvePrice: vi.fn(), computeBundleEconomics: vi.fn() }));
 vi.mock('./invoiceEvents', () => ({ emitInvoiceEvent: vi.fn().mockResolvedValue(undefined) }));
 
+import { SQL } from 'drizzle-orm';
 import * as svc from './invoiceService';
 import { db } from '../db';
 import { InvoiceServiceError } from './invoiceTypes';
@@ -199,6 +200,38 @@ describe('invoiceService guards', () => {
     const row = await svc.updateOrgBillingSettings('org1', { taxId: 'GB123', taxExempt: true, billingAddressCountry: 'GB' }, actor);
     expect(row.taxExempt).toBe(true);
     expect(row.billingAddressCountry).toBe('GB');
+  });
+
+  it('updateOrgBillingSettings merges billingContact via an atomic jsonb `||` expression, with no pre-read', async () => {
+    // The merge now happens in one UPDATE (COALESCE(billing_contact,'{}') || patch)
+    // — race-free and no read-modify-write round-trip. The unit layer asserts the
+    // SHAPE of the write (a SQL expression, no pre-read select); the actual
+    // key-preservation + null-clear semantics are proven against real Postgres in
+    // orgBillingSettings.integration.test.ts.
+    queueResult([{ id: 'org1', billingContact: { email: 'new@x.example', name: 'AP Dept' } }]); // returning row only
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+
+    await svc.updateOrgBillingSettings('org1', { billingContactEmail: 'new@x.example', billingContactName: 'AP Dept' }, actor);
+
+    const setMock = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set;
+    const setArg = setMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+    expect(setArg.billingContact).toBeInstanceOf(SQL); // a merge expression, not a plain object
+    // No pre-read: the merge is done entirely in the UPDATE.
+    expect((db.select as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(0);
+  });
+
+  it('updateOrgBillingSettings does NOT touch billingContact (nor select) when no contact field is in the patch', async () => {
+    queueResult([{ id: 'org1', taxExempt: true }]); // returning row only
+    const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+
+    await svc.updateOrgBillingSettings('org1', { taxExempt: true }, actor);
+
+    const setMock = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set;
+    const setArg = setMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+    expect(setArg).not.toHaveProperty('billingContact');
+    // Assert the pre-read select genuinely never fired — the `not.toHaveProperty`
+    // above would pass even if a stray select ran, so prove the branch directly.
+    expect((db.select as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -14,7 +14,7 @@ import { formatInvoiceNumber } from './invoiceNumbers';
 import { emitInvoiceEvent } from './invoiceEvents';
 import { enqueueInvoicePdfRender } from '../jobs/invoiceWorker';
 import { gatherOrgTimeEntries, gatherOrgParts, gatherTicketBillables, type DraftLineSpec } from './invoiceAssembly';
-import { buildSellerSnapshot } from './sellerSnapshot';
+import { buildSellerSnapshot, buildBillToAddress } from './sellerSnapshot';
 import { InvoiceServiceError } from './invoiceTypes';
 import type { InvoiceActor } from './invoiceTypes';
 import type { ManualLineInput, RecordPaymentInput } from '@breeze/shared';
@@ -372,6 +372,7 @@ export async function updateOrgBillingSettings(
   orgId: string,
   patch: {
     taxId?: string | null; taxExempt?: boolean; taxRate?: number | null;
+    billingContactEmail?: string | null; billingContactName?: string | null;
     billingAddressLine1?: string | null; billingAddressLine2?: string | null;
     billingAddressCity?: string | null; billingAddressRegion?: string | null;
     billingAddressPostalCode?: string | null; billingAddressCountry?: string | null;
@@ -383,6 +384,17 @@ export async function updateOrgBillingSettings(
   if (patch.taxId !== undefined) set.taxId = patch.taxId;
   if (patch.taxExempt !== undefined) set.taxExempt = patch.taxExempt;
   if (patch.taxRate !== undefined) set.taxRate = patch.taxRate === null ? null : Number(patch.taxRate).toFixed(5);
+  // billingContact is a jsonb bag other importers (e.g. QuickBooks) also write.
+  // Merge email/name in the DB with `||` (COALESCE handles a NULL start on a fresh
+  // org) so we never drop keys we don't model here AND never lose a concurrent
+  // writer's key to a read-modify-write race — the merge is one atomic statement,
+  // no pre-read round-trip. Only build it when a contact field is in the patch.
+  const contactPatch: Record<string, unknown> = {};
+  if (patch.billingContactEmail !== undefined) contactPatch.email = patch.billingContactEmail;
+  if (patch.billingContactName !== undefined) contactPatch.name = patch.billingContactName;
+  if (Object.keys(contactPatch).length > 0) {
+    set.billingContact = sql`COALESCE(${organizations.billingContact}, '{}'::jsonb) || ${JSON.stringify(contactPatch)}::jsonb`;
+  }
   if (patch.billingAddressLine1 !== undefined) set.billingAddressLine1 = patch.billingAddressLine1;
   if (patch.billingAddressLine2 !== undefined) set.billingAddressLine2 = patch.billingAddressLine2;
   if (patch.billingAddressCity !== undefined) set.billingAddressCity = patch.billingAddressCity;
@@ -391,6 +403,7 @@ export async function updateOrgBillingSettings(
   if (patch.billingAddressCountry !== undefined) set.billingAddressCountry = patch.billingAddressCountry;
   const [row] = await db.update(organizations).set(set).where(eq(organizations.id, orgId)).returning({
     id: organizations.id, taxId: organizations.taxId, taxExempt: organizations.taxExempt, taxRate: organizations.taxRate,
+    billingContact: organizations.billingContact,
     billingAddressLine1: organizations.billingAddressLine1, billingAddressLine2: organizations.billingAddressLine2,
     billingAddressCity: organizations.billingAddressCity, billingAddressRegion: organizations.billingAddressRegion,
     billingAddressPostalCode: organizations.billingAddressPostalCode, billingAddressCountry: organizations.billingAddressCountry,
@@ -497,11 +510,7 @@ export async function issueInvoice(invoiceId: string, actor: InvoiceActor) {
     // Recompute totals with the snapshotted rate, then write everything atomically.
     const lineRows = await db.select({ lineTotal: invoiceLines.lineTotal, taxable: invoiceLines.taxable, customerVisible: invoiceLines.customerVisible }).from(invoiceLines).where(eq(invoiceLines.invoiceId, invoiceId));
     const { subtotal, taxTotal, total } = computeInvoiceTotals(lineRows, taxRate);
-    const billToAddress = {
-      line1: org?.billingAddressLine1 ?? null, line2: org?.billingAddressLine2 ?? null,
-      city: org?.billingAddressCity ?? null, region: org?.billingAddressRegion ?? null,
-      postalCode: org?.billingAddressPostalCode ?? null, country: org?.billingAddressCountry ?? null
-    };
+    const billToAddress = buildBillToAddress(org);
 
     await db.update(invoices).set({
       // status 'sent' is the lifecycle "issued/finalized" state. sentAt is left

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -7,11 +7,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const results: unknown[][] = [];
 function queueResult(rows: unknown[]) { results.push(rows); }
 
+// Records every payload passed to `.set(...)` so tests can assert what a mutation
+// actually wrote (e.g. the frozen bill-to snapshot on send), not just what the
+// re-select mock returns.
+const setCalls: Array<Record<string, unknown>> = [];
+
 vi.mock('../db', () => {
   const makeChain = () => {
     const chain: Record<string, unknown> = {};
     const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'execute', 'transaction'];
     for (const m of methods) chain[m] = vi.fn(() => chain);
+    chain.set = vi.fn((payload: Record<string, unknown>) => { setCalls.push(payload); return chain; });
     (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
       const rows = results.shift() ?? [];
       return Promise.resolve(rows).then(resolve);
@@ -225,6 +231,7 @@ describe('sendQuote deposit validation', () => {
 describe('sendQuote customer-facing PDF', () => {
   beforeEach(() => {
     results.length = 0;
+    setCalls.length = 0;
     vi.clearAllMocks();
     capturedPdfArgs = null;
     sendEmailMock.mockResolvedValue(undefined);
@@ -253,10 +260,9 @@ describe('sendQuote customer-facing PDF', () => {
     queueResult([]); // blocks
     queueResult([visibleLine, internalLine]); // lines
 
-    queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow
+    queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow (reused for partner name)
+    queueResult([{ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } }]); // org (billing snapshot + recipient)
     queueResult([{ id: 'q1' }]); // update ... returning (claimed)
-    queueResult([{ billingContact: { email: 'billing@customer.example' } }]); // org billingContact
-    queueResult([{ name: 'Acme MSP' }]); // partner name
     queueResult([]); // portalBranding — none configured
     queueResult([{ // final re-select
       id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
@@ -276,5 +282,142 @@ describe('sendQuote customer-facing PDF', () => {
     expect(renderedLines.some((l) => l.name === 'Internal markup buffer')).toBe(false);
     // toCustomerLines also strips the cost-basis field, same as the portal route.
     expect(renderedLines[0]).not.toHaveProperty('unitCost');
+  });
+});
+
+/**
+ * Bill-to snapshot freeze (bug: org Billing address never appeared on the quote).
+ * `sendQuote` must copy the org's Billing-settings address into the quote's frozen
+ * `billToAddress` (+ name/taxId) at send time — the same snapshot the invoice issue
+ * path takes. Before this, `bill_to_address` stayed NULL and the PDF rendered no
+ * customer address no matter what the tech saved on the org.
+ */
+describe('sendQuote bill-to snapshot', () => {
+  beforeEach(() => {
+    results.length = 0;
+    setCalls.length = 0;
+    vi.clearAllMocks();
+    capturedPdfArgs = null;
+    sendEmailMock.mockResolvedValue(undefined);
+  });
+
+  /** Queue getQuote (quote/blocks/lines) + partnerRow + org + claim + email-path reads. */
+  function queueSendPath(quote: Record<string, unknown>, org: Record<string, unknown>) {
+    queueResult([quote]); // getQuote: quote
+    queueResult([]);       // getQuote: blocks
+    queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
+    queueResult([{ id: 'p1', name: 'Acme MSP', billingTermsAndConditions: null, invoiceFooter: null }]); // partnerRow (reused for partner name)
+    queueResult([org]);    // org (billing snapshot + recipient)
+    queueResult([{ id: 'q1' }]); // update ... returning (claimed)
+    queueResult([]);       // portalBranding
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]); // final re-select
+  }
+
+  const baseQuote = {
+    id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft',
+    taxRate: null, depositType: 'none', depositPercent: null,
+    quoteNumber: 'Q-2026-0001', issueDate: '2026-01-01', expiryDate: null,
+    total: '100.00', currencyCode: 'USD', terms: null, termsAndConditions: null,
+    sellerSnapshot: null, billToName: null, billToTaxId: null,
+  };
+
+  /** Pull the `.set(...)` payload from the status→sent claim update. */
+  function claimSet() {
+    const found = setCalls.find((s) => s.status === 'sent' && 'billToAddress' in s);
+    expect(found, 'send update should set billToAddress').toBeDefined();
+    return found!;
+  }
+
+  it('freezes the org billing address into billToAddress/name/taxId on send', async () => {
+    queueSendPath(baseQuote, {
+      name: 'Customer Co', taxId: 'TAX-42',
+      billingContact: { email: 'billing@customer.example' },
+      billingAddressLine1: '123 Main St', billingAddressLine2: 'Suite 4',
+      billingAddressCity: 'Austin', billingAddressRegion: 'TX',
+      billingAddressPostalCode: '78701', billingAddressCountry: 'US',
+    });
+
+    await sendQuote('q1', actor);
+
+    const set = claimSet();
+    expect(set.billToAddress).toEqual({
+      line1: '123 Main St', line2: 'Suite 4', city: 'Austin',
+      region: 'TX', postalCode: '78701', country: 'US',
+    });
+    expect(set.billToName).toBe('Customer Co'); // no draft override → org name
+    expect(set.billToTaxId).toBe('TAX-42');
+  });
+
+  it('preserves a tech-set draft billToName over the org name', async () => {
+    queueSendPath(
+      { ...baseQuote, billToName: 'Attn: Accounts Payable' },
+      {
+        name: 'Customer Co', taxId: null,
+        billingContact: { email: 'billing@customer.example' },
+        billingAddressLine1: '1 Elm', billingAddressLine2: null,
+        billingAddressCity: 'Reno', billingAddressRegion: 'NV',
+        billingAddressPostalCode: '89501', billingAddressCountry: 'US',
+      },
+    );
+
+    await sendQuote('q1', actor);
+
+    const set = claimSet();
+    expect(set.billToName).toBe('Attn: Accounts Payable'); // draft override wins
+    expect(set.billToAddress).toMatchObject({ line1: '1 Elm', city: 'Reno' });
+  });
+
+  it('falls back to the org name when a draft billToName is blank (not a bare ?? on "")', async () => {
+    // updateQuote persists billToName verbatim, so a draft can carry '' — a naive
+    // `quote.billToName ?? org.name` would freeze an empty name. Whitespace too.
+    queueSendPath(
+      { ...baseQuote, billToName: '   ' },
+      {
+        name: 'Customer Co', taxId: null,
+        billingContact: { email: 'billing@customer.example' },
+        billingAddressLine1: '1 Elm', billingAddressLine2: null,
+        billingAddressCity: 'Reno', billingAddressRegion: 'NV',
+        billingAddressPostalCode: '89501', billingAddressCountry: 'US',
+      },
+    );
+
+    await sendQuote('q1', actor);
+
+    expect(claimSet().billToName).toBe('Customer Co');
+  });
+
+  it('preserves a tech-set draft billToTaxId over the org taxId', async () => {
+    queueSendPath(
+      { ...baseQuote, billToTaxId: 'OVERRIDE-TAX' },
+      {
+        name: 'Customer Co', taxId: 'ORG-TAX',
+        billingContact: { email: 'billing@customer.example' },
+        billingAddressLine1: '1 Elm', billingAddressLine2: null,
+        billingAddressCity: 'Reno', billingAddressRegion: 'NV',
+        billingAddressPostalCode: '89501', billingAddressCountry: 'US',
+      },
+    );
+
+    await sendQuote('q1', actor);
+
+    expect(claimSet().billToTaxId).toBe('OVERRIDE-TAX'); // draft override wins over ORG-TAX
+  });
+
+  it('freezes an all-null address when the org has no billing address saved', async () => {
+    queueSendPath(baseQuote, {
+      name: 'Customer Co', taxId: null,
+      billingContact: { email: 'billing@customer.example' },
+      billingAddressLine1: null, billingAddressLine2: null,
+      billingAddressCity: null, billingAddressRegion: null,
+      billingAddressPostalCode: null, billingAddressCountry: null,
+    });
+
+    await sendQuote('q1', actor);
+
+    // Still a well-formed object (addressLines() renders nothing from it) — never
+    // a partial/undefined shape the PDF helper would choke on.
+    expect(claimSet().billToAddress).toEqual({
+      line1: null, line2: null, city: null, region: null, postalCode: null, country: null,
+    });
   });
 });

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -12,7 +12,7 @@ import { buildQuoteTemplate } from './quoteEmail';
 import { getEmailService } from './email';
 import { resolveBillingEmail } from './invoicePdf';
 import { isQuoteExpired } from './quoteExpiry';
-import { buildSellerSnapshot } from './sellerSnapshot';
+import { buildSellerSnapshot, buildBillToAddress } from './sellerSnapshot';
 
 type QuoteRow = typeof quotes.$inferSelect;
 
@@ -118,10 +118,47 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
   // quote (the second matches 0 rows and 409s). Counter gaps from the losing
   // send are acceptable, per allocateQuoteCounter's contract (C3).
   const [partnerRow] = await db.select().from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+  // Freeze the customer bill-to snapshot at send time from the org's Billing
+  // settings — the same fields, from the same columns, that the invoice issue
+  // path snapshots (invoiceService.ts). Without this, quotes.bill_to_address
+  // stays NULL and the org's saved billing address never renders on the PDF. A
+  // tech's explicit draft billToName override wins over the org name; taxId/
+  // address come straight from the org. This single fetch also supplies the
+  // email recipient below (billingContact), replacing the old post-update read.
+  const [org] = await db
+    .select({
+      name: organizations.name,
+      taxId: organizations.taxId,
+      billingContact: organizations.billingContact,
+      billingAddressLine1: organizations.billingAddressLine1,
+      billingAddressLine2: organizations.billingAddressLine2,
+      billingAddressCity: organizations.billingAddressCity,
+      billingAddressRegion: organizations.billingAddressRegion,
+      billingAddressPostalCode: organizations.billingAddressPostalCode,
+      billingAddressCountry: organizations.billingAddressCountry,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, quote.orgId))
+    .limit(1);
+  if (!org) {
+    // getQuote just read this quote in the SAME context, so its org should be
+    // visible too — an unreadable org here (orphaned/deleted row) is anomalous.
+    // The snapshot freezes ONCE at send, so a blank bill-to is permanent; log it
+    // rather than let the loss be indistinguishable from "org saved no address".
+    console.error(`[quoteLifecycle] org ${quote.orgId} not readable while freezing bill-to for quote ${id} — sending with an empty bill-to snapshot`);
+  }
+  const billToAddress = buildBillToAddress(org);
+  // Preserve a real tech-entered "Prepared for" override, but fall back to the org
+  // name when it's absent OR blank — updateQuote persists billToName verbatim,
+  // including '', which a bare `?? org.name` would freeze as an empty name.
+  const billToName = quote.billToName?.trim() ? quote.billToName : (org?.name ?? null);
   const claimed = await db
     .update(quotes)
     .set({
       status: 'sent', quoteNumber, issueDate, sentAt: now, updatedAt: now,
+      billToName,
+      billToAddress,
+      billToTaxId: quote.billToTaxId ?? org?.taxId ?? null,
       sellerSnapshot: buildSellerSnapshot(partnerRow),
       termsAndConditions: quote.termsAndConditions ?? partnerRow?.billingTermsAndConditions ?? null,
       terms: quote.terms ?? partnerRow?.invoiceFooter ?? null,
@@ -147,8 +184,9 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
   // follow-up (atom-3); the email-failure swallow keeps the send safe meanwhile.
   let emailed = false;
   try {
-    const [org] = await db.select({ billingContact: organizations.billingContact }).from(organizations).where(eq(organizations.id, quote.orgId)).limit(1);
-    const [partner] = await db.select({ name: partners.name }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
+    // Reuse partnerRow (already fetched above for the seller snapshot) rather than
+    // re-querying the partner just for its name — one fewer round-trip per send.
+    const partnerName = partnerRow?.name;
     const recipient = resolveBillingEmail(org?.billingContact);
     const emailService = getEmailService();
     if (emailService && recipient) {
@@ -175,11 +213,11 @@ export async function sendQuote(id: string, actor: QuoteActor): Promise<{ quote:
       const pdf = await renderQuotePdf(
         { ...quote, status: 'sent', quoteNumber, sellerSnapshot: quote.sellerSnapshot ?? buildSellerSnapshot(partnerRow) },
         blocks, customerLines, loadImage, {
-          partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
+          partnerName: partnerName ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
           footer: quote.terms ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? 'USD',
         });
       const template = buildQuoteTemplate({
-        quoteNumber, partnerName: partner?.name ?? 'your provider',
+        quoteNumber, partnerName: partnerName ?? 'your provider',
         total: formatMoneyish(quote.total, quote.currencyCode), acceptUrl,
         expiryDate: quote.expiryDate ?? undefined,
       });

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -15,7 +15,7 @@
 
 import PDFDocument from 'pdfkit';
 import { toCents, fromCents } from '@breeze/shared';
-import { sellerAddressLines, type SellerSnapshot } from './sellerSnapshot';
+import { sellerAddressLines, type SellerSnapshot, type BillToAddress } from './sellerSnapshot';
 import { captureException } from './sentry';
 
 // ---------------------------------------------------------------------------
@@ -62,11 +62,6 @@ function hexToColor(value: string | null | undefined, fallback: string): string 
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-interface BillToAddress {
-  line1?: string | null; line2?: string | null; city?: string | null;
-  region?: string | null; postalCode?: string | null; country?: string | null;
 }
 
 function addressLines(addr: BillToAddress | null | undefined): string[] {

--- a/apps/api/src/services/sellerSnapshot.ts
+++ b/apps/api/src/services/sellerSnapshot.ts
@@ -55,3 +55,36 @@ export function sellerAddressLines(snapshot: SellerSnapshot | null | undefined):
   const cityLine = [a.city, a.region, a.postalCode].filter(Boolean).join(', ');
   return [a.line1, a.line2, cityLine, a.country].filter((s): s is string => !!s && s.trim().length > 0);
 }
+
+// The frozen customer "Bill to" address snapshot. Same key shape as
+// SellerSnapshot['address'] and what the PDF addressLines() helper reads. The
+// invoice issue path and the quote send path both freeze this at issue/send time
+// so the two documents render identically — build it through buildBillToAddress
+// (below) rather than an inline literal so the shapes can never drift apart.
+export interface BillToAddress {
+  line1: string | null; line2: string | null; city: string | null;
+  region: string | null; postalCode: string | null; country: string | null;
+}
+
+interface OrgBillingAddressFields {
+  billingAddressLine1?: string | null;
+  billingAddressLine2?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressRegion?: string | null;
+  billingAddressPostalCode?: string | null;
+  billingAddressCountry?: string | null;
+}
+
+/** Freeze an org's billing-address columns into a BillToAddress. Always returns a
+ *  well-formed all-keys object (never partial), so addressLines() never sees an
+ *  undefined field. Shared by invoiceService (issue) and quoteLifecycle (send). */
+export function buildBillToAddress(org: OrgBillingAddressFields | null | undefined): BillToAddress {
+  return {
+    line1: org?.billingAddressLine1 ?? null,
+    line2: org?.billingAddressLine2 ?? null,
+    city: org?.billingAddressCity ?? null,
+    region: org?.billingAddressRegion ?? null,
+    postalCode: org?.billingAddressPostalCode ?? null,
+    country: org?.billingAddressCountry ?? null,
+  };
+}

--- a/apps/web/src/components/billing/OrgBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/OrgBillingSettings.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrgBillingSettings from './OrgBillingSettings';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// The org GET the billing tab loads from. Callers override individual fields.
+const orgPayload = (over: Record<string, unknown> = {}) => json({
+  taxId: null, taxExempt: false, taxRate: null,
+  billingContact: null,
+  billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null,
+  billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null,
+  ...over,
+});
+const findPatch = () =>
+  fetchMock.mock.calls.find((c) => c[0] === '/orgs/org-1/billing-settings' && (c[1] as RequestInit)?.method === 'PATCH');
+
+describe('OrgBillingSettings — billing contact', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loads and shows the saved billing contact email + name', async () => {
+    fetchMock.mockResolvedValue(orgPayload({ billingContact: { email: 'ap@customer.example', name: 'AP Dept' } }));
+    render(<OrgBillingSettings orgId="org-1" />);
+    await waitFor(() =>
+      expect((screen.getByTestId('org-billing-contact-email') as HTMLInputElement).value).toBe('ap@customer.example'));
+    expect((screen.getByTestId('org-billing-contact-name') as HTMLInputElement).value).toBe('AP Dept');
+  });
+
+  it('sends billingContactEmail/Name in the PATCH body when filled', async () => {
+    fetchMock.mockImplementation(async (_input: string, opts?: RequestInit) =>
+      opts?.method === 'PATCH' ? json({ data: {} }) : orgPayload());
+    render(<OrgBillingSettings orgId="org-1" />);
+    await waitFor(() => expect(screen.getByTestId('org-billing-settings')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('org-billing-contact-email'), { target: { value: 'billing@customer.example' } });
+    fireEvent.change(screen.getByTestId('org-billing-contact-name'), { target: { value: 'Accounts Payable' } });
+    fireEvent.click(screen.getByTestId('org-billing-save'));
+
+    await waitFor(() => {
+      const patch = findPatch();
+      expect(patch).toBeTruthy();
+      expect(JSON.parse((patch![1] as RequestInit).body as string)).toMatchObject({
+        billingContactEmail: 'billing@customer.example', billingContactName: 'Accounts Payable',
+      });
+    });
+  });
+
+  it('serializes a cleared contact email to null (never "") so the schema does not 400', async () => {
+    // The linchpin of the design: orgBillingSettingsSchema rejects '' via .email();
+    // clearing the field must send null. Mirrors PartnerBillingSettings' address test.
+    fetchMock.mockImplementation(async (_input: string, opts?: RequestInit) =>
+      opts?.method === 'PATCH' ? json({ data: {} }) : orgPayload({ billingContact: { email: 'ap@customer.example', name: 'AP' } }));
+    render(<OrgBillingSettings orgId="org-1" />);
+    await waitFor(() =>
+      expect((screen.getByTestId('org-billing-contact-email') as HTMLInputElement).value).toBe('ap@customer.example'));
+
+    // Clear the email to whitespace-only, then save.
+    fireEvent.change(screen.getByTestId('org-billing-contact-email'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByTestId('org-billing-save'));
+
+    await waitFor(() => {
+      const patch = findPatch();
+      expect(patch).toBeTruthy();
+      expect(JSON.parse((patch![1] as RequestInit).body as string).billingContactEmail).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/billing/OrgBillingSettings.tsx
+++ b/apps/web/src/components/billing/OrgBillingSettings.tsx
@@ -10,6 +10,7 @@ interface OrgBilling {
   taxId: string | null;
   taxExempt: boolean;
   taxRate: string | null;
+  billingContact: { email?: string | null; name?: string | null } | null;
   billingAddressLine1: string | null;
   billingAddressLine2: string | null;
   billingAddressCity: string | null;
@@ -30,6 +31,8 @@ export default function OrgBillingSettings({ orgId }: Props) {
   const [taxId, setTaxId] = useState('');
   const [taxExempt, setTaxExempt] = useState(false);
   const [taxPercent, setTaxPercent] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [contactName, setContactName] = useState('');
   const [line1, setLine1] = useState('');
   const [line2, setLine2] = useState('');
   const [city, setCity] = useState('');
@@ -48,6 +51,8 @@ export default function OrgBillingSettings({ orgId }: Props) {
       setTaxId(o.taxId ?? '');
       setTaxExempt(Boolean(o.taxExempt));
       setTaxPercent(pctFromFraction(o.taxRate));
+      setContactEmail(o.billingContact?.email ?? '');
+      setContactName(o.billingContact?.name ?? '');
       setLine1(o.billingAddressLine1 ?? '');
       setLine2(o.billingAddressLine2 ?? '');
       setCity(o.billingAddressCity ?? '');
@@ -75,6 +80,10 @@ export default function OrgBillingSettings({ orgId }: Props) {
             taxId: taxId.trim() === '' ? null : taxId.trim(),
             taxExempt,
             taxRate: pct === '' ? null : Number(pct) / 100,
+            // Send null (not '') when cleared — the schema validates email format
+            // and treats null as "no recipient" rather than rejecting a blank.
+            billingContactEmail: contactEmail.trim() === '' ? null : contactEmail.trim(),
+            billingContactName: contactName.trim() === '' ? null : contactName.trim(),
             billingAddressLine1: line1.trim() === '' ? null : line1,
             billingAddressLine2: line2.trim() === '' ? null : line2,
             billingAddressCity: city.trim() === '' ? null : city,
@@ -93,7 +102,7 @@ export default function OrgBillingSettings({ orgId }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [saving, taxId, taxExempt, taxPercent, line1, line2, city, region, postal, country, orgId, load]);
+  }, [saving, taxId, taxExempt, taxPercent, contactEmail, contactName, line1, line2, city, region, postal, country, orgId, load]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading billing settings…</p>;
   if (loadError) {
@@ -131,6 +140,23 @@ export default function OrgBillingSettings({ orgId }: Props) {
           <input type="checkbox" checked={taxExempt} onChange={(e) => setTaxExempt(e.target.checked)} data-testid="org-billing-exempt" />
           Tax exempt
         </label>
+      </section>
+
+      <section className="rounded-lg border bg-card p-6 shadow-xs">
+        <h2 className="text-lg font-semibold">Billing contact</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Quotes and invoices are emailed to this address. Without it, sending a proposal marks it Sent but nothing is emailed.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium" htmlFor="ob-contact-email">Contact email</label>
+            <input id="ob-contact-email" type="email" maxLength={255} value={contactEmail} onChange={(e) => setContactEmail(e.target.value)} placeholder="billing@customer.example" data-testid="org-billing-contact-email" className={inputCls} />
+          </div>
+          <div>
+            <label className="text-sm font-medium" htmlFor="ob-contact-name">Contact name</label>
+            <input id="ob-contact-name" type="text" maxLength={255} value={contactName} onChange={(e) => setContactName(e.target.value)} placeholder="Optional" data-testid="org-billing-contact-name" className={inputCls} />
+          </div>
+        </div>
       </section>
 
       <section className="rounded-lg border bg-card p-6 shadow-xs">

--- a/packages/shared/src/validators/invoices.test.ts
+++ b/packages/shared/src/validators/invoices.test.ts
@@ -84,6 +84,29 @@ describe('partnerBillingSettingsSchema — contact fields', () => {
   });
 });
 
+describe('orgBillingSettingsSchema — billing contact', () => {
+  it('accepts a billing contact email + name', () => {
+    const parsed = orgBillingSettingsSchema.parse({
+      billingContactEmail: 'billing@customer.example', billingContactName: 'AP Dept',
+    });
+    expect(parsed.billingContactEmail).toBe('billing@customer.example');
+    expect(parsed.billingContactName).toBe('AP Dept');
+  });
+
+  it('accepts null to clear the recipient', () => {
+    const parsed = orgBillingSettingsSchema.parse({ billingContactEmail: null, billingContactName: null });
+    expect(parsed.billingContactEmail).toBeNull();
+  });
+
+  it('rejects a malformed email', () => {
+    expect(() => orgBillingSettingsSchema.parse({ billingContactEmail: 'not-an-email' })).toThrow();
+  });
+
+  it('rejects an empty-string email (UI must send null, not "")', () => {
+    expect(() => orgBillingSettingsSchema.parse({ billingContactEmail: '' })).toThrow();
+  });
+});
+
 describe('invoice T&C field', () => {
   it('create accepts termsAndConditions', () => {
     const p = createManualInvoiceSchema.parse({ orgId: '00000000-0000-0000-0000-000000000000', termsAndConditions: 'Net 30' });

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -115,6 +115,13 @@ export const orgBillingSettingsSchema = z.object({
   taxId: z.string().max(100).nullable().optional(),
   taxExempt: z.boolean().optional(),
   taxRate: taxRate.nullable().optional(),
+  // Billing contact — the recipient quotes/invoices are actually emailed to
+  // (org.billingContact jsonb). Kept here, alongside the address, so the whole
+  // "who + where we bill" lives on one form. Clearing the field must send null,
+  // not '': `.email()` rejects an empty string (a 400), while `.nullable()`
+  // accepts null. Null flows through to resolveBillingEmail as "no recipient".
+  billingContactEmail: z.string().email().max(255).nullable().optional(),
+  billingContactName: z.string().max(255).nullable().optional(),
   billingAddressLine1: z.string().max(255).nullable().optional(),
   billingAddressLine2: z.string().max(255).nullable().optional(),
   billingAddressCity: z.string().max(120).nullable().optional(),


### PR DESCRIPTION
## Problem

Sending a quote never froze the org's billing address into `quotes.bill_to_address`, so the customer's saved billing address **never rendered on the quote PDF** — even though the invoice *issue* path already snapshots the exact same fields. Quotes went out with a blank "Bill to" block.

Separately, an org with no **billing contact** could have a proposal "sent" — it flips to `Sent` but silently emails no one, because there was no place in the UI to set the recipient (`org.billingContact`).

## Changes

- **`sendQuote` freezes the bill-to snapshot at send time** — address, name, and tax id — from the org's Billing settings, matching `issueInvoice` exactly. A tech's explicit "Prepared for" override still wins over the org name (with a blank-string guard so `''` doesn't freeze an empty name). Logs an anomaly if the org row is unreadable, since the snapshot freezes once and a blank bill-to would otherwise be permanent and indistinguishable from "no address saved".
- **Shared `buildBillToAddress` / `BillToAddress`** extracted into `sellerSnapshot.ts`, replacing the duplicated inline literals and three local `BillToAddress` interfaces (`invoiceService`, `invoicePdf`, `quotePdf`) so the invoice and quote shapes can't drift.
- **Billing contact (email + name) on the Org Billing Settings form** — editable, validated (`.email()`, clears to `null` not `''`), and merged into the `billingContact` jsonb via an atomic `COALESCE(..., '{}') || patch` so a concurrent writer's keys (e.g. QuickBooks) aren't lost to a read-modify-write race.
- Minor: `sendQuote` now reuses the already-fetched `partnerRow` for the partner name instead of a second query, and the org fetch does double duty (bill-to + email recipient), dropping the old post-update read.

## Tests

- Unit: `quoteLifecycle.test.ts`, `invoiceService.test.ts`, `invoices.test.ts` (validator), `OrgBillingSettings.test.tsx` — all pass locally.
- Integration (real Postgres, run in CI smoke-test): new `orgBillingSettings.integration.test.ts` + additions to `quoteLifecycle.integration.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)